### PR TITLE
 Merge experimental decisionweight branch

### DIFF
--- a/src/decision/decision_engine.h
+++ b/src/decision/decision_engine.h
@@ -27,6 +27,7 @@
 #include "prop/cnf_stream.h"
 #include "prop/prop_engine.h"
 #include "prop/sat_solver_types.h"
+#include "theory/decision_attributes.h"
 #include "util/ite_removal.h"
 #include "util/output.h"
 

--- a/src/decision/decision_mode.h
+++ b/src/decision/decision_mode.h
@@ -46,6 +46,15 @@ enum DecisionMode {
 
 };/* enum DecisionMode */
 
+
+/** Enumeration of combining functions for computing internal weights */
+enum DecisionWeightInternal {
+  DECISION_WEIGHT_INTERNAL_OFF,
+  DECISION_WEIGHT_INTERNAL_MAX,
+  DECISION_WEIGHT_INTERNAL_SUM,
+  DECISION_WEIGHT_INTERNAL_USR1
+};/* enum DecisionInternalWeight */
+
 }/* CVC4::decision namespace */
 
 std::ostream& operator<<(std::ostream& out, decision::DecisionMode mode) CVC4_PUBLIC;

--- a/src/decision/options
+++ b/src/decision/options
@@ -20,4 +20,16 @@ option decisionMustRelevancy bool
 # only use DE to determine when to stop, not to make decisions
 option decisionStopOnly bool
 
+expert-option decisionThreshold --decision-threshold=N decision::DecisionWeight :default 0 :include "theory/decision_attributes.h"
+ ignore all nodes greater than threshold in first attempt to pick decision
+
+expert-option decisionUseWeight --decision-use-weight bool :default false
+ use the weight nodes (locally, by looking at children) to direct recursive search
+
+expert-option decisionRandomWeight --decision-random-weight=N int :default 0
+ assign random weights to nodes between 0 and N-1 (0: disable)
+
+expert-option decisionWeightInternal --decision-weight-internal=HOW decision::DecisionWeightInternal :handler CVC4::decision::stringToDecisionWeightInternal :default decision::DECISION_WEIGHT_INTERNAL_OFF :handler-include "decision/options_handlers.h"
+ computer weights of internal nodes using children: off, max, sum, usr1 (meaning evolving)
+
 endmodule

--- a/src/decision/options_handlers.h
+++ b/src/decision/options_handlers.h
@@ -107,6 +107,19 @@ inline void checkDecisionBudget(std::string option, unsigned short budget, SmtEn
   }
 }
 
+inline DecisionWeightInternal stringToDecisionWeightInternal(std::string option, std::string optarg, SmtEngine* smt) throw(OptionException) {
+  if(optarg == "off")
+    return DECISION_WEIGHT_INTERNAL_OFF;
+  else if(optarg == "max")
+    return DECISION_WEIGHT_INTERNAL_MAX;
+  else if(optarg == "sum")
+    return DECISION_WEIGHT_INTERNAL_SUM;
+  else if(optarg == "usr1")
+    return DECISION_WEIGHT_INTERNAL_USR1;
+  else
+    throw OptionException(std::string("--decision-weight-internal must be off, max or sum."));
+}
+
 }/* CVC4::decision namespace */
 }/* CVC4 namespace */
 

--- a/src/prop/minisat/core/Solver.cc
+++ b/src/prop/minisat/core/Solver.cc
@@ -458,9 +458,8 @@ Lit Solver::pickBranchLit()
     }
 #endif /* CVC4_REPLAY */
 
-    // Theory/DE requests
-    bool stopSearch = false;
-    nextLit = MinisatSatSolver::toMinisatLit(proxy->getNextDecisionRequest(stopSearch));
+    // Theory requests
+    nextLit = MinisatSatSolver::toMinisatLit(proxy->getNextTheoryDecisionRequest());
     while (nextLit != lit_Undef) {
       if(value(var(nextLit)) == l_Undef) {
         Debug("propagateAsDecision") << "propagateAsDecision(): now deciding on " << nextLit << std::endl;
@@ -469,12 +468,21 @@ Lit Solver::pickBranchLit()
       } else {
         Debug("propagateAsDecision") << "propagateAsDecision(): would decide on " << nextLit << " but it already has an assignment" << std::endl;
       }
-      nextLit = MinisatSatSolver::toMinisatLit(proxy->getNextDecisionRequest(stopSearch));
+      nextLit = MinisatSatSolver::toMinisatLit(proxy->getNextTheoryDecisionRequest());
     }
+    Debug("propagateAsDecision") << "propagateAsDecision(): decide on another literal" << std::endl;
+
+    // DE requests
+    bool stopSearch = false;
+    nextLit = MinisatSatSolver::toMinisatLit(proxy->getNextDecisionEngineRequest(stopSearch));
     if(stopSearch) {
       return lit_Undef;
     }
-    Debug("propagateAsDecision") << "propagateAsDecision(): decide on another literal" << std::endl;
+    if(nextLit != lit_Undef) {
+      Assert(value(var(nextLit)) == l_Undef, "literal to decide already has value");
+      decisions++;
+      return nextLit;
+    }
 
     Var next = var_Undef;
 

--- a/src/prop/theory_proxy.cpp
+++ b/src/prop/theory_proxy.cpp
@@ -79,15 +79,12 @@ void TheoryProxy::enqueueTheoryLiteral(const SatLiteral& l) {
   d_queue.push(literalNode);
 }
 
-SatLiteral TheoryProxy::getNextDecisionRequest(bool &stopSearch) {
+SatLiteral TheoryProxy::getNextTheoryDecisionRequest() {
   TNode n = d_theoryEngine->getNextDecisionRequest();
-  if(not n.isNull()) {
-    return d_cnfStream->getLiteral(n);
-  }
+  return n.isNull() ? undefSatLiteral : d_cnfStream->getLiteral(n);
+}
 
-  // If theory doesn't give us a deicsion ask the decision engine. It
-  // may return in undefSatLiteral in which case the sat solver uses
-  // whatever default heuristic it has.
+SatLiteral TheoryProxy::getNextDecisionEngineRequest(bool &stopSearch) {
   Assert(d_decisionEngine != NULL);
   Assert(stopSearch != true);
   SatLiteral ret = d_decisionEngine->getNext(stopSearch);

--- a/src/prop/theory_proxy.h
+++ b/src/prop/theory_proxy.h
@@ -93,7 +93,9 @@ public:
 
   void enqueueTheoryLiteral(const SatLiteral& l);
 
-  SatLiteral getNextDecisionRequest(bool& stopSearch);
+  SatLiteral getNextTheoryDecisionRequest();
+
+  SatLiteral getNextDecisionEngineRequest(bool& stopSearch);
 
   bool theoryNeedCheck() const;
 

--- a/src/theory/bv/bitblaster.cpp
+++ b/src/theory/bv/bitblaster.cpp
@@ -108,6 +108,13 @@ void Bitblaster::bbAtom(TNode node) {
   }
 }
 
+uint64_t Bitblaster::computeAtomWeight(TNode node) {
+  node = node.getKind() == kind::NOT?  node[0] : node;
+
+  Node atom_bb = Rewriter::rewrite(d_atomBBStrategies[node.getKind()](node, this));
+  uint64_t size = utils::numNodes(atom_bb);
+  return size;
+}
 
 void Bitblaster::bbTerm(TNode node, Bits& bits) {
 

--- a/src/theory/bv/bitblaster.h
+++ b/src/theory/bv/bitblaster.h
@@ -165,6 +165,7 @@ public:
   }
 
   bool isSharedTerm(TNode node);
+  uint64_t computeAtomWeight(TNode node);
 
 private:
  

--- a/src/theory/bv/bv_subtheory_bitblast.cpp
+++ b/src/theory/bv/bv_subtheory_bitblast.cpp
@@ -19,6 +19,8 @@
 #include "theory/bv/theory_bv_utils.h"
 #include "theory/bv/bitblaster.h"
 #include "theory/bv/options.h"
+#include "theory/decision_attributes.h"
+#include "decision/options.h"
 
 using namespace std;
 using namespace CVC4;
@@ -58,7 +60,12 @@ void BitblastSolver::preRegister(TNode node) {
     if (options::bitvectorEagerBitblast()) {
       d_bitblaster->bbAtom(node);
     } else {
+      CodeTimer weightComputationTime(d_bv->d_statistics.d_weightComputationTimer);
       d_bitblastQueue.push_back(node);
+      if ((options::decisionUseWeight() || options::decisionThreshold() != 0) &&
+          !node.hasAttribute(theory::DecisionWeightAttr())) {
+        node.setAttribute(theory::DecisionWeightAttr(), d_bitblaster->computeAtomWeight(node));
+      }
     }
   }
 }

--- a/src/theory/bv/theory_bv.cpp
+++ b/src/theory/bv/theory_bv.cpp
@@ -78,13 +78,15 @@ TheoryBV::Statistics::Statistics():
   d_solveSubstitutions("theory::bv::NumberOfSolveSubstitutions", 0),
   d_solveTimer("theory::bv::solveTimer"),
   d_numCallsToCheckFullEffort("theory::bv::NumberOfFullCheckCalls", 0),
-  d_numCallsToCheckStandardEffort("theory::bv::NumberOfStandardCheckCalls", 0)
+  d_numCallsToCheckStandardEffort("theory::bv::NumberOfStandardCheckCalls", 0),
+  d_weightComputationTimer("theory::bv::weightComputationTimer")
 {
   StatisticsRegistry::registerStat(&d_avgConflictSize);
   StatisticsRegistry::registerStat(&d_solveSubstitutions);
   StatisticsRegistry::registerStat(&d_solveTimer);
   StatisticsRegistry::registerStat(&d_numCallsToCheckFullEffort);
   StatisticsRegistry::registerStat(&d_numCallsToCheckStandardEffort);
+  StatisticsRegistry::registerStat(&d_weightComputationTimer);
 }
 
 TheoryBV::Statistics::~Statistics() {
@@ -93,6 +95,7 @@ TheoryBV::Statistics::~Statistics() {
   StatisticsRegistry::unregisterStat(&d_solveTimer);
   StatisticsRegistry::unregisterStat(&d_numCallsToCheckFullEffort);
   StatisticsRegistry::unregisterStat(&d_numCallsToCheckStandardEffort);
+  StatisticsRegistry::unregisterStat(&d_weightComputationTimer);
 }
 
 
@@ -205,6 +208,7 @@ void TheoryBV::propagate(Effort e) {
     TNode literal = d_literalsToPropagate[d_literalsToPropagateIndex];
     // temporary fix for incremental bit-blasting 
     if (d_valuation.isSatLiteral(literal)) {
+      Debug("bitvector::propagate") << "TheoryBV:: propagating " << literal <<"\n";
       ok = d_out->propagate(literal);
     }
   }

--- a/src/theory/bv/theory_bv.h
+++ b/src/theory/bv/theory_bv.h
@@ -78,6 +78,7 @@ private:
     TimerStat   d_solveTimer;
     IntStat d_numCallsToCheckFullEffort;
     IntStat d_numCallsToCheckStandardEffort; 
+    TimerStat   d_weightComputationTimer;
     Statistics();
     ~Statistics();
   };

--- a/src/theory/bv/theory_bv_utils.h
+++ b/src/theory/bv/theory_bv_utils.h
@@ -23,7 +23,7 @@
 #include <vector>
 #include <sstream>
 #include "expr/node_manager.h"
-
+#include "theory/decision_attributes.h"
 
 
 namespace CVC4 {
@@ -492,6 +492,26 @@ inline T gcd(T a, T b) {
   return a;
 }
 
+
+typedef __gnu_cxx::hash_set<TNode, TNodeHashFunction> TNodeSet;
+
+inline uint64_t numNodesAux(TNode node, TNodeSet& seen) {
+  if (seen.find(node) != seen.end())
+    return 0;
+
+  uint64_t size = 1;
+  for (unsigned i = 0; i < node.getNumChildren(); ++i) {
+    size += numNodesAux(node[i], seen);
+  }
+  seen.insert(node);
+  return size;
+}
+
+inline uint64_t numNodes(TNode node) {
+  TNodeSet seen;
+  uint64_t size = numNodesAux(node, seen);
+  return size;
+}
 
 }
 }

--- a/src/theory/decision_attributes.h
+++ b/src/theory/decision_attributes.h
@@ -1,0 +1,36 @@
+/*********************                                                        */
+/*! \file decision_attributes.h
+ ** \verbatim
+ ** Original author: Kshitij Bansal
+ ** Major contributors: none
+ ** Minor contributors (to current version): none
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2013  New York University and The University of Iowa
+ ** See the file COPYING in the top-level source directory for licensing
+ ** information.\endverbatim
+ **
+ ** \brief Rewriter attributes
+ **
+ ** Rewriter attributes.
+ **/
+
+#ifndef __CVC4__THEORY__DECISION_ATRRIBUTES
+#define __CVC4__THEORY__DECISION_ATRRIBUTES
+
+#include "expr/attribute.h"
+
+namespace CVC4 {
+namespace decision {
+typedef uint64_t DecisionWeight;
+}
+namespace theory {
+namespace attr {
+  struct DecisionWeightTag {};
+}/* CVC4::theory::attr namespace */
+
+typedef expr::Attribute<attr::DecisionWeightTag, decision::DecisionWeight> DecisionWeightAttr;
+
+}/* CVC4::theory namespace */
+}/* CVC4 namespace */
+
+#endif /* __CVC4__THEORY__DECISION_ATRRIBUTES */

--- a/test/regress/regress0/bv/Makefile.am
+++ b/test/regress/regress0/bv/Makefile.am
@@ -20,6 +20,7 @@ MAKEFLAGS = -k
 # Regression tests for SMT inputs
 SMT_TESTS = \
 	fuzz01.smt \
+	fuzz02.delta01.smt \
 	fuzz02.smt \
 	fuzz03.smt \
 	fuzz04.smt \

--- a/test/regress/regress0/bv/decision-weight00.smt2
+++ b/test/regress/regress0/bv/decision-weight00.smt2
@@ -1,0 +1,19 @@
+(set-option :produce-models true)
+(set-logic QF_BV)
+(set-info :source |
+ Patrice Godefroid, SAGE (systematic dynamic test generation)
+ For more information: http://research.microsoft.com/en-us/um/people/pg/public_psfiles/ndss2008.pdf
+|)
+(set-info :smt-lib-version 2.0)
+(set-info :category "industrial")
+(set-info :status unknown)
+(declare-fun x () (_ BitVec 32))
+(declare-fun y () (_ BitVec 32))
+(declare-fun z () (_ BitVec 4))
+(assert (or
+		(= x (bvmul x y))
+		(and (= x y)
+		     (not (= ((_ extract 2 2) x) ((_ extract 2 2) z))))
+		))
+(check-sat)
+(exit)

--- a/test/regress/regress0/bv/fuzz02.delta01.smt
+++ b/test/regress/regress0/bv/fuzz02.delta01.smt
@@ -1,0 +1,18 @@
+(benchmark fuzzsmt
+:logic QF_BV
+:extrafuns ((v2 BitVec[9]))
+:status unsat
+:formula
+(let (?n1 bv0[2])
+(let (?n2 bv0[6])
+(flet ($n3 (bvult v2 v2))
+(let (?n4 bv1[1])
+(let (?n5 bv0[1])
+(let (?n6 (ite $n3 ?n4 ?n5))
+(let (?n7 (concat ?n2 ?n6))
+(let (?n8 bv0[7])
+(let (?n9 (bvcomp ?n7 ?n8))
+(let (?n10 (zero_extend[1] ?n9))
+(flet ($n11 (= ?n1 ?n10))
+$n11
+))))))))))))


### PR DESCRIPTION
None of these are enabled by default, so any performance impact
counts as a bug

Options added are:

--decision-threshold=N :default 0
- ignore all nodes greater than threshold in first attempt to pick decision

--decision-use-weight bool :default false
- use the weight nodes (locally, by looking at children) to direct recursive search

--decision-random-weight=N int :default 0
- assign random weights to nodes between 0 and N-1 (0: disable)

--decision-weight-internal=HOW
- computer weights of internal nodes using children: off, max, sum, usr1 (meaning evolving)

Squashed commit of the following:

commit 0dbae066c19abde37092517b50f23255398539db
Author: Kshitij Bansal kshitij@cs.nyu.edu
Date:   Fri Apr 26 16:42:36 2013 -0400

```
contentless cleanup
```

commit 62bb99b33deceb803ba5afc563fd322b4b5d1b7e
Author: Kshitij Bansal kshitij@cs.nyu.edu
Date:   Tue Apr 16 21:43:55 2013 -0400

```
bugfixes in usr1 auto weight computation
```

commit 9f039cba805bfd722466734920e758d48ae3b23e
Author: Kshitij Bansal kshitij@cs.nyu.edu
Date:   Fri Mar 29 15:01:33 2013 -0400

```
DECISION_WEIGHT_INTERNAL_USR1
```

commit 744e16d514594e5f1c69b36473b03cf501d9b9d1
Author: Kshitij Bansal kshitij@cs.nyu.edu
Date:   Wed Mar 27 11:05:43 2013 -0400

```
split theory and decision requests
```

commit f379d8a821df31c74b42a7722e891abc5c944f16
Author: Kshitij Bansal kshitij@cs.nyu.edu
Date:   Wed Mar 27 09:51:58 2013 -0400

```
fix potential bug with threshold
```

commit 3dcb45eb5ee648d3edbeddf76b838076afea3d12
Author: Kshitij Bansal kshitij@cs.nyu.edu
Date:   Wed Feb 27 20:29:38 2013 -0500

```
stat bv::weightComputationTimer
```

commit 2ab97d063e221357d2bb017af4589105777fd5a3
Author: Kshitij Bansal kshitij@cs.nyu.edu
Date:   Sat Feb 23 17:02:43 2013 -0500

```
decision: option to auto compute weight of boolean structure
```

commit 0a8c29e699ad96d5f73bc14d31ad9254f6711ae8
Author: Kshitij Bansal kshitij@cs.nyu.edu
Date:   Sat Feb 23 14:53:50 2013 -0500

```
decision: fix design to do partial explorations

* make findSplitterRec and all related helper functions' return
  type trivalued, to be able to distinguish between
  "partial exploration" vs "done exploration but found nothing"

* keep additional data structure to remember to what extent the
  partial exploration has been completed so not to repeat it. we
  can use this to make multiple passes on formula with arbritrary
  order of thresholds for exploration
```

commit 0815991fc1b0f1d63f0e8124d4672d782e89d671
Author: lianah lianahady@gmail.com
Date:   Fri Feb 22 17:55:40 2013 -0500

```
added simple node weight computation for bv.
```

commit e4c507e2e2fdc8794fd04c31093660a80c7f44c3
Author: Kshitij Bansal kshitij@cs.nyu.edu
Date:   Wed Feb 20 02:35:21 2013 -0500

```
--decision-use-weight, --decision-random-weight=N
```

commit 0624177d66d6ed2b3cc7fdb13df775990cfe50c2
Author: Kshitij Bansal kshitij@cs.nyu.edu
Date:   Tue Feb 19 23:36:49 2013 -0500

```
decisionThreshold option
```

commit ac3579a52e452e3118ce116ff1823d6c6885544b
Author: Kshitij Bansal kshitij@cs.nyu.edu
Date:   Tue Feb 19 20:22:51 2013 -0500

```
DecisionWeightAttr
```
