### PR TITLE
--stats-every-query option: print increment in addition to cumulative va...

### DIFF
--- a/src/main/command_executor.h
+++ b/src/main/command_executor.h
@@ -28,6 +28,8 @@ namespace CVC4 {
 namespace main {
 
 class CommandExecutor {
+private:
+  std::string d_lastStatistics;
 
 protected:
   ExprManager& d_exprMgr;

--- a/src/main/options
+++ b/src/main/options
@@ -22,8 +22,6 @@ option - --show-trace-tags void :handler CVC4::main::showTraceTags :handler-incl
 
 expert-option earlyExit --early-exit bool :default true
  do not run destructors at exit; default on except in debug builds
-expert-option statsEveryQuery --stats-every-query bool :default false
- print stats after every satisfiability or validity query
 
 # portfolio options
 option threads --threads=N unsigned :default 2 :predicate greater(0)

--- a/src/options/base_options
+++ b/src/options/base_options
@@ -107,6 +107,10 @@ common-option statistics statistics --stats bool :predicate CVC4::smt::statsEnab
  give statistics on exit
 undocumented-alias --statistics = --stats
 undocumented-alias --no-statistics = --no-stats
+option statsEveryQuery --stats-every-query bool :default false :link --stats
+ in incremental mode, print stats after every satisfiability or validity query 
+undocumented-alias --statistics-every-query = --stats-every-query
+undocumented-alias --no-statistics-every-query = --no-stats-every-query
 
 option parseOnly parse-only --parse-only bool :read-write
  exit after parsing input


### PR DESCRIPTION
...lue of each stat

the increment is printed in parantheses at the end, e.g.
sat::decisions, 100 (50)
