### PR TITLE
Fix compile errors with some versions of GCC.

### DIFF
--- a/src/theory/bv/bitblaster_template.h
+++ b/src/theory/bv/bitblaster_template.h
@@ -134,7 +134,7 @@ class TLazyBitblaster :  public TBitblaster<Node> {
   prop::BVSatSolverInterface*        d_satSolver;
   prop::CnfStream*                   d_cnfStream;
 
-  AssertionList d_assertedAtoms; /**< context dependent list storing the atoms
+  AssertionList* d_assertedAtoms; /**< context dependent list storing the atoms
                                      currently asserted by the DPLL SAT solver. */
   ExplanationMap d_explanations; /**< context dependent list of explanations for the propagated literals.
                                     Only used when bvEagerPropagate option enabled. */

--- a/src/theory/bv/bv_quick_check.h
+++ b/src/theory/bv/bv_quick_check.h
@@ -26,6 +26,7 @@
 #include "context/cdo.h"
 #include "prop/sat_solver_types.h"
 #include "util/statistics_registry.h"
+#include "theory/bv/theory_bv_utils.h"
 
 namespace CVC4 {
 namespace theory {
@@ -33,11 +34,6 @@ namespace theory {
 class TheoryModel;
 
 namespace bv {
-
-
-
-typedef __gnu_cxx::hash_set<Node, NodeHashFunction> NodeSet;
-typedef __gnu_cxx::hash_set<TNode, TNodeHashFunction> TNodeSet;
 
 class TLazyBitblaster; 
 class TheoryBV;

--- a/src/theory/bv/theory_bv_utils.h
+++ b/src/theory/bv/theory_bv_utils.h
@@ -24,10 +24,13 @@
 #include <sstream>
 #include "expr/node_manager.h"
 
-
 namespace CVC4 {
 namespace theory {
 namespace bv {
+
+typedef __gnu_cxx::hash_set<Node, NodeHashFunction> NodeSet;
+typedef __gnu_cxx::hash_set<TNode, TNodeHashFunction> TNodeSet;
+
 namespace utils {
 
 inline uint32_t pow2(uint32_t power) {
@@ -253,8 +256,6 @@ inline unsigned isPow2Const(TNode node) {
   BitVector bv = node.getConst<BitVector>();
   return bv.isPow2(); 
 }
-
-typedef __gnu_cxx::hash_set<TNode, TNodeHashFunction> TNodeSet;
 
 inline Node mkOr(const std::vector<Node>& nodes) {
   std::set<TNode> all;


### PR DESCRIPTION
Some older & newer GCC have problems with the new BV code, but it's easily worked around.  Some were ambiguous uses of typedefs defined both in namespace "bv" as well as "bv::utils".  Another issue was in calling the copy-constructor of a CDList<>, which you aren't supposed to be able to do (it's protected), but for some reason compilers were permitting (I think the spec of our copy constructor is in error).
