### PR TITLE
libc++ travis building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
    configureCVC4() {
      echo "CVC4 config - $TRAVIS_CVC4_CONFIG";
      ./configure --enable-unit-testing --enable-proof --with-portfolio $TRAVIS_CVC4_CONFIG ||
-       (echo; cat builds/config.log; error "CONFIGURE FAILED");
+       (echo; if test -e builds/config.log; then cat builds/config.log; else cat config.log; fi; error "CONFIGURE FAILED");
    }
    error() {
      echo;
@@ -67,7 +67,7 @@ script:
    }
    LFSCchecks() {
      cd proofs/lfsc_checker &&
-     (./configure || (echo; cat builds/config.log; echo; echo "${red}CONFIGURE FAILED${normal}"; exit 1)) &&
+     (./configure || (echo; if test -e builds/config.log; then cat builds/config.log; else cat config.log; fi; echo; echo "${red}CONFIGURE FAILED${normal}"; exit 1)) &&
      if [ -n "$TRAVIS_LFSC_DISTCHECK" ]; then
        make -j2 distcheck || (echo; echo "${red}LFSC DISTCHECK FAILED${normal}"; echo; exit 1);
      else


### PR DESCRIPTION
This adds support to .travis.yml for building with clang and libc++ (as opposed to libstdc++).  It adds 3 extra Travis-CI configurations (production, debug, and lfsc).  "Distcheck" tests aren't done (probably not necessary).
