### PR TITLE
Context-dependent expr attributes are now attached to a specific SmtEngi...

### DIFF
--- a/src/expr/expr_manager_template.cpp
+++ b/src/expr/expr_manager_template.cpp
@@ -17,7 +17,6 @@
 #include "expr/node_manager.h"
 #include "expr/expr_manager.h"
 #include "expr/variable_type_map.h"
-#include "context/context.h"
 #include "options/options.h"
 #include "util/statistics_registry.h"
 
@@ -29,7 +28,7 @@ ${includes}
 // compiler directs the user to the template file instead of the
 // generated one.  We don't want the user to modify the generated one,
 // since it'll get overwritten on a later build.
-#line 33 "${template}"
+#line 32 "${template}"
 
 #ifdef CVC4_STATISTICS_ON
   #define INC_STAT(kind) \
@@ -64,14 +63,12 @@ ${includes}
 #endif
 
 using namespace std;
-using namespace CVC4::context;
 using namespace CVC4::kind;
 
 namespace CVC4 {
 
 ExprManager::ExprManager() :
-  d_ctxt(new Context()),
-  d_nodeManager(new NodeManager(d_ctxt, this)) {
+  d_nodeManager(new NodeManager(this)) {
 #ifdef CVC4_STATISTICS_ON
   for (unsigned i = 0; i < kind::LAST_KIND; ++ i) {
     d_exprStatistics[i] = NULL;
@@ -83,8 +80,7 @@ ExprManager::ExprManager() :
 }
 
 ExprManager::ExprManager(const Options& options) :
-  d_ctxt(new Context()),
-  d_nodeManager(new NodeManager(d_ctxt, this, options)) {
+  d_nodeManager(new NodeManager(this, options)) {
 #ifdef CVC4_STATISTICS_ON
   for (unsigned i = 0; i < LAST_TYPE; ++ i) {
     d_exprStatisticsVars[i] = NULL;
@@ -119,8 +115,6 @@ ExprManager::~ExprManager() throw() {
 
     delete d_nodeManager;
     d_nodeManager = NULL;
-    delete d_ctxt;
-    d_ctxt = NULL;
 
   } catch(Exception& e) {
     Warning() << "CVC4 threw an exception during cleanup." << std::endl
@@ -960,10 +954,6 @@ unsigned ExprManager::maxArity(Kind kind) {
 
 NodeManager* ExprManager::getNodeManager() const {
   return d_nodeManager;
-}
-
-Context* ExprManager::getContext() const {
-  return d_ctxt;
 }
 
 Statistics ExprManager::getStatistics() const throw() {

--- a/src/expr/expr_manager_template.h
+++ b/src/expr/expr_manager_template.h
@@ -52,19 +52,12 @@ namespace expr {
   }/* CVC4::expr::pickle namespace */
 }/* CVC4::expr namespace */
 
-namespace context {
-  class Context;
-}/* CVC4::context namespace */
-
 namespace stats {
   StatisticsRegistry* getStatisticsRegistry(ExprManager*);
 }/* CVC4::stats namespace */
 
 class CVC4_PUBLIC ExprManager {
 private:
-  /** The context */
-  context::Context* d_ctxt;
-
   /** The internal node manager */
   NodeManager* d_nodeManager;
 
@@ -77,12 +70,6 @@ private:
    * internal users, i.e. the friend classes.
    */
   NodeManager* getNodeManager() const;
-
-  /**
-   * Returns the internal Context.  Used by internal users, i.e. the
-   * friend classes.
-   */
-  context::Context* getContext() const;
 
   /**
    * Check some things about a newly-created DatatypeType.

--- a/src/expr/node.h
+++ b/src/expr/node.h
@@ -149,6 +149,7 @@ class NodeValue;
 
   namespace attr {
     class AttributeManager;
+    class SmtAttributes;
   }/* CVC4::expr::attr namespace */
 
   class ExprSetDepth;
@@ -214,6 +215,7 @@ class NodeTemplate {
   friend class NodeBuilder;
 
   friend class ::CVC4::expr::attr::AttributeManager;
+  friend class ::CVC4::expr::attr::SmtAttributes;
 
   friend struct ::CVC4::kind::metakind::NodeValueConstPrinter;
 

--- a/src/expr/node_manager.h
+++ b/src/expr/node_manager.h
@@ -35,7 +35,6 @@
 #include "expr/kind.h"
 #include "expr/metakind.h"
 #include "expr/node_value.h"
-#include "context/context.h"
 #include "util/subrange_bound.h"
 #include "util/tls.h"
 #include "options/options.h"
@@ -66,6 +65,11 @@ public:
   virtual void nmNotifyNewDatatypes(const std::vector<DatatypeType>& datatypes) { }
   virtual void nmNotifyNewVar(TNode n, uint32_t flags) { }
   virtual void nmNotifyNewSkolem(TNode n, const std::string& comment, uint32_t flags) { }
+  /**
+   * Notify a listener of a Node that's being GCed.  If this function stores a reference
+   * to the Node somewhere, very bad things will happen.
+   */
+  virtual void nmNotifyDeleteNode(TNode n) { }
 };/* class NodeManagerListener */
 
 class NodeManager {
@@ -307,8 +311,8 @@ class NodeManager {
 
 public:
 
-  explicit NodeManager(context::Context* ctxt, ExprManager* exprManager);
-  explicit NodeManager(context::Context* ctxt, ExprManager* exprManager, const Options& options);
+  explicit NodeManager(ExprManager* exprManager);
+  explicit NodeManager(ExprManager* exprManager, const Options& options);
   ~NodeManager();
 
   /** The node manager in the current public-facing CVC4 library context */

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -71,6 +71,13 @@ namespace prop {
   class PropEngine;
 }/* CVC4::prop namespace */
 
+namespace expr {
+  namespace attr {
+    class AttributeManager;
+    struct SmtAttributes;
+  }/* CVC4::expr::attr namespace */
+}/* CVC4::expr namespace */
+
 namespace smt {
   /**
    * Representation of a defined function.  We keep these around in
@@ -342,8 +349,19 @@ class CVC4_PUBLIC SmtEngine {
   // to access d_modelCommands
   friend class ::CVC4::Model;
   friend class ::CVC4::theory::TheoryModel;
+  // to access SmtAttributes
+  friend class expr::attr::AttributeManager;
   // to access getModel(), which is private (for now)
   friend class GetModelCommand;
+
+  /**
+   * There's something of a handshake between the expr package's
+   * AttributeManager and the SmtEngine because the expr package
+   * doesn't have a Context on its own (that's owned by the
+   * SmtEngine).  Thus all context-dependent attributes are stored
+   * here.
+   */
+  expr::attr::SmtAttributes* d_smtAttributes;
 
   StatisticsRegistry* d_statisticsRegistry;
 

--- a/src/theory/quantifiers/first_order_reasoning.cpp
+++ b/src/theory/quantifiers/first_order_reasoning.cpp
@@ -23,7 +23,6 @@ using namespace std;
 using namespace CVC4::theory;
 using namespace CVC4::theory::quantifiers;
 using namespace CVC4::kind;
-using namespace CVC4::context;
 
 
 void FirstOrderPropagation::collectLits( Node n, std::vector<Node> & lits ){

--- a/src/theory/quantifiers/macros.cpp
+++ b/src/theory/quantifiers/macros.cpp
@@ -24,7 +24,6 @@ using namespace std;
 using namespace CVC4::theory;
 using namespace CVC4::theory::quantifiers;
 using namespace CVC4::kind;
-using namespace CVC4::context;
 
 
 bool QuantifierMacros::simplify( std::vector< Node >& assertions, bool doRewrite ){

--- a/test/unit/context/stacking_map_black.h
+++ b/test/unit/context/stacking_map_black.h
@@ -39,8 +39,8 @@ class StackingMapBlack : public CxxTest::TestSuite {
 public:
 
   void setUp() {
-    d_ctxt = new Context;
-    d_nm = new NodeManager(d_ctxt, NULL);
+    d_ctxt = new Context();
+    d_nm = new NodeManager(NULL);
     d_scope = new NodeManagerScope(d_nm);
     d_mapPtr = new StackingMap<TNode, TNode, TNodeHashFunction>(d_ctxt);
 

--- a/test/unit/context/stacking_vector_black.h
+++ b/test/unit/context/stacking_vector_black.h
@@ -39,8 +39,8 @@ class StackingVectorBlack : public CxxTest::TestSuite {
 public:
 
   void setUp() {
-    d_ctxt = new Context;
-    d_nm = new NodeManager(d_ctxt, NULL);
+    d_ctxt = new Context();
+    d_nm = new NodeManager(NULL);
     d_scope = new NodeManagerScope(d_nm);
     d_vectorPtr = new StackingVector<TNode>(d_ctxt);
 

--- a/test/unit/expr/attribute_black.h
+++ b/test/unit/expr/attribute_black.h
@@ -26,31 +26,35 @@
 #include "expr/node_manager.h"
 #include "expr/node.h"
 #include "expr/attribute.h"
+#include "smt/smt_engine.h"
+#include "smt/smt_engine_scope.h"
 
 using namespace CVC4;
 using namespace CVC4::kind;
-using namespace CVC4::context;
+using namespace CVC4::smt;
 using namespace std;
 
 class AttributeBlack : public CxxTest::TestSuite {
 private:
 
-  Context* d_ctxt;
+  ExprManager* d_exprManager;
   NodeManager* d_nodeManager;
-  NodeManagerScope* d_scope;
+  SmtEngine* d_smtEngine;
+  SmtScope* d_scope;
 
 public:
 
   void setUp() {
-    d_ctxt = new Context;
-    d_nodeManager = new NodeManager(d_ctxt, NULL);
-    d_scope = new NodeManagerScope(d_nodeManager);
+    d_exprManager = new ExprManager();
+    d_nodeManager = NodeManager::fromExprManager(d_exprManager);
+    d_smtEngine = new SmtEngine(d_exprManager);
+    d_scope = new SmtScope(d_smtEngine);
   }
 
   void tearDown() {
     delete d_scope;
-    delete d_nodeManager;
-    delete d_ctxt;
+    delete d_smtEngine;
+    delete d_exprManager;
   }
 
   class MyData {

--- a/test/unit/expr/node_black.h
+++ b/test/unit/expr/node_black.h
@@ -28,14 +28,12 @@
 
 using namespace CVC4;
 using namespace CVC4::kind;
-using namespace CVC4::context;
 using namespace std;
 
 class NodeBlack : public CxxTest::TestSuite {
 private:
 
   Options opts;
-  Context* d_ctxt;
   NodeManager* d_nodeManager;
   NodeManagerScope* d_scope;
   TypeNode* d_booleanType;
@@ -51,8 +49,7 @@ public:
     free(argv[0]);
     free(argv[1]);
 
-    d_ctxt = new Context();
-    d_nodeManager = new NodeManager(d_ctxt, NULL, opts);
+    d_nodeManager = new NodeManager(NULL, opts);
     d_scope = new NodeManagerScope(d_nodeManager);
     d_booleanType = new TypeNode(d_nodeManager->booleanType());
     d_realType = new TypeNode(d_nodeManager->realType());
@@ -62,7 +59,6 @@ public:
     delete d_booleanType;
     delete d_scope;
     delete d_nodeManager;
-    delete d_ctxt;
   }
 
   bool imp(bool a, bool b) const {

--- a/test/unit/expr/node_builder_black.h
+++ b/test/unit/expr/node_builder_black.h
@@ -25,19 +25,16 @@
 #include "expr/node_manager.h"
 #include "expr/node.h"
 #include "expr/kind.h"
-#include "context/context.h"
 #include "util/cvc4_assert.h"
 #include "util/rational.h"
 
 using namespace CVC4;
 using namespace CVC4::kind;
-using namespace CVC4::context;
 using namespace std;
 
 class NodeBuilderBlack : public CxxTest::TestSuite {
 private:
 
-  Context* d_ctxt;
   NodeManager* d_nm;
   NodeManagerScope* d_scope;
   TypeNode* d_booleanType;
@@ -47,8 +44,7 @@ private:
 public:
 
   void setUp() {
-    d_ctxt = new Context;
-    d_nm = new NodeManager(d_ctxt, NULL);
+    d_nm = new NodeManager(NULL);
     d_scope = new NodeManagerScope(d_nm);
 
     specKind = AND;
@@ -63,7 +59,6 @@ public:
     delete d_realType;
     delete d_scope;
     delete d_nm;
-    delete d_ctxt;
   }
 
 

--- a/test/unit/expr/node_manager_black.h
+++ b/test/unit/expr/node_manager_black.h
@@ -21,7 +21,6 @@
 
 #include "expr/node_manager.h"
 #include "expr/node_manager_attributes.h"
-#include "context/context.h"
 
 #include "util/rational.h"
 #include "util/integer.h"
@@ -29,26 +28,22 @@
 using namespace CVC4;
 using namespace CVC4::expr;
 using namespace CVC4::kind;
-using namespace CVC4::context;
 
 class NodeManagerBlack : public CxxTest::TestSuite {
 
-  Context* d_context;
   NodeManager* d_nodeManager;
   NodeManagerScope* d_scope;
 
 public:
 
   void setUp() {
-    d_context = new Context;
-    d_nodeManager = new NodeManager(d_context, NULL);
+    d_nodeManager = new NodeManager(NULL);
     d_scope = new NodeManagerScope(d_nodeManager);
   }
 
   void tearDown() {
     delete d_scope;
     delete d_nodeManager;
-    delete d_context;
   }
 
   void testMkNodeNot() {

--- a/test/unit/expr/node_manager_white.h
+++ b/test/unit/expr/node_manager_white.h
@@ -19,33 +19,28 @@
 #include <string>
 
 #include "expr/node_manager.h"
-#include "context/context.h"
 
 #include "util/rational.h"
 #include "util/integer.h"
 
 using namespace CVC4;
 using namespace CVC4::expr;
-using namespace CVC4::context;
 
 class NodeManagerWhite : public CxxTest::TestSuite {
 
-  Context* d_ctxt;
   NodeManager* d_nm;
   NodeManagerScope* d_scope;
 
 public:
 
   void setUp() {
-    d_ctxt = new Context();
-    d_nm = new NodeManager(d_ctxt, NULL);
+    d_nm = new NodeManager(NULL);
     d_scope = new NodeManagerScope(d_nm);
   }
 
   void tearDown() {
     delete d_scope;
     delete d_nm;
-    delete d_ctxt;
   }
 
   void testMkConstRational() {

--- a/test/unit/expr/node_self_iterator_black.h
+++ b/test/unit/expr/node_self_iterator_black.h
@@ -16,14 +16,12 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include "context/context.h"
 #include "expr/node.h"
 #include "expr/node_self_iterator.h"
 #include "expr/node_builder.h"
 #include "expr/convenience_node_builders.h"
 
 using namespace CVC4;
-using namespace CVC4::context;
 using namespace CVC4::kind;
 using namespace CVC4::expr;
 using namespace std;
@@ -31,7 +29,6 @@ using namespace std;
 class NodeSelfIteratorBlack : public CxxTest::TestSuite {
 private:
 
-  Context* d_ctxt;
   NodeManager* d_nodeManager;
   NodeManagerScope* d_scope;
   TypeNode* d_booleanType;
@@ -40,8 +37,7 @@ private:
 public:
 
   void setUp() {
-    d_ctxt = new Context;
-    d_nodeManager = new NodeManager(d_ctxt, NULL);
+    d_nodeManager = new NodeManager(NULL);
     d_scope = new NodeManagerScope(d_nodeManager);
     d_booleanType = new TypeNode(d_nodeManager->booleanType());
     d_realType = new TypeNode(d_nodeManager->realType());
@@ -51,7 +47,6 @@ public:
     delete d_booleanType;
     delete d_scope;
     delete d_nodeManager;
-    delete d_ctxt;
   }
 
   void testSelfIteration() {

--- a/test/unit/expr/node_white.h
+++ b/test/unit/expr/node_white.h
@@ -22,33 +22,28 @@
 #include "expr/node_builder.h"
 #include "expr/node_manager.h"
 #include "expr/node.h"
-#include "context/context.h"
 #include "util/cvc4_assert.h"
 
 using namespace CVC4;
 using namespace CVC4::kind;
-using namespace CVC4::context;
 using namespace CVC4::expr;
 using namespace std;
 
 class NodeWhite : public CxxTest::TestSuite {
 
-  Context* d_ctxt;
   NodeManager* d_nm;
   NodeManagerScope* d_scope;
 
 public:
 
   void setUp() {
-    d_ctxt = new Context();
-    d_nm = new NodeManager(d_ctxt, NULL);
+    d_nm = new NodeManager(NULL);
     d_scope = new NodeManagerScope(d_nm);
   }
 
   void tearDown() {
     delete d_scope;
     delete d_nm;
-    delete d_ctxt;
   }
 
   void testNull() {

--- a/test/unit/util/boolean_simplification_black.h
+++ b/test/unit/util/boolean_simplification_black.h
@@ -14,7 +14,6 @@
  ** Black box testing of CVC4::BooleanSimplification.
  **/
 
-#include "context/context.h"
 #include "util/language.h"
 #include "expr/node.h"
 #include "expr/kind.h"
@@ -26,12 +25,10 @@
 #include <set>
 
 using namespace CVC4;
-using namespace CVC4::context;
 using namespace std;
 
 class BooleanSimplificationBlack : public CxxTest::TestSuite {
 
-  Context* d_context;
   NodeManager* d_nm;
   NodeManagerScope* d_scope;
 
@@ -70,8 +67,7 @@ class BooleanSimplificationBlack : public CxxTest::TestSuite {
 public:
 
   void setUp() {
-    d_context = new Context();
-    d_nm = new NodeManager(d_context, NULL);
+    d_nm = new NodeManager(NULL);
     d_scope = new NodeManagerScope(d_nm);
 
     a = d_nm->mkSkolem("a", d_nm->booleanType());
@@ -116,7 +112,6 @@ public:
 
     delete d_scope;
     delete d_nm;
-    delete d_context;
   }
 
   void testNegate() {


### PR DESCRIPTION
...ne, and the SAT context is owned by the SmtEngine.
