### PR TITLE
Set Constant's normal form and other short fixes

### DIFF
--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1029,7 +1029,10 @@ void SmtEngine::setDefaults() {
 
   // Set the options for the theoryOf
   if(!options::theoryOfMode.wasSetByUser()) {
-    if(d_logic.isSharingEnabled() && !d_logic.isTheoryEnabled(THEORY_BV) && !d_logic.isTheoryEnabled(THEORY_STRINGS)) {
+    if(d_logic.isSharingEnabled() &&
+       !d_logic.isTheoryEnabled(THEORY_BV) &&
+       !d_logic.isTheoryEnabled(THEORY_STRINGS) &&
+       !d_logic.isTheoryEnabled(THEORY_SETS) ) {
       Trace("smt") << "setting theoryof-mode to term-based" << endl;
       options::theoryOfMode.set(THEORY_OF_TERM_BASED);
     }
@@ -1057,7 +1060,10 @@ void SmtEngine::setDefaults() {
   } else {
     Theory::setUninterpretedSortOwner(THEORY_UF);
   }
+
   // Turn on ite simplification for QF_LIA and QF_AUFBV
+  // WARNING: These checks match much more than just QF_AUFBV and
+  // QF_LIA logics. --K [2014/10/15]
   if(! options::doITESimp.wasSetByUser()) {
     bool qf_aufbv = !d_logic.isQuantified() &&
       d_logic.isTheoryEnabled(THEORY_ARRAY) &&

--- a/src/theory/sets/theory_sets_private.h
+++ b/src/theory/sets/theory_sets_private.h
@@ -100,6 +100,10 @@ private:
   /** Equality engine */
   eq::EqualityEngine d_equalityEngine;
 
+  /** True and false constant nodes */
+  Node d_trueNode;
+  Node d_falseNode;
+
   context::CDO<bool> d_conflict;
   Node d_conflictNode;
 

--- a/src/theory/sets/theory_sets_type_enumerator.h
+++ b/src/theory/sets/theory_sets_type_enumerator.h
@@ -97,6 +97,7 @@ public:
     Node n = NormalForm::elementsToSet(std::set<TNode>(elements.begin(), elements.end()),
                                        getType());
 
+    Assert(n.isConst());
     Assert(n == Rewriter::rewrite(n));
 
     return n;

--- a/src/theory/sets/theory_sets_type_rules.h
+++ b/src/theory/sets/theory_sets_type_rules.h
@@ -19,6 +19,8 @@
 #ifndef __CVC4__THEORY__SETS__THEORY_SETS_TYPE_RULES_H
 #define __CVC4__THEORY__SETS__THEORY_SETS_TYPE_RULES_H
 
+#include "theory/sets/normal_form.h"
+
 namespace CVC4 {
 namespace theory {
 namespace sets {
@@ -67,7 +69,11 @@ struct SetsBinaryOperatorTypeRule {
     Assert(n.getKind() == kind::UNION ||
            n.getKind() == kind::INTERSECTION ||
            n.getKind() == kind::SETMINUS);
-    return n[0].isConst() && n[1].isConst();
+    if(n.getKind() == kind::UNION) {
+      return NormalForm::checkNormalConstant(n);
+    } else {
+      return false;
+    }
   }
 };/* struct SetUnionTypeRule */
 
@@ -154,7 +160,7 @@ struct InsertTypeRule {
 
   inline static bool computeIsConst(NodeManager* nodeManager, TNode n) {
     Assert(n.getKind() == kind::INSERT);
-    return n[0].isConst() && n[1].isConst();
+    return false;
   }
 };/* struct InsertTypeRule */
 
@@ -162,7 +168,8 @@ struct InsertTypeRule {
 struct SetsProperties {
   inline static Cardinality computeCardinality(TypeNode type) {
     Assert(type.getKind() == kind::SET_TYPE);
-    Cardinality elementCard = type[0].getCardinality();
+    Cardinality elementCard = 2;
+    elementCard ^= type[0].getCardinality();
     return elementCard;
   }
 

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -379,6 +379,13 @@ void TheoryEngine::check(Theory::Effort effort) {
         printAssertions("theory::assertions");
       }
 
+      if(Theory::fullEffort(effort)) {
+        Trace("theory::assertions::fulleffort") << endl;
+        if (Trace.isOn("theory::assertions::fulleffort")) {
+          printAssertions("theory::assertions::fulleffort");
+        }
+      }
+        
       // Note that we've discharged all the facts
       d_factsAsserted = false;
 
@@ -1194,6 +1201,7 @@ theory::EqualityStatus TheoryEngine::getEqualityStatus(TNode a, TNode b) {
 }
 
 Node TheoryEngine::getModelValue(TNode var) {
+  if(var.isConst()) return var;  // FIXME: HACK!!!
   Assert(d_sharedTerms.isShared(var));
   return theoryOf(Theory::theoryOf(var.getType()))->getModelValue(var);
 }


### PR DESCRIPTION
Other short fixes:
- use debug tag "theory::assertions::fulleffort" to dump assertions only at FULL_EFFORT
- theoryof-mode fix in smt_engine.cpp
- hack in TheoryModel::getModelValue [TODO: notify Clark/Andy]
- Lemma generation when it rewrites to true/false fix
- TermInfoManager::addTerm(..) fix
- Move SUBSET rewrite to preRewrite
- On preRegister, queue up propagation to be done upfront
  *\* Hospital4 fails when all other fixes have been applied but not this one. Good to have an actual benchmark which relies on this code.
- TheorySetsProperties::getCardinality(..) fix

Thanks to Alvise Rabitti and Stefano Calzavara for reporting some of these; and to Morgan and Clark for help in fixing!
