### PR TITLE
Avoid explicit dependancy on Python 3

### DIFF
--- a/src/options/mkoptions.py
+++ b/src/options/mkoptions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
     Generate option handling code and documentation in one pass. The generated
     files are only written to the destination file if the contents of the file


### PR DESCRIPTION
Currently the `mkoptions.py` script explicitly depends on Python 3 -- it can actually be modified to run under Python 2, with some use of the `future`s package.

This PR simply introduces enough of futures to get `mkoptions.py` working via Python 2.
