### PR TITLE
Add flattened node view

### DIFF
--- a/src/expr/CMakeLists.txt
+++ b/src/expr/CMakeLists.txt
@@ -32,6 +32,8 @@ libcvc4_add_sources(
   node_trie.h
   node_value.cpp
   node_value.h
+  node_view.cpp
+  node_view.h
   symbol_table.cpp
   symbol_table.h
   term_canonize.cpp

--- a/src/expr/node_view.cpp
+++ b/src/expr/node_view.cpp
@@ -1,0 +1,118 @@
+/*********************                                                        */
+/*! \file node_view.cpp
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Andres Noetzli
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2020 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief Classes that provide different views on nodes
+ **
+ ** The classes in this file provide different views on a given node (e.g. an
+ ** iterator that treats a certain kind as flattened).
+ **/
+
+#include "expr/node_view.h"
+
+namespace CVC4 {
+namespace expr {
+
+template <bool ref_count>
+FlatViewTemplate<ref_count>::FlatViewTemplate(NodeTemplate<ref_count> node,
+                                              Kind kind,
+                                              bool skipDups)
+    : d_node(node), d_kind(kind), d_skipDups(skipDups)
+{
+  Assert(node.getKind() == kind);
+}
+
+template <bool ref_count>
+FlatViewTemplate<ref_count>::iterator::iterator(NodeTemplate<ref_count> node,
+                                                Kind kind,
+                                                bool end,
+                                                bool skipDups)
+    : d_kind(kind), d_skipDups(skipDups)
+{
+  if (end)
+  {
+    d_iters.emplace_back(node.end(), node.end());
+  }
+  else
+  {
+    do
+    {
+      d_iters.emplace_back(node.begin(), node.end());
+      node = node[0];
+    } while (node.getKind() == d_kind);
+
+    if (skipDups)
+    {
+      d_visited.insert(**this);
+    }
+  }
+}
+
+template <bool ref_count>
+typename FlatViewTemplate<ref_count>::iterator&
+FlatViewTemplate<ref_count>::iterator::operator++()
+{
+  do
+  {
+    NodeValue::iterator<NodeTemplate<ref_count>>* currIter =
+        &d_iters.back().first;
+    NodeValue::iterator<NodeTemplate<ref_count>>* currIterEnd =
+        &d_iters.back().second;
+
+    ++(*currIter);
+    while (*currIter == *currIterEnd && d_iters.size() > 1)
+    {
+      d_iters.pop_back();
+      currIter = &d_iters.back().first;
+      currIterEnd = &d_iters.back().second;
+      ++(*currIter);
+    }
+
+    if (*currIter != *currIterEnd)
+    {
+      NodeTemplate<ref_count> currNode = **currIter;
+      while (currNode.getKind() == d_kind)
+      {
+        d_iters.emplace_back(currNode.begin(), currNode.end());
+        currNode = *d_iters.back().first;
+      }
+    }
+  } while (d_skipDups && !isDone()
+           && d_visited.find(**this) != d_visited.end());
+
+  if (!isDone())
+  {
+    d_visited.insert(**this);
+  }
+
+  return *this;
+}
+
+template FlatViewTemplate<true>::FlatViewTemplate(NodeTemplate<true> node,
+                                                  Kind kind,
+                                                  bool skipDups);
+template FlatViewTemplate<false>::FlatViewTemplate(NodeTemplate<false> node,
+                                                   Kind kind,
+                                                   bool skipDups);
+template FlatViewTemplate<true>::iterator::iterator(NodeTemplate<true> node,
+                                                    Kind kind,
+                                                    bool end,
+                                                    bool skipDups);
+template FlatViewTemplate<false>::iterator::iterator(NodeTemplate<false> node,
+                                                     Kind kind,
+                                                     bool end,
+                                                     bool skipDups);
+template typename FlatViewTemplate<true>::iterator&
+FlatViewTemplate<true>::iterator::operator++();
+template typename FlatViewTemplate<false>::iterator&
+FlatViewTemplate<false>::iterator::operator++();
+
+}  // namespace expr
+}  // namespace CVC4

--- a/src/expr/node_view.h
+++ b/src/expr/node_view.h
@@ -1,0 +1,133 @@
+/*********************                                                        */
+/*! \file node_view.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Andres Noetzli
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2020 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief Classes that provide different views on nodes
+ **
+ ** The classes in this file provide different views on a given node (e.g. an
+ ** iterator that treats a certain kind as flattened).
+ **/
+
+#include "cvc4_private.h"
+
+#ifndef CVC4__EXPR__NODE_VIEW_H
+#define CVC4__EXPR__NODE_VIEW_H
+
+#include <iterator>
+#include <unordered_set>
+
+#include "expr/node.h"
+#include "expr/node_value.h"
+
+namespace CVC4 {
+namespace expr {
+
+/**
+ * This class provides an iterator over a node that treats a given kind as
+ * flattened. There are two primary use cases for this class:
+ *
+ * - We can't always fully flatten operators because we may exceed the maximum
+ *   number of children but we still want to treat a node as fully flattened.
+ * - Materializing the flattened node is not required. In this case, this class
+ *   provides a simple and efficient way to iterate over the node as if it were
+ *   flattened.
+ *
+ * For example a node of the form (1 + 2) + (3 + 4) is treated as 1 + 2 + 3 + 4
+ * by tihs class if we use "+" as the flattened kind.
+ */
+template <bool ref_count>
+class FlatViewTemplate
+{
+ public:
+  /**
+   * Creates an instance of a flat view.
+   *
+   * @param node The node to iterate over. The node is expected to be of kind
+   *             `kind`
+   * @param kind The kind to treat as flattened
+   * @param skipDups If true, then duplicate children are skipped
+   */
+  FlatViewTemplate(NodeTemplate<ref_count> node,
+                   Kind kind,
+                   bool skipDups = false);
+
+  class iterator
+  {
+   public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = NodeTemplate<ref_count>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = NodeTemplate<ref_count>*;
+    using reference = NodeTemplate<ref_count>&;
+
+    /**
+     * Creates an instance of the iterator over a flat view.
+     *
+     * @param node The node to iterate over
+     * @param kind The kind to treat as flattened
+     * @param end Determines whether this iterator should point to the end or
+     *            the beginning
+     * @param skipDups If true, then duplicate children are skipped
+     */
+    iterator(NodeTemplate<ref_count> node, Kind kind, bool end, bool skipDups);
+
+    NodeTemplate<ref_count> operator*() const { return *d_iters.back().first; }
+
+    bool operator==(const iterator& i) const
+    {
+      return d_iters.back().first == i.d_iters.back().first;
+    }
+
+    bool operator!=(const iterator& i) const
+    {
+      return d_iters.back().first != i.d_iters.back().first;
+    }
+
+    iterator& operator++();
+
+    bool isDone()
+    {
+      return d_iters.size() == 1 && d_iters[0].first == d_iters[0].second;
+    }
+
+   private:
+    /** The kind to be treated as flattened */
+    Kind d_kind;
+    /** Stack of iterators */
+    std::vector<std::pair<NodeValue::iterator<NodeTemplate<ref_count>>,
+                          NodeValue::iterator<NodeTemplate<ref_count>>>>
+        d_iters;
+    std::unordered_set<TNode, TNodeHashFunction> d_visited;
+    /** True if the iterator should skip duplicates */
+    bool d_skipDups;
+  };
+
+  /** Creates an iterator pointing to the first child */
+  iterator begin() { return iterator(d_node, d_kind, false, d_skipDups); }
+
+  /** Creates an iterator pointing to the end */
+  iterator end() { return iterator(d_node, d_kind, true, d_skipDups); }
+
+ private:
+  /** The node to iterate over */
+  NodeTemplate<ref_count> d_node;
+  /** The kind to be treated as flattened */
+  Kind d_kind;
+  /** True if the iterator should skip duplicates */
+  bool d_skipDups;
+};
+
+using FlatView = FlatViewTemplate<true>;
+using FlatTView = FlatViewTemplate<false>;
+
+}  // namespace expr
+}  // namespace CVC4
+
+#endif /* CVC4__EXPR__NODE_VIEW_H */

--- a/src/theory/bv/theory_bv_rewrite_rules_normalization.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_normalization.h
@@ -23,6 +23,7 @@
 #include <unordered_set>
 
 #include "expr/node_algorithm.h"
+#include "expr/node_view.h"
 #include "theory/bv/theory_bv_rewrite_rules.h"
 #include "theory/bv/theory_bv_utils.h"
 #include "theory/rewriter.h"
@@ -223,29 +224,10 @@ inline Node RewriteRule<FlattenAssocCommut>::apply(TNode node)
 {
   Debug("bv-rewrite") << "RewriteRule<FlattenAssocCommut>(" << node << ")"
                       << std::endl;
-  std::vector<Node> processingStack;
-  processingStack.push_back(node);
-  std::vector<Node> children;
   Kind kind = node.getKind();
+  expr::FlatView fv(node, kind);
+  std::vector<Node> children(fv.begin(), fv.end());
 
-  while (!processingStack.empty())
-  {
-    TNode current = processingStack.back();
-    processingStack.pop_back();
-
-    // flatten expression
-    if (current.getKind() == kind)
-    {
-      for (unsigned i = 0; i < current.getNumChildren(); ++i)
-      {
-        processingStack.push_back(current[i]);
-      }
-    }
-    else
-    {
-      children.push_back(current);
-    }
-  }
   if (node.getKind() == kind::BITVECTOR_PLUS
       || node.getKind() == kind::BITVECTOR_MULT)
   {
@@ -1135,29 +1117,9 @@ bool RewriteRule<FlattenAssocCommutNoDuplicates>::applies(TNode node) {
 template<> inline
 Node RewriteRule<FlattenAssocCommutNoDuplicates>::apply(TNode node) {
   Debug("bv-rewrite") << "RewriteRule<FlattenAssocCommut>(" << node << ")" << std::endl;
-  std::vector<Node> processingStack;
-  processingStack.push_back(node);
-  std::unordered_set<TNode, TNodeHashFunction> processed;
-  std::vector<Node> children;
-  Kind kind = node.getKind(); 
-  
-  while (! processingStack.empty()) {
-    TNode current = processingStack.back();
-    processingStack.pop_back();
-    if (processed.count(current))
-      continue;
-
-    processed.insert(current);
-    
-    // flatten expression
-    if (current.getKind() == kind) {
-      for (unsigned i = 0; i < current.getNumChildren(); ++i) {
-        processingStack.push_back(current[i]);
-      }
-    } else {
-      children.push_back(current); 
-    }
-  }
+  Kind kind = node.getKind();
+  expr::FlatView fv(node, kind, true);
+  std::vector<Node> children(fv.begin(), fv.end());
   return utils::mkSortedNode(kind, children);
 }
   


### PR DESCRIPTION
This commit adds `FlatView` and `FlatTView` that can be used to iterate
over a node as if it were flattened w.r.t. a given kind. For example,
`(1 + 2) + (3 + 4)` would be treated as `1 + 2 + 3 + 4` if `+` was the
flattened kind.