### PR TITLE
Add methods to obtain values from api::Term

### DIFF
--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -2104,17 +2104,17 @@ bool checkReal64Bounds(const Rational& r)
          && checkIntegerBounds<std::uint64_t>(r.getDenominator());
 }
 
-bool isRealString(const Node& node)
+bool isReal(const Node& node)
 {
   return node.getKind() == CVC4::Kind::CONST_RATIONAL;
 }
 bool isReal32(const Node& node)
 {
-  return isRealString(node) && checkReal32Bounds(getRational(node));
+  return isReal(node) && checkReal32Bounds(getRational(node));
 }
 bool isReal64(const Node& node)
 {
-  return isRealString(node) && checkReal64Bounds(getRational(node));
+  return isReal(node) && checkReal64Bounds(getRational(node));
 }
 
 bool isInteger(const Node& node)
@@ -2217,7 +2217,7 @@ bool checkReal64Bounds(const CVC4::Node& node)
 
 bool Term::isReal32() const
 {
-  return isRealString() && checkReal32Bounds(*d_node);
+  return isString() && checkReal32Bounds(*d_node);
 }
 std::pair<std::int32_t, std::uint32_t> Term::getReal32() const
 {
@@ -2229,7 +2229,7 @@ std::pair<std::int32_t, std::uint32_t> Term::getReal32() const
 }
 bool Term::isReal64() const
 {
-  return isRealString() && checkReal64Bounds(*d_node);
+  return isString() && checkReal64Bounds(*d_node);
 }
 std::pair<std::int64_t, std::uint64_t> Term::getReal64() const
 {
@@ -2239,11 +2239,11 @@ std::pair<std::int64_t, std::uint64_t> Term::getReal64() const
   return std::make_pair(r.getNumerator().getLong(),
                         r.getDenominator().getUnsignedLong());
 }
-bool Term::isRealString() const { return detail::isRealString(*d_node); }
-std::string Term::getRealString() const
+bool Term::isReal() const { return detail::isReal(*d_node); }
+std::string Term::getReal() const
 {
-  CVC4_API_CHECK(detail::isRealString(*d_node))
-      << "Term should be a Real when calling getRealString()";
+  CVC4_API_CHECK(detail::isReal(*d_node))
+      << "Term should be a Real when calling getReal()";
   return detail::getRational(*d_node).toString();
 }
 

--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -2299,7 +2299,7 @@ std::vector<Term> Term::getTuple() const
   std::vector<Term> res;
   for (std::size_t i = 1, n = d_node->getNumChildren(); i < n; ++i)
   {
-    res.emplace_back(Term(d_solver, d_node[i]));
+    res.emplace_back(Term(d_solver, (*d_node)[i]));
   }
   return res;
 }
@@ -2384,9 +2384,9 @@ void collectSet(std::set<Term>& set, TNode node, const Solver* slv)
 {
   switch (node.getKind())
   {
-    case Kind::EMPTYSET: break;
-    case Kind::SINGLETON: set.emplace(Term(slv, node[0])); break;
-    case Kind::UNION:
+    case CVC4::Kind::EMPTYSET: break;
+    case CVC4::Kind::SINGLETON: set.emplace(Term(slv, node[0])); break;
+    case CVC4::Kind::UNION:
     {
       for (const auto& sub : node)
       {

--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -2204,8 +2204,7 @@ bool checkReal64Bounds(const CVC4::Node& node)
 
 bool Term::isReal32() const
 {
-  return d_node->getKind() == CVC4::Kind::CONST_RATIONAL
-         && checkReal32Bounds(*d_node);
+  return isRealString() && checkReal32Bounds(*d_node);
 }
 std::pair<std::int32_t, std::uint32_t> Term::getReal32() const
 {
@@ -2217,8 +2216,7 @@ std::pair<std::int32_t, std::uint32_t> Term::getReal32() const
 }
 bool Term::isReal64() const
 {
-  return d_node->getKind() == CVC4::Kind::CONST_RATIONAL
-         && checkReal64Bounds(*d_node);
+  return isRealString() && checkReal64Bounds(*d_node);
 }
 std::pair<std::int64_t, std::uint64_t> Term::getReal64() const
 {
@@ -2228,6 +2226,17 @@ std::pair<std::int64_t, std::uint64_t> Term::getReal64() const
   return std::make_pair(r.getNumerator().getLong(),
                         r.getDenominator().getUnsignedLong());
 }
+bool Term::isRealString() const
+{
+  return d_node->getKind() == CVC4::Kind::CONST_RATIONAL;
+}
+std::string Term::getRealString() const
+{
+  CVC4_API_CHECK(isRealString())
+      << "Term should be a Real when calling getRealString()";
+  return detail::getRational(*d_node).toString();
+}
+
 bool Term::isPi() const { return d_node->getKind() == CVC4::Kind::PI; }
 
 bool Term::isConstArray() const
@@ -2385,7 +2394,9 @@ void collectSet(std::set<Term>& set, TNode node, const Solver* slv)
   switch (node.getKind())
   {
     case CVC4::Kind::EMPTYSET: break;
-    case CVC4::Kind::SINGLETON: set.emplace(Term(slv, node[0])); break;
+    case CVC4::Kind::SINGLETON:
+      // TODO: fix this
+      //set.emplace(Term(slv, node[0])); break;
     case CVC4::Kind::UNION:
     {
       for (const auto& sub : node)

--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -2223,8 +2223,8 @@ bool isInteger(const CVC4::Node& node)
 }
 Integer getInteger(const CVC4::Node& node)
 {
-  CVC4_API_CHECK(isInteger(node))
-      << "Term should be a integer when calling getInteger()";
+  CVC4_API_CHECK(isInteger())
+      << "Term should be an Integer when calling getInteger()";
   return node.getConst<Rational>().getNumerator();
 }
 template <typename T>

--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -2223,7 +2223,7 @@ bool isInteger(const CVC4::Node& node)
 }
 Integer getInteger(const CVC4::Node& node)
 {
-  CVC4_API_CHECK(isInteger())
+  CVC4_API_CHECK(isInteger(node))
       << "Term should be an Integer when calling getInteger()";
   return node.getConst<Rational>().getNumerator();
 }

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -1243,63 +1243,70 @@ class CVC4_PUBLIC Term
    */
   std::wstring getString() const;
 
-  // mkTuple
-  bool isTuple() const;
-  // mkTrue
-  bool isTrue() const;
-  // mkFalse
-  bool isFalse() const;
-  // mkBoolean
-  bool isBoolean() const;
-  bool getBoolean() const;
-  // mkPi
+  // Arithmetic
+  bool isReal32() const;
+  std::pair<std::int32_t, std::uint32_t> getReal32() const;
+  bool isReal64() const;
+  std::pair<std::int64_t, std::uint64_t> getReal64() const;
   bool isPi() const;
-  // mkReal
-  bool isValueReal() const;
-  // mkRegexpEmpty
-  bool isRegexpEmpty() const;
-  // mkRegexpSigma
-  bool isRegexpSigma() const;
-  // mkEmptySet
-  bool isEmptySet() const;
-  // mkEmptyBag
-  bool isEmptyBag() const;
-  // mkSepNil
-  bool isSepNil() const;
-  // mkChar
-  bool isChar() const;
-  std::string getChar() const;
-  // mkEmptySequence
-  bool isEmptySequence() const;
-  // mkUniverseSet
-  bool isUniverseSet() const;
-  // mkBitVector
-  bool isBitVector() const;
-  std::string getBitVector(std::uint32_t base = 2) const;
-  // mkConstArray
+
+  // Arrays
   bool isConstArray() const;
   Term getConstArray() const;
-  // mkPosInf
-  bool isPosInf() const;
-  // mkNegInf
-  bool isNegInf() const;
-  // mkNaN
-  bool isNaN() const;
-  // mkPosZero
-  bool isPosZero() const;
-  // mkNegZero
-  bool isNegZero() const;
-  // mkRoundingMode
-  bool isRoundingMode() const;
-  // mkUninterpretedConst
-  bool isUninterpretedConst() const;
-  std::pair<Sort, std::int32_t> getUninterpretedConst() const;
-  // mkAbstractValue
+
+  // Bags
+  bool isEmptyBag() const;
+
+  // Booleans
+  bool isBoolean() const;
+  bool isFalse() const;
+  bool isTrue() const;
+  bool getBoolean() const;
+
+  // BitVector
+  bool isBitVector() const;
+  std::string getBitVector(std::uint32_t base = 2) const;
+
+  // Builtin
   bool isAbstractValue() const;
   std::string getAbstractValue() const;
-  // mkFloatingPoint
+
+  // Datatypes
+  bool isTuple() const;
+
+  // FloatingPoint
+  bool isPosZero() const;
+  bool isNegZero() const;
+  bool isPosInf() const;
+  bool isNegInf() const;
+  bool isNaN() const;
+  bool isRoundingMode() const;
   bool isFloatingPoint() const;
   std::tuple<std::uint32_t, std::uint32_t, Term> getFloatingPoint() const;
+
+  // Quantifiers
+
+  // Separation Logic
+  bool isSepNil() const;
+
+  // Sets
+  bool isSet() const;
+  bool isEmptySet() const;
+  bool isUniverseSet() const;
+  std::set<Term> getSet() const;
+
+  // Strings
+  bool isChar() const;
+  bool isEmptySequence() const;
+  bool isSequence() const;
+  std::string getChar() const;
+  std::vector<Term> getSequence() const;
+  bool isRegexpEmpty() const;
+  bool isRegexpSigma() const;
+
+  // UF
+  bool isUninterpretedConst() const;
+  std::pair<Sort, std::int32_t> getUninterpretedConst() const;
 
  protected:
   /**

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -1243,6 +1243,64 @@ class CVC4_PUBLIC Term
    */
   std::wstring getString() const;
 
+  // mkTuple
+  bool isTuple() const;
+  // mkTrue
+  bool isTrue() const;
+  // mkFalse
+  bool isFalse() const;
+  // mkBoolean
+  bool isBoolean() const;
+  bool getBoolean() const;
+  // mkPi
+  bool isPi() const;
+  // mkReal
+  bool isValueReal() const;
+  // mkRegexpEmpty
+  bool isRegexpEmpty() const;
+  // mkRegexpSigma
+  bool isRegexpSigma() const;
+  // mkEmptySet
+  bool isEmptySet() const;
+  // mkEmptyBag
+  bool isEmptyBag() const;
+  // mkSepNil
+  bool isSepNil() const;
+  // mkChar
+  bool isChar() const;
+  std::string getChar() const;
+  // mkEmptySequence
+  bool isEmptySequence() const;
+  // mkUniverseSet
+  bool isUniverseSet() const;
+  // mkBitVector
+  bool isBitVector() const;
+  std::string getBitVector(std::uint32_t base = 2) const;
+  // mkConstArray
+  bool isConstArray() const;
+  Term getConstArray() const;
+  // mkPosInf
+  bool isPosInf() const;
+  // mkNegInf
+  bool isNegInf() const;
+  // mkNaN
+  bool isNaN() const;
+  // mkPosZero
+  bool isPosZero() const;
+  // mkNegZero
+  bool isNegZero() const;
+  // mkRoundingMode
+  bool isRoundingMode() const;
+  // mkUninterpretedConst
+  bool isUninterpretedConst() const;
+  std::pair<Sort, std::int32_t> getUninterpretedConst() const;
+  // mkAbstractValue
+  bool isAbstractValue() const;
+  std::string getAbstractValue() const;
+  // mkFloatingPoint
+  bool isFloatingPoint() const;
+  std::tuple<std::uint32_t, std::uint32_t, Term> getFloatingPoint() const;
+
  protected:
   /**
    * The associated solver object.

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -1263,12 +1263,12 @@ class CVC4_PUBLIC Term
   /**
    * Returns true if the term is a rational.
    */
-  bool isRealString() const;
+  bool isReal() const;
   /**
    * Returns the stored rational in (decimal) string representation.
    * Asserts isRealString().
    */
-  std::string getRealString() const;
+  std::string getReal() const;
   /**
    * Returns true if the term is the symbolic value for the transcendental
    * constant pi.

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -1245,71 +1245,191 @@ class CVC4_PUBLIC Term
 
   // Arithmetic
   bool isReal32() const;
+  /**
+   * Returns the stored rational as a pair of its numerator and denominator.
+   * Asserts isReal32().
+   */
   std::pair<std::int32_t, std::uint32_t> getReal32() const;
+  /**
+   * Returns true if the term is a rational whose numerator and denominator fit
+   * within std::int64_t and std::uint64_t, respectively.
+   */
   bool isReal64() const;
+  /**
+   * Returns the stored rational as a pair of its numerator and denominator.
+   * Asserts isReal64().
+   */
   std::pair<std::int64_t, std::uint64_t> getReal64() const;
+  /**
+   * Returns true if the term is a rational.
+   */
   bool isRealString() const;
+  /**
+   * Returns the stored rational in (decimal) string representation.
+   * Asserts isRealString().
+   */
   std::string getRealString() const;
+  /**
+   * Returns true if the term is the symbolic value for the transcendental
+   * constant pi.
+   */
   bool isPi() const;
 
-  // Arrays
+  /**
+   * Returns true if the term is a constant array.
+   */
   bool isConstArray() const;
+  /**
+   * Returns the value stored in the constant array. Asserts isConstArray().
+   */
   Term getConstArray() const;
 
-  // Bags
+  /**
+   * Returns true if the term is the empty bag.
+   */
   bool isEmptyBag() const;
 
-  // Booleans
+  /**
+   * Returns true if the term is a Boolean constant.
+   */
   bool isBoolean() const;
+  /**
+   * Returns true if the term is the Boolean constant false.
+   */
   bool isFalse() const;
+  /**
+   * Returns true if the term is the Boolean constant true.
+   */
   bool isTrue() const;
+  /**
+   * Returns the stored Boolean constant. Asserts isBoolean().
+   */
   bool getBoolean() const;
 
-  // BitVector
+  /**
+   * Returns true if the term is a BitVector constant.
+   */
   bool isBitVector() const;
+  /**
+   * Returns the stored BitVector constant in string representation. Supported
+   * bases are 2 (bit string), 10 (decimal string) or 16 (hexadecimal string).
+   */
   std::string getBitVector(std::uint32_t base = 2) const;
 
-  // Builtin
+  /**
+   * Returns true if the term is an abstract value.
+   */
   bool isAbstractValue() const;
+  /**
+   * Returns the stored abstract value in string representation.
+   */
   std::string getAbstractValue() const;
 
-  // Datatypes
+  /**
+   * Returns true if the term is a tuple.
+   */
   bool isTuple() const;
+  /**
+   * Returns the stored tuple as a vector of terms.
+   */
   std::vector<Term> getTuple() const;
 
-  // FloatingPoint
+  /**
+   * Returns true if the term is the floating-point constant for positive zero.
+   */
   bool isPosZero() const;
+  /**
+   * Returns true if the term is the floating-point constant for negative zero.
+   */
   bool isNegZero() const;
+  /**
+   * Returns true if the term is the floating-point constant for positive
+   * infinity.
+   */
   bool isPosInf() const;
+  /**
+   * Returns true if the term is the floating-point constant for negative
+   * infinity.
+   */
   bool isNegInf() const;
+  /**
+   * Returns true if the term is the floating-point constant for not a number.
+   */
   bool isNaN() const;
+  /**
+   * Returns true if the term is a floating-point rounding mode.
+   */
   bool isRoundingMode() const;
+  /**
+   * Returns true if the term is a floating-point constant.
+   */
   bool isFloatingPoint() const;
+  /**
+   * Returns the stored floating-point constant as a tuple of the exponent
+   * width, the significand with and a bit-vector constant. Asserts
+   * isFloatingPoint().
+   */
   std::tuple<std::uint32_t, std::uint32_t, Term> getFloatingPoint() const;
 
-  // Quantifiers
-
-  // Separation Logic
+  /**
+   * Returns true if the term is the nil constant for separation logic.
+   */
   bool isSepNil() const;
 
-  // Sets
+  /**
+   * Returns true if the term is a set.
+   */
   bool isSet() const;
+  /**
+   * Returns true if the term is the empty set.
+   */
   bool isEmptySet() const;
+  /**
+   * Returns true if the term is the universe set.
+   */
   bool isUniverseSet() const;
+  /**
+   * Returns true if the term is a singleton set.
+   */
   bool isSingletonSet() const;
+  /**
+   * Returns the stored set as a set of terms. Asserts isSet().
+   */
   std::set<Term> getSet() const;
 
-  // Strings
+  /**
+   * Returns true if the term is a single string character.
+   */
   bool isChar() const;
   bool isEmptySequence() const;
+  /**
+   * Returns true if the term is a constant sequence.
+   */
   bool isSequence() const;
+  /**
+   * Returns the stored character as a string that holds the unicode code point
+   * as hexadecimal numer. Asserts isChar().
+   */
   std::string getChar() const;
   std::vector<Term> getSequence() const;
+  /**
+   * Returns true if the term is the empty regular expression.
+   */
   bool isRegexpEmpty() const;
+  /**
+   * Returns true if the term is the regular expression that matches the whole
+   * alphabet.
+   */
   bool isRegexpSigma() const;
 
-  // UF
+  /**
+   * Returns true if the term is a constant from an uninterpreted sort.
+   */
   bool isUninterpretedConst() const;
+  /**
+   * Returns the stored uninterpreted constant as a pair of its sort and its
+   * index.
+   */
   std::pair<Sort, std::int32_t> getUninterpretedConst() const;
 
  protected:

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -1273,6 +1273,7 @@ class CVC4_PUBLIC Term
 
   // Datatypes
   bool isTuple() const;
+  std::vector<Term> getTuple() const;
 
   // FloatingPoint
   bool isPosZero() const;
@@ -1293,6 +1294,7 @@ class CVC4_PUBLIC Term
   bool isSet() const;
   bool isEmptySet() const;
   bool isUniverseSet() const;
+  bool isSingletonSet() const;
   std::set<Term> getSet() const;
 
   // Strings

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -1248,6 +1248,8 @@ class CVC4_PUBLIC Term
   std::pair<std::int32_t, std::uint32_t> getReal32() const;
   bool isReal64() const;
   std::pair<std::int64_t, std::uint64_t> getReal64() const;
+  bool isRealString() const;
+  std::string getRealString() const;
   bool isPi() const;
 
   // Arrays


### PR DESCRIPTION
This PR adds methods for `api::Term` to check whether it has some value that we can return as a native data type, and methods to return this data if appropriate.