### PR TITLE
[proof-new] Making alpha-equivalence reduction proof-producing

### DIFF
--- a/src/expr/proof_rule.cpp
+++ b/src/expr/proof_rule.cpp
@@ -131,6 +131,7 @@ const char* toString(PfRule id)
     case PfRule::EXISTS_INTRO: return "EXISTS_INTRO";
     case PfRule::SKOLEMIZE: return "SKOLEMIZE";
     case PfRule::INSTANTIATE: return "INSTANTIATE";
+    case PfRule::ALPHA_EQUIV: return "ALPHA_EQUIV";
     //================================================= String rules
     case PfRule::CONCAT_EQ: return "CONCAT_EQ";
     case PfRule::CONCAT_UNIFY: return "CONCAT_UNIFY";

--- a/src/expr/proof_rule.h
+++ b/src/expr/proof_rule.h
@@ -792,6 +792,14 @@ enum class PfRule : uint32_t
   // Conclusion: F*sigma
   // sigma maps x1 ... xn to t1 ... tn.
   INSTANTIATE,
+  // ======== Alpha equivalence
+  // Children: none
+  // Arguments: ((forall ((x1 T1) ... (xn Tn)) F), y1 ... yn)
+  // ----------------------------------------
+  // Conclusion: (= (forall ((x1 T1) ... (xn Tn)) F)
+  //                (forall ((y1 T1) ... (yn Tn)) F*sigma))
+  // sigma maps x1 ... xn to y1 ... yn.
+  ALPHA_EQUIV,
 
   //================================================= String rules
   //======================== Core solver

--- a/src/theory/quantifiers/alpha_equivalence.h
+++ b/src/theory/quantifiers/alpha_equivalence.h
@@ -22,6 +22,9 @@
 #include "expr/term_canonize.h"
 
 namespace CVC4 {
+
+class CDProof;
+
 namespace theory {
 namespace quantifiers {
 
@@ -81,22 +84,30 @@ class AlphaEquivalenceDb
 class AlphaEquivalence
 {
  public:
-  AlphaEquivalence(QuantifiersEngine* qe);
+  AlphaEquivalence(QuantifiersEngine* qe, ProofNodeManager* pnm = nullptr);
   ~AlphaEquivalence(){}
   /** reduce quantifier
    *
-   * If non-null, its return value is lemma justifying why q is reducible.
-   * This is of the form ( q = q' ) where q' is a quantified formula that
-   * was previously registered to this class via a call to reduceQuantifier,
-   * and q and q' are alpha-equivalent.
+   * If non-null, its return value is a trust node containing the lemma
+   * justifying why q is reducible.  This lemma is of the form ( q = q' ) where
+   * q' is a quantified formula that was previously registered to this class via
+   * a call to reduceQuantifier, and q and q' are alpha-equivalent.
    */
-  Node reduceQuantifier( Node q );
+  TrustNode reduceQuantifier(Node q);
 
  private:
   /** a term canonizer */
   expr::TermCanonize d_termCanon;
   /** the database of quantified formulas registered to this class */
   AlphaEquivalenceDb d_aedb;
+  /** Pointer to the proof node manager */
+  ProofNodeManager* d_pnm;
+  /**
+   * A CDProof storing alpha equivalence steps.
+   */
+  std::unique_ptr<CDProof> d_pfAlpha;
+  /** Are proofs enabled for this object? */
+  bool isProofEnabled() const;
 };
 
 }

--- a/src/theory/quantifiers/proof_checker.cpp
+++ b/src/theory/quantifiers/proof_checker.cpp
@@ -31,6 +31,7 @@ void QuantifiersProofRuleChecker::registerTo(ProofChecker* pc)
   pc->registerChecker(PfRule::EXISTS_INTRO, this);
   pc->registerChecker(PfRule::SKOLEMIZE, this);
   pc->registerChecker(PfRule::INSTANTIATE, this);
+  pc->registerChecker(PfRule::ALPHA_EQUIV, this);
 }
 
 Node QuantifiersProofRuleChecker::checkInternal(
@@ -115,6 +116,22 @@ Node QuantifiersProofRuleChecker::checkInternal(
     Node inst =
         body.substitute(vars.begin(), vars.end(), subs.begin(), subs.end());
     return inst;
+  }
+  if (id == PfRule::ALPHA_EQUIV)
+  {
+    Assert(children.empty());
+    if (args[0].getKind() != kind::FORALL
+        || args.size() != args[0][0].getNumChildren() + 1)
+    {
+      return Node::null();
+    }
+    Node body = args[0][1];
+    std::vector<Node> vars{args[0][0].begin(), args[0][0].end()};
+    std::vector<Node> newVars{args.begin() + 1, args.end()};
+    Node renamedBody =
+        body.substitute(vars.begin(), vars.end(), newVars.begin(), newVars.end());
+    return args[0].eqNode(nm->mkNode(
+        kind::FORALL, nm->mkNode(kind::BOUND_VAR_LIST, newVars), renamedBody));
   }
 
   // no rule

--- a/src/theory/quantifiers/proof_checker.cpp
+++ b/src/theory/quantifiers/proof_checker.cpp
@@ -128,8 +128,8 @@ Node QuantifiersProofRuleChecker::checkInternal(
     Node body = args[0][1];
     std::vector<Node> vars{args[0][0].begin(), args[0][0].end()};
     std::vector<Node> newVars{args.begin() + 1, args.end()};
-    Node renamedBody =
-        body.substitute(vars.begin(), vars.end(), newVars.begin(), newVars.end());
+    Node renamedBody = body.substitute(
+        vars.begin(), vars.end(), newVars.begin(), newVars.end());
     return args[0].eqNode(nm->mkNode(
         kind::FORALL, nm->mkNode(kind::BOUND_VAR_LIST, newVars), renamedBody));
   }

--- a/src/theory/quantifiers/quantifiers_modules.cpp
+++ b/src/theory/quantifiers/quantifiers_modules.cpp
@@ -43,6 +43,7 @@ void QuantifiersModules::initialize(QuantifiersEngine* qe,
                                     QuantifiersInferenceManager& qim,
                                     QuantifiersRegistry& qr,
                                     DecisionManager* dm,
+                                    ProofNodeManager* pnm,
                                     std::vector<QuantifiersModule*>& modules)
 {
   // add quantifiers modules
@@ -90,7 +91,7 @@ void QuantifiersModules::initialize(QuantifiersEngine* qe,
   }
   if (options::quantAlphaEquiv())
   {
-    d_alpha_equiv.reset(new AlphaEquivalence(qe));
+    d_alpha_equiv.reset(new AlphaEquivalence(qe, pnm));
   }
   // full saturation : instantiate from relevant domain, then arbitrary terms
   if (options::fullSaturateQuant() || options::fullSaturateInterleave())

--- a/src/theory/quantifiers/quantifiers_modules.h
+++ b/src/theory/quantifiers/quantifiers_modules.h
@@ -30,7 +30,7 @@
 
 namespace CVC4 {
 namespace theory {
-  
+
 class QuantifiersEngine;
 class DecisionManager;
 
@@ -57,6 +57,7 @@ class QuantifiersModules
                   QuantifiersInferenceManager& qim,
                   QuantifiersRegistry& qr,
                   DecisionManager* dm,
+                  ProofNodeManager* pnm,
                   std::vector<QuantifiersModule*>& modules);
 
  private:

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -116,7 +116,7 @@ void QuantifiersEngine::finishInit(TheoryEngine* te, DecisionManager* dm)
   d_decManager = dm;
   // Initialize the modules and the utilities here.
   d_qmodules.reset(new quantifiers::QuantifiersModules);
-  d_qmodules->initialize(this, d_qstate, d_qim, d_qreg, dm, d_modules);
+  d_qmodules->initialize(this, d_qstate, d_qim, d_qreg, dm, d_pnm, d_modules);
   if (d_qmodules->d_rel_dom.get())
   {
     d_util.push_back(d_qmodules->d_rel_dom.get());
@@ -590,35 +590,47 @@ void QuantifiersEngine::notifyCombineTheories() {
   // in quantifiers state.
 }
 
-bool QuantifiersEngine::reduceQuantifier( Node q ) {
-  //TODO: this can be unified with preregistration: AlphaEquivalence takes ownership of reducable quants
-  BoolMap::const_iterator it = d_quants_red.find( q );
-  if( it==d_quants_red.end() ){
-    Node lem;
+bool QuantifiersEngine::reduceQuantifier(Node q)
+{
+  // TODO: this can be unified with preregistration: AlphaEquivalence takes
+  // ownership of reducable quants
+  BoolMap::const_iterator it = d_quants_red.find(q);
+  if (it == d_quants_red.end())
+  {
+    TrustNode tlem;
     InferenceId id = InferenceId::UNKNOWN;
-    std::map< Node, Node >::iterator itr = d_quants_red_lem.find( q );
-    if( itr==d_quants_red_lem.end() ){
+    std::map<Node, TrustNode>::iterator itr = d_quantsRedTrustLem.find(q);
+    if (itr == d_quantsRedTrustLem.end())
+    {
       if (d_qmodules->d_alpha_equiv)
       {
-        Trace("quant-engine-red") << "Alpha equivalence " << q << "?" << std::endl;
-        //add equivalence with another quantified formula
-        lem = d_qmodules->d_alpha_equiv->reduceQuantifier(q);
+        Trace("quant-engine-red")
+            << "Alpha equivalence " << q << "?" << std::endl;
+        // add equivalence with another quantified formula
+        tlem = d_qmodules->d_alpha_equiv->reduceQuantifier(q);
         id = InferenceId::QUANTIFIERS_REDUCE_ALPHA_EQ;
-        if( !lem.isNull() ){
-          Trace("quant-engine-red") << "...alpha equivalence success." << std::endl;
+        if (!tlem.isNull())
+        {
+          Trace("quant-engine-red")
+              << "...alpha equivalence success." << std::endl;
           ++(d_statistics.d_red_alpha_equiv);
         }
       }
-      d_quants_red_lem[q] = lem;
-    }else{
-      lem = itr->second;
+      d_quantsRedTrustLem[q] = tlem;
     }
-    if( !lem.isNull() ){
-      d_qim.lemma(lem, id);
+    else
+    {
+      tlem = itr->second;
     }
-    d_quants_red[q] = !lem.isNull();
-    return !lem.isNull();
-  }else{
+    if (!tlem.isNull())
+    {
+      d_qim.trustedLemma(tlem, id);
+    }
+    d_quants_red[q] = !tlem.isNull();
+    return !tlem.isNull();
+  }
+  else
+  {
     return (*it).second;
   }
 }

--- a/src/theory/quantifiers_engine.h
+++ b/src/theory/quantifiers_engine.h
@@ -298,7 +298,7 @@ public:
   NodeSet d_quants_prereg;
   /** quantifiers reduced */
   BoolMap d_quants_red;
-  std::map<Node, Node> d_quants_red_lem;
+  std::map<Node, TrustNode> d_quantsRedTrustLem;
 };/* class QuantifiersEngine */
 
 }/* CVC4::theory namespace */

--- a/src/theory/uf/equality_engine.cpp
+++ b/src/theory/uf/equality_engine.cpp
@@ -1076,7 +1076,7 @@ void EqualityEngine::buildEqConclusion(EqualityNodeId id1,
         << id2 << "} " << d_nodes[id2] << "\n";
     // if has at least as many children as the minimal
     // number of children of the n-ary kind, build the node
-    if (numChildren >= kind::metakind::getMaxArityForKind(k1))
+    if (numChildren >= kind::metakind::getMinArityForKind(k1))
     {
       std::vector<Node> children;
       for (unsigned j = 0; j < numChildren; ++j)

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -772,6 +772,7 @@ set(regress_0_tests
   regress0/printer/let_shadowing.smt2
   regress0/printer/symbol_starting_w_digit.smt2
   regress0/printer/tuples_and_records.cvc
+  regress0/proofs/alpha-equivalence.smt2
   regress0/push-pop/boolean/fuzz_12.smt2
   regress0/push-pop/boolean/fuzz_13.smt2
   regress0/push-pop/boolean/fuzz_14.smt2

--- a/test/regress/regress0/proofs/alpha-equivalence.smt2
+++ b/test/regress/regress0/proofs/alpha-equivalence.smt2
@@ -1,0 +1,13 @@
+; REQUIRES: proof
+; COMMAND-LINE: --proof-pedantic=1
+; EXIT: 0
+; SCRUBBER: grep -v -E '.*'
+(set-logic AUFLIA)
+(set-option :produce-proofs true)
+(declare-sort A$ 0)
+(declare-fun p$ (A$) Bool)
+(assert (exists ((?v0 A$)) (p$ ?v0)))
+(assert (forall ((?v0 A$)) (not (p$ ?v0))))
+(assert (not false))
+(check-sat)
+(get-proof)

--- a/test/regress/regress0/proofs/alpha-equivalence.smt2
+++ b/test/regress/regress0/proofs/alpha-equivalence.smt2
@@ -1,9 +1,8 @@
 ; REQUIRES: proof
-; COMMAND-LINE: --proof-pedantic=1
+; COMMAND-LINE: --proof --proof-pedantic=1
 ; EXIT: 0
 ; SCRUBBER: grep -v -E '.*'
 (set-logic AUFLIA)
-(set-option :produce-proofs true)
 (declare-sort A$ 0)
 (declare-fun p$ (A$) Bool)
 (assert (exists ((?v0 A$)) (p$ ?v0)))


### PR DESCRIPTION
Previously we would generate `THEORY_LEMMA` proof nodes for this transformation. This showed up in an example from the Isabelle/HOL integration (minimized and added as a regression).