### PR TITLE
Move docs upload to a different workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,11 @@ jobs:
 
     - name: Build Documentation
       if: matrix.build-documentation
-      run: make -j2 docs-gh
+      run: |
+        make -j2 docs-gh
+        if [ "${{ github.event_name }}" == "pull_request" ] ; then
+          echo "${{ github.event.number }}" > docs/sphinx-gh/prnum
+        fi
       working-directory: build
     
     - name: Store Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
-on: [push, pull_request, pull_request_target]
+on: [push, pull_request]
 name: CI
 
 jobs:
   build:
-    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
     strategy:
       matrix:
         include:
@@ -229,67 +228,3 @@ jobs:
       with:
         name: documentation
         path: build/docs/sphinx-gh/
-
-  upload-docs:
-    if: github.event_name == 'push' || github.event_name == 'pull_request_target'
-    name: upload-docs
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    needs: build
-    steps:
-      - name: Setup Deploy Key
-        env:
-            SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: |
-            ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-            ssh-add - <<< "${{ secrets.CVC5_DOCS_TOKEN }}"
-      
-      - name: Setup Context
-        run: |
-          if [ "${{ github.event_name }}" == "push" ] ; then
-            NAME=$(echo "${GITHUB_REF}" | sed "s,refs/heads/,,")
-            HASH=${{ github.sha }}
-            echo "Identified branch $NAME"
-          elif [ "${{ github.event_name }}" == "pull_request_target" ] ; then
-            NAME="${{ github.event.number }}"
-            HASH="${{ github.event.pull_request.head.sha }}"
-            echo "Identified PR #$NAME (from $HASH)"
-            NAME="pr$NAME"
-          fi
-          echo "NAME=$NAME" >> $GITHUB_ENV
-          echo "HASH=$HASH" >> $GITHUB_ENV
-
-      - name: Clone Documentation Repository
-        env:
-            SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: |
-          git config --global user.email "docbot@cvc5"
-          git config --global user.name "DocBot"
-          git clone git@github.com:cvc5/docs-ci.git target/
-      
-      - name: Fetch artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: documentation
-          path: docs-new
-
-      - name: Update docs
-        continue-on-error: true
-        env:
-            SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: |
-          if [ -n "$NAME" ]; then
-            mv docs-new target/docs-$NAME-$HASH
-            cd target/
-            rm -f docs-$NAME
-            ln -s docs-$NAME-$HASH docs-$NAME
-            git add docs-$NAME docs-$NAME-$HASH
-
-            python3 genindex.py
-            git add README.md
-            git commit -m "Update docs for $NAME"
-
-            git push
-          else
-            echo "Ignored run"
-          fi

--- a/.github/workflows/docs_cleanup.yml
+++ b/.github/workflows/docs_cleanup.yml
@@ -45,8 +45,10 @@ jobs:
           git log
           first=`git rev-list --max-parents=0 HEAD`
           last=`git rev-list --until=1.month.ago -n1 HEAD`
-          git rebase -Xtheirs --onto $first $last
-          git log
+          if [ -n "$last" ]; then
+            git rebase -Xtheirs --onto $first $last
+            git log
+          fi
       
       - name: Push
         env:

--- a/.github/workflows/docs_upload.yml
+++ b/.github/workflows/docs_upload.yml
@@ -19,22 +19,6 @@ jobs:
         run: |
             ssh-agent -a $SSH_AUTH_SOCK > /dev/null
             ssh-add - <<< "${{ secrets.CVC5_DOCS_TOKEN }}"
-      
-      - name: Setup Context
-        run: |
-          if [ "${{ github.event.workflow_run.event_name }}" == "push" ] ; then
-            NAME=$(echo "${GITHUB_REF}" | sed "s,refs/heads/,,")
-            HASH=${{ github.event.workflow_run.sha }}
-            echo "Identified branch $NAME"
-          elif [ "${{ github.event.workflow_run.event_name }}" == "pull_request" ] ; then
-            NAME="${{ github.event.workflow_run.number }}"
-            HASH="${{ github.event.workflow_run.pull_request.head.sha }}"
-            echo "Identified PR #$NAME (from $HASH)"
-            NAME="pr$NAME"
-          fi
-          echo "NAME=$NAME" >> $GITHUB_ENV
-          echo "HASH=$HASH" >> $GITHUB_ENV
-
       - name: Clone Documentation Repository
         env:
             SSH_AUTH_SOCK: /tmp/ssh_agent.sock
@@ -66,6 +50,21 @@ jobs:
 
       - name: Unpack artifact
         run: unzip download.zip -d docs-new/
+      
+      - name: Setup Context
+        run: |
+          HASH=${{ github.event.workflow_run.head_commit.id }}
+          if [ "${{ github.event.workflow_run.event }}" == "push" ] ; then
+            NAME=${{ github.event.workflow_run.head_branch }}
+            echo "Identified branch $NAME"
+          elif [ "${{ github.event.workflow_run.event }}" == "pull_request" ] ; then
+            NAME=$(cat docs-new/prnum)
+            rm docs-new/prnum
+            echo "Identified PR #$NAME (from $HASH)"
+            NAME="pr$NAME"
+          fi
+          echo "NAME=$NAME" >> $GITHUB_ENV
+          echo "HASH=$HASH" >> $GITHUB_ENV
 
       - name: Update docs
         continue-on-error: true

--- a/.github/workflows/docs_upload.yml
+++ b/.github/workflows/docs_upload.yml
@@ -11,9 +11,6 @@ jobs:
     name: upload-docs
     runs-on: ubuntu-latest
     continue-on-error: true
-    if: >
-      ${{ github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Setup Deploy Key
         env:

--- a/.github/workflows/docs_upload.yml
+++ b/.github/workflows/docs_upload.yml
@@ -19,6 +19,7 @@ jobs:
         run: |
             ssh-agent -a $SSH_AUTH_SOCK > /dev/null
             ssh-add - <<< "${{ secrets.CVC5_DOCS_TOKEN }}"
+
       - name: Clone Documentation Repository
         env:
             SSH_AUTH_SOCK: /tmp/ssh_agent.sock

--- a/.github/workflows/docs_upload.yml
+++ b/.github/workflows/docs_upload.yml
@@ -28,9 +28,9 @@ jobs:
             NAME=$(echo "${GITHUB_REF}" | sed "s,refs/heads/,,")
             HASH=${{ github.event.workflow_run.sha }}
             echo "Identified branch $NAME"
-          elif [ "${{ github.event.workflow_run.event_name }}" == "pull_request_target" ] ; then
-            NAME="${{ github.event.workflow_run.event.number }}"
-            HASH="${{ github.event.workflow_run.event.pull_request.head.sha }}"
+          elif [ "${{ github.event.workflow_run.event_name }}" == "pull_request" ] ; then
+            NAME="${{ github.event.workflow_run.number }}"
+            HASH="${{ github.event.workflow_run.pull_request.head.sha }}"
             echo "Identified PR #$NAME (from $HASH)"
             NAME="pr$NAME"
           fi

--- a/.github/workflows/docs_upload.yml
+++ b/.github/workflows/docs_upload.yml
@@ -1,0 +1,129 @@
+name: Upload Docs
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  upload-docs:
+    name: upload-docs
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Setup Deploy Key
+        env:
+            SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: |
+            ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+            ssh-add - <<< "${{ secrets.CVC5_DOCS_TOKEN }}"
+      
+      - name: Setup Context
+        run: |
+          if [ "${{ github.event.workflow_run.event_name }}" == "push" ] ; then
+            NAME=$(echo "${GITHUB_REF}" | sed "s,refs/heads/,,")
+            HASH=${{ github.event.workflow_run.sha }}
+            echo "Identified branch $NAME"
+          elif [ "${{ github.event.workflow_run.event_name }}" == "pull_request_target" ] ; then
+            NAME="${{ github.event.workflow_run.event.number }}"
+            HASH="${{ github.event.workflow_run.event.pull_request.head.sha }}"
+            echo "Identified PR #$NAME (from $HASH)"
+            NAME="pr$NAME"
+          fi
+          echo "NAME=$NAME" >> $GITHUB_ENV
+          echo "HASH=$HASH" >> $GITHUB_ENV
+
+      - name: Clone Documentation Repository
+        env:
+            SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: |
+          git config --global user.email "docbot@cvc5"
+          git config --global user.name "DocBot"
+          git clone git@github.com:cvc5/docs-ci.git target/
+      
+      - name: Download artifact
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "documentation"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/download.zip', Buffer.from(download.data));
+
+      - name: Unpack artifact
+        run: unzip download.zip -d docs-new/
+
+      - name: Update docs
+        continue-on-error: true
+        env:
+            SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: |
+          if [ -n "$NAME" ]; then
+            mv docs-new target/docs-$NAME-$HASH
+            cd target/
+            rm -f docs-$NAME
+            ln -s docs-$NAME-$HASH docs-$NAME
+            git add docs-$NAME docs-$NAME-$HASH
+
+            python3 genindex.py
+            git add README.md
+            git commit -m "Update docs for $NAME"
+
+            git push
+          else
+            echo "Ignored run"
+          fi
+
+
+
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      - run: unzip pr.zip
+
+      - name: 'Comment on PR'
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var fs = require('fs');
+            var issue_number = Number(fs.readFileSync('./NR'));
+            await github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: 'Everything is OK. Thank you for the PR!'
+            });

--- a/.github/workflows/docs_upload.yml
+++ b/.github/workflows/docs_upload.yml
@@ -11,6 +11,7 @@ jobs:
     name: upload-docs
     runs-on: ubuntu-latest
     continue-on-error: true
+    #if: runs in upstream repository
     steps:
       - name: Setup Deploy Key
         env:
@@ -86,41 +87,3 @@ jobs:
           else
             echo "Ignored run"
           fi
-
-
-
-      - name: 'Download artifact'
-        uses: actions/github-script@v3.1.0
-        with:
-          script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: ${{github.event.workflow_run.id }},
-            });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "pr"
-            })[0];
-            var download = await github.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
-      - run: unzip pr.zip
-
-      - name: 'Comment on PR'
-        uses: actions/github-script@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            var fs = require('fs');
-            var issue_number = Number(fs.readFileSync('./NR'));
-            await github.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue_number,
-              body: 'Everything is OK. Thank you for the PR!'
-            });

--- a/.github/workflows/docs_upload.yml
+++ b/.github/workflows/docs_upload.yml
@@ -11,7 +11,7 @@ jobs:
     name: upload-docs
     runs-on: ubuntu-latest
     continue-on-error: true
-    #if: runs in upstream repository
+    if: github.repository == 'cvc5/cvc5'
     steps:
       - name: Setup Deploy Key
         env:


### PR DESCRIPTION
This PR (finally, I hope) uses a proper setup for uploading the documentation. One of the CI jobs generates the documentation and stores it in an artifact. Another workflow is triggered (via `workflow_run`) and then uploads this artifact. Only this setup seems to properly work for PR builds.