### PR TITLE
Restrict additional CI jobs

### DIFF
--- a/.github/workflows/docs_upload.yml
+++ b/.github/workflows/docs_upload.yml
@@ -11,7 +11,7 @@ jobs:
     name: upload-docs
     runs-on: ubuntu-latest
     continue-on-error: true
-    if: github.repository == 'cvc5/cvc5'
+    if: github.repository == 'cvc5/cvc5' && github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Setup Deploy Key
         env:

--- a/.github/workflows/update_pr.yml
+++ b/.github/workflows/update_pr.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   autoupdate:
     runs-on: ubuntu-latest
+    if: github.repository == 'cvc5/cvc5'
     steps:
       - name: Automatically update PR
         uses: adRise/update-pr-branch@v0.5.1


### PR DESCRIPTION
The new upload-docs CI job is currently run unconditionally after the CI job finishes. It can only work, though, if the CI job worked and stored an artifact. The PR update job is run for all commits on master, though it only has the necessary token when running on the main repository.
This PR restricts both jobs to cases where they work.