### PR TITLE
`STRINGS_CTN_DECOMPOSE`: Avoid multiple conflicts

### DIFF
--- a/src/theory/strings/extf_solver.cpp
+++ b/src/theory/strings/extf_solver.cpp
@@ -548,6 +548,8 @@ void ExtfSolver::checkExtfInference(Node n,
             {
               // we are in conflict
               d_im.sendInference(in.d_exp, conc, InferenceId::STRINGS_CTN_DECOMPOSE);
+              Assert(d_state.isInConflict());
+              return;
             }
             else if (d_extt.hasFunctionKind(conc.getKind()))
             {

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1132,6 +1132,7 @@ set(regress_0_tests
   regress0/strings/issue5090.smt2
   regress0/strings/issue5384-double-conflict.smt2
   regress0/strings/issue5428-re-diff-assoc.smt2
+  regress0/strings/issue5508-multiple-conflicts.smt2
   regress0/strings/issue5542-strings-seq-mix.smt2
   regress0/strings/issue5608-eager-pp.smt2
   regress0/strings/issue5666-orig-unit-deq.smt2

--- a/test/regress/regress0/strings/issue5508-multiple-conflicts.smt2
+++ b/test/regress/regress0/strings/issue5508-multiple-conflicts.smt2
@@ -1,0 +1,8 @@
+(set-logic QF_SLIA)
+(declare-fun i2 () Int)
+(declare-fun str10 () String)
+(declare-fun str19 () String)
+(declare-fun i19 () Int)
+(assert (str.contains (str.from_int i2) (str.++ str19 "uKykCsFtVM" (str.from_int i19) "hORknmKIFtylbjBJVLsMNyAUKzpayeBQPHqN" str10)))
+(set-info :status unsat)
+(check-sat)


### PR DESCRIPTION
Fixes #5508. `STRINGS_CTN_DECOMPOSE` could be triggered multiple times
by the same term, which resulted in an assertion failure. This commit
returns immediately after the first conflict to avoid the assertion
failure.