### PR TITLE
Remove Options::ref()

### DIFF
--- a/src/options/mkoptions.py
+++ b/src/options/mkoptions.py
@@ -139,17 +139,6 @@ TPL_OPTION_STRUCT_RW = \
   type operator()() const;
 }} thread_local {name};"""
 
-TPL_DECL_SET = \
-"""template <> options::{name}__option_t::type& Options::ref(
-    options::{name}__option_t);"""
-
-TPL_IMPL_SET = TPL_DECL_SET[:-1] + \
-"""
-{{
-    return {module}.{name};
-}}"""
-
-
 TPL_DECL_OP_BRACKET = \
 """template <> const options::{name}__option_t::type& Options::operator[](
     options::{name}__option_t) const;"""
@@ -612,7 +601,6 @@ def codegen_module(module, dst_dir, tpl_module_h, tpl_module_cpp):
 
         # Generate module specialization
         default_decl.append(TPL_DECL_SET_DEFAULT.format(module=module.id, name=option.name, funcname=capoptionname, type=option.type))
-        specs.append(TPL_DECL_SET.format(name=option.name))
         specs.append(TPL_DECL_OP_BRACKET.format(name=option.name))
         specs.append(TPL_DECL_WAS_SET_BY_USER.format(name=option.name))
 
@@ -635,7 +623,6 @@ def codegen_module(module, dst_dir, tpl_module_h, tpl_module_cpp):
 
         # Accessors
         default_impl.append(TPL_IMPL_SET_DEFAULT.format(module=module.id, name=option.name, funcname=capoptionname, type=option.type))
-        accs.append(TPL_IMPL_SET.format(module=module.id, name=option.name))
         accs.append(TPL_IMPL_OP_BRACKET.format(module=module.id, name=option.name))
         accs.append(TPL_IMPL_WAS_SET_BY_USER.format(module=module.id, name=option.name))
 

--- a/src/options/options_template.cpp
+++ b/src/options/options_template.cpp
@@ -242,14 +242,6 @@ ${holder_mem_copy}$
   }
 }
 
-std::string Options::formatThreadOptionException(const std::string& option) {
-  std::stringstream ss;
-  ss << "can't understand option `" << option
-     << "': expected something like --threadN=\"--option1 --option2\","
-     << " where N is a nonnegative integer";
-  return ss.str();
-}
-
 void Options::setListener(OptionsListener* ol) { d_olisten = ol; }
 
 // clang-format off

--- a/src/options/options_template.h
+++ b/src/options/options_template.h
@@ -84,8 +84,6 @@ ${holder_ref_decls}$
    */
   Options& operator=(const Options& options) = delete;
 
-  static std::string formatThreadOptionException(const std::string& option);
-
 public:
  class OptionsScope
  {
@@ -122,19 +120,6 @@ public:
    * This does not copy the listeners in the Options object.
    */
   void copyValues(const Options& options);
-
-  /**
-   * Get a non-const reference to the value of the given option. Causes a
-   * compile-time error if the given option is read-only. Writeable options
-   * specialize this template with a real implementation.
-   */
-  template <class T>
-  typename T::type& ref(T) {
-    // Flag a compile-time error.
-    T::you_are_trying_to_get_nonconst_access_to_a_read_only_option;
-    // Ensure the compiler does not complain about the return value.
-    return *static_cast<typename T::type*>(nullptr);
-  }
 
   /**
    * Set the value of the given option by key.


### PR DESCRIPTION
This PR gets rid of the templated `Options::ref()` method (and all its specializations for every option).