### PR TITLE
docs: Migrate input languages page.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,5 +18,6 @@ Table of Contents
    binary/binary
    api/api
    examples/examples
+   languages
    references
    genindex

--- a/docs/languages.rst
+++ b/docs/languages.rst
@@ -1,0 +1,8 @@
+Input Languages
+===============
+
+cvc5 supports the following input languages:
+
+* `SMT-LIB v2 <http://smtlib.cs.uiowa.edu/language.shtml>`_
+* `SyGuS-IF <https://sygus.org/language/>`_
+* `TPTP <http://www.tptp.org/>`_


### PR DESCRIPTION
This migrates page https://cvc4.github.io/input-languages.