### PR TITLE
[GitHub Actions] Make caching of dependencies depend on image version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,10 @@ jobs:
         sudo cmake .
         sudo cmake --build . --target install
         cd -
+        # Make ImageVersion accessible as env.image_version. Environment
+        # variables of the runner are not automatically imported:
+        #
+        # https://github.com/actions/runner/blob/master/docs/adrs/0278-env-context.md#dont-populate-the-env-context-with-environment-variables-from-runner-machine
         echo "image_version=$ImageVersion" >> $GITHUB_ENV
         echo "/usr/lib/ccache" >> $GITHUB_PATH
 
@@ -95,6 +99,10 @@ jobs:
         python3 -m pip install toml
         python3 -m pip install setuptools
         python3 -m pip install pexpect
+        # Make ImageVersion accessible as env.image_version. Environment
+        # variables of the runner are not automatically imported:
+        #
+        # https://github.com/actions/runner/blob/master/docs/adrs/0278-env-context.md#dont-populate-the-env-context-with-environment-variables-from-runner-machine
         echo "image_version=$ImageVersion" >> $GITHUB_ENV
         echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
 
@@ -173,6 +181,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: build/deps
+        # The cache depends on the image version to make sure that we do not
+        # restore the dependencies if the build environment has changed.
         key: cvc5-deps-${{ runner.os }}-${{ env.image_version }}-${{ matrix.cache-key }}-${{ hashFiles('cmake/Find**', 'cmake/deps-helper.cmake') }}-${{ hashFiles('.github/workflows/ci.yml') }}
 
     - name: Configure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Install Packages
       if: runner.os == 'Linux'
       run: |
-        echo $ImageVersion
+        echo ${{ env.ImageVersion }}
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \
@@ -78,6 +78,7 @@ jobs:
         sudo cmake .
         sudo cmake --build . --target install
         cd -
+        echo "image_version=$ImageVersion" >> $GITHUB_ENV
         echo "/usr/lib/ccache" >> $GITHUB_PATH
 
     # Note: macOS comes with a libedit; it does not need to brew-installed
@@ -94,6 +95,7 @@ jobs:
         python3 -m pip install toml
         python3 -m pip install setuptools
         python3 -m pip install pexpect
+        echo "image_version=$ImageVersion" >> $GITHUB_ENV
         echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
 
     - name: Install Python Dependencies
@@ -171,7 +173,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: build/deps
-        key: cvc5-deps-${{ runner.os }}-${{ matrix.env.ImageVersion }}-${{ matrix.cache-key }}-${{ hashFiles('cmake/Find**', 'cmake/deps-helper.cmake') }}-${{ hashFiles('.github/workflows/ci.yml') }}
+        key: cvc5-deps-${{ runner.os }}-${{ env.image_version }}-${{ matrix.cache-key }}-${{ hashFiles('cmake/Find**', 'cmake/deps-helper.cmake') }}-${{ hashFiles('.github/workflows/ci.yml') }}
 
     - name: Configure
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
             os: ubuntu-latest
             env: CC=clang CXX=clang++
             config: production --auto-download
-            cache-key: clangproduction
+            cache-key: productionclang
             check-examples: true
             exclude_regress: 3-4
             run_regression_args: --no-check-unsat-cores --no-check-proofs
@@ -45,7 +45,7 @@ jobs:
             os: ubuntu-latest
             env: CC=clang CXX=clang++
             config: production --auto-download --assertions --tracing --cln --gpl
-            cache-key: clangdbg
+            cache-key: dbgclang
             exclude_regress: 3-4
             run_regression_args: --no-check-proofs
 
@@ -59,6 +59,7 @@ jobs:
     - name: Install Packages
       if: runner.os == 'Linux'
       run: |
+        echo {{ matrix.env.ImageVersion }}
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \
@@ -170,7 +171,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: build/deps
-        key: cvc5-deps-${{ runner.os }}-${{ matrix.cache-key }}-${{ hashFiles('cmake/Find**', 'cmake/deps-helper.cmake') }}-${{ hashFiles('.github/workflows/ci.yml') }}
+        key: cvc5-deps-${{ runner.os }}-${{ matrix.env.ImageVersion }}-${{ matrix.cache-key }}-${{ hashFiles('cmake/Find**', 'cmake/deps-helper.cmake') }}-${{ hashFiles('.github/workflows/ci.yml') }}
 
     - name: Configure
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,7 @@ jobs:
     - name: Install Packages
       if: runner.os == 'Linux'
       run: |
-        echo $IMAGE_VERSION
-        echo $GITHUB_PATH
+        echo ${{ job.container.id }}
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         source <(grep /etc/environment ImageVersion)
-        echo ${{ env.ImageVersion }}
+        echo $ImageVersion
         echo $ImageVersion
         sudo apt-get update
         sudo apt-get install -y \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
     - name: Install Packages
       if: runner.os == 'Linux'
       run: |
-        echo ${{ env.ImageVersion }}
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Install Packages
       if: runner.os == 'Linux'
       run: |
-        echo ${{ env.IMAGE_VERSION }}
+        echo $IMAGE_VERSION
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         echo $IMAGE_VERSION
+        echo $GITHUB_PATH
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Install Packages
       if: runner.os == 'Linux'
       run: |
-        cat /etc/environment
+        source <(grep /etc/environment ImageVersion)
         echo ${{ env.ImageVersion }}
         echo $ImageVersion
         sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Install Packages
       if: runner.os == 'Linux'
       run: |
-        echo ${{ matrix.env.ImageVersion }}
+        echo ${{ user `image_version` }}
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Install Packages
       if: runner.os == 'Linux'
       run: |
-        echo {{ matrix.env.ImageVersion }}
+        echo ${{ matrix.env.ImageVersion }}
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,6 @@ jobs:
     - name: Install Packages
       if: runner.os == 'Linux'
       run: |
-        source <(grep /etc/environment ImageVersion)
-        echo $ImageVersion
         echo $ImageVersion
         sudo apt-get update
         sudo apt-get install -y \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         cat /etc/environment
+        echo ${{ env.ImageVersion }}
+        echo $ImageVersion
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Install Packages
       if: runner.os == 'Linux'
       run: |
-        echo ${{ user `image_version` }}
+        echo ${{ env.IMAGE_VERSION }}
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
             os: ubuntu-latest
             env: CC=clang CXX=clang++
             config: production --auto-download
-            cache-key: productionclang
+            cache-key: clangproduction
             check-examples: true
             exclude_regress: 3-4
             run_regression_args: --no-check-unsat-cores --no-check-proofs
@@ -45,7 +45,7 @@ jobs:
             os: ubuntu-latest
             env: CC=clang CXX=clang++
             config: production --auto-download --assertions --tracing --cln --gpl
-            cache-key: dbgclang
+            cache-key: clangdbg
             exclude_regress: 3-4
             run_regression_args: --no-check-proofs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Install Packages
       if: runner.os == 'Linux'
       run: |
-        echo ${{ job.container.id }}
+        cat /etc/environment
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \


### PR DESCRIPTION
Our Clang builds started to fail to link when the environment changed. This commit changes our CI to only use cached dependencies if the build environment has not changed.