### PR TITLE
Better support for HOL parsing and set up

### DIFF
--- a/src/options/options_public.cpp
+++ b/src/options/options_public.cpp
@@ -76,6 +76,7 @@ bool getIncrementalSolving(const Options& opts)
 bool getLanguageHelp(const Options& opts) { return opts.base.languageHelp; }
 bool getMemoryMap(const Options& opts) { return opts.parser.memoryMap; }
 bool getParseOnly(const Options& opts) { return opts.base.parseOnly; }
+bool getHOL(const Options& opts) { return opts.parser.hol; }
 bool getProduceModels(const Options& opts) { return opts.smt.produceModels; }
 bool getSemanticChecks(const Options& opts)
 {

--- a/src/options/options_public.h
+++ b/src/options/options_public.h
@@ -43,6 +43,7 @@ bool getIncrementalSolving(const Options& opts) CVC5_EXPORT;
 bool getLanguageHelp(const Options& opts) CVC5_EXPORT;
 bool getMemoryMap(const Options& opts) CVC5_EXPORT;
 bool getParseOnly(const Options& opts) CVC5_EXPORT;
+bool getHOL(const Options& opts) CVC5_EXPORT;
 bool getProduceModels(const Options& opts) CVC5_EXPORT;
 bool getSemanticChecks(const Options& opts) CVC5_EXPORT;
 bool getStatistics(const Options& opts) CVC5_EXPORT;

--- a/src/options/parser_options.toml
+++ b/src/options/parser_options.toml
@@ -2,6 +2,14 @@ id     = "PARSER"
 name   = "Parser"
 
 [[option]]
+  name       = "hol"
+  category   = "regular"
+  long       = "hol"
+  type       = "bool"
+  default    = "false"
+  help       = "Force higher-order logic."
+
+[[option]]
   name       = "strictParsing"
   category   = "common"
   long       = "strict-parsing"

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -118,8 +118,8 @@ api::Term Parser::getExpressionForNameAndType(const std::string& name,
   if(expr.isNull()) {
     // the variable is overloaded, try with type if the type exists
     if(!t.isNull()) {
-      // if we decide later to support annotations for function types, this will update to
-      // separate t into ( argument types, return type )
+      // if we decide later to support annotations for function types, this will
+      // update to separate t into ( argument types, return type )
       expr = getOverloadedConstantForType(name, t);
       if(expr.isNull()) {
         parseError("Cannot get overloaded constant for type ascription.");

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -51,10 +51,10 @@ Parser::Parser(api::Solver* solver,
       d_strictMode(strictMode),
       d_parseOnly(parseOnly),
       d_canIncludeFile(true),
-      d_hol(false),
       d_logicIsForced(false),
       d_forcedLogic(),
-      d_solver(solver)
+      d_solver(solver),
+      d_hol(false)
 {
 }
 

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -51,6 +51,7 @@ Parser::Parser(api::Solver* solver,
       d_strictMode(strictMode),
       d_parseOnly(parseOnly),
       d_canIncludeFile(true),
+      d_hol(false),
       d_logicIsForced(false),
       d_forcedLogic(),
       d_solver(solver)
@@ -84,6 +85,14 @@ void Parser::forceLogic(const std::string& logic)
   d_forcedLogic = logic;
 }
 
+void Parser::setHOL()
+{
+  Assert(!d_hol);
+  d_hol = true;
+}
+
+bool Parser::isHOL() const { return d_hol; }
+
 api::Term Parser::getVariable(const std::string& name)
 {
   return getSymbol(name, SYM_VARIABLE);
@@ -109,7 +118,7 @@ api::Term Parser::getExpressionForNameAndType(const std::string& name,
   if(expr.isNull()) {
     // the variable is overloaded, try with type if the type exists
     if(!t.isNull()) {
-      // if we decide later to support annotations for function types, this will update to 
+      // if we decide later to support annotations for function types, this will update to
       // separate t into ( argument types, return type )
       expr = getOverloadedConstantForType(name, t);
       if(expr.isNull()) {

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -149,9 +149,6 @@ private:
   */
  bool d_canIncludeFile;
 
- /** Whether the logic is higher order. */
- bool d_hol;
-
  /**
   * Whether the logic has been forced with --force-logic.
   */
@@ -194,6 +191,9 @@ private:
 protected:
  /** The API Solver object. */
  api::Solver* d_solver;
+
+ /** Whether the logic is higher order. */
+ Bool d_hol;
 
  /**
   * Create a parser state.
@@ -268,7 +268,7 @@ public:
   bool canIncludeFile() const { return d_canIncludeFile; }
 
   /** Set parser to accept higher-order logic. */
-  void setHOL();
+  virtual void setHOL();
 
   /** Expose the functionality from SMT/SMT2 parsers, while making
       implementation optional by returning false by default. */

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -149,6 +149,9 @@ private:
   */
  bool d_canIncludeFile;
 
+ /** Whether the logic is higher order. */
+ bool d_hol;
+
  /**
   * Whether the logic has been forced with --force-logic.
   */
@@ -264,11 +267,17 @@ public:
   void disallowIncludeFile() { d_canIncludeFile = false; }
   bool canIncludeFile() const { return d_canIncludeFile; }
 
+  /** Set parser to accept higher-order logic. */
+  void setHOL();
+
   /** Expose the functionality from SMT/SMT2 parsers, while making
       implementation optional by returning false by default. */
   virtual bool logicIsSet() { return false; }
 
   virtual void forceLogic(const std::string& logic);
+
+  /** Whether higher-order logic. */
+  bool isHOL() const;
 
   const std::string& getForcedLogic() const { return d_forcedLogic; }
   bool logicIsForced() const { return d_logicIsForced; }
@@ -305,7 +314,7 @@ public:
   /**
    * Returns the expression that name should be interpreted as, based on the current binding.
    *
-   * This is the same as above but where the name has been type cast to t. 
+   * This is the same as above but where the name has been type cast to t.
    */
   virtual api::Term getExpressionForNameAndType(const std::string& name,
                                                 api::Sort t);
@@ -331,9 +340,9 @@ public:
    * This is a generalization of ExprManager::operatorToKind that also
    * handles variables whose types are "function-like", i.e. where
    * checkFunctionLike(fun) returns true.
-   * 
+   *
    * For examples of the latter, this function returns
-   *   APPLY_UF if fun has function type, 
+   *   APPLY_UF if fun has function type,
    *   APPLY_CONSTRUCTOR if fun has constructor type.
    */
   api::Kind getKindForFunction(api::Term fun);
@@ -379,7 +388,7 @@ public:
 
   /**
    * Checks whether the given expression is function-like, i.e.
-   * it expects arguments. This is checked by looking at the type 
+   * it expects arguments. This is checked by looking at the type
    * of fun. Examples of function types are function, constructor,
    * selector, tester.
    * @param fun the expression to check
@@ -443,7 +452,7 @@ public:
   std::vector<api::Term> bindBoundVars(const std::vector<std::string> names,
                                        const api::Sort& type);
 
-  /** Create a new variable definition (e.g., from a let binding). 
+  /** Create a new variable definition (e.g., from a let binding).
    * levelZero is set if the binding must be done at level 0.
    * If a symbol with name already exists,
    *  then if doOverload is true, we create overloaded operators.
@@ -648,7 +657,7 @@ public:
   /** Is the symbol bound to a boolean variable? */
   bool isBoolean(const std::string& name);
 
-  /** Is fun a function (or function-like thing)? 
+  /** Is fun a function (or function-like thing)?
   * Currently this means its type is either a function, constructor, tester, or selector.
   */
   bool isFunctionLike(api::Term fun);

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -312,7 +312,8 @@ public:
   virtual api::Term getExpressionForName(const std::string& name);
 
   /**
-   * Returns the expression that name should be interpreted as, based on the current binding.
+   * Returns the expression that name should be interpreted as, based on the
+   * current binding.
    *
    * This is the same as above but where the name has been type cast to t.
    */
@@ -456,7 +457,8 @@ public:
    * levelZero is set if the binding must be done at level 0.
    * If a symbol with name already exists,
    *  then if doOverload is true, we create overloaded operators.
-   *  else if doOverload is false, the existing expression is shadowed by the new expression.
+   *  else if doOverload is false, the existing expression is shadowed by the
+   * new expression.
    */
   void defineVar(const std::string& name,
                  const api::Term& val,
@@ -658,8 +660,9 @@ public:
   bool isBoolean(const std::string& name);
 
   /** Is fun a function (or function-like thing)?
-  * Currently this means its type is either a function, constructor, tester, or selector.
-  */
+   * Currently this means its type is either a function, constructor, tester, or
+   * selector.
+   */
   bool isFunctionLike(api::Term fun);
 
   /** Is the symbol bound to a predicate? */

--- a/src/parser/parser_builder.cpp
+++ b/src/parser/parser_builder.cpp
@@ -56,6 +56,7 @@ void ParserBuilder::init(api::Solver* solver, SymbolManager* sm)
   d_strictMode = false;
   d_canIncludeFile = true;
   d_parseOnly = false;
+  d_hol = false;
   d_logicIsForced = false;
   d_forcedLogic = "";
 }
@@ -95,6 +96,11 @@ Parser* ParserBuilder::build()
     parser->disallowIncludeFile();
   }
 
+  if (d_hol)
+  {
+    parser->setHOL();
+  }
+
   if( d_logicIsForced ) {
     parser->forceLogic(d_forcedLogic);
   }
@@ -117,6 +123,12 @@ ParserBuilder& ParserBuilder::withParseOnly(bool flag) {
   return *this;
 }
 
+ParserBuilder& ParserBuilder::withHOL(bool flag)
+{
+  d_hol = flag;
+  return *this;
+}
+
 ParserBuilder& ParserBuilder::withOptions(const Options& opts)
 {
   ParserBuilder& retval = *this;
@@ -124,6 +136,7 @@ ParserBuilder& ParserBuilder::withOptions(const Options& opts)
                .withChecks(options::getSemanticChecks(opts))
                .withStrictMode(options::getStrictParsing(opts))
                .withParseOnly(options::getParseOnly(opts))
+               .withHOL(options::getHOL(opts))
                .withIncludeFile(options::getFilesystemAccess(opts));
   if (options::wasSetByUserForceLogicString(opts))
   {
@@ -143,9 +156,19 @@ ParserBuilder& ParserBuilder::withIncludeFile(bool flag) {
   return *this;
 }
 
-ParserBuilder& ParserBuilder::withForcedLogic(const std::string& logic) {
+ParserBuilder& ParserBuilder::withForcedLogic(const std::string& logic)
+{
   d_logicIsForced = true;
-  d_forcedLogic = logic;
+  if (d_hol)
+  {
+    std::stringstream ss;
+    ss << "HO_" << logic;
+    d_forcedLogic = ss.str();
+  }
+  else
+  {
+    d_forcedLogic = logic;
+  }
   return *this;
 }
 

--- a/src/parser/parser_builder.h
+++ b/src/parser/parser_builder.h
@@ -65,6 +65,9 @@ class CVC5_EXPORT ParserBuilder
   /** Are we parsing only? */
   bool d_parseOnly;
 
+  /** Is the logic higher order? */
+  bool d_hol;
+
   /** Is the logic forced by the user? */
   bool d_logicIsForced;
 
@@ -107,6 +110,9 @@ class CVC5_EXPORT ParserBuilder
    * language parser).
    */
   ParserBuilder& withParseOnly(bool flag = true);
+
+  /** Set the parser to use higher-order logic. */
+  ParserBuilder& withHOL(bool flag = true);
 
   /** Derive settings from the given options. */
   ParserBuilder& withOptions(const Options& opts);

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -315,10 +315,7 @@ bool Smt2::isTheoryEnabled(theory::TheoryId theory) const
   return d_logic.isTheoryEnabled(theory);
 }
 
-bool Smt2::isHoEnabled() const
-{
-  return d_logic.isHigherOrder();
-}
+bool Smt2::isHoEnabled() const { return d_logic.isHigherOrder(); }
 
 bool Smt2::logicIsSet() {
   return d_logicSet;

--- a/src/parser/tptp/tptp.h
+++ b/src/parser/tptp/tptp.h
@@ -184,6 +184,8 @@ class Tptp : public Parser {
  private:
   void addArithmeticOperators();
 
+  void setHOL() override;
+
   // In CNF variable are implicitly binded
   // d_freevar collect them
   std::vector<api::Term> d_freeVar;

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -762,7 +762,7 @@ void setDefaults(LogicInfo& logic, bool isInternalSubsolver)
   }
 
   // If in arrays, set the UF handler to arrays
-  if (logic.isTheoryEnabled(THEORY_ARRAYS) && !options::ufHo()
+  if (logic.isTheoryEnabled(THEORY_ARRAYS) && !logic.isHigherOrder()
       && !options::finiteModelFind()
       && (!logic.isQuantified()
           || (logic.isQuantified() && !logic.isTheoryEnabled(THEORY_UF))))
@@ -995,8 +995,9 @@ void setDefaults(LogicInfo& logic, bool isInternalSubsolver)
       opts.quantifiers.prenexQuant = options::PrenexQuantMode::NONE;
     }
   }
-  if (options::ufHo())
+  if (logic.isHigherOrder())
   {
+    opts.uf.ufHo = true;
     // if higher-order, then current variants of model-based instantiation
     // cannot be used
     if (options::mbqiMode() != options::MbqiMode::NONE)

--- a/src/theory/logic_info.cpp
+++ b/src/theory/logic_info.cpp
@@ -39,7 +39,7 @@ LogicInfo::LogicInfo()
       d_linear(false),
       d_differenceLogic(false),
       d_cardinalityConstraints(false),
-      d_higherOrder(true),
+      d_higherOrder(false),
       d_locked(false)
 {
   for (TheoryId id = THEORY_FIRST; id < THEORY_LAST; ++id)
@@ -309,7 +309,7 @@ std::string LogicInfo::getLogicString() const {
       if(d_theories[THEORY_FP]) {
         ss << "FP";
         ++seen;
-      } 
+      }
       if(d_theories[THEORY_DATATYPES]) {
         ss << "DT";
         ++seen;
@@ -373,7 +373,14 @@ void LogicInfo::setLogicString(std::string logicString)
   enableTheory(THEORY_BUILTIN);
   enableTheory(THEORY_BOOL);
 
+  bool isHOL = false;
+
   const char* p = logicString.c_str();
+  if (!strncmp(p, "HO_", 3))
+  {
+    isHOL = true;
+    p += 3;
+  }
   if(*p == '\0') {
     // propositional logic only; we're done.
   } else if(!strcmp(p, "QF_SAT")) {
@@ -535,6 +542,11 @@ void LogicInfo::setLogicString(std::string logicString)
       err << "junk (\"" << p << "\") at end of logic string: " << logicString;
     }
     IllegalArgument(logicString, err.str().c_str());
+  }
+
+  if (isHOL)
+  {
+    enableHigherOrder();
   }
 
   // ensure a getLogic() returns the same thing as was set

--- a/test/regress/regress0/declare-fun-is-match.smt2
+++ b/test/regress/regress0/declare-fun-is-match.smt2
@@ -1,5 +1,5 @@
 ; EXPECT: sat
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 (set-info :smt-lib-version 2.6)
 (set-logic UFIDL)
 (set-info :status sat)

--- a/test/regress/regress0/fp/issue4277-assign-func.smt2
+++ b/test/regress/regress0/fp/issue4277-assign-func.smt2
@@ -1,8 +1,7 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE: -q --hol
 ; EXPECT: sat
 ; REQUIRES: symfpu
 (set-logic ALL)
-(set-option :uf-ho true)
 (set-option :assign-function-values false)
 (set-info :status sat)
 (declare-fun b () (_ BitVec 1))

--- a/test/regress/regress0/ho/apply-collapse-sat.smt2
+++ b/test/regress/regress0/ho/apply-collapse-sat.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: sat
 (set-logic UF)
 (set-info :status sat)

--- a/test/regress/regress0/ho/apply-collapse-unsat.smt2
+++ b/test/regress/regress0/ho/apply-collapse-unsat.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic UF)
 (set-info :status unsat)

--- a/test/regress/regress0/ho/bug_nodbuilding_interpreted_SYO042^1.p
+++ b/test/regress/regress0/ho/bug_nodbuilding_interpreted_SYO042^1.p
@@ -1,4 +1,4 @@
-% COMMAND-LINE:  --uf-ho
+% COMMAND-LINE:  --hol
 % EXPECT: % SZS status Unsatisfiable for bug_nodbuilding_interpreted_SYO042^1
 
 %------------------------------------------------------------------------------

--- a/test/regress/regress0/ho/cong-full-apply.smt2
+++ b/test/regress/regress0/ho/cong-full-apply.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic UFLIA)
 (set-info :status unsat)

--- a/test/regress/regress0/ho/cong.smt2
+++ b/test/regress/regress0/ho/cong.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic UF)
 (set-info :status unsat)

--- a/test/regress/regress0/ho/declare-fun-variants.smt2
+++ b/test/regress/regress0/ho/declare-fun-variants.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/regress0/ho/def-fun-flatten.smt2
+++ b/test/regress/regress0/ho/def-fun-flatten.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/regress0/ho/ext-finite-unsat.smt2
+++ b/test/regress/regress0/ho/ext-finite-unsat.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic UF)
 (set-info :status unsat)

--- a/test/regress/regress0/ho/ext-ho-nested-lambda-model.smt2
+++ b/test/regress/regress0/ho/ext-ho-nested-lambda-model.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/regress0/ho/ext-ho.smt2
+++ b/test/regress/regress0/ho/ext-ho.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/regress0/ho/ext-sat-partial-eval.smt2
+++ b/test/regress/regress0/ho/ext-sat-partial-eval.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: sat
 (set-logic UF)
 (set-info :status sat)

--- a/test/regress/regress0/ho/ext-sat.smt2
+++ b/test/regress/regress0/ho/ext-sat.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: sat
 (set-logic UF)
 (set-info :status sat)

--- a/test/regress/regress0/ho/finite-fun-ext.smt2
+++ b/test/regress/regress0/ho/finite-fun-ext.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic ALL)
 

--- a/test/regress/regress0/ho/fta0144-alpha-eq.smt2
+++ b/test/regress/regress0/ho/fta0144-alpha-eq.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-sort Nat$ 0)

--- a/test/regress/regress0/ho/fta0210.smt2
+++ b/test/regress/regress0/ho/fta0210.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-sort A$ 0)

--- a/test/regress/regress0/ho/fun-subtyping.smt2
+++ b/test/regress/regress0/ho/fun-subtyping.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun g (Int) Real)

--- a/test/regress/regress0/ho/ho-exponential-model.smt2
+++ b/test/regress/regress0/ho/ho-exponential-model.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: sat
 (set-logic UFLIA)
 (set-info :status sat)

--- a/test/regress/regress0/ho/ho-match-fun-suffix.smt2
+++ b/test/regress/regress0/ho/ho-match-fun-suffix.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/regress0/ho/ho-matching-enum-2.smt2
+++ b/test/regress/regress0/ho/ho-matching-enum-2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/regress0/ho/ho-matching-enum.smt2
+++ b/test/regress/regress0/ho/ho-matching-enum.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/regress0/ho/ho-matching-nested-app.smt2
+++ b/test/regress/regress0/ho/ho-matching-nested-app.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/regress0/ho/ho-std-fmf.smt2
+++ b/test/regress/regress0/ho/ho-std-fmf.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho --finite-model-find
+; COMMAND-LINE: --hol --finite-model-find
 ; EXPECT: sat
 (set-logic UF)
 (set-info :status sat)

--- a/test/regress/regress0/ho/hoa0008.smt2
+++ b/test/regress/regress0/ho/hoa0008.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-sort A$ 0)

--- a/test/regress/regress0/ho/issue4990-care-graph.smt2
+++ b/test/regress/regress0/ho/issue4990-care-graph.smt2
@@ -1,7 +1,6 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: sat
 (set-logic QF_AUFBVLIA)
-(set-option :uf-ho true)
 (declare-fun a () Int)
 (declare-fun b () Int)
 (declare-fun c (Int) Int)

--- a/test/regress/regress0/ho/issue5233-part1-usort-owner.smt2
+++ b/test/regress/regress0/ho/issue5233-part1-usort-owner.smt2
@@ -1,7 +1,6 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: sat
 (set-logic QF_AUFBVLIA)
-(set-option :uf-ho true)
 (declare-fun a (Int) Int)
 (declare-fun b (Int) Int)
 (assert (distinct a b))

--- a/test/regress/regress0/ho/ite-apply-eq.smt2
+++ b/test/regress/regress0/ho/ite-apply-eq.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: sat
 (set-logic UFLIA)
 (set-info :status sat)

--- a/test/regress/regress0/ho/lambda-equality-non-canon.smt2
+++ b/test/regress/regress0/ho/lambda-equality-non-canon.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/regress0/ho/match-middle.smt2
+++ b/test/regress/regress0/ho/match-middle.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic UFLIA)
 (set-info :status unsat)

--- a/test/regress/regress0/ho/modulo-func-equality.smt2
+++ b/test/regress/regress0/ho/modulo-func-equality.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic UFLIA)
 (set-info :status unsat)

--- a/test/regress/regress0/ho/shadowing-defs.smt2
+++ b/test/regress/regress0/ho/shadowing-defs.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unknown
 (set-logic ALL)
 (declare-sort $$unsorted 0)

--- a/test/regress/regress0/ho/simple-matching-partial.smt2
+++ b/test/regress/regress0/ho/simple-matching-partial.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/regress0/ho/simple-matching.smt2
+++ b/test/regress/regress0/ho/simple-matching.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/regress0/ho/trans.smt2
+++ b/test/regress/regress0/ho/trans.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic UF)
 (set-info :status unsat)

--- a/test/regress/regress0/sygus/pLTL-sygus-syntax-err.sy
+++ b/test/regress/regress0/sygus/pLTL-sygus-syntax-err.sy
@@ -1,7 +1,7 @@
 ; REQUIRES: no-competition
-; COMMAND-LINE: --sygus-out=status --sygus-rec-fun --lang=sygus2
+; COMMAND-LINE: --sygus-out=status --sygus-rec-fun --lang=sygus2 --hol
 ; EXPECT-ERROR: (error "Parse Error: pLTL-sygus-syntax-err.sy:80.19: number of arguments does not match the constructor type
-; EXPECT-ERROR: 
+; EXPECT-ERROR:
 ; EXPECT-ERROR: (Op2 <O2> <F>)
 ; EXPECT-ERROR: ^
 ; EXPECT-ERROR: ")
@@ -10,7 +10,7 @@
 (set-option :lang sygus2)
 ;(set-option :sygus-out status)
 (set-option :sygus-rec-fun true)
-(set-option :uf-ho true)
+
 
 (define-sort Time () Int)
 
@@ -47,19 +47,19 @@
   (and (<= 0 t tn)
        (match f (
          ((P i) (val t i))
-      
-         ((Op1 op g) 
-           (match op (
-             (NOT (not (holds g t))) 
 
-             (Y (and (< 0 t) (holds g (- t 1))))    
+         ((Op1 op g)
+           (match op (
+             (NOT (not (holds g t)))
+
+             (Y (and (< 0 t) (holds g (- t 1))))
 
              (G (and (holds g t) (or (= t tn) (holds f (+ t 1)))))
 
              (H (and (holds g t) (or (= t 0) (holds f (- t 1)))))
           )))
 
-         ((Op2 op f g)     
+         ((Op2 op f g)
            (match op (
              (AND (and (holds f t) (holds g t)))
 
@@ -88,6 +88,3 @@
 (constraint (holds (Op1 G (phi X0 X1)) 0))
 
 (check-synth)
-
-
-

--- a/test/regress/regress0/sygus/sygus-uf.sy
+++ b/test/regress/regress0/sygus/sygus-uf.sy
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --lang=sygus2 --sygus-out=status --uf-ho
+; COMMAND-LINE: --lang=sygus2 --sygus-out=status --hol
 ; EXPECT: unsat
 (set-logic ALL)
 

--- a/test/regress/regress1/fmf/issue4225-univ-fun.smt2
+++ b/test/regress/regress1/fmf/issue4225-univ-fun.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --finite-model-find --uf-ho
+; COMMAND-LINE: --finite-model-find --hol
 ; EXPECT: unknown
 (set-logic ALL)
 ; this is not handled by fmf

--- a/test/regress/regress1/ho/NUM638^1.smt2
+++ b/test/regress/regress1/ho/NUM638^1.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho --finite-model-find
+; COMMAND-LINE: --hol --finite-model-find
 ; EXPECT: unsat
 
 (set-option :incremental false)

--- a/test/regress/regress1/ho/NUM925^1.p
+++ b/test/regress/regress1/ho/NUM925^1.p
@@ -1,4 +1,4 @@
-% COMMAND-LINE:  --uf-ho --ho-elim
+% COMMAND-LINE:  --hol --ho-elim
 % EXPECT: % SZS status Theorem for NUM925^1
 
 %------------------------------------------------------------------------------

--- a/test/regress/regress1/ho/SYO056^1.p
+++ b/test/regress/regress1/ho/SYO056^1.p
@@ -1,4 +1,4 @@
-% COMMAND-LINE:  --uf-ho --finite-model-find
+% COMMAND-LINE:  --hol --finite-model-find
 % EXPECT: % SZS status CounterSatisfiable for SYO056^1
 
 %------------------------------------------------------------------------------

--- a/test/regress/regress1/ho/bound_var_bug.p
+++ b/test/regress/regress1/ho/bound_var_bug.p
@@ -1,4 +1,4 @@
-% COMMAND-LINE: --uf-ho
+% COMMAND-LINE: --hol
 % EXPECT: % SZS status GaveUp for bound_var_bug
 
 % TIMEFORMAT='%3R'; { time (exec 2>&1; /Users/blanchette/misc/leo --foatp e --atp e="$E_HOME"/eprover --atp epclextract="$E_HOME"/epclextract --proofoutput 1 --timeout 30 /Users/blanchette/hgs/afp_mining/tools/judgment_day_2017/data_afp/leo2-mepo/Call_Arity_SestoftGC_data/prob_308__3244432_1 ) ; }

--- a/test/regress/regress1/ho/bug_freeVar_BDD_General_data_270.p
+++ b/test/regress/regress1/ho/bug_freeVar_BDD_General_data_270.p
@@ -1,4 +1,4 @@
-% COMMAND-LINE: --uf-ho --finite-model-find
+% COMMAND-LINE: --hol --finite-model-find
 % EXPECT: % SZS status Satisfiable for bug_freeVar_BDD_General_data_270
 
 thf(ty_n_t__Nat__Onat, type,

--- a/test/regress/regress1/ho/bug_freevar_PHI004^4-delta.smt2
+++ b/test/regress/regress1/ho/bug_freevar_PHI004^4-delta.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho --finite-model-find -q --decision=justification-old
+; COMMAND-LINE: --hol --finite-model-find -q --decision=justification-old
 ; EXPECT: sat
 
 (set-logic ALL)

--- a/test/regress/regress1/ho/fta0328.lfho.p
+++ b/test/regress/regress1/ho/fta0328.lfho.p
@@ -1,4 +1,4 @@
-% COMMAND-LINE:  --uf-ho --uf-ho --finite-model-find
+% COMMAND-LINE:  --hol --hol --finite-model-find
 % EXPECT: % SZS status CounterSatisfiable for fta0328.lfho
 
 % TIMEFORMAT='%3R'; { time (exec 2>&1; /Users/blanchette/.isabelle/contrib/e-2.0-2/x86_64-darwin/eprover --auto-schedule --tstp-in --tstp-out --silent --cpu-limit=2 --proof-object=1 /Users/blanchette/hgs/matryoshka/papers/2019-TACAS-ehoh/eval/judgment_day/judgment_day_lifting_32/fta/prob_804__4064966_1 ) ; }

--- a/test/regress/regress1/ho/hoa0102.smt2
+++ b/test/regress/regress1/ho/hoa0102.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho --full-saturate-quant
+; COMMAND-LINE: --hol --full-saturate-quant
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/regress1/ho/issue3136-fconst-bool-bool.smt2
+++ b/test/regress/regress1/ho/issue3136-fconst-bool-bool.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE:  --uf-ho --ho-elim
+; COMMAND-LINE:  --hol --ho-elim
 ; EXPECT: unsat
 
 (set-logic ALL)

--- a/test/regress/regress1/ho/issue4065-no-rep.smt2
+++ b/test/regress/regress1/ho/issue4065-no-rep.smt2
@@ -1,7 +1,7 @@
+; COMMAND-LINE: --hol
 (set-logic AUFBV)
 (set-info :status unsat)
 (set-option :fmf-bound-int true)
-(set-option :uf-ho true)
 (declare-fun _substvar_20_ () Bool)
 (declare-sort S4 0)
 (assert (forall ((q15 S4) (q16 (_ BitVec 20)) (q17 (_ BitVec 13))) (xor (= (_ bv0 13) (_ bv0 13) q17 (bvsrem (_ bv0 13) (_ bv0 13)) q17) _substvar_20_ true)))

--- a/test/regress/regress1/ho/issue4092-sinf.smt2
+++ b/test/regress/regress1/ho/issue4092-sinf.smt2
@@ -1,10 +1,9 @@
-; COMMAND-LINE: --uf-ho --sort-inference
+; COMMAND-LINE: --hol --sort-inference
 ; EXPECT: sat
 (set-logic ALL)
 (set-option :sort-inference true)
-(set-option :uf-ho true)
 (set-info :status sat)
-(declare-fun a ( Int ) Int) 
-(declare-fun b ( Int ) Int)  
-(assert (and (distinct 0 (b 5)) (distinct a b ))) 
-(check-sat) 
+(declare-fun a ( Int ) Int)
+(declare-fun b ( Int ) Int)
+(assert (and (distinct 0 (b 5)) (distinct a b )))
+(check-sat)

--- a/test/regress/regress1/ho/issue4134-sinf.smt2
+++ b/test/regress/regress1/ho/issue4134-sinf.smt2
@@ -1,7 +1,6 @@
-; COMMAND-LINE: --uf-ho --sort-inference
+; COMMAND-LINE: --hol --sort-inference
 ; EXPECT: sat
 (set-logic ALL)
-(set-option :uf-ho true)
 (set-option :sort-inference true)
 (set-info :status sat)
 (declare-fun a () Int)

--- a/test/regress/regress1/ho/nested_lambdas-AGT034^2.smt2
+++ b/test/regress/regress1/ho/nested_lambdas-AGT034^2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho --no-check-unsat-cores --no-produce-models --ho-elim
+; COMMAND-LINE: --hol --no-check-unsat-cores --no-produce-models --ho-elim
 ; EXPECT: unsat
 
 (set-logic ALL)

--- a/test/regress/regress1/ho/nested_lambdas-sat-SYO056^1-delta.smt2
+++ b/test/regress/regress1/ho/nested_lambdas-sat-SYO056^1-delta.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE:  --uf-ho --finite-model-find --no-check-models
+; COMMAND-LINE:  --hol --finite-model-find --no-check-models
 ; EXPECT: sat
 
 

--- a/test/regress/regress1/ho/soundness_fmf_SYO362^5-delta.p
+++ b/test/regress/regress1/ho/soundness_fmf_SYO362^5-delta.p
@@ -1,4 +1,4 @@
-% COMMAND-LINE:  --uf-ho --finite-model-find
+% COMMAND-LINE:  --hol --finite-model-find
 % EXPECT: % SZS status GaveUp for soundness_fmf_SYO362^5-delta
 
 %------------------------------------------------------------------------------

--- a/test/regress/regress1/ho/store-ax-min.p
+++ b/test/regress/regress1/ho/store-ax-min.p
@@ -1,5 +1,5 @@
-% COMMAND-LINE: --uf-ho --full-saturate-quant --ho-elim-store-ax
-% COMMAND-LINE: --uf-ho --full-saturate-quant --ho-elim
+% COMMAND-LINE: --hol --full-saturate-quant --ho-elim-store-ax
+% COMMAND-LINE: --hol --full-saturate-quant --ho-elim
 % EXPECT: % SZS status Theorem for store-ax-min
 
 thf(a, type, (a: $i)).

--- a/test/regress/regress1/quantifiers/issue3724-quant.smt2
+++ b/test/regress/regress1/quantifiers/issue3724-quant.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unknown
 (set-logic ALL)
 (assert

--- a/test/regress/regress1/quantifiers/issue4021-ind-opts.smt2
+++ b/test/regress/regress1/quantifiers/issue4021-ind-opts.smt2
@@ -1,9 +1,9 @@
+; COMMAND-LINE: --hol
 (set-logic ALL)
 (set-option :ag-miniscope-quant true)
 (set-option :conjecture-gen true)
 (set-option :int-wf-ind true)
 (set-option :sygus-inference true)
-(set-option :uf-ho true)
 (set-info :status unsat)
 (declare-fun a () Real)
 (declare-fun b () Real)

--- a/test/regress/regress1/sygus/eval-uc.sy
+++ b/test/regress/regress1/sygus/eval-uc.sy
@@ -1,5 +1,5 @@
 ; EXPECT: unsat
-; COMMAND-LINE: --lang=sygus2 --sygus-out=status --uf-ho
+; COMMAND-LINE: --lang=sygus2 --sygus-out=status --hol
 (set-logic ALL)
 (declare-sort S 0)
 (declare-var f Bool)

--- a/test/regress/regress1/sygus/ho-sygus.sy
+++ b/test/regress/regress1/sygus/ho-sygus.sy
@@ -1,5 +1,5 @@
 ; EXPECT: unsat
-; COMMAND-LINE: --lang=sygus2 --sygus-out=status --uf-ho
+; COMMAND-LINE: --lang=sygus2 --sygus-out=status --hol
 (set-logic ALL)
 (synth-fun f ((y (-> Int Int)) (z Int)) Int)
 (declare-var z (-> Int Int))

--- a/test/regress/regress1/sygus/issue3507.smt2
+++ b/test/regress/regress1/sygus/issue3507.smt2
@@ -1,5 +1,5 @@
 ; EXPECT: sat
-; COMMAND-LINE: --sygus-inference --uf-ho --quiet
+; COMMAND-LINE: --sygus-inference --hol --quiet
 (set-logic ALL)
 (declare-fun f (Int) Bool)
 (declare-fun g (Int) Bool)

--- a/test/regress/regress1/sygus/issue3995-fmf-var-op.smt2
+++ b/test/regress/regress1/sygus/issue3995-fmf-var-op.smt2
@@ -1,5 +1,5 @@
 ; EXPECT: unsat
-; COMMAND-LINE: --sygus-inference --fmf-bound --uf-ho
+; COMMAND-LINE: --sygus-inference --fmf-bound --hol
 (set-logic ALL)
 (declare-fun a () (_ BitVec 1))
 (assert (bvsgt (bvsmod a a) #b0))

--- a/test/regress/regress1/sygus/list_recursor.sy
+++ b/test/regress/regress1/sygus/list_recursor.sy
@@ -1,5 +1,5 @@
 ; EXPECT: unsat
-; COMMAND-LINE: --sygus-out=status --lang=sygus2 --uf-ho
+; COMMAND-LINE: --sygus-out=status --lang=sygus2 --hol
 
 (set-logic ALL)
 

--- a/test/regress/regress1/sygus/sygus-uf-ex.sy
+++ b/test/regress/regress1/sygus/sygus-uf-ex.sy
@@ -1,5 +1,5 @@
 ; EXPECT: unsat
-; COMMAND-LINE: --lang=sygus2 --sygus-out=status --uf-ho
+; COMMAND-LINE: --lang=sygus2 --sygus-out=status --hol
 (set-logic ALL)
 
 (declare-var uf (-> Int Int))

--- a/test/regress/regress1/sygus/uf-abduct.smt2
+++ b/test/regress/regress1/sygus/uf-abduct.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --produce-abducts --uf-ho
+; COMMAND-LINE: --produce-abducts --hol
 ; SCRUBBER: grep -v -E '(\(define-fun)'
 ; EXIT: 0
 (set-logic UFLIA)

--- a/test/regress/regress2/ho/auth0068.smt2
+++ b/test/regress/regress2/ho/auth0068.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/regress2/ho/bug_instfalse_SEU882^5.p
+++ b/test/regress/regress2/ho/bug_instfalse_SEU882^5.p
@@ -1,4 +1,4 @@
-% COMMAND-LINE:  --uf-ho --full-saturate-quant --ho-elim
+% COMMAND-LINE:  --hol --full-saturate-quant --ho-elim
 % EXPECT: % SZS status Theorem for bug_instfalse_SEU882^5
 
 %------------------------------------------------------------------------------

--- a/test/regress/regress2/ho/fta0409.smt2
+++ b/test/regress/regress2/ho/fta0409.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ho
+; COMMAND-LINE: --hol
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/regress2/ho/involved_parsing_ALG248^3.p
+++ b/test/regress/regress2/ho/involved_parsing_ALG248^3.p
@@ -1,4 +1,4 @@
-% COMMAND-LINE:  --uf-ho --ho-elim
+% COMMAND-LINE:  --hol --ho-elim
 % EXPECT: % SZS status Theorem for involved_parsing_ALG248^3
 
 %------------------------------------------------------------------------------

--- a/test/regress/regress2/ho/partial_app_interpreted_SWW474^2.p
+++ b/test/regress/regress2/ho/partial_app_interpreted_SWW474^2.p
@@ -1,4 +1,4 @@
-% COMMAND-LINE: --uf-ho --full-saturate-quant --ho-elim
+% COMMAND-LINE: --hol --full-saturate-quant --ho-elim
 % EXPECT: % SZS status Theorem for partial_app_interpreted_SWW474^2
 
 %------------------------------------------------------------------------------

--- a/test/regress/regress3/ho/SYO362^5.p
+++ b/test/regress/regress3/ho/SYO362^5.p
@@ -1,4 +1,4 @@
-% COMMAND-LINE: --uf-ho --full-saturate-quant --ho-elim --decision=justification-old
+% COMMAND-LINE: --hol --full-saturate-quant --ho-elim --decision=justification-old
 % EXPECT: % SZS status Theorem for SYO362^5
 
 thf(cK,type,(

--- a/test/regress/regress3/issue4170.smt2
+++ b/test/regress/regress3/issue4170.smt2
@@ -1,6 +1,6 @@
+; COMMAND-LINE: --hol
 (set-logic ALL)
 (set-option :sygus-inference true)
-(set-option :uf-ho true)
 (set-option :sygus-ext-rew false)
 (set-info :status sat)
 (declare-fun a (Int) Int)


### PR DESCRIPTION
This commit adds a new parser option, `--hol`, which marks that HOL is being used. This option has the effect of prepending the problem's logic with "HO_", which teels the solver that the logic is higher order. The parser builder, base parser, and SMT2 and TPTP parsers are all updated to work with this new setting, as is the logic info class.

For now this parser option is enabling the `--uf-ho` option for internal use, since for now higher-order solving relies it. In a future PR this dependency will be removed (since this information is already given to the SMT solver via the logic).