### PR TITLE
Add getDomainElements to C++ and Python APIs

### DIFF
--- a/src/api/cpp/cvc5.h
+++ b/src/api/cpp/cvc5.h
@@ -3740,6 +3740,13 @@ class CVC5_EXPORT Solver
   std::vector<Term> getValue(const std::vector<Term>& terms) const;
 
   /**
+   * Get the domain of the given uninterpreted sort.
+   * @param sort the sort for with the domain is queried
+   * @return the set of ground terms of the given sort
+   */
+  std::vector<Term> getDomainElements(const Sort& sort) const;
+
+  /**
    * Do quantifier elimination.
    * SMT-LIB:
    * \verbatim

--- a/src/api/python/cvc5.pxd
+++ b/src/api/python/cvc5.pxd
@@ -266,6 +266,7 @@ cdef extern from "api/cpp/cvc5.h" namespace "cvc5::api":
         vector[Term] getUnsatCore() except +
         Term getValue(Term term) except +
         vector[Term] getValue(const vector[Term]& terms) except +
+        vector[Term] getDomainElements(const Sort& sort) except +
         void declareSeparationHeap(Sort locSort, Sort dataSort) except +
         Term getSeparationHeap() except +
         Term getSeparationNilTerm() except +

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -1227,6 +1227,14 @@ cdef class Solver:
         term.cterm = self.csolver.getValue(t.cterm)
         return term
 
+    def getDomainElements(self, Sort s):
+        elements = []
+        for n in self.csolver.getDomainElements(s.csort):
+            term = Term(self)
+            term.cterm = n
+            elements.append(term)
+        return elements
+
     def getSeparationHeap(self):
         cdef Term term = Term(self)
         term.cterm = self.csolver.getSeparationHeap()

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1186,6 +1186,15 @@ std::vector<Node> SmtEngine::getValues(const std::vector<Node>& exprs)
   return result;
 }
 
+std::vector<Node> SmtEngine::getDomainElements(const TypeNode& sort)
+{
+  SmtScope smts(this);
+
+  const Model* m = getModel();
+  const theory::TheoryModel* tm = m->getTheoryModel();
+  return tm->getDomainElements(sort);
+}
+
 // TODO(#1108): Simplify the error reporting of this method.
 Model* SmtEngine::getModel() {
   Trace("smt") << "SMT getModel()" << endl;

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -529,6 +529,11 @@ class CVC5_EXPORT SmtEngine
    */
   std::vector<Node> getValues(const std::vector<Node>& exprs);
 
+  /**
+   * Get the domain of an (uninterpreted) sort
+   */
+  std::vector<Node> getDomainElements(const TypeNode& sort);
+
   /** print instantiations
    *
    * Print all instantiations for all quantified formulas on out,

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -129,7 +129,7 @@ std::vector<Node> TheoryModel::getDomainElements(TypeNode tn) const
   {
     // This is called when t is a sort that does not occur in this model.
     // Sorts are always interpreted as non-empty, thus we add a single element.
-    elements.push_back(tn.mkGroundTerm());
+    elements.push_back(tn.mkGroundValue());
     return elements;
   }
   return *type_refs;


### PR DESCRIPTION
Add the relevant methods to the Python API (src/api/python/cvc5.
{pxi,pxd}), C++ API (src/api/cpp/cvc5.{h,cpp}), and SMT engine
(src/smt/smt_engine.{h,cpp}).

Add missing checks to getValue(Term) in C++ API, so it is consistent
with getValue(vector<Term>).

Change mkGroundTerm to mkGroundValue in TheoryModel::getDomainElements
so that the result of getDomainElements is consistent with getValue
when an element needs to be synthesized (because e.g. no assertions are
made about that sort).

Signed-off-by: Jason Koenig <jrkoenig@stanford.edu>