### PR TITLE
Make env hold a pointer to the original options

### DIFF
--- a/src/smt/env.cpp
+++ b/src/smt/env.cpp
@@ -43,6 +43,7 @@ Env::Env(NodeManager* nm, Options* opts)
       d_logic(),
       d_statisticsRegistry(std::make_unique<StatisticsRegistry>()),
       d_options(),
+      d_originalOptions(opts),
       d_resourceManager()
 {
   if (opts != nullptr)
@@ -96,6 +97,8 @@ StatisticsRegistry& Env::getStatisticsRegistry()
 }
 
 const Options& Env::getOptions() const { return d_options; }
+
+const Options& Env::getOriginalOptions() const { return *d_originalOptions; }
 
 ResourceManager* Env::getResourceManager() const
 {

--- a/src/smt/env.h
+++ b/src/smt/env.h
@@ -94,6 +94,9 @@ class Env
   /** Get the options object (const version only) owned by this Env. */
   const Options& getOptions() const;
 
+  /** Get the original options object (const version only). */
+  const Options& getOriginalOptions() const;
+
   /** Get the resource manager owned by this Env. */
   ResourceManager* getResourceManager() const;
 
@@ -180,6 +183,12 @@ class Env
    * consider during solving and initialization.
    */
   Options d_options;
+  /**
+   * A pointer to the original options object as stored in the api::Solver.
+   * The referenced objects holds the options as initially parsed before being
+   * changed, e.g., by setDefaults().
+   */
+  const Options* d_originalOptions;
   /** Manager for limiting time and abstract resource usage. */
   std::unique_ptr<ResourceManager> d_resourceManager;
 }; /* class Env */


### PR DESCRIPTION
This PR extends the `Env` class to hold a pointer to the original options that are owned by the `api::Solver`. These original options will be used to properly initialize subsolvers as using the current options leads to subtle issues as `setDefaults` is not (in general) idempotent.