### PR TITLE
Add learned literal manager utility

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,8 @@ libcvc5_add_sources(
   omt/omt_optimizer.h
   preprocessing/assertion_pipeline.cpp
   preprocessing/assertion_pipeline.h
+  preprocessing/learned_literal_manager.cpp
+  preprocessing/learned_literal_manager.h
   preprocessing/passes/ackermann.cpp
   preprocessing/passes/ackermann.h
   preprocessing/passes/apply_substs.cpp

--- a/src/preprocessing/learned_literal_manager.cpp
+++ b/src/preprocessing/learned_literal_manager.cpp
@@ -1,0 +1,55 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2021 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Learned literal manager
+ */
+
+#include "preprocessing/learned_literal_manager.h"
+
+#include "theory/rewriter.h"
+
+namespace cvc5 {
+namespace preprocessing {
+
+LearnedLiteralManager::LearnedLiteralManager(theory::TrustSubstitutionMap& tls,
+                                             context::UserContext* u,
+                                             ProofNodeManager* pnm)
+    : d_topLevelSubs(tls), d_learnedLits(u)
+{
+}
+
+void LearnedLiteralManager::notifyLearnedLiteral(Node lit)
+{
+  d_learnedLits.insert(lit);
+  Trace("pp-llm") << "LLM:notifyLearnedLiteral: " << lit << std::endl;
+}
+
+std::vector<Node> LearnedLiteralManager::getLearnedLiterals()
+{
+  std::vector<Node> currLearnedLits;
+  for (NodeSet::const_iterator it = d_learnedLits.begin(),
+                               itEnd = d_learnedLits.end();
+       it != itEnd;
+       ++it)
+  {
+    // update based on substitutions
+    Node tlsNode = d_topLevelSubs.get().apply(*it);
+    tlsNode = theory::Rewriter::rewrite(tlsNode);
+    currLearnedLits.push_back(tlsNode);
+    Trace("pp-llm") << "Learned literal : " << tlsNode << " from " << (*it)
+                    << std::endl;
+  }
+  return currLearnedLits;
+}
+
+}  // namespace preprocessing
+}  // namespace cvc5

--- a/src/preprocessing/learned_literal_manager.cpp
+++ b/src/preprocessing/learned_literal_manager.cpp
@@ -36,16 +36,13 @@ void LearnedLiteralManager::notifyLearnedLiteral(Node lit)
 std::vector<Node> LearnedLiteralManager::getLearnedLiterals()
 {
   std::vector<Node> currLearnedLits;
-  for (NodeSet::const_iterator it = d_learnedLits.begin(),
-                               itEnd = d_learnedLits.end();
-       it != itEnd;
-       ++it)
+  for (const auto& lit: d_learnedLits)
   {
     // update based on substitutions
-    Node tlsNode = d_topLevelSubs.get().apply(*it);
+    Node tlsNode = d_topLevelSubs.get().apply(lit);
     tlsNode = theory::Rewriter::rewrite(tlsNode);
     currLearnedLits.push_back(tlsNode);
-    Trace("pp-llm") << "Learned literal : " << tlsNode << " from " << (*it)
+    Trace("pp-llm") << "Learned literal : " << tlsNode << " from " << lit
                     << std::endl;
   }
   return currLearnedLits;

--- a/src/preprocessing/learned_literal_manager.cpp
+++ b/src/preprocessing/learned_literal_manager.cpp
@@ -33,7 +33,7 @@ void LearnedLiteralManager::notifyLearnedLiteral(Node lit)
   Trace("pp-llm") << "LLM:notifyLearnedLiteral: " << lit << std::endl;
 }
 
-std::vector<Node> LearnedLiteralManager::getLearnedLiterals()
+std::vector<Node> LearnedLiteralManager::getLearnedLiterals() const
 {
   std::vector<Node> currLearnedLits;
   for (const auto& lit: d_learnedLits)

--- a/src/preprocessing/learned_literal_manager.h
+++ b/src/preprocessing/learned_literal_manager.h
@@ -54,7 +54,7 @@ class LearnedLiteralManager
    * provided to this class. These literals are refreshed so that the current
    * top-level substitutions are applied to them, and then are rewritten.
    */
-  std::vector<Node> getLearnedLiterals();
+  std::vector<Node> getLearnedLiterals() const;
 
  private:
   /** Learned literal map */

--- a/src/preprocessing/learned_literal_manager.h
+++ b/src/preprocessing/learned_literal_manager.h
@@ -1,0 +1,71 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2021 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Learned literal manager
+ */
+
+#include "cvc5_private.h"
+
+#ifndef CVC5__PREPROCESSING__LEARNED_LITERAL_MANAGER_H
+#define CVC5__PREPROCESSING__LEARNED_LITERAL_MANAGER_H
+
+#include "context/cdhashset.h"
+#include "expr/node.h"
+#include "theory/trust_substitutions.h"
+
+namespace cvc5 {
+namespace preprocessing {
+
+/**
+ * This class maintains the list of learned literals that have been inferred
+ * during preprocessing but we have not fully processed e.g. via substitutions.
+ *
+ * In particular, notice that if an equality (= x t) is learned at top level,
+ * we may add x -> t to top level substitutions if t does not contain x; we can
+ * henceforth forget that (= x t) is a learned literal. On the other hand, if
+ * a literal like (> x t) is learned at top-level, it may be useful to remember
+ * this information. This class is concerned with the latter kind of literals.
+ */
+class LearnedLiteralManager
+{
+ public:
+  LearnedLiteralManager(theory::TrustSubstitutionMap& tls,
+                        context::UserContext* u,
+                        ProofNodeManager* pnm);
+  /**
+   * Notify learned literal. This method is called when a literal is
+   * entailed by the current set of assertions.
+   *
+   * It should be rewritten, and such that top level substitutions have
+   * been applied to it.
+   */
+  void notifyLearnedLiteral(Node lit);
+  /**
+   * Get learned literals, which returns the current set of learned literals
+   * provided to this class. These literals are refreshed so that the current
+   * top-level substitutions are applied to them, and then are rewritten.
+   */
+  std::vector<Node> getLearnedLiterals();
+
+ private:
+  /** Learned literal map */
+  typedef context::CDHashSet<Node> NodeSet;
+  /* The top level substitutions */
+  theory::TrustSubstitutionMap& d_topLevelSubs;
+  /** Learned literals */
+  NodeSet d_learnedLits;
+};
+
+}  // namespace preprocessing
+}  // namespace cvc5
+
+#endif /* CVC5__PREPROCESSING__LEARNED_LITERAL_MANAGER_H */


### PR DESCRIPTION
This is a simple class to maintain a list of literals that we have learned that may be useful during preprocessing.

This is work towards a "learned rewrite" preprocessing pass / better support for Int/BV translations during preprocessing.