### PR TITLE
Require statistics for regression

### DIFF
--- a/test/regress/regress0/options/statistics.smt2
+++ b/test/regress/regress0/options/statistics.smt2
@@ -1,3 +1,4 @@
+; REQUIRES: statistics
 ; EXPECT: false
 ; EXPECT: false
 ; EXPECT: false


### PR DESCRIPTION
This PR makes a new regression explicitly require statistics.