### PR TITLE
Fix CaDiCaL build on Windows

### DIFF
--- a/cmake/FindCaDiCaL.cmake
+++ b/cmake/FindCaDiCaL.cmake
@@ -47,8 +47,6 @@ if(NOT CaDiCaL_FOUND_SYSTEM)
   include(CheckSymbolExists)
   include(ExternalProject)
 
-  fail_if_include_missing("sys/resource.h" "CaDiCaL")
-
   set(CaDiCaL_VERSION "88623ef0866370448c34f6e320c148fc18e6f4cc")
 
   # avoid configure script and instantiate the makefile manually the configure
@@ -109,6 +107,16 @@ set_target_properties(
 set_target_properties(
   CaDiCaL PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${CaDiCaL_INCLUDE_DIR}"
 )
+
+if (WIN32)
+  # The Windows version of CaDiCaL calls GetProcessMemoryInfo(), which is
+  # defined in the Process Status API (psapi), so we declare it as a dependency
+  # of the CaDiCaL library (without this, linking a static cvc5 executable
+  # fails).
+  set_target_properties(
+    CaDiCaL PROPERTIES IMPORTED_LINK_INTERFACE_LIBRARIES psapi
+  )
+endif ()
 
 mark_as_advanced(CaDiCaL_FOUND)
 mark_as_advanced(CaDiCaL_FOUND_SYSTEM)


### PR DESCRIPTION
The Windows version of CaDiCaL does not require the `sys/resource.h`
file, so this commit removes that check. It does, however, require
linking against the Process Status API (psapi), because of a call to
`GetProcessMemoryInfo()`, so this commit adds that dependency for
Windows builds.