### PR TITLE
docs: Remove 'View page source' link in right corner.

### DIFF
--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -67,6 +67,7 @@ html_theme = 'sphinx_rtd_theme'
 html_theme_options = {}
 html_static_path = ['${CMAKE_CURRENT_SOURCE_DIR}/_static/']
 html_css_files = ['custom.css']
+html_show_sourcelink = False
 
 # -- Breathe configuration ---------------------------------------------------
 breathe_default_project = "cvc5"


### PR DESCRIPTION
We don't upload the source files to the website, so this will always be
a 404.