### PR TITLE
Rewrite POW to POW2 when the base is 2

### DIFF
--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -255,6 +255,12 @@ RewriteResponse ArithRewriter::postRewriteTerm(TNode t){
             }
           }
         }
+        else if (t[0].getKind() == kind::CONST_RATIONAL
+                 && t[0].getConst<Rational>().getNumerator().toUnsignedInt())
+        {
+          return RewriteResponse(
+              REWRITE_DONE, NodeManager::currentNM()->mkNode(kind::POW2, t[1]));
+        }
 
         // Todo improve the exception thrown
         std::stringstream ss;

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -256,7 +256,7 @@ RewriteResponse ArithRewriter::postRewriteTerm(TNode t){
           }
         }
         else if (t[0].getKind() == kind::CONST_RATIONAL
-                 && t[0].getConst<Rational>().getNumerator().toUnsignedInt())
+                 && t[0].getConst<Rational>().getNumerator().toUnsignedInt() == 2)
         {
           return RewriteResponse(
               REWRITE_DONE, NodeManager::currentNM()->mkNode(kind::POW2, t[1]));

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -737,6 +737,7 @@ set(regress_0_tests
   regress0/nl/pow2-native-1.smt2
   regress0/nl/pow2-native-2.smt2
   regress0/nl/pow2-native-3.smt2
+  regress0/nl/pow2-pow.smt2
   regress0/nl/real-as-int.smt2
   regress0/nl/real-div-ufnra.smt2
   regress0/nl/sin-cos-346-b-chunk-0169.smt2

--- a/test/regress/regress0/nl/pow2-pow.smt2
+++ b/test/regress/regress0/nl/pow2-pow.smt2
@@ -1,0 +1,6 @@
+; EXPECT: unsat
+(set-logic QF_NIA)
+(declare-fun x () Int)
+(assert (< x 0))
+(assert (distinct (^ 2 x) 0))
+(check-sat)

--- a/test/regress/regress1/arith/bug716.1.cvc
+++ b/test/regress/regress1/arith/bug716.1.cvc
@@ -1,6 +1,6 @@
 % EXPECT: The exponent of the POW(^) operator can only be a positive integral constant below 67108864. Exception occurred in:
-% EXPECT:   2 ^ x
+% EXPECT:   3 ^ x
 % EXIT: 1
 x: INT;
-ASSERT 2^x = 8;
+ASSERT 3^x = 27;
 QUERY x=3;


### PR DESCRIPTION
This PR introduces a rewrite from `(^ 2 t)` to `(pow2 t)` in order to make use of the specialized `pow2` solver.
One regression that expects an error when `t` is not a constant is changed accordingly.