### PR TITLE
int-to-bv: correct model values

### DIFF
--- a/src/preprocessing/passes/int_to_bv.cpp
+++ b/src/preprocessing/passes/int_to_bv.cpp
@@ -29,6 +29,7 @@
 #include "options/base_options.h"
 #include "options/smt_options.h"
 #include "preprocessing/assertion_pipeline.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "theory/rewriter.h"
 #include "theory/theory.h"
 #include "util/bitvector.h"
@@ -41,7 +42,6 @@ namespace passes {
 using namespace std;
 using namespace cvc5::theory;
 
-using NodeMap = std::unordered_map<Node, Node>;
 
 namespace {
 
@@ -101,8 +101,9 @@ Node intToBVMakeBinary(TNode n, NodeMap& cache)
   }
   return cache[n];
 }
+}  // namespace
 
-Node intToBV(TNode n, NodeMap& cache)
+Node IntToBV::intToBV(TNode n, NodeMap& cache)
 {
   int size = options::solveIntAsBV();
   AlwaysAssert(size > 0);
@@ -217,6 +218,7 @@ Node intToBV(TNode n, NodeMap& cache)
                                      nm->mkBitVectorType(size),
                                      "Variable introduced in intToBV pass");
         }
+        // d_preprocContext->addSubstitution(current, result);
       }
       else if (current.isConst())
       {
@@ -249,9 +251,11 @@ Node intToBV(TNode n, NodeMap& cache)
       cache[current] = result;
     }
   }
+  Trace("int-to-bv-debug") << "original: " << n << std::endl;
+  Trace("int-to-bv-debug") << "binary: " << n_binary << std::endl;
+  Trace("int-to-bv-debug") << "result: " << cache[n_binary] << std::endl;
   return cache[n_binary];
 }
-}  // namespace
 
 IntToBV::IntToBV(PreprocessingPassContext* preprocContext)
     : PreprocessingPass(preprocContext, "int-to-bv"){};

--- a/src/preprocessing/passes/int_to_bv.cpp
+++ b/src/preprocessing/passes/int_to_bv.cpp
@@ -218,7 +218,8 @@ Node IntToBV::intToBV(TNode n, NodeMap& cache)
                                      nm->mkBitVectorType(size),
                                      "Variable introduced in intToBV pass");
         }
-        // d_preprocContext->addSubstitution(current, result);
+        Node bv2nat = nm->mkNode(kind::BITVECTOR_TO_NAT, result);
+        d_preprocContext->addSubstitution(current, bv2nat);
       }
       else if (current.isConst())
       {

--- a/src/preprocessing/passes/int_to_bv.cpp
+++ b/src/preprocessing/passes/int_to_bv.cpp
@@ -217,9 +217,9 @@ Node IntToBV::intToBV(TNode n, NodeMap& cache)
           result = sm->mkDummySkolem("__intToBV_var",
                                      nm->mkBitVectorType(size),
                                      "Variable introduced in intToBV pass");
+          Node bv2nat = nm->mkNode(kind::BITVECTOR_TO_NAT, result);
+          d_preprocContext->addSubstitution(current, bv2nat);
         }
-        Node bv2nat = nm->mkNode(kind::BITVECTOR_TO_NAT, result);
-        d_preprocContext->addSubstitution(current, bv2nat);
       }
       else if (current.isConst())
       {

--- a/src/preprocessing/passes/int_to_bv.h
+++ b/src/preprocessing/passes/int_to_bv.h
@@ -22,8 +22,8 @@
 #ifndef CVC5__PREPROCESSING__PASSES__INT_TO_BV_H
 #define CVC5__PREPROCESSING__PASSES__INT_TO_BV_H
 
-#include "preprocessing/preprocessing_pass.h"
 #include "expr/node.h"
+#include "preprocessing/preprocessing_pass.h"
 
 namespace cvc5 {
 namespace preprocessing {

--- a/src/preprocessing/passes/int_to_bv.h
+++ b/src/preprocessing/passes/int_to_bv.h
@@ -23,15 +23,19 @@
 #define CVC5__PREPROCESSING__PASSES__INT_TO_BV_H
 
 #include "preprocessing/preprocessing_pass.h"
+#include "expr/node.h"
 
 namespace cvc5 {
 namespace preprocessing {
 namespace passes {
 
+using NodeMap = std::unordered_map<Node, Node>;
+
 class IntToBV : public PreprocessingPass
 {
  public:
   IntToBV(PreprocessingPassContext* preprocContext);
+  Node intToBV(TNode n, NodeMap& cache);
 
  protected:
   PreprocessingPassResult applyInternal(

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -418,6 +418,7 @@ set(regress_0_tests
   regress0/bv/inequality04.smt2
   regress0/bv/inequality05.smt2
   regress0/bv/int_to_bv_err_on_demand_1.smt2
+  regress0/bv/int_to_bv_bug.smt2
   regress0/bv/issue-4075.smt2
   regress0/bv/issue-4076.smt2
   regress0/bv/issue-4130.smt2

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -418,7 +418,7 @@ set(regress_0_tests
   regress0/bv/inequality04.smt2
   regress0/bv/inequality05.smt2
   regress0/bv/int_to_bv_err_on_demand_1.smt2
-  regress0/bv/int_to_bv_bug.smt2
+  regress0/bv/int_to_bv_model.smt2
   regress0/bv/issue-4075.smt2
   regress0/bv/issue-4076.smt2
   regress0/bv/issue-4130.smt2

--- a/test/regress/regress0/bv/int_to_bv_bug.smt2
+++ b/test/regress/regress0/bv/int_to_bv_bug.smt2
@@ -1,9 +1,0 @@
-; COMMAND-LINE: --solve-int-as-bv=9 --produce-models
-; EXPECT: unknown
-(set-logic QF_NIA)
-(declare-const a Int)
-(declare-const b Int)
-(assert (= (+ (* a 251) a) (+ b (* b 211))))
-(assert (not (= a 0)))
-(check-sat)
-(get-model)

--- a/test/regress/regress0/bv/int_to_bv_bug.smt2
+++ b/test/regress/regress0/bv/int_to_bv_bug.smt2
@@ -1,0 +1,9 @@
+; COMMAND-LINE: --solve-int-as-bv=9 --produce-models
+; EXPECT: unknown
+(set-logic QF_NIA)
+(declare-const a Int)
+(declare-const b Int)
+(assert (= (+ (* a 251) a) (+ b (* b 211))))
+(assert (not (= a 0)))
+(check-sat)
+(get-model)

--- a/test/regress/regress0/bv/int_to_bv_model.smt2
+++ b/test/regress/regress0/bv/int_to_bv_model.smt2
@@ -1,0 +1,8 @@
+; COMMAND-LINE: --solve-int-as-bv=9 --check-models
+; EXPECT: sat
+(set-logic QF_NIA)
+(declare-const a Int)
+(declare-const b Int)
+(assert (= (+ (* a 251) a) (+ b (* b 211))))
+(assert (not (= a 0)))
+(check-sat)


### PR DESCRIPTION
the `int-to-bv` preprocessing pass produced wrong models.
This PR fixes this in a similar fashion to other preprocessing passes, by adding a substitution to the preprocessing pass context. This requires moving the main translation function to be a class method, rather than a helper method in an empty namespace.

Thanks to @alex-ozdemir for raising this issue and producing a triggering benchmark (added to regressions in this PR).