### PR TITLE
Fix cmake error message for CaDiCaL and SymFPU

### DIFF
--- a/cmake/FindCaDiCaL.cmake
+++ b/cmake/FindCaDiCaL.cmake
@@ -41,7 +41,7 @@ endif()
 if(NOT CaDiCaL_FOUND_SYSTEM)
   check_ep_downloaded("CaDiCaL-EP")
   if(NOT CaDiCaL-EP_DOWNLOADED)
-    check_auto_download("CaDiCaL" "--no-cadical")
+    check_auto_download("CaDiCaL" "")
   endif()
 
   include(CheckSymbolExists)

--- a/cmake/FindSymFPU.cmake
+++ b/cmake/FindSymFPU.cmake
@@ -26,7 +26,7 @@ endif()
 if(NOT SymFPU_FOUND_SYSTEM)
   check_ep_downloaded("SymFPU-EP")
   if(NOT SymFPU-EP_DOWNLOADED)
-    check_auto_download("SymFPU" "--no-symfpu")
+    check_auto_download("SymFPU" "")
   endif()
 
   include(ExternalProject)


### PR DESCRIPTION
As mentioned in #6822, we are currently printing an incorrect message if CaDiCaL or SymFPU are not found but auto-download is disabled. This PR fixes this issue.