### PR TITLE
Fix CaDiCaL auto-download on macOS

### DIFF
--- a/cmake/FindCaDiCaL.cmake
+++ b/cmake/FindCaDiCaL.cmake
@@ -56,7 +56,13 @@ if(NOT CaDiCaL_FOUND_SYSTEM)
   # check for getc_unlocked
   check_symbol_exists("getc_unlocked" "cstdio" HAVE_UNLOCKED_IO)
   if(NOT HAVE_UNLOCKED_IO)
-    set(CXXFLAGS "${CXXFLAGS} -DNUNLOCKED")
+    string(APPEND CXXFLAGS "${CXXFLAGS} -DNUNLOCKED")
+  endif()
+
+  # On macOS, we have to set `-isysroot` to make sure that include headers are
+  # found because they are not necessarily installed at /usr/include anymore.
+  if(CMAKE_OSX_SYSROOT)
+    string(APPEND CXXFLAGS " ${CMAKE_CXX_SYSROOT_FLAG} ${CMAKE_OSX_SYSROOT}")
   endif()
 
   if("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles")

--- a/cmake/FindCaDiCaL.cmake
+++ b/cmake/FindCaDiCaL.cmake
@@ -56,7 +56,7 @@ if(NOT CaDiCaL_FOUND_SYSTEM)
   # check for getc_unlocked
   check_symbol_exists("getc_unlocked" "cstdio" HAVE_UNLOCKED_IO)
   if(NOT HAVE_UNLOCKED_IO)
-    string(APPEND CXXFLAGS "${CXXFLAGS} -DNUNLOCKED")
+    string(APPEND CXXFLAGS " -DNUNLOCKED")
   endif()
 
   # On macOS, we have to set `-isysroot` to make sure that include headers are


### PR DESCRIPTION
If we are auto-downloading CaDiCaL, we are manually instantiating its makefile.
To do that, we use `CMAKE_CXX_COMPILER` for the compiler and assemble some
flags. However, we are missing the platform dependent flags. Specifically, we
need to set `-isysroot` on macOS to make sure that the header files are found
because they are not at /usr/include on newer versions of Apple's XCode [0].
Unfortunately, I could not find a CMake variable with the platform specific
flags. They are assembled here [1]. To solve this problem, the commit checks if
`CMAKE_OSX_SYSROOT` is set and adds a corresponding compiler flag if it is.

[0] https://developer.apple.com/documentation/xcode-release-notes/xcode-10-release-notes
[1] https://github.com/Kitware/CMake/blob/d60d6c269ae7ad15adbb82028e9ab50290db2a2b/Source/cmLocalGenerator.cxx#L1900-L1923