### PR TITLE
[Strings] Fix incorrect rewrite due to stale information

### DIFF
--- a/src/theory/strings/sequences_rewriter.h
+++ b/src/theory/strings/sequences_rewriter.h
@@ -117,12 +117,15 @@ class SequencesRewriter : public TheoryRewriter
    * The rewrite r indicates the justification for the rewrite, which is printed
    * by this function for debugging.
    *
-   * If node is not an equality and ret is an equality, this method applies
-   * an additional rewrite step (rewriteEqualityExt) that performs
-   * additional rewrites on ret, after which we return the result of this call.
-   * Otherwise, this method simply returns ret.
+   * If node is not an equality (or rewriteEq is true) and ret is an equality,
+   * this method applies an additional rewrite step (rewriteEqualityExt) that
+   * performs additional rewrites on ret, after which we return the result of
+   * this call. Otherwise, this method simply returns ret.
    */
-  Node returnRewrite(Node node, Node ret, Rewrite r);
+  Node returnRewrite(Node node,
+                     Node ret,
+                     Rewrite r,
+                     bool rewriteEqAgain = false);
 
  public:
   RewriteResponse postRewrite(TNode node) override;

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1178,6 +1178,7 @@ set(regress_0_tests
   regress0/strings/issue6604-re-elim.smt2
   regress0/strings/issue6643-ctn-decompose-conflict.smt2
   regress0/strings/issue6681-split-eq-strip-l.smt2
+  regress0/strings/issue6834-str-eq-const-nhomog.smt2
   regress0/strings/itos-entail.smt2
   regress0/strings/large-model.smt2
   regress0/strings/leadingzero001.smt2

--- a/test/regress/regress0/strings/issue6834-str-eq-const-nhomog.smt2
+++ b/test/regress/regress0/strings/issue6834-str-eq-const-nhomog.smt2
@@ -1,0 +1,5 @@
+(set-logic QF_SLIA)
+(declare-fun a () Int)
+(assert (= (str.++ (str.substr "A" 0 a) "B" (str.substr "A" 0 a)) "B"))
+(set-info :status sat)
+(check-sat)


### PR DESCRIPTION
Fixes #6834. There were two cases in our extended rewriter for string
equalities that were modifying the node without returning and without
updating information computed from the original node. This mismatch led
to incorrect rewrites. This commit fixes the issue by adding a flag to
`returnRewrite()` that determines whether node that was an equality
before and after the rewrite should be rewritten again with the extended
rewriter. We generally do not do that (we'd run in danger of rewriting
equality nodes with the extended rewriter even though we shouldn't) but
for the rewrites that were previously continuing to rewrite the node, we
set this flag and return. This ensures that we do not have an issue with
information being out of date. The commit additionally fixes an issue
where we would apply the rewrite `STR_EQ_UNIFY` even though the node
hadn't changed.