### PR TITLE
Use default visibility for `cvc5::Exception`

### DIFF
--- a/src/base/exception.h
+++ b/src/base/exception.h
@@ -26,7 +26,7 @@
 
 namespace cvc5 {
 
-class Exception : public std::exception
+class CVC5_EXPORT Exception : public std::exception
 {
  protected:
   std::string d_msg;


### PR DESCRIPTION
Currently, `cvc5::Exception` does not have default visibility, which can
cause cvc5 to terminate when trying to catch it in `main.cpp`.
Presumably, this is because the necessary typeinfo is missing [0]. Due
to this issue, production builds for M1 on macOS crashed when parser
exceptions were thrown. The commit changes the visibility of the
exception.

[0] https://gcc.gnu.org/wiki/Visibility,
    "Problems with C++ exceptions (please read!)"