### PR TITLE
Make regression test `issue4971-0` more robust

### DIFF
--- a/test/regress/regress0/cores/issue4971-0.smt2
+++ b/test/regress/regress0/cores/issue4971-0.smt2
@@ -1,5 +1,5 @@
-; COMMAND-LINE: --incremental -q --check-unsat-cores
-; EXPECT: unknown
+; COMMAND-LINE: --incremental -q --check-unsat-cores --cegqi-full
+; EXPECT: unsat
 ; EXPECT: unsat
 ; EXPECT: (
 ; EXPECT: IP_1


### PR DESCRIPTION
When compiling and running cvc5 on macOS with an M1 CPU, the regression
test `regress0/cores/issue4971-0.smt2` returned `unsat` instead of the
expected `unknown` for the first `(check-sat)` command. This commit
makes the regression more robust by adding `--cegqi-full` and expecting
`unsat`.