### PR TITLE
Improvements to debug check model

### DIFF
--- a/src/theory/model_manager.cpp
+++ b/src/theory/model_manager.cpp
@@ -95,10 +95,10 @@ bool ModelManager::buildModel()
   // now, finish building the model
   d_modelBuiltSuccess = finishBuildModel();
 
-  if (Trace.isOn("model-builder"))
+  if (Trace.isOn("model-final"))
   {
-    Trace("model-builder") << "Final model:" << std::endl;
-    Trace("model-builder") << d_model->debugPrintModelEqc() << std::endl;
+    Trace("model-final") << "Final model:" << std::endl;
+    Trace("model-final") << d_model->debugPrintModelEqc() << std::endl;
   }
 
   Trace("model-builder") << "ModelManager: model built success is "


### PR DESCRIPTION
This makes it so that debug-check-models applies in production mode, not just in debug mode.  It also verifies that type constraints are met.