### PR TITLE
Add trace for combination splits

### DIFF
--- a/src/theory/combination_care_graph.cpp
+++ b/src/theory/combination_care_graph.cpp
@@ -79,7 +79,8 @@ void CombinationCareGraph::combineTheories()
       Node split = equality.orNode(equality.notNode());
       tsplit = TrustNode::mkTrustLemma(split, nullptr);
     }
-    d_sharedSolver->sendLemma(tsplit, carePair.d_theory, InferenceId::COMBINATION_SPLIT);
+    d_sharedSolver->sendLemma(
+        tsplit, carePair.d_theory, InferenceId::COMBINATION_SPLIT);
 
     // Could check the equality status here:
     //   EqualityStatus es = getEqualityStatus(carePair.d_a, carePair.d_b);

--- a/src/theory/combination_care_graph.cpp
+++ b/src/theory/combination_care_graph.cpp
@@ -79,7 +79,7 @@ void CombinationCareGraph::combineTheories()
       Node split = equality.orNode(equality.notNode());
       tsplit = TrustNode::mkTrustLemma(split, nullptr);
     }
-    d_sharedSolver->sendLemma(tsplit, carePair.d_theory);
+    d_sharedSolver->sendLemma(tsplit, carePair.d_theory, InferenceId::COMBINATION_SPLIT);
 
     // Could check the equality status here:
     //   EqualityStatus es = getEqualityStatus(carePair.d_a, carePair.d_b);

--- a/src/theory/inference_id.cpp
+++ b/src/theory/inference_id.cpp
@@ -25,6 +25,7 @@ const char* toString(InferenceId i)
   switch (i)
   {
     case InferenceId::EQ_CONSTANT_MERGE: return "EQ_CONSTANT_MERGE";
+    case InferenceId::COMBINATION_SPLIT: return "COMBINATION_SPLIT";
     case InferenceId::ARITH_BLACK_BOX: return "ARITH_BLACK_BOX";
     case InferenceId::ARITH_CONF_EQ: return "ARITH_CONF_EQ";
     case InferenceId::ARITH_CONF_LOWER: return "ARITH_CONF_LOWER";

--- a/src/theory/inference_id.h
+++ b/src/theory/inference_id.h
@@ -41,6 +41,8 @@ enum class InferenceId
   // ---------------------------------- core
   // a conflict when two constants merge in the equality engine (of any theory)
   EQ_CONSTANT_MERGE,
+  // a split from theory combination
+  COMBINATION_SPLIT,
   // ---------------------------------- arith theory
   //-------------------- linear core
   // black box conflicts. It's magic.

--- a/src/theory/shared_solver.cpp
+++ b/src/theory/shared_solver.cpp
@@ -135,8 +135,9 @@ bool SharedSolver::propagateSharedEquality(theory::TheoryId theory,
 
 bool SharedSolver::isShared(TNode t) const { return d_sharedTerms.isShared(t); }
 
-void SharedSolver::sendLemma(TrustNode trn, TheoryId atomsTo)
+void SharedSolver::sendLemma(TrustNode trn, TheoryId atomsTo, InferenceId id)
 {
+  Trace("im") << "(lemma " << id << " " << trn.getProven() << ")" << std::endl;
   d_te.lemma(trn, LemmaProperty::NONE, atomsTo);
 }
 

--- a/src/theory/shared_solver.h
+++ b/src/theory/shared_solver.h
@@ -19,10 +19,10 @@
 #define CVC5__THEORY__SHARED_SOLVER__H
 
 #include "expr/node.h"
+#include "theory/inference_id.h"
 #include "theory/shared_terms_database.h"
 #include "theory/term_registration_visitor.h"
 #include "theory/valuation.h"
-#include "theory/inference_id.h"
 
 namespace cvc5 {
 

--- a/src/theory/shared_solver.h
+++ b/src/theory/shared_solver.h
@@ -22,6 +22,7 @@
 #include "theory/shared_terms_database.h"
 #include "theory/term_registration_visitor.h"
 #include "theory/valuation.h"
+#include "theory/inference_id.h"
 
 namespace cvc5 {
 

--- a/src/theory/shared_solver.h
+++ b/src/theory/shared_solver.h
@@ -123,7 +123,7 @@ class SharedSolver
                                TNode b,
                                bool value);
   /** Send lemma to the theory engine, atomsTo is the theory to send atoms to */
-  void sendLemma(TrustNode trn, TheoryId atomsTo);
+  void sendLemma(TrustNode trn, TheoryId atomsTo, InferenceId id);
   /** Send conflict to the theory engine */
   void sendConflict(TrustNode trn);
 


### PR DESCRIPTION
Followup PRs will unify these with the lemmas / stats infrastructure in theory inference manager.