### PR TITLE
libpoly follows the debug/release of cvc5

### DIFF
--- a/cmake/FindPoly.cmake
+++ b/cmake/FindPoly.cmake
@@ -79,7 +79,7 @@ if(NOT Poly_FOUND_SYSTEM)
       sed -i.orig
       "s,add_subdirectory(test/polyxx),add_subdirectory(test/polyxx EXCLUDE_FROM_ALL),g"
       <SOURCE_DIR>/CMakeLists.txt ${patchcmd}
-    CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
+    CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
                -DLIBPOLY_BUILD_PYTHON_API=OFF


### PR DESCRIPTION
I would suggest using the debug build of libpoly in the debug build of cvc5. 
IMPORTANT NOTE: please make sure that ${CMAKE_BUILD_TYPE} referenced here is actually the CMAKE_BUILD_TYPE passed from ./configure.sh. I'm not 100% sure about this. 

