### PR TITLE
Fix ANTLR build with CMake <3.11

### DIFF
--- a/cmake/FindANTLR3.cmake
+++ b/cmake/FindANTLR3.cmake
@@ -53,7 +53,7 @@ if(NOT ANTLR3_FOUND_SYSTEM)
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND ${CMAKE_COMMAND} -E copy
-            <SOURCE_DIR>/../antlr-3.4-complete.jar
+            <DOWNLOADED_FILE>
             <INSTALL_DIR>/share/java/antlr-3.4-complete.jar
         BUILD_BYPRODUCTS <INSTALL_DIR>/share/java/antlr-3.4-complete.jar
     )
@@ -68,7 +68,7 @@ if(NOT ANTLR3_FOUND_SYSTEM)
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND ${CMAKE_COMMAND} -E copy
-          <DOWNLOAD_DIR>/config.guess
+          <DOWNLOADED_FILE>
           <INSTALL_DIR>/share/config.guess
         BUILD_BYPRODUCTS <INSTALL_DIR>/share/config.guess
     )
@@ -83,7 +83,7 @@ if(NOT ANTLR3_FOUND_SYSTEM)
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND ${CMAKE_COMMAND} -E copy
-          <DOWNLOAD_DIR>/config.sub
+          <DOWNLOADED_FILE>
           <INSTALL_DIR>/share/config.sub
         BUILD_BYPRODUCTS <INSTALL_DIR>/share/config.sub
     )


### PR DESCRIPTION
With CMake 3.11 and later, `<DOWNLOAD_DIR>` is substituted in
`ExternalProject_Add` but not in older versions [0]. To maintain
compatibility with older versions of CMake, this commit changes
`ExternalProject_Add` to use `<DOWNLOADED_FILE>` instead, which is both
nicer and substituted in older versions of CMake.

[0] https://cmake.org/cmake/help/latest/release/3.11.html#modules