### PR TITLE
[rewriter] Add rewrite to order IFF (equality for Booleans)

### DIFF
--- a/src/prop/sat_proof_manager.cpp
+++ b/src/prop/sat_proof_manager.cpp
@@ -336,6 +336,10 @@ void SatProofManager::explainLit(SatLiteral lit,
   Trace("sat-proof") << push << "SatProofManager::explainLit: Lit: " << lit;
   Node litNode = getClauseNode(lit);
   Trace("sat-proof") << " [" << litNode << "]\n";
+  // Note that if we had two literals for (= a b) and (= b a) and we had already
+  // a proof for (= a b) this test would return true for (= b a), which could
+  // lead to open proof. However we should never have two literals like this in
+  // the SAT solver since they'd be rewritten to the same one
   if (d_resChainPg.hasProofFor(litNode))
   {
     Trace("sat-proof") << "SatProofManager::explainLit: already justified "

--- a/src/theory/booleans/theory_bool_rewriter.cpp
+++ b/src/theory/booleans/theory_bool_rewriter.cpp
@@ -36,7 +36,7 @@ RewriteResponse TheoryBoolRewriter::postRewrite(TNode node) {
  * flattenNode looks for children of same kind, and if found merges
  * them into the parent.
  *
- * It simultaneously handles a couple of other optimizations: 
+ * It simultaneously handles a couple of other optimizations:
  * - trivialNode - if found during exploration, return that node itself
  *    (like in case of OR, if "true" is found, makes sense to replace
  *     whole formula with "true")
@@ -287,7 +287,13 @@ RewriteResponse TheoryBoolRewriter::preRewrite(TNode n) {
         }
       }
     }
-    break;
+    // sort
+    if (n[0].getId() > n[1].getId())
+    {
+      return RewriteResponse(REWRITE_AGAIN,
+                             nodeManager->mkNode(kind::EQUAL, n[1], n[0]));
+    }
+    return RewriteResponse(REWRITE_DONE, n);
   }
   case kind::XOR: {
     // rewrite simple cases of XOR

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -828,6 +828,7 @@ set(regress_0_tests
   regress0/printer/symbol_starting_w_digit.smt2
   regress0/printer/tuples_and_records.cvc
   regress0/proofs/issue277-circuit-propagator.smt2
+  regress0/proofs/open-pf-if-unordered-iff.smt2
   regress0/proofs/scope.smt2
   regress0/proofs/trust-subs-eq-open.smt2
   regress0/push-pop/boolean/fuzz_12.smt2

--- a/test/regress/regress0/proofs/open-pf-if-unordered-iff.smt2
+++ b/test/regress/regress0/proofs/open-pf-if-unordered-iff.smt2
@@ -1,0 +1,10 @@
+; COMMAND-LINE: --check-proofs
+; EXPECT: unsat
+(set-logic ALL)
+(declare-const __ (_ BitVec 3))
+(declare-const ___ (_ BitVec 3))
+(assert (= (_ bv0 64) (bvand (_ bv1 64) ((_ zero_extend 32) ((_ zero_extend 16) ((_ zero_extend 8) ((_ zero_extend 4) ((_ zero_extend 1) __))))))))
+(assert (bvule __ ___))
+(assert (= (_ bv0 64) (bvand (_ bv1 64) (bvadd (_ bv1 64) ((_ zero_extend 32) ((_ zero_extend 16) ((_ zero_extend 8) ((_ zero_extend 4) ((_ zero_extend 1) ___)))))))))
+(assert (bvule ___ __))
+(check-sat)

--- a/test/regress/regress0/proofs/open-pf-if-unordered-iff.smt2
+++ b/test/regress/regress0/proofs/open-pf-if-unordered-iff.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE: --check-proofs
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-const __ (_ BitVec 3))


### PR DESCRIPTION
Not doing this rewrite for Booleans is probably an artifact of the old `IFF` kind being removed. This rewrite is important to simplify the generation of proofs for the SAT solver, as clarified in the new comment in the SAT proof manager.