### PR TITLE
bv: Add missing BV_EAGER_ATOM proof rule.

### DIFF
--- a/src/theory/bv/bv_solver_simple.cpp
+++ b/src/theory/bv/bv_solver_simple.cpp
@@ -123,6 +123,8 @@ bool BVSolverSimple::preNotifyFact(
     }
     else
     {
+      d_bitblaster->getProofGenerator()->addRewriteStep(
+          fact, n, PfRule::BV_EAGER_ATOM, {}, {fact});
       TrustNode tlem =
           TrustNode::mkTrustLemma(lemma, d_bitblaster->getProofGenerator());
       d_im.trustedLemma(tlem, InferenceId::BV_SIMPLE_LEMMA);


### PR DESCRIPTION
Fixes an issue with `--proof-eager-checking` and `--bitblast=eager`.