### PR TITLE
[Unit Tests] Avoid linking against external libs

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -45,13 +45,11 @@ macro(cvc5_add_unit_test is_white name output_dir)
   target_link_libraries(${name} PUBLIC GTest::Main)
   target_link_libraries(${name} PUBLIC GTest::GTest)
 
-  if(USE_CLN)
-    target_link_libraries(${name} PUBLIC CLN)
-  endif()
   if(USE_POLY)
-    target_link_libraries(${name} PUBLIC Polyxx)
+    # Make libpoly headers available for tests
+    target_include_directories(${name} PRIVATE "${Poly_INCLUDE_DIR}")
   endif()
-  target_link_libraries(${name} PUBLIC GMP)
+
   if(${is_white})
     target_compile_options(${name} PRIVATE -fno-access-control)
   endif()


### PR DESCRIPTION
Fixes #6866. The `theory_airth_cad_white` unit test has been failing on
some platforms (e.g., macOS) due to statically linking libpoly in
libcvc5 and then separately linking it in the unit tests. This resulted
in issues with `static` variables. This commit fixes the issue by
avoiding linking libpoly in the unit tests and instead relying solely on
libcvc5.

Co-authored-by: Ouyancheng <1024842937@qq.com>