### PR TITLE
Do not exhaustive instantiation when FMF is disabled

### DIFF
--- a/src/theory/quantifiers/fmf/full_model_check.cpp
+++ b/src/theory/quantifiers/fmf/full_model_check.cpp
@@ -1366,10 +1366,11 @@ void FullModelChecker::registerQuantifiedFormula(Node q)
   NodeManager* nm = NodeManager::currentNM();
   SkolemManager* sm = nm->getSkolemManager();
   std::vector<TypeNode> types;
+  QuantifiersBoundInference& qbi = d_qreg.getQuantifiersBoundInference();
   for (const Node& v : q[0])
   {
     TypeNode tn = v.getType();
-    if (tn.isFunction())
+    if (tn.isFunction() || !qbi.isFiniteBound(q, v))
     {
       // we will not use model-based quantifier instantiation for q, since
       // the model-based instantiation algorithm does not handle (universally

--- a/src/theory/quantifiers/fmf/full_model_check.cpp
+++ b/src/theory/quantifiers/fmf/full_model_check.cpp
@@ -1366,11 +1366,10 @@ void FullModelChecker::registerQuantifiedFormula(Node q)
   NodeManager* nm = NodeManager::currentNM();
   SkolemManager* sm = nm->getSkolemManager();
   std::vector<TypeNode> types;
-  QuantifiersBoundInference& qbi = d_qreg.getQuantifiersBoundInference();
   for (const Node& v : q[0])
   {
     TypeNode tn = v.getType();
-    if (tn.isFunction() || !qbi.isFiniteBound(q, v))
+    if (tn.isFunction())
     {
       // we will not use model-based quantifier instantiation for q, since
       // the model-based instantiation algorithm does not handle (universally

--- a/src/theory/quantifiers/fmf/model_engine.cpp
+++ b/src/theory/quantifiers/fmf/model_engine.cpp
@@ -217,7 +217,7 @@ int ModelEngine::checkModel(){
       Node q = fm->getAssertedQuantifier( i, true );
       Trace("fmf-exh-inst") << "-> Exhaustive instantiate " << q << ", effort = " << e << "..." << std::endl;
       //determine if we should check this quantifier
-      if (fm->isQuantifierActive(q))
+      if (!fm->isQuantifierActive(q))
       {
         Trace("fmf-exh-inst") << "-> Inactive : " << q << std::endl;
         continue;

--- a/src/theory/quantifiers/fmf/model_engine.cpp
+++ b/src/theory/quantifiers/fmf/model_engine.cpp
@@ -124,7 +124,7 @@ bool ModelEngine::checkComplete(IncompleteId& incId)
 }
 
 bool ModelEngine::checkCompleteFor( Node q ) {
-  return d_incompleteQuants.find(q)!=d_incompleteQuants.end();
+  return d_incompleteQuants.find(q)==d_incompleteQuants.end();
 }
 
 void ModelEngine::registerQuantifier( Node f ){

--- a/src/theory/quantifiers/fmf/model_engine.cpp
+++ b/src/theory/quantifiers/fmf/model_engine.cpp
@@ -103,7 +103,9 @@ void ModelEngine::check(Theory::Effort e, QEffort quant_e)
     }
 
     if( addedLemmas==0 ){
-      Trace("model-engine-debug") << "No lemmas added, incomplete = " << ( d_incomplete_check || !d_incompleteQuants.empty() ) << std::endl;
+      Trace("model-engine-debug")
+          << "No lemmas added, incomplete = "
+          << (d_incomplete_check || !d_incompleteQuants.empty()) << std::endl;
       // cvc5 will answer SAT or unknown
       if( Trace.isOn("fmf-consistent") ){
         Trace("fmf-consistent") << std::endl;
@@ -124,7 +126,7 @@ bool ModelEngine::checkComplete(IncompleteId& incId)
 }
 
 bool ModelEngine::checkCompleteFor( Node q ) {
-  return d_incompleteQuants.find(q)==d_incompleteQuants.end();
+  return d_incompleteQuants.find(q) == d_incompleteQuants.end();
 }
 
 void ModelEngine::registerQuantifier( Node f ){
@@ -228,7 +230,7 @@ int ModelEngine::checkModel(){
         d_incompleteQuants.insert(q);
         continue;
       }
-      exhaustiveInstantiate( q, e );
+      exhaustiveInstantiate(q, e);
       if (d_qstate.isInConflict())
       {
         break;
@@ -264,7 +266,7 @@ void ModelEngine::exhaustiveInstantiate( Node f, int effort ){
   if( retEi!=0 ){
     if( retEi<0 ){
       Trace("fmf-exh-inst") << "-> Builder determined complete instantiation was impossible." << std::endl;
-      d_incompleteQuants.insert( f );
+      d_incompleteQuants.insert(f);
     }else{
       Trace("fmf-exh-inst") << "-> Builder determined instantiation(s)." << std::endl;
     }
@@ -320,7 +322,7 @@ void ModelEngine::exhaustiveInstantiate( Node f, int effort ){
     }
     //if the iterator is incomplete, we will return unknown instead of sat if no instantiations are added this round
     if( riter.isIncomplete() ){
-      d_incompleteQuants.insert( f );
+      d_incompleteQuants.insert(f);
     }
   }
 }
@@ -361,7 +363,8 @@ bool ModelEngine::shouldProcess(Node q)
   {
     return true;
   }
-  // otherwise, we are only using model-based instantiation for internal quantified formulas
+  // otherwise, we are only using model-based instantiation for internal
+  // quantified formulas
   QuantAttributes& qattr = d_qreg.getQuantAttributes();
   return qattr.isInternal(q);
 }

--- a/src/theory/quantifiers/fmf/model_engine.cpp
+++ b/src/theory/quantifiers/fmf/model_engine.cpp
@@ -103,7 +103,7 @@ void ModelEngine::check(Theory::Effort e, QEffort quant_e)
     }
 
     if( addedLemmas==0 ){
-      Trace("model-engine-debug") << "No lemmas added, incomplete = " << ( d_incomplete_check || !d_incomplete_quants.empty() ) << std::endl;
+      Trace("model-engine-debug") << "No lemmas added, incomplete = " << ( d_incomplete_check || !d_incompleteQuants.empty() ) << std::endl;
       // cvc5 will answer SAT or unknown
       if( Trace.isOn("fmf-consistent") ){
         Trace("fmf-consistent") << std::endl;
@@ -124,7 +124,7 @@ bool ModelEngine::checkComplete(IncompleteId& incId)
 }
 
 bool ModelEngine::checkCompleteFor( Node q ) {
-  return std::find( d_incomplete_quants.begin(), d_incomplete_quants.end(), q )==d_incomplete_quants.end();
+  return d_incompleteQuants.find(q)!=d_incompleteQuants.end();
 }
 
 void ModelEngine::registerQuantifier( Node f ){
@@ -149,10 +149,6 @@ void ModelEngine::registerQuantifier( Node f ){
       Trace("fmf-warn") << "Warning : Model Engine : may not be able to answer SAT because of formula : " << f << std::endl;
     }
   }
-}
-
-void ModelEngine::assertNode( Node f ){
-
 }
 
 int ModelEngine::checkModel(){
@@ -194,7 +190,7 @@ int ModelEngine::checkModel(){
   if( Trace.isOn("model-engine") ){
     for( unsigned i=0; i<fm->getNumAssertedQuantifiers(); i++ ){
       Node f = fm->getAssertedQuantifier( i );
-      if (fm->isQuantifierActive(f) && d_qreg.hasOwnership(f, this))
+      if (fm->isQuantifierActive(f) && shouldProcess(f))
       {
         int totalInst = 1;
         for( unsigned j=0; j<f[0].getNumChildren(); j++ ){
@@ -216,20 +212,26 @@ int ModelEngine::checkModel(){
                   ? 2
                   : (options::mbqiMode() == options::MbqiMode::TRUST ? 0 : 1);
   for( int e=0; e<e_max; e++) {
-    d_incomplete_quants.clear();
+    d_incompleteQuants.clear();
     for( unsigned i=0; i<fm->getNumAssertedQuantifiers(); i++ ){
       Node q = fm->getAssertedQuantifier( i, true );
       Trace("fmf-exh-inst") << "-> Exhaustive instantiate " << q << ", effort = " << e << "..." << std::endl;
       //determine if we should check this quantifier
-      if (fm->isQuantifierActive(q) && d_qreg.hasOwnership(q, this))
+      if (fm->isQuantifierActive(q))
       {
-        exhaustiveInstantiate( q, e );
-        if (d_qstate.isInConflict())
-        {
-          break;
-        }
-      }else{
         Trace("fmf-exh-inst") << "-> Inactive : " << q << std::endl;
+        continue;
+      }
+      if (!shouldProcess(q))
+      {
+        Trace("fmf-exh-inst") << "-> Not processed : " << q << std::endl;
+        d_incompleteQuants.insert(q);
+        continue;
+      }
+      exhaustiveInstantiate( q, e );
+      if (d_qstate.isInConflict())
+      {
+        break;
       }
     }
     if( d_addedLemmas>0 ){
@@ -262,7 +264,7 @@ void ModelEngine::exhaustiveInstantiate( Node f, int effort ){
   if( retEi!=0 ){
     if( retEi<0 ){
       Trace("fmf-exh-inst") << "-> Builder determined complete instantiation was impossible." << std::endl;
-      d_incomplete_quants.push_back( f );
+      d_incompleteQuants.insert( f );
     }else{
       Trace("fmf-exh-inst") << "-> Builder determined instantiation(s)." << std::endl;
     }
@@ -318,7 +320,7 @@ void ModelEngine::exhaustiveInstantiate( Node f, int effort ){
     }
     //if the iterator is incomplete, we will return unknown instead of sat if no instantiations are added this round
     if( riter.isIncomplete() ){
-      d_incomplete_quants.push_back( f );
+      d_incompleteQuants.insert( f );
     }
   }
 }
@@ -346,6 +348,22 @@ void ModelEngine::debugPrint( const char* c ){
       }
     }
   }
+}
+
+bool ModelEngine::shouldProcess(Node q)
+{
+  if (!d_qreg.hasOwnership(q, this))
+  {
+    return false;
+  }
+  // if finite model finding or fmf bound is on, we process everything
+  if (options::finiteModelFind() || options::fmfBound())
+  {
+    return true;
+  }
+  // otherwise, we are only using model-based instantiation for internal quantified formulas
+  QuantAttributes& qattr = d_qreg.getQuantAttributes();
+  return qattr.isInternal(q);
 }
 
 }  // namespace quantifiers

--- a/src/theory/quantifiers/fmf/model_engine.h
+++ b/src/theory/quantifiers/fmf/model_engine.h
@@ -38,8 +38,6 @@ private:
   //temporary statistics
   //is the exhaustive instantiation incomplete?
   bool d_incomplete_check;
-  // set of quantified formulas for which check was incomplete
-  std::vector< Node > d_incomplete_quants;
   int d_addedLemmas;
   int d_triedLemmas;
   int d_totalLemmas;
@@ -59,15 +57,20 @@ public:
  bool checkComplete(IncompleteId& incId) override;
  bool checkCompleteFor(Node q) override;
  void registerQuantifier(Node f) override;
- void assertNode(Node f) override;
  Node explain(TNode n) { return Node::null(); }
  void debugPrint(const char* c);
  /** Identify this module */
  std::string identify() const override { return "ModelEngine"; }
 
-private:
- /** Pointer to the model builder of quantifiers engine */
- QModelBuilder* d_builder;
+ private:
+  /** Should we process quantified formula q? */
+  bool shouldProcess(Node q);
+  /** Pointer to the model builder of quantifiers engine */
+  QModelBuilder* d_builder;
+  /** Set of quantified formulas that are infinite */
+  std::unordered_map<Node, bool> d_infiniteQuants;
+  /** set of quantified formulas for which check was incomplete */
+  std::unordered_set< Node > d_incompleteQuants;
 };/* class ModelEngine */
 
 }  // namespace quantifiers

--- a/src/theory/quantifiers/fmf/model_engine.h
+++ b/src/theory/quantifiers/fmf/model_engine.h
@@ -67,8 +67,6 @@ private:
  bool shouldProcess(Node q);
  /** Pointer to the model builder of quantifiers engine */
  QModelBuilder* d_builder;
- /** Set of quantified formulas that are infinite */
- std::unordered_map<Node, bool> d_infiniteQuants;
  /** set of quantified formulas for which check was incomplete */
  std::unordered_set<Node> d_incompleteQuants;
 };/* class ModelEngine */

--- a/src/theory/quantifiers/fmf/model_engine.h
+++ b/src/theory/quantifiers/fmf/model_engine.h
@@ -62,15 +62,15 @@ public:
  /** Identify this module */
  std::string identify() const override { return "ModelEngine"; }
 
- private:
-  /** Should we process quantified formula q? */
-  bool shouldProcess(Node q);
-  /** Pointer to the model builder of quantifiers engine */
-  QModelBuilder* d_builder;
-  /** Set of quantified formulas that are infinite */
-  std::unordered_map<Node, bool> d_infiniteQuants;
-  /** set of quantified formulas for which check was incomplete */
-  std::unordered_set< Node > d_incompleteQuants;
+private:
+ /** Should we process quantified formula q? */
+ bool shouldProcess(Node q);
+ /** Pointer to the model builder of quantifiers engine */
+ QModelBuilder* d_builder;
+ /** Set of quantified formulas that are infinite */
+ std::unordered_map<Node, bool> d_infiniteQuants;
+ /** set of quantified formulas for which check was incomplete */
+ std::unordered_set<Node> d_incompleteQuants;
 };/* class ModelEngine */
 
 }  // namespace quantifiers


### PR DESCRIPTION
This makes FMF not handle quantified formulas when FMF options are disabled, apart from those marked internal.

This is required for combinations of sequences + quantified formulas.