### PR TITLE
'CryptoMiniSat_LIBRARIES' should respect lib/lib64

### DIFF
--- a/cmake/FindCryptoMiniSat.cmake
+++ b/cmake/FindCryptoMiniSat.cmake
@@ -66,7 +66,7 @@ if(NOT CryptoMiniSat_FOUND_SYSTEM)
                -DNOZLIB=ON
                -DONLY_SIMPLE=ON
                -DSTATICCOMPILE=ON
-    BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libcryptominisat5.a
+    BUILD_BYPRODUCTS <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/libcryptominisat5.a
   )
   # remove unused stuff to keep folder small
   ExternalProject_Add_Step(
@@ -77,7 +77,7 @@ if(NOT CryptoMiniSat_FOUND_SYSTEM)
   )
 
   set(CryptoMiniSat_INCLUDE_DIR "${DEPS_BASE}/include/")
-  set(CryptoMiniSat_LIBRARIES "${DEPS_BASE}/lib/libcryptominisat5.a")
+  set(CryptoMiniSat_LIBRARIES "${DEPS_BASE}/${CMAKE_INSTALL_LIBDIR}/libcryptominisat5.a")
 
   add_library(CryptoMiniSat STATIC IMPORTED GLOBAL)
   set_target_properties(


### PR DESCRIPTION
This PR is very similar to #6091.

On 64-bit openSUSE (and maybe other distributions), the default install directory for static libraries is `lib64` *not* `lib`. This has an impact on cvc5 when it is automatically building CMS (e.g., with `./configure.sh --cryptominisat --auto-download`): CMS adheres to the default value of `CMAKE_INSTALL_LIBDIR` to work out where to install the library files (so `lib64` on openSUSE), which fails when cvc5 tries to find these in `lib`.

Without this change, the build fails as follows:

```
<snip>
src/CMakeFiles/cvc5.dir/theory/type_enumerator.cpp.o  -Wl,-rpath,::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::  deps/lib/libcadical.a  deps/lib/libcryptominisat5.a  ../deps/install/lib64/libglpk.a  deps/lib/libpicpolyxx.a  /usr/lib64/libgmp.so  deps/lib/libpicpoly.a  /usr/lib64/libgmp.so && :
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: cannot find deps/lib/libcryptominisat5.a: No such file or directory
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

and where:

```
avj@platypus ~/clones/cvc5/master/build$ find . -iname "libcryptominisat5.a"
./deps/src/CryptoMiniSat-EP-build/lib/libcryptominisat5.a
./deps/lib64/libcryptominisat5.a
```

(notice: `lib64` in the second path!)

This PR fixes this discrepancy to ensure that cvc5 checks for CMS on `CMAKE_INSTALL_LIBDIR` as well.

**Note**: `CMAKE_INSTALL_LIBDIR` comes from `GNUInstallDirs`, and this is `include`'d in cvc5's top-level `CMakeLists.txt`

Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>