### PR TITLE
ANTLR3: Install into `CMAKE_INSTALL_LIBDIR`

### DIFF
--- a/cmake/FindANTLR3.cmake
+++ b/cmake/FindANTLR3.cmake
@@ -112,6 +112,7 @@ if(NOT ANTLR3_FOUND_SYSTEM)
             --with-pic
             --disable-antlrdebug
             --prefix=<INSTALL_DIR>
+            --libdir=<INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}
             --srcdir=<SOURCE_DIR>
             --disable-shared
             --enable-static


### PR DESCRIPTION
On some platforms, autotools installs ANTLR3's libraries into `lib` but
`CMAKE_INSTALL_LIBDIR` is set to `lib64` (e.g., Fedora 33).  This commit
sets `--libdir` to force autotools to install the library into the
directory specified by `CMAKE_INSTALL_LIBDIR`.