### PR TITLE
Fix CoCoA build for newer compilers

### DIFF
--- a/cmake/FindCoCoA.cmake
+++ b/cmake/FindCoCoA.cmake
@@ -56,6 +56,10 @@ if(NOT CoCoA_FOUND_SYSTEM)
     ${COMMON_EP_CONFIG}
     URL "http://cocoa.dima.unige.it/cocoalib/tgz/CoCoALib-${CoCoA_VERSION}.tgz"
     URL_HASH SHA1=873d0b60800cd3852939816ce0aa2e7f72dac4ce
+    # CoCoA requires C++14, but the check does not work with compilers that
+    # default to C++17 or newer. The patch fixes the check.
+    PATCH_COMMAND patch -p1 -d <SOURCE_DIR>
+        -i ${CMAKE_CURRENT_LIST_DIR}/deps-utils/CoCoA-patch-0.99712.patch
     BUILD_IN_SOURCE YES
     CONFIGURE_COMMAND ./configure --prefix=<INSTALL_DIR>
     BUILD_COMMAND ${make_cmd} library

--- a/cmake/deps-utils/CoCoA-patch-0.99712.patch
+++ b/cmake/deps-utils/CoCoA-patch-0.99712.patch
@@ -1,0 +1,13 @@
+diff --git a/configuration/cxx14.sh b/configuration/cxx14.sh
+index cdbf338..0436983 100755
+--- a/configuration/cxx14.sh
++++ b/configuration/cxx14.sh
+@@ -40,7 +40,7 @@ int main()
+ {
+   int ReturnCode = 0; // will mean c++14 compliant
+   std::cout << "C++ version: " << __cplusplus << std::endl;
+-#if __cplusplus < 201400L
++#if __cplusplus < 201400L || __cplusplus >= 201703L
+   ReturnCode = 1;  // NOT C++14 compilant
+ #endif
+   return ReturnCode;


### PR DESCRIPTION
Newer compilers, such as GCC 11, default to C++17. CoCoA does not
compile with C++17 and its check for the C++ version used by the
compiler does not take into account newer C++ versions. As a result,
building CoCoA using `--auto-download` fails with GCC 11. This commit
adds a patch that makes the test in CoCoA take into account compilers
that default to C++17 or newer.