### PR TITLE
More updates to arithmetic in preparation for central equality engine

### DIFF
--- a/src/options/arith_options.toml
+++ b/src/options/arith_options.toml
@@ -595,3 +595,11 @@ name   = "Arithmetic Theory"
   type       = "bool"
   default    = "false"
   help       = "whether to use the equality solver in the theory of arithmetic"
+
+[[option]]
+  name       = "arithCongMan"
+  category   = "regular"
+  long       = "arith-cong-man"
+  type       = "bool"
+  default    = "true"
+  help       = "(experimental) whether to use the congruence manager when the equality solver is enabled"

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -972,11 +972,11 @@ void setDefaults(LogicInfo& logic, bool isInternalSubsolver)
   // set up of central equality engine
   if (opts.arith.arithEqSolver)
   {
-    if (!options.arith.arithCongManSetByUser)
+    if (!opts.arith.arithCongManWasSetByUser)
     {
       // if we are using the arithmetic equality solver, do not use the
       // arithmetic congruence manager by default
-      options.arith.arithCongMan = false;
+      opts.arith.arithCongMan = false;
     }
   }
 

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -979,7 +979,7 @@ void setDefaults(LogicInfo& logic, bool isInternalSubsolver)
       options.arith.arithCongMan = false;
     }
   }
-  
+
   if (options::incrementalSolving())
   {
     // disable modes not supported by incremental

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -968,6 +968,18 @@ void setDefaults(LogicInfo& logic, bool isInternalSubsolver)
     Trace("smt") << "setting decision mode to " << opts.decision.decisionMode
                  << std::endl;
   }
+
+  // set up of central equality engine
+  if (opts.arith.arithEqSolver)
+  {
+    if (!options.arith.arithCongManSetByUser)
+    {
+      // if we are using the arithmetic equality solver, do not use the
+      // arithmetic congruence manager by default
+      options.arith.arithCongMan = false;
+    }
+  }
+  
   if (options::incrementalSolving())
   {
     // disable modes not supported by incremental

--- a/src/theory/arith/equality_solver.cpp
+++ b/src/theory/arith/equality_solver.cpp
@@ -80,6 +80,11 @@ TrustNode EqualitySolver::explain(TNode lit)
 }
 bool EqualitySolver::propagateLit(Node lit)
 {
+  // if we've already propagated, ignore
+  if (d_aim.hasPropagated(lit))
+  {
+    return true;
+  }
   // notice this is only used when ee-mode=distributed
   // remember that this was a literal we propagated
   Trace("arith-eq-solver-debug") << "propagate lit " << lit << std::endl;

--- a/src/theory/arith/inference_manager.cpp
+++ b/src/theory/arith/inference_manager.cpp
@@ -27,7 +27,8 @@ namespace arith {
 InferenceManager::InferenceManager(TheoryArith& ta,
                                    ArithState& astate,
                                    ProofNodeManager* pnm)
-    : InferenceManagerBuffered(ta, astate, pnm, "theory::arith::")
+    : InferenceManagerBuffered(ta, astate, pnm, "theory::arith::"),
+      d_propLits(astate.getSatContext())
 {
 }
 
@@ -144,6 +145,18 @@ bool InferenceManager::isEntailedFalse(const SimpleTheoryLemma& lem)
     }
   }
   return false;
+}
+
+bool InferenceManager::propagateLit(TNode lit)
+{
+  Assert(!hasPropagated(lit));
+  d_propLits.insert(lit);
+  return TheoryInferenceManager::propagateLit(lit);
+}
+
+bool InferenceManager::hasPropagated(TNode lit) const
+{
+  return d_propLits.find(lit) != d_propLits.end();
 }
 
 }  // namespace arith

--- a/src/theory/arith/inference_manager.cpp
+++ b/src/theory/arith/inference_manager.cpp
@@ -28,8 +28,8 @@ InferenceManager::InferenceManager(TheoryArith& ta,
                                    ArithState& astate,
                                    ProofNodeManager* pnm)
     : InferenceManagerBuffered(ta, astate, pnm, "theory::arith::"),
-    // currently must track propagated literals if using the equality solver
-    d_trackPropLits(options::arithEqSolver()),
+      // currently must track propagated literals if using the equality solver
+      d_trackPropLits(options::arithEqSolver()),
       d_propLits(astate.getSatContext())
 {
 }
@@ -160,7 +160,7 @@ bool InferenceManager::propagateLit(TNode lit)
 
 bool InferenceManager::hasPropagated(TNode lit) const
 {
-  Assert (d_trackPropLits);
+  Assert(d_trackPropLits);
   return d_propLits.find(lit) != d_propLits.end();
 }
 

--- a/src/theory/arith/inference_manager.cpp
+++ b/src/theory/arith/inference_manager.cpp
@@ -28,6 +28,8 @@ InferenceManager::InferenceManager(TheoryArith& ta,
                                    ArithState& astate,
                                    ProofNodeManager* pnm)
     : InferenceManagerBuffered(ta, astate, pnm, "theory::arith::"),
+    // currently must track propagated literals if using the equality solver
+    d_trackPropLits(options::arithEqSolver()),
       d_propLits(astate.getSatContext())
 {
 }
@@ -149,13 +151,16 @@ bool InferenceManager::isEntailedFalse(const SimpleTheoryLemma& lem)
 
 bool InferenceManager::propagateLit(TNode lit)
 {
-  Assert(!hasPropagated(lit));
-  d_propLits.insert(lit);
+  if (d_trackPropLits)
+  {
+    d_propLits.insert(lit);
+  }
   return TheoryInferenceManager::propagateLit(lit);
 }
 
 bool InferenceManager::hasPropagated(TNode lit) const
 {
+  Assert (d_trackPropLits);
   return d_propLits.find(lit) != d_propLits.end();
 }
 

--- a/src/theory/arith/inference_manager.h
+++ b/src/theory/arith/inference_manager.h
@@ -97,6 +97,10 @@ class InferenceManager : public InferenceManagerBuffered
 
   /** Checks whether the given lemma is already present in the cache. */
   virtual bool hasCachedLemma(TNode lem, LemmaProperty p) override;
+  /** overrides propagateLit to track which literals have been propagated */
+  bool propagateLit(TNode lit) override;
+  /** has propagated */
+  bool hasPropagated(TNode lit) const;
 
  protected:
   /**
@@ -114,6 +118,8 @@ class InferenceManager : public InferenceManagerBuffered
 
   /** The waiting lemmas. */
   std::vector<std::unique_ptr<SimpleTheoryLemma>> d_waitingLem;
+  /** The literals we have propagated */
+  NodeSet d_propLits;
 };
 
 }  // namespace arith

--- a/src/theory/arith/inference_manager.h
+++ b/src/theory/arith/inference_manager.h
@@ -115,9 +115,10 @@ class InferenceManager : public InferenceManagerBuffered
    * conflict.
    */
   bool isEntailedFalse(const SimpleTheoryLemma& lem);
-
   /** The waiting lemmas. */
   std::vector<std::unique_ptr<SimpleTheoryLemma>> d_waitingLem;
+  /** Whether we are tracking the set of propagated literals */
+  bool d_trackPropLits;
   /** The literals we have propagated */
   NodeSet d_propLits;
 };

--- a/src/theory/arith/inference_manager.h
+++ b/src/theory/arith/inference_manager.h
@@ -99,7 +99,10 @@ class InferenceManager : public InferenceManagerBuffered
   virtual bool hasCachedLemma(TNode lem, LemmaProperty p) override;
   /** overrides propagateLit to track which literals have been propagated */
   bool propagateLit(TNode lit) override;
-  /** has propagated */
+  /**
+   * Return true if we have propagated lit already. This call is only valid if
+   * d_trackPropLits is true.
+   */
   bool hasPropagated(TNode lit) const;
 
  protected:

--- a/src/theory/arith/theory_arith_private.cpp
+++ b/src/theory/arith/theory_arith_private.cpp
@@ -137,7 +137,7 @@ TheoryArithPrivate::TheoryArithPrivate(TheoryArith& containing,
                           d_partialModel,
                           RaiseEqualityEngineConflict(*this),
                           d_pnm),
-      d_cmEnabled(c, true),
+      d_cmEnabled(c, options::arithCongMan()),
 
       d_dualSimplex(
           d_linEq, d_errorSet, RaiseConflict(*this), TempVarMalloc(*this)),

--- a/src/theory/theory_inference_manager.h
+++ b/src/theory/theory_inference_manager.h
@@ -132,7 +132,7 @@ class TheoryInferenceManager
    * EqualityEngineNotify::eqNotifyTriggerPredicate and
    * EqualityEngineNotify::eqNotifyTriggerTermEquality.
    */
-  bool propagateLit(TNode lit);
+  virtual bool propagateLit(TNode lit);
   /**
    * Return an explanation for the literal represented by parameter lit
    * (which was previously propagated by this theory). By default, this


### PR DESCRIPTION
Makes arithEqSolver more robust to propagations from multiple sources, changes the default relationship to congruence manager based on preliminary results on SMT-LIB.