### PR TITLE
Add regression for fixed `str.indexof_re` issue

### DIFF
--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -2506,6 +2506,7 @@ set(regress_2_tests
   regress2/strings/issue6057-replace-re-all-simplified.smt2
   regress2/strings/issue6636-replace-re-all.smt2
   regress2/strings/issue6637-replace-re-all.smt2
+  regress2/strings/issue6639-replace-re-all.smt2
   regress2/strings/issue918.smt2
   regress2/strings/non_termination_regular_expression6.smt2
   regress2/strings/range-perf.smt2

--- a/test/regress/regress2/strings/issue6639-replace-re-all.smt2
+++ b/test/regress/regress2/strings/issue6639-replace-re-all.smt2
@@ -1,0 +1,6 @@
+(set-logic QF_SLIA)
+(declare-fun a () String)
+(assert (= a ""))
+(assert (not (str.in_re (str.replace_re_all "b" (re.comp (str.to_re a)) "a") (str.to_re "a"))))
+(set-info :status unsat)
+(check-sat)


### PR DESCRIPTION
Fixes #6639. The issue cannot be reproduced on current master and `git
bisect` suggests that commit adf497af7a3fc8b06b875eaf9feca2568d0ba9d8
fixed the issue.