### PR TITLE
Revert change to regression

### DIFF
--- a/test/regress/regress1/quantifiers/symmetric_unsat_7.smt2
+++ b/test/regress/regress1/quantifiers/symmetric_unsat_7.smt2
@@ -1,3 +1,8 @@
+; COMMAND-LINE: --no-check-unsat-cores --no-produce-proofs
+; EXPECT: unsat
+
+; Note we require disabling proofs/unsat cores due to timeouts in nightlies
+
 (set-logic AUFLIRA)
 (set-info :source | Example extracted from Peter Baumgartner's talk at CADE-21: Logical Engineering with Instance-Based Methods.
 


### PR DESCRIPTION
Although it works on most machines, it times out in the nightly builds.