### PR TITLE
Perform statistics printing via the API

### DIFF
--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -6643,6 +6643,7 @@ Result Solver::checkEntailed(const Term& term) const
   CVC5_API_SOLVER_CHECK_TERM(term);
   //////// all checks before this line
   cvc5::Result r = d_smtEngine->checkEntailed(*term.d_node);
+  d_smtEngine->printStatisticsDiff();
   return Result(r);
   ////////
   CVC5_API_TRY_CATCH_END;
@@ -6658,7 +6659,9 @@ Result Solver::checkEntailed(const std::vector<Term>& terms) const
          "(try --incremental)";
   CVC5_API_SOLVER_CHECK_TERMS(terms);
   //////// all checks before this line
-  return d_smtEngine->checkEntailed(Term::termVectorToNodes(terms));
+  cvc5::Result r = d_smtEngine->checkEntailed(Term::termVectorToNodes(terms));
+  d_smtEngine->printStatisticsDiff();
+  return Result(r);
   ////////
   CVC5_API_TRY_CATCH_END;
 }
@@ -6687,6 +6690,7 @@ Result Solver::checkSat(void) const
          "(try --incremental)";
   //////// all checks before this line
   cvc5::Result r = d_smtEngine->checkSat();
+  d_smtEngine->printStatisticsDiff();
   return Result(r);
   ////////
   CVC5_API_TRY_CATCH_END;
@@ -6703,6 +6707,7 @@ Result Solver::checkSatAssuming(const Term& assumption) const
   CVC5_API_SOLVER_CHECK_TERM_WITH_SORT(assumption, getBooleanSort());
   //////// all checks before this line
   cvc5::Result r = d_smtEngine->checkSat(*assumption.d_node);
+  d_smtEngine->printStatisticsDiff();
   return Result(r);
   ////////
   CVC5_API_TRY_CATCH_END;
@@ -6724,6 +6729,7 @@ Result Solver::checkSatAssuming(const std::vector<Term>& assumptions) const
   }
   std::vector<Node> eassumptions = Term::termVectorToNodes(assumptions);
   cvc5::Result r = d_smtEngine->checkSat(eassumptions);
+  d_smtEngine->printStatisticsDiff();
   return Result(r);
   ////////
   CVC5_API_TRY_CATCH_END;

--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -6647,9 +6647,7 @@ Result Solver::checkEntailed(const Term& term) const
          "(try --incremental)";
   CVC5_API_SOLVER_CHECK_TERM(term);
   //////// all checks before this line
-  cvc5::Result r = d_smtEngine->checkEntailed(*term.d_node);
-  d_smtEngine->printStatisticsDiff();
-  return Result(r);
+  return d_smtEngine->checkEntailed(*term.d_node);
   ////////
   CVC5_API_TRY_CATCH_END;
 }
@@ -6664,9 +6662,7 @@ Result Solver::checkEntailed(const std::vector<Term>& terms) const
          "(try --incremental)";
   CVC5_API_SOLVER_CHECK_TERMS(terms);
   //////// all checks before this line
-  cvc5::Result r = d_smtEngine->checkEntailed(Term::termVectorToNodes(terms));
-  d_smtEngine->printStatisticsDiff();
-  return Result(r);
+  return d_smtEngine->checkEntailed(Term::termVectorToNodes(terms));
   ////////
   CVC5_API_TRY_CATCH_END;
 }
@@ -6694,9 +6690,7 @@ Result Solver::checkSat(void) const
       << "Cannot make multiple queries unless incremental solving is enabled "
          "(try --incremental)";
   //////// all checks before this line
-  cvc5::Result r = d_smtEngine->checkSat();
-  d_smtEngine->printStatisticsDiff();
-  return Result(r);
+  return d_smtEngine->checkSat();
   ////////
   CVC5_API_TRY_CATCH_END;
 }
@@ -6711,9 +6705,7 @@ Result Solver::checkSatAssuming(const Term& assumption) const
          "(try --incremental)";
   CVC5_API_SOLVER_CHECK_TERM_WITH_SORT(assumption, getBooleanSort());
   //////// all checks before this line
-  cvc5::Result r = d_smtEngine->checkSat(*assumption.d_node);
-  d_smtEngine->printStatisticsDiff();
-  return Result(r);
+  return d_smtEngine->checkSat(*assumption.d_node);
   ////////
   CVC5_API_TRY_CATCH_END;
 }
@@ -6733,9 +6725,7 @@ Result Solver::checkSatAssuming(const std::vector<Term>& assumptions) const
     CVC5_API_SOLVER_CHECK_TERM(term);
   }
   std::vector<Node> eassumptions = Term::termVectorToNodes(assumptions);
-  cvc5::Result r = d_smtEngine->checkSat(eassumptions);
-  d_smtEngine->printStatisticsDiff();
-  return Result(r);
+  return d_smtEngine->checkSat(eassumptions);
   ////////
   CVC5_API_TRY_CATCH_END;
 }

--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -5389,6 +5389,11 @@ void Solver::resetStatistics()
   }
 }
 
+void Solver::printStatisticsSafe(int fd) const
+{
+  d_smtEngine->printStatisticsSafe(fd);
+}
+
 /* Helpers for mkTerm checks.                                                 */
 /* .......................................................................... */
 

--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -4762,7 +4762,9 @@ struct Stat::StatData
 
 Stat::~Stat() {}
 Stat::Stat(const Stat& s)
-    : d_expert(s.d_expert), d_data(std::make_unique<StatData>(s.d_data->data))
+    : d_expert(s.d_expert),
+      d_default(s.d_default),
+      d_data(std::make_unique<StatData>(s.d_data->data))
 {
 }
 Stat& Stat::operator=(const Stat& s)

--- a/src/api/cpp/cvc5.h
+++ b/src/api/cpp/cvc5.h
@@ -4161,6 +4161,11 @@ class CVC5_EXPORT Solver
   /** Reset the API statistics */
   void resetStatistics();
 
+  /**
+   * Print the statistics to the given file descriptor, suitable for usage in signal handlers.
+   */
+  void printStatisticsSafe(int fd) const;
+
   /** Helper to check for API misuse in mkOp functions. */
   void checkMkTerm(Kind kind, uint32_t nchildren) const;
   /** Helper for mk-functions that call d_nodeMgr->mkConst(). */

--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -152,12 +152,6 @@ bool CommandExecutor::doCommandSingleton(Command* cmd)
     d_result = res = q->getResult();
   }
 
-  if ((cs != nullptr || q != nullptr)
-      && d_solver->getOptions().base.statisticsEveryQuery)
-  {
-    getSmtEngine()->printStatisticsDiff(*d_solver->getOptions().base.err);
-  }
-
   bool isResultUnsat = res.isUnsat() || res.isEntailed();
 
   // dump the model/proof/unsat core if option is set

--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -68,7 +68,7 @@ void CommandExecutor::printStatistics(std::ostream& out) const
 {
   if (d_solver->getOptions().base.statistics)
   {
-    getSmtEngine()->printStatistics(out);
+    out << d_solver->getStatistics();
   }
 }
 

--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -29,7 +29,6 @@
 #include "options/base_options.h"
 #include "options/main_options.h"
 #include "smt/command.h"
-#include "smt/smt_engine.h"
 
 namespace cvc5 {
 namespace main {
@@ -76,7 +75,7 @@ void CommandExecutor::printStatisticsSafe(int fd) const
 {
   if (d_solver->getOptions().base.statistics)
   {
-    getSmtEngine()->printStatisticsSafe(fd);
+    d_solver->printStatisticsSafe(fd);
   }
 }
 

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1925,10 +1925,13 @@ void SmtEngine::printStatisticsSafe(int fd) const
   d_env->getStatisticsRegistry().printSafe(fd);
 }
 
-void SmtEngine::printStatisticsDiff(std::ostream& out) const
+void SmtEngine::printStatisticsDiff() const
 {
-  d_env->getStatisticsRegistry().printDiff(out);
-  d_env->getStatisticsRegistry().storeSnapshot();
+  if (d_env->getOptions().base.statisticsEveryQuery)
+  {
+    d_env->getStatisticsRegistry().printDiff(*d_env->getOptions().base.err);
+    d_env->getStatisticsRegistry().storeSnapshot();
+  }
 }
 
 void SmtEngine::setUserAttribute(const std::string& attr,

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -935,7 +935,10 @@ Result SmtEngine::checkSatInternal(const std::vector<Node>& assumptions,
         checkUnsatCore();
       }
     }
-    printStatisticsDiff();
+    if (d_env->getOptions().base.statisticsEveryQuery)
+    {
+      printStatisticsDiff();
+    }
     return r;
   }
   catch (UnsafeInterruptException& e)
@@ -948,8 +951,11 @@ Result SmtEngine::checkSatInternal(const std::vector<Node>& assumptions,
     Result::UnknownExplanation why = getResourceManager()->outOfResources()
                                          ? Result::RESOURCEOUT
                                          : Result::TIMEOUT;
-    
-    printStatisticsDiff();
+
+    if (d_env->getOptions().base.statisticsEveryQuery)
+    {
+      printStatisticsDiff();
+    }
     return Result(Result::SAT_UNKNOWN, why, d_state->getFilename());
   }
 }
@@ -1929,11 +1935,8 @@ void SmtEngine::printStatisticsSafe(int fd) const
 
 void SmtEngine::printStatisticsDiff() const
 {
-  if (d_env->getOptions().base.statisticsEveryQuery)
-  {
-    d_env->getStatisticsRegistry().printDiff(*d_env->getOptions().base.err);
-    d_env->getStatisticsRegistry().storeSnapshot();
-  }
+  d_env->getStatisticsRegistry().printDiff(*d_env->getOptions().base.err);
+  d_env->getStatisticsRegistry().storeSnapshot();
 }
 
 void SmtEngine::setUserAttribute(const std::string& attr,

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -935,7 +935,7 @@ Result SmtEngine::checkSatInternal(const std::vector<Node>& assumptions,
         checkUnsatCore();
       }
     }
-
+    printStatisticsDiff();
     return r;
   }
   catch (UnsafeInterruptException& e)
@@ -948,6 +948,8 @@ Result SmtEngine::checkSatInternal(const std::vector<Node>& assumptions,
     Result::UnknownExplanation why = getResourceManager()->outOfResources()
                                          ? Result::RESOURCEOUT
                                          : Result::TIMEOUT;
+    
+    printStatisticsDiff();
     return Result(Result::SAT_UNKNOWN, why, d_state->getFilename());
   }
 }

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -828,7 +828,7 @@ class CVC5_EXPORT SmtEngine
    * time. Internally prints the diff and then stores a snapshot for the next
    * call.
    */
-  void printStatisticsDiff(std::ostream&) const;
+  void printStatisticsDiff() const;
 
   /**
    * Set user attribute.


### PR DESCRIPTION
This PR changes how the command executor prints the statistics by moving stuff around a bit, eventually using only proper API methods of `api::Solver`. This PR also removes the `smt_engine.h` include from `command_executor.cpp`.