### PR TITLE
Refactor shared solver to use theory builtin inference manager

### DIFF
--- a/src/theory/builtin/theory_builtin.cpp
+++ b/src/theory/builtin/theory_builtin.cpp
@@ -31,8 +31,13 @@ TheoryBuiltin::TheoryBuiltin(context::Context* c,
                              Valuation valuation,
                              const LogicInfo& logicInfo,
                              ProofNodeManager* pnm)
-    : Theory(THEORY_BUILTIN, c, u, out, valuation, logicInfo, pnm)
+    : Theory(THEORY_BUILTIN, c, u, out, valuation, logicInfo, pnm),
+      d_state(c, u, valuation),
+      d_im(*this, d_state, pnm, "theory::builtin::")
 {
+  // indicate we are using the default theory state and inference managers
+  d_theoryState = &d_state;
+  d_inferManager = &d_im;
 }
 
 TheoryRewriter* TheoryBuiltin::getTheoryRewriter() { return &d_rewriter; }

--- a/src/theory/builtin/theory_builtin.h
+++ b/src/theory/builtin/theory_builtin.h
@@ -21,6 +21,8 @@
 #include "theory/builtin/proof_checker.h"
 #include "theory/builtin/theory_builtin_rewriter.h"
 #include "theory/theory.h"
+#include "theory/theory_inference_manager.h"
+#include "theory/theory_state.h"
 
 namespace cvc5 {
 namespace theory {
@@ -51,6 +53,10 @@ class TheoryBuiltin : public Theory
   TheoryBuiltinRewriter d_rewriter;
   /** Proof rule checker */
   BuiltinProofRuleChecker d_checker;
+  /** A (default) theory state object */
+  TheoryState d_state;
+  /** A (default) inference manager */
+  TheoryInferenceManager d_im;
 }; /* class TheoryBuiltin */
 
 }  // namespace builtin

--- a/src/theory/ee_manager_central.cpp
+++ b/src/theory/ee_manager_central.cpp
@@ -298,7 +298,8 @@ void EqEngineManagerCentral::eqNotifyConstantTermMerge(TNode t1, TNode t2)
   Node conflict = d_centralEqualityEngine.mkExplainLit(lit);
   Trace("eem-central") << "...explained conflict of " << lit << " ... "
                        << conflict << std::endl;
-  d_sharedSolver.sendConflict(TrustNode::mkTrustConflict(conflict));
+  d_sharedSolver.sendConflict(TrustNode::mkTrustConflict(conflict),
+                              InferenceId::EQ_CONSTANT_MERGE);
   return;
 }
 

--- a/src/theory/engine_output_channel.cpp
+++ b/src/theory/engine_output_channel.cpp
@@ -60,31 +60,7 @@ void EngineOutputChannel::safePoint(Resource r)
 
 void EngineOutputChannel::lemma(TNode lemma, LemmaProperty p)
 {
-  Trace("theory::lemma") << "EngineOutputChannel<" << d_theory << ">::lemma("
-                         << lemma << ")"
-                         << ", properties = " << p << std::endl;
-  ++d_statistics.lemmas;
-  d_engine->d_outputChannelUsed = true;
-
-  TrustNode tlem = TrustNode::mkTrustLemma(lemma);
-  d_engine->lemma(tlem,
-                  p,
-                  isLemmaPropertySendAtoms(p) ? d_theory : theory::THEORY_LAST,
-                  d_theory);
-}
-
-void EngineOutputChannel::splitLemma(TNode lemma, bool removable)
-{
-  Trace("theory::lemma") << "EngineOutputChannel<" << d_theory << ">::lemma("
-                         << lemma << ")" << std::endl;
-  ++d_statistics.lemmas;
-  d_engine->d_outputChannelUsed = true;
-
-  Trace("pf::explain") << "EngineOutputChannel::splitLemma( " << lemma << " )"
-                       << std::endl;
-  TrustNode tlem = TrustNode::mkTrustLemma(lemma);
-  LemmaProperty p = removable ? LemmaProperty::REMOVABLE : LemmaProperty::NONE;
-  d_engine->lemma(tlem, p, d_theory);
+  trustedLemma(TrustNode::mkTrustLemma(lemma), p);
 }
 
 bool EngineOutputChannel::propagate(TNode literal)
@@ -172,10 +148,13 @@ void EngineOutputChannel::trustedLemma(TrustNode plem, LemmaProperty p)
   }
   ++d_statistics.lemmas;
   d_engine->d_outputChannelUsed = true;
+  if (isLemmaPropertySendAtoms(p))
+  {
+    d_engine->ensureLemmaAtoms(plem.getNode(), d_theory);
+  }
   // now, call the normal interface for lemma
   d_engine->lemma(plem,
                   p,
-                  isLemmaPropertySendAtoms(p) ? d_theory : theory::THEORY_LAST,
                   d_theory);
 }
 

--- a/src/theory/engine_output_channel.h
+++ b/src/theory/engine_output_channel.h
@@ -53,8 +53,6 @@ class EngineOutputChannel : public theory::OutputChannel
 
   void lemma(TNode lemma, LemmaProperty p = LemmaProperty::NONE) override;
 
-  void splitLemma(TNode lemma, bool removable = false) override;
-
   void demandRestart() override;
 
   void requirePhase(TNode n, bool phase) override;

--- a/src/theory/output_channel.cpp
+++ b/src/theory/output_channel.cpp
@@ -77,8 +77,6 @@ std::ostream& operator<<(std::ostream& out, LemmaProperty p)
   return out;
 }
 
-void OutputChannel::split(TNode n) { lemma(n.orNode(n.notNode())); }
-
 void OutputChannel::trustedConflict(TrustNode pconf)
 {
   Unreachable() << "OutputChannel::trustedConflict: no implementation"

--- a/src/theory/output_channel.cpp
+++ b/src/theory/output_channel.cpp
@@ -77,7 +77,7 @@ std::ostream& operator<<(std::ostream& out, LemmaProperty p)
   return out;
 }
 
-void OutputChannel::split(TNode n) { splitLemma(n.orNode(n.notNode())); }
+void OutputChannel::split(TNode n) { lemma(n.orNode(n.notNode())); }
 
 void OutputChannel::trustedConflict(TrustNode pconf)
 {

--- a/src/theory/output_channel.h
+++ b/src/theory/output_channel.h
@@ -122,16 +122,6 @@ class OutputChannel {
   virtual void lemma(TNode n, LemmaProperty p = LemmaProperty::NONE) = 0;
 
   /**
-   * Request a split on a new theory atom.  This is equivalent to
-   * calling lemma({OR n (NOT n)}).
-   *
-   * @param n - a theory atom; must be of Boolean type
-   */
-  void split(TNode n);
-
-  virtual void splitLemma(TNode n, bool removable = false) = 0;
-
-  /**
    * If a decision is made on n, it must be in the phase specified.
    * Note that this is enforced *globally*, i.e., it is completely
    * context-INdependent.  If you ever requirePhase() on a literal,

--- a/src/theory/shared_solver.h
+++ b/src/theory/shared_solver.h
@@ -33,7 +33,7 @@ class TheoryEngine;
 namespace theory {
 
 struct EeSetupInfo;
-class OutputChannel;
+class TheoryInferenceManager;
 
 /**
  * A base class for shared solver. The shared solver is the component of theory
@@ -124,7 +124,7 @@ class SharedSolver
   /** Send lemma to the theory engine, atomsTo is the theory to send atoms to */
   void sendLemma(TrustNode trn, TheoryId atomsTo, InferenceId id);
   /** Send conflict to the theory engine */
-  void sendConflict(TrustNode trn);
+  void sendConflict(TrustNode trn, InferenceId id);
 
  protected:
   /** Solver-specific pre-register shared */
@@ -139,8 +139,8 @@ class SharedSolver
   PreRegisterVisitor d_preRegistrationVisitor;
   /** Visitor for collecting shared terms */
   SharedTermsVisitor d_sharedTermsVisitor;
-  /** Output channel of theory builtin */
-  OutputChannel& d_out;
+  /** Theory inference manager of theory builtin */
+  TheoryInferenceManager* d_im;
 };
 
 }  // namespace theory

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -1246,7 +1246,7 @@ struct AtomsCollect {
   }
 };
 
-void TheoryEngine::ensureLemmaAtoms(Node n, theory::TheoryId atomsTo)
+void TheoryEngine::ensureLemmaAtoms(TNode n, theory::TheoryId atomsTo)
 {
   Assert(atomsTo != THEORY_LAST);
   Debug("theory::atoms") << "TheoryEngine::ensureLemmaAtoms(" << n << ", "

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -1246,6 +1246,16 @@ struct AtomsCollect {
   }
 };
 
+void TheoryEngine::ensureLemmaAtoms(Node n, theory::TheoryId atomsTo)
+{
+  Assert(atomsTo != THEORY_LAST);
+  Debug("theory::atoms") << "TheoryEngine::ensureLemmaAtoms(" << n << ", "
+                         << atomsTo << ")" << endl;
+  AtomsCollect collectAtoms;
+  NodeVisitor<AtomsCollect>::run(collectAtoms, n);
+  ensureLemmaAtoms(collectAtoms.getAtoms(), atomsTo);
+}
+
 void TheoryEngine::ensureLemmaAtoms(const std::vector<TNode>& atoms, theory::TheoryId atomsTo) {
   for (unsigned i = 0; i < atoms.size(); ++ i) {
 
@@ -1314,7 +1324,6 @@ void TheoryEngine::ensureLemmaAtoms(const std::vector<TNode>& atoms, theory::The
 
 void TheoryEngine::lemma(TrustNode tlemma,
                          theory::LemmaProperty p,
-                         theory::TheoryId atomsTo,
                          theory::TheoryId from)
 {
   // For resource-limiting (also does a time check).
@@ -1344,15 +1353,6 @@ void TheoryEngine::lemma(TrustNode tlemma,
     }
     // ensure closed
     tlemma.debugCheckClosed("te-proof-debug", "TheoryEngine::lemma_initial");
-  }
-
-  // Do we need to check atoms
-  if (atomsTo != theory::THEORY_LAST) {
-    Debug("theory::atoms") << "TheoryEngine::lemma(" << node << ", " << atomsTo
-                           << ")" << endl;
-    AtomsCollect collectAtoms;
-    NodeVisitor<AtomsCollect>::run(collectAtoms, node);
-    ensureLemmaAtoms(collectAtoms.getAtoms(), atomsTo);
   }
 
   if(Dump.isOn("t-lemmas")) {
@@ -1504,7 +1504,7 @@ void TheoryEngine::conflict(TrustNode tconflict, TheoryId theoryId)
     // When only one theory, the conflict should need no processing
     Assert(properConflict(conflict));
     // pass the trust node that was sent from the theory
-    lemma(tconflict, LemmaProperty::REMOVABLE, THEORY_LAST, theoryId);
+    lemma(tconflict, LemmaProperty::REMOVABLE, theoryId);
   }
 }
 

--- a/src/theory/theory_engine.h
+++ b/src/theory/theory_engine.h
@@ -277,11 +277,13 @@ class TheoryEngine {
    */
   void lemma(TrustNode node,
              theory::LemmaProperty p,
-             theory::TheoryId atomsTo = theory::THEORY_LAST,
              theory::TheoryId from = theory::THEORY_LAST);
 
-  /** Enusre that the given atoms are send to the given theory */
-  void ensureLemmaAtoms(const std::vector<TNode>& atoms, theory::TheoryId theory);
+  /** Ensure atoms from the given node are sent to the given theory */
+  void ensureLemmaAtoms(Node n, theory::TheoryId atomsTo);
+  /** Ensure that the given atoms are send to the given theory */
+  void ensureLemmaAtoms(const std::vector<TNode>& atoms,
+                        theory::TheoryId atomsTo);
 
   /** sort inference module */
   std::unique_ptr<theory::SortInference> d_sortInfer;

--- a/src/theory/theory_engine.h
+++ b/src/theory/theory_engine.h
@@ -280,8 +280,8 @@ class TheoryEngine {
              theory::TheoryId from = theory::THEORY_LAST);
 
   /** Ensure atoms from the given node are sent to the given theory */
-  void ensureLemmaAtoms(Node n, theory::TheoryId atomsTo);
-  /** Ensure that the given atoms are send to the given theory */
+  void ensureLemmaAtoms(TNode n, theory::TheoryId atomsTo);
+  /** Ensure that the given atoms are sent to the given theory */
   void ensureLemmaAtoms(const std::vector<TNode>& atoms,
                         theory::TheoryId atomsTo);
 

--- a/test/unit/test_smt.h
+++ b/test/unit/test_smt.h
@@ -138,8 +138,6 @@ class DummyOutputChannel : public cvc5::theory::OutputChannel
   void setIncomplete(theory::IncompleteId id) override {}
   void handleUserAttribute(const char* attr, theory::Theory* t) override {}
 
-  void splitLemma(TNode n, bool removable = false) override { push(LEMMA, n); }
-
   void clear() { d_callHistory.clear(); }
 
   Node getIthNode(int i) const

--- a/test/unit/theory/theory_white.cpp
+++ b/test/unit/theory/theory_white.cpp
@@ -100,7 +100,7 @@ TEST_F(TestTheoryWhite, outputChannel)
 {
   Node n = d_atom0.orNode(d_atom1);
   d_outputChannel.lemma(n);
-  d_outputChannel.split(d_atom0);
+  d_outputChannel.lemma(d_atom0.orNode(d_atom0.notNode()));
   Node s = d_atom0.orNode(d_atom0.notNode());
   ASSERT_EQ(d_outputChannel.d_callHistory.size(), 2u);
   ASSERT_EQ(d_outputChannel.d_callHistory[0], std::make_pair(LEMMA, n));


### PR DESCRIPTION
This ensures that e.g. COMBINATION_SPLIT shows up under `theory::builtin::inferencesLemmas`, and `-t im`.  It also removes outdated interfaces from OutputChannel, and makes the feature `TheoryEngine::ensureLemmaAtoms` more modular, which was required for making these interfaces more consistent.

It also ensures that TheoryBuiltin has an inference manager, which will simplify special casing in https://github.com/cvc5/cvc5/pull/6956.