### PR TITLE
Properly honor --stats-all and --stats-expert when printing statistics

### DIFF
--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -65,9 +65,15 @@ CommandExecutor::~CommandExecutor()
 
 void CommandExecutor::printStatistics(std::ostream& out) const
 {
-  if (d_solver->getOptions().base.statistics)
+  const auto& baseopts = d_solver->getOptions().base;
+  if (baseopts.statistics)
   {
-    out << d_solver->getStatistics();
+    const auto& stats = d_solver->getStatistics();
+    auto it = stats.begin(baseopts.statisticsExpert, baseopts.statisticsAll);
+    for (; it != stats.end(); ++it)
+    {
+      out << it->first << " = " << it->second << std::endl;
+    }
   }
 }
 

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1923,11 +1923,6 @@ NodeManager* SmtEngine::getNodeManager() const
   return d_env->getNodeManager();
 }
 
-void SmtEngine::printStatistics(std::ostream& out) const
-{
-  d_env->getStatisticsRegistry().print(out);
-}
-
 void SmtEngine::printStatisticsSafe(int fd) const
 {
   d_env->getStatisticsRegistry().printSafe(fd);

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -812,12 +812,6 @@ class CVC5_EXPORT SmtEngine
 
   /**
    * Print statistics from the statistics registry in the env object owned by
-   * this SmtEngine.
-   */
-  void printStatistics(std::ostream& out) const;
-
-  /**
-   * Print statistics from the statistics registry in the env object owned by
    * this SmtEngine. Safe to use in a signal handler.
    */
   void printStatisticsSafe(int fd) const;


### PR DESCRIPTION
This PR fixes an issue that was introduced with fda46132b3f5c945a2b5e75bfa6bd5c84525fee6 where printing the statistics would only show non-defaulted and non-expert options.