### PR TITLE
[Unit Tests] Add missing include

### DIFF
--- a/test/unit/api/solver_black.cpp
+++ b/test/unit/api/solver_black.cpp
@@ -13,6 +13,8 @@
  * Black box testing of the Solver class of the  C++ API.
  */
 
+#include <algorithm>
+
 #include "test_api.h"
 
 namespace cvc5 {


### PR DESCRIPTION
For some configurations, the unit test `solver_black` was unable to find
the correct variant `std::find()`. This commit adds an explicit include
of `<algorithm>`, which declares the `std::find()` as required by the
unit test.