### PR TITLE
Support older CMake versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             run_regression_args: --no-check-unsat-cores --no-check-proofs
 
           - name: ubuntu:production-clang
-            os: ubuntu-latest
+            os: ubuntu-18.04
             env: CC=clang CXX=clang++
             config: production --auto-download
             cache-key: productionclang
@@ -35,7 +35,7 @@ jobs:
             run_regression_args: --no-check-unsat-cores --no-check-proofs
 
           - name: ubuntu:production-dbg
-            os: ubuntu-latest
+            os: ubuntu-18.04
             config: production --auto-download --assertions --tracing --unit-testing --editline
             cache-key: dbg
             exclude_regress: 3-4

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1190,8 +1190,8 @@ set(options_toml_files
 )
 string(REPLACE "toml" "cpp;" options_gen_cpp_files ${options_toml_files})
 string(REPLACE "toml" "h;"   options_gen_h_files ${options_toml_files})
-list(PREPEND options_gen_cpp_files "options/options.cpp" "options/options_public.cpp")
-list(PREPEND options_gen_h_files "options/options.h")
+list(APPEND options_gen_cpp_files "options/options.cpp" "options/options_public.cpp")
+list(APPEND options_gen_h_files "options/options.h")
 
 libcvc5_add_sources(GENERATED ${options_gen_cpp_files} ${options_gen_h_files})
 


### PR DESCRIPTION
Fixes #7001. Commit c8bc4881d4f3bf54258b0f01280fbda23a1dd651 introduced the use
of `list(PREPEND ...)` which was only introduced in version 3.15. We require
CMake 3.9 or later and this commit makes our build system compatible with older
CMake versions again. It also changes our CI to have two builds with Ubuntu
18.04 and two builds with Ubuntu 20.04 to better cover different versions of
build tools (including CMake 3.10).