### PR TITLE
Add check for static libraries when compiling CryptoMiniSat #7010

### DIFF
--- a/cmake/FindCryptoMiniSat.cmake
+++ b/cmake/FindCryptoMiniSat.cmake
@@ -42,6 +42,20 @@ if(NOT CryptoMiniSat_FOUND_SYSTEM)
     check_auto_download("CryptoMiniSat" "--no-cryptominisat")
   endif()
 
+  # Check for static libraries required by CryptoMiniSat
+  set(CMS_STATIC_LIBS "c;m;dl;pthread")
+  foreach(static_lib ${CMS_STATIC_LIBS})
+
+    # We can't use 'REQUIRED' here, as it needs a too-recent CMake
+    find_library(lib${static_lib}_static lib${static_lib}.a)
+
+    # Check if the static library has been found
+    if(NOT lib${static_lib}_static)
+      message(FATAL_ERROR "static lib${static_lib} not found")
+    endif()
+
+  endforeach()
+
   include(ExternalProject)
 
   ExternalProject_Add(


### PR DESCRIPTION
This PR adds a check for CryptoMiniSat's static dependencies when configuring CryptoMiniSat. It changes a build-time failure into a configure-time failure.

`find_library` in CMake > 3.18 supports `REQUIRED`; as `cvc5` targets 3.10, I've implemented a check for what `find_library` returns.

Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>