### PR TITLE
Correct copyright print for GLPK

### DIFF
--- a/src/base/configuration.cpp
+++ b/src/base/configuration.cpp
@@ -195,10 +195,10 @@ std::string Configuration::copyright() {
          << "  See http://www.ginac.de/CLN for copyright information.\n\n";
     }
     if (Configuration::isBuiltWithGlpk()) {
-      ss << "  glpk-cut-log -  a modified version of GPLK, "
+      ss << "  glpk-cut-log - a modified version of GPLK, "
          << "the GNU Linear Programming Kit\n"
          << "  See http://github.com/timothy-king/glpk-cut-log for copyright"
-         << "information\n\n";
+         << " information\n\n";
     }
   }
 


### PR DESCRIPTION
In `master`, starting `cvc5` interactively will give you:

```
  glpk-cut-log -  a modified version of GPLK, the GNU Linear Programming Kit
  See http://github.com/timothy-king/glpk-cut-log for copyrightinformation
```

Notice: there's a double-space after the dash following the library name, and there's no space between "copyrightinformation".

This PR corrects this print such that it gives:

```
  glpk-cut-log - a modified version of GPLK, the GNU Linear Programming Kit
  See http://github.com/timothy-king/glpk-cut-log for copyright information
```

Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>