### PR TITLE
Support sygus standard command syntax set-feature

### DIFF
--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -585,9 +585,22 @@ sygusCommand returns [std::unique_ptr<cvc5::Command> cmd]
     }
   | /* check-synth */
     CHECK_SYNTH_TOK
-    { PARSER_STATE->checkThatLogicIsSet(); }
     {
+      PARSER_STATE->checkThatLogicIsSet();
       cmd.reset(new CheckSynthCommand());
+    }
+  | /* set-feature */
+    SET_FEATURE_TOK keyword[name] symbolicExpr[expr]
+    {
+      PARSER_STATE->checkThatLogicIsSet();
+      // ":grammars" is defined in the SyGuS version 2.1 standard and is by
+      // default supported, all other features are not.
+      if (name!=":grammars")
+      {
+        std::stringstream ss;
+        ss << "SyGuS feature " << name << " not currently supported";
+        PARSER_STATE->warning(ss.str());
+      }
     }
   | command[&cmd]
   ;
@@ -2270,7 +2283,7 @@ CHECK_SYNTH_TOK : { PARSER_STATE->sygus()}?'check-synth';
 DECLARE_VAR_TOK : { PARSER_STATE->sygus()}?'declare-var';
 CONSTRAINT_TOK : { PARSER_STATE->sygus()}?'constraint';
 INV_CONSTRAINT_TOK : { PARSER_STATE->sygus()}?'inv-constraint';
-SET_OPTIONS_TOK : { PARSER_STATE->sygus() }? 'set-options';
+SET_FEATURE_TOK : { PARSER_STATE->sygus() }? 'set-feature';
 SYGUS_CONSTANT_TOK : { PARSER_STATE->sygus() }? 'Constant';
 SYGUS_VARIABLE_TOK : { PARSER_STATE->sygus() }? 'Variable';
 

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -601,6 +601,7 @@ sygusCommand returns [std::unique_ptr<cvc5::Command> cmd]
         ss << "SyGuS feature " << name << " not currently supported";
         PARSER_STATE->warning(ss.str());
       }
+      cmd.reset(new EmptyCommand());
     }
   | command[&cmd]
   ;

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -595,7 +595,7 @@ sygusCommand returns [std::unique_ptr<cvc5::Command> cmd]
       PARSER_STATE->checkThatLogicIsSet();
       // ":grammars" is defined in the SyGuS version 2.1 standard and is by
       // default supported, all other features are not.
-      if (name!=":grammars")
+      if (name != ":grammars")
       {
         std::stringstream ss;
         ss << "SyGuS feature " << name << " not currently supported";

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1262,6 +1262,7 @@ set(regress_0_tests
   regress0/sygus/print-debug.sy
   regress0/sygus/print-define-fun.sy
   regress0/sygus/real-si-all.sy
+  regress0/sygus/setFeature.sy
   regress0/sygus/strings-unconstrained.sy
   regress0/sygus/sygus-no-wf.sy
   regress0/sygus/sygus-uf.sy

--- a/test/regress/regress0/sygus/setFeature.sy
+++ b/test/regress/regress0/sygus/setFeature.sy
@@ -1,0 +1,4 @@
+; EXPECT: setFeature.sy:4.29: SyGuS feature :recursion not currently supported
+(set-logic ALL)
+(set-feature :grammars true)
+(set-feature :recursion false)

--- a/test/regress/regress0/sygus/setFeature.sy
+++ b/test/regress/regress0/sygus/setFeature.sy
@@ -1,4 +1,5 @@
-; EXPECT: setFeature.sy:4.29: SyGuS feature :recursion not currently supported
+; REQUIRES: no-competition
+; EXPECT-ERROR: setFeature.sy:5.29: SyGuS feature :recursion not currently supported
 (set-logic ALL)
 (set-feature :grammars true)
 (set-feature :recursion false)


### PR DESCRIPTION
This currently has no effect other than giving an unsupported warning.

In the future, `set-feature` will be implemented via the appropriate call to Solver::setOption if necessary.

Fixes #6182.