### PR TITLE
Prenex quantified formulas with user annotations by default

### DIFF
--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -54,8 +54,8 @@ name   = "Quantifiers"
   category   = "regular"
   long       = "prenex-quant-user"
   type       = "bool"
-  default    = "true"
-  help       = "prenex quantified formulas with user patterns or annotations"
+  default    = "false"
+  help       = "prenex quantified formulas with user patterns"
 
 # Whether to variable-eliminate quantifiers.
 # For example, forall x y. ( P( x, y ) V x != c ) will be rewritten to

--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -54,8 +54,8 @@ name   = "Quantifiers"
   category   = "regular"
   long       = "prenex-quant-user"
   type       = "bool"
-  default    = "false"
-  help       = "prenex quantified formulas with user patterns"
+  default    = "true"
+  help       = "prenex quantified formulas with user patterns or annotations"
 
 # Whether to variable-eliminate quantifiers.
 # For example, forall x y. ( P( x, y ) V x != c ) will be rewritten to

--- a/src/theory/quantifiers/ematching/inst_strategy_e_matching.cpp
+++ b/src/theory/quantifiers/ematching/inst_strategy_e_matching.cpp
@@ -147,7 +147,7 @@ InstStrategyStatus InstStrategyAutoGenTriggers::process(Node f,
   {
     generateTriggers(f);
     if (d_counter[f] == 0 && d_auto_gen_trigger[0][f].empty()
-        && d_auto_gen_trigger[1][f].empty() && f.getNumChildren() == 2)
+        && d_auto_gen_trigger[1][f].empty() && !QuantAttributes::hasPattern(f))
     {
       Trace("trigger-warn") << "Could not find trigger for " << f << std::endl;
       Output(options::OutputTag::TRIGGER)

--- a/src/theory/quantifiers/ematching/instantiation_engine.cpp
+++ b/src/theory/quantifiers/ematching/instantiation_engine.cpp
@@ -204,16 +204,7 @@ void InstantiationEngine::checkOwnership(Node q)
       && q.getNumChildren() == 3)
   {
     //if strict triggers, take ownership of this quantified formula
-    bool hasPat = false;
-    for (const Node& qc : q[2])
-    {
-      if (qc.getKind() == INST_PATTERN || qc.getKind() == INST_NO_PATTERN)
-      {
-        hasPat = true;
-        break;
-      }
-    }
-    if( hasPat ){
+    if( QuantAttributes::hasPattern(q) ){
       d_qreg.setOwner(q, this, 1);
     }
   }

--- a/src/theory/quantifiers/ematching/instantiation_engine.cpp
+++ b/src/theory/quantifiers/ematching/instantiation_engine.cpp
@@ -204,7 +204,8 @@ void InstantiationEngine::checkOwnership(Node q)
       && q.getNumChildren() == 3)
   {
     //if strict triggers, take ownership of this quantified formula
-    if( QuantAttributes::hasPattern(q) ){
+    if (QuantAttributes::hasPattern(q))
+    {
       d_qreg.setOwner(q, this, 1);
     }
   }

--- a/src/theory/quantifiers/quantifiers_attributes.cpp
+++ b/src/theory/quantifiers/quantifiers_attributes.cpp
@@ -165,6 +165,23 @@ bool QuantAttributes::checkQuantElimAnnotation( Node ipl ) {
   return false;
 }
 
+bool QuantAttributes::hasPattern(Node q)
+{
+  Assert (q.getKind()==FORALL);
+  if (q.getNumChildren()!=3)
+  {
+    return false;
+  }
+  for (const Node& qc : q[2])
+  {
+    if (qc.getKind() == INST_PATTERN || qc.getKind() == INST_NO_PATTERN)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
 void QuantAttributes::computeAttributes( Node q ) {
   computeQuantAttributes( q, d_qattr[q] );
   QAttributes& qa = d_qattr[q];

--- a/src/theory/quantifiers/quantifiers_attributes.cpp
+++ b/src/theory/quantifiers/quantifiers_attributes.cpp
@@ -167,8 +167,8 @@ bool QuantAttributes::checkQuantElimAnnotation( Node ipl ) {
 
 bool QuantAttributes::hasPattern(Node q)
 {
-  Assert (q.getKind()==FORALL);
-  if (q.getNumChildren()!=3)
+  Assert(q.getKind() == FORALL);
+  if (q.getNumChildren() != 3)
   {
     return false;
   }

--- a/src/theory/quantifiers/quantifiers_attributes.h
+++ b/src/theory/quantifiers/quantifiers_attributes.h
@@ -209,6 +209,8 @@ class QuantAttributes
   static Node getFunDefBody( Node q );
   /** is quant elim annotation */
   static bool checkQuantElimAnnotation( Node ipl );
+  /** does q have a user-provided pattern? */
+  static bool hasPattern(Node q);
 
   /** is function definition */
   bool isFunDef( Node q );

--- a/src/theory/quantifiers/quantifiers_rewriter.cpp
+++ b/src/theory/quantifiers/quantifiers_rewriter.cpp
@@ -1271,7 +1271,7 @@ Node QuantifiersRewriter::computePrenex(Node q,
   if (k == FORALL)
   {
     if ((pol || prenexAgg)
-        && (options::prenexQuantUser() || !QuantAttributes::hasPattern(q)))
+        && (options::prenexQuantUser() || !QuantAttributes::hasPattern(body)))
     {
       std::vector< Node > terms;
       std::vector< Node > subs;

--- a/src/theory/quantifiers/quantifiers_rewriter.cpp
+++ b/src/theory/quantifiers/quantifiers_rewriter.cpp
@@ -1270,7 +1270,7 @@ Node QuantifiersRewriter::computePrenex(Node q,
   Kind k = body.getKind();
   if (k == FORALL)
   {
-    if( ( pol || prenexAgg ) && ( options::prenexQuantUser() || body.getNumChildren()==2 ) ){
+    if( ( pol || prenexAgg ) && ( options::prenexQuantUser() || !QuantAttributes::hasPattern(q) ) ){
       std::vector< Node > terms;
       std::vector< Node > subs;
       BoundVarManager* bvm = nm->getBoundVarManager();

--- a/src/theory/quantifiers/quantifiers_rewriter.cpp
+++ b/src/theory/quantifiers/quantifiers_rewriter.cpp
@@ -1270,7 +1270,9 @@ Node QuantifiersRewriter::computePrenex(Node q,
   Kind k = body.getKind();
   if (k == FORALL)
   {
-    if( ( pol || prenexAgg ) && ( options::prenexQuantUser() || !QuantAttributes::hasPattern(q) ) ){
+    if ((pol || prenexAgg)
+        && (options::prenexQuantUser() || !QuantAttributes::hasPattern(q)))
+    {
       std::vector< Node > terms;
       std::vector< Node > subs;
       BoundVarManager* bvm = nm->getBoundVarManager();

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1832,6 +1832,7 @@ set(regress_1_tests
   regress1/quantifiers/cdt-0208-to.smt2
   regress1/quantifiers/const.cvc
   regress1/quantifiers/constfunc.cvc
+  regress1/quantifiers/ddatv-delta2.smt2
   regress1/quantifiers/dt-tc-opt-small.smt2
   regress1/quantifiers/dump-inst-i.smt2
   regress1/quantifiers/dump-inst-proof.smt2

--- a/test/regress/regress1/quantifiers/ddatv-delta2.smt2
+++ b/test/regress/regress1/quantifiers/ddatv-delta2.smt2
@@ -1,0 +1,11 @@
+(set-logic ALL)
+(set-info :status unsat)
+(declare-sort U 0)
+(declare-datatypes ((T 0) (D 0)) (((E) (o (b Bool)) (I (t Int)) (i (v D)) (R (l T) (u T))) ((i (v U)))))
+(declare-datatypes ((H 0)) (((M (h T)))))
+(declare-fun S (U Int) T)
+(declare-fun n () H)
+(assert (and 
+(not (b (o (or (b (o (or (b (o (or (b (o (= (t (S (v (v (S (v (v E)) 0))) (t E))) (t (S (v (v (S (v (v (h n))) 0))) (t E))))))))))))))))
+(b (o (forall ((i Int)) (or (< i (t (u (R E E)))) (b (o (forall ((z Int)) (! (or (b (o (or (b (o (< (t (S (v (v (S (v (v (h n))) z))) (t E))) (t (S (v (v (S (v (v (h n))) 0))) (t (I i))))))))))) :qid id))))))))))
+(check-sat)


### PR DESCRIPTION
Our policy is now accurate to the help message on prenexUserQuant: we only prenex quantified formulas if they do not have user-provided patterns.  Previously we also did not prenex any quantified formulas with *any* annotations.

This should avoid some more "unknown" responses on facebook benchmarks.

Also fixes a minor issue with when we print warnings about quantified formulas with no triggers.

FYI @barrettcw .