### PR TITLE
Add `isNull` to cpp api tests, python api, and python api tests

### DIFF
--- a/src/api/python/cvc5.pxd
+++ b/src/api/python/cvc5.pxd
@@ -58,6 +58,7 @@ cdef extern from "api/cpp/cvc5.h" namespace "cvc5::api":
         bint isFinite() except +
         bint isWellFounded() except +
         bint hasNestedRecursion() except +
+        bint isNull() except +
         string toString() except +
         cppclass const_iterator:
             const_iterator() except +
@@ -80,6 +81,7 @@ cdef extern from "api/cpp/cvc5.h" namespace "cvc5::api":
         size_t getNumSelectors() except +
         DatatypeSelector getSelector(const string& name) except +
         Term getSelectorTerm(const string& name) except +
+        bint isNull() except +
         string toString() except +
         cppclass const_iterator:
             const_iterator() except +
@@ -94,6 +96,7 @@ cdef extern from "api/cpp/cvc5.h" namespace "cvc5::api":
     cdef cppclass DatatypeConstructorDecl:
         void addSelector(const string& name, Sort sort) except +
         void addSelectorSelf(const string& name) except +
+        bint isNull() except +
         string toString() except +
 
 
@@ -103,6 +106,7 @@ cdef extern from "api/cpp/cvc5.h" namespace "cvc5::api":
         bint isParametric() except +
         string toString() except +
         string getName() except +
+        bint isNull() except +
 
 
     cdef cppclass DatatypeSelector:
@@ -111,6 +115,7 @@ cdef extern from "api/cpp/cvc5.h" namespace "cvc5::api":
         Term getSelectorTerm() except +
         Term getUpdaterTerm() except +
         Sort getRangeSort() except +
+        bint isNull() except +
         string toString() except +
 
 

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -176,6 +176,9 @@ cdef class Datatype:
         """:return: whether this datatype has nested recursion (see :cpp:func:`Datatype::hasNestedRecursion() <cvc5::api::Datatype::hasNestedRecursion>`)."""
         return self.cd.hasNestedRecursion()
 
+    def isNull(self):
+        return self.cd.isNull()
+
     def __str__(self):
         return self.cd.toString().decode()
 
@@ -237,6 +240,9 @@ cdef class DatatypeConstructor:
         term.cterm = self.cdc.getSelectorTerm(name.encode())
         return term
 
+    def isNull(self):
+        return self.cdc.isNull()
+
     def __str__(self):
         return self.cdc.toString().decode()
 
@@ -263,6 +269,9 @@ cdef class DatatypeConstructorDecl:
     def addSelectorSelf(self, str name):
         self.cddc.addSelectorSelf(name.encode())
 
+    def isNull(self):
+        self.cddc.isNull()
+
     def __str__(self):
         return self.cddc.toString().decode()
 
@@ -287,6 +296,9 @@ cdef class DatatypeDecl:
 
     def getName(self):
         return self.cdd.getName().decode()
+
+    def isNull(self):
+        return self.cdd.isNull()
 
     def __str__(self):
         return self.cdd.toString().decode()
@@ -319,6 +331,9 @@ cdef class DatatypeSelector:
         cdef Sort sort = Sort(self.solver)
         sort.csort = self.cds.getRangeSort()
         return sort
+
+    def isNull(self):
+        return self.cds.isNull()
 
     def __str__(self):
         return self.cds.toString().decode()

--- a/test/python/unit/api/test_datatype_api.py
+++ b/test/python/unit/api/test_datatype_api.py
@@ -33,6 +33,10 @@ def test_mk_datatype_sort(solver):
     d = listSort.getDatatype()
     consConstr = d[0]
     nilConstr = d[1]
+    assert not d.isNull()
+    assert not cons.isNull()
+    assert not consConstr.isNull()
+    assert not dtypeSpec.isNull()
     with pytest.raises(RuntimeError):
         d[2]
     consConstr.getConstructorTerm()
@@ -207,6 +211,7 @@ def test_datatype_names(solver):
 
     # get selector
     dselTail = dcons[1]
+    assert not dselTail.isNull()
     assert dselTail.getName() == "tail"
     assert dselTail.getRangeSort() == dtypeSort
 

--- a/test/unit/api/datatype_api_black.cpp
+++ b/test/unit/api/datatype_api_black.cpp
@@ -37,6 +37,10 @@ TEST_F(TestApiBlackDatatype, mkDatatypeSort)
   Datatype d = listSort.getDatatype();
   DatatypeConstructor consConstr = d[0];
   DatatypeConstructor nilConstr = d[1];
+  ASSERT_FALSE(d.isNull());
+  ASSERT_FALSE(cons.isNull());
+  ASSERT_FALSE(consConstr.isNull());
+  ASSERT_FALSE(dtypeSpec.isNull());
   ASSERT_THROW(d[2], CVC5ApiException);
   ASSERT_NO_THROW(consConstr.getConstructorTerm());
   ASSERT_NO_THROW(nilConstr.getConstructorTerm());
@@ -211,6 +215,7 @@ TEST_F(TestApiBlackDatatype, datatypeNames)
 
   // get selector
   DatatypeSelector dselTail = dcons[1];
+  ASSERT_FALSE(dselTail.isNull());
   ASSERT_EQ(dselTail.getName(), std::string("tail"));
   ASSERT_EQ(dselTail.getRangeSort(), dtypeSort);
 


### PR DESCRIPTION
While working on API documentation for python, I noticed that `isNull` is not wrapped by the python API. It is also not tested in the cpp API tests. This PR fixes both issues, and also updates the python api tests accordingly.