### PR TITLE
int2bv: Fix conversion of signed bit-vector values.

### DIFF
--- a/src/preprocessing/passes/int_to_bv.cpp
+++ b/src/preprocessing/passes/int_to_bv.cpp
@@ -217,8 +217,17 @@ Node IntToBV::intToBV(TNode n, NodeMap& cache)
           result = sm->mkDummySkolem("__intToBV_var",
                                      nm->mkBitVectorType(size),
                                      "Variable introduced in intToBV pass");
+          /* Correctly convert signed/unsigned BV values to Integers. */
+          BitVector bvzero(size, Integer(0));
+          Node negResult = nm->mkNode(kind::BITVECTOR_TO_NAT,
+                                      nm->mkNode(kind::BITVECTOR_NEG, result));
           Node bv2nat = nm->mkNode(kind::BITVECTOR_TO_NAT, result);
-          d_preprocContext->addSubstitution(current, bv2nat);
+          Node bv2int = nm->mkNode(
+              kind::ITE,
+              nm->mkNode(kind::BITVECTOR_SLT, result, nm->mkConst(bvzero)),
+              nm->mkNode(kind::UMINUS, negResult),
+              nm->mkNode(kind::BITVECTOR_TO_NAT, result));
+          d_preprocContext->addSubstitution(current, bv2int);
         }
       }
       else if (current.isConst())

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -420,6 +420,7 @@ set(regress_0_tests
   regress0/bv/inequality05.smt2
   regress0/bv/int_to_bv_err_on_demand_1.smt2
   regress0/bv/int_to_bv_model.smt2
+  regress0/bv/int_to_bv_model2.smt2
   regress0/bv/issue-4075.smt2
   regress0/bv/issue-4076.smt2
   regress0/bv/issue-4130.smt2

--- a/test/regress/regress0/bv/int_to_bv_model2.smt2
+++ b/test/regress/regress0/bv/int_to_bv_model2.smt2
@@ -1,0 +1,5 @@
+; COMMAND-LINE: --solve-int-as-bv=5 --check-models
+(set-logic QF_NIA)
+(declare-const x Int)
+(assert (< x 0))
+(check-sat)


### PR DESCRIPTION
This commit fixes the conversion of signed bit-vector values to integers.