### PR TITLE
Add missing include

### DIFF
--- a/src/theory/arith/nl/cad_solver.h
+++ b/src/theory/arith/nl/cad_solver.h
@@ -20,6 +20,7 @@
 
 #include "context/context.h"
 #include "expr/node.h"
+#include "smt/env.h"
 #include "theory/arith/nl/cad/cdcac.h"
 #include "theory/arith/nl/cad/proof_checker.h"
 


### PR DESCRIPTION
This PR adds a missing include. Compilation fails right now, if libpoly is disabled.