### PR TITLE
Further refactoring of set defaults for incompatibility methods

### DIFF
--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -349,17 +349,18 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
   }
 
   // if we requiring disabling proofs, disable them now
-  if (mustDisableProofs(opts) && opts.smt.produceProofs)
+  if (opts.smt.produceProofs)
   {
-    opts.smt.unsatCores = false;
-    opts.smt.unsatCoresMode = options::UnsatCoresMode::OFF;
-    if (opts.smt.produceProofs)
+    std::stringstream ssIncProofs;
+    if (incompatibleWithProofs(opts, ssIncProofs))
     {
-      Notice() << "SmtEngine: turning off produce-proofs." << std::endl;
+      opts.smt.unsatCores = false;
+      opts.smt.unsatCoresMode = options::UnsatCoresMode::OFF;
+      Notice() << "SmtEngine: turning off produce-proofs due to " << ssIncProofs.str() << "." << std::endl;
+      opts.smt.produceProofs = false;
+      opts.smt.checkProofs = false;
+      opts.proof.proofEagerChecking = false;
     }
-    opts.smt.produceProofs = false;
-    opts.smt.checkProofs = false;
-    opts.proof.proofEagerChecking = false;
   }
 
   // sygus core connective requires unsat cores
@@ -417,7 +418,7 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
             "cores/incremental solving");
       }
       Notice() << "SmtEngine: turning off unconstrained simplification to "
-                  "support old unsat cores/incremental solving"
+                  "support unsat cores/incremental solving"
                << std::endl;
       opts.smt.unconstrainedSimp = false;
     }
@@ -469,127 +470,14 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
   // explicitly
   if (safeUnsatCores(opts))
   {
-    if (opts.smt.simplificationMode != options::SimplificationMode::NONE)
+    // check if the options are not compatible with unsat cores
+    std::stringstream ssIncUc;
+    if (incompatibleWithUnsatCores(opts, ssIncUc))
     {
-      if (opts.smt.simplificationModeWasSetByUser)
-      {
-        throw OptionException(
-            "simplification not supported with old unsat cores");
-      }
-      Notice() << "SmtEngine: turning off simplification to support unsat "
-                  "cores"
-               << std::endl;
-      opts.smt.simplificationMode = options::SimplificationMode::NONE;
-    }
-
-    if (opts.smt.learnedRewrite)
-    {
-      if (opts.smt.learnedRewriteWasSetByUser)
-      {
-        throw OptionException(
-            "learned rewrites not supported with unsat cores");
-      }
-      Notice() << "SmtEngine: turning off learned rewrites to support "
-                  "unsat cores\n";
-      opts.smt.learnedRewrite = false;
-    }
-
-    if (opts.arith.pbRewrites)
-    {
-      if (opts.arith.pbRewritesWasSetByUser)
-      {
-        throw OptionException(
-            "pseudoboolean rewrites not supported with unsat cores");
-      }
-      Notice() << "SmtEngine: turning off pseudoboolean rewrites to support "
-                  "unsat cores\n";
-      opts.arith.pbRewrites = false;
-    }
-
-    if (opts.smt.sortInference)
-    {
-      if (opts.smt.sortInferenceWasSetByUser)
-      {
-        throw OptionException("sort inference not supported with unsat cores");
-      }
-      Notice() << "SmtEngine: turning off sort inference to support unsat "
-                  "cores\n";
-      opts.smt.sortInference = false;
-    }
-
-    if (opts.quantifiers.preSkolemQuant)
-    {
-      if (opts.quantifiers.preSkolemQuantWasSetByUser)
-      {
-        throw OptionException(
-            "pre-skolemization not supported with unsat cores");
-      }
-      Notice() << "SmtEngine: turning off pre-skolemization to support "
-                  "unsat cores\n";
-      opts.quantifiers.preSkolemQuant = false;
-    }
-
-    if (opts.bv.bitvectorToBool)
-    {
-      if (opts.bv.bitvectorToBoolWasSetByUser)
-      {
-        throw OptionException("bv-to-bool not supported with unsat cores");
-      }
-      Notice() << "SmtEngine: turning off bitvector-to-bool to support "
-                  "unsat cores\n";
-      opts.bv.bitvectorToBool = false;
-    }
-
-    if (opts.bv.boolToBitvector != options::BoolToBVMode::OFF)
-    {
-      if (opts.bv.boolToBitvectorWasSetByUser)
-      {
-        throw OptionException(
-            "bool-to-bv != off not supported with unsat cores");
-      }
-      Notice() << "SmtEngine: turning off bool-to-bv to support unsat cores\n";
-      opts.bv.boolToBitvector = options::BoolToBVMode::OFF;
-    }
-
-    if (opts.bv.bvIntroducePow2)
-    {
-      if (opts.bv.bvIntroducePow2WasSetByUser)
-      {
-        throw OptionException("bv-intro-pow2 not supported with unsat cores");
-      }
-      Notice() << "SmtEngine: turning off bv-intro-pow2 to support unsat cores";
-      opts.bv.bvIntroducePow2 = false;
-    }
-
-    if (opts.smt.repeatSimp)
-    {
-      if (opts.smt.repeatSimpWasSetByUser)
-      {
-        throw OptionException("repeat-simp not supported with unsat cores");
-      }
-      Notice() << "SmtEngine: turning off repeat-simp to support unsat cores\n";
-      opts.smt.repeatSimp = false;
-    }
-
-    if (opts.quantifiers.globalNegate)
-    {
-      if (opts.quantifiers.globalNegateWasSetByUser)
-      {
-        throw OptionException("global-negate not supported with unsat cores");
-      }
-      Notice() << "SmtEngine: turning off global-negate to support unsat "
-                  "cores\n";
-      opts.quantifiers.globalNegate = false;
-    }
-
-    if (opts.bv.bitvectorAig)
-    {
-      throw OptionException("bitblast-aig not supported with unsat cores");
-    }
-
-    if (opts.smt.doITESimp)
-    {
-      throw OptionException("ITE simp not supported with unsat cores");
+      // option exception
+      std::stringstream ss;
+      ss << ssIncUc.str() << " not supported with unsat cores";
+      throw OptionException(ss.str());
     }
   }
   else
@@ -827,6 +715,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
     opts.smt.sortInference = false;
     opts.uf.ufssFairnessMonotone = false;
     opts.quantifiers.globalNegate = false;
+    opts.quantifiers.cegqiNestedQE = false;
     opts.bv.bvAbstraction = false;
     opts.arith.arithMLTrick = false;
   }
@@ -892,30 +781,10 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
   }
 
   // !!! All options that require disabling models go here
-  bool disableModels = false;
-  std::string sOptNoModel;
-  if (opts.smt.unconstrainedSimpWasSetByUser && opts.smt.unconstrainedSimp)
+  std::stringstream ssOptNoModel;
+  if (incompatibleWithModels(opts, ssOptNoModel)
   {
-    disableModels = true;
-    sOptNoModel = "unconstrained-simp";
-  }
-  else if (opts.smt.sortInference)
-  {
-    disableModels = true;
-    sOptNoModel = "sort-inference";
-  }
-  else if (opts.prop.minisatUseElim)
-  {
-    disableModels = true;
-    sOptNoModel = "minisat-elimination";
-  }
-  else if (opts.quantifiers.globalNegate)
-  {
-    disableModels = true;
-    sOptNoModel = "global-negate";
-  }
-  if (disableModels)
-  {
+    std::string sOptNoModel = ssOptNoModel.str();
     if (opts.smt.produceModels)
     {
       if (opts.smt.produceModelsWasSetByUser)
@@ -1038,19 +907,196 @@ bool SetDefaults::usesSygus(const Options& opts) const
   return false;
 }
 
-bool SetDefaults::mustDisableProofs(const Options& opts) const
+bool SetDefaults::incompatibleWithProofs(const Options& opts, std::ostream& reason) const
 {
   if (opts.quantifiers.globalNegate)
   {
     // When global negate answers "unsat", it is not due to showing a set of
     // formulas is unsat. Thus, proofs do not apply.
+    reason << "global-negate";
     return true;
   }
   if (isSygus(opts))
   {
     // When sygus answers "unsat", it is not due to showing a set of
     // formulas is unsat in the standard way. Thus, proofs do not apply.
+    reason << "sygus";
     return true;
+  }
+  return false;
+}
+
+bool SetDefaults::incompatibleWithModels(const Options& opts, std::ostream& reason) const
+{
+  if (opts.smt.unconstrainedSimpWasSetByUser && opts.smt.unconstrainedSimp)
+  {
+    reason << "unconstrained-simp";
+    return true;
+  }
+  else if (opts.smt.sortInference)
+  {
+    reason << "sort-inference";
+    return true;
+  }
+  else if (opts.prop.minisatUseElim)
+  {
+    reason << "minisat-elimination";
+    return true;
+  }
+  else if (opts.quantifiers.globalNegate)
+  {
+    reason << "global-negate";
+    return true;
+  }
+  return false;
+}
+
+bool SetDefaults::incompatibleWithIncrementalMode(Options& opts) const
+{
+  return false;
+}
+
+bool SetDefaults::incompatibleWithUnsatCores(Options& opts, std::ostream& reason) const
+{
+  if (opts.smt.simplificationMode != options::SimplificationMode::NONE)
+  {
+    if (opts.smt.simplificationModeWasSetByUser)
+    {
+      reason << "simplification";
+      return true;
+    }
+    Notice() << "SmtEngine: turning off simplification to support unsat "
+                "cores"
+              << std::endl;
+    opts.smt.simplificationMode = options::SimplificationMode::NONE;
+  }
+
+  if (opts.smt.learnedRewrite)
+  {
+    if (opts.smt.learnedRewriteWasSetByUser)
+    {
+      reason << "learned rewrites";
+      return true;
+    }
+    Notice() << "SmtEngine: turning off learned rewrites to support "
+                "unsat cores\n";
+    opts.smt.learnedRewrite = false;
+  }
+
+  if (opts.arith.pbRewrites)
+  {
+    if (opts.arith.pbRewritesWasSetByUser)
+    {
+      reason << "pseudoboolean rewrites";
+      return true;
+    }
+    Notice() << "SmtEngine: turning off pseudoboolean rewrites to support "
+                "unsat cores\n";
+    opts.arith.pbRewrites = false;
+  }
+
+  if (opts.smt.sortInference)
+  {
+    if (opts.smt.sortInferenceWasSetByUser)
+    {
+      reason << "sort inference";
+      return true;
+    }
+    Notice() << "SmtEngine: turning off sort inference to support unsat "
+                "cores\n";
+    opts.smt.sortInference = false;
+  }
+
+  if (opts.quantifiers.preSkolemQuant)
+  {
+    if (opts.quantifiers.preSkolemQuantWasSetByUser)
+    {
+      reason << "pre-skolemization";
+      return true;
+    }
+    Notice() << "SmtEngine: turning off pre-skolemization to support "
+                "unsat cores\n";
+    opts.quantifiers.preSkolemQuant = false;
+  }
+
+  if (opts.bv.bitvectorToBool)
+  {
+    if (opts.bv.bitvectorToBoolWasSetByUser)
+    {
+      reason << "bv-to-bool";
+      return true;
+    }
+    Notice() << "SmtEngine: turning off bitvector-to-bool to support "
+                "unsat cores\n";
+    opts.bv.bitvectorToBool = false;
+  }
+
+  if (opts.bv.boolToBitvector != options::BoolToBVMode::OFF)
+  {
+    if (opts.bv.boolToBitvectorWasSetByUser)
+    {
+      reason << "bool-to-bv != off";
+      return true;
+    }
+    Notice() << "SmtEngine: turning off bool-to-bv to support unsat cores\n";
+    opts.bv.boolToBitvector = options::BoolToBVMode::OFF;
+  }
+
+  if (opts.bv.bvIntroducePow2)
+  {
+    if (opts.bv.bvIntroducePow2WasSetByUser)
+    {
+      reason << "bv-intro-pow2";
+      return true;
+    }
+    Notice() << "SmtEngine: turning off bv-intro-pow2 to support unsat cores";
+    opts.bv.bvIntroducePow2 = false;
+  }
+
+  if (opts.smt.repeatSimp)
+  {
+    if (opts.smt.repeatSimpWasSetByUser)
+    {
+      reason << "repeat-simp";
+      return true;
+    }
+    Notice() << "SmtEngine: turning off repeat-simp to support unsat cores\n";
+    opts.smt.repeatSimp = false;
+  }
+
+  if (opts.quantifiers.globalNegate)
+  {
+    if (opts.quantifiers.globalNegateWasSetByUser)
+    {
+      reason << "global-negate";
+      return true;
+    }
+    Notice() << "SmtEngine: turning off global-negate to support unsat "
+                "cores\n";
+    opts.quantifiers.globalNegate = false;
+  }
+
+  if (opts.bv.bitvectorAig)
+  {
+    reason << "bitblast-aig";
+    return true;
+  }
+
+  if (opts.smt.doITESimp)
+  {
+    reason << "ITE simp";
+    return true;
+  }
+  if (opts.smt.unconstrainedSimp)
+  {
+    if (opts.smt.unconstrainedSimpWasSetByUser)
+    {
+      reason << "unconstrained simplification";
+      return true;
+    }
+    Notice() << "SmtEngine: turning off unconstrained simplification to support unsat cores"
+              << std::endl;
+    opts.smt.unconstrainedSimp = false;
   }
   return false;
 }
@@ -1293,11 +1339,6 @@ void SetDefaults::setDefaultsQuantifiers(const LogicInfo& logic,
   }
   if (opts.quantifiers.cegqi)
   {
-    if (opts.base.incrementalSolving)
-    {
-      // cannot do nested quantifier elimination in incremental mode
-      opts.quantifiers.cegqiNestedQE = false;
-    }
     if (logic.isPure(THEORY_ARITH) || logic.isPure(THEORY_BV))
     {
       if (!opts.quantifiers.quantConflictFindWasSetByUser)

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -356,7 +356,8 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
     {
       opts.smt.unsatCores = false;
       opts.smt.unsatCoresMode = options::UnsatCoresMode::OFF;
-      Notice() << "SmtEngine: turning off produce-proofs due to " << ssIncProofs.str() << "." << std::endl;
+      Notice() << "SmtEngine: turning off produce-proofs due to "
+               << ssIncProofs.str() << "." << std::endl;
       opts.smt.produceProofs = false;
       opts.smt.checkProofs = false;
       opts.proof.proofEagerChecking = false;
@@ -907,7 +908,8 @@ bool SetDefaults::usesSygus(const Options& opts) const
   return false;
 }
 
-bool SetDefaults::incompatibleWithProofs(const Options& opts, std::ostream& reason) const
+bool SetDefaults::incompatibleWithProofs(const Options& opts,
+                                         std::ostream& reason) const
 {
   if (opts.quantifiers.globalNegate)
   {
@@ -926,7 +928,8 @@ bool SetDefaults::incompatibleWithProofs(const Options& opts, std::ostream& reas
   return false;
 }
 
-bool SetDefaults::incompatibleWithModels(const Options& opts, std::ostream& reason) const
+bool SetDefaults::incompatibleWithModels(const Options& opts,
+                                         std::ostream& reason) const
 {
   if (opts.smt.unconstrainedSimpWasSetByUser && opts.smt.unconstrainedSimp)
   {
@@ -956,7 +959,8 @@ bool SetDefaults::incompatibleWithIncrementalMode(Options& opts) const
   return false;
 }
 
-bool SetDefaults::incompatibleWithUnsatCores(Options& opts, std::ostream& reason) const
+bool SetDefaults::incompatibleWithUnsatCores(Options& opts,
+                                             std::ostream& reason) const
 {
   if (opts.smt.simplificationMode != options::SimplificationMode::NONE)
   {
@@ -967,7 +971,7 @@ bool SetDefaults::incompatibleWithUnsatCores(Options& opts, std::ostream& reason
     }
     Notice() << "SmtEngine: turning off simplification to support unsat "
                 "cores"
-              << std::endl;
+             << std::endl;
     opts.smt.simplificationMode = options::SimplificationMode::NONE;
   }
 
@@ -1094,8 +1098,9 @@ bool SetDefaults::incompatibleWithUnsatCores(Options& opts, std::ostream& reason
       reason << "unconstrained simplification";
       return true;
     }
-    Notice() << "SmtEngine: turning off unconstrained simplification to support unsat cores"
-              << std::endl;
+    Notice() << "SmtEngine: turning off unconstrained simplification to "
+                "support unsat cores"
+             << std::endl;
     opts.smt.unconstrainedSimp = false;
   }
   return false;

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -397,7 +397,7 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
              << std::endl;
     opts.bv.bvSolver = options::BVSolver::BITBLAST_INTERNAL;
   }
-  
+
   if (opts.smt.solveBVAsInt != options::SolveBVAsIntMode::OFF)
   {
     /**
@@ -418,11 +418,12 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
     if (incompatibleWithIncremental(logic, opts, reasonNoInc, suggestNoInc))
     {
       std::stringstream ss;
-      ss << reasonNoInc.str() << " not supported with incremental solving. " << suggestNoInc.str();
+      ss << reasonNoInc.str() << " not supported with incremental solving. "
+         << suggestNoInc.str();
       throw OptionException(ss.str());
     }
   }
-  
+
   // Disable options incompatible with unsat cores or output an error if enabled
   // explicitly
   if (safeUnsatCores(opts))
@@ -441,13 +442,14 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
   if (!opts.smt.unconstrainedSimpWasSetByUser)
   {
     // It is also currently incompatible with arithmetic, force the option off.
-    bool uncSimp = !opts.base.incrementalSolving && !logic.isQuantified() && !opts.smt.produceModels
-                    && !opts.smt.produceAssignments && !opts.smt.checkModels
-                    && logic.isTheoryEnabled(THEORY_ARRAYS)
-                    && logic.isTheoryEnabled(THEORY_BV)
-                    && !logic.isTheoryEnabled(THEORY_ARITH);
+    bool uncSimp = !opts.base.incrementalSolving && !logic.isQuantified()
+                   && !opts.smt.produceModels && !opts.smt.produceAssignments
+                   && !opts.smt.checkModels
+                   && logic.isTheoryEnabled(THEORY_ARRAYS)
+                   && logic.isTheoryEnabled(THEORY_BV)
+                   && !logic.isTheoryEnabled(THEORY_ARITH);
     Trace("smt") << "setting unconstrained simplification to " << uncSimp
-                  << std::endl;
+                 << std::endl;
     opts.smt.unconstrainedSimp = uncSimp;
   }
 
@@ -455,17 +457,15 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
   if (!opts.smt.simplificationModeWasSetByUser)
   {
     bool qf_sat = logic.isPure(THEORY_BOOL) && !logic.isQuantified();
-    Trace("smt") << "setting simplification mode to <"
-                  << logic.getLogicString() << "> " << (!qf_sat) << std::endl;
+    Trace("smt") << "setting simplification mode to <" << logic.getLogicString()
+                 << "> " << (!qf_sat) << std::endl;
     // simplification=none works better for SMT LIB benchmarks with
     // quantifiers, not others opts.set(options::simplificationMode, qf_sat ||
     // quantifiers ? options::SimplificationMode::NONE :
     // options::SimplificationMode::BATCH);
-    opts.smt.simplificationMode = qf_sat
-                                        ? options::SimplificationMode::NONE
-                                        : options::SimplificationMode::BATCH;
+    opts.smt.simplificationMode = qf_sat ? options::SimplificationMode::NONE
+                                         : options::SimplificationMode::BATCH;
   }
-
 
   if (opts.quantifiers.cegqiBv && logic.isQuantified())
   {
@@ -922,17 +922,17 @@ bool SetDefaults::incompatibleWithModels(const Options& opts,
   return false;
 }
 
-bool SetDefaults::incompatibleWithIncremental(const LogicInfo& logic, 
+bool SetDefaults::incompatibleWithIncremental(const LogicInfo& logic,
                                               Options& opts,
-                                             std::ostream& reason,
-                                             std::ostream& suggest) const
+                                              std::ostream& reason,
+                                              std::ostream& suggest) const
 {
-  if (opts.bv.bitblastMode == options::BitblastMode::EAGER && !logic.isPure(THEORY_BV))
+  if (opts.bv.bitblastMode == options::BitblastMode::EAGER
+      && !logic.isPure(THEORY_BV))
   {
     reason << "eager bit-blasting in non-QF_BV logic";
     suggest << "Try --bitblast=lazy.";
     return true;
-  
   }
   if (opts.quantifiers.sygusInference)
   {
@@ -943,7 +943,7 @@ bool SetDefaults::incompatibleWithIncremental(const LogicInfo& logic,
     }
     Notice() << "SmtEngine: turning off sygus inference to support "
                 "incremental solving"
-              << std::endl;
+             << std::endl;
     opts.quantifiers.sygusInference = false;
   }
   return false;

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -344,13 +344,13 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
   // if we requiring disabling proofs, disable them now
   if (opts.smt.produceProofs)
   {
-    std::stringstream ssIncProofs;
-    if (incompatibleWithProofs(opts, ssIncProofs))
+    std::stringstream reasonNoProofs;
+    if (incompatibleWithProofs(opts, reasonNoProofs))
     {
       opts.smt.unsatCores = false;
       opts.smt.unsatCoresMode = options::UnsatCoresMode::OFF;
       Notice() << "SmtEngine: turning off produce-proofs due to "
-               << ssIncProofs.str() << "." << std::endl;
+               << reasonNoProofs.str() << "." << std::endl;
       opts.smt.produceProofs = false;
       opts.smt.checkProofs = false;
       opts.proof.proofEagerChecking = false;
@@ -409,13 +409,13 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
     opts.bv.bitvectorToBool = true;
   }
 
-  // Disable options incompatible with incremental solving, unsat cores or
-  // output an error if enabled explicitly.
+  // Disable options incompatible with incremental solving, or output an error
+  // if enabled explicitly.
   if (opts.base.incrementalSolving)
   {
     std::stringstream reasonNoInc;
     std::stringstream suggestNoInc;
-    if (incompatibleWithIncremental(opts, reasonNoInc, suggestNoInc))
+    if (incompatibleWithIncremental(logic, opts, reasonNoInc, suggestNoInc))
     {
       std::stringstream ss;
       ss << reasonNoInc.str() << " not supported with incremental solving. " << suggestNoInc.str();
@@ -922,7 +922,8 @@ bool SetDefaults::incompatibleWithModels(const Options& opts,
   return false;
 }
 
-bool SetDefaults::incompatibleWithIncremental(Options& opts,
+bool SetDefaults::incompatibleWithIncremental(const LogicInfo& logic, 
+                                              Options& opts,
                                              std::ostream& reason,
                                              std::ostream& suggest) const
 {

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -440,17 +440,19 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
   else
   {
     // Turn on unconstrained simplification for QF_AUFBV
-    if (!opts.smt.unconstrainedSimpWasSetByUser && !opts.base.incrementalSolving)
+    if (!opts.smt.unconstrainedSimpWasSetByUser
+        && !opts.base.incrementalSolving)
     {
-      // It is also currently incompatible with arithmetic, force the option off.
+      // It is also currently incompatible with arithmetic, force the option
+      // off.
       bool uncSimp = !opts.base.incrementalSolving && !logic.isQuantified()
-                    && !opts.smt.produceModels && !opts.smt.produceAssignments
-                    && !opts.smt.checkModels
-                    && logic.isTheoryEnabled(THEORY_ARRAYS)
-                    && logic.isTheoryEnabled(THEORY_BV)
-                    && !logic.isTheoryEnabled(THEORY_ARITH);
+                     && !opts.smt.produceModels && !opts.smt.produceAssignments
+                     && !opts.smt.checkModels
+                     && logic.isTheoryEnabled(THEORY_ARRAYS)
+                     && logic.isTheoryEnabled(THEORY_BV)
+                     && !logic.isTheoryEnabled(THEORY_ARITH);
       Trace("smt") << "setting unconstrained simplification to " << uncSimp
-                  << std::endl;
+                   << std::endl;
       opts.smt.unconstrainedSimp = uncSimp;
     }
 
@@ -458,14 +460,14 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
     if (!opts.smt.simplificationModeWasSetByUser)
     {
       bool qf_sat = logic.isPure(THEORY_BOOL) && !logic.isQuantified();
-      Trace("smt") << "setting simplification mode to <" << logic.getLogicString()
-                  << "> " << (!qf_sat) << std::endl;
+      Trace("smt") << "setting simplification mode to <"
+                   << logic.getLogicString() << "> " << (!qf_sat) << std::endl;
       // simplification=none works better for SMT LIB benchmarks with
       // quantifiers, not others opts.set(options::simplificationMode, qf_sat ||
       // quantifiers ? options::SimplificationMode::NONE :
       // options::SimplificationMode::BATCH);
       opts.smt.simplificationMode = qf_sat ? options::SimplificationMode::NONE
-                                          : options::SimplificationMode::BATCH;
+                                           : options::SimplificationMode::BATCH;
     }
   }
 

--- a/src/smt/set_defaults.h
+++ b/src/smt/set_defaults.h
@@ -67,7 +67,9 @@ class SetDefaults
   /**
    * Check incompatible with incremental mode.
    */
-  bool incompatibleWithIncrementalMode(Options& opts) const;
+  bool incompatibleWithIncremental(Options& opts,
+                                             std::ostream& reason,
+                                             std::ostream& suggest) const;
   /**
    * Check incompatible with unsat cores.
    */

--- a/src/smt/set_defaults.h
+++ b/src/smt/set_defaults.h
@@ -58,7 +58,7 @@ class SetDefaults
   /**
    * Check incompatible with incremental mode. Notice this method may modify
    * the options to ensure that we are compatible with incremental mode.
-   * 
+   *
    * If this method returns true, then the reason why we were incompatible with
    * proofs is written on the reason output stream. Suggestions for how to
    * resolve the option exception are written on the suggest stream.
@@ -69,11 +69,13 @@ class SetDefaults
                                    std::ostream& suggest) const;
   /**
    * Return true if proofs must be disabled. This is the case for any technique
-   * that answers "unsat" without showing a proof of unsatisfiabilty. The output stream reason is similar to above.
+   * that answers "unsat" without showing a proof of unsatisfiabilty. The output
+   * stream reason is similar to above.
    */
   bool incompatibleWithProofs(const Options& opts, std::ostream& reason) const;
   /**
-   * Check whether we should disable models. The output stream reason is similar to above.
+   * Check whether we should disable models. The output stream reason is similar
+   * to above.
    */
   bool incompatibleWithModels(const Options& opts, std::ostream& reason) const;
   /**

--- a/src/smt/set_defaults.h
+++ b/src/smt/set_defaults.h
@@ -67,7 +67,8 @@ class SetDefaults
   /**
    * Check incompatible with incremental mode.
    */
-  bool incompatibleWithIncremental(Options& opts,
+  bool incompatibleWithIncremental(const LogicInfo& logic, 
+                                   Options& opts,
                                              std::ostream& reason,
                                              std::ostream& suggest) const;
   /**

--- a/src/smt/set_defaults.h
+++ b/src/smt/set_defaults.h
@@ -56,23 +56,30 @@ class SetDefaults
    */
   bool usesSygus(const Options& opts) const;
   /**
-   * Return true if proofs must be disabled. This is the case for any technique
-   * that answers "unsat" without showing a proof of unsatisfiabilty.
-   */
-  bool incompatibleWithProofs(const Options& opts, std::ostream& reason) const;
-  /**
-   * Check whether we should disable models.
-   */
-  bool incompatibleWithModels(const Options& opts, std::ostream& reason) const;
-  /**
-   * Check incompatible with incremental mode.
+   * Check incompatible with incremental mode. Notice this method may modify
+   * the options to ensure that we are compatible with incremental mode.
+   * 
+   * If this method returns true, then the reason why we were incompatible with
+   * proofs is written on the reason output stream. Suggestions for how to
+   * resolve the option exception are written on the suggest stream.
    */
   bool incompatibleWithIncremental(const LogicInfo& logic,
                                    Options& opts,
                                    std::ostream& reason,
                                    std::ostream& suggest) const;
   /**
-   * Check incompatible with unsat cores.
+   * Return true if proofs must be disabled. This is the case for any technique
+   * that answers "unsat" without showing a proof of unsatisfiabilty. The output stream reason is similar to above.
+   */
+  bool incompatibleWithProofs(const Options& opts, std::ostream& reason) const;
+  /**
+   * Check whether we should disable models. The output stream reason is similar to above.
+   */
+  bool incompatibleWithModels(const Options& opts, std::ostream& reason) const;
+  /**
+   * Check incompatible with unsat cores. Notice this method may modify
+   * the options to ensure that we are compatible with unsat cores.
+   * The output stream reason is similar to above.
    */
   bool incompatibleWithUnsatCores(Options& opts, std::ostream& reason) const;
   /**

--- a/src/smt/set_defaults.h
+++ b/src/smt/set_defaults.h
@@ -60,7 +60,7 @@ class SetDefaults
    * that answers "unsat" without showing a proof of unsatisfiabilty.
    */
   bool incompatibleWithProofs(const Options& opts, std::ostream& reason) const;
-  /** 
+  /**
    * Check whether we should disable models.
    */
   bool incompatibleWithModels(const Options& opts, std::ostream& reason) const;

--- a/src/smt/set_defaults.h
+++ b/src/smt/set_defaults.h
@@ -56,12 +56,12 @@ class SetDefaults
    */
   bool usesSygus(const Options& opts) const;
   /**
-   * Check incompatible with incremental mode. Notice this method may modify
+   * Check if incompatible with incremental mode. Notice this method may modify
    * the options to ensure that we are compatible with incremental mode.
    *
    * If this method returns true, then the reason why we were incompatible with
-   * proofs is written on the reason output stream. Suggestions for how to
-   * resolve the option exception are written on the suggest stream.
+   * incremental mode is written on the reason output stream. Suggestions for how to
+   * resolve the incompatibility exception are written on the suggest stream.
    */
   bool incompatibleWithIncremental(const LogicInfo& logic,
                                    Options& opts,
@@ -79,7 +79,7 @@ class SetDefaults
    */
   bool incompatibleWithModels(const Options& opts, std::ostream& reason) const;
   /**
-   * Check incompatible with unsat cores. Notice this method may modify
+   * Check if incompatible with unsat cores. Notice this method may modify
    * the options to ensure that we are compatible with unsat cores.
    * The output stream reason is similar to above.
    */

--- a/src/smt/set_defaults.h
+++ b/src/smt/set_defaults.h
@@ -67,10 +67,10 @@ class SetDefaults
   /**
    * Check incompatible with incremental mode.
    */
-  bool incompatibleWithIncremental(const LogicInfo& logic, 
+  bool incompatibleWithIncremental(const LogicInfo& logic,
                                    Options& opts,
-                                             std::ostream& reason,
-                                             std::ostream& suggest) const;
+                                   std::ostream& reason,
+                                   std::ostream& suggest) const;
   /**
    * Check incompatible with unsat cores.
    */

--- a/src/smt/set_defaults.h
+++ b/src/smt/set_defaults.h
@@ -59,7 +59,19 @@ class SetDefaults
    * Return true if proofs must be disabled. This is the case for any technique
    * that answers "unsat" without showing a proof of unsatisfiabilty.
    */
-  bool mustDisableProofs(const Options& opts) const;
+  bool incompatibleWithProofs(const Options& opts, std::ostream& reason) const;
+  /** 
+   * Check whether we should disable models.
+   */
+  bool incompatibleWithModels(const Options& opts, std::ostream& reason) const;
+  /**
+   * Check incompatible with incremental mode.
+   */
+  bool incompatibleWithIncrementalMode(Options& opts) const;
+  /**
+   * Check incompatible with unsat cores.
+   */
+  bool incompatibleWithUnsatCores(Options& opts, std::ostream& reason) const;
   /**
    * Return true if we are using "safe" unsat cores, which disables all
    * techniques that may interfere with producing correct unsat cores.


### PR DESCRIPTION
This introduces standard methods for checking incompatible with models, unsat-cores, incremental, proofs.

There is one minor change in behavior in this PR.When bitblast=eager and models were enabled in combined logics, then the set defaults would change the bitblast mode to lazy.  However, it would then in the same block complain that eager cannot be used in combination with incremental.  After this PR, we won't complain in this case since we've already decided to change the bitblast mode to lazy.