### PR TITLE
Fix a subtle issue with squashing the docs-ci history

### DIFF
--- a/.github/workflows/docs_cleanup.yml
+++ b/.github/workflows/docs_cleanup.yml
@@ -45,7 +45,8 @@ jobs:
         run: |
           cd target
           first=`git rev-list --max-parents=0 HEAD`
-          last=`git rev-list --until=1.month.ago -n1 HEAD`
+          cutoff=`date -d "-1 month" +%Y-%m-%d`
+          last=`git log --pretty='%as %H' | awk -v cutoff=$cutoff '$1 < cutoff { print $2 }' | head -n1`
           if [ -n "$last" ]; then
             git checkout $last
             ts=`git log -1 --format=%ct`


### PR DESCRIPTION
The docs-cleanup job squashes all commits from the docs-ci repository that are older than one month. The current solution to retrieve the newest commit older than this one month erroneously relied on the commit date. As the script cherry-picks all newer commits, it should rather use the author date, though. Unfortunately, `rev-list` does not support filtering by author date, hence we use awk now...