### PR TITLE
Make sure modes are sorted in ModeInfo

### DIFF
--- a/src/options/mkoptions.py
+++ b/src/options/mkoptions.py
@@ -806,7 +806,7 @@ def codegen_all_modules(modules, build_dir, dst_dir, tpls):
                     elif option.type == 'double' or is_numeric_cpp_type(option.type):
                         constr = 'OptionInfo::NumberInfo<{type}>{{{default}, {value}, {minimum}, {maximum}}}'.format(**fmt)
                     elif option.mode:
-                        values = ', '.join(map(lambda s: '"{}"'.format(s), option.mode.keys()))
+                        values = ', '.join(map(lambda s: '"{}"'.format(s), sorted(option.mode.keys())))
                         assert(option.default)
                         constr = 'OptionInfo::ModeInfo{{"{default}", {value}, {{ {modes} }}}}'.format(**fmt, modes=values)
                     else:

--- a/test/unit/api/solver_black.cpp
+++ b/test/unit/api/solver_black.cpp
@@ -1371,7 +1371,7 @@ TEST_F(TestApiBlackSolver, getOptionInfo)
     auto modeInfo = std::get<OptionInfo::ModeInfo>(info.valueInfo);
     EXPECT_EQ("NONE", modeInfo.defaultValue);
     EXPECT_EQ("OutputTag::NONE", modeInfo.currentValue);
-    std::vector<std::string> modes{"NONE", "INST", "SYGUS", "TRIGGER"};
+    std::vector<std::string> modes{"INST", "NONE", "SYGUS", "TRIGGER"};
     EXPECT_EQ(modes, modeInfo.modes);
   }
 }


### PR DESCRIPTION
This PR ensures that the possible modes returned in `getOptionInfo()` are always sorted. Their order would depend on the python dictionary ordering, which changed with a somewhat recent python version and thereby breaks our tests.