### PR TITLE
bv: Remove dump=bv-rewrites.

### DIFF
--- a/src/smt/dump.cpp
+++ b/src/smt/dump.cpp
@@ -134,7 +134,6 @@ void DumpC::setDumpFromString(const std::string& optarg) {
       else if (!strcmp(optargPtr, "t-conflicts")
                || !strcmp(optargPtr, "t-lemmas")
                || !strcmp(optargPtr, "t-explanations")
-               || !strcmp(optargPtr, "bv-rewrites")
                || !strcmp(optargPtr, "theory::fullcheck"))
       {
       }
@@ -224,9 +223,6 @@ t-lemmas\n\
 \n\
 t-explanations\n\
 + Output correctness queries for all theory explanations\n\
-\n\
-bv-rewrites\n\
-+ Output correctness queries for all bitvector rewrites\n\
 \n\
 theory::fullcheck\n\
 + Output completeness queries for all full-check effort-level theory checks\n\

--- a/src/theory/bv/theory_bv_rewrite_rules.h
+++ b/src/theory/bv/theory_bv_rewrite_rules.h
@@ -453,7 +453,6 @@ public:
       Debug("theory::bv::rewrite")
           << "RewriteRule<" << rule << ">(" << node << ")" << std::endl;
       Assert(checkApplies || applies(node));
-      //++ s_statistics->d_ruleApplications;
       Node result = apply(node);
       Debug("theory::bv::rewrite") << "RewriteRule<" << rule << ">(" << node
                                    << ") => " << result << std::endl;

--- a/src/theory/bv/theory_bv_rewrite_rules.h
+++ b/src/theory/bv/theory_bv_rewrite_rules.h
@@ -445,32 +445,22 @@ public:
     SuppressWrongNoReturnWarning;
   }
 
-  template<bool checkApplies>
-  static inline Node run(TNode node) {
-    if (!checkApplies || applies(node)) {
-      Debug("theory::bv::rewrite") << "RewriteRule<" << rule << ">(" << node << ")" << std::endl;
+  template <bool checkApplies>
+  static inline Node run(TNode node)
+  {
+    if (!checkApplies || applies(node))
+    {
+      Debug("theory::bv::rewrite")
+          << "RewriteRule<" << rule << ">(" << node << ")" << std::endl;
       Assert(checkApplies || applies(node));
       //++ s_statistics->d_ruleApplications;
       Node result = apply(node);
-      if (result != node) {
-        if(Dump.isOn("bv-rewrites")) {
-          std::ostringstream os;
-          os << "RewriteRule <"<<rule<<">; expect unsat";
-
-          Node condition = node.eqNode(result).notNode();
-
-          const Printer& printer =
-              smt::currentSmtEngine()->getOutputManager().getPrinter();
-          std::ostream& out =
-              smt::currentSmtEngine()->getOutputManager().getDumpOut();
-
-          printer.toStreamCmdComment(out, os.str());
-          printer.toStreamCmdCheckSat(out, condition);
-        }
-      }
-      Debug("theory::bv::rewrite") << "RewriteRule<" << rule << ">(" << node << ") => " << result << std::endl;
+      Debug("theory::bv::rewrite") << "RewriteRule<" << rule << ">(" << node
+                                   << ") => " << result << std::endl;
       return result;
-    } else {
+    }
+    else
+    {
       return node;
     }
   }


### PR DESCRIPTION
This is work towards eliminating calls to currentSmtEngine.
This dump mode will become obsolete with the DSL, and is thus now
removed.