### PR TITLE
Updated .clang_format for java

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,8 +20,20 @@ DerivePointerAlignment: false
 ---
 Language: Java
 BasedOnStyle:  Google
-ColumnLimit: 80
+AllowShortCaseLabelsOnASingleLine: true
 BinPackArguments: false
 BinPackParameters: false
 BreakBeforeBinaryOperators: NonAssignment
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterFunction: true
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+BreakBeforeBraces: Custom
+DerivePointerAlignment: false
 ...

--- a/src/api/java/cvc5/Grammar.java
+++ b/src/api/java/cvc5/Grammar.java
@@ -15,20 +15,23 @@
 
 package cvc5;
 
-public class Grammar extends AbstractPointer {
+public class Grammar extends AbstractPointer
+{
   // region construction and destruction
-  Grammar(Solver solver, long pointer) {
+  Grammar(Solver solver, long pointer)
+  {
     super(solver, pointer);
   }
 
   protected static native void deletePointer(long pointer);
 
-  public long getPointer() {
+  public long getPointer()
+  {
     return pointer;
   }
 
-  @Override
-  public void finalize() {
+  @Override public void finalize()
+  {
     deletePointer(pointer);
   }
 
@@ -39,31 +42,32 @@ public class Grammar extends AbstractPointer {
    * @param ntSymbol the non-terminal to which the rule is added
    * @param rule the rule to add
    */
-  public void addRule(Term ntSymbol, Term rule) {
+  public void addRule(Term ntSymbol, Term rule)
+  {
     addRule(pointer, ntSymbol.getPointer(), rule.getPointer());
   }
 
-  private native void addRule(
-      long pointer, long ntSymbolPointer, long rulePointer);
+  private native void addRule(long pointer, long ntSymbolPointer, long rulePointer);
 
   /**
    * Add \p rules to the set of rules corresponding to \p ntSymbol.
    * @param ntSymbol the non-terminal to which the rules are added
    * @param rules the rules to add
    */
-  public void addRules(Term ntSymbol, Term[] rules) {
+  public void addRules(Term ntSymbol, Term[] rules)
+  {
     long[] pointers = Utils.getPointers(rules);
     addRules(pointer, ntSymbol.getPointer(), pointers);
   }
 
-  public native void addRules(
-      long pointer, long ntSymbolPointer, long[] rulePointers);
+  public native void addRules(long pointer, long ntSymbolPointer, long[] rulePointers);
 
   /**
    * Allow \p ntSymbol to be an arbitrary constant.
    * @param ntSymbol the non-terminal allowed to be any constant
    */
-  void addAnyConstant(Term ntSymbol) {
+  void addAnyConstant(Term ntSymbol)
+  {
     addAnyConstant(pointer, ntSymbol.getPointer());
   }
 
@@ -74,7 +78,8 @@ public class Grammar extends AbstractPointer {
    * synth-fun/synth-inv with the same sort as \p ntSymbol.
    * @param ntSymbol the non-terminal allowed to be any input constant
    */
-  void addAnyVariable(Term ntSymbol) {
+  void addAnyVariable(Term ntSymbol)
+  {
     addAnyVariable(pointer, ntSymbol.getPointer());
   }
 

--- a/src/api/java/cvc5/Term.java
+++ b/src/api/java/cvc5/Term.java
@@ -19,21 +19,23 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-public class Term
-    extends AbstractPointer implements Comparable<Term>, Iterable<Term> {
+public class Term extends AbstractPointer implements Comparable<Term>, Iterable<Term>
+{
   // region construction and destruction
-  Term(Solver solver, long pointer) {
+  Term(Solver solver, long pointer)
+  {
     super(solver, pointer);
   }
 
   protected static native void deletePointer(long pointer);
 
-  public long getPointer() {
+  public long getPointer()
+  {
     return pointer;
   }
 
-  @Override
-  public void finalize() {
+  @Override public void finalize()
+  {
     deletePointer(pointer);
   }
 
@@ -47,14 +49,15 @@ public class Term
    * @param t the term to compare to for equality
    * @return true if the terms are equal
    */
-  @Override
-  public boolean equals(Object t) {
+  @Override public boolean equals(Object t)
+  {
     if (this == t)
       return true;
     if (t == null || getClass() != t.getClass())
       return false;
     Term term = (Term) t;
-    if (this.pointer == term.pointer) {
+    if (this.pointer == term.pointer)
+    {
       return true;
     }
     return equals(pointer, term.getPointer());
@@ -69,8 +72,8 @@ public class Term
    * @return a negative integer, zero, or a positive integer as this term
    * is less than, equal to, or greater than the specified term.
    */
-  @Override
-  public int compareTo(Term t) {
+  @Override public int compareTo(Term t)
+  {
     return this.compareTo(pointer, t.getPointer());
   }
 
@@ -79,7 +82,8 @@ public class Term
   /**
    * @return the number of children of this term
    */
-  public int getNumChildren() {
+  public int getNumChildren()
+  {
     return getNumChildren(pointer);
   }
 
@@ -91,7 +95,8 @@ public class Term
    * @param index the index of the child term to return
    * @return the child term with the given index
    */
-  public Term getChild(int index) throws CVC5ApiException {
+  public Term getChild(int index) throws CVC5ApiException
+  {
     Utils.validateUnsigned(index, "index");
     long termPointer = getChild(pointer, index);
     return new Term(solver, termPointer);
@@ -102,7 +107,8 @@ public class Term
   /**
    * @return the id of this term
    */
-  public long getId() {
+  public long getId()
+  {
     return getId(pointer);
   }
 
@@ -111,7 +117,8 @@ public class Term
   /**
    * @return the kind of this term
    */
-  public Kind getKind() throws CVC5ApiException {
+  public Kind getKind() throws CVC5ApiException
+  {
     int value = getKind(pointer);
     return Kind.fromInt(value);
   }
@@ -121,7 +128,8 @@ public class Term
   /**
    * @return the sort of this term
    */
-  public Sort getSort() {
+  public Sort getSort()
+  {
     long sortPointer = getSort(pointer);
     return new Sort(solver, sortPointer);
   }
@@ -131,35 +139,37 @@ public class Term
   /**
    * @return the result of replacing 'term' by 'replacement' in this term
    */
-  public Term substitute(Term term, Term replacement) {
-    long termPointer =
-        substitute(pointer, term.getPointer(), replacement.getPointer());
+  public Term substitute(Term term, Term replacement)
+  {
+    long termPointer = substitute(pointer, term.getPointer(), replacement.getPointer());
     return new Term(solver, termPointer);
   }
 
-  private native long substitute(
-      long pointer, long termPointer, long replacementPointer);
+  private native long substitute(long pointer, long termPointer, long replacementPointer);
 
   /**
    * @return the result of simultaneously replacing 'terms' by 'replacements'
    * in this term
    */
-  public Term substitute(List<Term> terms, List<Term> replacements) {
-    return substitute(
-        terms.toArray(new Term[0]), replacements.toArray(new Term[0]));
+  public Term substitute(List<Term> terms, List<Term> replacements)
+  {
+    return substitute(terms.toArray(new Term[0]), replacements.toArray(new Term[0]));
   }
 
   /**
    * @return the result of simultaneously replacing 'terms' by 'replacements'
    * in this term
    */
-  public Term substitute(Term[] terms, Term[] replacements) {
+  public Term substitute(Term[] terms, Term[] replacements)
+  {
     long[] termPointers = new long[terms.length];
-    for (int i = 0; i < termPointers.length; i++) {
+    for (int i = 0; i < termPointers.length; i++)
+    {
       termPointers[i] = terms[i].getPointer();
     }
     long[] replacementPointers = new long[replacements.length];
-    for (int i = 0; i < replacements.length; i++) {
+    for (int i = 0; i < replacements.length; i++)
+    {
       replacementPointers[i] = replacements[i].getPointer();
     }
 
@@ -167,13 +177,13 @@ public class Term
     return new Term(solver, termPointer);
   }
 
-  private native long substitute(
-      long pointer, long[] termPointers, long[] replacementPointers);
+  private native long substitute(long pointer, long[] termPointers, long[] replacementPointers);
 
   /**
    * @return true iff this term has an operator
    */
-  public boolean hasOp() {
+  public boolean hasOp()
+  {
     return hasOp(pointer);
   }
 
@@ -183,7 +193,8 @@ public class Term
    * @return the Op used to create this term
    * Note: This is safe to call when hasOp() returns true.
    */
-  public Op getOp() {
+  public Op getOp()
+  {
     long opPointer = getOp(pointer);
     return new Op(solver, opPointer);
   }
@@ -193,7 +204,8 @@ public class Term
   /**
    * @return true if this Term is a null term
    */
-  public boolean isNull() {
+  public boolean isNull()
+  {
     return isNull(pointer);
   }
 
@@ -205,7 +217,8 @@ public class Term
    *
    * @return the base value
    */
-  public Term getConstArrayBase() {
+  public Term getConstArrayBase()
+  {
     long termPointer = getConstArrayBase(pointer);
     return new Term(solver, termPointer);
   }
@@ -218,10 +231,12 @@ public class Term
    *
    * @return the elements of the constant sequence.
    */
-  public Term[] getConstSequenceElements() {
+  public Term[] getConstSequenceElements()
+  {
     long[] termPointers = getConstSequenceElements(pointer);
     Term[] terms = new Term[termPointers.length];
-    for (int i = 0; i < termPointers.length; i++) {
+    for (int i = 0; i < termPointers.length; i++)
+    {
       terms[i] = new Term(solver, termPointers[i]);
     }
 
@@ -235,7 +250,8 @@ public class Term
    *
    * @return the Boolean negation of this term
    */
-  public Term notTerm() {
+  public Term notTerm()
+  {
     long termPointer = notTerm(pointer);
     return new Term(solver, termPointer);
   }
@@ -248,7 +264,8 @@ public class Term
    * @param t a Boolean term
    * @return the conjunction of this term and the given term
    */
-  public Term andTerm(Term t) {
+  public Term andTerm(Term t)
+  {
     long termPointer = andTerm(pointer, t.getPointer());
     return new Term(solver, termPointer);
   }
@@ -261,7 +278,8 @@ public class Term
    * @param t a Boolean term
    * @return the disjunction of this term and the given term
    */
-  public Term orTerm(Term t) {
+  public Term orTerm(Term t)
+  {
     long termPointer = orTerm(pointer, t.getPointer());
     return new Term(solver, termPointer);
   }
@@ -274,7 +292,8 @@ public class Term
    * @param t a Boolean term
    * @return the exclusive disjunction of this term and the given term
    */
-  public Term xorTerm(Term t) {
+  public Term xorTerm(Term t)
+  {
     long termPointer = xorTerm(pointer, t.getPointer());
     return new Term(solver, termPointer);
   }
@@ -287,7 +306,8 @@ public class Term
    * @param t a Boolean term
    * @return the Boolean equivalence of this term and the given term
    */
-  public Term eqTerm(Term t) {
+  public Term eqTerm(Term t)
+  {
     long termPointer = eqTerm(pointer, t.getPointer());
     return new Term(solver, termPointer);
   }
@@ -300,7 +320,8 @@ public class Term
    * @param t a Boolean term
    * @return the implication of this term and the given term
    */
-  public Term impTerm(Term t) {
+  public Term impTerm(Term t)
+  {
     long termPointer = impTerm(pointer, t.getPointer());
     return new Term(solver, termPointer);
   }
@@ -314,9 +335,9 @@ public class Term
    * @param elseTerm the 'else' term
    * @return the if-then-else term with this term as the Boolean condition
    */
-  public Term iteTerm(Term thenTerm, Term elseTerm) {
-    long termPointer =
-        iteTerm(pointer, thenTerm.getPointer(), elseTerm.getPointer());
+  public Term iteTerm(Term thenTerm, Term elseTerm)
+  {
+    long termPointer = iteTerm(pointer, thenTerm.getPointer(), elseTerm.getPointer());
     return new Term(solver, termPointer);
   }
 
@@ -330,7 +351,8 @@ public class Term
   /**
    * @return true if the term is an integer that fits within a Java integer.
    */
-  public boolean isInt() {
+  public boolean isInt()
+  {
     return isInt(pointer);
   }
 
@@ -340,7 +362,8 @@ public class Term
    * @return the stored integer as an int.
    * Note: Asserts isInt().
    */
-  public int getInt() {
+  public int getInt()
+  {
     return getInt(pointer);
   }
 
@@ -349,7 +372,8 @@ public class Term
   /**
    * @return true if the term is an integer that fits within a Java long.
    */
-  public boolean isLong() {
+  public boolean isLong()
+  {
     return isLong(pointer);
   }
 
@@ -359,7 +383,8 @@ public class Term
    * @return the stored integer as a long.
    * Note: Asserts isLong().
    */
-  public long getLong() {
+  public long getLong()
+  {
     return getLong(pointer);
   }
 
@@ -368,7 +393,8 @@ public class Term
   /**
    * @return true if the term is an integer.
    */
-  public boolean isInteger() {
+  public boolean isInteger()
+  {
     return isInteger(pointer);
   }
 
@@ -378,7 +404,8 @@ public class Term
    * @return the stored integer in (decimal) string representation.
    * Note: Asserts isInteger().
    */
-  public String getInteger() {
+  public String getInteger()
+  {
     return getInteger(pointer);
   }
 
@@ -387,7 +414,8 @@ public class Term
   /**
    * @return true if the term is a string constant.
    */
-  public boolean isString() {
+  public boolean isString()
+  {
     return isString(pointer);
   }
 
@@ -400,43 +428,50 @@ public class Term
    * term in some string representation, whatever data it may hold.
    * Asserts isString().
    */
-  public String getString() {
+  public String getString()
+  {
     return getString(pointer);
   }
 
   private native String getString(long pointer);
 
-  public class ConstIterator implements Iterator<Term> {
+  public class ConstIterator implements Iterator<Term>
+  {
     private int currentIndex;
     private int size;
 
-    public ConstIterator() {
+    public ConstIterator()
+    {
       currentIndex = -1;
       size = getNumChildren();
     }
 
-    @Override
-    public boolean hasNext() {
+    @Override public boolean hasNext()
+    {
       return currentIndex < size - 1;
     }
 
-    @Override
-    public Term next() {
-      if (currentIndex >= size - 1) {
+    @Override public Term next()
+    {
+      if (currentIndex >= size - 1)
+      {
         throw new NoSuchElementException();
       }
       currentIndex++;
-      try {
+      try
+      {
         return getChild(currentIndex);
-      } catch (CVC5ApiException e) {
+      }
+      catch (CVC5ApiException e)
+      {
         e.printStackTrace();
         throw new RuntimeException(e.getMessage());
       }
     }
   }
 
-  @Override
-  public Iterator<Term> iterator() {
+  @Override public Iterator<Term> iterator()
+  {
     return new ConstIterator();
   }
 }

--- a/test/unit/api/java/cvc5/GrammarTest.java
+++ b/test/unit/api/java/cvc5/GrammarTest.java
@@ -23,16 +23,17 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class GrammarTest {
+class GrammarTest
+{
   private Solver d_solver;
 
-  @BeforeEach
-  void setUp() {
+  @BeforeEach void setUp()
+  {
     d_solver = new Solver();
   }
 
-  @Test
-  void addRule() {
+  @Test void addRule()
+  {
     Sort bool = d_solver.getBooleanSort();
     Sort integer = d_solver.getIntegerSort();
 
@@ -44,23 +45,19 @@ class GrammarTest {
 
     assertDoesNotThrow(() -> g.addRule(start, d_solver.mkBoolean(false)));
 
-    assertThrows(CVC5ApiException.class,
-        () -> g.addRule(nullTerm, d_solver.mkBoolean(false)));
+    assertThrows(CVC5ApiException.class, () -> g.addRule(nullTerm, d_solver.mkBoolean(false)));
     assertThrows(CVC5ApiException.class, () -> g.addRule(start, nullTerm));
-    assertThrows(CVC5ApiException.class,
-        () -> g.addRule(nts, d_solver.mkBoolean(false)));
-    assertThrows(
-        CVC5ApiException.class, () -> g.addRule(start, d_solver.mkInteger(0)));
+    assertThrows(CVC5ApiException.class, () -> g.addRule(nts, d_solver.mkBoolean(false)));
+    assertThrows(CVC5ApiException.class, () -> g.addRule(start, d_solver.mkInteger(0)));
     assertThrows(CVC5ApiException.class, () -> g.addRule(start, nts));
 
     d_solver.synthFun("f", new Term[] {}, bool, g);
 
-    assertThrows(CVC5ApiException.class,
-        () -> g.addRule(start, d_solver.mkBoolean(false)));
+    assertThrows(CVC5ApiException.class, () -> g.addRule(start, d_solver.mkBoolean(false)));
   }
 
-  @Test
-  void addRules() {
+  @Test void addRules()
+  {
     Sort bool = d_solver.getBooleanSort();
     Sort integer = d_solver.getIntegerSort();
 
@@ -70,28 +67,25 @@ class GrammarTest {
 
     Grammar g = d_solver.mkSygusGrammar(new Term[] {}, new Term[] {start});
 
-    assertDoesNotThrow(
-        () -> g.addRules(start, new Term[] {d_solver.mkBoolean(false)}));
+    assertDoesNotThrow(() -> g.addRules(start, new Term[] {d_solver.mkBoolean(false)}));
 
-    assertThrows(CVC5ApiException.class,
-        () -> g.addRules(nullTerm, new Term[] {d_solver.mkBoolean(false)}));
     assertThrows(
-        CVC5ApiException.class, () -> g.addRules(start, new Term[] {nullTerm}));
-    assertThrows(CVC5ApiException.class,
-        () -> g.addRules(nts, new Term[] {d_solver.mkBoolean(false)}));
-    assertThrows(CVC5ApiException.class,
-        () -> g.addRules(start, new Term[] {d_solver.mkInteger(0)}));
+        CVC5ApiException.class, () -> g.addRules(nullTerm, new Term[] {d_solver.mkBoolean(false)}));
+    assertThrows(CVC5ApiException.class, () -> g.addRules(start, new Term[] {nullTerm}));
     assertThrows(
-        CVC5ApiException.class, () -> g.addRules(start, new Term[] {nts}));
+        CVC5ApiException.class, () -> g.addRules(nts, new Term[] {d_solver.mkBoolean(false)}));
+    assertThrows(
+        CVC5ApiException.class, () -> g.addRules(start, new Term[] {d_solver.mkInteger(0)}));
+    assertThrows(CVC5ApiException.class, () -> g.addRules(start, new Term[] {nts}));
 
     d_solver.synthFun("f", new Term[] {}, bool, g);
 
-    assertThrows(CVC5ApiException.class,
-        () -> g.addRules(start, new Term[] {d_solver.mkBoolean(false)}));
+    assertThrows(
+        CVC5ApiException.class, () -> g.addRules(start, new Term[] {d_solver.mkBoolean(false)}));
   }
 
-  @Test
-  void addAnyConstant() {
+  @Test void addAnyConstant()
+  {
     Sort bool = d_solver.getBooleanSort();
 
     Term nullTerm = d_solver.getNullTerm();
@@ -111,8 +105,8 @@ class GrammarTest {
     assertThrows(CVC5ApiException.class, () -> g.addAnyConstant(start));
   }
 
-  @Test
-  void addAnyVariable() {
+  @Test void addAnyVariable()
+  {
     Sort bool = d_solver.getBooleanSort();
 
     Term nullTerm = d_solver.getNullTerm();

--- a/test/unit/api/java/cvc5/SolverTest.java
+++ b/test/unit/api/java/cvc5/SolverTest.java
@@ -13,7 +13,6 @@
  * Black box testing of the Solver class of the Java API.
  */
 
-
 package cvc5;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -39,6 +38,6 @@ class SolverTest
   @Test void setLogic()
   {
     assertDoesNotThrow(() -> d_solver.setLogic("AUFLIRA"));
-    assertThrows(CVC5ApiException.class, () -> d_solver.setLogic("AF_BV"));    
+    assertThrows(CVC5ApiException.class, () -> d_solver.setLogic("AF_BV"));
   }
 }

--- a/test/unit/api/java/cvc5/TermTest.java
+++ b/test/unit/api/java/cvc5/TermTest.java
@@ -27,16 +27,17 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class TermTest {
+class TermTest
+{
   private Solver d_solver;
 
-  @BeforeEach
-  void setUp() {
+  @BeforeEach void setUp()
+  {
     d_solver = new Solver();
   }
 
-  @Test
-  void eq() {
+  @Test void eq()
+  {
     Sort uSort = d_solver.mkUninterpretedSort("u");
     Term x = d_solver.mkVar(uSort, "x");
     Term y = d_solver.mkVar(uSort, "y");
@@ -50,8 +51,8 @@ class TermTest {
     assertTrue(x != z);
   }
 
-  @Test
-  void getId() {
+  @Test void getId()
+  {
     Term n = d_solver.getNullTerm();
     assertThrows(CVC5ApiException.class, () -> n.getId());
     Term x = d_solver.mkVar(d_solver.getIntegerSort(), "x");
@@ -63,8 +64,8 @@ class TermTest {
     assertNotEquals(x.getId(), z.getId());
   }
 
-  @Test
-  void getKind() throws CVC5ApiException {
+  @Test void getKind() throws CVC5ApiException
+  {
     Sort uSort = d_solver.mkUninterpretedSort("u");
     Sort intSort = d_solver.getIntegerSort();
     Sort boolSort = d_solver.getBooleanSort();
@@ -105,8 +106,8 @@ class TermTest {
     assertEquals(ss.getKind(), SEQ_CONCAT);
   }
 
-  @Test
-  void getSort() throws CVC5ApiException {
+  @Test void getSort() throws CVC5ApiException
+  {
     Sort bvSort = d_solver.mkBitVectorSort(8);
     Sort intSort = d_solver.getIntegerSort();
     Sort boolSort = d_solver.getBooleanSort();
@@ -150,8 +151,8 @@ class TermTest {
     assertEquals(p_f_y.getSort(), boolSort);
   }
 
-  @Test
-  void getOp() throws CVC5ApiException {
+  @Test void getOp() throws CVC5ApiException
+  {
     Sort intsort = d_solver.getIntegerSort();
     Sort bvsort = d_solver.mkBitVectorSort(8);
     Sort arrsort = d_solver.mkArraySort(bvsort, intsort);
@@ -184,7 +185,8 @@ class TermTest {
     List<Term> children = new ArrayList();
 
     Iterator<Term> iterator = fx.iterator();
-    for (Term t : fx) {
+    for (Term t : fx)
+    {
       children.add(t);
     }
 
@@ -201,8 +203,7 @@ class TermTest {
     listDecl.addConstructor(cons);
     listDecl.addConstructor(nil);
     Sort listSort = d_solver.mkDatatypeSort(listDecl);
-    Sort intListSort =
-        listSort.instantiate(new Sort[] {d_solver.getIntegerSort()});
+    Sort intListSort = listSort.instantiate(new Sort[] {d_solver.getIntegerSort()});
     Term c = d_solver.mkConst(intListSort, "c");
     Datatype list = listSort.getDatatype();
     // list datatype constructor and selector operator terms
@@ -210,24 +211,23 @@ class TermTest {
     Term nilOpTerm = list.getConstructorTerm("nil");
   }
 
-  @Test
-  void isNull() throws CVC5ApiException {
+  @Test void isNull() throws CVC5ApiException
+  {
     Term x = d_solver.getNullTerm();
     assertTrue(x.isNull());
     x = d_solver.mkVar(d_solver.mkBitVectorSort(4), "x");
     assertFalse(x.isNull());
   }
 
-  @Test
-  void notTerm() throws CVC5ApiException {
+  @Test void notTerm() throws CVC5ApiException
+  {
     Sort bvSort = d_solver.mkBitVectorSort(8);
     Sort intSort = d_solver.getIntegerSort();
     Sort boolSort = d_solver.getBooleanSort();
     Sort funSort1 = d_solver.mkFunctionSort(bvSort, intSort);
     Sort funSort2 = d_solver.mkFunctionSort(intSort, boolSort);
 
-    assertThrows(
-        CVC5ApiException.class, () -> d_solver.getNullTerm().notTerm());
+    assertThrows(CVC5ApiException.class, () -> d_solver.getNullTerm().notTerm());
     Term b = d_solver.mkTrue();
     assertDoesNotThrow(() -> b.notTerm());
     Term x = d_solver.mkVar(d_solver.mkBitVectorSort(8), "x");
@@ -248,8 +248,8 @@ class TermTest {
     assertDoesNotThrow(() -> p_f_x.notTerm());
   }
 
-  @Test
-  void andTerm() throws CVC5ApiException {
+  @Test void andTerm() throws CVC5ApiException
+  {
     Sort bvSort = d_solver.mkBitVectorSort(8);
     Sort intSort = d_solver.getIntegerSort();
     Sort boolSort = d_solver.getBooleanSort();
@@ -257,10 +257,8 @@ class TermTest {
     Sort funSort2 = d_solver.mkFunctionSort(intSort, boolSort);
 
     Term b = d_solver.mkTrue();
-    assertThrows(
-        CVC5ApiException.class, () -> d_solver.getNullTerm().andTerm(b));
-    assertThrows(
-        CVC5ApiException.class, () -> b.andTerm(d_solver.getNullTerm()));
+    assertThrows(CVC5ApiException.class, () -> d_solver.getNullTerm().andTerm(b));
+    assertThrows(CVC5ApiException.class, () -> b.andTerm(d_solver.getNullTerm()));
     assertDoesNotThrow(() -> b.andTerm(b));
     Term x = d_solver.mkVar(d_solver.mkBitVectorSort(8), "x");
     assertThrows(CVC5ApiException.class, () -> x.andTerm(b));
@@ -316,8 +314,8 @@ class TermTest {
     assertDoesNotThrow(() -> p_f_x.andTerm(p_f_x));
   }
 
-  @Test
-  void orTerm() throws CVC5ApiException {
+  @Test void orTerm() throws CVC5ApiException
+  {
     Sort bvSort = d_solver.mkBitVectorSort(8);
     Sort intSort = d_solver.getIntegerSort();
     Sort boolSort = d_solver.getBooleanSort();
@@ -325,10 +323,8 @@ class TermTest {
     Sort funSort2 = d_solver.mkFunctionSort(intSort, boolSort);
 
     Term b = d_solver.mkTrue();
-    assertThrows(
-        CVC5ApiException.class, () -> d_solver.getNullTerm().orTerm(b));
-    assertThrows(
-        CVC5ApiException.class, () -> b.orTerm(d_solver.getNullTerm()));
+    assertThrows(CVC5ApiException.class, () -> d_solver.getNullTerm().orTerm(b));
+    assertThrows(CVC5ApiException.class, () -> b.orTerm(d_solver.getNullTerm()));
     assertDoesNotThrow(() -> b.orTerm(b));
     Term x = d_solver.mkVar(d_solver.mkBitVectorSort(8), "x");
     assertThrows(CVC5ApiException.class, () -> x.orTerm(b));
@@ -384,8 +380,8 @@ class TermTest {
     assertDoesNotThrow(() -> p_f_x.orTerm(p_f_x));
   }
 
-  @Test
-  void xorTerm() throws CVC5ApiException {
+  @Test void xorTerm() throws CVC5ApiException
+  {
     Sort bvSort = d_solver.mkBitVectorSort(8);
     Sort intSort = d_solver.getIntegerSort();
     Sort boolSort = d_solver.getBooleanSort();
@@ -393,10 +389,8 @@ class TermTest {
     Sort funSort2 = d_solver.mkFunctionSort(intSort, boolSort);
 
     Term b = d_solver.mkTrue();
-    assertThrows(
-        CVC5ApiException.class, () -> d_solver.getNullTerm().xorTerm(b));
-    assertThrows(
-        CVC5ApiException.class, () -> b.xorTerm(d_solver.getNullTerm()));
+    assertThrows(CVC5ApiException.class, () -> d_solver.getNullTerm().xorTerm(b));
+    assertThrows(CVC5ApiException.class, () -> b.xorTerm(d_solver.getNullTerm()));
     assertDoesNotThrow(() -> b.xorTerm(b));
     Term x = d_solver.mkVar(d_solver.mkBitVectorSort(8), "x");
     assertThrows(CVC5ApiException.class, () -> x.xorTerm(b));
@@ -452,8 +446,8 @@ class TermTest {
     assertDoesNotThrow(() -> p_f_x.xorTerm(p_f_x));
   }
 
-  @Test
-  void eqTerm() throws CVC5ApiException {
+  @Test void eqTerm() throws CVC5ApiException
+  {
     Sort bvSort = d_solver.mkBitVectorSort(8);
     Sort intSort = d_solver.getIntegerSort();
     Sort boolSort = d_solver.getBooleanSort();
@@ -461,10 +455,8 @@ class TermTest {
     Sort funSort2 = d_solver.mkFunctionSort(intSort, boolSort);
 
     Term b = d_solver.mkTrue();
-    assertThrows(
-        CVC5ApiException.class, () -> d_solver.getNullTerm().eqTerm(b));
-    assertThrows(
-        CVC5ApiException.class, () -> b.eqTerm(d_solver.getNullTerm()));
+    assertThrows(CVC5ApiException.class, () -> d_solver.getNullTerm().eqTerm(b));
+    assertThrows(CVC5ApiException.class, () -> b.eqTerm(d_solver.getNullTerm()));
     assertDoesNotThrow(() -> b.eqTerm(b));
     Term x = d_solver.mkVar(d_solver.mkBitVectorSort(8), "x");
     assertThrows(CVC5ApiException.class, () -> x.eqTerm(b));
@@ -520,8 +512,8 @@ class TermTest {
     assertDoesNotThrow(() -> p_f_x.eqTerm(p_f_x));
   }
 
-  @Test
-  void impTerm() throws CVC5ApiException {
+  @Test void impTerm() throws CVC5ApiException
+  {
     Sort bvSort = d_solver.mkBitVectorSort(8);
     Sort intSort = d_solver.getIntegerSort();
     Sort boolSort = d_solver.getBooleanSort();
@@ -529,10 +521,8 @@ class TermTest {
     Sort funSort2 = d_solver.mkFunctionSort(intSort, boolSort);
 
     Term b = d_solver.mkTrue();
-    assertThrows(
-        CVC5ApiException.class, () -> d_solver.getNullTerm().impTerm(b));
-    assertThrows(
-        CVC5ApiException.class, () -> b.impTerm(d_solver.getNullTerm()));
+    assertThrows(CVC5ApiException.class, () -> d_solver.getNullTerm().impTerm(b));
+    assertThrows(CVC5ApiException.class, () -> b.impTerm(d_solver.getNullTerm()));
     assertDoesNotThrow(() -> b.impTerm(b));
     Term x = d_solver.mkVar(d_solver.mkBitVectorSort(8), "x");
     assertThrows(CVC5ApiException.class, () -> x.impTerm(b));
@@ -588,8 +578,8 @@ class TermTest {
     assertDoesNotThrow(() -> p_f_x.impTerm(p_f_x));
   }
 
-  @Test
-  void iteTerm() throws CVC5ApiException {
+  @Test void iteTerm() throws CVC5ApiException
+  {
     Sort bvSort = d_solver.mkBitVectorSort(8);
     Sort intSort = d_solver.getIntegerSort();
     Sort boolSort = d_solver.getBooleanSort();
@@ -597,12 +587,9 @@ class TermTest {
     Sort funSort2 = d_solver.mkFunctionSort(intSort, boolSort);
 
     Term b = d_solver.mkTrue();
-    assertThrows(
-        CVC5ApiException.class, () -> d_solver.getNullTerm().iteTerm(b, b));
-    assertThrows(
-        CVC5ApiException.class, () -> b.iteTerm(d_solver.getNullTerm(), b));
-    assertThrows(
-        CVC5ApiException.class, () -> b.iteTerm(b, d_solver.getNullTerm()));
+    assertThrows(CVC5ApiException.class, () -> d_solver.getNullTerm().iteTerm(b, b));
+    assertThrows(CVC5ApiException.class, () -> b.iteTerm(d_solver.getNullTerm(), b));
+    assertThrows(CVC5ApiException.class, () -> b.iteTerm(b, d_solver.getNullTerm()));
     assertDoesNotThrow(() -> b.iteTerm(b, b));
     Term x = d_solver.mkVar(d_solver.mkBitVectorSort(8), "x");
     assertDoesNotThrow(() -> b.iteTerm(x, x));
@@ -635,30 +622,27 @@ class TermTest {
     assertThrows(CVC5ApiException.class, () -> p_f_x.iteTerm(x, b));
   }
 
-  @Test
-  void termAssignment() {
+  @Test void termAssignment()
+  {
     Term t1 = d_solver.mkInteger(1);
     Term t2 = t1;
     t2 = d_solver.mkInteger(2);
     assertEquals(t1, d_solver.mkInteger(1));
   }
 
-  @Test
-  void termCompare() {
+  @Test void termCompare()
+  {
     Term t1 = d_solver.mkInteger(1);
-    Term t2 =
-        d_solver.mkTerm(PLUS, d_solver.mkInteger(2), d_solver.mkInteger(2));
-    Term t3 =
-        d_solver.mkTerm(PLUS, d_solver.mkInteger(2), d_solver.mkInteger(2));
+    Term t2 = d_solver.mkTerm(PLUS, d_solver.mkInteger(2), d_solver.mkInteger(2));
+    Term t3 = d_solver.mkTerm(PLUS, d_solver.mkInteger(2), d_solver.mkInteger(2));
     assertTrue(t2.compareTo(t3) >= 0);
     assertTrue(t2.compareTo(t3) <= 0);
     assertTrue((t1.compareTo(t2) > 0) != (t1.compareTo(t2) < 0));
-    assertTrue(
-        (t1.compareTo(t2) > 0 || t1.equals(t2)) == (t1.compareTo(t2) >= 0));
+    assertTrue((t1.compareTo(t2) > 0 || t1.equals(t2)) == (t1.compareTo(t2) >= 0));
   }
 
-  @Test
-  void termChildren() throws CVC5ApiException {
+  @Test void termChildren() throws CVC5ApiException
+  {
     // simple term 2+3
     Term two = d_solver.mkInteger(2);
     Term t1 = d_solver.mkTerm(PLUS, two, d_solver.mkInteger(3));
@@ -679,8 +663,8 @@ class TermTest {
     assertThrows(CVC5ApiException.class, () -> tnull.getChild(0));
   }
 
-  @Test
-  void getInteger() throws CVC5ApiException {
+  @Test void getInteger() throws CVC5ApiException
+  {
     Term int1 = d_solver.mkInteger("-18446744073709551616");
     Term int2 = d_solver.mkInteger("-18446744073709551615");
     Term int3 = d_solver.mkInteger("-4294967296");
@@ -735,23 +719,23 @@ class TermTest {
     assertEquals(int9.getInteger(), "4294967296");
     assertTrue(!int10.isInt() && !int10.isLong() && int10.isInteger());
 
-    assertEquals(Long.compareUnsigned(int10.getLong(),
-                     new BigInteger("18446744073709551615").longValue()),
+    assertEquals(
+        Long.compareUnsigned(int10.getLong(), new BigInteger("18446744073709551615").longValue()),
         0);
     assertEquals(int10.getInteger(), "18446744073709551615");
     assertTrue(!int11.isInt() && !int11.isLong() && int11.isInteger());
     assertEquals(int11.getInteger(), "18446744073709551616");
   }
 
-  @Test
-  void getString() {
+  @Test void getString()
+  {
     Term s1 = d_solver.mkString("abcde");
     assertTrue(s1.isString());
     assertEquals(s1.getString(), "abcde");
   }
 
-  @Test
-  void substitute() {
+  @Test void substitute()
+  {
     Term x = d_solver.mkConst(d_solver.getIntegerSort(), "x");
     Term one = d_solver.mkInteger(1);
     Term ttrue = d_solver.mkTrue();
@@ -801,8 +785,8 @@ class TermTest {
     assertThrows(CVC5ApiException.class, () -> xpx.substitute(es, rs));
   }
 
-  @Test
-  void constArray() throws CVC5ApiException {
+  @Test void constArray() throws CVC5ApiException
+  {
     Sort intsort = d_solver.getIntegerSort();
     Sort arrsort = d_solver.mkArraySort(intsort, intsort);
     Term a = d_solver.mkConst(arrsort, "a");
@@ -813,19 +797,15 @@ class TermTest {
     assertEquals(constarr.getConstArrayBase(), one);
     assertThrows(CVC5ApiException.class, () -> a.getConstArrayBase());
 
-    arrsort =
-        d_solver.mkArraySort(d_solver.getRealSort(), d_solver.getRealSort());
+    arrsort = d_solver.mkArraySort(d_solver.getRealSort(), d_solver.getRealSort());
     Term zero_array = d_solver.mkConstArray(arrsort, d_solver.mkReal(0));
-    Term stores = d_solver.mkTerm(
-        STORE, zero_array, d_solver.mkReal(1), d_solver.mkReal(2));
-    stores =
-        d_solver.mkTerm(STORE, stores, d_solver.mkReal(2), d_solver.mkReal(3));
-    stores =
-        d_solver.mkTerm(STORE, stores, d_solver.mkReal(4), d_solver.mkReal(5));
+    Term stores = d_solver.mkTerm(STORE, zero_array, d_solver.mkReal(1), d_solver.mkReal(2));
+    stores = d_solver.mkTerm(STORE, stores, d_solver.mkReal(2), d_solver.mkReal(3));
+    stores = d_solver.mkTerm(STORE, stores, d_solver.mkReal(4), d_solver.mkReal(5));
   }
 
-  @Test
-  void constSequenceElements() throws CVC5ApiException {
+  @Test void constSequenceElements() throws CVC5ApiException
+  {
     Sort realsort = d_solver.getRealSort();
     Sort seqsort = d_solver.mkSequenceSort(realsort);
     Term s = d_solver.mkEmptySequence(seqsort);
@@ -841,8 +821,8 @@ class TermTest {
     assertThrows(CVC5ApiException.class, () -> su.getConstSequenceElements());
   }
 
-  @Test
-  void termScopedToString() {
+  @Test void termScopedToString()
+  {
     Sort intsort = d_solver.getIntegerSort();
     Term x = d_solver.mkConst(intsort, "x");
     assertEquals(x.toString(), "x");


### PR DESCRIPTION
This PR updates .clang_format file to format java files, in particular, the java test files for easy comparison with the corresponding c++ test files. 
Other than .clang_format, the only change in the java files are their format. 