### PR TITLE
EnvObj: Restrict access.

### DIFF
--- a/src/preprocessing/preprocessing_pass.h
+++ b/src/preprocessing/preprocessing_pass.h
@@ -49,7 +49,7 @@ class PreprocessingPassContext;
  */
 enum PreprocessingPassResult { CONFLICT, NO_CONFLICT };
 
-class PreprocessingPass : public EnvObj
+class PreprocessingPass : protected EnvObj
 {
  public:
   /* Preprocesses a list of assertions assertionsToPreprocess */

--- a/src/preprocessing/util/ite_utilities.h
+++ b/src/preprocessing/util/ite_utilities.h
@@ -67,7 +67,7 @@ class ContainsTermITEVisitor
   NodeBoolMap d_cache;
 };
 
-class ITEUtilities : public EnvObj
+class ITEUtilities : protected EnvObj
 {
  public:
   ITEUtilities(Env& env);
@@ -164,7 +164,7 @@ class TermITEHeightCounter
  * A routine designed to undo the potentially large blow up
  * due to expansion caused by the ite simplifier.
  */
-class ITECompressor : public EnvObj
+class ITECompressor : protected EnvObj
 {
  public:
   ITECompressor(Env& env, ContainsTermITEVisitor* contains);
@@ -206,7 +206,7 @@ class ITECompressor : public EnvObj
   Statistics d_statistics;
 }; /* class ITECompressor */
 
-class ITESimplifier : public EnvObj
+class ITESimplifier : protected EnvObj
 {
  public:
   ITESimplifier(Env& env, ContainsTermITEVisitor* d_containsVisitor);

--- a/src/smt/env_obj.h
+++ b/src/smt/env_obj.h
@@ -31,7 +31,7 @@ class Options;
 
 class EnvObj
 {
- public:
+ protected:
   /** Constructor. */
   EnvObj(Env& env);
   EnvObj() = delete;
@@ -44,7 +44,6 @@ class EnvObj
    */
   Node rewrite(TNode node);
 
- protected:
   /** The associated environment. */
   Env& d_env;
 };

--- a/src/smt/env_obj.h
+++ b/src/smt/env_obj.h
@@ -36,7 +36,7 @@ class EnvObj
   EnvObj(Env& env);
   EnvObj() = delete;
   /** Destructor.  */
-  ~EnvObj() {}
+  virtual ~EnvObj() {}
 
   /**
    * Rewrite a node.


### PR DESCRIPTION
This makes all members of EnvObj protected in order to prevent creating
EnvObj instances and call member functions. It further uses protected
inheritance (instead of public) for derived classes in order to disallow
`EnvObj* a = new DerivedObj();`.