### PR TITLE
Remove "experimental" options

### DIFF
--- a/src/options/arrays_options.toml
+++ b/src/options/arrays_options.toml
@@ -67,7 +67,7 @@ name   = "Arrays Theory"
 
 [[option]]
   name       = "arraysExp"
-  category   = "experimental"
+  category   = "expert"
   long       = "arrays-exp"
   type       = "bool"
   default    = "false"

--- a/src/options/bv_options.toml
+++ b/src/options/bv_options.toml
@@ -78,7 +78,7 @@ name   = "Bitvector Theory"
 
 [[option]]
   name       = "bitvectorAlgebraicSolver"
-  category   = "experimental"
+  category   = "expert"
   long       = "bv-algebraic-solver"
   type       = "bool"
   default    = "false"

--- a/src/options/datatypes_options.toml
+++ b/src/options/datatypes_options.toml
@@ -23,7 +23,7 @@ name   = "Datatypes Theory"
 
 [[option]]
   name       = "dtPoliteOptimize"
-  category   = "experimental"
+  category   = "expert"
   long       = "dt-polite-optimize"
   type       = "bool"
   default    = "true"

--- a/src/options/fp_options.toml
+++ b/src/options/fp_options.toml
@@ -11,7 +11,7 @@ name   = "Floating-Point"
 
 [[option]]
   name       = "fpLazyWb"
-  category   = "experimental"
+  category   = "expert"
   long       = "fp-lazy-wb"
   type       = "bool"
   default    = "false"

--- a/src/options/mkoptions.py
+++ b/src/options/mkoptions.py
@@ -990,6 +990,10 @@ def parse_module(filename, module):
                 perr(filename,
                      'defining handlers for bool options is not allowed',
                      option)
+            if option.category not in CATEGORY_VALUES:
+                perr(filename,
+                     "has invalid category '{}'".format(option.category),
+                     option)
             if option.category != 'undocumented' and not option.help:
                 perr(filename,
                      'help text required for {} options'.format(option.category),

--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -301,7 +301,7 @@ name   = "SMT Layer"
 
 [[option]]
   name       = "earlyIteRemoval"
-  category   = "experimental"
+  category   = "expert"
   long       = "early-ite-removal"
   type       = "bool"
   default    = "false"


### PR DESCRIPTION
This PR changes all options from `experimental` to `expert` and adds a check that only the well-defined option categories are used (common, regular, expert, undocumented).