### PR TITLE
Refactor options::get() and options::getNames()

### DIFF
--- a/src/options/options_public.h
+++ b/src/options/options_public.h
@@ -35,6 +35,11 @@
 namespace cvc5::options {
 
 /**
+ * Get a (sorted) list of all option names that are available.
+ */
+std::vector<std::string> getNames() CVC5_EXPORT;
+
+/**
  * Retrieve an option value by name (as given in key) from the Options object
  * opts as a string.
  */
@@ -47,11 +52,6 @@ std::string get(const Options& opts, const std::string& name) CVC5_EXPORT;
 void set(Options& opts,
          const std::string& name,
          const std::string& optionarg) CVC5_EXPORT;
-
-/**
- * Get a (sorted) list of all option names that are available.
- */
-std::vector<std::string> getNames() CVC5_EXPORT;
 
 /**
  * Represents information we can provide about a particular option. It contains

--- a/src/options/options_public_template.cpp
+++ b/src/options/options_public_template.cpp
@@ -13,23 +13,25 @@
  * Global (command-line, set-option, ...) parameters for SMT.
  */
 
-#include "options/options_public.h"
-
-
 #include "base/check.h"
 #include "base/output.h"
+#include "options/options.h"
 #include "options/options_handler.h"
 #include "options/options_listener.h"
-#include "options/options.h"
+#include "options/options_public.h"
 #include "options/uf_options.h"
+
+// clang-format off
 ${headers_module}$
-${headers_handler}$
+${options_includes}$
+// clang-format on
 
 #include <cstring>
 #include <iostream>
 #include <limits>
 
-namespace cvc5::options {
+namespace cvc5::options
+{
   // Contains the default option handlers (i.e. parsers)
   namespace handlers {
 
@@ -191,17 +193,26 @@ namespace cvc5::options {
   }
   }
 
-std::string get(const Options& options, const std::string& name)
-{
-  Trace("options") << "Options::getOption(" << name << ")" << std::endl;
-  // clang-format off
-  ${getoption_handlers}$
-  // clang-format on
-  throw OptionException("Unrecognized option key or setting: " + name);
-}
+  std::vector<std::string> getNames()
+  {
+    return {
+        // clang-format off
+    ${getnames_impl}$
+        // clang-format on
+    };
+  }
 
-void setInternal(Options& opts, const std::string& name,
-                                const std::string& optionarg)
+  std::string get(const Options& options, const std::string& name)
+  {
+    Trace("options") << "Options::getOption(" << name << ")" << std::endl;
+    // clang-format off
+  ${get_impl}$
+        // clang-format on
+        throw OptionException("Unrecognized option key or setting: " + name);
+  }
+
+void setInternal(Options & opts, const std::string& name,
+                                 const std::string& optionarg)
 {
   // clang-format off
 ${setoption_handlers}$
@@ -221,15 +232,6 @@ void set(Options& opts, const std::string& name, const std::string& optionarg)
                    << std::endl;
   // first update this object
   setInternal(opts, name, optionarg);
-}
-
-std::vector<std::string> getNames()
-{
-  return {
-    // clang-format off
-    ${options_all_names}$
-    // clang-format on
-  };
 }
 
 #if defined(CVC5_MUZZLED) || defined(CVC5_COMPETITION_MODE)

--- a/src/options/options_public_template.cpp
+++ b/src/options/options_public_template.cpp
@@ -207,8 +207,8 @@ namespace cvc5::options
     Trace("options") << "Options::getOption(" << name << ")" << std::endl;
     // clang-format off
   ${get_impl}$
-        // clang-format on
-        throw OptionException("Unrecognized option key or setting: " + name);
+    // clang-format on
+    throw OptionException("Unrecognized option key or setting: " + name);
   }
 
 void setInternal(Options & opts, const std::string& name,


### PR DESCRIPTION
This PR refactors the code generation and the generated code for `options::get()` and `options::getNames()`.