### PR TITLE
Add option for using bound inference for relevant assertions

### DIFF
--- a/src/options/arith_options.toml
+++ b/src/options/arith_options.toml
@@ -418,6 +418,14 @@ name   = "Arithmetic Theory"
   help = "Use all lemma schemes"
 
 [[option]]
+  name       = "nlRlvAssertBounds"
+  category   = "regular"
+  long       = "nl-rlv-assert-bounds"
+  type       = "bool"
+  default    = "false"
+  help       = "use bound inference utility to prune when an assertion is entailed by another"
+
+[[option]]
   name       = "nlExtResBound"
   category   = "regular"
   long       = "nl-ext-rbound"

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -649,6 +649,12 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
       opts.arith.nlExtTangentPlanesInterleave = true;
     }
   }
+  if (!opts.arith.nlRlvAssertBoundsWasSetByUser)
+  {
+    // use bound inference to determine when bounds are irrelevant only when
+    // the logic is quantifier-free
+    opts.arith.nlRlvAssertBounds = !logic.isQuantified();
+  }
 
   // set the default decision mode
   setDefaultDecisionMode(logic, opts);

--- a/src/theory/arith/nl/nonlinear_extension.cpp
+++ b/src/theory/arith/nl/nonlinear_extension.cpp
@@ -140,7 +140,8 @@ void NonlinearExtension::getAssertions(std::vector<Node>& assertions)
       // not relevant, skip
       continue;
     }
-    if (bounds.add(lit, false))
+    // if using the bound inference utility
+    if (options().arith.nlRlvAssertBounds && bounds.add(lit, false))
     {
       continue;
     }


### PR DESCRIPTION
The method for discarding assertions based on bound inference is quite expensive (40% of runtime) for some benchmarks with quantified formulas from Facebook.  This adds an option to disable this, which is done by default for quantified logics.