### PR TITLE
FP: Do not send trivial lemmas.

### DIFF
--- a/src/theory/fp/theory_fp.cpp
+++ b/src/theory/fp/theory_fp.cpp
@@ -72,7 +72,8 @@ TheoryFp::TheoryFp(Env& env, OutputChannel& out, Valuation valuation)
       d_rewriter(userContext()),
       d_state(env, valuation),
       d_im(env, *this, d_state, d_pnm, "theory::fp::", false),
-      d_wbFactsCache(userContext())
+      d_wbFactsCache(userContext()),
+      d_true(d_env.getNodeManager()->mkConst(true))
 {
   // indicate we are using the default theory state and inference manager
   d_theoryState = &d_state;
@@ -701,7 +702,11 @@ void TheoryFp::handleLemma(Node node, InferenceId id)
   Trace("fp") << "TheoryFp::handleLemma(): asserting " << node << std::endl;
   // will be preprocessed when sent, which is important because it contains
   // embedded ITEs
-  d_im.lemma(node, id);
+  if (rewrite(node) != d_true)
+  {
+    /* We only send non-trivial lemmas. */
+    d_im.lemma(node, id);
+  }
 }
 
 bool TheoryFp::propagateLit(TNode node)

--- a/src/theory/fp/theory_fp.h
+++ b/src/theory/fp/theory_fp.h
@@ -157,6 +157,9 @@ class TheoryFp : public Theory
   TheoryInferenceManager d_im;
   /** Cache of word-blasted facts. */
   context::CDHashSet<Node> d_wbFactsCache;
+
+  /** True constant. */
+  Node d_true;
 };
 
 }  // namespace fp

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -605,6 +605,7 @@ set(regress_0_tests
   regress0/fp/issue5511.smt2
   regress0/fp/issue5734.smt2
   regress0/fp/issue6164.smt2
+  regress0/fp/issue7002.smt2
   regress0/fp/rti_3_5_bug.smt2
   regress0/fp/simple.smt2
   regress0/fp/word-blast.smt2

--- a/test/regress/regress0/fp/issue7002.smt2
+++ b/test/regress/regress0/fp/issue7002.smt2
@@ -1,0 +1,4 @@
+; EXPECT: sat
+(set-logic ALL)
+(assert (= 0.0 (fp.to_real (_ NaN 8 24))))
+(check-sat)

--- a/test/regress/regress0/fp/issue7002.smt2
+++ b/test/regress/regress0/fp/issue7002.smt2
@@ -1,3 +1,4 @@
+; COMMAND-LINE: -q
 ; EXPECT: sat
 (set-logic ALL)
 (assert (= 0.0 (fp.to_real (_ NaN 8 24))))


### PR DESCRIPTION
Fixes #7002.

Results on SMT-LIB, errors due to misclassified benchmarks.

```
                             status  total  solved    sat  unsat   best  timeout  memout  error  uniq  disagr  time_cpu    memory
config                                                                                                                           
2021-09-09-issue-7002-pre/       ee  80379   79310  49177  30133  77998      701      36     11     1       0  262850.2 1933938.3
2021-09-09-issue-7002-fixed/     ee  80379   79310  49176  30134  78009      701      36     11     1       0  262897.7 1933898.2
