### PR TITLE
FP: Enable caching in the theory inference manager.

### DIFF
--- a/src/theory/fp/theory_fp.cpp
+++ b/src/theory/fp/theory_fp.cpp
@@ -72,7 +72,7 @@ TheoryFp::TheoryFp(Env& env, OutputChannel& out, Valuation valuation)
       d_rewriter(userContext()),
       d_state(env, valuation),
       d_im(env, *this, d_state, d_pnm, "theory::fp::", true),
-      d_wbFactsCache(userContext())
+      d_wbFactsCache(userContext()),
       d_true(d_env.getNodeManager()->mkConst(true))
 {
   // indicate we are using the default theory state and inference manager

--- a/src/theory/fp/theory_fp.cpp
+++ b/src/theory/fp/theory_fp.cpp
@@ -71,7 +71,7 @@ TheoryFp::TheoryFp(Env& env, OutputChannel& out, Valuation valuation)
       d_abstractionMap(getUserContext()),
       d_rewriter(getUserContext()),
       d_state(env, valuation),
-      d_im(*this, d_state, d_pnm, "theory::fp::", false),
+      d_im(*this, d_state, d_pnm, "theory::fp::", true),
       d_wbFactsCache(getUserContext())
 {
   // indicate we are using the default theory state and inference manager


### PR DESCRIPTION
Results on SMT-LIB, errors due to misclassified benchmarks:
```
                              status  total  solved    sat  unsat   best  timeout  memout  error  uniq  disagr  time_cpu    memory
config                                                                                                                            
2021-09-09-tim-caching-false/     ee  80379   79311  49178  30133  77983      699      36     11     2       0  262753.1 1928085.7
2021-09-09-tim-caching-true       ee  80379   79310  49178  30132  77971      700      36     11     1       0  262914.8 1928887.6
