### PR TITLE
Fix relevant domain for parametric operators

### DIFF
--- a/src/theory/quantifiers/relevant_domain.cpp
+++ b/src/theory/quantifiers/relevant_domain.cpp
@@ -85,8 +85,15 @@ RelevantDomain::RelevantDomain(Env& env,
 }
 
 RelevantDomain::~RelevantDomain() {
-  for( std::map< Node, std::map< size_t, RDomain * > >::iterator itr = d_rel_doms.begin(); itr != d_rel_doms.end(); ++itr ){
-    for( std::map< size_t, RDomain * >::iterator itr2 = itr->second.begin(); itr2 != itr->second.end(); ++itr2 ){
+  for (std::map<Node, std::map<size_t, RDomain*> >::iterator itr =
+           d_rel_doms.begin();
+       itr != d_rel_doms.end();
+       ++itr)
+  {
+    for (std::map<size_t, RDomain*>::iterator itr2 = itr->second.begin();
+         itr2 != itr->second.end();
+         ++itr2)
+    {
       RDomain * current = (*itr2).second;
       Assert(current != NULL);
       delete current;
@@ -94,7 +101,10 @@ RelevantDomain::~RelevantDomain() {
   }
 }
 
-RelevantDomain::RDomain * RelevantDomain::getRDomain( Node n, size_t i, bool getParent ) {
+RelevantDomain::RDomain* RelevantDomain::getRDomain(Node n,
+                                                    size_t i,
+                                                    bool getParent)
+{
   if( d_rel_doms.find( n )==d_rel_doms.end() || d_rel_doms[n].find( i )==d_rel_doms[n].end() ){
     d_rel_doms[n][i] = new RDomain;
   }
@@ -110,8 +120,15 @@ void RelevantDomain::registerQuantifier(Node q) {}
 void RelevantDomain::compute(){
   if( !d_is_computed ){
     d_is_computed = true;
-    for( std::map< Node, std::map< size_t, RDomain * > >::iterator it = d_rel_doms.begin(); it != d_rel_doms.end(); ++it ){
-      for( std::map< size_t, RDomain * >::iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2 ){
+    for (std::map<Node, std::map<size_t, RDomain*> >::iterator it =
+             d_rel_doms.begin();
+         it != d_rel_doms.end();
+         ++it)
+    {
+      for (std::map<size_t, RDomain*>::iterator it2 = it->second.begin();
+           it2 != it->second.end();
+           ++it2)
+      {
         it2->second->reset();
       }
     }
@@ -142,9 +159,16 @@ void RelevantDomain::compute(){
       }
     }
     //print debug
-    for( std::map< Node, std::map< size_t, RDomain * > >::iterator it = d_rel_doms.begin(); it != d_rel_doms.end(); ++it ){
+    for (std::map<Node, std::map<size_t, RDomain*> >::iterator it =
+             d_rel_doms.begin();
+         it != d_rel_doms.end();
+         ++it)
+    {
       Trace("rel-dom") << "Relevant domain for " << it->first << " : " << std::endl;
-      for( std::map< size_t, RDomain * >::iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2 ){
+      for (std::map<size_t, RDomain*>::iterator it2 = it->second.begin();
+           it2 != it->second.end();
+           ++it2)
+      {
         Trace("rel-dom") << "   " << it2->first << " : ";
         RDomain * r = it2->second;
         RDomain * rp = r->getParent();
@@ -152,19 +176,21 @@ void RelevantDomain::compute(){
           r->removeRedundantTerms(d_qs);
           Trace("rel-dom") << r->d_terms;
         }else{
-          Trace("rel-dom") << "Dom( " << it->first << ", " << it2->first << " ) ";
+          Trace("rel-dom") << "Dom( " << it->first << ", " << it2->first
+                           << " ) ";
         }
         Trace("rel-dom") << std::endl;
         if (Configuration::isAssertionBuild())
         {
-          if (it->first.getKind()==FORALL)
+          if (it->first.getKind() == FORALL)
           {
             TypeNode expectedType = it->first[0][it2->first].getType();
             for (const Node& t : r->d_terms)
             {
               if (!t.getType().isComparableTo(expectedType))
               {
-                Unhandled() << "Relevant domain: bad type " << t.getType() << ", expected " << expectedType;
+                Unhandled() << "Relevant domain: bad type " << t.getType()
+                            << ", expected " << expectedType;
               }
             }
           }
@@ -225,7 +251,7 @@ void RelevantDomain::computeRelevantDomainNode(Node q,
   // Relevant domain only makes sense for non-parametric operators, thus we
   // check op==n.getOperator() here. This otherwise would lead to bad types
   // for terms in the relevant domain.
-  if (!op.isNull() && op==n.getOperator())
+  if (!op.isNull() && op == n.getOperator())
   {
     for (size_t i = 0, nchild = n.getNumChildren(); i < nchild; i++)
     {
@@ -244,19 +270,23 @@ void RelevantDomain::computeRelevantDomainNode(Node q,
     //compute the information for what this literal does
     computeRelevantDomainLit( q, hasPol, pol, n );
     RDomainLit& rdl = d_rel_dom_lit[hasPol][pol][n];
-    if( rdl.d_merge ){
-      Assert(rdl.d_rd[0] != NULL
-             && rdl.d_rd[1] != NULL);
-      RDomain * rd1 = rdl.d_rd[0]->getParent();
-      RDomain * rd2 = rdl.d_rd[1]->getParent();
+    if (rdl.d_merge)
+    {
+      Assert(rdl.d_rd[0] != NULL && rdl.d_rd[1] != NULL);
+      RDomain* rd1 = rdl.d_rd[0]->getParent();
+      RDomain* rd2 = rdl.d_rd[1]->getParent();
       if( rd1!=rd2 ){
         rd1->merge( rd2 );
       }
-    }else{
-      if( rdl.d_rd[0]!=NULL ){
-        RDomain * rd = rdl.d_rd[0]->getParent();
-        for( unsigned i=0; i<rdl.d_val.size(); i++ ){
-          rd->addTerm( rdl.d_val[i] );
+    }
+    else
+    {
+      if (rdl.d_rd[0] != NULL)
+      {
+        RDomain* rd = rdl.d_rd[0]->getParent();
+        for (unsigned i = 0; i < rdl.d_val.size(); i++)
+        {
+          rd->addTerm(rdl.d_val[i]);
         }
       }
     }
@@ -349,14 +379,17 @@ void RelevantDomain::computeRelevantDomainLit( Node q, bool hasPol, bool pol, No
                   if( veq_c.isNull() ){
                     r_add = val;
                     varLhs = (ires==1);
-                    rdl.d_rd[0] = getRDomain( q, var.getAttribute(InstVarNumAttribute()), false );
+                    rdl.d_rd[0] = getRDomain(
+                        q, var.getAttribute(InstVarNumAttribute()), false);
                     rdl.d_rd[1] = NULL;
                   }
                 }
               }else if( !hasNonVar ){
                 //merge the domains
-                rdl.d_rd[0] = getRDomain( q, var.getAttribute(InstVarNumAttribute()), false );
-                rdl.d_rd[1] = getRDomain( q, var2.getAttribute(InstVarNumAttribute()), false );
+                rdl.d_rd[0] = getRDomain(
+                    q, var.getAttribute(InstVarNumAttribute()), false);
+                rdl.d_rd[1] = getRDomain(
+                    q, var2.getAttribute(InstVarNumAttribute()), false);
                 rdl.d_merge = true;
               }
             }
@@ -364,30 +397,33 @@ void RelevantDomain::computeRelevantDomainLit( Node q, bool hasPol, bool pol, No
         }
       }
     }
-    if( rdl.d_merge ){
+    if (rdl.d_merge)
+    {
       //do not merge if constant negative polarity
       if( hasPol && !pol ){
         rdl.d_merge = false;
       }
-    }else if( !r_add.isNull() && !TermUtil::hasInstConstAttr( r_add ) ){
+    }
+    else if (!r_add.isNull() && !TermUtil::hasInstConstAttr(r_add))
+    {
       Trace("rel-dom-debug") << "...add term " << r_add << ", pol = " << pol << ", kind = " << n.getKind() << std::endl;
       //the negative occurrence adds the term to the domain
       if( !hasPol || !pol ){
-        rdl.d_val.push_back( r_add );
+        rdl.d_val.push_back(r_add);
       }
       //the positive occurence adds other terms
       if( ( !hasPol || pol ) && n[0].getType().isInteger() ){
         if( n.getKind()==EQUAL ){
           for( unsigned i=0; i<2; i++ ){
-            rdl.d_val.push_back(
-                ArithMSum::offset(r_add, i == 0 ? 1 : -1));
+            rdl.d_val.push_back(ArithMSum::offset(r_add, i == 0 ? 1 : -1));
           }
         }else if( n.getKind()==GEQ ){
-          rdl.d_val.push_back(
-              ArithMSum::offset(r_add, varLhs ? 1 : -1));
+          rdl.d_val.push_back(ArithMSum::offset(r_add, varLhs ? 1 : -1));
         }
       }
-    }else{
+    }
+    else
+    {
       rdl.d_rd[0] = NULL;
       rdl.d_rd[1] = NULL;
     }

--- a/src/theory/quantifiers/relevant_domain.cpp
+++ b/src/theory/quantifiers/relevant_domain.cpp
@@ -85,15 +85,8 @@ RelevantDomain::RelevantDomain(Env& env,
 }
 
 RelevantDomain::~RelevantDomain() {
-  for (std::map<Node, std::map<size_t, RDomain*> >::iterator itr =
-           d_rel_doms.begin();
-       itr != d_rel_doms.end();
-       ++itr)
-  {
-    for (std::map<size_t, RDomain*>::iterator itr2 = itr->second.begin();
-         itr2 != itr->second.end();
-         ++itr2)
-    {
+  for( std::map< Node, std::map< size_t, RDomain * > >::iterator itr = d_rel_doms.begin(); itr != d_rel_doms.end(); ++itr ){
+    for( std::map< size_t, RDomain * >::iterator itr2 = itr->second.begin(); itr2 != itr->second.end(); ++itr2 ){
       RDomain * current = (*itr2).second;
       Assert(current != NULL);
       delete current;
@@ -101,10 +94,7 @@ RelevantDomain::~RelevantDomain() {
   }
 }
 
-RelevantDomain::RDomain* RelevantDomain::getRDomain(Node n,
-                                                    size_t i,
-                                                    bool getParent)
-{
+RelevantDomain::RDomain * RelevantDomain::getRDomain( Node n, size_t i, bool getParent ) {
   if( d_rel_doms.find( n )==d_rel_doms.end() || d_rel_doms[n].find( i )==d_rel_doms[n].end() ){
     d_rel_doms[n][i] = new RDomain;
   }
@@ -120,15 +110,8 @@ void RelevantDomain::registerQuantifier(Node q) {}
 void RelevantDomain::compute(){
   if( !d_is_computed ){
     d_is_computed = true;
-    for (std::map<Node, std::map<size_t, RDomain*> >::iterator it =
-             d_rel_doms.begin();
-         it != d_rel_doms.end();
-         ++it)
-    {
-      for (std::map<size_t, RDomain*>::iterator it2 = it->second.begin();
-           it2 != it->second.end();
-           ++it2)
-      {
+    for( std::map< Node, std::map< size_t, RDomain * > >::iterator it = d_rel_doms.begin(); it != d_rel_doms.end(); ++it ){
+      for( std::map< size_t, RDomain * >::iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2 ){
         it2->second->reset();
       }
     }
@@ -159,16 +142,9 @@ void RelevantDomain::compute(){
       }
     }
     //print debug
-    for (std::map<Node, std::map<size_t, RDomain*> >::iterator it =
-             d_rel_doms.begin();
-         it != d_rel_doms.end();
-         ++it)
-    {
+    for( std::map< Node, std::map< size_t, RDomain * > >::iterator it = d_rel_doms.begin(); it != d_rel_doms.end(); ++it ){
       Trace("rel-dom") << "Relevant domain for " << it->first << " : " << std::endl;
-      for (std::map<size_t, RDomain*>::iterator it2 = it->second.begin();
-           it2 != it->second.end();
-           ++it2)
-      {
+      for( std::map< size_t, RDomain * >::iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2 ){
         Trace("rel-dom") << "   " << it2->first << " : ";
         RDomain * r = it2->second;
         RDomain * rp = r->getParent();
@@ -176,21 +152,19 @@ void RelevantDomain::compute(){
           r->removeRedundantTerms(d_qs);
           Trace("rel-dom") << r->d_terms;
         }else{
-          Trace("rel-dom") << "Dom( " << it->first << ", " << it2->first
-                           << " ) ";
+          Trace("rel-dom") << "Dom( " << it->first << ", " << it2->first << " ) ";
         }
         Trace("rel-dom") << std::endl;
         if (Configuration::isAssertionBuild())
         {
-          if (it->first.getKind() == FORALL)
+          if (it->first.getKind()==FORALL)
           {
             TypeNode expectedType = it->first[0][it2->first].getType();
             for (const Node& t : r->d_terms)
             {
               if (!t.getType().isComparableTo(expectedType))
               {
-                Unhandled() << "Relevant domain: bad type " << t.getType()
-                            << ", expected " << expectedType;
+                Unhandled() << "Relevant domain: bad type " << t.getType() << ", expected " << expectedType;
               }
             }
           }
@@ -251,7 +225,7 @@ void RelevantDomain::computeRelevantDomainNode(Node q,
   // Relevant domain only makes sense for non-parametric operators, thus we
   // check op==n.getOperator() here. This otherwise would lead to bad types
   // for terms in the relevant domain.
-  if (!op.isNull() && op == n.getOperator())
+  if (!op.isNull() && op==n.getOperator())
   {
     for (size_t i = 0, nchild = n.getNumChildren(); i < nchild; i++)
     {
@@ -270,23 +244,19 @@ void RelevantDomain::computeRelevantDomainNode(Node q,
     //compute the information for what this literal does
     computeRelevantDomainLit( q, hasPol, pol, n );
     RDomainLit& rdl = d_rel_dom_lit[hasPol][pol][n];
-    if (rdl.d_merge)
-    {
-      Assert(rdl.d_rd[0] != NULL && rdl.d_rd[1] != NULL);
-      RDomain* rd1 = rdl.d_rd[0]->getParent();
-      RDomain* rd2 = rdl.d_rd[1]->getParent();
+    if( rdl.d_merge ){
+      Assert(rdl.d_rd[0] != NULL
+             && rdl.d_rd[1] != NULL);
+      RDomain * rd1 = rdl.d_rd[0]->getParent();
+      RDomain * rd2 = rdl.d_rd[1]->getParent();
       if( rd1!=rd2 ){
         rd1->merge( rd2 );
       }
-    }
-    else
-    {
-      if (rdl.d_rd[0] != NULL)
-      {
-        RDomain* rd = rdl.d_rd[0]->getParent();
-        for (unsigned i = 0; i < rdl.d_val.size(); i++)
-        {
-          rd->addTerm(rdl.d_val[i]);
+    }else{
+      if( rdl.d_rd[0]!=NULL ){
+        RDomain * rd = rdl.d_rd[0]->getParent();
+        for( unsigned i=0; i<rdl.d_val.size(); i++ ){
+          rd->addTerm( rdl.d_val[i] );
         }
       }
     }
@@ -330,7 +300,7 @@ void RelevantDomain::computeRelevantDomainLit( Node q, bool hasPol, bool pol, No
         varCount++;
         varCh = i;
       }else{
-        rdl.d_rd[i] = NULL;
+        rdl.d_rd[i] = nullptr;
       }
     }
     
@@ -343,7 +313,7 @@ void RelevantDomain::computeRelevantDomainLit( Node q, bool hasPol, bool pol, No
         r_add = n[1-varCh];
         varLhs = (varCh==0);
         rdl.d_rd[0] = rdl.d_rd[varCh];
-        rdl.d_rd[1] = NULL;
+        rdl.d_rd[1] = nullptr;
       }else{
         //solve the inequality for one/two variables, if possible
         if( n[0].getType().isReal() ){
@@ -368,7 +338,9 @@ void RelevantDomain::computeRelevantDomainLit( Node q, bool hasPol, bool pol, No
                 hasNonVar = true;
               }
             }
+            Trace("rel-dom") << "Process lit " << n << ", var/var2=" << var << "/" << var2 << std::endl;
             if( !var.isNull() ){
+              Assert (var.hasAttribute(InstVarNumAttribute()));
               if( var2.isNull() ){
                 //single variable solve
                 Node veq_c;
@@ -379,17 +351,15 @@ void RelevantDomain::computeRelevantDomainLit( Node q, bool hasPol, bool pol, No
                   if( veq_c.isNull() ){
                     r_add = val;
                     varLhs = (ires==1);
-                    rdl.d_rd[0] = getRDomain(
-                        q, var.getAttribute(InstVarNumAttribute()), false);
-                    rdl.d_rd[1] = NULL;
+                    rdl.d_rd[0] = getRDomain( q, var.getAttribute(InstVarNumAttribute()), false );
+                    rdl.d_rd[1] = nullptr;
                   }
                 }
               }else if( !hasNonVar ){
+                Assert (var2.hasAttribute(InstVarNumAttribute()));
                 //merge the domains
-                rdl.d_rd[0] = getRDomain(
-                    q, var.getAttribute(InstVarNumAttribute()), false);
-                rdl.d_rd[1] = getRDomain(
-                    q, var2.getAttribute(InstVarNumAttribute()), false);
+                rdl.d_rd[0] = getRDomain( q, var.getAttribute(InstVarNumAttribute()), false );
+                rdl.d_rd[1] = getRDomain( q, var2.getAttribute(InstVarNumAttribute()), false );
                 rdl.d_merge = true;
               }
             }
@@ -397,33 +367,30 @@ void RelevantDomain::computeRelevantDomainLit( Node q, bool hasPol, bool pol, No
         }
       }
     }
-    if (rdl.d_merge)
-    {
+    if( rdl.d_merge ){
       //do not merge if constant negative polarity
       if( hasPol && !pol ){
         rdl.d_merge = false;
       }
-    }
-    else if (!r_add.isNull() && !TermUtil::hasInstConstAttr(r_add))
-    {
+    }else if( !r_add.isNull() && !TermUtil::hasInstConstAttr( r_add ) ){
       Trace("rel-dom-debug") << "...add term " << r_add << ", pol = " << pol << ", kind = " << n.getKind() << std::endl;
       //the negative occurrence adds the term to the domain
       if( !hasPol || !pol ){
-        rdl.d_val.push_back(r_add);
+        rdl.d_val.push_back( r_add );
       }
       //the positive occurence adds other terms
       if( ( !hasPol || pol ) && n[0].getType().isInteger() ){
         if( n.getKind()==EQUAL ){
           for( unsigned i=0; i<2; i++ ){
-            rdl.d_val.push_back(ArithMSum::offset(r_add, i == 0 ? 1 : -1));
+            rdl.d_val.push_back(
+                ArithMSum::offset(r_add, i == 0 ? 1 : -1));
           }
         }else if( n.getKind()==GEQ ){
-          rdl.d_val.push_back(ArithMSum::offset(r_add, varLhs ? 1 : -1));
+          rdl.d_val.push_back(
+              ArithMSum::offset(r_add, varLhs ? 1 : -1));
         }
       }
-    }
-    else
-    {
+    }else{
       rdl.d_rd[0] = NULL;
       rdl.d_rd[1] = NULL;
     }

--- a/src/theory/quantifiers/relevant_domain.cpp
+++ b/src/theory/quantifiers/relevant_domain.cpp
@@ -85,8 +85,15 @@ RelevantDomain::RelevantDomain(Env& env,
 }
 
 RelevantDomain::~RelevantDomain() {
-  for( std::map< Node, std::map< size_t, RDomain * > >::iterator itr = d_rel_doms.begin(); itr != d_rel_doms.end(); ++itr ){
-    for( std::map< size_t, RDomain * >::iterator itr2 = itr->second.begin(); itr2 != itr->second.end(); ++itr2 ){
+  for (std::map<Node, std::map<size_t, RDomain*> >::iterator itr =
+           d_rel_doms.begin();
+       itr != d_rel_doms.end();
+       ++itr)
+  {
+    for (std::map<size_t, RDomain*>::iterator itr2 = itr->second.begin();
+         itr2 != itr->second.end();
+         ++itr2)
+    {
       RDomain * current = (*itr2).second;
       Assert(current != NULL);
       delete current;
@@ -94,7 +101,10 @@ RelevantDomain::~RelevantDomain() {
   }
 }
 
-RelevantDomain::RDomain * RelevantDomain::getRDomain( Node n, size_t i, bool getParent ) {
+RelevantDomain::RDomain* RelevantDomain::getRDomain(Node n,
+                                                    size_t i,
+                                                    bool getParent)
+{
   if( d_rel_doms.find( n )==d_rel_doms.end() || d_rel_doms[n].find( i )==d_rel_doms[n].end() ){
     d_rel_doms[n][i] = new RDomain;
   }
@@ -110,8 +120,15 @@ void RelevantDomain::registerQuantifier(Node q) {}
 void RelevantDomain::compute(){
   if( !d_is_computed ){
     d_is_computed = true;
-    for( std::map< Node, std::map< size_t, RDomain * > >::iterator it = d_rel_doms.begin(); it != d_rel_doms.end(); ++it ){
-      for( std::map< size_t, RDomain * >::iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2 ){
+    for (std::map<Node, std::map<size_t, RDomain*> >::iterator it =
+             d_rel_doms.begin();
+         it != d_rel_doms.end();
+         ++it)
+    {
+      for (std::map<size_t, RDomain*>::iterator it2 = it->second.begin();
+           it2 != it->second.end();
+           ++it2)
+      {
         it2->second->reset();
       }
     }
@@ -142,9 +159,16 @@ void RelevantDomain::compute(){
       }
     }
     //print debug
-    for( std::map< Node, std::map< size_t, RDomain * > >::iterator it = d_rel_doms.begin(); it != d_rel_doms.end(); ++it ){
+    for (std::map<Node, std::map<size_t, RDomain*> >::iterator it =
+             d_rel_doms.begin();
+         it != d_rel_doms.end();
+         ++it)
+    {
       Trace("rel-dom") << "Relevant domain for " << it->first << " : " << std::endl;
-      for( std::map< size_t, RDomain * >::iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2 ){
+      for (std::map<size_t, RDomain*>::iterator it2 = it->second.begin();
+           it2 != it->second.end();
+           ++it2)
+      {
         Trace("rel-dom") << "   " << it2->first << " : ";
         RDomain * r = it2->second;
         RDomain * rp = r->getParent();
@@ -152,19 +176,21 @@ void RelevantDomain::compute(){
           r->removeRedundantTerms(d_qs);
           Trace("rel-dom") << r->d_terms;
         }else{
-          Trace("rel-dom") << "Dom( " << it->first << ", " << it2->first << " ) ";
+          Trace("rel-dom") << "Dom( " << it->first << ", " << it2->first
+                           << " ) ";
         }
         Trace("rel-dom") << std::endl;
         if (Configuration::isAssertionBuild())
         {
-          if (it->first.getKind()==FORALL)
+          if (it->first.getKind() == FORALL)
           {
             TypeNode expectedType = it->first[0][it2->first].getType();
             for (const Node& t : r->d_terms)
             {
               if (!t.getType().isComparableTo(expectedType))
               {
-                Unhandled() << "Relevant domain: bad type " << t.getType() << ", expected " << expectedType;
+                Unhandled() << "Relevant domain: bad type " << t.getType()
+                            << ", expected " << expectedType;
               }
             }
           }
@@ -225,7 +251,7 @@ void RelevantDomain::computeRelevantDomainNode(Node q,
   // Relevant domain only makes sense for non-parametric operators, thus we
   // check op==n.getOperator() here. This otherwise would lead to bad types
   // for terms in the relevant domain.
-  if (!op.isNull() && op==n.getOperator())
+  if (!op.isNull() && op == n.getOperator())
   {
     for (size_t i = 0, nchild = n.getNumChildren(); i < nchild; i++)
     {
@@ -244,19 +270,23 @@ void RelevantDomain::computeRelevantDomainNode(Node q,
     //compute the information for what this literal does
     computeRelevantDomainLit( q, hasPol, pol, n );
     RDomainLit& rdl = d_rel_dom_lit[hasPol][pol][n];
-    if( rdl.d_merge ){
-      Assert(rdl.d_rd[0] != NULL
-             && rdl.d_rd[1] != NULL);
-      RDomain * rd1 = rdl.d_rd[0]->getParent();
-      RDomain * rd2 = rdl.d_rd[1]->getParent();
+    if (rdl.d_merge)
+    {
+      Assert(rdl.d_rd[0] != NULL && rdl.d_rd[1] != NULL);
+      RDomain* rd1 = rdl.d_rd[0]->getParent();
+      RDomain* rd2 = rdl.d_rd[1]->getParent();
       if( rd1!=rd2 ){
         rd1->merge( rd2 );
       }
-    }else{
-      if( rdl.d_rd[0]!=NULL ){
-        RDomain * rd = rdl.d_rd[0]->getParent();
-        for( unsigned i=0; i<rdl.d_val.size(); i++ ){
-          rd->addTerm( rdl.d_val[i] );
+    }
+    else
+    {
+      if (rdl.d_rd[0] != NULL)
+      {
+        RDomain* rd = rdl.d_rd[0]->getParent();
+        for (unsigned i = 0; i < rdl.d_val.size(); i++)
+        {
+          rd->addTerm(rdl.d_val[i]);
         }
       }
     }
@@ -338,9 +368,10 @@ void RelevantDomain::computeRelevantDomainLit( Node q, bool hasPol, bool pol, No
                 hasNonVar = true;
               }
             }
-            Trace("rel-dom") << "Process lit " << n << ", var/var2=" << var << "/" << var2 << std::endl;
+            Trace("rel-dom") << "Process lit " << n << ", var/var2=" << var
+                             << "/" << var2 << std::endl;
             if( !var.isNull() ){
-              Assert (var.hasAttribute(InstVarNumAttribute()));
+              Assert(var.hasAttribute(InstVarNumAttribute()));
               if( var2.isNull() ){
                 //single variable solve
                 Node veq_c;
@@ -351,15 +382,18 @@ void RelevantDomain::computeRelevantDomainLit( Node q, bool hasPol, bool pol, No
                   if( veq_c.isNull() ){
                     r_add = val;
                     varLhs = (ires==1);
-                    rdl.d_rd[0] = getRDomain( q, var.getAttribute(InstVarNumAttribute()), false );
+                    rdl.d_rd[0] = getRDomain(
+                        q, var.getAttribute(InstVarNumAttribute()), false);
                     rdl.d_rd[1] = nullptr;
                   }
                 }
               }else if( !hasNonVar ){
-                Assert (var2.hasAttribute(InstVarNumAttribute()));
+                Assert(var2.hasAttribute(InstVarNumAttribute()));
                 //merge the domains
-                rdl.d_rd[0] = getRDomain( q, var.getAttribute(InstVarNumAttribute()), false );
-                rdl.d_rd[1] = getRDomain( q, var2.getAttribute(InstVarNumAttribute()), false );
+                rdl.d_rd[0] = getRDomain(
+                    q, var.getAttribute(InstVarNumAttribute()), false);
+                rdl.d_rd[1] = getRDomain(
+                    q, var2.getAttribute(InstVarNumAttribute()), false);
                 rdl.d_merge = true;
               }
             }
@@ -367,30 +401,33 @@ void RelevantDomain::computeRelevantDomainLit( Node q, bool hasPol, bool pol, No
         }
       }
     }
-    if( rdl.d_merge ){
+    if (rdl.d_merge)
+    {
       //do not merge if constant negative polarity
       if( hasPol && !pol ){
         rdl.d_merge = false;
       }
-    }else if( !r_add.isNull() && !TermUtil::hasInstConstAttr( r_add ) ){
+    }
+    else if (!r_add.isNull() && !TermUtil::hasInstConstAttr(r_add))
+    {
       Trace("rel-dom-debug") << "...add term " << r_add << ", pol = " << pol << ", kind = " << n.getKind() << std::endl;
       //the negative occurrence adds the term to the domain
       if( !hasPol || !pol ){
-        rdl.d_val.push_back( r_add );
+        rdl.d_val.push_back(r_add);
       }
       //the positive occurence adds other terms
       if( ( !hasPol || pol ) && n[0].getType().isInteger() ){
         if( n.getKind()==EQUAL ){
           for( unsigned i=0; i<2; i++ ){
-            rdl.d_val.push_back(
-                ArithMSum::offset(r_add, i == 0 ? 1 : -1));
+            rdl.d_val.push_back(ArithMSum::offset(r_add, i == 0 ? 1 : -1));
           }
         }else if( n.getKind()==GEQ ){
-          rdl.d_val.push_back(
-              ArithMSum::offset(r_add, varLhs ? 1 : -1));
+          rdl.d_val.push_back(ArithMSum::offset(r_add, varLhs ? 1 : -1));
         }
       }
-    }else{
+    }
+    else
+    {
       rdl.d_rd[0] = NULL;
       rdl.d_rd[1] = NULL;
     }

--- a/src/theory/quantifiers/relevant_domain.cpp
+++ b/src/theory/quantifiers/relevant_domain.cpp
@@ -85,16 +85,11 @@ RelevantDomain::RelevantDomain(Env& env,
 }
 
 RelevantDomain::~RelevantDomain() {
-  for (std::map<Node, std::map<size_t, RDomain*> >::iterator itr =
-           d_rel_doms.begin();
-       itr != d_rel_doms.end();
-       ++itr)
+  for (auto& r : d_rel_doms)
   {
-    for (std::map<size_t, RDomain*>::iterator itr2 = itr->second.begin();
-         itr2 != itr->second.end();
-         ++itr2)
+    for (auto& rr : r.second)
     {
-      RDomain * current = (*itr2).second;
+      RDomain * current = rr.second;
       Assert(current != NULL);
       delete current;
     }
@@ -120,16 +115,11 @@ void RelevantDomain::registerQuantifier(Node q) {}
 void RelevantDomain::compute(){
   if( !d_is_computed ){
     d_is_computed = true;
-    for (std::map<Node, std::map<size_t, RDomain*> >::iterator it =
-             d_rel_doms.begin();
-         it != d_rel_doms.end();
-         ++it)
+    for (auto& r : d_rel_doms)
     {
-      for (std::map<size_t, RDomain*>::iterator it2 = it->second.begin();
-           it2 != it->second.end();
-           ++it2)
+      for (auto& rr : r.second)
       {
-        it2->second->reset();
+        rr.second->reset();
       }
     }
     FirstOrderModel* fm = d_treg.getModel();

--- a/src/theory/quantifiers/relevant_domain.cpp
+++ b/src/theory/quantifiers/relevant_domain.cpp
@@ -149,32 +149,27 @@ void RelevantDomain::compute(){
       }
     }
     //print debug
-    for (std::map<Node, std::map<size_t, RDomain*> >::iterator it =
-             d_rel_doms.begin();
-         it != d_rel_doms.end();
-         ++it)
+    for (std::pair<const Node, std::map<size_t, RDomain*> >& d : d_rel_doms)
     {
-      Trace("rel-dom") << "Relevant domain for " << it->first << " : " << std::endl;
-      for (std::map<size_t, RDomain*>::iterator it2 = it->second.begin();
-           it2 != it->second.end();
-           ++it2)
+      Trace("rel-dom") << "Relevant domain for " << d.first << " : " << std::endl;
+      for (std::pair<const size_t, RDomain*>& dd : d.second)
       {
-        Trace("rel-dom") << "   " << it2->first << " : ";
-        RDomain * r = it2->second;
+        Trace("rel-dom") << "   " << dd.first << " : ";
+        RDomain * r = dd.second;
         RDomain * rp = r->getParent();
         if( r==rp ){
           r->removeRedundantTerms(d_qs);
           Trace("rel-dom") << r->d_terms;
         }else{
-          Trace("rel-dom") << "Dom( " << it->first << ", " << it2->first
+          Trace("rel-dom") << "Dom( " << d.first << ", " << dd.first
                            << " ) ";
         }
         Trace("rel-dom") << std::endl;
         if (Configuration::isAssertionBuild())
         {
-          if (it->first.getKind() == FORALL)
+          if (d.first.getKind() == FORALL)
           {
-            TypeNode expectedType = it->first[0][it2->first].getType();
+            TypeNode expectedType = d.first[0][dd.first].getType();
             for (const Node& t : r->d_terms)
             {
               if (!t.getType().isComparableTo(expectedType))

--- a/src/theory/quantifiers/relevant_domain.cpp
+++ b/src/theory/quantifiers/relevant_domain.cpp
@@ -212,7 +212,10 @@ void RelevantDomain::computeRelevantDomainNode(Node q,
 {
   Trace("rel-dom-debug") << "Compute relevant domain " << n << "..." << std::endl;
   Node op = d_treg.getTermDatabase()->getMatchOperator(n);
-  if (!op.isNull())
+  // Relevant domain only makes sense for non-parametric operators, thus we
+  // check op==n.getOperator() here. This otherwise would lead to bad types
+  // for terms in the relevant domain.
+  if (!op.isNull() && op==n.getOperator())
   {
     for (size_t i = 0, nchild = n.getNumChildren(); i < nchild; i++)
     {

--- a/src/theory/quantifiers/relevant_domain.cpp
+++ b/src/theory/quantifiers/relevant_domain.cpp
@@ -89,7 +89,7 @@ RelevantDomain::~RelevantDomain() {
   {
     for (auto& rr : r.second)
     {
-      RDomain * current = rr.second;
+      RDomain* current = rr.second;
       Assert(current != NULL);
       delete current;
     }
@@ -151,18 +151,18 @@ void RelevantDomain::compute(){
     //print debug
     for (std::pair<const Node, std::map<size_t, RDomain*> >& d : d_rel_doms)
     {
-      Trace("rel-dom") << "Relevant domain for " << d.first << " : " << std::endl;
+      Trace("rel-dom") << "Relevant domain for " << d.first << " : "
+                       << std::endl;
       for (std::pair<const size_t, RDomain*>& dd : d.second)
       {
         Trace("rel-dom") << "   " << dd.first << " : ";
-        RDomain * r = dd.second;
+        RDomain* r = dd.second;
         RDomain * rp = r->getParent();
         if( r==rp ){
           r->removeRedundantTerms(d_qs);
           Trace("rel-dom") << r->d_terms;
         }else{
-          Trace("rel-dom") << "Dom( " << d.first << ", " << dd.first
-                           << " ) ";
+          Trace("rel-dom") << "Dom( " << d.first << ", " << dd.first << " ) ";
         }
         Trace("rel-dom") << std::endl;
         if (Configuration::isAssertionBuild())

--- a/src/theory/quantifiers/relevant_domain.cpp
+++ b/src/theory/quantifiers/relevant_domain.cpp
@@ -257,7 +257,7 @@ void RelevantDomain::computeRelevantDomainNode(Node q,
     RDomainLit& rdl = d_rel_dom_lit[hasPol][pol][n];
     if (rdl.d_merge)
     {
-      Assert(rdl.d_rd[0] != NULL && rdl.d_rd[1] != NULL);
+      Assert(rdl.d_rd[0] != nullptr && rdl.d_rd[1] != nullptr);
       RDomain* rd1 = rdl.d_rd[0]->getParent();
       RDomain* rd2 = rdl.d_rd[1]->getParent();
       if( rd1!=rd2 ){
@@ -266,7 +266,7 @@ void RelevantDomain::computeRelevantDomainNode(Node q,
     }
     else
     {
-      if (rdl.d_rd[0] != NULL)
+      if (rdl.d_rd[0] != nullptr)
       {
         RDomain* rd = rdl.d_rd[0]->getParent();
         for (unsigned i = 0; i < rdl.d_val.size(); i++)
@@ -413,8 +413,8 @@ void RelevantDomain::computeRelevantDomainLit( Node q, bool hasPol, bool pol, No
     }
     else
     {
-      rdl.d_rd[0] = NULL;
-      rdl.d_rd[1] = NULL;
+      rdl.d_rd[0] = nullptr;
+      rdl.d_rd[1] = nullptr;
     }
   }
 }

--- a/src/theory/quantifiers/relevant_domain.h
+++ b/src/theory/quantifiers/relevant_domain.h
@@ -114,7 +114,7 @@ class RelevantDomain : public QuantifiersUtil
   /** the relevant domains for each quantified formula and function,
    * for each variable # and argument #.
    */
-  std::map< Node, std::map< size_t, RDomain * > > d_rel_doms;
+  std::map<Node, std::map<size_t, RDomain*> > d_rel_doms;
   /** Reference to the quantifiers state object */
   QuantifiersState& d_qs;
   /** Reference to the quantifiers registry */

--- a/src/theory/quantifiers/relevant_domain.h
+++ b/src/theory/quantifiers/relevant_domain.h
@@ -108,21 +108,13 @@ class RelevantDomain : public QuantifiersUtil
    * of the equivalence class of relevant domain objects,
    * which is computed as a union find (see RDomain::d_parent).
    */
-  RDomain* getRDomain(Node n, int i, bool getParent = true);
+  RDomain* getRDomain(Node n, size_t i, bool getParent = true);
 
  private:
   /** the relevant domains for each quantified formula and function,
    * for each variable # and argument #.
    */
-  std::map< Node, std::map< int, RDomain * > > d_rel_doms;
-  /** stores the function or quantified formula associated with
-   * each relevant domain object.
-   */
-  std::map< RDomain *, Node > d_rn_map;
-  /** stores the argument or variable number associated with
-   * each relevant domain object.
-   */
-  std::map< RDomain *, int > d_ri_map;
+  std::map< Node, std::map< size_t, RDomain * > > d_rel_doms;
   /** Reference to the quantifiers state object */
   QuantifiersState& d_qs;
   /** Reference to the quantifiers registry */

--- a/src/theory/quantifiers/term_database.cpp
+++ b/src/theory/quantifiers/term_database.cpp
@@ -178,7 +178,7 @@ Node TermDb::getMatchOperator( Node n ) {
   if (k == SELECT || k == STORE || k == UNION || k == INTERSECTION
       || k == SUBSET || k == SETMINUS || k == MEMBER || k == SINGLETON
       || k == APPLY_SELECTOR_TOTAL || k == APPLY_SELECTOR || k == APPLY_TESTER
-      || k == SEP_PTO || k == HO_APPLY || k == SEQ_NTH)
+      || k == SEP_PTO || k == HO_APPLY || k == SEQ_NTH || k == STRING_LENGTH)
   {
     //since it is parametric, use a particular one as op
     TypeNode tn = n[0].getType();

--- a/src/theory/quantifiers/term_tuple_enumerator.cpp
+++ b/src/theory/quantifiers/term_tuple_enumerator.cpp
@@ -292,9 +292,9 @@ void TermTupleEnumeratorBase::next(/*out*/ std::vector<Node>& terms)
                        : getTerm(variableIx, d_termIndex[variableIx]);
     terms[variableIx] = t;
     Trace("inst-alg-rd") << t << "  ";
-    Assert(terms[variableIx].isNull()
-           || terms[variableIx].getType().isComparableTo(
-               d_quantifier[0][variableIx].getType()));
+    Assert(t.isNull()
+           || t.getType().isComparableTo(
+               d_quantifier[0][variableIx].getType())) << "Bad type: " << t << " " << t.getType() << " " << d_quantifier[0][variableIx].getType();
   }
   Trace("inst-alg-rd") << std::endl;
 }

--- a/src/theory/quantifiers/term_tuple_enumerator.cpp
+++ b/src/theory/quantifiers/term_tuple_enumerator.cpp
@@ -293,8 +293,9 @@ void TermTupleEnumeratorBase::next(/*out*/ std::vector<Node>& terms)
     terms[variableIx] = t;
     Trace("inst-alg-rd") << t << "  ";
     Assert(t.isNull()
-           || t.getType().isComparableTo(
-               d_quantifier[0][variableIx].getType())) << "Bad type: " << t << " " << t.getType() << " " << d_quantifier[0][variableIx].getType();
+           || t.getType().isComparableTo(d_quantifier[0][variableIx].getType()))
+        << "Bad type: " << t << " " << t.getType() << " "
+        << d_quantifier[0][variableIx].getType();
   }
   Trace("inst-alg-rd") << std::endl;
 }


### PR DESCRIPTION
Fixes #6531.

This issue also occurs when using `--full-saturate-quant` on facebook benchmarks that combine multiple sequence types.

It does some cleanup on relevant domain in the process.