### PR TITLE
Refactor tag suggestion mechanism

### DIFF
--- a/src/base/collect_tags.py
+++ b/src/base/collect_tags.py
@@ -45,8 +45,15 @@ def write_file(filename, type, tags):
     """Render the header file to the given filename."""
     with open(filename, 'w') as out:
         out.write('static const std::vector<std::string> {}_tags = {{\n'.format(type))
+        if type == 'Debug':
+            out.write('#if defined(CVC5_DEBUG) && defined(CVC5_TRACING)\n')
+        elif type == 'Trace':
+            out.write('#if defined(CVC5_TRACING)\n')
+        else:
+            raise 'type is neither Debug nor Trace: {}'.format(type)
         for t in tags:
             out.write('"{}",\n'.format(t))
+        out.write('#endif\n')
         out.write('};\n')
 
 

--- a/src/base/collect_tags.py
+++ b/src/base/collect_tags.py
@@ -44,10 +44,9 @@ def collect_tags(basedir):
 def write_file(filename, type, tags):
     """Render the header file to the given filename."""
     with open(filename, 'w') as out:
-        out.write('static char const* const {}_tags[] = {{\n'.format(type))
+        out.write('static const std::vector<std::string> {}_tags = {{\n'.format(type))
         for t in tags:
             out.write('"{}",\n'.format(t))
-        out.write('nullptr\n')
         out.write('};\n')
 
 

--- a/src/base/configuration.cpp
+++ b/src/base/configuration.cpp
@@ -255,11 +255,8 @@ const std::vector<std::string>& Configuration::getDebugTags()
 
 bool Configuration::isDebugTag(const std::string& tag)
 {
-#if defined(CVC5_DEBUG) && defined(CVC5_TRACING)
   return std::find(Debug_tags.begin(), Debug_tags.end(), tag)
          != Debug_tags.end();
-#endif /* CVC5_DEBUG && CVC5_TRACING */
-  return false;
 }
 
 const std::vector<std::string>& Configuration::getTraceTags()
@@ -269,11 +266,8 @@ const std::vector<std::string>& Configuration::getTraceTags()
 
 bool Configuration::isTraceTag(const std::string& tag)
 {
-#if CVC5_TRACING
   return std::find(Trace_tags.begin(), Trace_tags.end(), tag)
          != Trace_tags.end();
-#endif /* CVC5_TRACING */
-  return false;
 }
 
 bool Configuration::isGitBuild() {

--- a/src/base/configuration.cpp
+++ b/src/base/configuration.cpp
@@ -25,13 +25,8 @@
 #include "base/configuration_private.h"
 #include "base/cvc5config.h"
 
-#if defined(CVC5_DEBUG) && defined(CVC5_TRACING)
-#  include "base/Debug_tags.h"
-#endif /* CVC5_DEBUG && CVC5_TRACING */
-
-#ifdef CVC5_TRACING
-#  include "base/Trace_tags.h"
-#endif /* CVC5_TRACING */
+#include "base/Debug_tags.h"
+#include "base/Trace_tags.h"
 
 using namespace std;
 
@@ -254,13 +249,9 @@ bool Configuration::isBuiltWithPoly()
   return IS_POLY_BUILD;
 }
 
-std::vector<std::string> Configuration::getDebugTags()
+const std::vector<std::string>& Configuration::getDebugTags()
 {
-#if defined(CVC5_DEBUG) && defined(CVC5_TRACING)
   return Debug_tags;
-#else  /* CVC5_DEBUG && CVC5_TRACING */
-  return {};
-#endif /* CVC5_DEBUG && CVC5_TRACING */
 }
 
 bool Configuration::isDebugTag(const std::string& tag)
@@ -272,13 +263,9 @@ bool Configuration::isDebugTag(const std::string& tag)
   return false;
 }
 
-std::vector<std::string> Configuration::getTraceTags()
+const std::vector<std::string>& Configuration::getTraceTags()
 {
-#if CVC5_TRACING
   return Trace_tags;
-#else  /* CVC5_TRACING */
-  return {};
-#endif /* CVC5_TRACING */
 }
 
 bool Configuration::isTraceTag(const std::string& tag)

--- a/src/base/configuration.cpp
+++ b/src/base/configuration.cpp
@@ -22,11 +22,10 @@
 #include <sstream>
 #include <string>
 
-#include "base/configuration_private.h"
-#include "base/cvc5config.h"
-
 #include "base/Debug_tags.h"
 #include "base/Trace_tags.h"
+#include "base/configuration_private.h"
+#include "base/cvc5config.h"
 
 using namespace std;
 

--- a/src/base/configuration.cpp
+++ b/src/base/configuration.cpp
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <algorithm>
 #include <sstream>
 #include <string>
 
@@ -253,68 +254,38 @@ bool Configuration::isBuiltWithPoly()
   return IS_POLY_BUILD;
 }
 
-unsigned Configuration::getNumDebugTags() {
-#if defined(CVC5_DEBUG) && defined(CVC5_TRACING)
-  /* -1 because a NULL pointer is inserted as the last value */
-  return (sizeof(Debug_tags) / sizeof(Debug_tags[0])) - 1;
-#else  /* CVC5_DEBUG && CVC5_TRACING */
-  return 0;
-#endif /* CVC5_DEBUG && CVC5_TRACING */
-}
-
-char const* const* Configuration::getDebugTags() {
+std::vector<std::string> Configuration::getDebugTags()
+{
 #if defined(CVC5_DEBUG) && defined(CVC5_TRACING)
   return Debug_tags;
 #else  /* CVC5_DEBUG && CVC5_TRACING */
-  static char const* no_tags[] = { NULL };
-  return no_tags;
+  return {};
 #endif /* CVC5_DEBUG && CVC5_TRACING */
 }
 
-int strcmpptr(const char **s1, const char **s2){
-  return strcmp(*s1,*s2);
-}
-
-bool Configuration::isDebugTag(char const *tag){
+bool Configuration::isDebugTag(const std::string& tag)
+{
 #if defined(CVC5_DEBUG) && defined(CVC5_TRACING)
-  unsigned ntags = getNumDebugTags();
-  char const* const* tags = getDebugTags();
-  for (unsigned i = 0; i < ntags; ++ i) {
-    if (strcmp(tag, tags[i]) == 0) {
-      return true;
-    }
-  }
+  return std::find(Debug_tags.begin(), Debug_tags.end(), tag)
+         != Debug_tags.end();
 #endif /* CVC5_DEBUG && CVC5_TRACING */
   return false;
 }
 
-unsigned Configuration::getNumTraceTags() {
-#if CVC5_TRACING
-  /* -1 because a NULL pointer is inserted as the last value */
-  return sizeof(Trace_tags) / sizeof(Trace_tags[0]) - 1;
-#else  /* CVC5_TRACING */
-  return 0;
-#endif /* CVC5_TRACING */
-}
-
-char const* const* Configuration::getTraceTags() {
+std::vector<std::string> Configuration::getTraceTags()
+{
 #if CVC5_TRACING
   return Trace_tags;
 #else  /* CVC5_TRACING */
-  static char const* no_tags[] = { NULL };
-  return no_tags;
+  return {};
 #endif /* CVC5_TRACING */
 }
 
-bool Configuration::isTraceTag(char const * tag){
+bool Configuration::isTraceTag(const std::string& tag)
+{
 #if CVC5_TRACING
-  unsigned ntags = getNumTraceTags();
-  char const* const* tags = getTraceTags();
-  for (unsigned i = 0; i < ntags; ++ i) {
-    if (strcmp(tag, tags[i]) == 0) {
-      return true;
-    }
-  }
+  return std::find(Trace_tags.begin(), Trace_tags.end(), tag)
+         != Trace_tags.end();
 #endif /* CVC5_TRACING */
   return false;
 }

--- a/src/base/configuration.h
+++ b/src/base/configuration.h
@@ -113,12 +113,12 @@ public:
   static bool isBuiltWithPoly();
 
   /* Return a sorted array of the debug tags name */
-  static std::vector<std::string> getDebugTags();
+  static const std::vector<std::string>& getDebugTags();
   /* Test if the given argument is a known debug tag name */
   static bool isDebugTag(const std::string& tag);
 
   /* Return a sorted array of the trace tags name */
-  static std::vector<std::string> getTraceTags();
+  static const std::vector<std::string>& getTraceTags();
   /* Test if the given argument is a known trace tag name */
   static bool isTraceTag(const std::string& tag);
 

--- a/src/base/configuration.h
+++ b/src/base/configuration.h
@@ -20,6 +20,7 @@
 #define CVC5__CONFIGURATION_H
 
 #include <string>
+#include <vector>
 
 #include "cvc5_export.h"
 
@@ -111,19 +112,15 @@ public:
 
   static bool isBuiltWithPoly();
 
-  /* Return the number of debug tags */
-  static unsigned getNumDebugTags();
   /* Return a sorted array of the debug tags name */
-  static char const* const* getDebugTags();
+  static std::vector<std::string> getDebugTags();
   /* Test if the given argument is a known debug tag name */
-  static bool isDebugTag(char const *);
+  static bool isDebugTag(const std::string& tag);
 
-  /* Return the number of trace tags */
-  static unsigned getNumTraceTags();
   /* Return a sorted array of the trace tags name */
-  static char const* const* getTraceTags();
+  static std::vector<std::string> getTraceTags();
   /* Test if the given argument is a known trace tag name */
-  static bool isTraceTag(char const *);
+  static bool isTraceTag(const std::string& tag);
 
   static bool isGitBuild();
   static const char* getGitBranchName();

--- a/src/options/didyoumean.h
+++ b/src/options/didyoumean.h
@@ -36,6 +36,9 @@ class CVC5_EXPORT DidYouMean {
   ~DidYouMean() {}
 
   void addWord(std::string word) { d_words.insert(std::move(word)); }
+  void addWords(const std::vector<std::string>& words) {
+    d_words.insert(words.begin(), words.end());
+  }
 
   std::vector<std::string> getMatch(const std::string& input);
 

--- a/src/options/didyoumean.h
+++ b/src/options/didyoumean.h
@@ -36,7 +36,8 @@ class CVC5_EXPORT DidYouMean {
   ~DidYouMean() {}
 
   void addWord(std::string word) { d_words.insert(std::move(word)); }
-  void addWords(const std::vector<std::string>& words) {
+  void addWords(const std::vector<std::string>& words)
+  {
     d_words.insert(words.begin(), words.end());
   }
 

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -426,7 +426,7 @@ void OptionsHandler::enableTraceTag(const std::string& option,
   {
     throw OptionException("trace tags not available in non-tracing builds");
   }
-  else if(!Configuration::isTraceTag(optarg))
+  else if (!Configuration::isTraceTag(optarg))
   {
     if (optarg == "help")
     {
@@ -454,8 +454,7 @@ void OptionsHandler::enableDebugTag(const std::string& option,
     throw OptionException("debug tags not available in non-tracing builds");
   }
 
-  if (!Configuration::isDebugTag(optarg)
-      && !Configuration::isTraceTag(optarg))
+  if (!Configuration::isDebugTag(optarg) && !Configuration::isTraceTag(optarg))
   {
     if (optarg == "help")
     {

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -372,12 +372,12 @@ void OptionsHandler::showConfiguration(const std::string& option,
   exit(0);
 }
 
-static void printTags(unsigned ntags, char const* const* tags)
+static void printTags(const std::vector<std::string>& tags)
 {
   std::cout << "available tags:";
-  for (unsigned i = 0; i < ntags; ++ i)
+  for (const auto& t : tags)
   {
-    std::cout << "  " << tags[i] << std::endl;
+    std::cout << "  " << t << std::endl;
   }
   std::cout << std::endl;
 }
@@ -393,8 +393,8 @@ void OptionsHandler::showDebugTags(const std::string& option,
   {
     throw OptionException("debug tags not available in non-tracing builds");
   }
-  printTags(Configuration::getNumDebugTags(),Configuration::getDebugTags());
-  exit(0);
+  printTags(Configuration::getDebugTags());
+  std::exit(0);
 }
 
 void OptionsHandler::showTraceTags(const std::string& option,
@@ -404,29 +404,23 @@ void OptionsHandler::showTraceTags(const std::string& option,
   {
     throw OptionException("trace tags not available in non-tracing build");
   }
-  printTags(Configuration::getNumTraceTags(), Configuration::getTraceTags());
-  exit(0);
+  printTags(Configuration::getTraceTags());
+  std::exit(0);
 }
 
-static std::string suggestTags(char const* const* validTags,
+static std::string suggestTags(const std::vector<std::string>& validTags,
                                std::string inputTag,
-                               char const* const* additionalTags)
+                               const std::vector<std::string>& additionalTags)
 {
   DidYouMean didYouMean;
-
-  const char* opt;
-  for (size_t i = 0; (opt = validTags[i]) != nullptr; ++i)
+  for (const auto& tag : validTags)
   {
-    didYouMean.addWord(validTags[i]);
+    didYouMean.addWord(tag);
   }
-  if (additionalTags != nullptr)
+  for (const auto& tag : additionalTags)
   {
-    for (size_t i = 0; (opt = additionalTags[i]) != nullptr; ++i)
-    {
-      didYouMean.addWord(additionalTags[i]);
-    }
+    didYouMean.addWord(tag);
   }
-
   return didYouMean.getMatchAsString(inputTag);
 }
 
@@ -442,14 +436,13 @@ void OptionsHandler::enableTraceTag(const std::string& option,
   {
     if (optarg == "help")
     {
-      printTags(
-          Configuration::getNumTraceTags(), Configuration::getTraceTags());
-      exit(0);
+      printTags(Configuration::getTraceTags());
+      std::exit(0);
     }
 
     throw OptionException(
         std::string("trace tag ") + optarg + std::string(" not available.")
-        + suggestTags(Configuration::getTraceTags(), optarg, nullptr));
+        + suggestTags(Configuration::getTraceTags(), optarg, {}));
   }
   Trace.on(optarg);
 }
@@ -472,9 +465,8 @@ void OptionsHandler::enableDebugTag(const std::string& option,
   {
     if (optarg == "help")
     {
-      printTags(
-          Configuration::getNumDebugTags(), Configuration::getDebugTags());
-      exit(0);
+      printTags(Configuration::getDebugTags());
+      std::exit(0);
     }
 
     throw OptionException(std::string("debug tag ") + optarg

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -413,14 +413,8 @@ static std::string suggestTags(const std::vector<std::string>& validTags,
                                const std::vector<std::string>& additionalTags)
 {
   DidYouMean didYouMean;
-  for (const auto& tag : validTags)
-  {
-    didYouMean.addWord(tag);
-  }
-  for (const auto& tag : additionalTags)
-  {
-    didYouMean.addWord(tag);
-  }
+  didYouMean.addWords(validTags);
+  didYouMean.addWords(additionalTags);
   return didYouMean.getMatchAsString(inputTag);
 }
 
@@ -432,7 +426,7 @@ void OptionsHandler::enableTraceTag(const std::string& option,
   {
     throw OptionException("trace tags not available in non-tracing builds");
   }
-  else if(!Configuration::isTraceTag(optarg.c_str()))
+  else if(!Configuration::isTraceTag(optarg))
   {
     if (optarg == "help")
     {
@@ -460,8 +454,8 @@ void OptionsHandler::enableDebugTag(const std::string& option,
     throw OptionException("debug tags not available in non-tracing builds");
   }
 
-  if (!Configuration::isDebugTag(optarg.c_str())
-      && !Configuration::isTraceTag(optarg.c_str()))
+  if (!Configuration::isDebugTag(optarg)
+      && !Configuration::isTraceTag(optarg))
   {
     if (optarg == "help")
     {


### PR DESCRIPTION
This PR refactors the internal tag suggestion mechanism to no longer rely on C-style char arrays, but use a C++ vector of strings instead.