### PR TITLE
Add anchors to cmdline options

### DIFF
--- a/src/options/mkoptions.py
+++ b/src/options/mkoptions.py
@@ -784,6 +784,7 @@ def _sphinx_help_add(module, option, common, others):
             modes[data[0]['name']] = data[0].get('help', '')
 
     data = {
+        'long_name': option.long_name,
         'name': names,
         'help': option.help,
         'expert': option.category == 'expert',
@@ -805,6 +806,8 @@ def _sphinx_help_render_option(res, opt):
     indent = ' ' * 4
     desc = '``{}``'
     val = indent + '{}'
+    res.append('.. _lbl-option-{}:'.format(opt['long_name']))
+    res.append('')
     if opt['expert']:
         res.append('.. admonition:: This option is intended for Experts only!')
         res.append(indent)


### PR DESCRIPTION
This PR adds anchors to the auto-generates command line option documentation. This allows to link to specific options from other parts of the documentation.