### PR TITLE
Alethe: Add helper function to remove attributes

### DIFF
--- a/src/proof/alethe/alethe_post_processor.cpp
+++ b/src/proof/alethe/alethe_post_processor.cpp
@@ -24,8 +24,8 @@ namespace cvc5 {
 
 namespace proof {
 
-// This function removes all attributes contained in the list of attributes from
-// a Node res while only recursively updating the node further if
+// This function removes all attributes contained in a given list of attributes
+// from a Node res while only recursively updating the node further if
 // continueRemoval is true.
 static Node removeAttributes(Node res,
                              const std::vector<Kind>& attributes,

--- a/src/proof/alethe/alethe_post_processor.cpp
+++ b/src/proof/alethe/alethe_post_processor.cpp
@@ -1,0 +1,57 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Hanna Lachnitt, Haniel Barbosa
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2021 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The module for processing proof nodes into Alethe proof nodes
+ */
+
+#include "proof/alethe/alethe_post_processor.h"
+
+#include "expr/node_algorithm.h"
+#include "proof/proof.h"
+#include "proof/proof_checker.h"
+#include "util/rational.h"
+
+namespace cvc5 {
+
+namespace proof {
+
+// This function removes all attributes contained in the list of attributes from
+// a Node res while only recursively updating the node further if
+// continueRemoval is true.
+static Node removeAttributes(Node res,
+                             const std::vector<Kind>& attributes,
+                             bool (*continueRemoval)(Node))
+{
+  if (res.getNumChildren() != 0)
+  {
+    std::vector<Node> new_children;
+    if (res.hasOperator())
+    {
+      new_children.push_back(res.getOperator());
+    }
+    for (int i = 0; i < res.end() - res.begin(); i++)
+    {
+      if (std::find(attributes.begin(), attributes.end(), res[i].getKind())
+          == attributes.end())
+      {
+        new_children.push_back(
+            proof::removeAttributes(res[i], attributes, continueRemoval));
+      }
+    }
+    return NodeManager::currentNM()->mkNode(res.getKind(), new_children);
+  }
+  return res;
+}
+
+}  // namespace proof
+
+}  // namespace cvc5

--- a/src/proof/alethe/alethe_post_processor.cpp
+++ b/src/proof/alethe/alethe_post_processor.cpp
@@ -38,13 +38,13 @@ static Node removeAttributes(Node res,
     {
       new_children.push_back(res.getOperator());
     }
-    for (int i = 0; i < res.end() - res.begin(); i++)
+    for (Node r : res)
     {
-      if (std::find(attributes.begin(), attributes.end(), res[i].getKind())
+      if (std::find(attributes.begin(), attributes.end(), r.getKind())
           == attributes.end())
       {
         new_children.push_back(
-            proof::removeAttributes(res[i], attributes, continueRemoval));
+            proof::removeAttributes(r, attributes, continueRemoval));
       }
     }
     return NodeManager::currentNM()->mkNode(res.getKind(), new_children);


### PR DESCRIPTION
This function is later used to remove nodes with the kind INST_PATTERN and INST_PATTERN_LIST from a node.

Should this be renamed?

Co-authored-by: Haniel Barbosa <hanielbbarbosa@gmail.com>