### PR TITLE
a quick fix on solver_black unit test

### DIFF
--- a/test/unit/api/solver_black.cpp
+++ b/test/unit/api/solver_black.cpp
@@ -1496,7 +1496,7 @@ TEST_F(TestApiBlackSolver, getDifficulty3)
   std::map<Term, Term> dmap;
   ASSERT_NO_THROW(dmap = d_solver.getDifficulty());
   // difficulty should map assertions to integer values
-  for (const std::pair<Term, Term>& t : dmap)
+  for (const std::pair<const Term, Term>& t : dmap)
   {
     ASSERT_TRUE(t.first == f0 || t.first == f1);
     ASSERT_TRUE(t.second.getKind() == CONST_RATIONAL);


### PR DESCRIPTION
In file `test/unit/api/solver_black.cpp` line 1499, 
`for (const std::pair<Term, Term>& t : dmap)` is not the correct way of iterating through the element pairs, 
it should be `for (const std::pair<const Term, Term>& t : dmap)` as the keys are immutable. 
This triggers a warning on LLVM clang 12.0.1 (not AppleClang) on macOS. 
