### PR TITLE
Update large-model.smt2 to use regular sed syntax

### DIFF
--- a/test/regress/regress0/strings/large-model.smt2
+++ b/test/regress/regress0/strings/large-model.smt2
@@ -1,5 +1,5 @@
 ; COMMAND-LINE: --lang=smt2.6 --check-models
-; SCRUBBER: sed -E 's/of length [0-9]+/of length LENGTH/'
+; SCRUBBER: sed 's/of length [0-9]\+/of length LENGTH/'
 ; EXPECT: (error "The model was computed to have strings of length LENGTH. We only allow strings up to length 4294967295")
 ; EXIT: 1
 (set-logic SLIA)


### PR DESCRIPTION
On some older systems sed does not accept the `-E` option. This uses the non-extended syntax to match the digits.