### PR TITLE
contrib: Fix check for get-script-header.sh.

### DIFF
--- a/contrib/get-script-header.sh
+++ b/contrib/get-script-header.sh
@@ -12,7 +12,7 @@ INSTALL_BIN_DIR="$INSTALL_DIR/bin"
 
 mkdir -p "$DEPS_DIR"
 
-if ! [ -e src/parser/cvc/Cvc.g ]; then
+if ! [ -e src/parser/smt2/Smt2.g ]; then
   echo "$(basename $0): I expect to be in the contrib/ of a cvc5 source tree," >&2
   echo "but apparently:" >&2
   echo >&2


### PR DESCRIPTION
PR #7219 removed CVC language support and therefore also the file `src/parser/cvc/Cvc.g`. This commit fixes the check (and the nightlies).