### PR TITLE
Update `--lang=help`

### DIFF
--- a/src/main/options_template.cpp
+++ b/src/main/options_template.cpp
@@ -66,7 +66,6 @@ static const std::string languageDescription =
     "\
 Languages currently supported as arguments to the -L / --lang option:\n\
   auto                           attempt to automatically determine language\n\
-  cvc | presentation | pl        CVC presentation language\n\
   smt | smtlib | smt2 |\n\
   smt2.6 | smtlib2.6             SMT-LIB format 2.6 with support for the strings standard\n\
   tptp                           TPTP format (cnf, fof and tff)\n\
@@ -74,7 +73,6 @@ Languages currently supported as arguments to the -L / --lang option:\n\
 \n\
 Languages currently supported as arguments to the --output-lang option:\n\
   auto                           match output language to input language\n\
-  cvc | presentation | pl        CVC presentation language\n\
   smt | smtlib | smt2 |\n\
   smt2.6 | smtlib2.6             SMT-LIB format 2.6 with support for the strings standard\n\
   tptp                           TPTP format\n\


### PR DESCRIPTION
Support for the CVC language was removed in #7219 but the help message
for languages was not updated. This removes the mention of CVC from the
help message.