### PR TITLE
Execute `set-option` commands in parse-only mode

### DIFF
--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -205,7 +205,11 @@ bool solverInvoke(api::Solver* solver,
     cmd->toStream(ss);
   }
 
-  if (solver->getOptionInfo("parse-only").boolValue())
+  // In parse-only mode, we do not execute any of the commands except
+  // set-option commands. We execute set-option commands because the parser may
+  // rely on the options to determine which symbols are defined.
+  if (solver->getOptionInfo("parse-only").boolValue()
+      && dynamic_cast<SetOptionCommand*>(cmd) == nullptr)
   {
     return true;
   }

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -784,6 +784,7 @@ set(regress_0_tests
   regress0/parser/linear_arithmetic_err3.smt2
   regress0/parser/named-attr-error.smt2
   regress0/parser/named-attr.smt2
+  regress0/parser/parse-only.smt2
   regress0/parser/shadow_fun_symbol_all.smt2
   regress0/parser/shadow_fun_symbol_nirat.smt2
   regress0/parser/strings20.smt2

--- a/test/regress/regress0/parser/parse-only.smt2
+++ b/test/regress/regress0/parser/parse-only.smt2
@@ -1,0 +1,9 @@
+; EXIT: 0
+; COMMAND-LINE: --parse-only
+(set-logic QF_ABV)
+(set-option :arrays-exp true)
+(declare-fun a1 () (Array (_ BitVec 2) (_ BitVec 2)))
+(declare-fun a2 () (Array (_ BitVec 2) (_ BitVec 2)))
+(assert (eqrange a1 a2 #b00 #b01))
+(assert (eqrange a1 a2 #b11 #b11))
+(check-sat)


### PR DESCRIPTION
Under some circumstances, the parser relies on options to determine
which symbols are defined. In parse-only mode, we were not executing
_any_ commands, which lead to spurious parse failures in `--parse-only`
mode (see regression in this commit). This fixes the issue by always
executing commands that set options.