### PR TITLE
Properly restrict PBE symmetry breaking for abduction queries

### DIFF
--- a/src/smt/abduction_solver.cpp
+++ b/src/smt/abduction_solver.cpp
@@ -69,8 +69,6 @@ bool AbductionSolver::getAbduct(const std::vector<Node>& axioms,
   // enable everything needed for sygus
   l.enableSygus();
   d_subsolver->setLogic(l);
-  // options that are not compatible with abduction
-  d_subsolver->setOption("sygus-sym-break-pbe", "false");
   // assert the abduction query
   d_subsolver->assertFormula(aconj);
   return getAbductInternal(axioms, abd);

--- a/src/smt/abduction_solver.cpp
+++ b/src/smt/abduction_solver.cpp
@@ -53,7 +53,7 @@ bool AbductionSolver::getAbduct(const std::vector<Node>& axioms,
   conjn = conjn.negate();
   d_abdConj = conjn;
   asserts.push_back(conjn);
-  std::string name("A");
+  std::string name("__internal_abduct");
   Node aconj = quantifiers::SygusAbduct::mkAbductionConjecture(
       name, asserts, axioms, grammarType);
   // should be a quantified conjecture with one function-to-synthesize

--- a/src/smt/abduction_solver.cpp
+++ b/src/smt/abduction_solver.cpp
@@ -69,6 +69,8 @@ bool AbductionSolver::getAbduct(const std::vector<Node>& axioms,
   // enable everything needed for sygus
   l.enableSygus();
   d_subsolver->setLogic(l);
+  // options that are not compatible with abduction
+  d_subsolver->setOption("sygus-sym-break-pbe", "false");
   // assert the abduction query
   d_subsolver->assertFormula(aconj);
   return getAbductInternal(axioms, abd);

--- a/src/smt/interpolation_solver.cpp
+++ b/src/smt/interpolation_solver.cpp
@@ -51,7 +51,7 @@ bool InterpolationSolver::getInterpol(const std::vector<Node>& axioms,
                           << std::endl;
   // must expand definitions
   Node conjn = d_env.getTopLevelSubstitutions().apply(conj);
-  std::string name("A");
+  std::string name("__internal_interpol");
 
   quantifiers::SygusInterpol interpolSolver(d_env);
   if (interpolSolver.solveInterpolation(

--- a/src/theory/quantifiers/sygus/sygus_enumerator_callback.cpp
+++ b/src/theory/quantifiers/sygus/sygus_enumerator_callback.cpp
@@ -46,7 +46,7 @@ bool SygusEnumeratorCallback::addTerm(Node n, std::unordered_set<Node>& bterms)
   // First, must be unique up to rewriting
   if (bterms.find(bnr) != bterms.end())
   {
-    Trace("sygus-enum-exc") << "Exclude: " << bn << std::endl;
+    Trace("sygus-enum-exc") << "Exclude (by rewriting): " << bn << std::endl;
     return false;
   }
   // insert to builtin term cache, regardless of whether it is redundant
@@ -55,8 +55,6 @@ bool SygusEnumeratorCallback::addTerm(Node n, std::unordered_set<Node>& bterms)
   // callback-specific add term
   if (!addTermInternal(n, bn, bnr))
   {
-    Trace("sygus-enum-exc")
-        << "Exclude: " << bn << " due to callback" << std::endl;
     return false;
   }
   Trace("sygus-enum-terms") << "tc(" << d_tn << "): term " << bn << std::endl;

--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -64,7 +64,7 @@ SynthConjecture::SynthConjecture(Env& env,
       d_ceg_proc(new SynthConjectureProcess),
       d_ceg_gc(new CegGrammarConstructor(d_tds, this)),
       d_sygus_rconst(new SygusRepairConst(env, d_tds)),
-      d_exampleInfer(new ExampleInfer(d_tds)),
+      d_exampleInfer(options().datatypes.sygusSymBreakPbe ? new ExampleInfer(d_tds) : nullptr),
       d_ceg_pbe(new SygusPbe(env, qs, qim, d_tds, this)),
       d_ceg_cegis(new Cegis(env, qs, qim, d_tds, this)),
       d_ceg_cegisUnif(new CegisUnif(env, qs, qim, d_tds, this)),
@@ -204,7 +204,7 @@ void SynthConjecture::assign(Node q)
     }
   }
   // initialize the example inference utility
-  if (!d_exampleInfer->initialize(d_base_inst, d_candidates))
+  if (d_exampleInfer!=nullptr && !d_exampleInfer->initialize(d_base_inst, d_candidates))
   {
     // there is a contradictory example pair, the conjecture is infeasible.
     Node infLem = d_feasible_guard.negate();
@@ -761,7 +761,7 @@ EnumValueManager* SynthConjecture::getEnumValueManagerFor(Node e)
   }
   // otherwise, allocate it
   Node f = d_tds->getSynthFunForEnumerator(e);
-  bool hasExamples = (d_exampleInfer->hasExamples(f)
+  bool hasExamples = (d_exampleInfer != nullptr && d_exampleInfer->hasExamples(f)
                       && d_exampleInfer->getNumExamples(f) != 0);
   d_enumManager[e].reset(new EnumValueManager(
       d_env, d_qstate, d_qim, d_treg, d_stats, e, hasExamples));

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -2283,6 +2283,7 @@ set(regress_1_tests
   regress1/sygus/abd-simple-conj-4.smt2
   regress1/sygus/abduction_1255.corecstrs.readable.smt2
   regress1/sygus/abduction_streq.readable.smt2
+  regress1/sygus/abduction-no-pbe-sym-break.smt2
   regress1/sygus/abv.sy
   regress1/sygus/array-grammar-store.sy
   regress1/sygus/array_search_5-Q-easy.sy

--- a/test/regress/regress1/sygus/abduction-no-pbe-sym-break.smt2
+++ b/test/regress/regress1/sygus/abduction-no-pbe-sym-break.smt2
@@ -1,0 +1,11 @@
+; COMMAND-LINE: --produce-abducts
+; SCRUBBER: grep -v -E '(\(define-fun)'
+; EXIT: 0
+
+(set-logic UF)
+(set-option :produce-abducts true)
+(declare-const A Bool)
+(declare-const B Bool)
+(declare-const C Bool)
+(assert (=> A C))
+(get-abduct D (=> A B)); ((Start Bool)) ((Start Bool ((=> C B)))))

--- a/test/regress/regress1/sygus/abduction-no-pbe-sym-break.smt2
+++ b/test/regress/regress1/sygus/abduction-no-pbe-sym-break.smt2
@@ -8,4 +8,4 @@
 (declare-const B Bool)
 (declare-const C Bool)
 (assert (=> A C))
-(get-abduct D (=> A B)); ((Start Bool)) ((Start Bool ((=> C B)))))
+(get-abduct D (=> A B))


### PR DESCRIPTION
This ensures we infer when a conjecture is PBE based on the conjecture *plus* the side condition for abduction.  This fixes issues where the sygus solver was over-pruning solutions for abduction queries.

It also changes the names of internal symbols used for abduction/interpolation queries. These names are used when the experimental `sygus-stream` is used.  These symbols are changed (from `"A"`) to avoid confusion with user symbols.