### PR TITLE
Enable static builds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,20 +6,20 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: ubuntu:production
+          - name: ubuntu:production-static
             os: ubuntu-latest
-            config: production --auto-download --all-bindings --editline --docs
-            cache-key: production
+            config: production --auto-download --all-bindings --editline --docs --static
+            cache-key: production-static
             python-bindings: true
             build-documentation: true
             check-examples: true
             exclude_regress: 3-4
             run_regression_args: --no-check-unsat-cores --no-check-proofs
 
-          - name: macos:production
+          - name: macos:production-static
             os: macos-11
-            config: production --auto-download --all-bindings --editline
-            cache-key: production
+            config: production --auto-download --all-bindings --editline --static
+            cache-key: production-static
             python-bindings: true
             check-examples: true
             exclude_regress: 3-4
@@ -64,10 +64,12 @@ jobs:
         sudo apt-get install -y \
           build-essential \
           ccache \
+          libbsd-dev \
           libcln-dev \
+          libedit-dev \
           libgmp-dev \
           libgtest-dev \
-          libedit-dev \
+          libtinfo-dev \
           flex \
           libfl-dev \
           flexc++


### PR DESCRIPTION
This PR modifies our CI builds to have two static production builds. These binaries will be used as release artifacts later.