### PR TITLE
No longer build docs by default. Use make docs.

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -239,8 +239,6 @@ Building the API documentation of cvc5 requires the following dependencies:
 
 To build the documentation, configure cvc5 with ``./configure.sh --docs`` and
 run ``make docs`` from within the build directory.
-Note that, for various reasons, building the documentation may first need to
-build cvc5 itself as well.
 
 The API documentation can then be found at
 ``<build_dir>/docs/sphinx/index.html``.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -237,14 +237,13 @@ Building the API documentation of cvc5 requires the following dependencies:
   `sphinxcontrib-bibtex <https://sphinxcontrib-bibtex.readthedocs.io>`_
 - `Breathe <https://breathe.readthedocs.io>`_
 
-To build the documentation, configure cvc5 with ``./configure.sh --docs``.
-Building cvc5 will then include building the API documentation.
+To build the documentation, configure cvc5 with ``./configure.sh --docs`` and
+run ``make docs`` from within the build directory.
+Note that, for various reasons, building the documentation may first need to
+build cvc5 itself as well.
 
 The API documentation can then be found at
 ``<build_dir>/docs/sphinx/index.html``.
-
-To only build the documentation, change to the build directory and call
-``make docs``.
 
 To build the documentation for GitHub pages, change to the build directory and
 call ``make docs-gh``. The content of directory ``<build_dir>/docs/sphinx-gh``

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -25,7 +25,7 @@ set(SPHINX_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/sphinx)
 configure_file(conf.py.in ${CMAKE_CURRENT_BINARY_DIR}/conf.py)
 
 add_custom_target(
-  docs ALL
+  docs
   DEPENDS docs-cpp docs-java docs-python gen-options
   COMMAND
     ${SPHINX_EXECUTABLE} -b html -c ${CMAKE_CURRENT_BINARY_DIR}
@@ -46,7 +46,7 @@ add_custom_command(
 
 set(SPHINX_GH_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/sphinx-gh)
 add_custom_target(
-  docs-gh ALL
+  docs-gh
   DEPENDS docs
   # remove existing sphinx-gh/ directory
   COMMAND ${CMAKE_COMMAND} -E remove_directory ${SPHINX_GH_OUTPUT_DIR}

--- a/docs/api/cpp/CMakeLists.txt
+++ b/docs/api/cpp/CMakeLists.txt
@@ -39,7 +39,7 @@ add_custom_command(
           ${PROJECT_SOURCE_DIR}/src/api/cpp/cvc5_kind.h
   COMMENT "Generating doxygen API docs"
 )
-add_custom_target(docs-cpp ALL DEPENDS ${DOXYGEN_INDEX_FILE})
+add_custom_target(docs-cpp DEPENDS ${DOXYGEN_INDEX_FILE})
 
 # tell parent scope where to find the output xml
 set(CPP_DOXYGEN_XML_DIR


### PR DESCRIPTION
This PR changes our policy when to build the documentation. Beforehand, `make docs` was included in `make` and `make all`.
Now, you need to run `make docs` explicitly.