### PR TITLE
Add missing methods to Solver.java

### DIFF
--- a/src/api/cpp/cvc5.h
+++ b/src/api/cpp/cvc5.h
@@ -2623,7 +2623,7 @@ class CVC5_EXPORT DriverOptions
 
 /**
  * Holds some description about a particular option, including its name, its
- * aliases, whether the option was explcitly set by the user, and information
+ * aliases, whether the option was explicitly set by the user, and information
  * concerning its value. The `valueInfo` member holds any of the following
  * alternatives:
  * - VoidInfo if the option holds no value (or the value has no native type)

--- a/src/api/java/CMakeLists.txt
+++ b/src/api/java/CMakeLists.txt
@@ -50,15 +50,18 @@ include(UseJava)
 set(JAVA_FILES
   ${CMAKE_CURRENT_LIST_DIR}/cvc5/AbstractPointer.java
   ${CMAKE_CURRENT_LIST_DIR}/cvc5/CVC5ApiException.java
+  ${CMAKE_CURRENT_LIST_DIR}/cvc5/CVC5ApiOptionException.java
   ${CMAKE_CURRENT_LIST_DIR}/cvc5/CVC5ApiRecoverableException.java
   ${CMAKE_CURRENT_LIST_DIR}/cvc5/Datatype.java
   ${CMAKE_CURRENT_LIST_DIR}/cvc5/DatatypeConstructor.java
   ${CMAKE_CURRENT_LIST_DIR}/cvc5/DatatypeConstructorDecl.java
   ${CMAKE_CURRENT_LIST_DIR}/cvc5/DatatypeDecl.java
   ${CMAKE_CURRENT_LIST_DIR}/cvc5/DatatypeSelector.java
+  ${CMAKE_CURRENT_LIST_DIR}/cvc5/DriverOptions.java
   ${CMAKE_CURRENT_LIST_DIR}/cvc5/Grammar.java
   ${CMAKE_CURRENT_LIST_DIR}/cvc5/IPointer.java
   ${CMAKE_CURRENT_LIST_DIR}/cvc5/Op.java
+  ${CMAKE_CURRENT_LIST_DIR}/cvc5/OptionInfo.java
   ${CMAKE_CURRENT_LIST_DIR}/cvc5/Pair.java
   ${CMAKE_CURRENT_LIST_DIR}/cvc5/Result.java
   ${CMAKE_CURRENT_LIST_DIR}/cvc5/RoundingMode.java
@@ -114,12 +117,15 @@ add_library(cvc5jni SHARED
   jni/cvc5_DatatypeSelector.cpp
   jni/cvc5_Grammar.cpp
   jni/cvc5_Op.cpp
+  jni/cvc5_OptionInfo.cpp
   jni/cvc5_Result.cpp
   jni/cvc5_Solver.cpp
   jni/cvc5_Sort.cpp
   jni/cvc5_Stat.cpp
   jni/cvc5_Statistics.cpp
-  jni/cvc5_Term.cpp)
+  jni/cvc5_Term.cpp
+  jni/cvc5JavaApi.cpp)
+
 add_dependencies(cvc5jni generate-jni-headers)
 
 target_include_directories(cvc5jni PUBLIC ${JNI_INCLUDE_DIRS})

--- a/src/api/java/CMakeLists.txt
+++ b/src/api/java/CMakeLists.txt
@@ -115,6 +115,7 @@ add_library(cvc5jni SHARED
   jni/cvc5_DatatypeConstructorDecl.cpp
   jni/cvc5_DatatypeDecl.cpp
   jni/cvc5_DatatypeSelector.cpp
+  jni/cvc5_DriverOptions.cpp
   jni/cvc5_Grammar.cpp
   jni/cvc5_Op.cpp
   jni/cvc5_OptionInfo.cpp

--- a/src/api/java/cvc5/CVC5ApiOptionException.java
+++ b/src/api/java/cvc5/CVC5ApiOptionException.java
@@ -1,0 +1,24 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Gereon Kremer, Mudathir Mohamed
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2021 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The cvc5 java API.
+ */
+
+package cvc5;
+
+public class CVC5ApiOptionException extends CVC5ApiRecoverableException
+{
+  public CVC5ApiOptionException(String message)
+  {
+    super(message);
+  }
+}

--- a/src/api/java/cvc5/DatatypeSelector.java
+++ b/src/api/java/cvc5/DatatypeSelector.java
@@ -69,7 +69,7 @@ public class DatatypeSelector extends AbstractPointer
 
   private native long getUpdaterTerm(long pointer);
 
-  /** @return the range sort of this argument. */
+  /** @return the range sort of this selector. */
   Sort getRangeSort()
   {
     long sortPointer = getRangeSort(pointer);

--- a/src/api/java/cvc5/DriverOptions.java
+++ b/src/api/java/cvc5/DriverOptions.java
@@ -1,0 +1,63 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Gereon Kremer, Mudathir Mohamed
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2021 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The cvc5 java API.
+ */
+
+package cvc5;
+
+import java.util.Optional;
+
+/**
+ * Holds some description about a particular option, including its name, its
+ * aliases, whether the option was explicitly set by the user, and information
+ * concerning its value. The `valueInfo` member holds any of the following
+ * alternatives:
+ * - VoidInfo if the option holds no value (or the value has no native type)
+ * - ValueInfo<T> if the option is of type boolean or String, holds the
+ *   current value and the default value.
+ * - NumberInfo<T> if the option is of type BigInteger or double, holds
+ *   the current and default value, as well as the minimum and maximum.
+ * - ModeInfo if the option is a mode option, holds the current and default
+ *   values, as well as a list of valid modes.
+ * Additionally, this class provides convenience functions to obtain the
+ * current value of an option in a type-safe manner using boolValue(),
+ * stringValue(), intValue(), and doubleValue(). They assert that
+ * the option has the respective type and return the current value.
+ */
+public class DriverOptions extends AbstractPointer
+{
+  // region construction and destruction
+  DriverOptions(Solver solver, long pointer)
+  {
+    super(solver, pointer);
+  }
+
+  protected static native void deletePointer(long pointer);
+
+  public long getPointer()
+  {
+    return pointer;
+  }
+
+  @Override public void finalize()
+  {
+    deletePointer(pointer);
+  }
+
+  /**
+   * @return a string representation of this optionInfo.
+   */
+  protected native String toString(long pointer);
+
+  // endregion
+};

--- a/src/api/java/cvc5/DriverOptions.java
+++ b/src/api/java/cvc5/DriverOptions.java
@@ -15,24 +15,11 @@
 
 package cvc5;
 
-import java.util.Optional;
-
 /**
- * Holds some description about a particular option, including its name, its
- * aliases, whether the option was explicitly set by the user, and information
- * concerning its value. The `valueInfo` member holds any of the following
- * alternatives:
- * - VoidInfo if the option holds no value (or the value has no native type)
- * - ValueInfo<T> if the option is of type boolean or String, holds the
- *   current value and the default value.
- * - NumberInfo<T> if the option is of type BigInteger or double, holds
- *   the current and default value, as well as the minimum and maximum.
- * - ModeInfo if the option is a mode option, holds the current and default
- *   values, as well as a list of valid modes.
- * Additionally, this class provides convenience functions to obtain the
- * current value of an option in a type-safe manner using boolValue(),
- * stringValue(), intValue(), and doubleValue(). They assert that
- * the option has the respective type and return the current value.
+ * Provides access to options that can not be communicated via the regular
+ * getOption() or getOptionInfo() methods. This class does not store the options
+ * itself, but only acts as a wrapper to the solver object. It can thus no
+ * longer be used after the solver object has been destroyed.
  */
 public class DriverOptions extends AbstractPointer
 {
@@ -57,7 +44,10 @@ public class DriverOptions extends AbstractPointer
   /**
    * @return a string representation of this optionInfo.
    */
-  protected native String toString(long pointer);
+  protected String toString(long pointer)
+  {
+    throw new UnsupportedOperationException();
+  }
 
   // endregion
 };

--- a/src/api/java/cvc5/OptionInfo.java
+++ b/src/api/java/cvc5/OptionInfo.java
@@ -1,0 +1,210 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Gereon Kremer, Mudathir Mohamed
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2021 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The cvc5 java API.
+ */
+
+package cvc5;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+/**
+ * Holds some description about a particular option, including its name, its
+ * aliases, whether the option was explicitly set by the user, and information
+ * concerning its value. The `valueInfo` member holds any of the following
+ * alternatives:
+ * - VoidInfo if the option holds no value (or the value has no native type)
+ * - ValueInfo<T> if the option is of type boolean or String, holds the
+ *   current value and the default value.
+ * - NumberInfo<T> if the option is of type BigInteger or double, holds
+ *   the current and default value, as well as the minimum and maximum.
+ * - ModeInfo if the option is a mode option, holds the current and default
+ *   values, as well as a list of valid modes.
+ * Additionally, this class provides convenience functions to obtain the
+ * current value of an option in a type-safe manner using boolValue(),
+ * stringValue(), intValue(), and doubleValue(). They assert that
+ * the option has the respective type and return the current value.
+ */
+public class OptionInfo extends AbstractPointer
+{
+  // region construction and destruction
+  OptionInfo(Solver solver, long pointer)
+  {
+    super(solver, pointer);
+    this.name = getName(pointer);
+    this.aliases = getAliases(pointer);
+    this.setByUser = getSetByUser(pointer);
+    this.valueInfo = getValueInfo(pointer);
+  }
+
+  protected static native void deletePointer(long pointer);
+
+  public long getPointer()
+  {
+    return pointer;
+  }
+
+  @Override public void finalize()
+  {
+    deletePointer(pointer);
+  }
+
+  /**
+   * @return a string representation of this optionInfo.
+   */
+  protected native String toString(long pointer);
+
+  // endregion
+
+  private native String getName(long pointer);
+
+  private native String[] getAliases(long pointer);
+
+  private native boolean getSetByUser(long pointer);
+
+  private native ValueInfo getValueInfo(long pointer);
+
+  /** Has no value information */
+  public class VoidInfo extends ValueInfo<Object>
+  {
+    public VoidInfo()
+    {
+      super(null, null);
+    }
+  }
+
+  /** Has the current and the default value */
+  public abstract class ValueInfo<T>
+  {
+    private final T defaultValue;
+    private final T currentValue;
+    public ValueInfo(T defaultValue, T currentValue)
+    {
+      this.defaultValue = defaultValue;
+      this.currentValue = currentValue;
+    }
+    public T getDefaultValue()
+    {
+      return defaultValue;
+    }
+    public T getCurrentValue()
+    {
+      return currentValue;
+    }
+  }
+
+  /** Default value, current value, minimum and maximum of a numeric value */
+  public class NumberInfo<T> extends ValueInfo<T>
+  {
+    private final T minimum;
+    private final T maximum;
+    public NumberInfo(T defaultValue, T currentValue, T minimum, T maximum)
+    {
+      super(defaultValue, currentValue);
+      this.minimum = minimum;
+      this.maximum = maximum;
+    }
+    public T getMinimum()
+    {
+      return minimum;
+    }
+    public T getMaximum()
+    {
+      return maximum;
+    }
+  }
+
+  /** Default value, current value and choices of a mode option */
+  public class ModeInfo extends ValueInfo<String>
+  {
+    private final String[] modes;
+
+    public ModeInfo(String defaultValue, String currentValue, String[] modes)
+    {
+      super(defaultValue, currentValue);
+      this.modes = modes;
+    }
+    public String[] getModes()
+    {
+      return modes;
+    }
+  }
+
+  /** The option name */
+  private final String name;
+  public String getName()
+  {
+    return name;
+  }
+  /** The option name aliases */
+  private final String[] aliases;
+  public String[] getAliases()
+  {
+    return aliases;
+  }
+  /** Whether the option was explicitly set by the user */
+  private final boolean setByUser;
+  public boolean getSetByUser()
+  {
+    return setByUser;
+  }
+
+  /** The option value information */
+  private final ValueInfo valueInfo;
+  public ValueInfo getValueInfo()
+  {
+    return valueInfo;
+  }
+
+  /**
+   * Obtain the current value as a boolean. Asserts that valueInfo holds a boolean.
+   */
+  public boolean booleanValue()
+  {
+    return booleanValue(pointer);
+  }
+
+  private native boolean booleanValue(long pointer);
+
+  /**
+   * Obtain the current value as a string. Asserts that valueInfo holds a
+   * string.
+   */
+  public String stringValue()
+  {
+    return stringValue(pointer);
+  }
+
+  private native String stringValue(long pointer);
+
+  /**
+   * Obtain the current value as as int. Asserts that valueInfo holds an int.
+   */
+  public BigInteger intValue()
+  {
+    return intValue(pointer);
+  }
+
+  private native BigInteger intValue(long pointer);
+
+  /**
+   * Obtain the current value as a double. Asserts that valueInfo holds a
+   * double.
+   */
+  public double doubleValue()
+  {
+    return doubleValue(pointer);
+  }
+
+  private native double doubleValue(long pointer);
+};

--- a/src/api/java/cvc5/Term.java
+++ b/src/api/java/cvc5/Term.java
@@ -19,7 +19,6 @@ import java.math.BigInteger;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.math.BigInteger;
 
 public class Term extends AbstractPointer implements Comparable<Term>, Iterable<Term>
 {

--- a/src/api/java/jni/cvc5JavaApi.cpp
+++ b/src/api/java/jni/cvc5JavaApi.cpp
@@ -31,3 +31,12 @@ jobjectArray getStringArrayFromStrings(JNIEnv* env,
   }
   return ret;
 }
+
+jobject getDoubleObject(JNIEnv* env, double cValue)
+{
+  jdouble jValue = static_cast<jdouble>(cValue);
+  jclass doubleClass = env->FindClass("java/lang/Double");
+  jmethodID methodId = env->GetMethodID(doubleClass, "<init>", "(D)V");
+  jobject ret = env->NewObject(doubleClass, methodId, jValue);
+  return ret;
+}

--- a/src/api/java/jni/cvc5JavaApi.cpp
+++ b/src/api/java/jni/cvc5JavaApi.cpp
@@ -1,0 +1,33 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Mudathir Mohamed
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2021 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The cvc5 Java API.
+ */
+
+#include "cvc5JavaApi.h"
+
+#include <string>
+#include <vector>
+
+jobjectArray getStringArrayFromStrings(JNIEnv* env,
+                                       const std::vector<std::string>& cStrings)
+{
+  jclass stringClass = env->FindClass("java/lang/String");
+  jobjectArray ret =
+      env->NewObjectArray(cStrings.size(), stringClass, env->NewStringUTF(""));
+  for (size_t i = 0; i < cStrings.size(); i++)
+  {
+    jstring jString = env->NewStringUTF(cStrings[i].c_str());
+    env->SetObjectArrayElement(ret, i, jString);
+  }
+  return ret;
+}

--- a/src/api/java/jni/cvc5JavaApi.cpp
+++ b/src/api/java/jni/cvc5JavaApi.cpp
@@ -18,8 +18,8 @@
 #include <string>
 #include <vector>
 
-jobjectArray getStringArrayFromStrings(JNIEnv* env,
-                                       const std::vector<std::string>& cStrings)
+jobjectArray getStringArrayFromStringVector(
+    JNIEnv* env, const std::vector<std::string>& cStrings)
 {
   jclass stringClass = env->FindClass("java/lang/String");
   jobjectArray ret =

--- a/src/api/java/jni/cvc5JavaApi.cpp
+++ b/src/api/java/jni/cvc5JavaApi.cpp
@@ -40,3 +40,15 @@ jobject getDoubleObject(JNIEnv* env, double cValue)
   jobject ret = env->NewObject(doubleClass, methodId, jValue);
   return ret;
 }
+
+jobject getBooleanObject(JNIEnv* env, bool cValue)
+{
+  jboolean jValue = static_cast<jboolean>(cValue);
+  jclass booleanClass = env->FindClass("Ljava/lang/Boolean;");
+  jmethodID booleanConstructor =
+      env->GetMethodID(booleanClass, "<init>", "(Z)V");
+  jobject currentValue =
+      env->NewObject(booleanClass, booleanConstructor, jValue);
+  jobject ret = env->NewObject(booleanClass, booleanConstructor, jValue);
+  return ret;
+}

--- a/src/api/java/jni/cvc5JavaApi.cpp
+++ b/src/api/java/jni/cvc5JavaApi.cpp
@@ -47,8 +47,6 @@ jobject getBooleanObject(JNIEnv* env, bool cValue)
   jclass booleanClass = env->FindClass("Ljava/lang/Boolean;");
   jmethodID booleanConstructor =
       env->GetMethodID(booleanClass, "<init>", "(Z)V");
-  jobject currentValue =
-      env->NewObject(booleanClass, booleanConstructor, jValue);
   jobject ret = env->NewObject(booleanClass, booleanConstructor, jValue);
   return ret;
 }

--- a/src/api/java/jni/cvc5JavaApi.h
+++ b/src/api/java/jni/cvc5JavaApi.h
@@ -18,6 +18,7 @@
 
 #include <jni.h>
 
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -92,6 +93,21 @@ jlongArray getPointersFromObjects(JNIEnv* env, std::vector<T> objects)
   return ret;
 }
 
+template <class T>
+jobject getBigIntegerObject(JNIEnv* env, T value)
+{
+  std::stringstream ss;
+  ss << value;
+  jstring javaString = env->NewStringUTF(ss.str().c_str());
+  jclass bigIntegerClass = env->FindClass("java/math/BigInteger");
+  jmethodID bigIntegerConstructor =
+      env->GetMethodID(bigIntegerClass, "<init>", "(Ljava/lang/String;)V");
+  jobject ret =
+      env->NewObject(bigIntegerClass, bigIntegerConstructor, javaString);
+  return ret;
+}
+
 jobjectArray getStringArrayFromStrings(
     JNIEnv* env, const std::vector<std::string>& cStrings);
+
 #endif  // CVC5__JAVA_API_H

--- a/src/api/java/jni/cvc5JavaApi.h
+++ b/src/api/java/jni/cvc5JavaApi.h
@@ -120,7 +120,7 @@ jobject getBigIntegerObject(JNIEnv* env, T value)
  * @param cStrings a vector of strings
  * @return an array of java strings
  */
-jobjectArray getStringArrayFromStrings(
+jobjectArray getStringArrayFromStringVector(
     JNIEnv* env, const std::vector<std::string>& cStrings);
 
 /**

--- a/src/api/java/jni/cvc5JavaApi.h
+++ b/src/api/java/jni/cvc5JavaApi.h
@@ -131,4 +131,12 @@ jobjectArray getStringArrayFromStringVector(
  */
 jobject getDoubleObject(JNIEnv* env, double value);
 
+/**
+ * Generate a Boolean object from cpp bool value
+ * @param env jni environment
+ * @param value
+ * @return a Boolean object
+ */
+jobject getBooleanObject(JNIEnv* env, bool value);
+
 #endif  // CVC5__JAVA_API_H

--- a/src/api/java/jni/cvc5JavaApi.h
+++ b/src/api/java/jni/cvc5JavaApi.h
@@ -93,6 +93,13 @@ jlongArray getPointersFromObjects(JNIEnv* env, std::vector<T> objects)
   return ret;
 }
 
+/**
+ * Convert a cpp signed (unsigned) integer to an object of BigInteger class
+ * @tparam T cpp types (int64_t, uint64_t, int32_t, int32_t, etc)
+ * @param env jni environment
+ * @param value cpp integer value
+ * @return an object of java BigInteger
+ */
 template <class T>
 jobject getBigIntegerObject(JNIEnv* env, T value)
 {
@@ -107,7 +114,21 @@ jobject getBigIntegerObject(JNIEnv* env, T value)
   return ret;
 }
 
+/**
+ * Generate an array of java strings from a vector of cpp strings
+ * @param env jni environment
+ * @param cStrings a vector of strings
+ * @return an array of java strings
+ */
 jobjectArray getStringArrayFromStrings(
     JNIEnv* env, const std::vector<std::string>& cStrings);
+
+/**
+ * Generate a Double object from cpp double value
+ * @param env jni environment
+ * @param value
+ * @return a Double object
+ */
+jobject getDoubleObject(JNIEnv* env, double value);
 
 #endif  // CVC5__JAVA_API_H

--- a/src/api/java/jni/cvc5JavaApi.h
+++ b/src/api/java/jni/cvc5JavaApi.h
@@ -13,31 +13,38 @@
  * The cvc5 Java API.
  */
 
-#include <jni.h>
-
 #ifndef CVC5__JAVA_API_H
 #define CVC5__JAVA_API_H
+
+#include <jni.h>
+
+#include <string>
+#include <vector>
 
 #define CVC5_JAVA_API_TRY_CATCH_BEGIN \
   try                                 \
   {
-#define CVC5_JAVA_API_TRY_CATCH_END(env)                             \
-  }                                                                  \
-  catch (const CVC5ApiRecoverableException& e)                       \
-  {                                                                  \
-    jclass exceptionClass =                                          \
-        env->FindClass("cvc5/CVC5ApiRecoverableException");          \
-    env->ThrowNew(exceptionClass, e.what());                         \
-  }                                                                  \
-  catch (const CVC5ApiException& e)                                  \
-  {                                                                  \
-    jclass exceptionClass = env->FindClass("cvc5/CVC5ApiException"); \
-    env->ThrowNew(exceptionClass, e.what());                         \
+#define CVC5_JAVA_API_TRY_CATCH_END(env)                                   \
+  }                                                                        \
+  catch (const CVC5ApiOptionException& e)                                  \
+  {                                                                        \
+    jclass exceptionClass = env->FindClass("cvc5/CVC5ApiOptionException"); \
+    env->ThrowNew(exceptionClass, e.what());                               \
+  }                                                                        \
+  catch (const CVC5ApiRecoverableException& e)                             \
+  {                                                                        \
+    jclass exceptionClass =                                                \
+        env->FindClass("cvc5/CVC5ApiRecoverableException");                \
+    env->ThrowNew(exceptionClass, e.what());                               \
+  }                                                                        \
+  catch (const CVC5ApiException& e)                                        \
+  {                                                                        \
+    jclass exceptionClass = env->FindClass("cvc5/CVC5ApiException");       \
+    env->ThrowNew(exceptionClass, e.what());                               \
   }
 #define CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, returnValue) \
   CVC5_JAVA_API_TRY_CATCH_END(env)                           \
   return returnValue;
-#endif  // CVC5__JAVA_API_H
 
 /**
  * Convert pointers coming from Java to cvc5 objects
@@ -84,3 +91,7 @@ jlongArray getPointersFromObjects(JNIEnv* env, std::vector<T> objects)
   env->SetLongArrayRegion(ret, 0, objects.size(), pointers.data());
   return ret;
 }
+
+jobjectArray getStringArrayFromStrings(
+    JNIEnv* env, const std::vector<std::string>& cStrings);
+#endif  // CVC5__JAVA_API_H

--- a/src/api/java/jni/cvc5JavaApi.h
+++ b/src/api/java/jni/cvc5JavaApi.h
@@ -18,7 +18,6 @@
 
 #include <jni.h>
 
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -103,9 +102,8 @@ jlongArray getPointersFromObjects(JNIEnv* env, std::vector<T> objects)
 template <class T>
 jobject getBigIntegerObject(JNIEnv* env, T value)
 {
-  std::stringstream ss;
-  ss << value;
-  jstring javaString = env->NewStringUTF(ss.str().c_str());
+  std::string s = std::to_string(value);
+  jstring javaString = env->NewStringUTF(s.c_str());
   jclass bigIntegerClass = env->FindClass("java/math/BigInteger");
   jmethodID bigIntegerConstructor =
       env->GetMethodID(bigIntegerClass, "<init>", "(Ljava/lang/String;)V");

--- a/src/api/java/jni/cvc5_DriverOptions.cpp
+++ b/src/api/java/jni/cvc5_DriverOptions.cpp
@@ -1,0 +1,33 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Mudathir Mohamed
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2021 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The cvc5 Java API.
+ */
+
+#include "cvc5_DriverOptions.h"
+
+#include "api/cpp/cvc5.h"
+#include "cvc5JavaApi.h"
+
+using namespace cvc5::api;
+
+/*
+ * Class:     cvc5_DriverOptions
+ * Method:    deletePointer
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_cvc5_DriverOptions_deletePointer(JNIEnv* env,
+                                                             jclass,
+                                                             jlong pointer)
+{
+  delete reinterpret_cast<DriverOptions*>(pointer);
+}

--- a/src/api/java/jni/cvc5_OptionInfo.cpp
+++ b/src/api/java/jni/cvc5_OptionInfo.cpp
@@ -226,6 +226,60 @@ JNIEXPORT jobject JNICALL Java_cvc5_OptionInfo_getValueInfo(JNIEnv* env,
     return ret;
   }
 
+  if (std::holds_alternative<OptionInfo::NumberInfo<double>>(v))
+  {
+    jclass valueInfoClass = env->FindClass("cvc5/OptionInfo$NumberInfo");
+    jmethodID methodId =
+        env->GetMethodID(valueInfoClass,
+                         "<init>",
+                         "(Lcvc5/OptionInfo;Ljava/lang/Object;Ljava/lang/"
+                         "Object;Ljava/lang/Object;Ljava/lang/Object;)V");
+
+    auto info = std::get<OptionInfo::NumberInfo<double>>(v);
+
+    jobject defaultValue = getDoubleObject(env, info.defaultValue);
+    jobject currentValue = getDoubleObject(env, info.currentValue);
+    jobject minimum = nullptr;
+    if (info.minimum)
+    {
+      minimum = getDoubleObject(env, *info.minimum);
+    }
+    jobject maximum = nullptr;
+    if (info.maximum)
+    {
+      maximum = getDoubleObject(env, *info.maximum);
+    }
+    ret = env->NewObject(valueInfoClass,
+                         methodId,
+                         optionInfo,
+                         defaultValue,
+                         currentValue,
+                         minimum,
+                         maximum);
+    return ret;
+  }
+
+  if (std::holds_alternative<OptionInfo::ModeInfo>(v))
+  {
+    auto info = std::get<OptionInfo::ModeInfo>(v);
+    jclass modeInfoClass = env->FindClass("cvc5/OptionInfo$ModeInfo");
+    jmethodID methodId =
+        env->GetMethodID(modeInfoClass,
+                         "<init>",
+                         "(Lcvc5/OptionInfo;Ljava/lang/String;Ljava/lang/"
+                         "String;[Ljava/lang/String;)V");
+    jstring defaultValue = env->NewStringUTF(info.defaultValue.c_str());
+    jstring currentValue = env->NewStringUTF(info.currentValue.c_str());
+    jobject stringArray = getStringArrayFromStrings(env, info.modes);
+    ret = env->NewObject(modeInfoClass,
+                         methodId,
+                         optionInfo,
+                         defaultValue,
+                         currentValue,
+                         stringArray);
+    return ret;
+  }
+
   return ret;
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, nullptr);
 }

--- a/src/api/java/jni/cvc5_OptionInfo.cpp
+++ b/src/api/java/jni/cvc5_OptionInfo.cpp
@@ -115,13 +115,12 @@ JNIEXPORT jobject JNICALL Java_cvc5_OptionInfo_getValueInfo(JNIEnv* env,
                OptionInfo::ModeInfo>
       v = current->valueInfo;
 
-  jobject ret;
   if (std::holds_alternative<OptionInfo::VoidInfo>(v))
   {
     jclass voidInfoClass = env->FindClass("cvc5/OptionInfo$VoidInfo");
     jmethodID methodId =
         env->GetMethodID(voidInfoClass, "<init>", "(Lcvc5/OptionInfo;)V");
-    ret = env->NewObject(voidInfoClass, methodId, optionInfo);
+    jobject ret = env->NewObject(voidInfoClass, methodId, optionInfo);
     return ret;
   }
 
@@ -133,18 +132,10 @@ JNIEXPORT jobject JNICALL Java_cvc5_OptionInfo_getValueInfo(JNIEnv* env,
         valueInfoClass,
         "<init>",
         "(Lcvc5/OptionInfo;Ljava/lang/Object;Ljava/lang/Object;)V");
-    jclass booleanClass = env->FindClass("Ljava/lang/Boolean;");
-    jmethodID booleanConstructor =
-        env->GetMethodID(booleanClass, "<init>", "(Z)V");
-    jobject currentValue =
-        env->NewObject(booleanClass,
-                       booleanConstructor,
-                       static_cast<jboolean>(info.currentValue));
-    jobject defaultValue =
-        env->NewObject(booleanClass,
-                       booleanConstructor,
-                       static_cast<jboolean>(info.defaultValue));
-    ret = env->NewObject(
+
+    jobject currentValue = getBooleanObject(env, info.currentValue);
+    jobject defaultValue = getBooleanObject(env, info.defaultValue);
+    jobject ret = env->NewObject(
         valueInfoClass, methodId, optionInfo, defaultValue, currentValue);
     return ret;
   }
@@ -160,17 +151,18 @@ JNIEXPORT jobject JNICALL Java_cvc5_OptionInfo_getValueInfo(JNIEnv* env,
 
     jstring defaultValue = env->NewStringUTF(info.defaultValue.c_str());
     jstring currentValue = env->NewStringUTF(info.currentValue.c_str());
-    ret = env->NewObject(
+    jobject ret = env->NewObject(
         valueInfoClass, methodId, optionInfo, defaultValue, currentValue);
     return ret;
   }
 
   if (std::holds_alternative<OptionInfo::NumberInfo<int64_t>>(v)
-      || std::holds_alternative<OptionInfo::NumberInfo<uint64_t>>(v))
+      || std::holds_alternative<OptionInfo::NumberInfo<uint64_t>>(v)
+      || std::holds_alternative<OptionInfo::NumberInfo<double>>(v))
   {
-    jclass valueInfoClass = env->FindClass("cvc5/OptionInfo$NumberInfo");
+    jclass numberInfoClass = env->FindClass("cvc5/OptionInfo$NumberInfo");
     jmethodID methodId =
-        env->GetMethodID(valueInfoClass,
+        env->GetMethodID(numberInfoClass,
                          "<init>",
                          "(Lcvc5/OptionInfo;Ljava/lang/Object;Ljava/lang/"
                          "Object;Ljava/lang/Object;Ljava/lang/Object;)V");
@@ -193,70 +185,69 @@ JNIEXPORT jobject JNICALL Java_cvc5_OptionInfo_getValueInfo(JNIEnv* env,
       {
         maximum = getBigIntegerObject<int64_t>(env, *info.maximum);
       }
-      ret = env->NewObject(valueInfoClass,
-                           methodId,
-                           optionInfo,
-                           defaultValue,
-                           currentValue,
-                           minimum,
-                           maximum);
+      jobject ret = env->NewObject(numberInfoClass,
+                                   methodId,
+                                   optionInfo,
+                                   defaultValue,
+                                   currentValue,
+                                   minimum,
+                                   maximum);
       return ret;
     }
 
-    auto info = std::get<OptionInfo::NumberInfo<uint64_t>>(v);
-    jobject defaultValue = getBigIntegerObject<int64_t>(env, info.defaultValue);
-    jobject currentValue = getBigIntegerObject<int64_t>(env, info.currentValue);
-    jobject minimum = nullptr;
-    if (info.minimum)
+    if (std::holds_alternative<OptionInfo::NumberInfo<uint64_t>>(v))
     {
-      minimum = getBigIntegerObject<int64_t>(env, *info.minimum);
-    }
-    jobject maximum = nullptr;
-    if (info.maximum)
-    {
-      maximum = getBigIntegerObject<int64_t>(env, *info.maximum);
-    }
-    ret = env->NewObject(valueInfoClass,
-                         methodId,
-                         optionInfo,
-                         defaultValue,
-                         currentValue,
-                         minimum,
-                         maximum);
-    return ret;
-  }
+      auto info = std::get<OptionInfo::NumberInfo<uint64_t>>(v);
 
-  if (std::holds_alternative<OptionInfo::NumberInfo<double>>(v))
-  {
-    jclass valueInfoClass = env->FindClass("cvc5/OptionInfo$NumberInfo");
-    jmethodID methodId =
-        env->GetMethodID(valueInfoClass,
-                         "<init>",
-                         "(Lcvc5/OptionInfo;Ljava/lang/Object;Ljava/lang/"
-                         "Object;Ljava/lang/Object;Ljava/lang/Object;)V");
-
-    auto info = std::get<OptionInfo::NumberInfo<double>>(v);
-
-    jobject defaultValue = getDoubleObject(env, info.defaultValue);
-    jobject currentValue = getDoubleObject(env, info.currentValue);
-    jobject minimum = nullptr;
-    if (info.minimum)
-    {
-      minimum = getDoubleObject(env, *info.minimum);
+      jobject defaultValue =
+          getBigIntegerObject<uint64_t>(env, info.defaultValue);
+      jobject currentValue =
+          getBigIntegerObject<uint64_t>(env, info.currentValue);
+      jobject minimum = nullptr;
+      if (info.minimum)
+      {
+        minimum = getBigIntegerObject<uint64_t>(env, *info.minimum);
+      }
+      jobject maximum = nullptr;
+      if (info.maximum)
+      {
+        maximum = getBigIntegerObject<uint64_t>(env, *info.maximum);
+      }
+      jobject ret = env->NewObject(numberInfoClass,
+                                   methodId,
+                                   optionInfo,
+                                   defaultValue,
+                                   currentValue,
+                                   minimum,
+                                   maximum);
+      return ret;
     }
-    jobject maximum = nullptr;
-    if (info.maximum)
+
+    if (std::holds_alternative<OptionInfo::NumberInfo<double>>(v))
     {
-      maximum = getDoubleObject(env, *info.maximum);
+      auto info = std::get<OptionInfo::NumberInfo<double>>(v);
+
+      jobject defaultValue = getDoubleObject(env, info.defaultValue);
+      jobject currentValue = getDoubleObject(env, info.currentValue);
+      jobject minimum = nullptr;
+      if (info.minimum)
+      {
+        minimum = getDoubleObject(env, *info.minimum);
+      }
+      jobject maximum = nullptr;
+      if (info.maximum)
+      {
+        maximum = getDoubleObject(env, *info.maximum);
+      }
+      jobject ret = env->NewObject(numberInfoClass,
+                                   methodId,
+                                   optionInfo,
+                                   defaultValue,
+                                   currentValue,
+                                   minimum,
+                                   maximum);
+      return ret;
     }
-    ret = env->NewObject(valueInfoClass,
-                         methodId,
-                         optionInfo,
-                         defaultValue,
-                         currentValue,
-                         minimum,
-                         maximum);
-    return ret;
   }
 
   if (std::holds_alternative<OptionInfo::ModeInfo>(v))
@@ -271,16 +262,16 @@ JNIEXPORT jobject JNICALL Java_cvc5_OptionInfo_getValueInfo(JNIEnv* env,
     jstring defaultValue = env->NewStringUTF(info.defaultValue.c_str());
     jstring currentValue = env->NewStringUTF(info.currentValue.c_str());
     jobject stringArray = getStringArrayFromStringVector(env, info.modes);
-    ret = env->NewObject(modeInfoClass,
-                         methodId,
-                         optionInfo,
-                         defaultValue,
-                         currentValue,
-                         stringArray);
+    jobject ret = env->NewObject(modeInfoClass,
+                                 methodId,
+                                 optionInfo,
+                                 defaultValue,
+                                 currentValue,
+                                 stringArray);
     return ret;
   }
 
-  return ret;
+  return nullptr;
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, nullptr);
 }
 

--- a/src/api/java/jni/cvc5_OptionInfo.cpp
+++ b/src/api/java/jni/cvc5_OptionInfo.cpp
@@ -75,7 +75,7 @@ JNIEXPORT jobjectArray JNICALL Java_cvc5_OptionInfo_getAliases(JNIEnv* env,
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   OptionInfo* current = reinterpret_cast<OptionInfo*>(pointer);
-  jobjectArray ret = getStringArrayFromStrings(env, current->aliases);
+  jobjectArray ret = getStringArrayFromStringVector(env, current->aliases);
   return ret;
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, nullptr);
 }
@@ -270,7 +270,7 @@ JNIEXPORT jobject JNICALL Java_cvc5_OptionInfo_getValueInfo(JNIEnv* env,
                          "String;[Ljava/lang/String;)V");
     jstring defaultValue = env->NewStringUTF(info.defaultValue.c_str());
     jstring currentValue = env->NewStringUTF(info.currentValue.c_str());
-    jobject stringArray = getStringArrayFromStrings(env, info.modes);
+    jobject stringArray = getStringArrayFromStringVector(env, info.modes);
     ret = env->NewObject(modeInfoClass,
                          methodId,
                          optionInfo,

--- a/src/api/java/jni/cvc5_OptionInfo.cpp
+++ b/src/api/java/jni/cvc5_OptionInfo.cpp
@@ -124,36 +124,34 @@ JNIEXPORT jobject JNICALL Java_cvc5_OptionInfo_getValueInfo(JNIEnv* env,
     return ret;
   }
 
-  if (std::holds_alternative<OptionInfo::ValueInfo<bool>>(v))
+  if (std::holds_alternative<OptionInfo::ValueInfo<bool>>(v)
+      || std::holds_alternative<OptionInfo::ValueInfo<std::string>>(v))
   {
-    auto info = std::get<OptionInfo::ValueInfo<bool>>(v);
     jclass valueInfoClass = env->FindClass("cvc5/OptionInfo$ValueInfo");
     jmethodID methodId = env->GetMethodID(
         valueInfoClass,
         "<init>",
         "(Lcvc5/OptionInfo;Ljava/lang/Object;Ljava/lang/Object;)V");
 
-    jobject currentValue = getBooleanObject(env, info.currentValue);
-    jobject defaultValue = getBooleanObject(env, info.defaultValue);
-    jobject ret = env->NewObject(
-        valueInfoClass, methodId, optionInfo, defaultValue, currentValue);
-    return ret;
-  }
+    if (std::holds_alternative<OptionInfo::ValueInfo<bool>>(v))
+    {
+      auto info = std::get<OptionInfo::ValueInfo<bool>>(v);
+      jobject currentValue = getBooleanObject(env, info.currentValue);
+      jobject defaultValue = getBooleanObject(env, info.defaultValue);
+      jobject ret = env->NewObject(
+          valueInfoClass, methodId, optionInfo, defaultValue, currentValue);
+      return ret;
+    }
 
-  if (std::holds_alternative<OptionInfo::ValueInfo<std::string>>(v))
-  {
-    auto info = std::get<OptionInfo::ValueInfo<std::string>>(v);
-    jclass valueInfoClass = env->FindClass("cvc5/OptionInfo$ValueInfo");
-    jmethodID methodId = env->GetMethodID(
-        valueInfoClass,
-        "<init>",
-        "(Lcvc5/OptionInfo;Ljava/lang/Object;Ljava/lang/Object;)V");
-
-    jstring defaultValue = env->NewStringUTF(info.defaultValue.c_str());
-    jstring currentValue = env->NewStringUTF(info.currentValue.c_str());
-    jobject ret = env->NewObject(
-        valueInfoClass, methodId, optionInfo, defaultValue, currentValue);
-    return ret;
+    if (std::holds_alternative<OptionInfo::ValueInfo<std::string>>(v))
+    {
+      auto info = std::get<OptionInfo::ValueInfo<std::string>>(v);
+      jstring defaultValue = env->NewStringUTF(info.defaultValue.c_str());
+      jstring currentValue = env->NewStringUTF(info.currentValue.c_str());
+      jobject ret = env->NewObject(
+          valueInfoClass, methodId, optionInfo, defaultValue, currentValue);
+      return ret;
+    }
   }
 
   if (std::holds_alternative<OptionInfo::NumberInfo<int64_t>>(v)

--- a/src/api/java/jni/cvc5_OptionInfo.cpp
+++ b/src/api/java/jni/cvc5_OptionInfo.cpp
@@ -1,0 +1,254 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Mudathir Mohamed
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2021 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The cvc5 Java API.
+ */
+
+#include "cvc5_OptionInfo.h"
+
+#include <iostream>
+#include <sstream>
+
+#include "api/cpp/cvc5.h"
+#include "cvc5JavaApi.h"
+
+using namespace cvc5::api;
+
+/*
+ * Class:     cvc5_OptionInfo
+ * Method:    deletePointer
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_cvc5_OptionInfo_deletePointer(JNIEnv*,
+                                                          jclass,
+                                                          jlong pointer)
+{
+  delete reinterpret_cast<OptionInfo*>(pointer);
+}
+
+/*
+ * Class:     cvc5_OptionInfo
+ * Method:    toString
+ * Signature: (J)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_cvc5_OptionInfo_toString(JNIEnv* env,
+                                                        jobject,
+                                                        jlong pointer)
+{
+  CVC5_JAVA_API_TRY_CATCH_BEGIN;
+  OptionInfo* current = reinterpret_cast<OptionInfo*>(pointer);
+  std::stringstream ss;
+  ss << *current;
+  return env->NewStringUTF(ss.str().c_str());
+  CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, nullptr);
+}
+
+/*
+ * Class:     cvc5_OptionInfo
+ * Method:    getName
+ * Signature: (J)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_cvc5_OptionInfo_getName(JNIEnv* env,
+                                                       jobject,
+                                                       jlong pointer)
+{
+  CVC5_JAVA_API_TRY_CATCH_BEGIN;
+  OptionInfo* current = reinterpret_cast<OptionInfo*>(pointer);
+  return env->NewStringUTF(current->name.c_str());
+  CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, nullptr);
+}
+
+/*
+ * Class:     cvc5_OptionInfo
+ * Method:    getAliases
+ * Signature: (J)[Ljava/lang/String;
+ */
+JNIEXPORT jobjectArray JNICALL Java_cvc5_OptionInfo_getAliases(JNIEnv* env,
+                                                               jobject,
+                                                               jlong pointer)
+{
+  CVC5_JAVA_API_TRY_CATCH_BEGIN;
+  OptionInfo* current = reinterpret_cast<OptionInfo*>(pointer);
+  jobjectArray ret = getStringArrayFromStrings(env, current->aliases);
+  return ret;
+  CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, nullptr);
+}
+
+/*
+ * Class:     cvc5_OptionInfo
+ * Method:    getSetByUser
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL Java_cvc5_OptionInfo_getSetByUser(JNIEnv* env,
+                                                             jobject,
+                                                             jlong pointer)
+{
+  CVC5_JAVA_API_TRY_CATCH_BEGIN;
+  OptionInfo* current = reinterpret_cast<OptionInfo*>(pointer);
+  return static_cast<jboolean>(current->setByUser);
+  CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, static_cast<jboolean>(false));
+}
+
+/*
+ * Class:     cvc5_OptionInfo
+ * Method:    getValueInfo
+ * Signature: (J)Lcvc5/OptionInfo/ValueInfo;
+ */
+JNIEXPORT jobject JNICALL Java_cvc5_OptionInfo_getValueInfo(JNIEnv* env,
+                                                            jobject optionInfo,
+                                                            jlong pointer)
+{
+  CVC5_JAVA_API_TRY_CATCH_BEGIN;
+  OptionInfo* current = reinterpret_cast<OptionInfo*>(pointer);
+  std::variant<OptionInfo::VoidInfo,
+               OptionInfo::ValueInfo<bool>,
+               OptionInfo::ValueInfo<std::string>,
+               OptionInfo::NumberInfo<int64_t>,
+               OptionInfo::NumberInfo<uint64_t>,
+               OptionInfo::NumberInfo<double>,
+               OptionInfo::ModeInfo>
+      v = current->valueInfo;
+
+  jobject ret;
+  if (std::holds_alternative<OptionInfo::VoidInfo>(v))
+  {
+    jclass voidInfoClass = env->FindClass("cvc5/OptionInfo$VoidInfo");
+    jmethodID methodId =
+        env->GetMethodID(voidInfoClass, "<init>", "(Lcvc5/OptionInfo;)V");
+    ret = env->CallObjectMethod(voidInfoClass, methodId, optionInfo);
+    return ret;
+  }
+
+  if (std::holds_alternative<OptionInfo::ValueInfo<bool>>(v))
+  {
+    auto info = std::get<OptionInfo::ValueInfo<bool>>(v);
+    jclass valueInfoClass = env->FindClass("cvc5/OptionInfo$ValueInfo");
+    jmethodID methodId = env->GetMethodID(
+        valueInfoClass,
+        "<init>",
+        "(Lcvc5/OptionInfo;Ljava/lang/Object;Ljava/lang/Object;)V");
+    std::cout << "methodId: " << methodId << std::endl;
+    jclass booleanClass = env->FindClass("Ljava/lang/Boolean;");
+    jmethodID booleanConstructor =
+        env->GetMethodID(booleanClass, "<init>", "(Z)V");
+    jobject currentValue =
+        env->NewObject(booleanClass,
+                       booleanConstructor,
+                       static_cast<jboolean>(info.currentValue));
+    jobject defaultValue =
+        env->NewObject(booleanClass,
+                       booleanConstructor,
+                       static_cast<jboolean>(info.defaultValue));
+    ret = env->CallObjectMethod(
+        valueInfoClass, methodId, optionInfo, defaultValue, currentValue);
+    return ret;
+  }
+
+  if (std::holds_alternative<OptionInfo::ValueInfo<std::string>>(v))
+  {
+    auto info = std::get<OptionInfo::ValueInfo<std::string>>(v);
+    jclass valueInfoClass = env->FindClass("cvc5/OptionInfo$ValueInfo");
+    jmethodID methodId = env->GetMethodID(
+        valueInfoClass,
+        "<init>",
+        "(Lcvc5/OptionInfo;Ljava/lang/Object;Ljava/lang/Object;)V");
+    std::cout << "methodId: " << methodId << std::endl;
+    jstring defaultValue = env->NewStringUTF(info.defaultValue.c_str());
+    jstring currentValue = env->NewStringUTF(info.currentValue.c_str());
+    ret = env->CallObjectMethod(
+        valueInfoClass, methodId, optionInfo, defaultValue, currentValue);
+    return ret;
+  }
+
+  if (std::holds_alternative<OptionInfo::NumberInfo<int64_t>>(v) ||
+      std::holds_alternative<OptionInfo::NumberInfo<uint64_t>>(v)
+      )
+  {
+    auto info = std::get<OptionInfo::NumberInfo<uint64_t>>(v);
+    jclass valueInfoClass = env->FindClass("cvc5/OptionInfo$NumberInfo");
+    jmethodID methodId = env->GetMethodID(
+        valueInfoClass,
+        "<init>",
+        "(Lcvc5/OptionInfo;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V");
+    std::stringstream ssDefault, ssCurrent;
+    ssDefault << info.defaultValue;
+    ssCurrent << info.currentValue;
+    jstring jDefault = env->NewStringUTF(ssDefault.str().c_str());
+    jstring jCurrent = env->NewStringUTF(ssCurrent.str().c_str());
+    jclass bigIntegerClass = env->FindClass("java/math/BigInteger");
+    jmethodID bigIntegerConstructor = env->GetMethodID(bigIntegerClass, "<init>", "(Ljava/lang/String;)V");
+    jobject defaultValue = env->NewObject(bigIntegerClass, bigIntegerConstructor, jDefault);
+    jobject currentValue = env->NewObject(bigIntegerClass, bigIntegerConstructor, jCurrent);
+    ret = env->CallObjectMethod(
+        valueInfoClass, methodId, optionInfo, defaultValue, currentValue, nullptr, nullptr);
+    return ret;
+  }
+
+  return ret;
+  CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, nullptr);
+}
+
+/*
+ * Class:     cvc5_OptionInfo
+ * Method:    booleanValue
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL Java_cvc5_OptionInfo_booleanValue(JNIEnv* env,
+                                                             jobject,
+                                                             jlong pointer)
+{
+  CVC5_JAVA_API_TRY_CATCH_BEGIN;
+  OptionInfo* current = reinterpret_cast<OptionInfo*>(pointer);
+  return static_cast<jboolean>(current->boolValue());
+  CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, static_cast<jboolean>(false));
+}
+
+/*
+ * Class:     cvc5_OptionInfo
+ * Method:    stringValue
+ * Signature: (J)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_cvc5_OptionInfo_stringValue(JNIEnv* env,
+                                                           jobject,
+                                                           jlong pointer)
+{
+  CVC5_JAVA_API_TRY_CATCH_BEGIN;
+  OptionInfo* current = reinterpret_cast<OptionInfo*>(pointer);
+  std::string ret = current->stringValue();
+  return env->NewStringUTF(ret.c_str());
+  CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, nullptr);
+}
+
+/*
+ * Class:     cvc5_OptionInfo
+ * Method:    intValue
+ * Signature: (J)Ljava/math/BigInteger;
+ */
+JNIEXPORT jobject JNICALL Java_cvc5_OptionInfo_intValue(JNIEnv*,
+                                                        jobject,
+                                                        jlong);
+
+/*
+ * Class:     cvc5_OptionInfo
+ * Method:    doubleValue
+ * Signature: (J)D
+ */
+JNIEXPORT jdouble JNICALL Java_cvc5_OptionInfo_doubleValue(JNIEnv* env,
+                                                           jobject,
+                                                           jlong pointer)
+{
+  CVC5_JAVA_API_TRY_CATCH_BEGIN;
+  OptionInfo* current = reinterpret_cast<OptionInfo*>(pointer);
+  double ret = current->doubleValue();
+  return static_cast<jdouble>(ret);
+  CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, static_cast<jdouble>(0.0));
+}

--- a/src/api/java/jni/cvc5_Solver.cpp
+++ b/src/api/java/jni/cvc5_Solver.cpp
@@ -1881,7 +1881,7 @@ JNIEXPORT jobjectArray JNICALL Java_cvc5_Solver_getOptionNames(JNIEnv* env,
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   Solver* solver = reinterpret_cast<Solver*>(pointer);
   std::vector<std::string> options = solver->getOptionNames();
-  jobjectArray ret = getStringArrayFromStrings(env, options);
+  jobjectArray ret = getStringArrayFromStringVector(env, options);
   return ret;
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, nullptr);
 }

--- a/test/unit/api/java/cvc5/SolverTest.java
+++ b/test/unit/api/java/cvc5/SolverTest.java
@@ -1359,53 +1359,54 @@ class SolverTest
     {
       OptionInfo info = d_solver.getOptionInfo("verbose");
       assertions.add(() -> assertEquals("verbose", info.getName()));
-      assertions.add(() -> assertEquals(new String[] {}, info.getAliases()));
+      assertions.add(
+          () -> assertEquals(Arrays.asList(new String[] {}), Arrays.asList(info.getAliases())));
       assertions.add(() -> assertTrue(info.getValueInfo().getClass() == OptionInfo.VoidInfo.class));
     }
     {
       // int64 type with default
       OptionInfo info = d_solver.getOptionInfo("verbosity");
-      System.err.println("info: " + info);
       assertions.add(() -> assertEquals("verbosity", info.getName()));
-      assertions.add(() -> assertEquals(new String[] {}, info.getAliases()));
+      assertions.add(
+          () -> assertEquals(Arrays.asList(new String[] {}), Arrays.asList(info.getAliases())));
       assertions.add(
           () -> assertTrue(info.getValueInfo().getClass() == OptionInfo.NumberInfo.class));
-          System.out.println("ValueInfo: " + info.getValueInfo());
       OptionInfo.NumberInfo<BigInteger> numInfo =
           (OptionInfo.NumberInfo<BigInteger>) info.getValueInfo();
-      assertions.add(() -> assertEquals(0, numInfo.getDefaultValue()));
-      assertions.add(() -> assertEquals(0, numInfo.getCurrentValue()));
+      assertions.add(() -> assertEquals(0, numInfo.getDefaultValue().intValue()));
+      assertions.add(() -> assertEquals(0, numInfo.getCurrentValue().intValue()));
       assertions.add(
-          () -> assertFalse(numInfo.getMinimum() == null || numInfo.getMaximum() == null));
-      assertions.add(() -> assertEquals(info.intValue(), 0));
+          () -> assertFalse(numInfo.getMinimum() != null || numInfo.getMaximum() != null));
+      assertions.add(() -> assertEquals(info.intValue().intValue(), 0));
     }
     assertAll(assertions);
-    {
-      OptionInfo info = d_solver.getOptionInfo("random-freq");
-      assertEquals(info.getName(), "random-freq");
-      assertEquals(info.getAliases(), new String[] {"random-frequency"});
-      assertTrue(info.getValueInfo().getClass() == OptionInfo.NumberInfo.class);
-      OptionInfo.NumberInfo<Double> ni = (OptionInfo.NumberInfo<Double>) info.getValueInfo();
-      assertEquals(ni.getCurrentValue(), 0.0);
-      assertEquals(ni.getDefaultValue(), 0.0);
-      assertTrue(ni.getMinimum() == null && ni.getMaximum() == null);
-      assertEquals(ni.getMinimum(), 0.0);
-      assertEquals(ni.getMaximum(), 1.0);
-      assertEquals(info.doubleValue(), 0.0);
-    }
-    {
-      // mode option
-      OptionInfo info = d_solver.getOptionInfo("output");
-      assertions.clear();
-      assertions.add(() -> assertEquals("output", info.getName()));
-      assertions.add(() -> assertEquals(new String[] {}, info.getAliases()));
-      assertions.add(() -> assertTrue(info.getValueInfo().getClass() == OptionInfo.ModeInfo.class));
-      OptionInfo.ModeInfo modeInfo = (OptionInfo.ModeInfo) info.getValueInfo();
-      assertions.add(() -> assertEquals("NONE", modeInfo.getDefaultValue()));
-      assertions.add(() -> assertEquals("OutputTag::NONE", modeInfo.getCurrentValue()));
-      assertions.add(() -> assertTrue(Arrays.asList(modeInfo.getModes()).contains("NONE")));
-    }
-    assertAll(assertions);
+    //     {
+    //       OptionInfo info = d_solver.getOptionInfo("random-freq");
+    //       assertEquals(info.getName(), "random-freq");
+    //       assertEquals(info.getAliases(), new String[] {"random-frequency"});
+    //       assertTrue(info.getValueInfo().getClass() == OptionInfo.NumberInfo.class);
+    //       OptionInfo.NumberInfo<Double> ni = (OptionInfo.NumberInfo<Double>) info.getValueInfo();
+    //       assertEquals(ni.getCurrentValue(), 0.0);
+    //       assertEquals(ni.getDefaultValue(), 0.0);
+    //       assertTrue(ni.getMinimum() == null && ni.getMaximum() == null);
+    //       assertEquals(ni.getMinimum(), 0.0);
+    //       assertEquals(ni.getMaximum(), 1.0);
+    //       assertEquals(info.doubleValue(), 0.0);
+    //     }
+    //     {
+    //       // mode option
+    //       OptionInfo info = d_solver.getOptionInfo("output");
+    //       assertions.clear();
+    //       assertions.add(() -> assertEquals("output", info.getName()));
+    //       assertions.add(() -> assertEquals(new String[] {}, info.getAliases()));
+    //       assertions.add(() -> assertTrue(info.getValueInfo().getClass() ==
+    //       OptionInfo.ModeInfo.class)); OptionInfo.ModeInfo modeInfo = (OptionInfo.ModeInfo)
+    //       info.getValueInfo(); assertions.add(() -> assertEquals("NONE",
+    //       modeInfo.getDefaultValue())); assertions.add(() -> assertEquals("OutputTag::NONE",
+    //       modeInfo.getCurrentValue())); assertions.add(() ->
+    //       assertTrue(Arrays.asList(modeInfo.getModes()).contains("NONE")));
+    //     }
+    //     assertAll(assertions);
   }
 
   @Test void getUnsatAssumptions1()

--- a/test/unit/api/java/cvc5/SolverTest.java
+++ b/test/unit/api/java/cvc5/SolverTest.java
@@ -1380,33 +1380,34 @@ class SolverTest
       assertions.add(() -> assertEquals(info.intValue().intValue(), 0));
     }
     assertAll(assertions);
-    //     {
-    //       OptionInfo info = d_solver.getOptionInfo("random-freq");
-    //       assertEquals(info.getName(), "random-freq");
-    //       assertEquals(info.getAliases(), new String[] {"random-frequency"});
-    //       assertTrue(info.getValueInfo().getClass() == OptionInfo.NumberInfo.class);
-    //       OptionInfo.NumberInfo<Double> ni = (OptionInfo.NumberInfo<Double>) info.getValueInfo();
-    //       assertEquals(ni.getCurrentValue(), 0.0);
-    //       assertEquals(ni.getDefaultValue(), 0.0);
-    //       assertTrue(ni.getMinimum() == null && ni.getMaximum() == null);
-    //       assertEquals(ni.getMinimum(), 0.0);
-    //       assertEquals(ni.getMaximum(), 1.0);
-    //       assertEquals(info.doubleValue(), 0.0);
-    //     }
-    //     {
-    //       // mode option
-    //       OptionInfo info = d_solver.getOptionInfo("output");
-    //       assertions.clear();
-    //       assertions.add(() -> assertEquals("output", info.getName()));
-    //       assertions.add(() -> assertEquals(new String[] {}, info.getAliases()));
-    //       assertions.add(() -> assertTrue(info.getValueInfo().getClass() ==
-    //       OptionInfo.ModeInfo.class)); OptionInfo.ModeInfo modeInfo = (OptionInfo.ModeInfo)
-    //       info.getValueInfo(); assertions.add(() -> assertEquals("NONE",
-    //       modeInfo.getDefaultValue())); assertions.add(() -> assertEquals("OutputTag::NONE",
-    //       modeInfo.getCurrentValue())); assertions.add(() ->
-    //       assertTrue(Arrays.asList(modeInfo.getModes()).contains("NONE")));
-    //     }
-    //     assertAll(assertions);
+    {
+      OptionInfo info = d_solver.getOptionInfo("random-freq");
+      assertEquals(info.getName(), "random-freq");
+      assertEquals(
+          Arrays.asList(info.getAliases()), Arrays.asList(new String[] {"random-frequency"}));
+      assertTrue(info.getValueInfo().getClass() == OptionInfo.NumberInfo.class);
+      OptionInfo.NumberInfo<Double> ni = (OptionInfo.NumberInfo<Double>) info.getValueInfo();
+      assertEquals(ni.getCurrentValue(), 0.0);
+      assertEquals(ni.getDefaultValue(), 0.0);
+      assertTrue(ni.getMinimum() != null && ni.getMaximum() != null);
+      assertEquals(ni.getMinimum(), 0.0);
+      assertEquals(ni.getMaximum(), 1.0);
+      assertEquals(info.doubleValue(), 0.0);
+    }
+    {
+      // mode option
+      OptionInfo info = d_solver.getOptionInfo("output");
+      assertions.clear();
+      assertions.add(() -> assertEquals("output", info.getName()));
+      assertions.add(
+          () -> assertEquals(Arrays.asList(new String[] {}), Arrays.asList(info.getAliases())));
+      assertions.add(() -> assertTrue(info.getValueInfo().getClass() == OptionInfo.ModeInfo.class));
+      OptionInfo.ModeInfo modeInfo = (OptionInfo.ModeInfo) info.getValueInfo();
+      assertions.add(() -> assertEquals("NONE", modeInfo.getDefaultValue()));
+      assertions.add(() -> assertEquals("OutputTag::NONE", modeInfo.getCurrentValue()));
+      assertions.add(() -> assertTrue(Arrays.asList(modeInfo.getModes()).contains("NONE")));
+    }
+    assertAll(assertions);
   }
 
   @Test void getUnsatAssumptions1()

--- a/test/unit/api/java/cvc5/SolverTest.java
+++ b/test/unit/api/java/cvc5/SolverTest.java
@@ -19,11 +19,11 @@ import static cvc5.Kind.*;
 import static cvc5.RoundingMode.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.math.BigInteger;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.function.Executable;
 
 class SolverTest
 {
@@ -1341,6 +1341,73 @@ class SolverTest
     assertThrows(CVC5ApiException.class, () -> d_solver.getOption("asdf"));
   }
 
+  @Test void getOptionNames()
+  {
+    String[] names = d_solver.getOptionNames();
+    assertTrue(names.length > 100);
+    assertTrue(Arrays.asList(names).contains("verbose"));
+    assertFalse(Arrays.asList(names).contains("foobar"));
+  }
+
+  @Test void getOptionInfo()
+  {
+    List<Executable> assertions = new ArrayList<>();
+    {
+      assertions.add(
+          () -> assertThrows(CVC5ApiException.class, () -> d_solver.getOptionInfo("asdf-invalid")));
+    }
+    {
+      OptionInfo info = d_solver.getOptionInfo("verbose");
+      assertions.add(() -> assertEquals("verbose", info.getName()));
+      assertions.add(() -> assertEquals(new String[] {}, info.getAliases()));
+      assertions.add(() -> assertTrue(info.getValueInfo().getClass() == OptionInfo.VoidInfo.class));
+    }
+    {
+      // int64 type with default
+      OptionInfo info = d_solver.getOptionInfo("verbosity");
+      System.err.println("info: " + info);
+      assertions.add(() -> assertEquals("verbosity", info.getName()));
+      assertions.add(() -> assertEquals(new String[] {}, info.getAliases()));
+      assertions.add(
+          () -> assertTrue(info.getValueInfo().getClass() == OptionInfo.NumberInfo.class));
+          System.out.println("ValueInfo: " + info.getValueInfo());
+      OptionInfo.NumberInfo<BigInteger> numInfo =
+          (OptionInfo.NumberInfo<BigInteger>) info.getValueInfo();
+      assertions.add(() -> assertEquals(0, numInfo.getDefaultValue()));
+      assertions.add(() -> assertEquals(0, numInfo.getCurrentValue()));
+      assertions.add(
+          () -> assertFalse(numInfo.getMinimum() == null || numInfo.getMaximum() == null));
+      assertions.add(() -> assertEquals(info.intValue(), 0));
+    }
+    assertAll(assertions);
+    {
+      OptionInfo info = d_solver.getOptionInfo("random-freq");
+      assertEquals(info.getName(), "random-freq");
+      assertEquals(info.getAliases(), new String[] {"random-frequency"});
+      assertTrue(info.getValueInfo().getClass() == OptionInfo.NumberInfo.class);
+      OptionInfo.NumberInfo<Double> ni = (OptionInfo.NumberInfo<Double>) info.getValueInfo();
+      assertEquals(ni.getCurrentValue(), 0.0);
+      assertEquals(ni.getDefaultValue(), 0.0);
+      assertTrue(ni.getMinimum() == null && ni.getMaximum() == null);
+      assertEquals(ni.getMinimum(), 0.0);
+      assertEquals(ni.getMaximum(), 1.0);
+      assertEquals(info.doubleValue(), 0.0);
+    }
+    {
+      // mode option
+      OptionInfo info = d_solver.getOptionInfo("output");
+      assertions.clear();
+      assertions.add(() -> assertEquals("output", info.getName()));
+      assertions.add(() -> assertEquals(new String[] {}, info.getAliases()));
+      assertions.add(() -> assertTrue(info.getValueInfo().getClass() == OptionInfo.ModeInfo.class));
+      OptionInfo.ModeInfo modeInfo = (OptionInfo.ModeInfo) info.getValueInfo();
+      assertions.add(() -> assertEquals("NONE", modeInfo.getDefaultValue()));
+      assertions.add(() -> assertEquals("OutputTag::NONE", modeInfo.getCurrentValue()));
+      assertions.add(() -> assertTrue(Arrays.asList(modeInfo.getModes()).contains("NONE")));
+    }
+    assertAll(assertions);
+  }
+
   @Test void getUnsatAssumptions1()
   {
     d_solver.setOption("incremental", "false");
@@ -1383,17 +1450,17 @@ class SolverTest
     assertThrows(CVC5ApiException.class, () -> d_solver.getUnsatCore());
   }
 
-  @Test void getUnsatCore3()
+  @Test void getUnsatCoreAndProof()
   {
     d_solver.setOption("incremental", "true");
     d_solver.setOption("produce-unsat-cores", "true");
+    d_solver.setOption("produce-proofs", "true");
 
     Sort uSort = d_solver.mkUninterpretedSort("u");
     Sort intSort = d_solver.getIntegerSort();
     Sort boolSort = d_solver.getBooleanSort();
     Sort uToIntSort = d_solver.mkFunctionSort(uSort, intSort);
     Sort intPredSort = d_solver.mkFunctionSort(intSort, boolSort);
-    Term[] unsat_core;
 
     Term x = d_solver.mkConst(uSort, "x");
     Term y = d_solver.mkConst(uSort, "y");
@@ -1401,21 +1468,21 @@ class SolverTest
     Term p = d_solver.mkConst(intPredSort, "p");
     Term zero = d_solver.mkInteger(0);
     Term one = d_solver.mkInteger(1);
-    Term f_x = d_solver.mkTerm(APPLY_UF, f, x);
-    Term f_y = d_solver.mkTerm(APPLY_UF, f, y);
-    Term sum = d_solver.mkTerm(PLUS, f_x, f_y);
-    Term p_0 = d_solver.mkTerm(APPLY_UF, p, zero);
+    Term f_x = d_solver.mkTerm(Kind.APPLY_UF, f, x);
+    Term f_y = d_solver.mkTerm(Kind.APPLY_UF, f, y);
+    Term sum = d_solver.mkTerm(Kind.PLUS, f_x, f_y);
+    Term p_0 = d_solver.mkTerm(Kind.APPLY_UF, p, zero);
     Term p_f_y = d_solver.mkTerm(APPLY_UF, p, f_y);
-    d_solver.assertFormula(d_solver.mkTerm(GT, zero, f_x));
-    d_solver.assertFormula(d_solver.mkTerm(GT, zero, f_y));
-    d_solver.assertFormula(d_solver.mkTerm(GT, sum, one));
+    d_solver.assertFormula(d_solver.mkTerm(Kind.GT, zero, f_x));
+    d_solver.assertFormula(d_solver.mkTerm(Kind.GT, zero, f_y));
+    d_solver.assertFormula(d_solver.mkTerm(Kind.GT, sum, one));
     d_solver.assertFormula(p_0);
     d_solver.assertFormula(p_f_y.notTerm());
     assertTrue(d_solver.checkSat().isUnsat());
 
-    AtomicReference<Term[]> atomic = new AtomicReference<>();
-    assertDoesNotThrow(() -> atomic.set(d_solver.getUnsatCore()));
-    unsat_core = atomic.get();
+    Term[] unsat_core = d_solver.getUnsatCore();
+
+    assertDoesNotThrow(() -> d_solver.getProof());
 
     d_solver.resetAssertions();
     for (Term t : unsat_core)
@@ -1424,6 +1491,42 @@ class SolverTest
     }
     Result res = d_solver.checkSat();
     assertTrue(res.isUnsat());
+    assertDoesNotThrow(() -> d_solver.getProof());
+  }
+
+  @Test void getDifficulty()
+  {
+    d_solver.setOption("produce-difficulty", "true");
+    // cannot ask before a check sat
+    assertThrows(CVC5ApiException.class, () -> d_solver.getDifficulty());
+    d_solver.checkSat();
+    assertDoesNotThrow(() -> d_solver.getDifficulty());
+  }
+
+  @Test void getDifficulty2()
+  {
+    d_solver.checkSat();
+    // option is not set
+    assertThrows(CVC5ApiException.class, () -> d_solver.getDifficulty());
+  }
+
+  @Test void getDifficulty3() throws CVC5ApiException
+  {
+    d_solver.setOption("produce-difficulty", "true");
+    Sort intSort = d_solver.getIntegerSort();
+    Term x = d_solver.mkConst(intSort, "x");
+    Term zero = d_solver.mkInteger(0);
+    Term ten = d_solver.mkInteger(10);
+    Term f0 = d_solver.mkTerm(GEQ, x, ten);
+    Term f1 = d_solver.mkTerm(GEQ, zero, x);
+    d_solver.checkSat();
+    Map<Term, Term> dmap = d_solver.getDifficulty();
+    // difficulty should map assertions to integer values
+    for (Map.Entry<Term, Term> t : dmap.entrySet())
+    {
+      assertTrue(t.getKey() == f0 || t.getKey() == f1);
+      assertTrue(t.getValue().getKind() == Kind.CONST_RATIONAL);
+    }
   }
 
   @Test void getValue1()
@@ -1481,6 +1584,95 @@ class SolverTest
 
     Solver slv = new Solver();
     assertThrows(CVC5ApiException.class, () -> slv.getValue(x));
+  }
+
+  @Test void getModelDomainElements()
+  {
+    d_solver.setOption("produce-models", "true");
+    Sort uSort = d_solver.mkUninterpretedSort("u");
+    Sort intSort = d_solver.getIntegerSort();
+    Term x = d_solver.mkConst(uSort, "x");
+    Term y = d_solver.mkConst(uSort, "y");
+    Term z = d_solver.mkConst(uSort, "z");
+    Term f = d_solver.mkTerm(DISTINCT, x, y, z);
+    d_solver.assertFormula(f);
+    d_solver.checkSat();
+    assertDoesNotThrow(() -> d_solver.getModelDomainElements(uSort));
+    assertTrue(d_solver.getModelDomainElements(uSort).length >= 3);
+    assertThrows(CVC5ApiException.class, () -> d_solver.getModelDomainElements(intSort));
+  }
+
+  @Test void getModelDomainElements2()
+  {
+    d_solver.setOption("produce-models", "true");
+    d_solver.setOption("finite-model-find", "true");
+    Sort uSort = d_solver.mkUninterpretedSort("u");
+    Term x = d_solver.mkVar(uSort, "x");
+    Term y = d_solver.mkVar(uSort, "y");
+    Term eq = d_solver.mkTerm(EQUAL, x, y);
+    Term bvl = d_solver.mkTerm(BOUND_VAR_LIST, x, y);
+    Term f = d_solver.mkTerm(FORALL, bvl, eq);
+    d_solver.assertFormula(f);
+    d_solver.checkSat();
+    assertDoesNotThrow(() -> d_solver.getModelDomainElements(uSort));
+    // a model for the above must interpret u as size 1
+    assertTrue(d_solver.getModelDomainElements(uSort).length == 1);
+  }
+
+  @Test void isModelCoreSymbol()
+  {
+    d_solver.setOption("produce-models", "true");
+    d_solver.setOption("model-cores", "simple");
+    Sort uSort = d_solver.mkUninterpretedSort("u");
+    Term x = d_solver.mkConst(uSort, "x");
+    Term y = d_solver.mkConst(uSort, "y");
+    Term z = d_solver.mkConst(uSort, "z");
+    Term zero = d_solver.mkInteger(0);
+    Term f = d_solver.mkTerm(NOT, d_solver.mkTerm(EQUAL, x, y));
+    d_solver.assertFormula(f);
+    d_solver.checkSat();
+    assertTrue(d_solver.isModelCoreSymbol(x));
+    assertTrue(d_solver.isModelCoreSymbol(y));
+    assertFalse(d_solver.isModelCoreSymbol(z));
+    assertThrows(CVC5ApiException.class, () -> d_solver.isModelCoreSymbol(zero));
+  }
+
+  @Test void getModel()
+  {
+    d_solver.setOption("produce-models", "true");
+    Sort uSort = d_solver.mkUninterpretedSort("u");
+    Term x = d_solver.mkConst(uSort, "x");
+    Term y = d_solver.mkConst(uSort, "y");
+    Term z = d_solver.mkConst(uSort, "z");
+    Term f = d_solver.mkTerm(NOT, d_solver.mkTerm(EQUAL, x, y));
+    d_solver.assertFormula(f);
+    d_solver.checkSat();
+    Sort[] sorts = new Sort[] {uSort};
+    Term[] terms = new Term[] {x, y};
+    assertDoesNotThrow(() -> d_solver.getModel(sorts, terms));
+    Term nullTerm = d_solver.getNullTerm();
+    Term[] terms2 = new Term[] {x, y, nullTerm};
+    assertThrows(CVC5ApiException.class, () -> d_solver.getModel(sorts, terms2));
+  }
+
+  @Test void getModel2()
+  {
+    d_solver.setOption("produce-models", "true");
+    Sort[] sorts = new Sort[] {};
+    Term[] terms = new Term[] {};
+    assertThrows(CVC5ApiException.class, () -> d_solver.getModel(sorts, terms));
+  }
+
+  @Test void getModel3()
+  {
+    d_solver.setOption("produce-models", "true");
+    Sort[] sorts = new Sort[] {};
+    final Term[] terms = new Term[] {};
+    d_solver.checkSat();
+    assertDoesNotThrow(() -> d_solver.getModel(sorts, terms));
+    Sort integer = d_solver.getIntegerSort();
+    Sort[] sorts2 = new Sort[] {integer};
+    assertThrows(CVC5ApiException.class, () -> d_solver.getModel(sorts2, terms));
   }
 
   @Test void getQuantifierElimination()
@@ -2178,6 +2370,20 @@ class SolverTest
 
     Solver slv = new Solver();
     assertThrows(CVC5ApiException.class, () -> slv.addSygusConstraint(boolTerm));
+  }
+
+  @Test void addSygusAssume()
+  {
+    Term nullTerm = d_solver.getNullTerm();
+    Term boolTerm = d_solver.mkBoolean(false);
+    Term intTerm = d_solver.mkInteger(1);
+
+    assertDoesNotThrow(() -> d_solver.addSygusAssume(boolTerm));
+    assertThrows(CVC5ApiException.class, () -> d_solver.addSygusAssume(nullTerm));
+    assertThrows(CVC5ApiException.class, () -> d_solver.addSygusAssume(intTerm));
+
+    Solver slv = new Solver();
+    assertThrows(CVC5ApiException.class, () -> slv.addSygusAssume(boolTerm));
   }
 
   @Test void addSygusInvConstraint() throws CVC5ApiException


### PR DESCRIPTION
A life of solver object was simple before summer. Then it got complicated with `getDifficulty`, optional proofs `getDifficulty`, more assumptions `addSygusAssume`, and finally different options to choose from `OptionInfo`. 
This PR attempts to prepare solver objects for this new life. 