### PR TITLE
Add sygus examples to documentation

### DIFF
--- a/docs/examples/sygus-fun.rst
+++ b/docs/examples/sygus-fun.rst
@@ -6,3 +6,4 @@ SyGuS: Functions
     ../../examples/api/cpp/sygus-fun.cpp
     ../../examples/api/java/SygusFun.java
     ../../examples/api/python/sygus-fun.py
+    ../../examples/api/smtlib/sygus-fun.sy

--- a/docs/examples/sygus-grammar.rst
+++ b/docs/examples/sygus-grammar.rst
@@ -6,3 +6,4 @@ SyGuS: Grammars
     ../../examples/api/cpp/sygus-grammar.cpp
     ../../examples/api/java/SygusGrammar.java
     ../../examples/api/python/sygus-grammar.py
+    ../../examples/api/smtlib/sygus-grammar.sy

--- a/docs/examples/sygus-inv.rst
+++ b/docs/examples/sygus-inv.rst
@@ -6,3 +6,4 @@ SyGuS: Invariants
     ../../examples/api/cpp/sygus-inv.cpp
     ../../examples/api/java/SygusInv.java
     ../../examples/api/python/sygus-inv.py
+    ../../examples/api/smtlib/sygus-inv.sy

--- a/docs/ext/examples.py
+++ b/docs/ext/examples.py
@@ -24,6 +24,7 @@ class APIExamples(SphinxDirective):
         '.java': {'title': 'Java', 'lang': 'java'},
         '.py': {'title': 'Python', 'lang': 'python'},
         '.smt2': {'title': 'SMT-LIBv2', 'lang': 'smtlib'},
+        '.sy': {'title': 'SyGuS', 'lang': 'smtlib'},
     }
 
     # The "arguments" are actually the content of the directive
@@ -36,7 +37,7 @@ class APIExamples(SphinxDirective):
         # collect everything in a list of strings
         content = ['.. tabs::', '']
 
-        remaining = set(self.exts.keys())
+        remaining = set([self.exts[e]['lang'] for e in self.exts])
         location = '{}:{}'.format(*self.get_source_info())
 
         for file in self.content:
@@ -45,7 +46,7 @@ class APIExamples(SphinxDirective):
             if ext in self.exts:
                 title = self.exts[ext]['title']
                 lang = self.exts[ext]['lang']
-                remaining.remove(ext)
+                remaining.remove(lang)
             else:
                 self.logger.warning(f'{location} is using unknown file extension "{ext}"')
                 title = ext

--- a/examples/api/smtlib/sygus-fun.sy
+++ b/examples/api/smtlib/sygus-fun.sy
@@ -1,0 +1,24 @@
+; The printed output for this example should be equivalent to:
+; (
+;   (define-fun max ((x Int) (y Int)) Int (ite (<= x y) y x))
+;   (define-fun min ((x Int) (y Int)) Int (ite (<= x y) x y))
+; )
+
+(set-logic LIA)
+(synth-fun max ((x Int) (y Int)) Int
+  ((Start Int) (StartBool Bool))
+  ((Start Int (0 1 x y
+               (+ Start Start)
+               (- Start Start)
+               (ite StartBool Start Start)))
+   (StartBool Bool ((and StartBool StartBool)
+                    (not StartBool)
+                    (<= Start Start)))))
+(synth-fun min ((x Int) (y Int)) Int)
+(declare-var x Int)
+(declare-var y Int)
+(constraint (>= (max x y) x))
+(constraint (>= (max x y) y))
+(constraint (or (= x (max x y)) (= y (max x y))))
+(constraint (= (+ (max x y) (min x y)) (+ x y)))
+(check-synth)

--- a/examples/api/smtlib/sygus-grammar.sy
+++ b/examples/api/smtlib/sygus-grammar.sy
@@ -1,0 +1,16 @@
+; The printed output for this example should look like:
+; (
+;   (define-fun id1 ((x Int)) Int (+ x (+ x (- x))))
+;   (define-fun id2 ((x Int)) Int x)
+;   (define-fun id3 ((x Int)) Int (+ x 0))
+;   (define-fun id4 ((x Int)) Int (+ x (+ x (- x))))
+; )
+
+(set-logic LIA)
+(synth-fun id1 ((x Int)) Int ((Start Int)) ((Start Int ((- x) (+ x Start)))))
+(synth-fun id2 ((x Int)) Int ((Start Int)) ((Start Int ((Variable Int) (- x) (+ x Start)))))
+(synth-fun id3 ((x Int)) Int ((Start Int)) ((Start Int (0 (- x) (+ x Start)))))
+(synth-fun id4 ((x Int)) Int ((Start Int)) ((Start Int ((- x) (+ x Start)))))
+(declare-var x Int)
+(constraint (= (id1 x) (id2 x) (id3 x) (id4 x) x))
+(check-synth)

--- a/examples/api/smtlib/sygus-inv.sy
+++ b/examples/api/smtlib/sygus-inv.sy
@@ -1,0 +1,12 @@
+; The printed output for this example should be equivalent to:
+; (
+;   (define-fun inv-f ((x Int)) Bool (not (>= x 11)))
+; )
+
+(set-logic LIA)
+(synth-inv inv-f ((x Int)))
+(define-fun pre-f ((x Int)) Bool (= x 0))
+(define-fun trans-f ((x Int) (xp Int)) Bool (ite (< x 10) (= xp (+ x 1)) (= xp x)))
+(define-fun post-f ((x Int)) Bool (<= x 10))
+(inv-constraint inv-f pre-f trans-f post-f)
+(check-synth)

--- a/src/api/cpp/cvc5.h
+++ b/src/api/cpp/cvc5.h
@@ -935,9 +935,9 @@ class CVC5_EXPORT Op
   size_t getNumIndicesHelper() const;
 
   /**
-   * Helper for operator[](size_t i).
-   * @param i position of the index. Should be less than getNumIndicesHelper().
-   * @return the index at position i
+   * Helper for operator[](size_t index).
+   * @param index position of the index. Should be less than getNumIndicesHelper().
+   * @return the index at position index
    */
   Term getIndexHelper(size_t index) const;
 


### PR DESCRIPTION
For some reason, we didn't have any SMT-LIB (or rather SyGuS) example files for the SyGuS examples yet.
This PR adds these missing examples.