### PR TITLE
Refactor skolem definitions notifications for the decision engine

### DIFF
--- a/src/decision/decision_engine.h
+++ b/src/decision/decision_engine.h
@@ -61,10 +61,15 @@ class DecisionEngine : protected EnvObj
    */
   virtual void addSkolemDefinition(TNode lem, TNode skolem) = 0;
   /**
-   * Notify this class that the literal n has been asserted, possibly
-   * propagated by the SAT solver.
+   * Notify this class that the list of lemmas defs are now active in the
+   * current SAT context.
    */
-  virtual void notifyAsserted(TNode n) {}
+  virtual void notifyActiveSkolemDefs(std::vector<TNode>& defs) {}
+  /**
+   * Track active skolem defs, whether we need to call the above method
+   * when appropriate.
+   */
+  virtual bool needsActiveSkolemDefs() const { return false; }
 
  protected:
   /** Get next internal, the engine-specific implementation of getNext */

--- a/src/decision/justification_strategy.cpp
+++ b/src/decision/justification_strategy.cpp
@@ -23,10 +23,8 @@ using namespace cvc5::prop;
 namespace cvc5 {
 namespace decision {
 
-JustificationStrategy::JustificationStrategy(Env& env,
-                                             prop::SkolemDefManager* skdm)
+JustificationStrategy::JustificationStrategy(Env& env)
     : DecisionEngine(env),
-      d_skdm(skdm),
       d_assertions(
           userContext(),
           context(),
@@ -500,19 +498,20 @@ void JustificationStrategy::addSkolemDefinition(TNode lem, TNode skolem)
     insertToAssertionList(toProcess, false);
   }
 }
-
-void JustificationStrategy::notifyAsserted(TNode n)
+bool JustificationStrategy::needsActiveSkolemDefs() const
 {
-  if (d_jhSkRlvMode == options::JutificationSkolemRlvMode::ASSERT)
-  {
-    // assertion processed makes all skolems in assertion active,
-    // which triggers their definitions to becoming relevant
-    std::vector<TNode> defs;
-    d_skdm->notifyAsserted(n, defs, true);
-    insertToAssertionList(defs, true);
-  }
-  // NOTE: can update tracking triggers, pop stack to where a child implied
-  // that a node on the current stack is justified.
+  return d_jhSkRlvMode == options::JutificationSkolemRlvMode::ASSERT;
+}
+
+void JustificationStrategy::notifyActiveSkolemDefs(std::vector<TNode>& defs)
+{
+  Assert(d_jhSkRlvMode == options::JutificationSkolemRlvMode::ASSERT);
+  // assertion processed makes all skolems in assertion active,
+  // which triggers their definitions to becoming relevant
+  insertToAssertionList(defs, true);
+  // NOTE: if we had a notifyAsserted callback, we could update tracking
+  // triggers, pop stack to where a child implied that a node on the current
+  // stack is justified.
 }
 
 void JustificationStrategy::insertToAssertionList(std::vector<TNode>& toProcess,

--- a/src/decision/justification_strategy.h
+++ b/src/decision/justification_strategy.h
@@ -158,7 +158,7 @@ class JustificationStrategy : public DecisionEngine
    * context, where defs are the skolem definitions for each such skolem.
    */
   void notifyActiveSkolemDefs(std::vector<TNode>& defs) override;
-  /** 
+  /**
    * We need notification of active skolem definitions when our skolem
    * relevance policy is JutificationSkolemRlvMode::ASSERT.
    */

--- a/src/decision/justification_strategy.h
+++ b/src/decision/justification_strategy.h
@@ -152,12 +152,16 @@ class JustificationStrategy : public DecisionEngine
    */
   void addSkolemDefinition(TNode lem, TNode skolem) override;
   /**
-   * Notify this class that literal n has been asserted. This is triggered when
-   * n is sent to TheoryEngine. This activates skolem definitions for skolems
-   * k that occur in n.
+   * Notify this class that the list of lemmas defs are now active in the
+   * current SAT context. This is triggered when a literal lit is sent to
+   * TheoryEngine that contains skolems we have yet to see in the current SAT
+   * context, where defs are the skolem definitions for each such skolem.
    */
   void notifyActiveSkolemDefs(std::vector<TNode>& defs) override;
-  /** */
+  /** 
+   * We need notification of active skolem definitions when our skolem
+   * relevance policy is JutificationSkolemRlvMode::ASSERT.
+   */
   bool needsActiveSkolemDefs() const override;
 
  private:

--- a/src/decision/justification_strategy.h
+++ b/src/decision/justification_strategy.h
@@ -32,11 +32,6 @@
 #include "prop/sat_solver_types.h"
 
 namespace cvc5 {
-
-namespace prop {
-class SkolemDefManager;
-}
-
 namespace decision {
 
 /**
@@ -122,7 +117,7 @@ class JustificationStrategy : public DecisionEngine
 {
  public:
   /** Constructor */
-  JustificationStrategy(Env& env, prop::SkolemDefManager* skdm);
+  JustificationStrategy(Env& env);
 
   /** Presolve, called at the beginning of each check-sat call */
   void presolve() override;
@@ -161,7 +156,9 @@ class JustificationStrategy : public DecisionEngine
    * n is sent to TheoryEngine. This activates skolem definitions for skolems
    * k that occur in n.
    */
-  void notifyAsserted(TNode n) override;
+  void notifyActiveSkolemDefs(std::vector<TNode>& defs) override;
+  /** */
+  bool needsActiveSkolemDefs() const override;
 
  private:
   /**
@@ -221,8 +218,6 @@ class JustificationStrategy : public DecisionEngine
   static bool isTheoryLiteral(TNode n);
   /** Is n a theory atom? */
   static bool isTheoryAtom(TNode n);
-  /** Pointer to the skolem definition manager */
-  prop::SkolemDefManager* d_skdm;
   /** The assertions, which are user-context dependent. */
   AssertionList d_assertions;
   /** The skolem assertions */

--- a/src/prop/prop_engine.cpp
+++ b/src/prop/prop_engine.cpp
@@ -87,8 +87,7 @@ PropEngine::PropEngine(TheoryEngine* te, Env& env)
   if (dmode == options::DecisionMode::JUSTIFICATION
       || dmode == options::DecisionMode::STOPONLY)
   {
-    d_decisionEngine.reset(
-        new decision::JustificationStrategy(env));
+    d_decisionEngine.reset(new decision::JustificationStrategy(env));
   }
   else if (dmode == options::DecisionMode::JUSTIFICATION_OLD
            || dmode == options::DecisionMode::STOPONLY_OLD)

--- a/src/prop/prop_engine.cpp
+++ b/src/prop/prop_engine.cpp
@@ -87,7 +87,8 @@ PropEngine::PropEngine(TheoryEngine* te, Env& env)
   if (dmode == options::DecisionMode::JUSTIFICATION
       || dmode == options::DecisionMode::STOPONLY)
   {
-    d_decisionEngine.reset(new decision::JustificationStrategy(env));
+    d_decisionEngine.reset(
+        new decision::JustificationStrategy(env));
   }
   else if (dmode == options::DecisionMode::JUSTIFICATION_OLD
            || dmode == options::DecisionMode::STOPONLY_OLD)
@@ -321,7 +322,6 @@ void PropEngine::assertLemmasInternal(TrustNode trn,
     Assert(ppSkolems.size() == ppLemmas.size());
     for (size_t i = 0, lsize = ppLemmas.size(); i < lsize; ++i)
     {
-      Node lem = ppLemmas[i].getProven();
       d_theoryProxy->notifyAssertion(ppLemmas[i].getProven(), ppSkolems[i]);
     }
   }
@@ -382,9 +382,8 @@ Result PropEngine::checkSat() {
   ScopedBool scopedBool(d_inCheckSat);
   d_inCheckSat = true;
 
-  // TODO This currently ignores conflicts (a dangerous practice).
-  d_decisionEngine->presolve();
-  d_theoryEngine->presolve();
+  // Note this currently ignores conflicts (a dangerous practice).
+  d_theoryProxy->presolve();
 
   if(options::preprocessOnly()) {
     return Result(Result::SAT_UNKNOWN, Result::REQUIRES_FULL_CHECK);

--- a/src/prop/prop_engine.cpp
+++ b/src/prop/prop_engine.cpp
@@ -88,7 +88,7 @@ PropEngine::PropEngine(TheoryEngine* te, Env& env)
       || dmode == options::DecisionMode::STOPONLY)
   {
     d_decisionEngine.reset(
-        new decision::JustificationStrategy(env, d_skdm.get()));
+        new decision::JustificationStrategy(env));
   }
   else if (dmode == options::DecisionMode::JUSTIFICATION_OLD
            || dmode == options::DecisionMode::STOPONLY_OLD)

--- a/src/prop/theory_proxy.cpp
+++ b/src/prop/theory_proxy.cpp
@@ -56,6 +56,12 @@ TheoryProxy::~TheoryProxy() {
 
 void TheoryProxy::finishInit(CnfStream* cnfStream) { d_cnfStream = cnfStream; }
 
+void TheoryProxy::presolve()
+{
+  d_decisionEngine->presolve();
+  d_theoryEngine->presolve();
+}
+
 void TheoryProxy::notifyAssertion(Node a, TNode skolem)
 {
   if (skolem.isNull())

--- a/src/prop/theory_proxy.cpp
+++ b/src/prop/theory_proxy.cpp
@@ -79,23 +79,18 @@ void TheoryProxy::theoryCheck(theory::Theory::Effort effort) {
     d_queue.pop();
     // now, assert to theory engine
     d_theoryEngine->assertFact(assertion);
-    if (d_dmNeedsActiveDefs || d_satRlv != nullptr)
+    if (d_dmNeedsActiveDefs)
     {
       Assert(d_skdm != nullptr);
       Trace("sat-rlv-assert")
           << "Assert to theory engine: " << assertion << std::endl;
-      // assertion processed makes all skolems in assertion active,
-      // which triggers their definitions to becoming relevant
+      // Assertion makes all skolems in assertion active,
+      // which triggers their definitions to becoming active.
       std::vector<TNode> activeSkolemDefs;
       d_skdm->notifyAsserted(assertion, activeSkolemDefs, true);
-      if (d_satRlv != nullptr)
-      {
-        d_satRlv->notifyActivatedSkolemDefs(activeSkolemDefs, d_queue);
-      }
-      if (dmNeedsActiveDefs)
-      {
-        d_decisionEngine->notifyActiveSkolemDefs(activeSkolemDefs);
-      }
+      // notify the decision engine of the skolem definitions that have become
+      // active due to the assertion.
+      d_decisionEngine->notifyActiveSkolemDefs(activeSkolemDefs);
     }
   }
   d_theoryEngine->check(effort);

--- a/src/prop/theory_proxy.h
+++ b/src/prop/theory_proxy.h
@@ -65,6 +65,9 @@ class TheoryProxy : public Registrar
   /** Finish initialize */
   void finishInit(CnfStream* cnfStream);
 
+  /** Presolve, which calls presolve for the modules managed by this class */
+  void presolve();
+  
   /** Notify a lemma, possibly corresponding to a skolem definition */
   void notifyAssertion(Node lem, TNode skolem = TNode::null());
 
@@ -144,7 +147,7 @@ class TheoryProxy : public Registrar
 
   /** The decision engine we are using. */
   decision::DecisionEngine* d_decisionEngine;
-
+  
   /**
    * Whether the decision engine needs notification of active skolem
    * definitions, see DecisionEngine::needsActiveSkolemDefs.

--- a/src/prop/theory_proxy.h
+++ b/src/prop/theory_proxy.h
@@ -144,7 +144,7 @@ class TheoryProxy : public Registrar
 
   /** The decision engine we are using. */
   decision::DecisionEngine* d_decisionEngine;
-  
+
   /**
    * Whether the decision engine needs notification of active skolem
    * definitions, see DecisionEngine::needsActiveSkolemDefs.

--- a/src/prop/theory_proxy.h
+++ b/src/prop/theory_proxy.h
@@ -67,7 +67,7 @@ class TheoryProxy : public Registrar
 
   /** Presolve, which calls presolve for the modules managed by this class */
   void presolve();
-  
+
   /** Notify a lemma, possibly corresponding to a skolem definition */
   void notifyAssertion(Node lem, TNode skolem = TNode::null());
 
@@ -147,7 +147,7 @@ class TheoryProxy : public Registrar
 
   /** The decision engine we are using. */
   decision::DecisionEngine* d_decisionEngine;
-  
+
   /**
    * Whether the decision engine needs notification of active skolem
    * definitions, see DecisionEngine::needsActiveSkolemDefs.

--- a/src/prop/theory_proxy.h
+++ b/src/prop/theory_proxy.h
@@ -144,6 +144,12 @@ class TheoryProxy : public Registrar
 
   /** The decision engine we are using. */
   decision::DecisionEngine* d_decisionEngine;
+  
+  /**
+   * Whether the decision engine needs notification of active skolem
+   * definitions, see DecisionEngine::needsActiveSkolemDefs.
+   */
+  bool d_dmNeedsActiveDefs;
 
   /** The theory engine we are using. */
   TheoryEngine* d_theoryEngine;


### PR DESCRIPTION
These changes are taken from the SAT relevancy branch.  This PR does not change the behavior of the current code, it breaks the dependency of decision engine on the skolem definition manager and makes the latter solely managed by TheoryProxy.

This is in preparation for virtual clause deletion.