### PR TITLE
Fast exit for string extended equality rewriter

### DIFF
--- a/src/theory/strings/sequences_rewriter.cpp
+++ b/src/theory/strings/sequences_rewriter.cpp
@@ -90,11 +90,12 @@ Node SequencesRewriter::rewriteStrEqualityExt(Node node)
 {
   Assert(node.getKind() == EQUAL && node[0].getType().isStringLike());
   TypeNode stype = node[0].getType();
-  
+
   bool hasStrTerm = false;
-  for (size_t r=0; r<2; r++)
+  for (size_t r = 0; r < 2; r++)
   {
-    if (!node[0].isConst() && kindToTheoryId(node[0].getKind())==THEORY_STRINGS)
+    if (!node[0].isConst()
+        && kindToTheoryId(node[0].getKind()) == THEORY_STRINGS)
     {
       hasStrTerm = true;
       break;

--- a/src/theory/strings/sequences_rewriter.cpp
+++ b/src/theory/strings/sequences_rewriter.cpp
@@ -90,6 +90,21 @@ Node SequencesRewriter::rewriteStrEqualityExt(Node node)
 {
   Assert(node.getKind() == EQUAL && node[0].getType().isStringLike());
   TypeNode stype = node[0].getType();
+  
+  bool hasStrTerm = false;
+  for (size_t r=0; r<2; r++)
+  {
+    if (!node[0].isConst() && kindToTheoryId(node[0].getKind())==THEORY_STRINGS)
+    {
+      hasStrTerm = true;
+      break;
+    }
+  }
+  if (!hasStrTerm)
+  {
+    // equality between variables and constants, no rewrites apply
+    return node;
+  }
 
   NodeManager* nm = NodeManager::currentNM();
   // ( ~contains( s, t ) V ~contains( t, s ) ) => ( s == t ---> false )


### PR DESCRIPTION
In benchmarks with many string equalities between variables and constants, a significant portion of the run time is spent on extended equality rewriting. This adds a fast exit when the equality is between variable/constants only.