### PR TITLE
Change semantics of dumpUnsatCoresFull

### DIFF
--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -162,8 +162,7 @@ bool CommandExecutor::doCommandSingleton(Command* cmd)
       getterCommands.emplace_back(new GetInstantiationsCommand());
     }
 
-    if ((d_solver->getOptionInfo("dump-unsat-cores").boolValue()
-         || d_solver->getOptionInfo("dump-unsat-cores-full").boolValue())
+    if (d_solver->getOptionInfo("dump-unsat-cores").boolValue()
         && isResultUnsat)
     {
       getterCommands.emplace_back(new GetUnsatCoreCommand());

--- a/src/options/main_options.toml
+++ b/src/options/main_options.toml
@@ -125,9 +125,9 @@ name   = "Driver"
   help       = "output unsat cores after every UNSAT/VALID response"
 
 [[option]]
-  name       = "dumpUnsatCoresFull"
+  name       = "printUnsatCoresFull"
   category   = "regular"
-  long       = "dump-unsat-cores-full"
+  long       = "print-unsat-cores-full"
   type       = "bool"
   default    = "false"
   help       = "dump the full unsat core, including unlabeled assertions"

--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -2339,7 +2339,7 @@ void GetUnsatCoreCommand::printResult(std::ostream& out,
   }
   else
   {
-    if (options::dumpUnsatCoresFull())
+    if (options::printUnsatCoresFull())
     {
       // use the assertions
       UnsatCore ucr(termVectorToNodes(d_result));

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -77,7 +77,7 @@ void SetDefaults::setDefaultsPre(Options& opts)
     opts.smt.produceAssignments = true;
   }
   // unsat cores and proofs shenanigans
-  if (opts.driver.dumpUnsatCoresFull)
+  if (opts.driver.printUnsatCoresFull)
   {
     opts.driver.dumpUnsatCores = true;
   }

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -77,10 +77,6 @@ void SetDefaults::setDefaultsPre(Options& opts)
     opts.smt.produceAssignments = true;
   }
   // unsat cores and proofs shenanigans
-  if (opts.driver.printUnsatCoresFull)
-  {
-    opts.driver.dumpUnsatCores = true;
-  }
   if (opts.driver.dumpDifficulty)
   {
     opts.smt.produceDifficulty = true;

--- a/test/regress/regress0/dump-unsat-core-full.smt2
+++ b/test/regress/regress0/dump-unsat-core-full.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --dump-unsat-cores-full
+; COMMAND-LINE: --print-unsat-cores-full --dump-unsat-cores
 ; EXPECT: unsat
 ; EXPECT: (
 ; EXPECT: (and (= x y) (< x y))


### PR DESCRIPTION
This PR changes `--dump-unsat-cores-full` to `--print-unsat-cores-full`.
It also makes it so that solely having `--dump-unsat-cores-full` no longer automatically prints unsat cores.