### PR TITLE
Fix linking ANTLR3 on some systems

### DIFF
--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -101,14 +101,14 @@ endforeach()
 add_library(cvc5parser-objs OBJECT ${libcvc5parser_src_files})
 set_target_properties(cvc5parser-objs PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_compile_definitions(cvc5parser-objs PUBLIC -D__BUILDING_CVC5PARSERLIB)
-target_link_libraries(cvc5parser-objs PRIVATE ANTLR3)
-
+target_include_directories(cvc5parser-objs PRIVATE ${ANTLR3_INCLUDE_DIR})
 
 add_library(cvc5parser-shared SHARED)
 set_target_properties(cvc5parser-shared PROPERTIES SOVERSION ${CVC5_SOVERSION})
 set_target_properties(cvc5parser-shared PROPERTIES OUTPUT_NAME cvc5parser)
 target_link_libraries(cvc5parser-shared PRIVATE cvc5-shared)
 target_link_libraries(cvc5parser-shared PRIVATE cvc5parser-objs)
+target_link_libraries(cvc5parser-shared PRIVATE ANTLR3)
 
 install(TARGETS cvc5parser-shared
   EXPORT cvc5-targets
@@ -119,6 +119,7 @@ if(ENABLE_STATIC_LIBRARY)
   set_target_properties(cvc5parser-static PROPERTIES OUTPUT_NAME cvc5parser)
   target_link_libraries(cvc5parser-static PRIVATE cvc5parser-objs)
   target_link_libraries(cvc5parser-static PRIVATE cvc5-static)
+  target_link_libraries(cvc5parser-static PRIVATE ANTLR3)
 
   install(TARGETS cvc5parser-objs cvc5parser-static
     EXPORT cvc5-targets


### PR DESCRIPTION
Fixes #7318. This changes how we link ANTLR3 to more closely resemble
what we do for, e.g., GMP. This fixes the issue on Amazon Linux 2
(tested using a Docker image) with CMake 3.13.3.