### PR TITLE
Attach the static binaries to a release

### DIFF
--- a/.github/actions/add-to-release/action.yml
+++ b/.github/actions/add-to-release/action.yml
@@ -1,0 +1,17 @@
+name: Add binary to release
+description: Add cvc5 binary to the current release
+inputs:
+  github-token:
+    description: token to upload binary
+runs:
+  using: composite
+  steps:
+    - name: Rename binaries for release
+      run: |
+        cp build/bin/cvc5 cvc5-${{ runner.os }}
+
+    - name: Add binaries to release
+      uses: softprops/action-gh-release@v1
+      with:
+        token: ${{ inputs.github-token }}
+        files: cvc5-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
             python-bindings: true
             build-documentation: true
             check-examples: true
+            store-to-release: true
             exclude_regress: 3-4
             run_regression_args: --no-check-unsat-cores --no-check-proofs
 
@@ -22,6 +23,7 @@ jobs:
             cache-key: production
             python-bindings: true
             check-examples: true
+            store-to-release: true
             exclude_regress: 3-4
             run_regression_args: --no-check-unsat-cores --no-check-proofs
 
@@ -254,3 +256,9 @@ jobs:
       with:
         name: documentation
         path: build/docs/sphinx-gh/
+
+    - name: Add binary to release
+      if: matrix.store-to-release && startsWith(github.ref, 'refs/tags/')
+      uses: ./.github/actions/add-to-release
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds another step to our CI pipeline that uploads the binary build by some of the jobs to a release.