### PR TITLE
Add regression for fixed issue

### DIFF
--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -2206,6 +2206,7 @@ set(regress_1_tests
   regress1/strings/issue6604-2.smt2
   regress1/strings/issue6635-rre.smt2
   regress1/strings/issue6653-2-update-c-len.smt2
+  regress1/strings/issue6653-3-seq.smt2
   regress1/strings/issue6653-4-rre.smt2
   regress1/strings/issue6653-rre.smt2
   regress1/strings/issue6653-rre-small.smt2

--- a/test/regress/regress1/strings/issue6653-3-seq.smt2
+++ b/test/regress/regress1/strings/issue6653-3-seq.smt2
@@ -1,0 +1,6 @@
+(set-option :strings-lazy-pp false)
+(declare-fun z () Int)
+(declare-fun a () (Seq Int))
+(assert (not (= (seq.nth a 1) (seq.nth a z))))
+(assert (= z (- 1)))
+(check-sat)

--- a/test/regress/regress1/strings/issue6653-3-seq.smt2
+++ b/test/regress/regress1/strings/issue6653-3-seq.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: -q
+; EXPECT: sat
 (set-logic QF_SLIA)
 (set-info :status sat)
 (set-option :strings-lazy-pp false)

--- a/test/regress/regress1/strings/issue6653-3-seq.smt2
+++ b/test/regress/regress1/strings/issue6653-3-seq.smt2
@@ -1,3 +1,5 @@
+(set-logic QF_SLIA)
+(set-info :status sat)
 (set-option :strings-lazy-pp false)
 (declare-fun z () Int)
 (declare-fun a () (Seq Int))


### PR DESCRIPTION
Fixes #6653.

The third benchmark on that issue is no longer an issue, this adds it as a regression, which is the last open benchmark on the referenced issue.