### PR TITLE
Move variadic trie utility to its own file

### DIFF
--- a/src/expr/CMakeLists.txt
+++ b/src/expr/CMakeLists.txt
@@ -95,6 +95,8 @@ libcvc5_add_sources(
   sygus_datatype.h
   uninterpreted_constant.cpp
   uninterpreted_constant.h
+  variadic_trie.cpp
+  variadic_trie.h
 )
 
 libcvc5_add_sources(GENERATED

--- a/src/expr/variadic_trie.cpp
+++ b/src/expr/variadic_trie.cpp
@@ -1,0 +1,55 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2021 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Variadic trie utility
+ */
+
+#include "expr/variadic_trie.h"
+
+namespace cvc5 {
+
+bool VariadicTrie::add(Node n, const std::vector<Node>& i)
+{
+  VariadicTrie* curr = this;
+  for (const Node& ic : i)
+  {
+    curr = &(curr->d_children[ic]);
+  }
+  if (curr->d_data.isNull())
+  {
+    curr->d_data = n;
+    return true;
+  }
+  return false;
+}
+
+bool VariadicTrie::hasSubset(const std::vector<Node>& is) const
+{
+  if (!d_data.isNull())
+  {
+    return true;
+  }
+  for (const std::pair<const Node, VariadicTrie>& p : d_children)
+  {
+    Node n = p.first;
+    if (std::find(is.begin(), is.end(), n) != is.end())
+    {
+      if (p.second.hasSubset(is))
+      {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+}  // namespace cvc5

--- a/src/expr/variadic_trie.h
+++ b/src/expr/variadic_trie.h
@@ -1,0 +1,54 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2021 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Variadic trie utility
+ */
+
+#include "cvc5_private.h"
+
+#ifndef CVC5__EXPR__VARIADIC_TRIE_H
+#define CVC5__EXPR__VARIADIC_TRIE_H
+
+#include <map>
+#include <vector>
+
+#include "expr/node.h"
+
+namespace cvc5 {
+
+/**
+ * A trie that stores data at undetermined depth. Storing data at
+ * undetermined depth is in contrast to the NodeTrie (expr/node_trie.h), which
+ * assumes all data is stored at a fixed depth.
+ *
+ * Since data can be stored at any depth, we require both a d_children field
+ * and a d_data field.
+ */
+class VariadicTrie
+{
+ public:
+  /** the children of this node */
+  std::map<Node, VariadicTrie> d_children;
+  /** the data at this node */
+  Node d_data;
+  /**
+   * Add data with identifier n indexed by i, return true if data is not already
+   * stored at the node indexed by i.
+   */
+  bool add(Node n, const std::vector<Node>& i);
+  /** Is there any data in this trie that is indexed by any subset of is? */
+  bool hasSubset(const std::vector<Node>& is) const;
+};
+
+}  // namespace cvc5
+
+#endif /* CVC5__EXPR__VARIADIC_TRIE_H */


### PR DESCRIPTION
Work towards a new internal fuzzing technique.

The new fuzzing technique leverages elements of the IJCAR 2020 paper on abduction, this moves https://github.com/cvc5/cvc5/blob/master/src/theory/quantifiers/sygus/cegis_core_connective.h#L44 to its own file.  A followup PR will break this and further utility methods out of this file.