### PR TITLE
Fix expected conclusion for EQ_RESOLVE when expanding MACRO_SR_PRED_TRANSFORM

### DIFF
--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -654,7 +654,7 @@ Node ProofPostprocessCallback::expandMacros(PfRule id,
     // apply transitivity if necessary
     Node eq = addProofForTrans(tchildren, cdp);
 
-    cdp->addStep(args[0], PfRule::EQ_RESOLVE, {children[0], eq}, {});
+    cdp->addStep(eq[1], PfRule::EQ_RESOLVE, {children[0], eq}, {});
     return args[0];
   }
   else if (id == PfRule::MACRO_RESOLUTION

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1760,6 +1760,7 @@ set(regress_1_tests
   regress1/proofs/issue6625-unsat-core-proofs.smt2
   regress1/proofs/macro-res-exp-crowding-lit-inside-unit.smt2
   regress1/proofs/macro-res-exp-singleton-after-elimCrowd.smt2
+  regress1/proofs/qgu-fuzz-1-strings-pp.smt2
   regress1/proofs/quant-alpha-eq.smt2
   regress1/proofs/sat-trivial-cycle.smt2
   regress1/proofs/unsat-cores-proofs.smt2

--- a/test/regress/regress1/proofs/qgu-fuzz-1-strings-pp.smt2
+++ b/test/regress/regress1/proofs/qgu-fuzz-1-strings-pp.smt2
@@ -1,0 +1,5 @@
+(set-logic ALL)
+(set-info :status unsat)
+(declare-fun x () String)
+(assert (let ((_let_1 (str.to_re "B"))) (and (str.in_re x (re.++ re.allchar  (str.to_re (str.++ "B" "A")))) (str.in_re x (re.* (re.union re.allchar  (str.to_re "A")))) (str.in_re x (re.* (re.union re.allchar  _let_1))) (str.in_re x (re.* (re.++ re.allchar  _let_1))))))
+(check-sat)


### PR DESCRIPTION
Fixes a proof checking failure during post-processing.

Fixes a rare case where the RHS of equality resolve step requires a symmetry step.