### PR TITLE
Add basic regular expression type enumerator

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1081,6 +1081,8 @@ libcvc5_add_sources(
   theory/strings/normal_form.h
   theory/strings/proof_checker.cpp
   theory/strings/proof_checker.h
+  theory/strings/regexp_enumerator.cpp
+  theory/strings/regexp_enumerator.h
   theory/strings/regexp_elim.cpp
   theory/strings/regexp_elim.h
   theory/strings/regexp_entail.cpp

--- a/src/theory/strings/kinds
+++ b/src/theory/strings/kinds
@@ -56,6 +56,10 @@ enumerator STRING_TYPE \
     "::cvc5::theory::strings::StringEnumerator" \
     "theory/strings/type_enumerator.h"
 
+enumerator REGEXP_TYPE \
+    "::cvc5::theory::strings::RegExpEnumerator" \
+    "theory/strings/regexp_enumerator.h"
+
 constant CONST_STRING \
   class \
   String \

--- a/src/theory/strings/regexp_enumerator.cpp
+++ b/src/theory/strings/regexp_enumerator.cpp
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds, Mathias Preiner, Andres Noetzli
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2021 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Implementation of enumerators for strings.
+ */
+
+#include "theory/strings/regexp_enumerator.h"
+
+#include "expr/sequence.h"
+#include "theory/strings/theory_strings_utils.h"
+#include "util/string.h"
+
+namespace cvc5 {
+namespace theory {
+namespace strings {
+
+RegExpEnumerator::RegExpEnumerator(TypeNode type, TypeEnumeratorProperties* tep)
+    : TypeEnumeratorBase<RegExpEnumerator>(type),
+      d_senum(type, tep)
+{
+}
+
+RegExpEnumerator::RegExpEnumerator(const RegExpEnumerator& enumerator)
+    : TypeEnumeratorBase<RegExpEnumerator>(enumerator.getType()),
+      d_senum(enumerator.d_senum)
+{
+}
+
+Node RegExpEnumerator::operator*() { 
+  NodeManager * nm = NodeManager::currentNM();
+  return nm->mkNode(kind::STRING_TO_REGEXP, *d_senum);
+}
+
+RegExpEnumerator& RegExpEnumerator::operator++()
+{
+  ++d_senum;
+  return *this;
+}
+
+bool RegExpEnumerator::isFinished() { return d_senum.isFinished(); }
+
+}  // namespace strings
+}  // namespace theory
+}  // namespace cvc5

--- a/src/theory/strings/regexp_enumerator.cpp
+++ b/src/theory/strings/regexp_enumerator.cpp
@@ -24,8 +24,7 @@ namespace theory {
 namespace strings {
 
 RegExpEnumerator::RegExpEnumerator(TypeNode type, TypeEnumeratorProperties* tep)
-    : TypeEnumeratorBase<RegExpEnumerator>(type),
-      d_senum(type, tep)
+    : TypeEnumeratorBase<RegExpEnumerator>(type), d_senum(type, tep)
 {
 }
 
@@ -35,8 +34,9 @@ RegExpEnumerator::RegExpEnumerator(const RegExpEnumerator& enumerator)
 {
 }
 
-Node RegExpEnumerator::operator*() { 
-  NodeManager * nm = NodeManager::currentNM();
+Node RegExpEnumerator::operator*()
+{
+  NodeManager* nm = NodeManager::currentNM();
   return nm->mkNode(kind::STRING_TO_REGEXP, *d_senum);
 }
 

--- a/src/theory/strings/regexp_enumerator.cpp
+++ b/src/theory/strings/regexp_enumerator.cpp
@@ -10,7 +10,7 @@
  * directory for licensing information.
  * ****************************************************************************
  *
- * Implementation of enumerators for strings.
+ * Implementation of enumerator for regular expressions.
  */
 
 #include "theory/strings/regexp_enumerator.h"

--- a/src/theory/strings/regexp_enumerator.cpp
+++ b/src/theory/strings/regexp_enumerator.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Top contributors (to current version):
- *   Andrew Reynolds, Mathias Preiner, Andres Noetzli
+ *   Andrew Reynolds
  *
  * This file is part of the cvc5 project.
  *
@@ -14,10 +14,6 @@
  */
 
 #include "theory/strings/regexp_enumerator.h"
-
-#include "expr/sequence.h"
-#include "theory/strings/theory_strings_utils.h"
-#include "util/string.h"
 
 namespace cvc5 {
 namespace theory {

--- a/src/theory/strings/regexp_enumerator.h
+++ b/src/theory/strings/regexp_enumerator.h
@@ -1,0 +1,57 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds, Tianyi Liang, Mathias Preiner
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2021 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Enumerators for strings.
+ */
+
+#include "cvc5_private.h"
+
+#ifndef CVC5__THEORY__STRINGS__REGEXP_ENUMERATOR_H
+#define CVC5__THEORY__STRINGS__REGEXP_ENUMERATOR_H
+
+#include <vector>
+
+#include "expr/node.h"
+#include "expr/type_node.h"
+#include "theory/strings/type_enumerator.h"
+
+namespace cvc5 {
+namespace theory {
+namespace strings {
+
+/**
+ * Simple regular expression enumerator, generates only singleton language
+ * regular expressions from a string enumeration.
+ */
+class RegExpEnumerator : public TypeEnumeratorBase<RegExpEnumerator>
+{
+ public:
+  RegExpEnumerator(TypeNode type, TypeEnumeratorProperties* tep = nullptr);
+  RegExpEnumerator(const RegExpEnumerator& enumerator);
+  ~RegExpEnumerator() {}
+  /** get the current term */
+  Node operator*() override;
+  /** increment */
+  RegExpEnumerator& operator++() override;
+  /** is this enumerator finished? */
+  bool isFinished() override;
+
+ private:
+  /** underlying string enumerator */
+  StringEnumerator d_senum;
+};
+
+}  // namespace strings
+}  // namespace theory
+}  // namespace cvc5
+
+#endif /* CVC5__THEORY__STRINGS__TYPE_ENUMERATOR_H */

--- a/src/theory/strings/regexp_enumerator.h
+++ b/src/theory/strings/regexp_enumerator.h
@@ -10,7 +10,7 @@
  * directory for licensing information.
  * ****************************************************************************
  *
- * Enumerators for strings.
+ * Enumerators for regular expressions.
  */
 
 #include "cvc5_private.h"
@@ -30,7 +30,9 @@ namespace strings {
 
 /**
  * Simple regular expression enumerator, generates only singleton language
- * regular expressions from a string enumeration.
+ * regular expressions from a string enumeration, in other words:
+ *   (str.to_re s1) ... (str.to_re sn) ....
+ * where s1 ... sn ... is the enumeration for strings.
  */
 class RegExpEnumerator : public TypeEnumeratorBase<RegExpEnumerator>
 {
@@ -44,7 +46,6 @@ class RegExpEnumerator : public TypeEnumeratorBase<RegExpEnumerator>
   RegExpEnumerator& operator++() override;
   /** is this enumerator finished? */
   bool isFinished() override;
-
  private:
   /** underlying string enumerator */
   StringEnumerator d_senum;

--- a/src/theory/strings/regexp_enumerator.h
+++ b/src/theory/strings/regexp_enumerator.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Top contributors (to current version):
- *   Andrew Reynolds, Tianyi Liang, Mathias Preiner
+ *   Andrew Reynolds
  *
  * This file is part of the cvc5 project.
  *

--- a/src/theory/strings/regexp_enumerator.h
+++ b/src/theory/strings/regexp_enumerator.h
@@ -46,6 +46,7 @@ class RegExpEnumerator : public TypeEnumeratorBase<RegExpEnumerator>
   RegExpEnumerator& operator++() override;
   /** is this enumerator finished? */
   bool isFinished() override;
+
  private:
   /** underlying string enumerator */
   StringEnumerator d_senum;


### PR DESCRIPTION
The lack of a type enumerator for regular expressions makes certain things impossible e.g. sygus-based sampling for RE queries.

It is trivial to support a basic RE enumerator that takes singleton languages of strings.  This PR add this utility as the type enumerator for RE.