### PR TITLE
Fix inadvertent failure of workflow step

### DIFF
--- a/.github/workflows/docs_upload.yml
+++ b/.github/workflows/docs_upload.yml
@@ -81,8 +81,7 @@ jobs:
             mv docs-new target/docs-$NAME-$HASH
             cd target/
 
-            (diff -r -x "*.zip" docs-master/ docs-$NAME-$HASH)
-            issame=$?
+            issame=$(diff -r -x "*.zip" docs-master/ docs-$NAME-$HASH; echo $?; exit 0)
 
             if [[ -n $ISTAG && $issame ]]
             then


### PR DESCRIPTION
This PR fixes an issue introduced with #7352: jobs fail immediately if any command has a non-zero exit code. The way we obtained the exit code of the `diff` command was incompatible with this policy, which is why we currently never upload any docs to `docs-ci`.