### PR TITLE
Use codatatype bound variables for codatatype values

### DIFF
--- a/src/expr/CMakeLists.txt
+++ b/src/expr/CMakeLists.txt
@@ -26,6 +26,8 @@ libcvc5_add_sources(
   bound_var_manager.h
   cardinality_constraint.cpp
   cardinality_constraint.h
+  codatatype_bound_variable.cpp
+  codatatype_bound_variable.h
   emptyset.cpp
   emptyset.h
   emptybag.cpp

--- a/src/expr/codatatype_bound_variable.cpp
+++ b/src/expr/codatatype_bound_variable.cpp
@@ -28,51 +28,67 @@ using namespace std;
 namespace cvc5 {
 
 CodatatypeBoundVariable::CodatatypeBoundVariable(const TypeNode& type,
-                                             Integer index)
+                                                 Integer index)
     : d_type(new TypeNode(type)), d_index(index)
 {
-  PrettyCheckArgument(type.isCodatatype(), type, "codatatype bound variables can only be created for codatatype sorts, not `%s'", type.toString().c_str());
-  PrettyCheckArgument(index >= 0, index, "index >= 0 required for codatatype bound variable index, not `%s'", index.toString().c_str());
+  PrettyCheckArgument(type.isCodatatype(),
+                      type,
+                      "codatatype bound variables can only be created for "
+                      "codatatype sorts, not `%s'",
+                      type.toString().c_str());
+  PrettyCheckArgument(
+      index >= 0,
+      index,
+      "index >= 0 required for codatatype bound variable index, not `%s'",
+      index.toString().c_str());
 }
 
 CodatatypeBoundVariable::~CodatatypeBoundVariable() {}
 
-CodatatypeBoundVariable::CodatatypeBoundVariable(const CodatatypeBoundVariable& other)
+CodatatypeBoundVariable::CodatatypeBoundVariable(
+    const CodatatypeBoundVariable& other)
     : d_type(new TypeNode(other.getType())), d_index(other.getIndex())
 {
 }
 
 const TypeNode& CodatatypeBoundVariable::getType() const { return *d_type; }
 const Integer& CodatatypeBoundVariable::getIndex() const { return d_index; }
-bool CodatatypeBoundVariable::operator==(const CodatatypeBoundVariable& cbv) const
+bool CodatatypeBoundVariable::operator==(
+    const CodatatypeBoundVariable& cbv) const
 {
   return getType() == cbv.getType() && d_index == cbv.d_index;
 }
-bool CodatatypeBoundVariable::operator!=(const CodatatypeBoundVariable& cbv) const
+bool CodatatypeBoundVariable::operator!=(
+    const CodatatypeBoundVariable& cbv) const
 {
   return !(*this == cbv);
 }
 
-bool CodatatypeBoundVariable::operator<(const CodatatypeBoundVariable& cbv) const
+bool CodatatypeBoundVariable::operator<(
+    const CodatatypeBoundVariable& cbv) const
 {
   return getType() < cbv.getType()
          || (getType() == cbv.getType() && d_index < cbv.d_index);
 }
-bool CodatatypeBoundVariable::operator<=(const CodatatypeBoundVariable& cbv) const
+bool CodatatypeBoundVariable::operator<=(
+    const CodatatypeBoundVariable& cbv) const
 {
   return getType() < cbv.getType()
          || (getType() == cbv.getType() && d_index <= cbv.d_index);
 }
-bool CodatatypeBoundVariable::operator>(const CodatatypeBoundVariable& cbv) const
+bool CodatatypeBoundVariable::operator>(
+    const CodatatypeBoundVariable& cbv) const
 {
   return !(*this <= cbv);
 }
-bool CodatatypeBoundVariable::operator>=(const CodatatypeBoundVariable& cbv) const
+bool CodatatypeBoundVariable::operator>=(
+    const CodatatypeBoundVariable& cbv) const
 {
   return !(*this < cbv);
 }
 
-std::ostream& operator<<(std::ostream& out, const CodatatypeBoundVariable& cbv) {
+std::ostream& operator<<(std::ostream& out, const CodatatypeBoundVariable& cbv)
+{
   std::stringstream ss;
   ss << cbv.getType();
   std::string st(ss.str());

--- a/src/expr/codatatype_bound_variable.cpp
+++ b/src/expr/codatatype_bound_variable.cpp
@@ -1,0 +1,97 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2021 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Representation of bound variables in codatatype values
+ */
+
+#include "expr/codatatype_bound_variable.h"
+
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "base/check.h"
+#include "expr/type_node.h"
+
+using namespace std;
+
+namespace cvc5 {
+
+CodatatypeBoundVariable::CodatatypeBoundVariable(const TypeNode& type,
+                                             Integer index)
+    : d_type(new TypeNode(type)), d_index(index)
+{
+  PrettyCheckArgument(type.isCodatatype(), type, "codatatype bound variables can only be created for codatatype sorts, not `%s'", type.toString().c_str());
+  PrettyCheckArgument(index >= 0, index, "index >= 0 required for codatatype bound variable index, not `%s'", index.toString().c_str());
+}
+
+CodatatypeBoundVariable::~CodatatypeBoundVariable() {}
+
+CodatatypeBoundVariable::CodatatypeBoundVariable(const CodatatypeBoundVariable& other)
+    : d_type(new TypeNode(other.getType())), d_index(other.getIndex())
+{
+}
+
+const TypeNode& CodatatypeBoundVariable::getType() const { return *d_type; }
+const Integer& CodatatypeBoundVariable::getIndex() const { return d_index; }
+bool CodatatypeBoundVariable::operator==(const CodatatypeBoundVariable& cbv) const
+{
+  return getType() == cbv.getType() && d_index == cbv.d_index;
+}
+bool CodatatypeBoundVariable::operator!=(const CodatatypeBoundVariable& cbv) const
+{
+  return !(*this == cbv);
+}
+
+bool CodatatypeBoundVariable::operator<(const CodatatypeBoundVariable& cbv) const
+{
+  return getType() < cbv.getType()
+         || (getType() == cbv.getType() && d_index < cbv.d_index);
+}
+bool CodatatypeBoundVariable::operator<=(const CodatatypeBoundVariable& cbv) const
+{
+  return getType() < cbv.getType()
+         || (getType() == cbv.getType() && d_index <= cbv.d_index);
+}
+bool CodatatypeBoundVariable::operator>(const CodatatypeBoundVariable& cbv) const
+{
+  return !(*this <= cbv);
+}
+bool CodatatypeBoundVariable::operator>=(const CodatatypeBoundVariable& cbv) const
+{
+  return !(*this < cbv);
+}
+
+std::ostream& operator<<(std::ostream& out, const CodatatypeBoundVariable& cbv) {
+  std::stringstream ss;
+  ss << cbv.getType();
+  std::string st(ss.str());
+  // must remove delimiting quotes from the name of the type
+  // this prevents us from printing symbols like |@cbv_|T|_n|
+  std::string q("|");
+  size_t pos;
+  while ((pos = st.find(q)) != std::string::npos)
+  {
+    st.replace(pos, 1, "");
+  }
+  return out << "cbv_" << st.c_str() << "_" << cbv.getIndex();
+}
+
+size_t CodatatypeBoundVariableHashFunction::operator()(
+    const CodatatypeBoundVariable& cbv) const
+{
+  return std::hash<TypeNode>()(cbv.getType())
+         * IntegerHashFunction()(cbv.getIndex());
+}
+
+}  // namespace cvc5

--- a/src/expr/codatatype_bound_variable.h
+++ b/src/expr/codatatype_bound_variable.h
@@ -1,0 +1,91 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2021 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Representation of bound variables in codatatype values
+ */
+
+#include "cvc5_public.h"
+
+#ifndef CVC5__EXPR__CODATATYPE_BOUND_VARIABLE_H
+#define CVC5__EXPR__CODATATYPE_BOUND_VARIABLE_H
+
+#include <iosfwd>
+#include <memory>
+
+#include "util/integer.h"
+
+namespace cvc5 {
+
+class TypeNode;
+
+/**
+ * In theory, codatatype values are represented in using a MU-notation form,
+ * where recursive values may contain free constants indexed by their de Bruijn
+ * indices. This is sometimes written:
+ *    MU x. (cons 0 x).
+ * where the MU binder is label for a term position, which x references.
+ * Instead of construct an explicit MU binder (which is problematic for
+ * canonicity), we use de Bruijn indices for representing bound variables,
+ * whose index indicates the level in which it is nested. For example, we
+ * represent the above value as:
+ *    (cons 0 @cbv_0)
+ * In the above value, @cbv_0 is a pointer to its direct parent, so the above
+ * value represents the infintite list (cons 0 (cons 0 (cons 0 ... ))).
+ * Another example, the value:
+ *    (cons 0 (cons 1 @cbv_1))
+ * @cbv_1 is pointer to the top most node of this value, so this is value
+ * represents the infinite list (cons 0 (cons 1 (cons 0 (cons 1 ...)))). The
+ * value:
+ *    (cons 0 (cons 1 @cbv_0))
+ * on the other hand represents the lasso:
+ *    (cons 0 (cons 1 (cons 1 (cons 1 ... ))))
+ *
+ * This class is used for representing the indexed bound variables in the above
+ * values. It is considered a constant (isConst is true). However, constants
+ * of codatatype type are normalized by the rewriter (see datatypes rewriter
+ * normalizeCodatatypeConstant) to ensure their canonicity, via a variant
+ * of Hopcroft's algorithm.
+ */
+class CodatatypeBoundVariable
+{
+ public:
+  CodatatypeBoundVariable(const TypeNode& type, Integer index);
+  ~CodatatypeBoundVariable();
+
+  CodatatypeBoundVariable(const CodatatypeBoundVariable& other);
+
+  const TypeNode& getType() const;
+  const Integer& getIndex() const;
+  bool operator==(const CodatatypeBoundVariable& cbv) const;
+  bool operator!=(const CodatatypeBoundVariable& cbv) const;
+  bool operator<(const CodatatypeBoundVariable& cbv) const;
+  bool operator<=(const CodatatypeBoundVariable& cbv) const;
+  bool operator>(const CodatatypeBoundVariable& cbv) const;
+  bool operator>=(const CodatatypeBoundVariable& cbv) const;
+
+ private:
+  std::unique_ptr<TypeNode> d_type;
+  const Integer d_index;
+};
+std::ostream& operator<<(std::ostream& out, const CodatatypeBoundVariable& cbv);
+
+/**
+ * Hash function for codatatype bound variables.
+ */
+struct CodatatypeBoundVariableHashFunction
+{
+  size_t operator()(const CodatatypeBoundVariable& cbv) const;
+};
+
+}  // namespace cvc5
+
+#endif /* CVC5__UNINTERPRETED_CONSTANT_H */

--- a/src/expr/uninterpreted_constant.cpp
+++ b/src/expr/uninterpreted_constant.cpp
@@ -31,7 +31,11 @@ UninterpretedConstant::UninterpretedConstant(const TypeNode& type,
                                              Integer index)
     : d_type(new TypeNode(type)), d_index(index)
 {
-  PrettyCheckArgument(type.isSort(), type, "uninterpreted constants can only be created for uninterpreted sorts, not `%s'", type.toString().c_str());
+  PrettyCheckArgument(type.isSort(),
+                      type,
+                      "uninterpreted constants can only be created for "
+                      "uninterpreted sorts, not `%s'",
+                      type.toString().c_str());
   PrettyCheckArgument(index >= 0, index, "index >= 0 required for uninterpreted constant index, not `%s'", index.toString().c_str());
 }
 

--- a/src/expr/uninterpreted_constant.cpp
+++ b/src/expr/uninterpreted_constant.cpp
@@ -31,7 +31,7 @@ UninterpretedConstant::UninterpretedConstant(const TypeNode& type,
                                              Integer index)
     : d_type(new TypeNode(type)), d_index(index)
 {
-  //PrettyCheckArgument(type.isSort(), type, "uninterpreted constants can only be created for uninterpreted sorts, not `%s'", type.toString().c_str());
+  PrettyCheckArgument(type.isSort(), type, "uninterpreted constants can only be created for uninterpreted sorts, not `%s'", type.toString().c_str());
   PrettyCheckArgument(index >= 0, index, "index >= 0 required for uninterpreted constant index, not `%s'", index.toString().c_str());
 }
 

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -16,12 +16,12 @@
 #include "theory/datatypes/datatypes_rewriter.h"
 
 #include "expr/ascription_type.h"
+#include "expr/codatatype_bound_variable.h"
 #include "expr/dtype.h"
 #include "expr/dtype_cons.h"
 #include "expr/node_algorithm.h"
 #include "expr/skolem_manager.h"
 #include "expr/sygus_datatype.h"
-#include "expr/codatatype_bound_variable.h"
 #include "options/datatypes_options.h"
 #include "theory/datatypes/sygus_datatype_utils.h"
 #include "theory/datatypes/theory_datatypes_utils.h"

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -21,7 +21,7 @@
 #include "expr/node_algorithm.h"
 #include "expr/skolem_manager.h"
 #include "expr/sygus_datatype.h"
-#include "expr/uninterpreted_constant.h"
+#include "expr/codatatype_bound_variable.h"
 #include "options/datatypes_options.h"
 #include "theory/datatypes/sygus_datatype_utils.h"
 #include "theory/datatypes/theory_datatypes_utils.h"
@@ -729,7 +729,7 @@ Node DatatypesRewriter::collectRef(Node n,
       else
       {
         // a loop
-        const Integer& i = n.getConst<UninterpretedConstant>().getIndex();
+        const Integer& i = n.getConst<CodatatypeBoundVariable>().getIndex();
         uint32_t index = i.toUnsignedInt();
         if (index >= sk.size())
         {
@@ -771,7 +771,7 @@ Node DatatypesRewriter::normalizeCodatatypeConstantEqc(
     {
       int debruijn = depth - it->second - 1;
       return NodeManager::currentNM()->mkConst(
-          UninterpretedConstant(n.getType(), debruijn));
+          CodatatypeBoundVariable(n.getType(), debruijn));
     }
     std::vector<Node> children;
     bool childChanged = false;
@@ -801,7 +801,7 @@ Node DatatypesRewriter::replaceDebruijn(Node n,
   if (n.getKind() == kind::UNINTERPRETED_CONSTANT && n.getType() == orig_tn)
   {
     unsigned index =
-        n.getConst<UninterpretedConstant>().getIndex().toUnsignedInt();
+        n.getConst<CodatatypeBoundVariable>().getIndex().toUnsignedInt();
     if (index == depth)
     {
       return orig;

--- a/src/theory/datatypes/kinds
+++ b/src/theory/datatypes/kinds
@@ -145,4 +145,13 @@ parameterized TUPLE_PROJECT TUPLE_PROJECT_OP 1 \
 typerule TUPLE_PROJECT_OP  "SimpleTypeRule<RBuiltinOperator>"
 typerule TUPLE_PROJECT     ::cvc5::theory::datatypes::TupleProjectTypeRule
 
+# For representing codatatype values
+constant CODATATYPE_BOUND_VARIABLE \
+    class \
+    CodatatypeBoundVariable \
+    ::cvc5::CodatatypeBoundVariableHashFunction \
+    "expr/codatatype_bound_variable.h" \
+    "the kind of expressions representing bound variables in codatatype constants, which are de Bruijn indexed variables; payload is an instance of the cvc5::CodatatypeBoundVariable class (used in models)"
+typerule CODATATYPE_BOUND_VARIABLE ::cvc5::theory::datatypes::CodatatypeBoundVariableTypeRule
+
 endtheory

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -18,11 +18,11 @@
 #include <sstream>
 
 #include "base/check.h"
+#include "expr/codatatype_bound_variable.h"
 #include "expr/dtype.h"
 #include "expr/dtype_cons.h"
 #include "expr/kind.h"
 #include "expr/skolem_manager.h"
-#include "expr/codatatype_bound_variable.h"
 #include "options/datatypes_options.h"
 #include "options/quantifiers_options.h"
 #include "options/smt_options.h"
@@ -1290,11 +1290,10 @@ bool TheoryDatatypes::collectModelValues(TheoryModel* m,
 
 Node TheoryDatatypes::getCodatatypesValue( Node n, std::map< Node, Node >& eqc_cons, std::map< Node, int >& vmap, int depth ){
   std::map< Node, int >::iterator itv = vmap.find( n );
-  NodeManager * nm = NodeManager::currentNM();
+  NodeManager* nm = NodeManager::currentNM();
   if( itv!=vmap.end() ){
     int debruijn = depth - 1 - itv->second;
-    return nm->mkConst(
-        CodatatypeBoundVariable(n.getType(), debruijn));
+    return nm->mkConst(CodatatypeBoundVariable(n.getType(), debruijn));
   }else if( n.getType().isDatatype() ){
     Node nc = eqc_cons[n];
     if( !nc.isNull() ){
@@ -1309,7 +1308,7 @@ Node TheoryDatatypes::getCodatatypesValue( Node n, std::map< Node, Node >& eqc_c
         children.push_back( rv );
       }
       vmap.erase( n );
-      return nm->mkNode( APPLY_CONSTRUCTOR, children );
+      return nm->mkNode(APPLY_CONSTRUCTOR, children);
     }
   }
   return n;

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -22,7 +22,7 @@
 #include "expr/dtype_cons.h"
 #include "expr/kind.h"
 #include "expr/skolem_manager.h"
-#include "expr/uninterpreted_constant.h"
+#include "expr/codatatype_bound_variable.h"
 #include "options/datatypes_options.h"
 #include "options/quantifiers_options.h"
 #include "options/smt_options.h"
@@ -1290,10 +1290,11 @@ bool TheoryDatatypes::collectModelValues(TheoryModel* m,
 
 Node TheoryDatatypes::getCodatatypesValue( Node n, std::map< Node, Node >& eqc_cons, std::map< Node, int >& vmap, int depth ){
   std::map< Node, int >::iterator itv = vmap.find( n );
+  NodeManager * nm = NodeManager::currentNM();
   if( itv!=vmap.end() ){
     int debruijn = depth - 1 - itv->second;
-    return NodeManager::currentNM()->mkConst(
-        UninterpretedConstant(n.getType(), debruijn));
+    return nm->mkConst(
+        CodatatypeBoundVariable(n.getType(), debruijn));
   }else if( n.getType().isDatatype() ){
     Node nc = eqc_cons[n];
     if( !nc.isNull() ){
@@ -1308,7 +1309,7 @@ Node TheoryDatatypes::getCodatatypesValue( Node n, std::map< Node, Node >& eqc_c
         children.push_back( rv );
       }
       vmap.erase( n );
-      return NodeManager::currentNM()->mkNode( APPLY_CONSTRUCTOR, children );
+      return nm->mkNode( APPLY_CONSTRUCTOR, children );
     }
   }
   return n;

--- a/src/theory/datatypes/theory_datatypes_type_rules.cpp
+++ b/src/theory/datatypes/theory_datatypes_type_rules.cpp
@@ -598,8 +598,8 @@ TypeNode TupleProjectTypeRule::computeType(NodeManager* nm, TNode n, bool check)
 }
 
 TypeNode CodatatypeBoundVariableTypeRule::computeType(NodeManager* nodeManager,
-                                                    TNode n,
-                                                    bool check)
+                                                      TNode n,
+                                                      bool check)
 {
   return n.getConst<CodatatypeBoundVariable>().getType();
 }

--- a/src/theory/datatypes/theory_datatypes_type_rules.cpp
+++ b/src/theory/datatypes/theory_datatypes_type_rules.cpp
@@ -597,6 +597,13 @@ TypeNode TupleProjectTypeRule::computeType(NodeManager* nm, TNode n, bool check)
   return nm->mkTupleType(types);
 }
 
+TypeNode CodatatypeBoundVariableTypeRule::computeType(NodeManager* nodeManager,
+                                                    TNode n,
+                                                    bool check)
+{
+  return n.getConst<CodatatypeBoundVariable>().getType();
+}
+
 }  // namespace datatypes
 }  // namespace theory
 }  // namespace cvc5

--- a/src/theory/datatypes/theory_datatypes_type_rules.h
+++ b/src/theory/datatypes/theory_datatypes_type_rules.h
@@ -99,6 +99,11 @@ class TupleProjectTypeRule
   static TypeNode computeType(NodeManager* nm, TNode n, bool check);
 };
 
+class CodatatypeBoundVariableTypeRule {
+ public:
+  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+};
+
 }  // namespace datatypes
 }  // namespace theory
 }  // namespace cvc5

--- a/src/theory/datatypes/theory_datatypes_type_rules.h
+++ b/src/theory/datatypes/theory_datatypes_type_rules.h
@@ -99,7 +99,8 @@ class TupleProjectTypeRule
   static TypeNode computeType(NodeManager* nm, TNode n, bool check);
 };
 
-class CodatatypeBoundVariableTypeRule {
+class CodatatypeBoundVariableTypeRule
+{
  public:
   static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
 };

--- a/src/theory/datatypes/type_enumerator.cpp
+++ b/src/theory/datatypes/type_enumerator.cpp
@@ -16,10 +16,10 @@
 #include "theory/datatypes/type_enumerator.h"
 
 #include "expr/ascription_type.h"
+#include "expr/codatatype_bound_variable.h"
 #include "expr/dtype_cons.h"
 #include "theory/datatypes/datatypes_rewriter.h"
 #include "theory/datatypes/theory_datatypes_utils.h"
-#include "expr/codatatype_bound_variable.h"
 
 using namespace cvc5;
 using namespace theory;
@@ -109,9 +109,8 @@ Node DatatypesEnumerator::getTermEnum( TypeNode tn, unsigned i ){
    {
      if (d_child_enum)
      {
-       NodeManager * nm = NodeManager::currentNM();
-       ret = nm->mkConst(
-           CodatatypeBoundVariable(d_type, d_size_limit));
+       NodeManager* nm = NodeManager::currentNM();
+       ret = nm->mkConst(CodatatypeBoundVariable(d_type, d_size_limit));
      }
      else
      {

--- a/src/theory/datatypes/type_enumerator.cpp
+++ b/src/theory/datatypes/type_enumerator.cpp
@@ -19,6 +19,7 @@
 #include "expr/dtype_cons.h"
 #include "theory/datatypes/datatypes_rewriter.h"
 #include "theory/datatypes/theory_datatypes_utils.h"
+#include "expr/codatatype_bound_variable.h"
 
 using namespace cvc5;
 using namespace theory;
@@ -108,8 +109,9 @@ Node DatatypesEnumerator::getTermEnum( TypeNode tn, unsigned i ){
    {
      if (d_child_enum)
      {
-       ret = NodeManager::currentNM()->mkConst(
-           UninterpretedConstant(d_type, d_size_limit));
+       NodeManager * nm = NodeManager::currentNM();
+       ret = nm->mkConst(
+           CodatatypeBoundVariable(d_type, d_size_limit));
      }
      else
      {


### PR DESCRIPTION
Previously, we had conflated codatatype bound variables and uninterpreted constants (as they have the same functionality). However, we should separate these concepts so we can ensure that uninterpreted constants are only used for uninterpreted sorts.