### PR TITLE
Reintroduce support for option interactive-mode

### DIFF
--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -259,6 +259,7 @@ name   = "SMT Layer"
   category   = "common"
   long       = "produce-assertions"
   type       = "bool"
+  alias      = ["interactive-mode"]
   help       = "keep an assertions list (enables get-assertions command)"
 
 [[option]]

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -767,6 +767,7 @@ set(regress_0_tests
   regress0/nl/very-simple-unsat.smt2
   regress0/opt-abd-no-use.smt2
   regress0/options/ast-and-sexpr.smt2
+  regress0/options/interactive-mode.smt2
   regress0/options/invalid_dump.smt2
   regress0/options/set-after-init.smt2
   regress0/options/set-and-get-options.smt2

--- a/test/regress/regress0/options/interactive-mode.smt2
+++ b/test/regress/regress0/options/interactive-mode.smt2
@@ -1,0 +1,10 @@
+; EXPECT: true
+; EXPECT: true
+; EXPECT: false
+; EXPECT: false
+(set-option :interactive-mode true)
+(get-option :interactive-mode)
+(get-option :produce-assertions)
+(set-option :produce-assertions false)
+(get-option :interactive-mode)
+(get-option :produce-assertions)


### PR DESCRIPTION
This PR reintroduces support for the (deprecated) option `interactive-mode`. It was erroneously removed in #7295.

Fixes #7379.