### PR TITLE
Fix frequent rebuild of options target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1270,7 +1270,6 @@ add_custom_command(
 add_custom_target(gen-options
   DEPENDS
     options/options.stamp
-    ${options_gen_cpp_files} ${options_gen_h_files} ${options_gen_doc_files}
 )
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1243,33 +1243,34 @@ if (BUILD_DOCS)
 endif()
 
 add_custom_command(
-    OUTPUT
-      ${options_gen_cpp_files} ${options_gen_h_files}
-      ${options_gen_doc_files}
-    COMMAND
-      ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/options
-    COMMAND
-      ${PYTHON_EXECUTABLE}
-      ${CMAKE_CURRENT_LIST_DIR}/options/mkoptions.py
-      ${CMAKE_CURRENT_LIST_DIR}
-      ${CMAKE_BINARY_DIR}
-      ${CMAKE_CURRENT_BINARY_DIR}
-      ${abs_toml_files}
-    DEPENDS
-      options/mkoptions.py
-      ${options_toml_files}
-      main/options_template.cpp
-      options/module_template.h
-      options/module_template.cpp
-      options/options_public_template.cpp
-      options/options_template.h
-      options/options_template.cpp
+  OUTPUT
+    options/options.stamp
+  COMMAND
+    ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/options
+  COMMAND
+    ${PYTHON_EXECUTABLE}
+    ${CMAKE_CURRENT_LIST_DIR}/options/mkoptions.py
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_BINARY_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${abs_toml_files}
+  BYPRODUCTS
+    ${options_gen_cpp_files} ${options_gen_h_files} ${options_gen_doc_files}
+  DEPENDS
+    options/mkoptions.py
+    ${options_toml_files}
+    main/options_template.cpp
+    options/module_template.h
+    options/module_template.cpp
+    options/options_public_template.cpp
+    options/options_template.h
+    options/options_template.cpp
 )
 
 add_custom_target(gen-options
   DEPENDS
-    ${options_gen_cpp_files}
-    ${options_gen_h_files}
+    options/options.stamp
+    ${options_gen_cpp_files} ${options_gen_h_files} ${options_gen_doc_files}
 )
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1277,10 +1277,7 @@ add_custom_command(
     options/options_template.cpp
 )
 
-add_custom_target(gen-options
-  DEPENDS
-    options/options.stamp
-)
+add_custom_target(gen-options DEPENDS options/options.stamp)
 
 
 #-----------------------------------------------------------------------------#

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1242,6 +1242,16 @@ if (BUILD_DOCS)
   )
 endif()
 
+# The mkoptions.py script only updates its output files if their content would
+# actually change. This mechanism makes sure that running the script does not
+# automatically trigger a full rebuild, but only a rebuild of those parts that
+# include files that did actually change.
+# This approach also means that the output files (which gen-options used to
+# depend on) may not actually be updated and thus cmake would keep re-running
+# mkoptions.py over and over again.
+# We thus have an artificial options.stamp file that mkoptions.py always writes
+# to, and can thus be used to communicate that all options files have been
+# proper updated.
 add_custom_command(
   OUTPUT
     options/options.stamp

--- a/src/options/mkoptions.py
+++ b/src/options/mkoptions.py
@@ -1060,6 +1060,9 @@ def mkoptions_main():
         codegen_module(module, dst_dir, module_tpls)
     codegen_all_modules(modules, build_dir, dst_dir, global_tpls)
 
+    # Generate output file to signal cmake when this script was run last
+    open(os.path.join(dst_dir, 'options/options.stamp'), 'w').write('')
+
 
 if __name__ == "__main__":
     mkoptions_main()


### PR DESCRIPTION
The `mkoptions.py` script only updates its output files if their content would actually change. This avoid a full rebuild on every run, and makes sure that only parts that actually change are rebuild.
Unfortunately this interacts badly with how cmake/make/... do inter-target dependency tracking.
This PR adds a stamp file `options.stamp` that is always updated by `mkoptions.py` and used by cmake as main output.