### PR TITLE
Fix proofs in circuit propagator for negated ITEs

### DIFF
--- a/src/theory/booleans/proof_circuit_propagator.cpp
+++ b/src/theory/booleans/proof_circuit_propagator.cpp
@@ -402,7 +402,8 @@ std::shared_ptr<ProofNode> ProofCircuitPropagatorBackward::iteIsCase(unsigned c)
                         true);
   }
   return mkResolution(
-      mkProof(PfRule::NOT_ITE_ELIM2, {assume(d_parent.notNode())}),
+      mkProof(c == 0 ? PfRule::NOT_ITE_ELIM1 : PfRule::NOT_ITE_ELIM2,
+              {assume(d_parent.notNode())}),
       d_parent[c + 1],
       false);
 }

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -837,6 +837,8 @@ set(regress_0_tests
   regress0/preprocess/proj-issue304-circuit-prop-xor.smt2
   regress0/preprocess/proj-issue305-circuit-prop-ite-a.smt2
   regress0/preprocess/proj-issue305-circuit-prop-ite-b.smt2
+  regress0/preprocess/proj-issue305-circuit-prop-ite-c.smt2
+  regress0/preprocess/proj-issue305-circuit-prop-ite-d.smt2
   regress0/print_define_fun_internal.smt2
   regress0/print_lambda.cvc.smt2
   regress0/print_model.cvc.smt2

--- a/test/regress/regress0/preprocess/proj-issue305-circuit-prop-ite-c.smt2
+++ b/test/regress/regress0/preprocess/proj-issue305-circuit-prop-ite-c.smt2
@@ -1,0 +1,10 @@
+; EXPECT: sat
+(set-logic ALL)
+(set-option :check-proofs true)
+(declare-fun a () Bool)
+(declare-fun b () Bool)
+(declare-fun c () Bool)
+(assert (not (ite a b c)))
+(assert b)
+(assert (not c))
+(check-sat)

--- a/test/regress/regress0/preprocess/proj-issue305-circuit-prop-ite-d.smt2
+++ b/test/regress/regress0/preprocess/proj-issue305-circuit-prop-ite-d.smt2
@@ -1,0 +1,10 @@
+; EXPECT: sat
+(set-logic ALL)
+(set-option :check-proofs true)
+(declare-fun a () Bool)
+(declare-fun b () Bool)
+(declare-fun c () Bool)
+(assert (not (ite a b c)))
+(assert c)
+(assert (not b))
+(check-sat)


### PR DESCRIPTION
This PR follows #7452 and fixes the proofs generated for backward propagation of negated ite terms.