### PR TITLE
Remove HOL/fmf bound messages in set defaults

### DIFF
--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -1340,18 +1340,6 @@ void SetDefaults::setDefaultsQuantifiers(const LogicInfo& logic,
     {
       opts.quantifiers.macrosQuant = false;
     }
-    // HOL is incompatible with fmfBound
-    if (opts.quantifiers.fmfBound)
-    {
-      if (opts.quantifiers.fmfBoundWasSetByUser
-          || opts.quantifiers.fmfBoundLazyWasSetByUser
-          || opts.quantifiers.fmfBoundIntWasSetByUser)
-      {
-        Notice() << "Disabling bound finite-model finding since it is "
-                    "incompatible with HOL.\n";
-      }
-      Trace("smt") << "turning off fmf-bound, since HOL\n";
-    }
   }
   if (opts.quantifiers.fmfFunWellDefinedRelevant)
   {


### PR DESCRIPTION
This block is misleading after the last commit.