### PR TITLE
[FP] Fix refinement for nested conversions

### DIFF
--- a/src/theory/fp/theory_fp.cpp
+++ b/src/theory/fp/theory_fp.cpp
@@ -216,7 +216,7 @@ bool TheoryFp::refineAbstraction(TheoryModel *m, TNode abstract, TNode concrete)
     if (abstractValue != concreteValue)
     {
       // Need refinement lemmas
-      // only in the normal, subnormal
+      // only in the normal and subnormal case
       Assert(floatValue.getConst<FloatingPoint>().isNormal()
              || floatValue.getConst<FloatingPoint>().isSubnormal());
 

--- a/src/theory/fp/theory_fp.h
+++ b/src/theory/fp/theory_fp.h
@@ -142,6 +142,11 @@ class TheoryFp : public Theory
   bool refineAbstraction(TheoryModel* m, TNode abstract, TNode concrete);
 
  private:
+  /**
+   * Purifies operators that convert between real and floating-point.
+   */
+  Node purifyConversions(TNode n);
+
   AbstractionMap d_abstractionMap;  // abstract -> original
 
   /** The theory rewriter for this theory. */

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1956,6 +1956,7 @@ set(regress_1_tests
   regress1/difficulty-polarity.smt2
   regress1/errorcrash.smt2
   regress1/fp/fp_to_real.smt2
+  regress1/fp/proj-issue327-nested-conversions.smt2
   regress1/fp/rti_3_5_bug_report.smt2
   regress1/fmf-fun-dbu.smt2
   regress1/fmf/ALG008-1.smt2

--- a/test/regress/cli/regress1/fp/proj-issue327-nested-conversions.smt2
+++ b/test/regress/cli/regress1/fp/proj-issue327-nested-conversions.smt2
@@ -1,0 +1,6 @@
+(set-logic ALL)
+(declare-const x Real)
+(declare-const x6 RoundingMode)
+(assert (or (= x (/ 1 1000000000000000000000000000000000000000000000000000000)) (= x 1.0)))
+(set-info :status unsat)
+(check-sat-assuming ((and (> x 0.0) (> 0.0 (fp.to_real ((_ to_fp 8 24) x6 x))))))


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5-projects/issues/327.

Background
==========

Our abstraction refinement for conversions from floating-point values to
real values is based on the model and happens at last effort. It asserts
that the value of the first argument (the floating-point term to be
converted) in the model is either a normal or a subnormal. Other cases
such as zero are handled through lemmas that are generated during term
registration.

Problem
=======

This approach led to problems with nested conversions, because
`TheoryModel::getValue()` evaluates terms starting from the bottom. If
we have nested conversions and the inner conversion needs to be refined,
it can happen that `TheoryModel::getValue()` returns unexpected values
(such as zero in this case).

To make this more concrete, let's take a look at the input in the issue.
The term of interest is ` (fp.to_real ((_ to_fp 8 24) x6 x))` (i.e., a
nested conversion from real to floating-point followed by a conversion
back) here is the output of `-t fp-refineAbstraction` on the example
before the fix:

```
TheoryFp::refineAbstraction(): real_to_fp_3 vs. ((_ to_fp 8 24) x6 x)
TheoryFp::refineAbstraction(): x6 = roundTowardZero
TheoryFp::refineAbstraction(): x = (/ 1 1000000000000000000000000000000000000000000000000000000)
TheoryFp::refineAbstraction(): real_to_fp_3 = (fp #b1 #b01111111 #b00000000000000000000000)
TheoryFp::refineAbstraction(): ((_ to_fp 8 24) x6 x) = (fp #b0 #b00000000 #b00000000000000000000000)
TheoryFp::refineAbstraction(): fp_to_real_4 vs. (let ((_let_1 ((_ to_fp 8 24) x6 x))) (fp.to_real_total _let_1 (floatingpoint_to_real_infinity_and_NaN_case_2 _let_1)))
TheoryFp::refineAbstraction(): ((_ to_fp 8 24) x6 x) = (fp #b0 #b00000000 #b00000000000000000000000)
TheoryFp::refineAbstraction(): (floatingpoint_to_real_infinity_and_NaN_case_2 ((_ to_fp 8 24) x6 x)) = 0.0
TheoryFp::refineAbstraction(): fp_to_real_4 = (/ (- 1) 2000000000000000000000000000000000000000000000000000000)
TheoryFp::refineAbstraction(): (let ((_let_1 ((_ to_fp 8 24) x6 x))) (fp.to_real_total _let_1 (floatingpoint_to_real_infinity_and_NaN_case_2 _let_1))) = 0.0
```

The value of the first argument to `fp.to_real_total` is unexpected:

```
 TheoryFp::refineAbstraction(): ((_ to_fp 8 24) x6 x) = (fp #b0 #b00000000 #b00000000000000000000000)
```

The assertion in the issue fails because this value is zero and this
case should have been dealt with by one of the
[lemmas](https://github.com/cvc5/cvc5/blob/66d374cd5c74c39e533b9639243f3a87978b6838/src/theory/fp/theory_fp.cpp#L573-L577)
sent out in term registration (i.e., if the first argument is zero, then
we assert that the result of the conversion is `0.0`, so we should never
need a refinement in that case).

This can happen, because the conversion `((_ to_fp 8 24) x6 x)` itself
still needs refinement. When we get the value of `((_ to_fp 8 24) x6
x)` from the model, we get zero, because evaluation in the model is from
the bottom up. However, the value for its abstraction is non-zero:

```
TheoryFp::refineAbstraction(): real_to_fp_3 = (fp #b1 #b01111111 #b00000000000000000000000)
```

and this is the value that we need to refine the abstraction for the
outer conversion.

Solution
========

The solution is to purify nested conversions when looking up values for
the arguments of conversions. This commit does that upon term
registration. This ensures that when we refine abstractions, we get
values for the arguments that are not affected by other conversions that
still need to be refined.