### PR TITLE
Fix the element split lemma for join operator

### DIFF
--- a/src/theory/sets/theory_sets_rels.cpp
+++ b/src/theory/sets/theory_sets_rels.cpp
@@ -1130,7 +1130,10 @@ void TheorySetsRels::check(Theory::Effort level)
             {
               // If we have (a,b) in R1, (c,d) in R2, and we are considering
               // join(R1, R2) must split on b=c if they are neither equal nor
-              // disequal.
+              // disequal. The generated lemma would be:
+              // (or
+              //  (and (= b c) (member (tuple a d) (join R1 R2))
+              //  (not (= b c))
               Node eq = r1_rmost.eqNode(r2_lmost);
               Node andNode = eq.andNode(fact);
               Node lem = nm->mkNode(kind::OR, andNode, eq.negate());


### PR DESCRIPTION
This PR is inspired by #7515 and fixes the element split lemma for join operator introduced by #7511. 
It fixes this regression https://github.com/cvc5/cvc5/pull/7515/files#diff-6346d885e851d40bf48565eccf09318b498c18308c8a8c517696150a440c2d3bR7 but the other one still fails. 