### PR TITLE
Fix proof of nl lemma for a corner case

### DIFF
--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -867,6 +867,7 @@ set(regress_0_tests
   regress0/proofs/open-pf-rederivation.smt2
   regress0/proofs/project-issue317-inc-sat-conflictlit.smt2
   regress0/proofs/project-issue330-eqproof.smt2
+  regress0/proofs/proj-issue326-nl-bounds-check.smt2
   regress0/proofs/qgu-fuzz-1-bool-sat.smt2
   regress0/proofs/qgu-fuzz-2-bool-chainres-checking.smt2
   regress0/proofs/qgu-fuzz-3-chainres-checking.smt2

--- a/test/regress/regress0/proofs/proj-issue326-nl-bounds-check.smt2
+++ b/test/regress/regress0/proofs/proj-issue326-nl-bounds-check.smt2
@@ -1,0 +1,13 @@
+; EXPECT: unknown
+(set-logic ALL)
+(set-option :check-proofs true)
+(set-option :proof-check eager)
+(declare-const x Real)
+(assert
+    (and
+        (< 1.0 x)
+        (<= x (/ 0.0 0.0 x))
+        (<= (/ 0.0 0.0 x) x)
+    )
+)
+(check-sat)


### PR DESCRIPTION
This PR fixes the proof generated for the nonlinear monomial bounds check lemmas. In some cases, it implies an equality (multiplied by a monomial) not from the equality but from the two weak inequalities. We now properly detect this special case and add a rather involved proof.
Fixes cvc5/cvc5-projects#326.