### PR TITLE
Clean up CLN includes

### DIFF
--- a/src/util/integer_cln_imp.cpp
+++ b/src/util/integer_cln_imp.cpp
@@ -12,6 +12,12 @@
  *
  * A multiprecision integer constant; wraps a CLN multiprecision integer.
  */
+
+#include <cln/input.h>
+#include <cln/integer_io.h>
+#include <cln/modinteger.h>
+
+#include <iostream>
 #include <sstream>
 #include <string>
 

--- a/src/util/integer_cln_imp.h
+++ b/src/util/integer_cln_imp.h
@@ -18,18 +18,19 @@
 #ifndef CVC5__INTEGER_H
 #define CVC5__INTEGER_H
 
-#include <cln/input.h>
 #include <cln/integer.h>
-#include <cln/integer_io.h>
-#include <cln/modinteger.h>
 
-#include <iostream>
+#include <iosfwd>
 #include <limits>
-#include <sstream>
 #include <string>
 
 #include "base/exception.h"
 #include "cvc5_export.h"  // remove when Cvc language support is removed
+
+namespace cln
+{
+  struct cl_read_flags;
+}
 
 namespace cvc5 {
 


### PR DESCRIPTION
This PR pushes a couple of includes for the CLN integers from the header into the source files.