### PR TITLE
Fix debug trace for miplib

### DIFF
--- a/src/preprocessing/passes/miplib_trick.cpp
+++ b/src/preprocessing/passes/miplib_trick.cpp
@@ -648,7 +648,7 @@ PreprocessingPassResult MipLibTrick::applyInternal(
           d_statistics.d_numMiplibAssertionsRemoved += removals;
         }
       }
-      Debug("miplib") << "had: " << assertion[i] << endl;
+      Debug("miplib") << "had: " << assertion << endl;
       assertionsToPreprocess->replace(
           i, rewrite(top_level_substs.apply(assertion)));
       Debug("miplib") << "now: " << assertion << endl;


### PR DESCRIPTION
A debug trace on miplib referred to a possibly out of bounds child.

This is causing debug failures locally for me, although the debug trace should not be enabled.