### PR TITLE
Minor cleanup in SolverEngine::setInfo()

### DIFF
--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -389,19 +389,17 @@ void SolverEngine::setInfo(const std::string& key, const std::string& value)
   else if (key == "smt-lib-version"
            && !getOptions().base.inputLanguageWasSetByUser)
   {
-    Language ilang = Language::LANG_SMTLIB_V2_6;
-
     if (value != "2" && value != "2.6")
     {
       Warning() << "SMT-LIB version " << value
                 << " unsupported, defaulting to language (and semantics of) "
                    "SMT-LIB 2.6\n";
     }
-    getOptions().base.inputLanguage = ilang;
+    getOptions().base.inputLanguage = Language::LANG_SMTLIB_V2_6;
     // also update the output language
     if (!getOptions().base.outputLanguageWasSetByUser)
     {
-      setOption("output-language", "smtlib" + value);
+      setOption("output-language", "smtlib2.6");
       getOptions().base.outputLanguageWasSetByUser = false;
     }
   }

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -401,12 +401,8 @@ void SolverEngine::setInfo(const std::string& key, const std::string& value)
     // also update the output language
     if (!getOptions().base.outputLanguageWasSetByUser)
     {
-      Language olang = ilang;
-      if (d_env->getOptions().base.outputLanguage != olang)
-      {
-        getOptions().base.outputLanguage = olang;
-        *d_env->getOptions().base.out << language::SetLanguage(olang);
-      }
+      setOption("output-language", "smtlib" + value);
+      getOptions().base.outputLanguageWasSetByUser = false;
     }
   }
   else if (key == "status")


### PR DESCRIPTION
This PR does a bit of cleanup by properly calling the option handler instead of trying to manually replicating it. This is way more robust in the face of modifications to the option handlers.