### PR TITLE
Minor changes to circuit propagator

### DIFF
--- a/src/theory/booleans/circuit_propagator.cpp
+++ b/src/theory/booleans/circuit_propagator.cpp
@@ -87,14 +87,9 @@ void CircuitPropagator::assertTrue(TNode assertion)
     // Analyze the assertion for back-edges and all that
     computeBackEdges(assertion);
     // Assign the given assertion to true
-    if (isProofEnabled())
-    {
-      assignAndEnqueue(assertion, true, d_pnm->mkAssume(assertion));
-    }
-    else
-    {
-      assignAndEnqueue(assertion, true, nullptr);
-    }
+    assignAndEnqueue(assertion,
+                     true,
+                     isProofEnabled() ? d_pnm->mkAssume(assertion) : nullptr);
   }
 }
 
@@ -805,11 +800,18 @@ void CircuitPropagator::addProof(TNode f, std::shared_ptr<ProofNode> pf)
                             << "\t" << *pf << std::endl;
       d_epg->setProofFor(f, std::move(pf));
     }
-    else
+    else if (Trace.isOn("circuit-prop"))
     {
-      auto prf = d_epg->getProofFor(f);
-      Trace("circuit-prop") << "Ignoring proof, we already have" << std::endl
-                            << "\t" << *prf << std::endl;
+      if (d_epg->hasProofFor(f))
+      {
+        auto prf = d_epg->getProofFor(f);
+        Trace("circuit-prop") << "Ignoring proof\n\t" << *pf
+                              << "\nwe already have\n\t" << *prf << std::endl;
+      }
+      else
+      {
+        Trace("circuit-prop") << "Ignoring ASSUME proof" << std::endl;
+      }
     }
   }
 }

--- a/src/theory/booleans/circuit_propagator.cpp
+++ b/src/theory/booleans/circuit_propagator.cpp
@@ -802,16 +802,9 @@ void CircuitPropagator::addProof(TNode f, std::shared_ptr<ProofNode> pf)
     }
     else if (Trace.isOn("circuit-prop"))
     {
-      if (d_epg->hasProofFor(f))
-      {
-        auto prf = d_epg->getProofFor(f);
-        Trace("circuit-prop") << "Ignoring proof\n\t" << *pf
-                              << "\nwe already have\n\t" << *prf << std::endl;
-      }
-      else
-      {
-        Trace("circuit-prop") << "Ignoring ASSUME proof" << std::endl;
-      }
+      auto prf = d_epg->getProofFor(f);
+      Trace("circuit-prop") << "Ignoring proof\n\t" << *pf
+                            << "\nwe already have\n\t" << *prf << std::endl;
     }
   }
 }


### PR DESCRIPTION
Previously in a given part of the code a proof would be retrieved only so that it'd be printed. This commit guards that part of the code with whether the trace is on and gives more information in what is printed.

Also changes the style of a call.