### PR TITLE
[proofs] Generalize trivial cycle detection in LazyCDProofChain

### DIFF
--- a/test/regress/regress1/quantifiers/recfact.cvc.smt2
+++ b/test/regress/regress1/quantifiers/recfact.cvc.smt2
@@ -1,4 +1,9 @@
 ; EXPECT: unsat
+; COMMAND-LINE:
+; COMMAND-LINE: --produce-proofs
+;; The second command line option, other than the default, is to test
+;; unsat core checking with proofs, which at one point had issues for
+;; this benchmark due to cycle detection in LazyCDProofChain
 (set-logic ALL)
 (set-option :incremental false)
 (set-option :fmf-fun true)

--- a/test/regress/regress1/strings/issue6184-unsat-core.smt2
+++ b/test/regress/regress1/strings/issue6184-unsat-core.smt2
@@ -1,5 +1,9 @@
-; COMMAND-LINE: --strings-exp
 ; EXPECT: unsat
+; COMMAND-LINE: --strings-exp
+; COMMAND-LINE: --strings-exp --produce-proofs
+;; The second command line option is to test unsat core checking with
+;; proofs, which at one point had issues for this benchmark due to
+;; cycle detection in LazyCDProofChain
 (set-logic ALL)
 (set-info :status unsat)
 (set-option :check-unsat-cores true)


### PR DESCRIPTION
Previously the trivial cycle check only covered the case in which the currently-being-expanded assumption `A` had as its stored proof node `pf` an assumption proof justifying itself. However, it can be the case that `pf` is not an assumption proof, but a proof that nevertheless has `A` as one of its free assumptions. This commit generalizes the trivial cycle check to account for this.

