### PR TITLE
[proofs] Further handling of int/real subtyping for Alethe backend

### DIFF
--- a/src/proof/alethe/alethe_nosubtype_node_converter.cpp
+++ b/src/proof/alethe/alethe_nosubtype_node_converter.cpp
@@ -15,45 +15,163 @@
 
 #include "proof/alethe/alethe_nosubtype_node_converter.h"
 
+#include "expr/node_algorithm.h"
+#include "theory/theory.h"
+
 namespace cvc5 {
 namespace proof {
 
 Node AletheNoSubtypeNodeConverter::postConvert(Node n)
 {
+  NodeManager* nm = NodeManager::currentNM();
+  // corce function applications
   if (n.getKind() == kind::APPLY_UF)
   {
-    NodeManager* nm = NodeManager::currentNM();
-    TypeNode tn = n.getOperator().getType();
+    Node op = n.getOperator();
+    TypeNode tn = op.getType();
     std::vector<TypeNode> argTypes = tn.getArgTypes();
     // if any of the argument types is real, in case the argument of that
     // position is an integer constant we must turn it into a real constant
     // look at all args, if any is an integer constant, transform it
     bool childChanged = false;
-    std::vector<Node> children;
+    std::vector<Node> children{op};
     for (size_t i = 0, size = n.getNumChildren(); i < size; ++i)
     {
-      if (!argTypes[i].isReal() || argTypes[i].isInteger() || !n[i].isConst()
+      if (!argTypes[i].isReal() || argTypes[i].isInteger()
           || !n[i].getType().isInteger())
       {
         children.push_back(n[i]);
         continue;
       }
       Trace("alethe-proof-subtyping")
-          << "\t\t..arg " << i << " is integer constant " << n[i]
+          << "\t\t..fun app arg " << i << " is integer term " << n[i]
           << " in real position.\n";
+      if (!n[i].isConst())
+      {
+        Unreachable() << "AletheBackend: Can't handle subtyping case of "
+                         "non-value integers.\n";
+      }
       childChanged = true;
       children.push_back(nm->mkNode(kind::CAST_TO_REAL, n[i]));
     }
     if (childChanged)
     {
-      if (n.getMetaKind() == kind::metakind::PARAMETERIZED)
+      return nm->mkNode(kind::APPLY_UF, children);
+    }
+    return n;
+  }
+  // Ignore interpreted terms that are not applications of arithmetic operators
+  // (or equalities between arithmetic terms) which may have a real and an
+  // integer argument
+  if (n.getNumChildren() < 2
+      || theory::Theory::theoryOf(n) != theory::TheoryId::THEORY_ARITH)
+  {
+    if (n.getNumChildren() > 1)
+    {
+      Trace("alethe-proof-subtyping2") << "\tIgnoring " << n << " with theory "
+                                       << theory::Theory::theoryOf(n) << "\n";
+    }
+    return n;
+  }
+  Trace("alethe-proof-subtyping2")
+      << "\tCheck " << n << " of kind " << n.getKind() << "\n";
+  // coerce equalities where one of the terms is real and the other integer.
+  // This handles for example the case instantiation
+  bool childChanged = false;
+  std::vector<Node> children{n.begin(), n.end()};
+  size_t i, size = n.getNumChildren();
+  size_t hasReal = size;
+  for (i = 0; i < size; ++i)
+  {
+    if (n[i].getType().isReal() && !n[i].getType().isInteger())
+    {
+      hasReal = i;
+      break;
+    }
+  }
+  if (hasReal < size)
+  {
+    for (i = 0; i < size; ++i)
+    {
+      if (n[i].getType().isInteger())
       {
-        children.insert(children.begin(), n.getOperator());
+        Trace("alethe-proof-subtyping")
+            << "\t\t..arith term arg " << n[i] << " (kind " << n[i].getKind()
+            << ") is integer but should be real, from arg " << hasReal << " "
+            << n[hasReal] << " (kind " << n[hasReal].getKind() << ")\n";
+        if (!n[i].isConst())
+        {
+          // there are two cases here: either this is a term that contains
+          // somewhere an uninterpreted constant or not. If it does not, than
+          // this is salvageable. Otherwise it's not.
+          if (expr::hasSubtermKinds({kind::APPLY_UF, kind::SKOLEM}, n[i]))
+          {
+            Unreachable() << "AletheBackend: Can't handle subtyping case of "
+                             "non-value integers.\n";
+          }
+          Trace("alethe-proof-subtyping")
+              << "\t\t..traverse and convert term with only consts\n";
+          childChanged = true;
+          children[i] = traverseAndConvertAllConsts(n[i]);
+          Trace("alethe-proof-subtyping")
+              << "\t\t..converted " << n[i] << " into " << children[i] << "\n";
+          continue;
+        }
+        childChanged = true;
+        children[i] = nm->mkNode(kind::CAST_TO_REAL, n[i]);
+        break;
       }
+    }
+    if (childChanged)
+    {
       return nm->mkNode(n.getKind(), children);
     }
   }
   return n;
+}
+
+Node AletheNoSubtypeNodeConverter::traverseAndConvertAllConsts(Node n)
+{
+  AlwaysAssert(n.getType().isReal());
+  std::unordered_map<Node, Node> visited;
+  std::unordered_map<Node, Node>::iterator it;
+  std::vector<Node> visit;
+  Node cur;
+  visit.push_back(n);
+  NodeManager* nm = NodeManager::currentNM();
+  do
+  {
+    cur = visit.back();
+    visit.pop_back();
+    AlwaysAssert(cur.getMetaKind() != kind::metakind::PARAMETERIZED);
+    it = visited.find(cur);
+    if (it == visited.end())
+    {
+      if (cur.isConst())
+      {
+        AlwaysAssert(cur.getType().isInteger());
+        visited[cur] = nm->mkNode(kind::CAST_TO_REAL, cur);
+        continue;
+      }
+      AlwaysAssert(cur.getNumChildren() > 0);
+      visited[cur] = Node::null();
+      visit.push_back(cur);
+      visit.insert(visit.end(), cur.begin(), cur.end());
+    }
+    else if (it->second.isNull())
+    {
+      bool childChanged = false;
+      std::vector<Node> children;
+      for (const Node& child : cur)
+      {
+        AlwaysAssert(visited.find(child) != visited.end());
+        childChanged |= child != visited[child];
+        children.push_back(visited[child]);
+      }
+      visited[cur] = !childChanged ? cur : nm->mkNode(cur.getKind(), children);
+    }
+  } while (!visit.empty());
+  return visited[n];
 }
 
 }  // namespace proof

--- a/src/proof/alethe/alethe_nosubtype_node_converter.h
+++ b/src/proof/alethe/alethe_nosubtype_node_converter.h
@@ -38,6 +38,14 @@ class AletheNoSubtypeNodeConverter : public NodeConverter
    * they occur in "real" positions. For example, (f 1 a), with f having as its
    * type f : Real -> Real -> Real, will be turned into (f 1.0 a). */
   Node postConvert(Node n) override;
+
+ private:
+  /** Convert all integer constants in `n` into CAST_TO_REAL applications.
+   *
+   * This method will fail if `n` has non-integer constants or uninterpreted
+   * terms.
+   **/
+  Node traverseAndConvertAllConsts(Node n);
 };
 
 }  // namespace proof


### PR DESCRIPTION
Extends the conversion to prevent subtyping in applications of arithmetic operators when one of the arguments is a "true real" and some is an integer. While the conversion is restricted to constants (since the whole procedure for now is based on wrapping integers with `CAST_TO_REAL`), it supports terms that are not constants but that amount to applications of arithmetic operators to constants, such as `(* (+ 1 1) (- 1))`.