### PR TITLE
Generalize front-end checks to check for shadowed variables

### DIFF
--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -5080,9 +5080,11 @@ Term Solver::getValueHelper(const Term& term) const
 {
   // Note: Term is checked in the caller to avoid double checks
   bool wasShadow = false;
-  bool freeOrShadowedVar = expr::hasFreeOrShadowedVar(term.getNode(), wasShadow);
+  bool freeOrShadowedVar =
+      expr::hasFreeOrShadowedVar(term.getNode(), wasShadow);
   CVC5_API_RECOVERABLE_CHECK(!freeOrShadowedVar)
-      << "Cannot get value of term containing " << (wasShadow ? "shadowed" : "free") << " variables";
+      << "Cannot get value of term containing "
+      << (wasShadow ? "shadowed" : "free") << " variables";
   //////// all checks before this line
   Node value = d_slv->getValue(*term.d_node);
   Term res = Term(this, value);

--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -442,7 +442,7 @@ bool hasClosure(Node n)
     }
     else
     {
-      for (const auto& i = n.begin(); i != n.end() && !hasC; ++i)
+      for (auto i = n.begin(); i != n.end() && !hasC; ++i)
       {
         hasC = hasClosure(*i);
       }

--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -348,12 +348,13 @@ bool checkVariablesInternal(TNode n,
           {
             // should not shadow
             Assert(scope.find(cn) == scope.end())
-              << "Shadowed variable " << cn << " in " << cur << "\n";
+                << "Shadowed variable " << cn << " in " << cur << "\n";
           }
           scope.insert(cn);
         }
         // must make recursive call to use separate cache
-        if (checkVariablesInternal(cur[1], fvs, scope, computeFv, checkShadow) && !computeFv)
+        if (checkVariablesInternal(cur[1], fvs, scope, computeFv, checkShadow)
+            && !computeFv)
         {
           return true;
         }

--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -281,6 +281,102 @@ bool hasBoundVar(TNode n)
   return n.getAttribute(HasBoundVarAttr());
 }
 
+/**
+ * Get the free variables in n, that is, the subterms of n of kind
+ * BOUND_VARIABLE that are not bound in n or occur in scope, adds these to fvs
+ * if computeFv is true.
+ * @param n The node under investigation
+ * @param fvs The set which free variables are added to
+ * @param scope The scope we are considering.
+ * @param computeFv If this flag is false, then we only return true/false and
+ * do not add to fvs.
+ * @param checkShadow If this flag is true, we immediately return true if a
+ * variable is shadowing. If this flag is false, we give an assertion failure
+ * when this occurs.
+ * @return true iff this node contains a free variable.
+ */
+bool checkVariablesInternal(TNode n,
+                            std::unordered_set<Node>& fvs,
+                            std::unordered_set<TNode>& scope,
+                            bool computeFv = true,
+                            bool checkShadow = false)
+{
+  std::unordered_set<TNode> visited;
+  std::vector<TNode> visit;
+  TNode cur;
+  visit.push_back(n);
+  do
+  {
+    cur = visit.back();
+    visit.pop_back();
+    // can skip if it doesn't have a bound variable
+    if (!hasBoundVar(cur))
+    {
+      continue;
+    }
+    std::unordered_set<TNode>::iterator itv = visited.find(cur);
+    if (itv == visited.end())
+    {
+      visited.insert(cur);
+      if (cur.getKind() == kind::BOUND_VARIABLE)
+      {
+        if (scope.find(cur) == scope.end())
+        {
+          if (computeFv)
+          {
+            fvs.insert(cur);
+          }
+          else
+          {
+            return true;
+          }
+        }
+      }
+      else if (cur.isClosure())
+      {
+        // add to scope
+        for (const TNode& cn : cur[0])
+        {
+          if (checkShadow)
+          {
+            if (scope.find(cn) != scope.end())
+            {
+              return true;
+            }
+          }
+          else
+          {
+            // should not shadow
+            Assert(scope.find(cn) == scope.end())
+              << "Shadowed variable " << cn << " in " << cur << "\n";
+          }
+          scope.insert(cn);
+        }
+        // must make recursive call to use separate cache
+        if (checkVariablesInternal(cur[1], fvs, scope, computeFv, checkShadow) && !computeFv)
+        {
+          return true;
+        }
+        // cleanup
+        for (const TNode& cn : cur[0])
+        {
+          scope.erase(cn);
+        }
+      }
+      else
+      {
+        if (cur.hasOperator())
+        {
+          visit.push_back(cur.getOperator());
+        }
+        visit.insert(visit.end(), cur.begin(), cur.end());
+      }
+    }
+  } while (!visit.empty());
+
+  return !fvs.empty();
+}
+
 bool hasFreeVar(TNode n)
 {
   // optimization for variables and constants
@@ -289,7 +385,20 @@ bool hasFreeVar(TNode n)
     return n.getKind() == kind::BOUND_VARIABLE;
   }
   std::unordered_set<Node> fvs;
-  return getFreeVariables(n, fvs, false);
+  std::unordered_set<TNode> scope;
+  return checkVariablesInternal(n, fvs, scope, false);
+}
+
+bool hasFreeOrShadowedVar(TNode n)
+{
+  // optimization for variables and constants
+  if (n.getNumChildren() == 0)
+  {
+    return n.getKind() == kind::BOUND_VARIABLE;
+  }
+  std::unordered_set<Node> fvs;
+  std::unordered_set<TNode> scope;
+  return checkVariablesInternal(n, fvs, scope, false, true);
 }
 
 struct HasClosureTag
@@ -329,81 +438,17 @@ bool hasClosure(Node n)
   return n.getAttribute(HasClosureAttr());
 }
 
-bool getFreeVariables(TNode n, std::unordered_set<Node>& fvs, bool computeFv)
+bool getFreeVariables(TNode n, std::unordered_set<Node>& fvs)
 {
   std::unordered_set<TNode> scope;
-  return getFreeVariablesScope(n, fvs, scope, computeFv);
+  return checkVariablesInternal(n, fvs, scope);
 }
 
 bool getFreeVariablesScope(TNode n,
                            std::unordered_set<Node>& fvs,
-                           std::unordered_set<TNode>& scope,
-                           bool computeFv)
+                           std::unordered_set<TNode>& scope)
 {
-  std::unordered_set<TNode> visited;
-  std::vector<TNode> visit;
-  TNode cur;
-  visit.push_back(n);
-  do
-  {
-    cur = visit.back();
-    visit.pop_back();
-    // can skip if it doesn't have a bound variable
-    if (!hasBoundVar(cur))
-    {
-      continue;
-    }
-    std::unordered_set<TNode>::iterator itv = visited.find(cur);
-    if (itv == visited.end())
-    {
-      visited.insert(cur);
-      if (cur.getKind() == kind::BOUND_VARIABLE)
-      {
-        if (scope.find(cur) == scope.end())
-        {
-          if (computeFv)
-          {
-            fvs.insert(cur);
-          }
-          else
-          {
-            return true;
-          }
-        }
-      }
-      else if (cur.isClosure())
-      {
-        // add to scope
-        for (const TNode& cn : cur[0])
-        {
-          // should not shadow
-          Assert(scope.find(cn) == scope.end())
-              << "Shadowed variable " << cn << " in " << cur << "\n";
-          scope.insert(cn);
-        }
-        // must make recursive call to use separate cache
-        if (getFreeVariablesScope(cur[1], fvs, scope, computeFv) && !computeFv)
-        {
-          return true;
-        }
-        // cleanup
-        for (const TNode& cn : cur[0])
-        {
-          scope.erase(cn);
-        }
-      }
-      else
-      {
-        if (cur.hasOperator())
-        {
-          visit.push_back(cur.getOperator());
-        }
-        visit.insert(visit.end(), cur.begin(), cur.end());
-      }
-    }
-  } while (!visit.empty());
-
-  return !fvs.empty();
+  return checkVariablesInternal(n, fvs, scope);
 }
 
 bool getVariables(TNode n, std::unordered_set<TNode>& vs)

--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -288,7 +288,7 @@ bool hasBoundVar(TNode n)
  * This computes the free variables in n, that is, the subterms of n of kind
  * BOUND_VARIABLE that are not bound in n or occur in scope, adds these to fvs
  * if computeFv is true.
- * 
+ *
  * @param n The node under investigation
  * @param fvs The set which free variables are added to
  * @param scope The scope we are considering.
@@ -361,7 +361,8 @@ bool checkVariablesInternal(TNode n,
           scope.insert(cn);
         }
         // must make recursive call to use separate cache
-        if (checkVariablesInternal(cur[1], fvs, scope, wasShadow, computeFv, checkShadow)
+        if (checkVariablesInternal(
+                cur[1], fvs, scope, wasShadow, computeFv, checkShadow)
             && !computeFv)
         {
           return true;
@@ -388,9 +389,9 @@ bool checkVariablesInternal(TNode n,
 
 /** Same as above, without checking for shadowing */
 bool getVariablesInternal(TNode n,
-                            std::unordered_set<Node>& fvs,
-                            std::unordered_set<TNode>& scope,
-                            bool computeFv = true)
+                          std::unordered_set<Node>& fvs,
+                          std::unordered_set<TNode>& scope,
+                          bool computeFv = true)
 {
   bool wasShadow = false;
   return checkVariablesInternal(n, fvs, scope, wasShadow, computeFv, false);
@@ -469,8 +470,7 @@ bool getFreeVariablesScope(TNode n,
 {
   return getVariablesInternal(n, fvs, scope);
 }
-bool hasFreeVariablesScope(TNode n,
-                           std::unordered_set<TNode>& scope)
+bool hasFreeVariablesScope(TNode n, std::unordered_set<TNode>& scope)
 {
   std::unordered_set<Node> fvs;
   return getVariablesInternal(n, fvs, scope, false);

--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -442,7 +442,7 @@ bool hasClosure(Node n)
     }
     else
     {
-      for (auto i = n.begin(); i != n.end() && !hasC; ++i)
+      for (const auto& i = n.begin(); i != n.end() && !hasC; ++i)
       {
         hasC = hasClosure(*i);
       }

--- a/src/expr/node_algorithm.h
+++ b/src/expr/node_algorithm.h
@@ -85,6 +85,15 @@ bool hasBoundVar(TNode n);
 bool hasFreeVar(TNode n);
 
 /**
+ * Returns true iff the node n contains a free variable, that is, a node
+ * of kind BOUND_VARIABLE that is not bound in n, or a BOUND_VARIABLE that
+ * is shadowed (e.g. it is bound twice in the same context).
+ * @param n The node under investigation
+ * @return true iff this node contains a free or shadowed variable.
+ */
+bool hasFreeOrShadowedVar(TNode n);
+
+/**
  * Returns true iff the node n contains a closure, that is, a node
  * whose kind is FORALL, EXISTS, WITNESS, LAMBDA, or any other closure currently
  * supported.
@@ -98,27 +107,21 @@ bool hasClosure(Node n);
  * BOUND_VARIABLE that are not bound in n, adds these to fvs.
  * @param n The node under investigation
  * @param fvs The set which free variables are added to
- * @param computeFv If this flag is false, then we only return true/false and
- * do not add to fvs.
  * @return true iff this node contains a free variable.
  */
 bool getFreeVariables(TNode n,
-                      std::unordered_set<Node>& fvs,
-                      bool computeFv = true);
+                      std::unordered_set<Node>& fvs);
 /**
  * Get the free variables in n, that is, the subterms of n of kind
  * BOUND_VARIABLE that are not bound in n or occur in scope, adds these to fvs.
  * @param n The node under investigation
  * @param fvs The set which free variables are added to
  * @param scope The scope we are considering.
- * @param computeFv If this flag is false, then we only return true/false and
- * do not add to fvs.
  * @return true iff this node contains a free variable.
  */
 bool getFreeVariablesScope(TNode n,
                            std::unordered_set<Node>& fvs,
-                           std::unordered_set<TNode>& scope,
-                           bool computeFv = true);
+                           std::unordered_set<TNode>& scope);
 
 /**
  * Get all variables in n.

--- a/src/expr/node_algorithm.h
+++ b/src/expr/node_algorithm.h
@@ -128,8 +128,7 @@ bool getFreeVariablesScope(TNode n,
  * @param scope The scope we are considering.
  * @return true iff this node contains a free variable.
  */
-bool hasFreeVariablesScope(TNode n,
-                           std::unordered_set<TNode>& scope);
+bool hasFreeVariablesScope(TNode n, std::unordered_set<TNode>& scope);
 
 /**
  * Get all variables in n.

--- a/src/expr/node_algorithm.h
+++ b/src/expr/node_algorithm.h
@@ -109,8 +109,7 @@ bool hasClosure(Node n);
  * @param fvs The set which free variables are added to
  * @return true iff this node contains a free variable.
  */
-bool getFreeVariables(TNode n,
-                      std::unordered_set<Node>& fvs);
+bool getFreeVariables(TNode n, std::unordered_set<Node>& fvs);
 /**
  * Get the free variables in n, that is, the subterms of n of kind
  * BOUND_VARIABLE that are not bound in n or occur in scope, adds these to fvs.

--- a/src/expr/node_algorithm.h
+++ b/src/expr/node_algorithm.h
@@ -89,9 +89,10 @@ bool hasFreeVar(TNode n);
  * of kind BOUND_VARIABLE that is not bound in n, or a BOUND_VARIABLE that
  * is shadowed (e.g. it is bound twice in the same context).
  * @param n The node under investigation
+ * @param wasShadow Set to true if n had a shadowed variable.
  * @return true iff this node contains a free or shadowed variable.
  */
-bool hasFreeOrShadowedVar(TNode n);
+bool hasFreeOrShadowedVar(TNode n, bool& wasShadow);
 
 /**
  * Returns true iff the node n contains a closure, that is, a node
@@ -120,6 +121,14 @@ bool getFreeVariables(TNode n, std::unordered_set<Node>& fvs);
  */
 bool getFreeVariablesScope(TNode n,
                            std::unordered_set<Node>& fvs,
+                           std::unordered_set<TNode>& scope);
+/**
+ * Return true if n has any free variables in the given scope.
+ * @param n The node under investigation
+ * @param scope The scope we are considering.
+ * @return true iff this node contains a free variable.
+ */
+bool hasFreeVariablesScope(TNode n,
                            std::unordered_set<TNode>& scope);
 
 /**

--- a/src/smt/assertions.cpp
+++ b/src/smt/assertions.cpp
@@ -190,16 +190,18 @@ void Assertions::addFormula(TNode n,
   // Ensure that it does not contain free variables
   if (maybeHasFv)
   {
-    if (expr::hasFreeVar(n))
+    bool wasShadow = false;
+    if (expr::hasFreeOrShadowedVar(n, wasShadow))
     {
+      std::string varType(wasShadow ? "shadowed" : "free");
       std::stringstream se;
       if (isFunDef)
       {
-        se << "Cannot process function definition with free variable.";
+        se << "Cannot process function definition with " << varType << " variable.";
       }
       else
       {
-        se << "Cannot process assertion with free variable.";
+        se << "Cannot process assertion with " << varType << " variable.";
         if (language::isLangSygus(options().base.inputLanguage))
         {
           // Common misuse of SyGuS is to use top-level assert instead of

--- a/src/smt/assertions.cpp
+++ b/src/smt/assertions.cpp
@@ -197,7 +197,8 @@ void Assertions::addFormula(TNode n,
       std::stringstream se;
       if (isFunDef)
       {
-        se << "Cannot process function definition with " << varType << " variable.";
+        se << "Cannot process function definition with " << varType
+           << " variable.";
       }
       else
       {


### PR DESCRIPTION
When using the API, we currently check for free variables in assertions and in terms passed to get-value. 

We also require checking for variable shadowing.

This generalizes the utility method so that both free variables and shadowed variables are checked and reported to the user.