### PR TITLE
Push output language inside the printing code

### DIFF
--- a/src/expr/node.h
+++ b/src/expr/node.h
@@ -819,11 +819,10 @@ public:
    */
   inline void toStream(std::ostream& out,
                        int toDepth = -1,
-                       size_t dagThreshold = 1,
-                       Language language = Language::LANG_AUTO) const
+                       size_t dagThreshold = 1) const
   {
     assertTNodeNotExpired();
-    d_nv->toStream(out, toDepth, dagThreshold, language);
+    d_nv->toStream(out, toDepth, dagThreshold);
   }
 
   void constToStream(std::ostream& out) const
@@ -867,8 +866,7 @@ public:
 inline std::ostream& operator<<(std::ostream& out, TNode n) {
   n.toStream(out,
              options::ioutils::getNodeDepth(out),
-             options::ioutils::getDagThresh(out),
-             options::ioutils::getOutputLang(out));
+             options::ioutils::getDagThresh(out));
   return out;
 }
 

--- a/src/expr/node_value.cpp
+++ b/src/expr/node_value.cpp
@@ -25,6 +25,7 @@
 #include "expr/metakind.h"
 #include "expr/node.h"
 #include "options/base_options.h"
+#include "options/io_utils.h"
 #include "options/language.h"
 #include "options/options.h"
 #include "printer/printer.h"
@@ -36,23 +37,20 @@ namespace expr {
 
 string NodeValue::toString() const {
   stringstream ss;
-
-  Language outlang =
-      (this == &null()) ? Language::LANG_AUTO : options::outputLanguage();
-  toStream(ss, -1, false, outlang);
+  toStream(ss, -1, false);
   return ss.str();
 }
 
 void NodeValue::toStream(std::ostream& out,
                          int toDepth,
-                         size_t dag,
-                         Language language) const
+                         size_t dag) const
 {
   // Ensure that this node value is live for the length of this call.
   // It really breaks things badly if we don't have a nonzero ref
   // count, even just for printing.
   RefCountGuard guard(this);
 
+  auto language = options::ioutils::getOutputLang(out);
   Printer::getPrinter(language)->toStream(out, TNode(this), toDepth, dag);
 }
 

--- a/src/expr/node_value.h
+++ b/src/expr/node_value.h
@@ -230,8 +230,7 @@ class NodeValue
 
   void toStream(std::ostream& out,
                 int toDepth = -1,
-                size_t dag = 1,
-                Language = Language::LANG_AUTO) const;
+                size_t dag = 1) const;
 
   void printAst(std::ostream& out, int indent = 0) const;
 
@@ -509,8 +508,7 @@ inline T NodeValue::iterator<T>::operator*() const {
 inline std::ostream& operator<<(std::ostream& out, const NodeValue& nv) {
   nv.toStream(out,
               options::ioutils::getNodeDepth(out),
-              options::ioutils::getDagThresh(out),
-              options::ioutils::getOutputLang(out));
+              options::ioutils::getDagThresh(out));
   return out;
 }
 

--- a/src/expr/type_node.cpp
+++ b/src/expr/type_node.cpp
@@ -660,9 +660,7 @@ bool TypeNode::isSygusDatatype() const
 
 std::string TypeNode::toString() const {
   std::stringstream ss;
-  Language outlang =
-      (this == &s_null) ? Language::LANG_AUTO : options::outputLanguage();
-  d_nv->toStream(ss, -1, 0, outlang);
+  d_nv->toStream(ss, -1, 0);
   return ss.str();
 }
 

--- a/src/expr/type_node.h
+++ b/src/expr/type_node.h
@@ -374,10 +374,9 @@ private:
    * @param out the stream to serialize this node to
    * @param language the language in which to output
    */
-  inline void toStream(std::ostream& out,
-                       Language language = Language::LANG_AUTO) const
+  inline void toStream(std::ostream& out) const
   {
-    d_nv->toStream(out, -1, 0, language);
+    d_nv->toStream(out, -1, 0);
   }
 
   /**
@@ -729,7 +728,7 @@ private:
  * @return the stream
  */
 inline std::ostream& operator<<(std::ostream& out, const TypeNode& n) {
-  n.toStream(out, options::ioutils::getOutputLang(out));
+  n.toStream(out);
   return out;
 }
 

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1220,7 +1220,7 @@ std::string Smt2Printer::smtKindString(Kind k, Variant v)
 void Smt2Printer::toStreamType(std::ostream& out, TypeNode tn) const
 {
   // we currently must call TypeNode::toStream here.
-  tn.toStream(out, Language::LANG_SMTLIB_V2_6);
+  tn.toStream(out);
 }
 
 template <class T>

--- a/src/printer/tptp/tptp_printer.cpp
+++ b/src/printer/tptp/tptp_printer.cpp
@@ -37,7 +37,9 @@ void TptpPrinter::toStream(std::ostream& out,
                            int toDepth,
                            size_t dag) const
 {
-  n.toStream(out, toDepth, dag, Language::LANG_SMTLIB_V2_6);
+  options::ioutils::Scope scope(out);
+  options::ioutils::applyOutputLang(out, Language::LANG_SMTLIB_V2_6);
+  n.toStream(out, toDepth, dag);
 }/* TptpPrinter::toStream() */
 
 void TptpPrinter::toStream(std::ostream& out, const CommandStatus* s) const

--- a/src/proof/lfsc/lfsc_node_converter.cpp
+++ b/src/proof/lfsc/lfsc_node_converter.cpp
@@ -531,7 +531,8 @@ TypeNode LfscNodeConverter::postConvertType(TypeNode tn)
     if (tnn.isNull())
     {
       std::stringstream ss;
-      tn.toStream(ss, Language::LANG_SMTLIB_V2_6);
+      options::ioutils::applyOutputLang(ss, Language::LANG_SMTLIB_V2_6);
+      tn.toStream(ss);
       if (tn.isSort() || (tn.isDatatype() && !tn.isTuple()))
       {
         std::stringstream sss;

--- a/src/proof/lfsc/lfsc_print_channel.cpp
+++ b/src/proof/lfsc/lfsc_print_channel.cpp
@@ -79,7 +79,8 @@ void LfscPrintChannelOut::printNodeInternal(std::ostream& out, Node n)
 {
   // due to use of special names in the node converter, we must clean symbols
   std::stringstream ss;
-  n.toStream(ss, -1, 0, Language::LANG_SMTLIB_V2_6);
+  options::ioutils::applyOutputLang(ss, Language::LANG_SMTLIB_V2_6);
+  n.toStream(ss, -1, 0);
   std::string s = ss.str();
   cleanSymbols(s);
   out << s;
@@ -89,7 +90,8 @@ void LfscPrintChannelOut::printTypeNodeInternal(std::ostream& out, TypeNode tn)
 {
   // due to use of special names in the node converter, we must clean symbols
   std::stringstream ss;
-  tn.toStream(ss, Language::LANG_SMTLIB_V2_6);
+  options::ioutils::applyOutputLang(ss, Language::LANG_SMTLIB_V2_6);
+  tn.toStream(ss);
   std::string s = ss.str();
   cleanSymbols(s);
   out << s;

--- a/src/util/result.cpp
+++ b/src/util/result.cpp
@@ -289,7 +289,7 @@ ostream& operator<<(ostream& out, enum Result::UnknownExplanation e)
 }
 
 ostream& operator<<(ostream& out, const Result& r) {
-  r.toStream(out, options::ioutils::getOutputLang(out));
+  r.toStream(out);
   return out;
 } /* operator<<(ostream&, const Result&) */
 
@@ -354,8 +354,9 @@ void Result::toStreamTptp(std::ostream& out) const {
   out << " for " << getInputName();
 }
 
-void Result::toStream(std::ostream& out, Language language) const
+void Result::toStream(std::ostream& out) const
 {
+  Language language = options::ioutils::getOutputLang(out);
   switch (language) {
     case Language::LANG_SYGUS_V2: toStreamSmt2(out); break;
     case Language::LANG_TPTP: toStreamTptp(out); break;

--- a/src/util/result.cpp
+++ b/src/util/result.cpp
@@ -289,7 +289,20 @@ ostream& operator<<(ostream& out, enum Result::UnknownExplanation e)
 }
 
 ostream& operator<<(ostream& out, const Result& r) {
-  r.toStream(out);
+  Language language = options::ioutils::getOutputLang(out);
+  switch (language) {
+    case Language::LANG_SYGUS_V2: r.toStreamSmt2(out); break;
+    case Language::LANG_TPTP: r.toStreamTptp(out); break;
+    default:
+      if (language::isLangSmt2(language))
+      {
+        r.toStreamSmt2(out);
+      }
+      else
+      {
+        r.toStreamDefault(out);
+      }
+  };
   return out;
 } /* operator<<(ostream&, const Result&) */
 
@@ -352,25 +365,6 @@ void Result::toStreamTptp(std::ostream& out) const {
     out << "GaveUp";
   }
   out << " for " << getInputName();
-}
-
-void Result::toStream(std::ostream& out) const
-{
-  Language language = options::ioutils::getOutputLang(out);
-  switch (language) {
-    case Language::LANG_SYGUS_V2: toStreamSmt2(out); break;
-    case Language::LANG_TPTP: toStreamTptp(out); break;
-    default:
-      if (language::isLangSmt2(language))
-      {
-        toStreamSmt2(out);
-      }
-      else
-      {
-        toStreamDefault(out);
-      }
-      break;
-  };
 }
 
 }  // namespace cvc5

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -120,9 +120,9 @@ class Result
   std::string getInputName() const { return d_inputName; }
 
   /**
-   * Write a Result out to a stream in this language.
+   * Write a Result out to a stream.
    */
-  void toStream(std::ostream& out, Language language) const;
+  void toStream(std::ostream& out) const;
 
   /**
    * This is mostly the same the default

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -120,11 +120,6 @@ class Result
   std::string getInputName() const { return d_inputName; }
 
   /**
-   * Write a Result out to a stream.
-   */
-  void toStream(std::ostream& out) const;
-
-  /**
    * This is mostly the same the default
    * If getType() == Result::TYPE_SAT && isSat() == Result::SAT_UNKNOWN,
    *


### PR DESCRIPTION
This PR pushes the explicit specification of the output language further inside the printing methods.
The general way to specify the output language is to attach it to the output stream. The changes simplify the interface, while we still allow printing in another output language via using a scope (as used in the lfsc and tptp printers).