### PR TITLE
cmake: Add option --[no]-static-binary.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,10 @@ option(BUILD_BINDINGS_JAVA "Build Java bindings based on new C++ API ")
 # Api documentation
 option(BUILD_DOCS "Build Api documentation")
 
+# Link against static system libraries
+cvc5_option(STATIC_BINARY "Link against static system libraries \
+(enabled by default for static builds)")
+
 #-----------------------------------------------------------------------------#
 # Internal cmake variables
 
@@ -443,6 +447,9 @@ if(BUILD_SHARED_LIBS)
   set(CVC5_STATIC_BUILD OFF)
 else()
   set(CVC5_STATIC_BUILD ON)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    cvc5_set_option(STATIC_BINARY ON)
+  endif()
 endif()
 
 #-----------------------------------------------------------------------------#

--- a/configure.sh
+++ b/configure.sh
@@ -31,6 +31,7 @@ General options;
 Features:
 The following flags enable optional features (disable with --no-<option name>).
   --static                 build static libraries and binaries [default=no]
+  --static-binary          link against static system libraries
   --auto-download          automatically download dependencies if necessary
   --debug-symbols          include debug symbols
   --valgrind               Valgrind instrumentation
@@ -123,6 +124,7 @@ python_bindings=default
 java_bindings=default
 editline=default
 build_shared=ON
+static_binary=default
 statistics=default
 tracing=default
 tsan=default
@@ -237,6 +239,9 @@ do
     --static) build_shared=OFF;;
     --no-static) build_shared=ON;;
 
+    --static-binary) static_binary=ON;;
+    --no-static-binary) static_binary=OFF;;
+
     --auto-download) auto_download=ON;;
     --no-auto-download) auto_download=OFF;;
 
@@ -337,6 +342,8 @@ fi
   && cmake_opts="$cmake_opts -DENABLE_MUZZLE=$muzzle"
 [ $build_shared != default ] \
   && cmake_opts="$cmake_opts -DBUILD_SHARED_LIBS=$build_shared"
+[ $static_binary != default ] \
+  && cmake_opts="$cmake_opts -DSTATIC_BINARY=$static_binary"
 [ $statistics != default ] \
   && cmake_opts="$cmake_opts -DENABLE_STATISTICS=$statistics"
 [ $tracing != default ] \

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -77,7 +77,7 @@ endif()
 #   https://cmake.org/cmake/help/v3.0/prop_tgt/LINK_SEARCH_START_STATIC.html
 #   https://cmake.org/cmake/help/v3.0/prop_tgt/LINK_SEARCH_END_STATIC.html
 if(NOT BUILD_SHARED_LIBS)
-  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  if(STATIC_BINARY)
     set_target_properties(cvc5-bin PROPERTIES LINK_FLAGS -static)
     set_target_properties(cvc5-bin PROPERTIES LINK_SEARCH_START_STATIC ON)
     set_target_properties(cvc5-bin PROPERTIES LINK_SEARCH_END_STATIC ON)


### PR DESCRIPTION
Allows to disable linking against static system libraries explicitly.