### PR TITLE
Guard regression tests that require libpoly to pass.

### DIFF
--- a/test/regress/regress0/nl/issue3003.smt2
+++ b/test/regress/regress0/nl/issue3003.smt2
@@ -1,5 +1,6 @@
 ; COMMAND-LINE: --nl-ext=none --no-check-models
 ; EXPECT: sat
+; REQUIRES: poly
 (set-logic QF_NRA)
 (set-info :status sat)
 (declare-fun _substvar_15_ () Real)                                                                                                                                 

--- a/test/regress/regress0/nl/issue3411.smt2
+++ b/test/regress/regress0/nl/issue3411.smt2
@@ -1,5 +1,6 @@
 ; COMMAND-LINE: --no-check-models
 ; EXPECT: sat
+; REQUIRES: poly
 (set-logic NRA)
 (set-info :status sat)
 (declare-fun a () Real)

--- a/test/regress/regress0/nl/issue3652.smt2
+++ b/test/regress/regress0/nl/issue3652.smt2
@@ -1,4 +1,5 @@
 ;COMMAND-LINE: --check-models
+;REQUIRES: poly
 ;EXIT: 1
 ;EXPECT: (error "Cannot run check-model on a model with approximate values.")
 (set-logic QF_NRA)

--- a/test/regress/regress0/nl/issue3719.smt2
+++ b/test/regress/regress0/nl/issue3719.smt2
@@ -1,3 +1,4 @@
+; REQUIRES: poly
 (set-logic QF_NRA)
 (set-info :status sat)
 (declare-fun a () Real)

--- a/test/regress/regress0/nl/sin-cos-346-b-chunk-0169.smt2
+++ b/test/regress/regress0/nl/sin-cos-346-b-chunk-0169.smt2
@@ -1,4 +1,5 @@
 ; COMMAND-LINE: --no-check-models --nl-ext-tplanes
+; REQUIRES: poly
 ; EXPECT: sat
 (set-info :smt-lib-version 2.6)
 (set-logic QF_NRA)

--- a/test/regress/regress0/nl/sqrt2-value.smt2
+++ b/test/regress/regress0/nl/sqrt2-value.smt2
@@ -1,5 +1,6 @@
 ; SCRUBBER: sed -e 's/witness.*/witness/'
 ; COMMAND-LINE: --no-check-models
+; REQUIRES: poly
 ; EXPECT: sat
 ; EXPECT: ((x (witness
 (set-option :produce-models true)

--- a/test/regress/regress1/nl/approx-sqrt.smt2
+++ b/test/regress/regress1/nl/approx-sqrt.smt2
@@ -1,4 +1,5 @@
 ; COMMAND-LINE: --no-check-models
+; REQUIRES: poly
 ; EXPECT: sat
 (set-logic QF_NRA)
 (set-info :status sat)

--- a/test/regress/regress1/nl/issue3300-approx-sqrt-witness.smt2
+++ b/test/regress/regress1/nl/issue3300-approx-sqrt-witness.smt2
@@ -1,5 +1,6 @@
 ; SCRUBBER: sed -e 's/BOUND_VARIABLE_[0-9]*/BOUND_VARIABLE/; s/((x (witness ((BOUND_VARIABLE Real)) (.*/SUCCESS/'
 ; COMMAND-LINE: --produce-models --model-witness-value --no-check-models
+; REQUIRES: poly
 ; EXPECT: sat
 ; EXPECT: SUCCESS
 (set-logic QF_NRA)

--- a/test/regress/regress1/nl/solve-eq-small-qf-nra.smt2
+++ b/test/regress/regress1/nl/solve-eq-small-qf-nra.smt2
@@ -1,4 +1,5 @@
 ; COMMAND-LINE: --no-check-models
+; REQUIRES: poly
 ; EXPECT: sat
 (set-info :smt-lib-version 2.6)
 (set-logic QF_NRA)

--- a/test/regress/regress1/quantifiers/issue6607-witness-te.smt2
+++ b/test/regress/regress1/quantifiers/issue6607-witness-te.smt2
@@ -1,4 +1,5 @@
 ; COMMAND-LINE: --no-check-models
+; REQUIRES: poly
 (set-logic NRA)
 (set-info :status sat)
 (assert (exists ((skoY Real)) (forall ((skoX Real)) (or (= 0.0 (* skoY skoY)) (and (< skoY 0.0) (or (= skoY skoX) (= 2 (* skoY skoY))))))))

--- a/test/regress/regress1/sqrt2-sort-inf-unk.smt2
+++ b/test/regress/regress1/sqrt2-sort-inf-unk.smt2
@@ -1,4 +1,5 @@
 ; COMMAND-LINE: --sort-inference
+; REQUIRES: poly
 ; EXPECT: sat
 (set-logic QF_NRA)
 (declare-fun x () Real)


### PR DESCRIPTION
Regression tests either timeout or return unknown if cvc5 is configured with --no-poly.