### PR TITLE
Bug in utils.define_fun_to_string for printing parameter list in 'examples/api/python'

### DIFF
--- a/examples/api/python/utils.py
+++ b/examples/api/python/utils.py
@@ -33,8 +33,7 @@ def define_fun_to_string(f, params, body):
     for i in range(0, len(params)):
         if i > 0:
             result += " "
-        else:
-            result += "(" + str(params[i]) + " " + str(params[i].getSort()) + ")"
+        result += "(" + str(params[i]) + " " + str(params[i].getSort()) + ")"
     result += ") " + str(sort) + " " + str(body) + ")"
     return result
 


### PR DESCRIPTION
This PR contains fix for `utils.define_fun_to_string` in `examples/api/python`. It doesn't not print the synthesized function's parameter list properly.

To reproduce run the sygus example in `examples/api/python/sygus-fun.py`.  It prints
```
  (define-fun max ((x Int) ) Int (ite (<= x y) y x))
  (define-fun min ((x Int) ) Int (ite (<= y x) y x))
```
instead of 

```
  (define-fun max ((x Int) (y Int)) Int (ite (<= x y) y x))
  (define-fun min ((x Int) (y Int)) Int (ite (<= y x) y x))
```