### PR TITLE
[proofs] Add method to CDProof to obtain number of proof nodes

### DIFF
--- a/src/proof/proof.cpp
+++ b/src/proof/proof.cpp
@@ -408,6 +408,8 @@ bool CDProof::hasStep(Node fact)
   return false;
 }
 
+size_t CDProof::getNumProofNodes() const { return d_nodes.size(); }
+
 ProofNodeManager* CDProof::getManager() const { return d_manager; }
 
 bool CDProof::shouldOverwrite(ProofNode* pn, PfRule newId, CDPOverwrite opol)

--- a/src/proof/proof.h
+++ b/src/proof/proof.h
@@ -227,6 +227,8 @@ class CDProof : public ProofGenerator
                 bool doCopy = false);
   /** Return true if fact already has a proof step */
   bool hasStep(Node fact);
+  /** Return how many proof nodes currently in proof */
+  size_t getNumProofNodes() const;
   /** Get the proof manager for this proof */
   ProofNodeManager* getManager() const;
   /**


### PR DESCRIPTION
Useful for example to easily see by how much a proof grew after some reconstruction expansion.