### PR TITLE
More robust fix for 32bit issues.

### DIFF
--- a/src/util/integer_gmp_imp.cpp
+++ b/src/util/integer_gmp_imp.cpp
@@ -486,11 +486,8 @@ uint64_t Integer::getUnsigned64() const
     }
     try
     {
-      if (sgn() < 0)
-      {
-        CheckArgument(
-            false, this, "Overflow detected in Integer::getUnsigned64().");
-      }
+      CheckArgument(
+          sgn() >= 0, this, "Overflow detected in Integer::getUnsigned64().");
       return std::stoull(toString());
     }
     catch (const std::exception& e)

--- a/src/util/integer_gmp_imp.cpp
+++ b/src/util/integer_gmp_imp.cpp
@@ -461,8 +461,10 @@ int64_t Integer::getSigned64() const
       return getLong();
     }
     // ensure there is no overflow.
-    // mpz_sizeinbase ignores the sign bit, thus at most 63 bits.
-    CheckArgument(mpz_sizeinbase(d_value.get_mpz_t(), 2) < 64,
+    CheckArgument(mpz_class(std::to_string(std::numeric_limits<int64_t>::min()))
+                          <= d_value
+                      && d_value <= mpz_class(std::to_string(
+                             std::numeric_limits<int64_t>::max())),
                   this,
                   "Overflow detected in Integer::getSigned64().");
     return std::stoll(toString());
@@ -480,10 +482,14 @@ uint64_t Integer::getUnsigned64() const
     {
       return getUnsignedLong();
     }
-    // ensure there isn't overflow
-    CheckArgument(mpz_sizeinbase(d_value.get_mpz_t(), 2) <= 64,
-                  this,
-                  "Overflow detected in Integer::getUnsigned64().");
+    // ensure there is no overflow
+    CheckArgument(
+        mpz_class(std::to_string(std::numeric_limits<uint64_t>::min()))
+                <= d_value
+            && d_value <= mpz_class(
+                   std::to_string(std::numeric_limits<uint64_t>::max())),
+        this,
+        "Overflow detected in Integer::getUnsigned64().");
     return std::stoull(toString());
   }
 }

--- a/src/util/integer_gmp_imp.cpp
+++ b/src/util/integer_gmp_imp.cpp
@@ -468,6 +468,7 @@ int64_t Integer::getSigned64() const
     {
       CheckArgument(
           false, this, "Overflow detected in Integer::getSigned64().");
+      return 0;
     }
   }
 }
@@ -491,6 +492,7 @@ uint64_t Integer::getUnsigned64() const
     {
       CheckArgument(
           false, this, "Overflow detected in Integer::getUnsigned64().");
+      return 0;
     }
   }
 }

--- a/src/util/integer_gmp_imp.cpp
+++ b/src/util/integer_gmp_imp.cpp
@@ -468,9 +468,9 @@ int64_t Integer::getSigned64() const
     {
       CheckArgument(
           false, this, "Overflow detected in Integer::getSigned64().");
-      return 0;
     }
   }
+  return 0;
 }
 uint64_t Integer::getUnsigned64() const
 {
@@ -486,15 +486,20 @@ uint64_t Integer::getUnsigned64() const
     }
     try
     {
+      if (sgn() < 0)
+      {
+        CheckArgument(
+            false, this, "Overflow detected in Integer::getUnsigned64().");
+      }
       return std::stoull(toString());
     }
     catch (const std::exception& e)
     {
       CheckArgument(
           false, this, "Overflow detected in Integer::getUnsigned64().");
-      return 0;
     }
   }
+  return 0;
 }
 
 size_t Integer::hash() const { return gmpz_hash(d_value.get_mpz_t()); }

--- a/src/util/integer_gmp_imp.cpp
+++ b/src/util/integer_gmp_imp.cpp
@@ -460,14 +460,15 @@ int64_t Integer::getSigned64() const
     {
       return getLong();
     }
-    // ensure there is no overflow.
-    CheckArgument(mpz_class(std::to_string(std::numeric_limits<int64_t>::min()))
-                          <= d_value
-                      && d_value <= mpz_class(std::to_string(
-                             std::numeric_limits<int64_t>::max())),
-                  this,
-                  "Overflow detected in Integer::getSigned64().");
-    return std::stoll(toString());
+    try
+    {
+      return std::stoll(toString());
+    }
+    catch (const std::exception& e)
+    {
+      CheckArgument(
+          false, this, "Overflow detected in Integer::getSigned64().");
+    }
   }
 }
 uint64_t Integer::getUnsigned64() const
@@ -482,15 +483,15 @@ uint64_t Integer::getUnsigned64() const
     {
       return getUnsignedLong();
     }
-    // ensure there is no overflow
-    CheckArgument(
-        mpz_class(std::to_string(std::numeric_limits<uint64_t>::min()))
-                <= d_value
-            && d_value <= mpz_class(
-                   std::to_string(std::numeric_limits<uint64_t>::max())),
-        this,
-        "Overflow detected in Integer::getUnsigned64().");
-    return std::stoull(toString());
+    try
+    {
+      return std::stoull(toString());
+    }
+    catch (const std::exception& e)
+    {
+      CheckArgument(
+          false, this, "Overflow detected in Integer::getUnsigned64().");
+    }
   }
 }
 


### PR DESCRIPTION
This PR implements a more robust fix for the 32bit issues with GMP. Relying on `mpz_sizeinbase` proves to be very tricky for the corner cases. This PR instead does a simple comparison against the min and max values of the respective types.