### PR TITLE
Disable option regression for competition build

### DIFF
--- a/test/regress/regress0/options/didyoumean.smt2
+++ b/test/regress/regress0/options/didyoumean.smt2
@@ -1,3 +1,4 @@
+; REQUIRES: no-competition
 ; COMMAND-LINE: --input-agnuage
 ; ERROR-SCRUBBER: grep -o "--[a-zA-Z-]+"
 ; ERROR-EXPECT: --input-language


### PR DESCRIPTION
This PR disables a regression that checks the didyoumean output for an invalid output on competition builds. On competition builds, we simply print "unknown" instead of shown any exceptions.