### PR TITLE
Fix 32bit issue in sep_log_api test

### DIFF
--- a/test/api/cpp/sep_log_api.cpp
+++ b/test/api/cpp/sep_log_api.cpp
@@ -247,8 +247,7 @@ int validate_getters(void)
        * than the random constant -- if we get a value that is LTE, then
        * something has gone wrong!
        */
-      if (std::stoll(value.toString())
-          <= std::stoll(random_constant.toString()))
+      if (value.getInt64Value() <= random_constant.getInt64Value())
       {
         return -1;
       }


### PR DESCRIPTION
This PR uses the proper `t.getInt64Value()` getter instead of `std::stoll(t.toString())`, fixing an issue on 32bit platforms.