### PR TITLE
Make some undocumented options regular/expert

### DIFF
--- a/src/options/README.md
+++ b/src/options/README.md
@@ -26,7 +26,7 @@ Specifying Options
 Options can be defined within a module file with the `[[option]]` tag, the
 required attributes for an option are:
 
-* `category` (string): one of `common`, `expert`, `regular`, or `undocumented`
+* `category` (string): one of `common`, `regular`, `expert`, or `undocumented`
 * `type` (string): the C++ type of the option value, see below for more details.
 
 Optional attributes are:
@@ -58,6 +58,16 @@ Optional attributes are:
 * `help_mode` (string): documentation for the mode enum (required if `mode` is
   given)
 
+
+Option categories
+-----------------
+
+Every option has one of the following categories that influences where and how an option is visible:
+
+* `common`: used for the most common options. All `common` options are shown at the very top in both the online documentation and the output of `--help` on the command line.
+* `regular`: this should be used for most options.
+* `expert`: used for options that should be used with care only. A warning is shown in both the online documentation and the command line help.
+* `undocumented`: such an option is skipped entirely in both the online documentation and the command line help. This should only be used when no user has a (reasonable) use case for this option (e.g. because it stores data that is added via another option like for `output` and `outputTagHolder`).
 
 Option types
 ------------

--- a/src/options/base_options.toml
+++ b/src/options/base_options.toml
@@ -3,27 +3,30 @@ name   = "Base"
 
 [[option]]
   name       = "err"
-  category   = "undocumented"
+  category   = "regular"
   long       = "err=erroutput"
   type       = "ManagedErr"
   alias      = ["diagnostic-output-channel"]
   predicates = ["setErrStream"]
   includes   = ["<iostream>", "options/managed_streams.h"]
+  help       = "Set the error (or diagnostic) output channel. Writes to stderr for \"stderr\" or \"--\", stdout for \"stdout\" or the given filename otherwise."
 
 [[option]]
   name       = "in"
-  category   = "undocumented"
+  category   = "regular"
   long       = "in=input"
   type       = "ManagedIn"
   includes   = ["<iostream>", "options/managed_streams.h"]
+  help       = "Set the error (or diagnostic) output channel. Reads from stdin for \"stdin\" or \"--\" and the given filename otherwise."
 
 [[option]]
   name       = "out"
-  category   = "undocumented"
+  category   = "regular"
   long       = "out=output"
   type       = "ManagedOut"
   alias      = ["regular-output-channel"]
   includes   = ["<iostream>", "options/managed_streams.h"]
+  help       = "Set the error (or diagnostic) output channel. Writes to stdout for \"stdout\" or \"--\", stderr for \"stderr\" or the given filename otherwise."
 
 [[option]]
   name       = "inputLanguage"

--- a/src/options/parser_options.toml
+++ b/src/options/parser_options.toml
@@ -45,10 +45,11 @@ name   = "Parser"
 # overwrite an existing file with malicious content.
 [[option]]
   name       = "filesystemAccess"
-  category   = "undocumented"
+  category   = "expert"
   long       = "filesystem-access"
   type       = "bool"
   default    = "true"
+  help       = "limits the file system access if set to false"
 
 [[option]]
   name       = "forceLogicString"


### PR DESCRIPTION
We have some options that are currently `"undocumented"` for no good reason. This PR makes them regular or expert options.