### PR TITLE
Disable unsat cores for quaternion_ds1_symm_0428.fof.smt2.

### DIFF
--- a/test/regress/regress1/quantifiers/quaternion_ds1_symm_0428.fof.smt2
+++ b/test/regress/regress1/quantifiers/quaternion_ds1_symm_0428.fof.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --full-saturate-quant --multi-trigger-cache
+; COMMAND-LINE: --full-saturate-quant --multi-trigger-cache --no-check-unsat-cores
 ; EXPECT: unsat
 (set-logic AUFLIRA)
 (set-info :status unsat)


### PR DESCRIPTION
Avoids timeout for nightly ASAN builds.