### PR TITLE
Refactoring initialization of proofs

### DIFF
--- a/src/preprocessing/assertion_pipeline.cpp
+++ b/src/preprocessing/assertion_pipeline.cpp
@@ -117,7 +117,7 @@ void AssertionPipeline::replaceTrusted(size_t i, TrustNode trn)
   replace(i, trn.getNode(), trn.getGenerator());
 }
 
-void AssertionPipeline::setProofGenerator(smt::PreprocessProofGenerator* pppg)
+void AssertionPipeline::enableProofs(smt::PreprocessProofGenerator* pppg)
 {
   d_pppg = pppg;
 }

--- a/src/preprocessing/assertion_pipeline.h
+++ b/src/preprocessing/assertion_pipeline.h
@@ -158,8 +158,14 @@ class AssertionPipeline
     return d_storeSubstsInAsserts && i == d_substsIndex;
   }
   //------------------------------------ for proofs
-  /** Set proof generator */
-  void setProofGenerator(smt::PreprocessProofGenerator* pppg);
+  /** 
+   * Enable proofs for this assertions pipeline. This must be called
+   * explicitly since we construct the assertions pipeline before we know
+   * whether proofs are enabled.
+   * 
+   * @param pppg The preprocess proof generator of the proof manager.
+   */
+  void enableProofs(smt::PreprocessProofGenerator* pppg);
   /** Is proof enabled? */
   bool isProofEnabled() const;
   //------------------------------------ end for proofs

--- a/src/preprocessing/assertion_pipeline.h
+++ b/src/preprocessing/assertion_pipeline.h
@@ -158,11 +158,11 @@ class AssertionPipeline
     return d_storeSubstsInAsserts && i == d_substsIndex;
   }
   //------------------------------------ for proofs
-  /** 
+  /**
    * Enable proofs for this assertions pipeline. This must be called
    * explicitly since we construct the assertions pipeline before we know
    * whether proofs are enabled.
-   * 
+   *
    * @param pppg The preprocess proof generator of the proof manager.
    */
   void enableProofs(smt::PreprocessProofGenerator* pppg);

--- a/src/preprocessing/passes/non_clausal_simp.cpp
+++ b/src/preprocessing/passes/non_clausal_simp.cpp
@@ -54,7 +54,7 @@ NonClausalSimp::NonClausalSimp(PreprocessingPassContext* preprocContext)
       d_statistics(statisticsRegistry()),
       d_pnm(d_env.getProofNodeManager()),
       d_llpg(d_pnm ? new smt::PreprocessProofGenerator(
-                         d_pnm, userContext(), "NonClausalSimp::llpg")
+                         d_env, userContext(), "NonClausalSimp::llpg")
                    : nullptr),
       d_llra(d_pnm ? new LazyCDProof(
                          d_pnm, nullptr, userContext(), "NonClausalSimp::llra")

--- a/src/preprocessing/passes/non_clausal_simp.cpp
+++ b/src/preprocessing/passes/non_clausal_simp.cpp
@@ -54,10 +54,10 @@ NonClausalSimp::NonClausalSimp(PreprocessingPassContext* preprocContext)
       d_statistics(statisticsRegistry()),
       d_pnm(d_env.getProofNodeManager()),
       d_llpg(d_pnm ? new smt::PreprocessProofGenerator(
-                         d_env, userContext(), "NonClausalSimp::llpg")
+                 d_env, userContext(), "NonClausalSimp::llpg")
                    : nullptr),
       d_llra(d_pnm ? new LazyCDProof(
-                         d_pnm, nullptr, userContext(), "NonClausalSimp::llra")
+                 d_pnm, nullptr, userContext(), "NonClausalSimp::llra")
                    : nullptr),
       d_tsubsList(userContext())
 {

--- a/src/smt/assertions.cpp
+++ b/src/smt/assertions.cpp
@@ -251,9 +251,9 @@ void Assertions::ensureBoolean(const Node& n)
   }
 }
 
-void Assertions::setProofGenerator(smt::PreprocessProofGenerator* pppg)
+void Assertions::enableProofs(smt::PreprocessProofGenerator* pppg)
 {
-  d_assertions.setProofGenerator(pppg);
+  d_assertions.enableProofs(pppg);
 }
 
 bool Assertions::isProofEnabled() const

--- a/src/smt/assertions.h
+++ b/src/smt/assertions.h
@@ -126,11 +126,11 @@ class Assertions : protected EnvObj
   void flipGlobalNegated();
 
   //------------------------------------ for proofs
-  /** 
+  /**
    * Enable proofs for this assertions class. This must be called
    * explicitly since we construct the assertions before we know
    * whether proofs are enabled.
-   * 
+   *
    * @param pppg The preprocess proof generator of the proof manager.
    */
   void enableProofs(smt::PreprocessProofGenerator* pppg);

--- a/src/smt/assertions.h
+++ b/src/smt/assertions.h
@@ -126,8 +126,14 @@ class Assertions : protected EnvObj
   void flipGlobalNegated();
 
   //------------------------------------ for proofs
-  /** Set proof generator */
-  void setProofGenerator(smt::PreprocessProofGenerator* pppg);
+  /** 
+   * Enable proofs for this assertions class. This must be called
+   * explicitly since we construct the assertions before we know
+   * whether proofs are enabled.
+   * 
+   * @param pppg The preprocess proof generator of the proof manager.
+   */
+  void enableProofs(smt::PreprocessProofGenerator* pppg);
   /** Is proof enabled? */
   bool isProofEnabled() const;
   //------------------------------------ end for proofs

--- a/src/smt/expand_definitions.cpp
+++ b/src/smt/expand_definitions.cpp
@@ -169,7 +169,7 @@ void ExpandDefs::enableProofs()
   // initialize if not done already
   if (d_tpg == nullptr)
   {
-    Assert (d_env.getProofNodeManager()!=nullptr);
+    Assert(d_env.getProofNodeManager() != nullptr);
     d_tpg.reset(new TConvProofGenerator(d_env.getProofNodeManager(),
                                         d_env.getUserContext(),
                                         TConvPolicy::FIXPOINT,

--- a/src/smt/expand_definitions.cpp
+++ b/src/smt/expand_definitions.cpp
@@ -34,7 +34,7 @@ using namespace cvc5::kind;
 namespace cvc5 {
 namespace smt {
 
-ExpandDefs::ExpandDefs(Env& env) : d_env(env), d_tpg(nullptr) {}
+ExpandDefs::ExpandDefs(Env& env) : EnvObj(env), d_tpg(nullptr) {}
 
 ExpandDefs::~ExpandDefs() {}
 
@@ -164,11 +164,13 @@ TrustNode ExpandDefs::expandDefinitions(TNode n,
   return TrustNode::mkTrustRewrite(orig, res, tpg);
 }
 
-void ExpandDefs::setProofNodeManager(ProofNodeManager* pnm)
+void ExpandDefs::enableProofs()
 {
+  // initialize if not done already
   if (d_tpg == nullptr)
   {
-    d_tpg.reset(new TConvProofGenerator(pnm,
+    Assert (d_env.getProofNodeManager()!=nullptr);
+    d_tpg.reset(new TConvProofGenerator(d_env.getProofNodeManager(),
                                         d_env.getUserContext(),
                                         TConvPolicy::FIXPOINT,
                                         TConvCachePolicy::NEVER,

--- a/src/smt/expand_definitions.h
+++ b/src/smt/expand_definitions.h
@@ -22,10 +22,10 @@
 
 #include "expr/node.h"
 #include "proof/trust_node.h"
+#include "smt/env_obj.h"
 
 namespace cvc5 {
 
-class Env;
 class ProofNodeManager;
 class TConvProofGenerator;
 
@@ -37,7 +37,7 @@ namespace smt {
  * Its main features is expandDefinitions(TNode, ...), which returns the
  * expanded formula of a term.
  */
-class ExpandDefs
+class ExpandDefs : protected EnvObj
 {
  public:
   ExpandDefs(Env& env);
@@ -51,11 +51,8 @@ class ExpandDefs
    */
   Node expandDefinitions(TNode n, std::unordered_map<Node, Node>& cache);
 
-  /**
-   * Set proof node manager, which signals this class to enable proofs using the
-   * given proof node manager.
-   */
-  void setProofNodeManager(ProofNodeManager* pnm);
+  /** Enable proofs using the proof node manager of the env. */
+  void enableProofs();
 
  private:
   /**
@@ -65,8 +62,6 @@ class ExpandDefs
   TrustNode expandDefinitions(TNode n,
                               std::unordered_map<Node, Node>& cache,
                               TConvProofGenerator* tpg);
-  /** Reference to the environment. */
-  Env& d_env;
   /** A proof generator for the term conversion. */
   std::unique_ptr<TConvProofGenerator> d_tpg;
 };

--- a/src/smt/preprocess_proof_generator.cpp
+++ b/src/smt/preprocess_proof_generator.cpp
@@ -23,17 +23,14 @@
 #include "proof/proof.h"
 #include "proof/proof_checker.h"
 #include "proof/proof_node.h"
-#include "theory/quantifiers/extended_rewrite.h"
 #include "smt/env.h"
+#include "theory/quantifiers/extended_rewrite.h"
 
 namespace cvc5 {
 namespace smt {
 
-PreprocessProofGenerator::PreprocessProofGenerator(Env& env,
-                                                   context::Context* c,
-                                                   std::string name,
-                                                   PfRule ra,
-                                                   PfRule rpp)
+PreprocessProofGenerator::PreprocessProofGenerator(
+    Env& env, context::Context* c, std::string name, PfRule ra, PfRule rpp)
     : EnvObj(env),
       d_ctx(c ? c : &d_context),
       d_src(d_ctx),

--- a/src/smt/preprocess_proof_generator.cpp
+++ b/src/smt/preprocess_proof_generator.cpp
@@ -24,21 +24,21 @@
 #include "proof/proof_checker.h"
 #include "proof/proof_node.h"
 #include "theory/quantifiers/extended_rewrite.h"
-#include "theory/rewriter.h"
+#include "smt/env.h"
 
 namespace cvc5 {
 namespace smt {
 
-PreprocessProofGenerator::PreprocessProofGenerator(ProofNodeManager* pnm,
+PreprocessProofGenerator::PreprocessProofGenerator(Env& env,
                                                    context::Context* c,
                                                    std::string name,
                                                    PfRule ra,
                                                    PfRule rpp)
-    : d_pnm(pnm),
+    : EnvObj(env),
       d_ctx(c ? c : &d_context),
       d_src(d_ctx),
-      d_helperProofs(pnm, d_ctx),
-      d_inputPf(pnm, c, "InputProof"),
+      d_helperProofs(env.getProofNodeManager(), d_ctx),
+      d_inputPf(env.getProofNodeManager(), c, "InputProof"),
       d_name(name),
       d_ra(ra),
       d_rpp(rpp)
@@ -131,7 +131,7 @@ std::shared_ptr<ProofNode> PreprocessProofGenerator::getProofFor(Node f)
     return nullptr;
   }
   // make CDProof to construct the proof below
-  CDProof cdp(d_pnm);
+  CDProof cdp(d_env.getProofNodeManager());
 
   Node curr = f;
   std::vector<Node> transChildren;
@@ -180,7 +180,7 @@ std::shared_ptr<ProofNode> PreprocessProofGenerator::getProofFor(Node f)
         if (!proofStepProcessed)
         {
           // maybe its just an (extended) rewrite?
-          Node pr = theory::Rewriter::callExtendedRewrite(proven[0]);
+          Node pr = extendedRewrite(proven[0]);
           if (proven[1] == pr)
           {
             Node idr = mkMethodId(MethodId::RW_EXT_REWRITE);
@@ -244,8 +244,6 @@ std::shared_ptr<ProofNode> PreprocessProofGenerator::getProofFor(Node f)
   return cdp.getProofFor(f);
 }
 
-ProofNodeManager* PreprocessProofGenerator::getManager() { return d_pnm; }
-
 LazyCDProof* PreprocessProofGenerator::allocateHelperProof()
 {
   return d_helperProofs.allocateProof(nullptr, d_ctx);
@@ -259,7 +257,7 @@ void PreprocessProofGenerator::checkEagerPedantic(PfRule r)
   {
     // catch a pedantic failure now, which otherwise would not be
     // triggered since we are doing lazy proof generation
-    ProofChecker* pc = d_pnm->getChecker();
+    ProofChecker* pc = d_env.getProofNodeManager()->getChecker();
     std::stringstream serr;
     if (pc->isPedanticFailure(r, serr))
     {

--- a/src/smt/preprocess_proof_generator.h
+++ b/src/smt/preprocess_proof_generator.h
@@ -24,6 +24,7 @@
 #include "proof/proof_generator.h"
 #include "proof/proof_set.h"
 #include "proof/trust_node.h"
+#include "smt/env_obj.h"
 
 namespace cvc5 {
 
@@ -53,13 +54,13 @@ namespace smt {
  * whose free assumptions are intended to be input assertions, which are
  * implictly all assertions that are not notified to this class.
  */
-class PreprocessProofGenerator : public ProofGenerator
+class PreprocessProofGenerator : protected EnvObj, public ProofGenerator
 {
   typedef context::CDHashMap<Node, TrustNode> NodeTrustNodeMap;
 
  public:
   /**
-   * @param pnm The proof node manager
+   * @param env Reference to the environment
    * @param c The context this class depends on
    * @param name The name of this generator (for debugging)
    * @param ra The proof rule to use when no generator is provided for new
@@ -67,7 +68,7 @@ class PreprocessProofGenerator : public ProofGenerator
    * @param rpp The proof rule to use when no generator is provided for
    * preprocessing steps.
    */
-  PreprocessProofGenerator(ProofNodeManager* pnm,
+  PreprocessProofGenerator(Env& env,
                            context::Context* c = nullptr,
                            std::string name = "PreprocessProofGenerator",
                            PfRule ra = PfRule::PREPROCESS_LEMMA,
@@ -98,8 +99,6 @@ class PreprocessProofGenerator : public ProofGenerator
   std::shared_ptr<ProofNode> getProofFor(Node f) override;
   /** Identify */
   std::string identify() const override;
-  /** Get the proof manager */
-  ProofNodeManager* getManager();
   /**
    * Allocate a helper proof. This returns a fresh lazy proof object that
    * remains alive in the context. This feature is used to construct
@@ -114,8 +113,6 @@ class PreprocessProofGenerator : public ProofGenerator
    * to this class.
    */
   void checkEagerPedantic(PfRule r);
-  /** The proof node manager */
-  ProofNodeManager* d_pnm;
   /** A dummy context used by this class if none is provided */
   context::Context d_context;
   /** The context used here */

--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -42,8 +42,7 @@ Preprocessor::Preprocessor(Env& env,
       d_propagator(env, true, true),
       d_assertionsProcessed(env.getUserContext(), false),
       d_exDefs(env),
-      d_processor(env, stats),
-      d_pnm(nullptr)
+      d_processor(env, stats)
 {
 }
 
@@ -149,12 +148,11 @@ Node Preprocessor::simplify(const Node& node)
   return ret;
 }
 
-void Preprocessor::setProofGenerator(PreprocessProofGenerator* pppg)
+void Preprocessor::enableProofs(PreprocessProofGenerator* pppg)
 {
   Assert(pppg != nullptr);
-  d_pnm = pppg->getManager();
-  d_exDefs.setProofNodeManager(d_pnm);
-  d_propagator.setProof(d_pnm, userContext(), pppg);
+  d_exDefs.enableProofs();
+  d_propagator.enableProofs(userContext(), pppg);
 }
 
 }  // namespace smt

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -102,7 +102,7 @@ class Preprocessor : protected EnvObj
    * Enable proofs for this preprocessor. This must be called
    * explicitly since we construct the preprocessor before we know
    * whether proofs are enabled.
-   * 
+   *
    * @param pppg The preprocess proof generator of the proof manager.
    */
   void enableProofs(PreprocessProofGenerator* pppg);

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -99,9 +99,13 @@ class Preprocessor : protected EnvObj
   /** Same as above, for a list of assertions, updating in place */
   void expandDefinitions(std::vector<Node>& ns);
   /**
-   * Set proof node manager. Enables proofs in this preprocessor.
+   * Enable proofs for this preprocessor. This must be called
+   * explicitly since we construct the preprocessor before we know
+   * whether proofs are enabled.
+   * 
+   * @param pppg The preprocess proof generator of the proof manager.
    */
-  void setProofGenerator(PreprocessProofGenerator* pppg);
+  void enableProofs(PreprocessProofGenerator* pppg);
 
  private:
   /** Reference to the abstract values utility */
@@ -123,8 +127,6 @@ class Preprocessor : protected EnvObj
    * passes.
    */
   ProcessAssertions d_processor;
-  /** Proof node manager */
-  ProofNodeManager* d_pnm;
 };
 
 }  // namespace smt

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -44,7 +44,7 @@ PfManager::PfManager(Env& env)
       d_pnm(new ProofNodeManager(
           env.getOptions(), env.getRewriter(), d_pchecker.get())),
       d_pppg(new PreprocessProofGenerator(
-          d_pnm.get(), env.getUserContext(), "smt::PreprocessProofGenerator")),
+          env, env.getUserContext(), "smt::PreprocessProofGenerator")),
       d_pfpp(nullptr),
       d_finalProof(nullptr)
 {

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -51,7 +51,7 @@ PfManager::PfManager(Env& env)
   d_env.setProofNodeManager(d_pnm.get());
   // now construct preprocess proof generator
   d_pppg = std::make_unique<PreprocessProofGenerator>(
-          env, env.getUserContext(), "smt::PreprocessProofGenerator");
+      env, env.getUserContext(), "smt::PreprocessProofGenerator");
   // Now, initialize the proof postprocessor with the environment.
   // By default the post-processor will update all assumptions, which
   // can lead to SCOPE subproofs of the form

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -43,13 +43,15 @@ PfManager::PfManager(Env& env)
           options().proof.proofPedantic)),
       d_pnm(new ProofNodeManager(
           env.getOptions(), env.getRewriter(), d_pchecker.get())),
-      d_pppg(new PreprocessProofGenerator(
-          env, env.getUserContext(), "smt::PreprocessProofGenerator")),
+      d_pppg(nullptr),
       d_pfpp(nullptr),
       d_finalProof(nullptr)
 {
   // enable proof support in the environment/rewriter
   d_env.setProofNodeManager(d_pnm.get());
+  // now construct preprocess proof generator
+  d_pppg = std::make_unique<PreprocessProofGenerator>(
+          env, env.getUserContext(), "smt::PreprocessProofGenerator");
   // Now, initialize the proof postprocessor with the environment.
   // By default the post-processor will update all assumptions, which
   // can lead to SCOPE subproofs of the form
@@ -67,11 +69,11 @@ PfManager::PfManager(Env& env)
   // be inferred from A, it was updated). This shape is problematic for
   // the Alethe reconstruction, so we disable the update of scoped
   // assumptions (which would disable the update of B1 in this case).
-  d_pfpp.reset(new ProofPostproccess(
+  d_pfpp = std::make_unique<ProofPostproccess>(
       env,
       d_pppg.get(),
       nullptr,
-      options().proof.proofFormatMode != options::ProofFormatMode::ALETHE));
+      options().proof.proofFormatMode != options::ProofFormatMode::ALETHE);
 
   // add rules to eliminate here
   if (options().proof.proofGranularityMode

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -192,9 +192,9 @@ void SolverEngine::finishInit()
     // start the unsat core manager
     d_ucManager.reset(new UnsatCoreManager());
     // enable it in the assertions pipeline
-    d_asserts->setProofGenerator(pppg);
+    d_asserts->enableProofs(pppg);
     // enabled proofs in the preprocessor
-    d_smtSolver->getPreprocessor()->setProofGenerator(pppg);
+    d_smtSolver->getPreprocessor()->enableProofs(pppg);
   }
 
   Trace("smt-debug") << "SolverEngine::finishInit" << std::endl;

--- a/src/smt/solver_engine.h
+++ b/src/smt/solver_engine.h
@@ -81,8 +81,6 @@ class AbstractValues;
 class Assertions;
 class ResourceOutListener;
 class SmtNodeManagerListener;
-class OptionsManager;
-class Preprocessor;
 class CheckModels;
 /** Subsolvers */
 class SmtSolver;

--- a/src/theory/arith/nl/cad/cdcac.cpp
+++ b/src/theory/arith/nl/cad/cdcac.cpp
@@ -252,7 +252,7 @@ PolyVector requiredCoefficientsLazardModified(
     const poly::Polynomial& p,
     const poly::Assignment& assignment,
     VariableMapper& vm,
-                                              Rewriter * rewriter)
+    Rewriter* rewriter)
 {
   PolyVector res;
   auto lc = poly::leading_coefficient(p);
@@ -275,8 +275,8 @@ PolyVector requiredCoefficientsLazardModified(
         Kind::EQUAL, nl::as_cvc_polynomial(coeff, vm), zero));
   }
   // if phi is false (i.e. p can not vanish)
-  Node rewritten = rewriter->extendedRewrite(
-      NodeManager::currentNM()->mkAnd(conditions));
+  Node rewritten =
+      rewriter->extendedRewrite(NodeManager::currentNM()->mkAnd(conditions));
   if (rewritten.isConst())
   {
     Assert(rewritten.getKind() == Kind::CONST_BOOLEAN);

--- a/src/theory/arith/nl/cad/cdcac.cpp
+++ b/src/theory/arith/nl/cad/cdcac.cpp
@@ -251,7 +251,8 @@ PolyVector requiredCoefficientsLazard(const poly::Polynomial& p,
 PolyVector requiredCoefficientsLazardModified(
     const poly::Polynomial& p,
     const poly::Assignment& assignment,
-    VariableMapper& vm)
+    VariableMapper& vm,
+                                              Rewriter * rewriter)
 {
   PolyVector res;
   auto lc = poly::leading_coefficient(p);
@@ -274,7 +275,7 @@ PolyVector requiredCoefficientsLazardModified(
         Kind::EQUAL, nl::as_cvc_polynomial(coeff, vm), zero));
   }
   // if phi is false (i.e. p can not vanish)
-  Node rewritten = Rewriter::callExtendedRewrite(
+  Node rewritten = rewriter->extendedRewrite(
       NodeManager::currentNM()->mkAnd(conditions));
   if (rewritten.isConst())
   {
@@ -301,7 +302,7 @@ PolyVector CDCAC::requiredCoefficients(const poly::Polynomial& p)
     Trace("cdcac::projection")
         << "LMod: "
         << requiredCoefficientsLazardModified(
-               p, d_assignment, d_constraints.varMapper())
+               p, d_assignment, d_constraints.varMapper(), d_env.getRewriter())
         << std::endl;
     Trace("cdcac::projection")
         << "Original: " << requiredCoefficientsOriginal(p, d_assignment)
@@ -315,7 +316,7 @@ PolyVector CDCAC::requiredCoefficients(const poly::Polynomial& p)
       return requiredCoefficientsLazard(p, d_assignment);
     case options::NlCadProjectionMode::LAZARDMOD:
       return requiredCoefficientsLazardModified(
-          p, d_assignment, d_constraints.varMapper());
+          p, d_assignment, d_constraints.varMapper(), d_env.getRewriter());
     default:
       Assert(false);
       return requiredCoefficientsOriginal(p, d_assignment);

--- a/src/theory/arith/nl/cad/cdcac.cpp
+++ b/src/theory/arith/nl/cad/cdcac.cpp
@@ -251,8 +251,7 @@ PolyVector requiredCoefficientsLazard(const poly::Polynomial& p,
 PolyVector requiredCoefficientsLazardModified(
     const poly::Polynomial& p,
     const poly::Assignment& assignment,
-    VariableMapper& vm,
-    Rewriter* rewriter)
+    VariableMapper& vm)
 {
   PolyVector res;
   auto lc = poly::leading_coefficient(p);
@@ -275,8 +274,8 @@ PolyVector requiredCoefficientsLazardModified(
         Kind::EQUAL, nl::as_cvc_polynomial(coeff, vm), zero));
   }
   // if phi is false (i.e. p can not vanish)
-  Node rewritten =
-      rewriter->extendedRewrite(NodeManager::currentNM()->mkAnd(conditions));
+  Node rewritten = Rewriter::callExtendedRewrite(
+      NodeManager::currentNM()->mkAnd(conditions));
   if (rewritten.isConst())
   {
     Assert(rewritten.getKind() == Kind::CONST_BOOLEAN);
@@ -302,7 +301,7 @@ PolyVector CDCAC::requiredCoefficients(const poly::Polynomial& p)
     Trace("cdcac::projection")
         << "LMod: "
         << requiredCoefficientsLazardModified(
-               p, d_assignment, d_constraints.varMapper(), d_env.getRewriter())
+               p, d_assignment, d_constraints.varMapper())
         << std::endl;
     Trace("cdcac::projection")
         << "Original: " << requiredCoefficientsOriginal(p, d_assignment)
@@ -316,7 +315,7 @@ PolyVector CDCAC::requiredCoefficients(const poly::Polynomial& p)
       return requiredCoefficientsLazard(p, d_assignment);
     case options::NlCadProjectionMode::LAZARDMOD:
       return requiredCoefficientsLazardModified(
-          p, d_assignment, d_constraints.varMapper(), d_env.getRewriter());
+          p, d_assignment, d_constraints.varMapper());
     default:
       Assert(false);
       return requiredCoefficientsOriginal(p, d_assignment);

--- a/src/theory/booleans/circuit_propagator.cpp
+++ b/src/theory/booleans/circuit_propagator.cpp
@@ -767,21 +767,21 @@ TrustNode CircuitPropagator::propagate()
   return d_conflict;
 }
 
-void CircuitPropagator::setProof(ProofNodeManager* pnm,
-                                 context::Context* ctx,
+void CircuitPropagator::enableProofs(context::Context* ctx,
                                  ProofGenerator* defParent)
 {
-  d_pnm = pnm;
-  d_epg.reset(new EagerProofGenerator(pnm, ctx));
+  d_pnm = d_env.getProofNodeManager();
+  Assert (d_pnm!=nullptr);
+  d_epg.reset(new EagerProofGenerator(d_pnm, ctx));
   d_proofInternal.reset(new LazyCDProofChain(
-      pnm, true, ctx, d_epg.get(), true, "CircuitPropInternalLazyChain"));
+      d_pnm, true, ctx, d_epg.get(), true, "CircuitPropInternalLazyChain"));
   if (defParent != nullptr)
   {
     // If we provide a parent proof generator (defParent), we want the ASSUME
     // leafs of proofs provided by this class to call the getProofFor method on
     // the parent. To do this, we use a LazyCDProofChain.
     d_proofExternal.reset(new LazyCDProofChain(
-        pnm, true, ctx, defParent, false, "CircuitPropExternalLazyChain"));
+        d_pnm, true, ctx, defParent, false, "CircuitPropExternalLazyChain"));
   }
 }
 

--- a/src/theory/booleans/circuit_propagator.cpp
+++ b/src/theory/booleans/circuit_propagator.cpp
@@ -768,10 +768,10 @@ TrustNode CircuitPropagator::propagate()
 }
 
 void CircuitPropagator::enableProofs(context::Context* ctx,
-                                 ProofGenerator* defParent)
+                                     ProofGenerator* defParent)
 {
   d_pnm = d_env.getProofNodeManager();
-  Assert (d_pnm!=nullptr);
+  Assert(d_pnm != nullptr);
   d_epg.reset(new EagerProofGenerator(d_pnm, ctx));
   d_proofInternal.reset(new LazyCDProofChain(
       d_pnm, true, ctx, d_epg.get(), true, "CircuitPropInternalLazyChain"));

--- a/src/theory/booleans/circuit_propagator.h
+++ b/src/theory/booleans/circuit_propagator.h
@@ -134,7 +134,7 @@ class CircuitPropagator : protected EnvObj
     return false;
   }
   /**
-   * Set proof node manager, context and parent proof generator.
+   * Enable proofs based on context and parent proof generator.
    *
    * If parent is non-null, then it is responsible for the proofs provided
    * to this class.

--- a/src/theory/booleans/circuit_propagator.h
+++ b/src/theory/booleans/circuit_propagator.h
@@ -139,8 +139,7 @@ class CircuitPropagator : protected EnvObj
    * If parent is non-null, then it is responsible for the proofs provided
    * to this class.
    */
-  void setProof(ProofNodeManager* pnm,
-                context::Context* ctx,
+  void enableProofs(context::Context* ctx,
                 ProofGenerator* defParent);
 
  private:

--- a/src/theory/booleans/circuit_propagator.h
+++ b/src/theory/booleans/circuit_propagator.h
@@ -139,8 +139,7 @@ class CircuitPropagator : protected EnvObj
    * If parent is non-null, then it is responsible for the proofs provided
    * to this class.
    */
-  void enableProofs(context::Context* ctx,
-                ProofGenerator* defParent);
+  void enableProofs(context::Context* ctx, ProofGenerator* defParent);
 
  private:
   /** A context-notify object that clears out stale data. */


### PR DESCRIPTION
Eliminates one of the remaining calls to `Rewriter::callExtendedRewrite`, as well as making the initialization much clearer through use of Env.