### PR TITLE
Change default granularity of proofs to macro

### DIFF
--- a/src/options/proof_options.toml
+++ b/src/options/proof_options.toml
@@ -75,12 +75,12 @@ name   = "Proof"
   category   = "regular"
   long       = "proof-granularity=MODE"
   type       = "ProofGranularityMode"
-  default    = "THEORY_REWRITE"
+  default    = "MACRO"
   help       = "modes for proof granularity"
   help_mode  = "Modes for proof granularity."
-[[option.mode.OFF]]
-  name = "off"
-  help = "Do not improve the granularity of proofs."
+[[option.mode.MACRO]]
+  name = "macro"
+  help = "Allow macros. Do not improve the granularity of proofs."
 [[option.mode.REWRITE]]
   name = "rewrite"
   help = "Allow rewrite or substitution steps, expand macros."

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -77,7 +77,7 @@ PfManager::PfManager(Env& env)
 
   // add rules to eliminate here
   if (options().proof.proofGranularityMode
-      != options::ProofGranularityMode::OFF)
+      != options::ProofGranularityMode::MACRO)
   {
     d_pfpp->setEliminateRule(PfRule::MACRO_SR_EQ_INTRO);
     d_pfpp->setEliminateRule(PfRule::MACRO_SR_PRED_INTRO);

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -86,7 +86,6 @@ void SetDefaults::setDefaultsPre(Options& opts)
     {
       opts.smt.unsatCoresMode = options::UnsatCoresMode::PP_ONLY;
     }
-    opts.proof.proofGranularityMode = options::ProofGranularityMode::OFF;
   }
   if (opts.smt.checkUnsatCores || opts.driver.dumpUnsatCores
       || opts.smt.unsatAssumptions || opts.smt.minimalUnsatCores
@@ -137,17 +136,6 @@ void SetDefaults::setDefaultsPre(Options& opts)
   // if unsat cores are disabled, then unsat cores mode should be OFF
   Assert(opts.smt.unsatCores
          == (opts.smt.unsatCoresMode != options::UnsatCoresMode::OFF));
-
-  // new unsat core specific restrictions for proofs
-  if (opts.smt.unsatCores
-      && opts.smt.unsatCoresMode != options::UnsatCoresMode::FULL_PROOF)
-  {
-    // no fine-graininess
-    if (!opts.proof.proofGranularityModeWasSetByUser)
-    {
-      opts.proof.proofGranularityMode = options::ProofGranularityMode::OFF;
-    }
-  }
 
   // if we requiring disabling proofs, disable them now
   if (opts.smt.produceProofs)


### PR DESCRIPTION
Also changes the name "off" to "macro" to be more consistent.