### PR TITLE
Execute `(reset)` command in parse-only mode

### DIFF
--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -207,7 +207,8 @@ bool solverInvoke(api::Solver* solver,
   // commands. We invoke define-fun commands because they add function names
   // to the symbol table.
   if (solver->getOptionInfo("parse-only").boolValue()
-      && dynamic_cast<DefineFunctionCommand*>(cmd) == nullptr)
+      && dynamic_cast<DefineFunctionCommand*>(cmd) == nullptr
+      && dynamic_cast<ResetCommand*>(cmd) == nullptr)
   {
     return true;
   }

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -810,6 +810,7 @@ set(regress_0_tests
   regress0/parser/issue5163.smt2
   regress0/parser/issue6908-get-value-uc.smt2
   regress0/parser/issue7274.smt2
+  regress0/parser/issue7860-parse-only-reset.smt2
   regress0/parser/linear_arithmetic_err1.smt2
   regress0/parser/linear_arithmetic_err2.smt2
   regress0/parser/linear_arithmetic_err3.smt2

--- a/test/regress/regress0/parser/issue7860-parse-only-reset.smt2
+++ b/test/regress/regress0/parser/issue7860-parse-only-reset.smt2
@@ -1,0 +1,6 @@
+; COMMAND-LINE: --parse-only
+; EXIT: 0
+(set-logic ALL)
+(reset)
+(set-logic QF_UF)
+(declare-sort U 0)


### PR DESCRIPTION
Fixes #7860.

This commit fixes an issue where `--parse-only` would not execute
`(reset)` commands, leading to issues with symbols being defined
multiple times.