### PR TITLE
Make alpha equivalence user context dependent

### DIFF
--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -7466,7 +7466,7 @@ Term Solver::getQuantifierElimination(const Term& q) const
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_SOLVER_CHECK_TERM(q);
   //////// all checks before this line
-  return Term(this, d_slv->getQuantifierElimination(q.getNode(), true, true));
+  return Term(this, d_slv->getQuantifierElimination(q.getNode(), true));
   ////////
   CVC5_API_TRY_CATCH_END;
 }

--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -7476,7 +7476,7 @@ Term Solver::getQuantifierEliminationDisjunct(const Term& q) const
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_SOLVER_CHECK_TERM(q);
   //////// all checks before this line
-  return Term(this, d_slv->getQuantifierElimination(q.getNode(), false, true));
+  return Term(this, d_slv->getQuantifierElimination(q.getNode(), false));
   ////////
   CVC5_API_TRY_CATCH_END;
 }

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1615,16 +1615,10 @@ bool SolverEngine::getSubsolverSynthSolutions(std::map<Node, Node>& solMap)
   return d_sygusSolver->getSubsolverSynthSolutions(solMap);
 }
 
-Node SolverEngine::getQuantifierElimination(Node q, bool doFull, bool strict)
+Node SolverEngine::getQuantifierElimination(Node q, bool doFull)
 {
   SolverEngineScope smts(this);
   finishInit();
-  const LogicInfo& logic = getLogicInfo();
-  if (!logic.isPure(THEORY_ARITH) && strict)
-  {
-    d_env->warning() << "Unexpected logic for quantifier elimination " << logic
-              << endl;
-  }
   return d_quantElimSolver->getQuantifierElimination(
       *d_asserts, q, doFull, d_isInternalSubsolver);
 }

--- a/src/smt/solver_engine.h
+++ b/src/smt/solver_engine.h
@@ -617,13 +617,8 @@ class CVC5_EXPORT SolverEngine
    * extended command get-qe-disjunct, which can be used
    * for incrementally computing the result of a
    * quantifier elimination.
-   *
-   * The argument strict is whether to output
-   * warnings, such as when an unexpected logic is used.
-   *
-   * throw@ Exception
    */
-  Node getQuantifierElimination(Node q, bool doFull, bool strict = true);
+  Node getQuantifierElimination(Node q, bool doFull);
 
   /**
    * This method asks this SMT engine to find an interpolant with respect to

--- a/src/theory/quantifiers/alpha_equivalence.cpp
+++ b/src/theory/quantifiers/alpha_equivalence.cpp
@@ -46,22 +46,34 @@ Node AlphaEquivalenceTypeNode::registerNode(
 {
   AlphaEquivalenceTypeNode* aetn = this;
   size_t index = 0;
+  std::map<std::pair<TypeNode, size_t>,
+           std::shared_ptr<AlphaEquivalenceTypeNode>>::iterator itc;
   while (index < typs.size())
   {
     TypeNode curr = typs[index];
     Assert(typCount.find(curr) != typCount.end());
     Trace("aeq-debug") << "[" << curr << " " << typCount[curr] << "] ";
     std::pair<TypeNode, size_t> key(curr, typCount[curr]);
-    aetn->d_children[key] = std::make_shared<AlphaEquivalenceTypeNode>(c);
-    aetn = aetn->d_children[key].get();
+    itc = aetn->d_children.find(key);
+    if (itc==aetn->d_children.end())
+    {
+      aetn->d_children[key] = std::make_shared<AlphaEquivalenceTypeNode>(c);
+      aetn = aetn->d_children[key].get();
+    }
+    else
+    {
+      aetn = itc->second.get();
+    }
     index = index + 1;
   }
   Trace("aeq-debug") << " : ";
   NodeMap::iterator it = aetn->d_quant.find(t);
-  if (it != aetn->d_quant.end())
+  if (it != aetn->d_quant.end() && !it->second.isNull())
   {
+    Trace("aeq-debug") << it->second << std::endl;
     return it->second;
   }
+  Trace("aeq-debug") << "(new)" << std::endl;
   aetn->d_quant[t] = q;
   return q;
 }

--- a/src/theory/quantifiers/alpha_equivalence.cpp
+++ b/src/theory/quantifiers/alpha_equivalence.cpp
@@ -47,7 +47,7 @@ Node AlphaEquivalenceTypeNode::registerNode(
   AlphaEquivalenceTypeNode* aetn = this;
   size_t index = 0;
   std::map<std::pair<TypeNode, size_t>,
-           std::shared_ptr<AlphaEquivalenceTypeNode>>::iterator itc;
+           std::unique_ptr<AlphaEquivalenceTypeNode>>::iterator itc;
   while (index < typs.size())
   {
     TypeNode curr = typs[index];
@@ -57,7 +57,7 @@ Node AlphaEquivalenceTypeNode::registerNode(
     itc = aetn->d_children.find(key);
     if (itc == aetn->d_children.end())
     {
-      aetn->d_children[key] = std::make_shared<AlphaEquivalenceTypeNode>(c);
+      aetn->d_children[key] = std::make_unique<AlphaEquivalenceTypeNode>(c);
       aetn = aetn->d_children[key].get();
     }
     else

--- a/src/theory/quantifiers/alpha_equivalence.cpp
+++ b/src/theory/quantifiers/alpha_equivalence.cpp
@@ -53,7 +53,7 @@ Node AlphaEquivalenceTypeNode::registerNode(
     Trace("aeq-debug") << "[" << curr << " " << typCount[curr] << "] ";
     std::pair<TypeNode, size_t> key(curr, typCount[curr]);
     aetn->d_children[key] = std::make_shared<AlphaEquivalenceTypeNode>(c);
-    aetn =aetn->d_children[key].get();
+    aetn = aetn->d_children[key].get();
     index = index + 1;
   }
   Trace("aeq-debug") << " : ";
@@ -69,7 +69,10 @@ Node AlphaEquivalenceTypeNode::registerNode(
 AlphaEquivalenceDb::AlphaEquivalenceDb(context::Context* c,
                                        expr::TermCanonize* tc,
                                        bool sortCommChildren)
-    : d_context(c), d_ae_typ_trie(c), d_tc(tc), d_sortCommutativeOpChildren(sortCommChildren)
+    : d_context(c),
+      d_ae_typ_trie(c),
+      d_tc(tc),
+      d_sortCommutativeOpChildren(sortCommChildren)
 {
 }
 Node AlphaEquivalenceDb::addTerm(Node q)

--- a/src/theory/quantifiers/alpha_equivalence.cpp
+++ b/src/theory/quantifiers/alpha_equivalence.cpp
@@ -55,7 +55,7 @@ Node AlphaEquivalenceTypeNode::registerNode(
     Trace("aeq-debug") << "[" << curr << " " << typCount[curr] << "] ";
     std::pair<TypeNode, size_t> key(curr, typCount[curr]);
     itc = aetn->d_children.find(key);
-    if (itc==aetn->d_children.end())
+    if (itc == aetn->d_children.end())
     {
       aetn->d_children[key] = std::make_shared<AlphaEquivalenceTypeNode>(c);
       aetn = aetn->d_children[key].get();

--- a/src/theory/quantifiers/alpha_equivalence.cpp
+++ b/src/theory/quantifiers/alpha_equivalence.cpp
@@ -52,7 +52,8 @@ Node AlphaEquivalenceTypeNode::registerNode(
     Assert(typCount.find(curr) != typCount.end());
     Trace("aeq-debug") << "[" << curr << " " << typCount[curr] << "] ";
     std::pair<TypeNode, size_t> key(curr, typCount[curr]);
-    aetn = &(aetn->d_children[key].emplace(c));
+    aetn->d_children[key] = std::make_shared<AlphaEquivalenceTypeNode>(c);
+    aetn =aetn->d_children[key].get();
     index = index + 1;
   }
   Trace("aeq-debug") << " : ";
@@ -68,7 +69,7 @@ Node AlphaEquivalenceTypeNode::registerNode(
 AlphaEquivalenceDb::AlphaEquivalenceDb(context::Context* c,
                                        expr::TermCanonize* tc,
                                        bool sortCommChildren)
-    : d_context(c), d_tc(tc), d_sortCommutativeOpChildren(sortCommChildren)
+    : d_context(c), d_ae_typ_trie(c), d_tc(tc), d_sortCommutativeOpChildren(sortCommChildren)
 {
 }
 Node AlphaEquivalenceDb::addTerm(Node q)

--- a/src/theory/quantifiers/alpha_equivalence.cpp
+++ b/src/theory/quantifiers/alpha_equivalence.cpp
@@ -32,7 +32,10 @@ struct sortTypeOrder {
   }
 };
 
+AlphaEquivalenceTypeNode::AlphaEquivalenceTypeNode(context::Context * c) : d_quant(c){}
+
 Node AlphaEquivalenceTypeNode::registerNode(
+  context::Context * c,
     Node q,
     Node t,
     std::vector<TypeNode>& typs,
@@ -46,11 +49,11 @@ Node AlphaEquivalenceTypeNode::registerNode(
     Assert(typCount.find(curr) != typCount.end());
     Trace("aeq-debug") << "[" << curr << " " << typCount[curr] << "] ";
     std::pair<TypeNode, size_t> key(curr, typCount[curr]);
-    aetn = &(aetn->d_children[key]);
+    aetn = &(aetn->d_children[key].emplace(c));
     index = index + 1;
   }
   Trace("aeq-debug") << " : ";
-  std::map<Node, Node>::iterator it = aetn->d_quant.find(t);
+  NodeMap::iterator it = aetn->d_quant.find(t);
   if (it != aetn->d_quant.end())
   {
     return it->second;
@@ -59,6 +62,11 @@ Node AlphaEquivalenceTypeNode::registerNode(
   return q;
 }
 
+
+AlphaEquivalenceDb::AlphaEquivalenceDb(context::Context * c, expr::TermCanonize* tc, bool sortCommChildren)
+    : d_context(c), d_tc(tc), d_sortCommutativeOpChildren(sortCommChildren)
+{
+}
 Node AlphaEquivalenceDb::addTerm(Node q)
 {
   Assert(q.getKind() == FORALL);
@@ -129,7 +137,7 @@ Node AlphaEquivalenceDb::addTermToTypeTrie(Node t, Node q)
   sto.d_tu = d_tc;
   std::sort( typs.begin(), typs.end(), sto );
   Trace("aeq-debug") << "  ";
-  Node ret = d_ae_typ_trie.registerNode(q, t, typs, typCount);
+  Node ret = d_ae_typ_trie.registerNode(d_context, q, t, typs, typCount);
   Trace("aeq") << "  ...result : " << ret << std::endl;
   return ret;
 }
@@ -137,7 +145,7 @@ Node AlphaEquivalenceDb::addTermToTypeTrie(Node t, Node q)
 AlphaEquivalence::AlphaEquivalence(Env& env)
     : EnvObj(env),
       d_termCanon(),
-      d_aedb(&d_termCanon, true),
+      d_aedb(userContext(), &d_termCanon, true),
       d_pnm(env.getProofNodeManager()),
       d_pfAlpha(d_pnm ? new EagerProofGenerator(d_pnm) : nullptr)
 {

--- a/src/theory/quantifiers/alpha_equivalence.cpp
+++ b/src/theory/quantifiers/alpha_equivalence.cpp
@@ -32,10 +32,13 @@ struct sortTypeOrder {
   }
 };
 
-AlphaEquivalenceTypeNode::AlphaEquivalenceTypeNode(context::Context * c) : d_quant(c){}
+AlphaEquivalenceTypeNode::AlphaEquivalenceTypeNode(context::Context* c)
+    : d_quant(c)
+{
+}
 
 Node AlphaEquivalenceTypeNode::registerNode(
-  context::Context * c,
+    context::Context* c,
     Node q,
     Node t,
     std::vector<TypeNode>& typs,
@@ -62,8 +65,9 @@ Node AlphaEquivalenceTypeNode::registerNode(
   return q;
 }
 
-
-AlphaEquivalenceDb::AlphaEquivalenceDb(context::Context * c, expr::TermCanonize* tc, bool sortCommChildren)
+AlphaEquivalenceDb::AlphaEquivalenceDb(context::Context* c,
+                                       expr::TermCanonize* tc,
+                                       bool sortCommChildren)
     : d_context(c), d_tc(tc), d_sortCommutativeOpChildren(sortCommChildren)
 {
 }

--- a/src/theory/quantifiers/alpha_equivalence.h
+++ b/src/theory/quantifiers/alpha_equivalence.h
@@ -36,25 +36,26 @@ namespace quantifiers {
  */
 class AlphaEquivalenceTypeNode {
   using NodeMap = context::CDHashMap<Node, Node>;
-public:
-  AlphaEquivalenceTypeNode(context::Context * c);
- /** children of this node */
- std::map<std::pair<TypeNode, size_t>, AlphaEquivalenceTypeNode> d_children;
- /**
-  * map from canonized quantifier bodies to a quantified formula whose
-  * canonized body is that term.
-  */
- NodeMap d_quant;
- /** register node
-  *
-  * This registers term q to this trie. The term t is the canonical form of
-  * q, typs/typCount represent a multi-set of types of free variables in t.
-  */
- Node registerNode(context::Context * c,
-                   Node q,
-                   Node t,
-                   std::vector<TypeNode>& typs,
-                   std::map<TypeNode, size_t>& typCount);
+
+ public:
+  AlphaEquivalenceTypeNode(context::Context* c);
+  /** children of this node */
+  std::map<std::pair<TypeNode, size_t>, AlphaEquivalenceTypeNode> d_children;
+  /**
+   * map from canonized quantifier bodies to a quantified formula whose
+   * canonized body is that term.
+   */
+  NodeMap d_quant;
+  /** register node
+   *
+   * This registers term q to this trie. The term t is the canonical form of
+   * q, typs/typCount represent a multi-set of types of free variables in t.
+   */
+  Node registerNode(context::Context* c,
+                    Node q,
+                    Node t,
+                    std::vector<TypeNode>& typs,
+                    std::map<TypeNode, size_t>& typCount);
 };
 
 /**
@@ -63,7 +64,9 @@ public:
 class AlphaEquivalenceDb
 {
  public:
-  AlphaEquivalenceDb(context::Context * c, expr::TermCanonize* tc, bool sortCommChildren);
+  AlphaEquivalenceDb(context::Context* c,
+                     expr::TermCanonize* tc,
+                     bool sortCommChildren);
   /** adds quantified formula q to this database
    *
    * This function returns a quantified formula q' that is alpha-equivalent to
@@ -88,7 +91,7 @@ class AlphaEquivalenceDb
    */
   Node addTermToTypeTrie(Node t, Node q);
   /** The context we depend on */
-  context::Context * d_context;
+  context::Context* d_context;
   /** a trie per # of variables per type */
   AlphaEquivalenceTypeNode d_ae_typ_trie;
   /** pointer to the term canonize utility */

--- a/src/theory/quantifiers/alpha_equivalence.h
+++ b/src/theory/quantifiers/alpha_equivalence.h
@@ -41,7 +41,7 @@ class AlphaEquivalenceTypeNode {
   AlphaEquivalenceTypeNode(context::Context* c);
   /** children of this node */
   std::map<std::pair<TypeNode, size_t>,
-           std::shared_ptr<AlphaEquivalenceTypeNode>>
+           std::unique_ptr<AlphaEquivalenceTypeNode>>
       d_children;
   /**
    * map from canonized quantifier bodies to a quantified formula whose

--- a/src/theory/quantifiers/alpha_equivalence.h
+++ b/src/theory/quantifiers/alpha_equivalence.h
@@ -40,7 +40,7 @@ class AlphaEquivalenceTypeNode {
  public:
   AlphaEquivalenceTypeNode(context::Context* c);
   /** children of this node */
-  std::map<std::pair<TypeNode, size_t>, AlphaEquivalenceTypeNode> d_children;
+  std::map<std::pair<TypeNode, size_t>, std::shared_ptr<AlphaEquivalenceTypeNode>> d_children;
   /**
    * map from canonized quantifier bodies to a quantified formula whose
    * canonized body is that term.

--- a/src/theory/quantifiers/alpha_equivalence.h
+++ b/src/theory/quantifiers/alpha_equivalence.h
@@ -40,7 +40,9 @@ class AlphaEquivalenceTypeNode {
  public:
   AlphaEquivalenceTypeNode(context::Context* c);
   /** children of this node */
-  std::map<std::pair<TypeNode, size_t>, std::shared_ptr<AlphaEquivalenceTypeNode>> d_children;
+  std::map<std::pair<TypeNode, size_t>,
+           std::shared_ptr<AlphaEquivalenceTypeNode>>
+      d_children;
   /**
    * map from canonized quantifier bodies to a quantified formula whose
    * canonized body is that term.

--- a/src/theory/quantifiers/alpha_equivalence.h
+++ b/src/theory/quantifiers/alpha_equivalence.h
@@ -35,20 +35,23 @@ namespace quantifiers {
  * d_children[T1][2].d_children[T2][3].
  */
 class AlphaEquivalenceTypeNode {
+  using NodeMap = context::CDHashMap<Node, Node>;
 public:
+  AlphaEquivalenceTypeNode(context::Context * c);
  /** children of this node */
  std::map<std::pair<TypeNode, size_t>, AlphaEquivalenceTypeNode> d_children;
  /**
   * map from canonized quantifier bodies to a quantified formula whose
   * canonized body is that term.
   */
- std::map<Node, Node> d_quant;
+ NodeMap d_quant;
  /** register node
   *
   * This registers term q to this trie. The term t is the canonical form of
   * q, typs/typCount represent a multi-set of types of free variables in t.
   */
- Node registerNode(Node q,
+ Node registerNode(context::Context * c,
+                   Node q,
                    Node t,
                    std::vector<TypeNode>& typs,
                    std::map<TypeNode, size_t>& typCount);
@@ -60,10 +63,7 @@ public:
 class AlphaEquivalenceDb
 {
  public:
-  AlphaEquivalenceDb(expr::TermCanonize* tc, bool sortCommChildren)
-      : d_tc(tc), d_sortCommutativeOpChildren(sortCommChildren)
-  {
-  }
+  AlphaEquivalenceDb(context::Context * c, expr::TermCanonize* tc, bool sortCommChildren);
   /** adds quantified formula q to this database
    *
    * This function returns a quantified formula q' that is alpha-equivalent to
@@ -87,6 +87,8 @@ class AlphaEquivalenceDb
    * had been added to this class, or q otherwise.
    */
   Node addTermToTypeTrie(Node t, Node q);
+  /** The context we depend on */
+  context::Context * d_context;
   /** a trie per # of variables per type */
   AlphaEquivalenceTypeNode d_ae_typ_trie;
   /** pointer to the term canonize utility */

--- a/src/theory/quantifiers/cegqi/nested_qe.cpp
+++ b/src/theory/quantifiers/cegqi/nested_qe.cpp
@@ -139,7 +139,7 @@ Node NestedQe::doQe(Env& env, Node q)
   q = nm->mkNode(kind::EXISTS, q[0], q[1].negate());
   std::unique_ptr<SolverEngine> smt_qe;
   initializeSubsolver(smt_qe, env);
-  Node qqe = smt_qe->getQuantifierElimination(q, true, false);
+  Node qqe = smt_qe->getQuantifierElimination(q, true);
   if (expr::hasBoundVar(qqe))
   {
     Trace("cegqi-nested-qe") << "  ...failed QE" << std::endl;

--- a/src/theory/quantifiers/sygus/sygus_qe_preproc.cpp
+++ b/src/theory/quantifiers/sygus/sygus_qe_preproc.cpp
@@ -117,7 +117,7 @@ Node SygusQePreproc::preprocess(Node q)
 
   Trace("cegqi-qep") << "Run quantifier elimination on " << conj_se_ngsi_subs
                      << std::endl;
-  Node qeRes = smt_qe->getQuantifierElimination(conj_se_ngsi_subs, true, false);
+  Node qeRes = smt_qe->getQuantifierElimination(conj_se_ngsi_subs, true);
   Trace("cegqi-qep") << "Result : " << qeRes << std::endl;
 
   // create single invocation conjecture, if QE was successful

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -2018,6 +2018,8 @@ set(regress_1_tests
   regress1/quantifiers/issue5279-nqe.smt2
   regress1/quantifiers/issue5288-vts-real-int.smt2
   regress1/quantifiers/issue5365-nqe.smt2
+  regress1/quantifiers/issue5373-1-qe-inc.smt2 
+  regress1/quantifiers/issue5373-2.smt2 
   regress1/quantifiers/issue5378-witness.smt2
   regress1/quantifiers/issue5469-aext.smt2
   regress1/quantifiers/issue5470-aext.smt2

--- a/test/regress/regress1/quantifiers/issue5373-1-qe-inc.smt2
+++ b/test/regress/regress1/quantifiers/issue5373-1-qe-inc.smt2
@@ -1,0 +1,6 @@
+; COMMAND-LINE: -i
+; EXPECT: true
+; EXPECT: true
+(set-logic ALL)
+(get-qe (exists ((q Real) (q Bool) (q Bool) (q Bool) (q Real) (q Real) (q Real)) true))
+(get-qe (exists ((q Real) (q Bool) (f Bool) (q Bool) (q Real) (q Real) (q Real)) true))

--- a/test/regress/regress1/quantifiers/issue5373-2.smt2
+++ b/test/regress/regress1/quantifiers/issue5373-2.smt2
@@ -1,0 +1,13 @@
+; COMMAND-LINE: -i
+; EXPECT: sat
+; EXPECT: sat
+; EXPECT: sat
+(set-logic ALL)
+(declare-sort U 0)
+(declare-fun c (U U) U)
+(declare-fun k () U)
+(declare-fun a (U Int) Int)
+(assert (or (not (forall ((g U)) (! (or (forall ((x Int)) (! (distinct (a g x) (a k x)) :qid k!10))) :qid k!10))) (exists ((f U) (g U) (x Int)) (distinct (a (c f g) x) (a f (a g x))))))
+(check-sat)
+(check-sat-assuming ((exists ((f U) (g U) (x Int)) (distinct (a (c f g) x) (a f (a g x))))))
+(check-sat-assuming ((exists ((f U) (g U) (x Int)) (distinct (a (c f g) x) (a f (a g x))))))


### PR DESCRIPTION
Fixes #5373

Issues were occurring due to using quantified formulas in alpha equivalence that were stale.

This also removes spurious warnings from quantifier elimination (dropping the "strict" requirement, which unnecessarily warns if we are in a non-arithmetic logic).