### PR TITLE
api: Remove Sort::isComparableTo().

### DIFF
--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -1391,16 +1391,6 @@ bool Sort::isSubsortOf(const Sort& s) const
   CVC5_API_TRY_CATCH_END;
 }
 
-bool Sort::isComparableTo(const Sort& s) const
-{
-  CVC5_API_TRY_CATCH_BEGIN;
-  CVC5_API_ARG_CHECK_SOLVER("sort", s);
-  //////// all checks before this line
-  return d_type->isComparableTo(*s.d_type);
-  ////////
-  CVC5_API_TRY_CATCH_END;
-}
-
 Datatype Sort::getDatatype() const
 {
   CVC5_API_TRY_CATCH_BEGIN;
@@ -2483,8 +2473,8 @@ Term Term::substitute(const Term& term, const Term& replacement) const
   CVC5_API_CHECK_NOT_NULL;
   CVC5_API_CHECK_TERM(term);
   CVC5_API_CHECK_TERM(replacement);
-  CVC5_API_CHECK(term.getSort().isComparableTo(replacement.getSort()))
-      << "Expecting terms of comparable sort in substitute";
+  CVC5_API_CHECK(term.getSort() == replacement.getSort())
+      << "Expecting terms of the same sort in substitute";
   //////// all checks before this line
   return Term(
       d_solver,
@@ -2500,7 +2490,7 @@ Term Term::substitute(const std::vector<Term>& terms,
   CVC5_API_CHECK_NOT_NULL;
   CVC5_API_CHECK(terms.size() == replacements.size())
       << "Expecting vectors of the same arity in substitute";
-  CVC5_API_TERM_CHECK_TERMS_WITH_TERMS_COMPARABLE_TO(terms, replacements);
+  CVC5_API_TERM_CHECK_TERMS_WITH_TERMS_SORT_EQUAL_TO(terms, replacements);
   //////// all checks before this line
   std::vector<Node> nodes = Term::termVectorToNodes(terms);
   std::vector<Node> nodeReplacements = Term::termVectorToNodes(replacements);

--- a/src/api/cpp/cvc5.h
+++ b/src/api/cpp/cvc5.h
@@ -574,13 +574,6 @@ class CVC5_EXPORT Sort
   bool isSubsortOf(const Sort& s) const;
 
   /**
-   * Is this sort comparable to the given sort (i.e., do they share
-   * a common ancestor in the subsort tree)?
-   * @return true if this sort is comparable to s
-   */
-  bool isComparableTo(const Sort& s) const;
-
-  /**
    * @return the underlying datatype of a datatype sort
    */
   Datatype getDatatype() const;

--- a/src/api/cpp/cvc5_checks.h
+++ b/src/api/cpp/cvc5_checks.h
@@ -298,9 +298,9 @@ namespace api {
  * Term check for member functions of classes other than class Solver.
  * Check if each term in both the given container is not null, associated with
  * the solver object this object is associated with, and their sorts are
- * pairwise comparable to.
+ * pairwise equal.
  */
-#define CVC5_API_TERM_CHECK_TERMS_WITH_TERMS_COMPARABLE_TO(terms1, terms2)  \
+#define CVC5_API_TERM_CHECK_TERMS_WITH_TERMS_SORT_EQUAL_TO(terms1, terms2)  \
   do                                                                        \
   {                                                                         \
     size_t i = 0;                                                           \
@@ -317,8 +317,8 @@ namespace api {
           this->d_solver == t2.d_solver, "term", terms2, i)                 \
           << "a term associated with the solver this object is associated " \
              "with";                                                        \
-      CVC5_API_CHECK(t1.getSort().isComparableTo(t2.getSort()))             \
-          << "Expecting terms of comparable sort at index " << i;           \
+      CVC5_API_CHECK(t1.getSort() == t2.getSort())                          \
+          << "Expecting terms of the same sort at index " << i;             \
       i += 1;                                                               \
     }                                                                       \
   } while (0)

--- a/src/api/java/io/github/cvc5/api/Sort.java
+++ b/src/api/java/io/github/cvc5/api/Sort.java
@@ -416,18 +416,6 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   private native boolean isSubsortOf(long pointer, long sortPointer);
 
   /**
-   * Is this sort comparable to the given sort (i.e., do they share
-   * a common ancestor in the subsort tree)?
-   * @return true if this sort is comparable to s
-   */
-  public boolean isComparableTo(Sort s)
-  {
-    return isComparableTo(pointer, s.getPointer());
-  }
-
-  private native boolean isComparableTo(long pointer, long sortPointer);
-
-  /**
    * @return the underlying datatype of a datatype sort
    */
   public Datatype getDatatype()

--- a/src/api/java/jni/sort.cpp
+++ b/src/api/java/jni/sort.cpp
@@ -511,21 +511,6 @@ JNIEXPORT jboolean JNICALL Java_io_github_cvc5_api_Sort_isSubsortOf(
 
 /*
  * Class:     io_github_cvc5_api_Sort
- * Method:    isComparableTo
- * Signature: (JJ)Z
- */
-JNIEXPORT jboolean JNICALL Java_io_github_cvc5_api_Sort_isComparableTo(
-    JNIEnv* env, jobject, jlong pointer, jlong sortPointer)
-{
-  CVC5_JAVA_API_TRY_CATCH_BEGIN;
-  Sort* current = reinterpret_cast<Sort*>(pointer);
-  Sort* sort = reinterpret_cast<Sort*>(sortPointer);
-  return static_cast<jboolean>(current->isComparableTo(*sort));
-  CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, static_cast<jboolean>(false));
-}
-
-/*
- * Class:     io_github_cvc5_api_Sort
  * Method:    getDatatype
  * Signature: (J)J
  */

--- a/src/api/python/cvc5.pxd
+++ b/src/api/python/cvc5.pxd
@@ -348,7 +348,6 @@ cdef extern from "api/cpp/cvc5.h" namespace "cvc5::api":
         bint isFirstClass() except +
         bint isFunctionLike() except +
         bint isSubsortOf(Sort s) except +
-        bint isComparableTo(Sort s) except +
         Datatype getDatatype() except +
         Sort instantiate(const vector[Sort]& params) except +
         Sort substitute(const vector[Sort] & es, const vector[Sort] & reps) except +

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -2629,15 +2629,6 @@ cdef class Sort:
         """
         return self.csort.isSubsortOf(sort.csort)
 
-    def isComparableTo(self, Sort sort):
-        """
-            Is this sort comparable to the given sort
-            (i.e., do they share a common ancestor in the subsort tree)?
-
-            :return: True if this sort is comparable to s
-        """
-        return self.csort.isComparableTo(sort.csort)
-
     def getDatatype(self):
         """
             :return: the underlying datatype of a datatype sort

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -1005,7 +1005,7 @@ api::Term Smt2::applyParseOp(ParseOp& p, std::vector<api::Term>& args)
     }
     api::Term constVal = args[0];
 
-    if (!p.d_type.getArrayElementSort().isComparableTo(constVal.getSort()))
+    if (p.d_type.getArrayElementSort() != constVal.getSort())
     {
       std::stringstream ss;
       ss << "type mismatch inside array constant term:" << std::endl

--- a/test/regress/regress1/sygus/node-discrete.sy
+++ b/test/regress/regress1/sygus/node-discrete.sy
@@ -76,7 +76,7 @@
 )
 
 (define-fun nilPState () PState
-  (mkPState nilSL ((as const (Array State Real)) 0))
+  (mkPState nilSL ((as const (Array State Real)) 0.0))
 )
 (define-fun-rec appendStateToPState ((s State) (r Real) (p PState)) PState
   (let ((pstates (states p)))

--- a/test/unit/api/cpp/datatype_api_black.cpp
+++ b/test/unit/api/cpp/datatype_api_black.cpp
@@ -302,23 +302,6 @@ TEST_F(TestApiBlackDatatype, parametricDatatype)
   ASSERT_NE(pairIntInt, pairRealInt);
   ASSERT_NE(pairIntReal, pairRealInt);
 
-  ASSERT_TRUE(pairRealReal.isComparableTo(pairRealReal));
-  ASSERT_FALSE(pairIntReal.isComparableTo(pairRealReal));
-  ASSERT_FALSE(pairRealInt.isComparableTo(pairRealReal));
-  ASSERT_FALSE(pairIntInt.isComparableTo(pairRealReal));
-  ASSERT_FALSE(pairRealReal.isComparableTo(pairRealInt));
-  ASSERT_FALSE(pairIntReal.isComparableTo(pairRealInt));
-  ASSERT_TRUE(pairRealInt.isComparableTo(pairRealInt));
-  ASSERT_FALSE(pairIntInt.isComparableTo(pairRealInt));
-  ASSERT_FALSE(pairRealReal.isComparableTo(pairIntReal));
-  ASSERT_TRUE(pairIntReal.isComparableTo(pairIntReal));
-  ASSERT_FALSE(pairRealInt.isComparableTo(pairIntReal));
-  ASSERT_FALSE(pairIntInt.isComparableTo(pairIntReal));
-  ASSERT_FALSE(pairRealReal.isComparableTo(pairIntInt));
-  ASSERT_FALSE(pairIntReal.isComparableTo(pairIntInt));
-  ASSERT_FALSE(pairRealInt.isComparableTo(pairIntInt));
-  ASSERT_TRUE(pairIntInt.isComparableTo(pairIntInt));
-
   ASSERT_TRUE(pairRealReal.isSubsortOf(pairRealReal));
   ASSERT_FALSE(pairIntReal.isSubsortOf(pairRealReal));
   ASSERT_FALSE(pairRealInt.isSubsortOf(pairRealReal));

--- a/test/unit/api/cpp/sort_black.cpp
+++ b/test/unit/api/cpp/sort_black.cpp
@@ -295,16 +295,6 @@ TEST_F(TestApiBlackSort, isSubsortOf)
   ASSERT_NO_THROW(Sort().isSubsortOf(Sort()));
 }
 
-TEST_F(TestApiBlackSort, isComparableTo)
-{
-  ASSERT_TRUE(
-      d_solver.getIntegerSort().isComparableTo(d_solver.getIntegerSort()));
-  ASSERT_TRUE(d_solver.getIntegerSort().isComparableTo(d_solver.getRealSort()));
-  ASSERT_FALSE(
-      d_solver.getIntegerSort().isComparableTo(d_solver.getBooleanSort()));
-  ASSERT_NO_THROW(Sort().isComparableTo(Sort()));
-}
-
 TEST_F(TestApiBlackSort, getDatatype)
 {
   Sort dtypeSort = create_datatype_sort();
@@ -596,21 +586,14 @@ TEST_F(TestApiBlackSort, sortSubtyping)
   Sort realSort = d_solver.getRealSort();
   ASSERT_TRUE(intSort.isSubsortOf(realSort));
   ASSERT_FALSE(realSort.isSubsortOf(intSort));
-  ASSERT_TRUE(intSort.isComparableTo(realSort));
-  ASSERT_TRUE(realSort.isComparableTo(intSort));
 
   Sort arraySortII = d_solver.mkArraySort(intSort, intSort);
   Sort arraySortIR = d_solver.mkArraySort(intSort, realSort);
-  ASSERT_FALSE(arraySortII.isComparableTo(intSort));
-  // we do not support subtyping for arrays
-  ASSERT_FALSE(arraySortII.isComparableTo(arraySortIR));
 
   Sort setSortI = d_solver.mkSetSort(intSort);
   Sort setSortR = d_solver.mkSetSort(realSort);
   // we don't support subtyping for sets
-  ASSERT_FALSE(setSortI.isComparableTo(setSortR));
   ASSERT_FALSE(setSortI.isSubsortOf(setSortR));
-  ASSERT_FALSE(setSortR.isComparableTo(setSortI));
   ASSERT_FALSE(setSortR.isSubsortOf(setSortI));
 }
 

--- a/test/unit/api/java/DatatypeTest.java
+++ b/test/unit/api/java/DatatypeTest.java
@@ -275,23 +275,6 @@ class DatatypeTest
     assertNotEquals(pairIntInt, pairRealInt);
     assertNotEquals(pairIntReal, pairRealInt);
 
-    assertTrue(pairRealReal.isComparableTo(pairRealReal));
-    assertFalse(pairIntReal.isComparableTo(pairRealReal));
-    assertFalse(pairRealInt.isComparableTo(pairRealReal));
-    assertFalse(pairIntInt.isComparableTo(pairRealReal));
-    assertFalse(pairRealReal.isComparableTo(pairRealInt));
-    assertFalse(pairIntReal.isComparableTo(pairRealInt));
-    assertTrue(pairRealInt.isComparableTo(pairRealInt));
-    assertFalse(pairIntInt.isComparableTo(pairRealInt));
-    assertFalse(pairRealReal.isComparableTo(pairIntReal));
-    assertTrue(pairIntReal.isComparableTo(pairIntReal));
-    assertFalse(pairRealInt.isComparableTo(pairIntReal));
-    assertFalse(pairIntInt.isComparableTo(pairIntReal));
-    assertFalse(pairRealReal.isComparableTo(pairIntInt));
-    assertFalse(pairIntReal.isComparableTo(pairIntInt));
-    assertFalse(pairRealInt.isComparableTo(pairIntInt));
-    assertTrue(pairIntInt.isComparableTo(pairIntInt));
-
     assertTrue(pairRealReal.isSubsortOf(pairRealReal));
     assertFalse(pairIntReal.isSubsortOf(pairRealReal));
     assertFalse(pairRealInt.isSubsortOf(pairRealReal));

--- a/test/unit/api/java/SortTest.java
+++ b/test/unit/api/java/SortTest.java
@@ -284,14 +284,6 @@ class SortTest
     assertDoesNotThrow(() -> d_solver.getNullSort().isSubsortOf(d_solver.getNullSort()));
   }
 
-  @Test void isComparableTo()
-  {
-    assertTrue(d_solver.getIntegerSort().isComparableTo(d_solver.getIntegerSort()));
-    assertTrue(d_solver.getIntegerSort().isComparableTo(d_solver.getRealSort()));
-    assertFalse(d_solver.getIntegerSort().isComparableTo(d_solver.getBooleanSort()));
-    assertDoesNotThrow(() -> d_solver.getNullSort().isComparableTo(d_solver.getNullSort()));
-  }
-
   @Test void getDatatype() throws CVC5ApiException
   {
     Sort dtypeSort = create_datatype_sort();
@@ -581,21 +573,14 @@ class SortTest
     Sort realSort = d_solver.getRealSort();
     assertTrue(intSort.isSubsortOf(realSort));
     assertFalse(realSort.isSubsortOf(intSort));
-    assertTrue(intSort.isComparableTo(realSort));
-    assertTrue(realSort.isComparableTo(intSort));
 
     Sort arraySortII = d_solver.mkArraySort(intSort, intSort);
     Sort arraySortIR = d_solver.mkArraySort(intSort, realSort);
-    assertFalse(arraySortII.isComparableTo(intSort));
-    // we do not support subtyping for arrays
-    assertFalse(arraySortII.isComparableTo(arraySortIR));
 
     Sort setSortI = d_solver.mkSetSort(intSort);
     Sort setSortR = d_solver.mkSetSort(realSort);
     // we don't support subtyping for sets
-    assertFalse(setSortI.isComparableTo(setSortR));
     assertFalse(setSortI.isSubsortOf(setSortR));
-    assertFalse(setSortR.isComparableTo(setSortI));
     assertFalse(setSortR.isSubsortOf(setSortI));
   }
 

--- a/test/unit/api/python/test_datatype_api.py
+++ b/test/unit/api/python/test_datatype_api.py
@@ -300,23 +300,6 @@ def test_parametric_datatype(solver):
     assert pairIntInt != pairRealInt
     assert pairIntReal != pairRealInt
 
-    assert pairRealReal.isComparableTo(pairRealReal)
-    assert not pairIntReal.isComparableTo(pairRealReal)
-    assert not pairRealInt.isComparableTo(pairRealReal)
-    assert not pairIntInt.isComparableTo(pairRealReal)
-    assert not pairRealReal.isComparableTo(pairRealInt)
-    assert not pairIntReal.isComparableTo(pairRealInt)
-    assert pairRealInt.isComparableTo(pairRealInt)
-    assert not pairIntInt.isComparableTo(pairRealInt)
-    assert not pairRealReal.isComparableTo(pairIntReal)
-    assert pairIntReal.isComparableTo(pairIntReal)
-    assert not pairRealInt.isComparableTo(pairIntReal)
-    assert not pairIntInt.isComparableTo(pairIntReal)
-    assert not pairRealReal.isComparableTo(pairIntInt)
-    assert not pairIntReal.isComparableTo(pairIntInt)
-    assert not pairRealInt.isComparableTo(pairIntInt)
-    assert pairIntInt.isComparableTo(pairIntInt)
-
     assert pairRealReal.isSubsortOf(pairRealReal)
     assert not pairIntReal.isSubsortOf(pairRealReal)
     assert not pairRealInt.isSubsortOf(pairRealReal)

--- a/test/unit/api/python/test_sort.py
+++ b/test/unit/api/python/test_sort.py
@@ -264,13 +264,6 @@ def test_is_subsort_of(solver):
     Sort(solver).isSubsortOf(Sort(solver))
 
 
-def test_is_comparable_to(solver):
-    assert solver.getIntegerSort().isComparableTo(solver.getIntegerSort())
-    assert solver.getIntegerSort().isComparableTo(solver.getRealSort())
-    assert not solver.getIntegerSort().isComparableTo(solver.getBooleanSort())
-    Sort(solver).isComparableTo(Sort(solver))
-
-
 def test_get_datatype(solver):
     dtypeSort = create_datatype_sort(solver)
     dtypeSort.getDatatype()
@@ -565,21 +558,14 @@ def test_sort_subtyping(solver):
     realSort = solver.getRealSort()
     assert intSort.isSubsortOf(realSort)
     assert not realSort.isSubsortOf(intSort)
-    assert intSort.isComparableTo(realSort)
-    assert realSort.isComparableTo(intSort)
 
     arraySortII = solver.mkArraySort(intSort, intSort)
     arraySortIR = solver.mkArraySort(intSort, realSort)
-    assert not arraySortII.isComparableTo(intSort)
-    # we do not support subtyping for arrays
-    assert not arraySortII.isComparableTo(arraySortIR)
 
     setSortI = solver.mkSetSort(intSort)
     setSortR = solver.mkSetSort(realSort)
     # we don't support subtyping for sets
-    assert not setSortI.isComparableTo(setSortR)
     assert not setSortI.isSubsortOf(setSortR)
-    assert not setSortR.isComparableTo(setSortI)
     assert not setSortR.isSubsortOf(setSortI)
 
 


### PR DESCRIPTION
Since we do not support arithmetic subtyping on the API level anymore,
this function is obsolete. Consequently, this now requires that
replacement terms as arguments to Term::substitute() are of the same
sort as the replaced terms.