### PR TITLE
Add new methods for RealAlgebraicNumber

### DIFF
--- a/cmake/FindPoly.cmake
+++ b/cmake/FindPoly.cmake
@@ -45,7 +45,7 @@ if(NOT Poly_FOUND_SYSTEM)
 
   include(ExternalProject)
 
-  set(Poly_VERSION "f543721215ec17a724dc86820a0430233931a637")
+  set(Poly_VERSION "c85d394ed9a3ae3425362fc7636f73aac5473a83")
 
   check_if_cross_compiling(CCWIN "Windows" "")
   if(CCWIN)
@@ -69,16 +69,16 @@ if(NOT Poly_FOUND_SYSTEM)
   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     list(APPEND POLY_BYPRODUCTS
       <INSTALL_DIR>/lib/libpoly.0${CMAKE_SHARED_LIBRARY_SUFFIX}
-      <INSTALL_DIR>/lib/libpoly.0.1.9${CMAKE_SHARED_LIBRARY_SUFFIX}
+      <INSTALL_DIR>/lib/libpoly.0.1.11${CMAKE_SHARED_LIBRARY_SUFFIX}
       <INSTALL_DIR>/lib/libpolyxx.0${CMAKE_SHARED_LIBRARY_SUFFIX}
-      <INSTALL_DIR>/lib/libpolyxx.0.1.9${CMAKE_SHARED_LIBRARY_SUFFIX}
+      <INSTALL_DIR>/lib/libpolyxx.0.1.11${CMAKE_SHARED_LIBRARY_SUFFIX}
     )
   elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     list(APPEND POLY_BYPRODUCTS
       <INSTALL_DIR>/lib/libpoly${CMAKE_SHARED_LIBRARY_SUFFIX}.0
-      <INSTALL_DIR>/lib/libpoly${CMAKE_SHARED_LIBRARY_SUFFIX}.0.1.9
+      <INSTALL_DIR>/lib/libpoly${CMAKE_SHARED_LIBRARY_SUFFIX}.0.1.11
       <INSTALL_DIR>/lib/libpolyxx${CMAKE_SHARED_LIBRARY_SUFFIX}.0
-      <INSTALL_DIR>/lib/libpolyxx${CMAKE_SHARED_LIBRARY_SUFFIX}.0.1.9
+      <INSTALL_DIR>/lib/libpolyxx${CMAKE_SHARED_LIBRARY_SUFFIX}.0.1.11
     )
   endif()
 
@@ -86,7 +86,7 @@ if(NOT Poly_FOUND_SYSTEM)
     Poly-EP
     ${COMMON_EP_CONFIG}
     URL https://github.com/SRI-CSL/libpoly/archive/${Poly_VERSION}.tar.gz
-    URL_HASH SHA1=3fad3b310727fa0fb2fdff5a8857709d12f72e04
+    URL_HASH SHA1=65c16e86bc56c8214b609807eee05c4d0c271772
     PATCH_COMMAND
       sed -i.orig
       "s,add_subdirectory(test/polyxx),add_subdirectory(test/polyxx EXCLUDE_FROM_ALL),g"

--- a/src/util/real_algebraic_number_poly_imp.cpp
+++ b/src/util/real_algebraic_number_poly_imp.cpp
@@ -149,6 +149,12 @@ RealAlgebraicNumber operator*(const RealAlgebraicNumber& lhs,
 {
   return lhs.getValue() * rhs.getValue();
 }
+RealAlgebraicNumber operator/(const RealAlgebraicNumber& lhs,
+                              const RealAlgebraicNumber& rhs)
+{
+  Assert(!isZero(rhs)) << "Can not divide by zero";
+  return lhs.getValue() / rhs.getValue();
+}
 
 RealAlgebraicNumber& operator+=(RealAlgebraicNumber& lhs,
                                 const RealAlgebraicNumber& rhs)
@@ -172,5 +178,18 @@ RealAlgebraicNumber& operator*=(RealAlgebraicNumber& lhs,
 int sgn(const RealAlgebraicNumber& ran) { return sgn(ran.getValue()); }
 bool isZero(const RealAlgebraicNumber& ran) { return is_zero(ran.getValue()); }
 bool isOne(const RealAlgebraicNumber& ran) { return is_one(ran.getValue()); }
+RealAlgebraicNumber inverse(const RealAlgebraicNumber& ran)
+{
+  Assert(!isZero(rhs)) << "Can not invert zero";
+  return inverse(ran.getValue());
+}
 
 }  // namespace cvc5
+
+namespace std {
+size_t hash<cvc5::RealAlgebraicNumber>::operator()(
+    const cvc5::RealAlgebraicNumber& ran) const
+{
+  return lp_algebraic_number_hash_approx(ran.getValue().get_internal(), 2);
+}
+}  // namespace std

--- a/src/util/real_algebraic_number_poly_imp.cpp
+++ b/src/util/real_algebraic_number_poly_imp.cpp
@@ -180,7 +180,7 @@ bool isZero(const RealAlgebraicNumber& ran) { return is_zero(ran.getValue()); }
 bool isOne(const RealAlgebraicNumber& ran) { return is_one(ran.getValue()); }
 RealAlgebraicNumber inverse(const RealAlgebraicNumber& ran)
 {
-  Assert(!isZero(rhs)) << "Can not invert zero";
+  Assert(!isZero(ran)) << "Can not invert zero";
   return inverse(ran.getValue());
 }
 

--- a/src/util/real_algebraic_number_poly_imp.cpp
+++ b/src/util/real_algebraic_number_poly_imp.cpp
@@ -152,8 +152,12 @@ RealAlgebraicNumber operator*(const RealAlgebraicNumber& lhs,
 RealAlgebraicNumber operator/(const RealAlgebraicNumber& lhs,
                               const RealAlgebraicNumber& rhs)
 {
+#ifdef CVC5_POLY_IMP
   Assert(!isZero(rhs)) << "Can not divide by zero";
   return lhs.getValue() / rhs.getValue();
+#else
+  return lhs;
+#endif
 }
 
 RealAlgebraicNumber& operator+=(RealAlgebraicNumber& lhs,
@@ -180,8 +184,12 @@ bool isZero(const RealAlgebraicNumber& ran) { return is_zero(ran.getValue()); }
 bool isOne(const RealAlgebraicNumber& ran) { return is_one(ran.getValue()); }
 RealAlgebraicNumber inverse(const RealAlgebraicNumber& ran)
 {
+#ifdef CVC5_POLY_IMP
   Assert(!isZero(ran)) << "Can not invert zero";
   return inverse(ran.getValue());
+#else
+  return ran;
+#endif
 }
 
 }  // namespace cvc5
@@ -190,6 +198,10 @@ namespace std {
 size_t hash<cvc5::RealAlgebraicNumber>::operator()(
     const cvc5::RealAlgebraicNumber& ran) const
 {
+#ifdef CVC5_POLY_IMP
   return lp_algebraic_number_hash_approx(ran.getValue().get_internal(), 2);
+#else
+  return 0;
+#endif
 }
 }  // namespace std

--- a/src/util/real_algebraic_number_poly_imp.h
+++ b/src/util/real_algebraic_number_poly_imp.h
@@ -160,6 +160,12 @@ namespace std {
 template <>
 struct hash<cvc5::RealAlgebraicNumber>
 {
+  /**
+   * Computes a hash of the given real algebraic number. Given that the internal
+   * representation of real algebraic numbers are inherently mutable (th
+   * interval may be refined for comparisons) we hash a well-defined rational
+   * approximation.
+   */
   size_t operator()(const cvc5::RealAlgebraicNumber& ran) const;
 };
 }  // namespace std

--- a/src/util/real_algebraic_number_poly_imp.h
+++ b/src/util/real_algebraic_number_poly_imp.h
@@ -128,6 +128,9 @@ RealAlgebraicNumber operator-(const RealAlgebraicNumber& ran);
 /** Multiply two real algebraic numbers. */
 RealAlgebraicNumber operator*(const RealAlgebraicNumber& lhs,
                               const RealAlgebraicNumber& rhs);
+/** Divide two real algebraic numbers. */
+RealAlgebraicNumber operator/(const RealAlgebraicNumber& lhs,
+                              const RealAlgebraicNumber& rhs);
 
 /** Add and assign two real algebraic numbers. */
 RealAlgebraicNumber& operator+=(RealAlgebraicNumber& lhs,
@@ -146,7 +149,19 @@ int sgn(const RealAlgebraicNumber& ran);
 bool isZero(const RealAlgebraicNumber& ran);
 /** Check whether a real algebraic number is one. */
 bool isOne(const RealAlgebraicNumber& ran);
+/** Compute the inverse of a real algebraic number. */
+RealAlgebraicNumber inverse(const RealAlgebraicNumber& ran);
+
+using RealAlgebraicNumberHashFunction = std::hash<RealAlgebraicNumber>;
 
 }  // namespace cvc5
+
+namespace std {
+template <>
+struct hash<cvc5::RealAlgebraicNumber>
+{
+  size_t operator()(const cvc5::RealAlgebraicNumber& ran) const;
+};
+}  // namespace std
 
 #endif /* CVC5__REAL_ALGEBRAIC_NUMBER_H */

--- a/test/unit/util/real_algebraic_number_black.cpp
+++ b/test/unit/util/real_algebraic_number_black.cpp
@@ -37,7 +37,7 @@ TEST_F(TestUtilBlackRealAlgebraicNumber, creation)
   ASSERT_TRUE(sqrt2 < RealAlgebraicNumber(Integer(2)));
 }
 
-TEST_F(TestUtilBlackRealAlgebraicNumber, comprison)
+TEST_F(TestUtilBlackRealAlgebraicNumber, comparison)
 {
   RealAlgebraicNumber msqrt3({-3, 0, 1}, -2, -1);
   RealAlgebraicNumber msqrt2({-2, 0, 1}, -2, -1);
@@ -79,5 +79,16 @@ TEST_F(TestUtilBlackRealAlgebraicNumber, arithmetic)
   ASSERT_EQ(-msqrt2 + sqrt2, sqrt2 + sqrt2);
   ASSERT_EQ(msqrt2 * sqrt2, RealAlgebraicNumber(Integer(-2)));
 }
+
+TEST_F(TestUtilBlackRealAlgebraicNumber, division)
+{
+  RealAlgebraicNumber msqrt2({-2, 0, 1}, -2, -1);
+  RealAlgebraicNumber sqrt2({-2, 0, 1}, 1, 2);
+  RealAlgebraicNumber mone({1, 1}, -2, 0);
+
+  ASSERT_EQ(msqrt2 / sqrt2, mone);
+  ASSERT_TRUE(isOne(sqrt2 / sqrt2));
+}
+
 }  // namespace test
 }  // namespace cvc5


### PR DESCRIPTION
This PR adds some new methods for the RealAlgebraicNumber class: division, computing the (multiplicative) inverse and a specialization of `std::hash`.