### PR TITLE
Ensure configuration of shared selectors is consistent in SyGuS subsolver

### DIFF
--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -677,6 +677,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
   {
     if (logic.isQuantified() && !usesSygus(opts))
     {
+      Trace("smt") << "Disabling shared selectors for quantified logic without SyGuS" << std::endl;
       opts.datatypes.dtSharedSelectors = false;
     }
   }

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -677,7 +677,9 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
   {
     if (logic.isQuantified() && !usesSygus(opts))
     {
-      Trace("smt") << "Disabling shared selectors for quantified logic without SyGuS" << std::endl;
+      Trace("smt")
+          << "Disabling shared selectors for quantified logic without SyGuS"
+          << std::endl;
       opts.datatypes.dtSharedSelectors = false;
     }
   }

--- a/src/theory/quantifiers/sygus/synth_verify.cpp
+++ b/src/theory/quantifiers/sygus/synth_verify.cpp
@@ -18,8 +18,8 @@
 #include "expr/node_algorithm.h"
 #include "options/arith_options.h"
 #include "options/base_options.h"
-#include "options/quantifiers_options.h"
 #include "options/datatypes_options.h"
+#include "options/quantifiers_options.h"
 #include "smt/smt_statistics_registry.h"
 #include "theory/quantifiers/first_order_model.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
@@ -55,7 +55,8 @@ SynthVerify::SynthVerify(Env& env, TermDbSygus* tds)
   }
   // we must use the same setting for datatype selectors, since shared selectors
   // can appear in solutions
-  d_subOptions.datatypes.dtSharedSelectors = options().datatypes.dtSharedSelectors;
+  d_subOptions.datatypes.dtSharedSelectors =
+      options().datatypes.dtSharedSelectors;
   d_subOptions.datatypes.dtSharedSelectorsWasSetByUser = true;
 }
 

--- a/src/theory/quantifiers/sygus/synth_verify.cpp
+++ b/src/theory/quantifiers/sygus/synth_verify.cpp
@@ -19,6 +19,7 @@
 #include "options/arith_options.h"
 #include "options/base_options.h"
 #include "options/quantifiers_options.h"
+#include "options/datatypes_options.h"
 #include "smt/smt_statistics_registry.h"
 #include "theory/quantifiers/first_order_model.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"

--- a/src/theory/quantifiers/sygus/synth_verify.cpp
+++ b/src/theory/quantifiers/sygus/synth_verify.cpp
@@ -52,6 +52,9 @@ SynthVerify::SynthVerify(Env& env, TermDbSygus* tds)
   {
     d_subOptions.arith.nlExtTangentPlanes = true;
   }
+  // we must use the same setting for datatype selectors, since shared selectors
+  // can appear in solutions
+  d_subOptions.datatypes.dtSharedSelectors = options().datatypes.dtSharedSelectors;
 }
 
 SynthVerify::~SynthVerify() {}

--- a/src/theory/quantifiers/sygus/synth_verify.cpp
+++ b/src/theory/quantifiers/sygus/synth_verify.cpp
@@ -56,6 +56,7 @@ SynthVerify::SynthVerify(Env& env, TermDbSygus* tds)
   // we must use the same setting for datatype selectors, since shared selectors
   // can appear in solutions
   d_subOptions.datatypes.dtSharedSelectors = options().datatypes.dtSharedSelectors;
+  d_subOptions.datatypes.dtSharedSelectorsWasSetByUser = true;
 }
 
 SynthVerify::~SynthVerify() {}

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -2535,6 +2535,7 @@ set(regress_1_tests
   regress1/sygus/issue4009-qep.smt2
   regress1/sygus/issue4025-no-rlv-cond.smt2
   regress1/sygus/issue4083-var-shadow.smt2
+  regress1/sygus/issue7925-dt-share-config.sy
   regress1/sygus/large-const-simp.sy
   regress1/sygus/let-bug-simp.sy
   regress1/sygus/list-head-x.sy

--- a/test/regress/regress1/sygus/issue7925-dt-share-config.sy
+++ b/test/regress/regress1/sygus/issue7925-dt-share-config.sy
@@ -1,0 +1,8 @@
+; COMMAND-LINE:
+; EXPECT: fail
+(set-logic ALL)
+(declare-datatypes ((wrapped_integer 0)) (((constructor (value Int)))))
+(synth-fun f ((input wrapped_integer)) Bool ((bool Bool)) ((bool Bool ( (= (value input) 0)))))
+(declare-var x wrapped_integer)
+(constraint (f x))
+(check-synth)


### PR DESCRIPTION
This prevents the SyGuS subsolver from having a different configuration of `dt-share-sel` than the main SyGuS solver.  Having this mismatch can lead to incorrect synthesis results.

Fixes #7925.