### PR TITLE
Preprare central model building for RANs

### DIFF
--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1019,10 +1019,11 @@ Node SolverEngine::getValue(const Node& ex) const
          || resultNode.getType().isSubtypeOf(expectedType))
       << "Run with -t smt for details.";
 
-  // Ensure it's a constant, or a lambda (for uninterpreted functions). This
-  // assertion only holds for models that do not have approximate values.
+  // Ensure it's an evaluation result (constant or const-ish like real algebraic
+  // numbers), or a lambda (for uninterpreted functions). This assertion only
+  // holds for models that do not have approximate values.
   Assert(m->hasApproximations() || resultNode.getKind() == kind::LAMBDA
-         || resultNode.isConst());
+         || TheoryModel::isEvaluationResult(resultNode));
 
   if (d_env->getOptions().smt.abstractValues && resultNode.getType().isArray())
   {

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1019,11 +1019,10 @@ Node SolverEngine::getValue(const Node& ex) const
          || resultNode.getType().isSubtypeOf(expectedType))
       << "Run with -t smt for details.";
 
-  // Ensure it's an evaluation result (constant or const-ish like real algebraic
+  // Ensure it's a value (constant or const-ish like real algebraic
   // numbers), or a lambda (for uninterpreted functions). This assertion only
   // holds for models that do not have approximate values.
-  Assert(m->hasApproximations() || resultNode.getKind() == kind::LAMBDA
-         || TheoryModel::isEvaluationResult(resultNode));
+  Assert(m->hasApproximations() || TheoryModel::isValue(resultNode));
 
   if (d_env->getOptions().smt.abstractValues && resultNode.getType().isArray())
   {

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -803,5 +803,10 @@ std::string TheoryModel::debugPrintModelEqc() const
   return ss.str();
 }
 
+bool TheoryModel::isEvaluationResult(TNode node)
+{
+  return node.isConst() || node.getKind() == Kind::REAL_ALGEBRAIC_NUMBER;
+}
+
 }  // namespace theory
 }  // namespace cvc5

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -803,9 +803,10 @@ std::string TheoryModel::debugPrintModelEqc() const
   return ss.str();
 }
 
-bool TheoryModel::isEvaluationResult(TNode node)
+bool TheoryModel::isValue(TNode node)
 {
-  return node.isConst() || node.getKind() == Kind::REAL_ALGEBRAIC_NUMBER;
+  return node.isConst() || node.getKind() == Kind::REAL_ALGEBRAIC_NUMBER
+         || node.getKind() == Kind::LAMBDA;
 }
 
 }  // namespace theory

--- a/src/theory/theory_model.h
+++ b/src/theory/theory_model.h
@@ -358,11 +358,10 @@ class TheoryModel : protected EnvObj
   std::string debugPrintModelEqc() const;
 
   /**
-   * Checks whether a node is an evaluation result, i.e., whether it is a proper
-   * constant-like value. This includes `node.isConst()`, but also real
-   * algebraic numbers.
+   * Is the node n a "value"? This is true if n is constant, a constant-like
+   * value (e.g. a real algebraic number) or if n is a lambda.
    */
-  static bool isEvaluationResult(TNode node);
+  static bool isValue(TNode node);
 
  protected:
   /** Unique name of this model */

--- a/src/theory/theory_model.h
+++ b/src/theory/theory_model.h
@@ -357,6 +357,13 @@ class TheoryModel : protected EnvObj
    */
   std::string debugPrintModelEqc() const;
 
+  /**
+   * Checks whether a node is an evaluation result, i.e., whether it is a proper
+   * constant-like value. This includes `node.isConst()`, but also real
+   * algebraic numbers.
+   */
+  static bool isEvaluationResult(TNode node);
+
  protected:
   /** Unique name of this model */
   std::string d_name;

--- a/src/theory/theory_model_builder.cpp
+++ b/src/theory/theory_model_builder.cpp
@@ -79,7 +79,7 @@ Node TheoryEngineModelBuilder::evaluateEqc(TheoryModel* m, TNode r)
     {
       Trace("model-builder-debug") << "...try to normalize" << std::endl;
       Node normalized = normalize(m, n, true);
-      if (normalized.isConst())
+      if (TheoryModel::isEvaluationResult(normalized))
       {
         return normalized;
       }
@@ -101,7 +101,7 @@ bool TheoryEngineModelBuilder::isAssignerActive(TheoryModel* tm, Assigner& a)
     // Members of exclusion set must have values, otherwise we are not yet
     // assignable.
     Node er = eset[i];
-    if (er.isConst())
+    if (TheoryModel::isEvaluationResult(er))
     {
       // already processed
       continue;
@@ -737,7 +737,7 @@ bool TheoryEngineModelBuilder::buildModel(TheoryModel* tm)
             }
             if (!normalized.isNull())
             {
-              Assert(normalized.isConst());
+              Assert(TheoryModel::isEvaluationResult(normalized));
               typeConstSet.add(tb, normalized);
               assignConstantRep(tm, *i2, normalized);
               Trace("model-builder") << "    Eval: Setting constant rep of "
@@ -776,7 +776,7 @@ bool TheoryEngineModelBuilder::buildModel(TheoryModel* tm)
             Trace("model-builder") << "    Normalizing rep (" << rep
                                    << "), normalized to (" << normalized << ")"
                                    << endl;
-            if (normalized.isConst())
+            if (TheoryModel::isEvaluationResult(normalized))
             {
               changed = true;
               typeConstSet.add(tb, normalized);
@@ -1208,7 +1208,7 @@ Node TheoryEngineModelBuilder::normalize(TheoryModel* m, TNode r, bool evalOnly)
         {
           ri = normalize(m, ri, evalOnly);
         }
-        if (!ri.isConst())
+        if (!TheoryModel::isEvaluationResult(ri))
         {
           childrenConst = false;
         }
@@ -1255,7 +1255,7 @@ void TheoryEngineModelBuilder::assignFunction(TheoryModel* m, Node f)
       Node rc = m->getRepresentative(un[j]);
       Trace("model-builder-debug2") << "    get rep : " << un[j] << " returned "
                                     << rc << std::endl;
-      Assert(rc.isConst());
+      Assert(TheoryModel::isEvaluationResult(rc));
       children.push_back(rc);
     }
     Node simp = NodeManager::currentNM()->mkNode(un.getKind(), children);

--- a/src/theory/theory_model_builder.cpp
+++ b/src/theory/theory_model_builder.cpp
@@ -79,7 +79,7 @@ Node TheoryEngineModelBuilder::evaluateEqc(TheoryModel* m, TNode r)
     {
       Trace("model-builder-debug") << "...try to normalize" << std::endl;
       Node normalized = normalize(m, n, true);
-      if (TheoryModel::isEvaluationResult(normalized))
+      if (TheoryModel::isValue(normalized))
       {
         return normalized;
       }
@@ -101,7 +101,7 @@ bool TheoryEngineModelBuilder::isAssignerActive(TheoryModel* tm, Assigner& a)
     // Members of exclusion set must have values, otherwise we are not yet
     // assignable.
     Node er = eset[i];
-    if (TheoryModel::isEvaluationResult(er))
+    if (TheoryModel::isValue(er))
     {
       // already processed
       continue;
@@ -123,11 +123,6 @@ bool TheoryEngineModelBuilder::isAssignerActive(TheoryModel* tm, Assigner& a)
   Trace("model-build-aes") << "isAssignerActive: active!" << std::endl;
   a.d_isActive = true;
   return true;
-}
-
-bool TheoryEngineModelBuilder::isValue(TNode n)
-{
-  return n.getKind() == kind::LAMBDA || n.isConst();
 }
 
 bool TheoryEngineModelBuilder::isAssignable(TNode n)
@@ -508,7 +503,7 @@ bool TheoryEngineModelBuilder::buildModel(TheoryModel* tm)
       // applicable. We check if n is a value here, e.g. a term for which
       // isConst returns true, or a lambda. The latter is required only for
       // higher-order.
-      if (isValue(n))
+      if (TheoryModel::isValue(n))
       {
         Assert(constRep.isNull());
         constRep = n;
@@ -737,7 +732,7 @@ bool TheoryEngineModelBuilder::buildModel(TheoryModel* tm)
             }
             if (!normalized.isNull())
             {
-              Assert(TheoryModel::isEvaluationResult(normalized));
+              Assert(TheoryModel::isValue(normalized));
               typeConstSet.add(tb, normalized);
               assignConstantRep(tm, *i2, normalized);
               Trace("model-builder") << "    Eval: Setting constant rep of "
@@ -776,7 +771,7 @@ bool TheoryEngineModelBuilder::buildModel(TheoryModel* tm)
             Trace("model-builder") << "    Normalizing rep (" << rep
                                    << "), normalized to (" << normalized << ")"
                                    << endl;
-            if (TheoryModel::isEvaluationResult(normalized))
+            if (TheoryModel::isValue(normalized))
             {
               changed = true;
               typeConstSet.add(tb, normalized);
@@ -1208,7 +1203,7 @@ Node TheoryEngineModelBuilder::normalize(TheoryModel* m, TNode r, bool evalOnly)
         {
           ri = normalize(m, ri, evalOnly);
         }
-        if (!TheoryModel::isEvaluationResult(ri))
+        if (!TheoryModel::isValue(ri))
         {
           childrenConst = false;
         }
@@ -1255,7 +1250,7 @@ void TheoryEngineModelBuilder::assignFunction(TheoryModel* m, Node f)
       Node rc = m->getRepresentative(un[j]);
       Trace("model-builder-debug2") << "    get rep : " << un[j] << " returned "
                                     << rc << std::endl;
-      Assert(TheoryModel::isEvaluationResult(rc));
+      Assert(TheoryModel::isValue(rc));
       children.push_back(rc);
     }
     Node simp = NodeManager::currentNM()->mkNode(un.getKind(), children);

--- a/src/theory/theory_model_builder.h
+++ b/src/theory/theory_model_builder.h
@@ -126,11 +126,6 @@ class TheoryEngineModelBuilder : protected EnvObj
    * state of the model m.
    */
   Node evaluateEqc(TheoryModel* m, TNode r);
-  /**
-   * Is the node n a "value"? This is true if n is constant, or if n is a
-   * lambda.
-   */
-  static bool isValue(TNode n);
   /** is n an assignable expression?
    *
    * A term n is an assignable expression if its value is unconstrained by a


### PR DESCRIPTION
This PR uses a new utility `isEvaluationResult()` instead of `isConst()` within the core model building. This prepares model building for model values that are not constants (in the sense of `isConst()`) but still constant-lilke values, like real algebraic numbers.