### PR TITLE
Add operator<<(RewriteStatus)

### DIFF
--- a/src/theory/theory_rewriter.cpp
+++ b/src/theory/theory_rewriter.cpp
@@ -20,6 +20,18 @@
 namespace cvc5 {
 namespace theory {
 
+std::ostream& operator<<(std::ostream& os, RewriteStatus rs)
+{
+  switch (rs)
+  {
+    case RewriteStatus::REWRITE_DONE:       return os << "DONE";
+    case RewriteStatus::REWRITE_AGAIN:      return os << "AGAIN";
+    case RewriteStatus::REWRITE_AGAIN_FULL: return os << "AGAIN_FULL";
+  }
+  Unreachable();
+  return os;
+}
+
 TrustRewriteResponse::TrustRewriteResponse(RewriteStatus status,
                                            Node n,
                                            Node nr,

--- a/src/theory/theory_rewriter.h
+++ b/src/theory/theory_rewriter.h
@@ -42,6 +42,9 @@ enum RewriteStatus
   REWRITE_AGAIN_FULL
 }; /* enum RewriteStatus */
 
+/** Print a RewriteStatus to an output stream */
+std::ostream& operator<<(std::ostream& os, RewriteStatus rs);
+
 /**
  * Instances of this class serve as response codes from
  * TheoryRewriter::preRewrite() and TheoryRewriter::postRewrite(). The response


### PR DESCRIPTION
Adds a streaming operator for `RewriteStatus`. I found it helpful while refactoring / debugging the rewriter.