### PR TITLE
Fix CMake script for static, auto-download, cln configuration

### DIFF
--- a/cmake/FindCLN.cmake
+++ b/cmake/FindCLN.cmake
@@ -74,7 +74,7 @@ if(NOT CLN_FOUND_SYSTEM)
   if(BUILD_SHARED_LIBS)
     set(CLN_LIBRARIES "${DEPS_BASE}/lib/libcln${CMAKE_SHARED_LIBRARY_SUFFIX}")
   else()
-    set(CLN_STATIC_LIBRARIES "${DEPS_BASE}/lib/libcln.a")
+    set(CLN_LIBRARIES "${DEPS_BASE}/lib/libcln.a")
   endif()
 endif()
 


### PR DESCRIPTION
The script was previously creating a 'CLN_STATIC_LIBRARIES' variable that
wasn't known about elsewhere in the code and caused issues when the Makefiles
depended on a CLN_LIBRARIES variable. Instead, the static libraries should just
go into CLN_LIBRARIES as normal.

This only seems to have affected the case where cln is set to auto-download and
the build is static.

Signed-off-by: Matthew Sotoudeh <sotoudeh@stanford.edu>