### PR TITLE
Fix proofs for trivial cases of datatypes tester merge

### DIFF
--- a/src/theory/datatypes/infer_proof_cons.cpp
+++ b/src/theory/datatypes/infer_proof_cons.cpp
@@ -223,14 +223,12 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
       Node tester1c =
           nm->mkNode(APPLY_TESTER, expv[1].getOperator(), expv[0][0]);
       std::vector<Node> targs{expv[1]};
-      if (expv.size()==3)
+      if (expv.size() == 3)
       {
         targs.push_back(expv[2]);
       }
-      cdp->addStep(tester1c,
-                   PfRule::MACRO_SR_PRED_TRANSFORM,
-                   targs,
-                   {tester1c});
+      cdp->addStep(
+          tester1c, PfRule::MACRO_SR_PRED_TRANSFORM, targs, {tester1c});
       Node fn = nm->mkConst(false);
       cdp->addStep(fn, PfRule::DT_CLASH, {tester1, tester1c}, {});
       success = true;

--- a/src/theory/datatypes/infer_proof_cons.cpp
+++ b/src/theory/datatypes/infer_proof_cons.cpp
@@ -218,13 +218,18 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
     break;
     case InferenceId::DATATYPES_TESTER_MERGE_CONFLICT:
     {
-      Assert(expv.size() == 3);
+      Assert(2 <= expv.size() && expv.size() <= 3);
       Node tester1 = expv[0];
       Node tester1c =
           nm->mkNode(APPLY_TESTER, expv[1].getOperator(), expv[0][0]);
+      std::vector<Node> targs{expv[1]};
+      if (expv.size()==3)
+      {
+        targs.push_back(expv[2]);
+      }
       cdp->addStep(tester1c,
                    PfRule::MACRO_SR_PRED_TRANSFORM,
-                   {expv[1], expv[2]},
+                   targs,
                    {tester1c});
       Node fn = nm->mkConst(false);
       cdp->addStep(fn, PfRule::DT_CLASH, {tester1, tester1c}, {});

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -902,7 +902,10 @@ void TheoryDatatypes::addTester(
     std::vector<Node> conf;
     conf.push_back(j);
     conf.push_back(t);
-    conf.push_back(jt[0].eqNode(t_arg));
+    if (jt[0]!=t_arg)
+    {
+      conf.push_back(jt[0].eqNode(t_arg));
+    }
     Trace("dt-conflict") << "CONFLICT: Tester conflict : " << conf << std::endl;
     d_im.sendDtConflict(conf, InferenceId::DATATYPES_TESTER_MERGE_CONFLICT);
   }

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -902,7 +902,7 @@ void TheoryDatatypes::addTester(
     std::vector<Node> conf;
     conf.push_back(j);
     conf.push_back(t);
-    if (jt[0]!=t_arg)
+    if (jt[0] != t_arg)
     {
       conf.push_back(jt[0].eqNode(t_arg));
     }

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1708,6 +1708,7 @@ set(regress_1_tests
   regress1/datatypes/non-simple-rec.smt2
   regress1/datatypes/non-simple-rec-mut-unsat.smt2
   regress1/datatypes/non-simple-rec-param.smt2
+  regress1/datatypes/proj-issue433-tester-merge-pf.smt2
   regress1/datatypes/tuple_projection.smt2
   regress1/decision/bug374a.smtv1.smt2
   regress1/decision/error3.smtv1.smt2

--- a/test/regress/regress1/datatypes/proj-issue433-tester-merge-pf.smt2
+++ b/test/regress/regress1/datatypes/proj-issue433-tester-merge-pf.smt2
@@ -1,0 +1,8 @@
+(set-logic ALL)
+(set-info :status unsat)
+(declare-datatypes ((L 0)) (((i))))
+(declare-datatypes ((O 0)) (((N) (S (i (_ BitVec 3))))))
+(declare-fun m (L) O)
+(declare-fun g ((_ BitVec 3) L) L)
+(assert (exists ((B L) (n (_ BitVec 3))) (not (ite ((_ is S) (m (g n B))) (not ((_ is N) (m (g n B)))) true))))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5-projects/issues/433.

Also ensures we don't add (= t t) as part of a reported conflict.