### PR TITLE
Fix CI build for macOS

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -51,7 +51,6 @@ runs:
         brew update --quiet
         brew install \
           ccache \
-           \
           cln \
           gmp \
           pkgconfig \

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -51,6 +51,7 @@ runs:
         brew update --quiet
         brew install \
           ccache \
+           \
           cln \
           gmp \
           pkgconfig \
@@ -75,8 +76,7 @@ runs:
         if [[ "${{ inputs.with-python-bindings }}" != "true" ]]; then exit 0; fi
         python3 -m pip install pytest scikit-build
         python3 -m pytest --version
-        python3 -m pip install \
-          Cython==0.29.* --install-option="--no-cython-compile"
+        python3 -m pip install Cython==0.29.*
         echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
         echo "::endgroup::"
     


### PR DESCRIPTION
The macOS CI could not find the Cython executable anymore for some reason. This commit fixes the issue.