### PR TITLE
Fix trivial explantions in sequences array solver

### DIFF
--- a/src/theory/strings/array_solver.cpp
+++ b/src/theory/strings/array_solver.cpp
@@ -382,7 +382,7 @@ void ArraySolver::checkTerm(Node t, bool checkInv)
   {
     d_im.addToExplanation(r, t[0], exp);
     exp.insert(exp.end(), nf.d_exp.begin(), nf.d_exp.end());
-    exp.push_back(t[0].eqNode(nf.d_base));
+    d_im.addToExplanation(t[0], nf.d_base, exp);
   }
   if (d_eqProc.find(eq) == d_eqProc.end())
   {

--- a/src/theory/strings/array_solver.cpp
+++ b/src/theory/strings/array_solver.cpp
@@ -373,14 +373,12 @@ void ArraySolver::checkTerm(Node t, bool checkInv)
   std::vector<Node> exp;
   if (checkInv)
   {
-    d_im.addToExplanation(rself, t, exp);
     NormalForm& nfSelf = d_csolver.getNormalForm(rself);
     exp.insert(exp.end(), nfSelf.d_exp.begin(), nfSelf.d_exp.end());
-    exp.push_back(t.eqNode(nfSelf.d_base));
+    d_im.addToExplanation(t, nfSelf.d_base, exp);
   }
   else
   {
-    d_im.addToExplanation(r, t[0], exp);
     exp.insert(exp.end(), nf.d_exp.begin(), nf.d_exp.end());
     d_im.addToExplanation(t[0], nf.d_base, exp);
   }

--- a/test/regress/regress0/seq/array/update-word-eq.smt2
+++ b/test/regress/regress0/seq/array/update-word-eq.smt2
@@ -1,5 +1,4 @@
 ; COMMAND-LINE: --strings-exp --seq-array=eager
-; DISABLE-TESTER: proof
 (set-logic QF_SLIA)
 (set-info :status unsat)
 


### PR DESCRIPTION
Also tightens the explanation slightly, we were previously adding a spurious equality to the representative, instead of the base of the normal form.