### PR TITLE
Disable regression if poly is not available

### DIFF
--- a/test/regress/regress0/proofs/proj-issue430-coverings-double-negation.smt2
+++ b/test/regress/regress0/proofs/proj-issue430-coverings-double-negation.smt2
@@ -1,3 +1,4 @@
+; REQUIRES: poly
 ; COMMAND-LINE: --check-proofs
 ; EXPECT: unsat
 ; EXPECT: unsat


### PR DESCRIPTION
This regression fails if poly is not available.