### PR TITLE
Rename docs-releases to docs

### DIFF
--- a/.github/workflows/docs_upload.yml
+++ b/.github/workflows/docs_upload.yml
@@ -118,7 +118,7 @@ jobs:
             eval $(ssh-agent -s)
             ssh-add - <<< "${{ secrets.CVC5_DOCS_RELEASE_TOKEN }}"
 
-            git clone git@github.com:cvc5/docs-releases.git target-releases/
+            git clone git@github.com:cvc5/docs.git target-releases/
             cp -r docs-new target-releases/$NAME
             cd target-releases/
 

--- a/.github/workflows/docs_upload.yml
+++ b/.github/workflows/docs_upload.yml
@@ -122,7 +122,8 @@ jobs:
             cp -r docs-new target-releases/$NAME
             cd target-releases/
 
-            git add $NAME
+            python3 genversions.py
+            git add .
 
             git commit -m "Update docs for $NAME"
             git push


### PR DESCRIPTION
This PR renames the repository URL where documentation for releases is stored. It now lives at https://cvc5.github.io/docs/