### PR TITLE
Add variant of get-difficulty for full effort lemmas

### DIFF
--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -215,6 +215,9 @@ name   = "SMT Layer"
   help_mode  = "difficulty output modes."
 [[option.mode.LEMMA_LITERAL]]
   name = "lemma-literal"
+  help = "Difficulty of an assertion is how many lemmas (at full effort) use a literal that the assertion depends on to be satisfied."
+[[option.mode.LEMMA_LITERAL_ALL]]
+  name = "lemma-literal-all"
   help = "Difficulty of an assertion is how many lemmas use a literal that the assertion depends on to be satisfied."
 [[option.mode.MODEL_CHECK]]
   name = "model-check"

--- a/src/theory/difficulty_manager.cpp
+++ b/src/theory/difficulty_manager.cpp
@@ -51,11 +51,14 @@ void DifficultyManager::getDifficultyMap(std::map<Node, Node>& dmap)
   }
 }
 
-void DifficultyManager::notifyLemma(Node n)
+void DifficultyManager::notifyLemma(Node n, bool inFullEffortCheck)
 {
-  if (options::difficultyMode() != options::DifficultyMode::LEMMA_LITERAL)
+  if (options::difficultyMode() != options::DifficultyMode::LEMMA_LITERAL_ALL)
   {
-    return;
+    if (inFullEffortCheck || options::difficultyMode() != options::DifficultyMode::LEMMA_LITERAL)
+    {
+      return;
+    }
   }
   Trace("diff-man") << "notifyLemma: " << n << std::endl;
   Kind nk = n.getKind();

--- a/src/theory/difficulty_manager.cpp
+++ b/src/theory/difficulty_manager.cpp
@@ -55,7 +55,7 @@ void DifficultyManager::notifyLemma(Node n, bool inFullEffortCheck)
 {
   if (options::difficultyMode() != options::DifficultyMode::LEMMA_LITERAL_ALL)
   {
-    if (inFullEffortCheck
+    if (!inFullEffortCheck
         || options::difficultyMode() != options::DifficultyMode::LEMMA_LITERAL)
     {
       return;

--- a/src/theory/difficulty_manager.cpp
+++ b/src/theory/difficulty_manager.cpp
@@ -55,7 +55,8 @@ void DifficultyManager::notifyLemma(Node n, bool inFullEffortCheck)
 {
   if (options::difficultyMode() != options::DifficultyMode::LEMMA_LITERAL_ALL)
   {
-    if (inFullEffortCheck || options::difficultyMode() != options::DifficultyMode::LEMMA_LITERAL)
+    if (inFullEffortCheck
+        || options::difficultyMode() != options::DifficultyMode::LEMMA_LITERAL)
     {
       return;
     }

--- a/src/theory/difficulty_manager.h
+++ b/src/theory/difficulty_manager.h
@@ -57,9 +57,11 @@ class DifficultyManager
    *
    * @param rse Mapping from literals to the preprocessed assertion that was
    * the reason why that literal was relevant in the current context
+   * @param inFullEffortCheck Whether we are in a full effort check when the
+   * lemma was sent.
    * @param lem The lemma
    */
-  void notifyLemma(Node lem);
+  void notifyLemma(Node lem, bool inFullEffortCheck);
   /**
    * Notify that `m` is a (candidate) model. This increments the difficulty
    * of assertions that are not satisfied by that model.

--- a/src/theory/relevance_manager.cpp
+++ b/src/theory/relevance_manager.cpp
@@ -533,7 +533,7 @@ void RelevanceManager::notifyLemma(TNode n)
   {
     // notice that we don't compute relevance here, instead it is computed
     // on demand based on the literals in n.
-    d_dman->notifyLemma(n);
+    d_dman->notifyLemma(n, d_inFullEffortCheck);
   }
 }
 


### PR DESCRIPTION
Makes it so that we don't consider lemmas at standard effort by default.  This ensures e.g. arith unate lemmas do not impact difficulty by default.