### PR TITLE
Simplify handling of disequalities in strings

### DIFF
--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2477,7 +2477,7 @@ void CoreSolver::processDeqExtensionality(Node n1, Node n2)
   // A != B => ( seq.len(A) != seq.len(B) or
   //             ( seq.nth(A, d) != seq.nth(B, d) ^ 0 <= d < seq.len(A) ) )
   d_im.sendInference(
-      {deq}, conc, InferenceId::STRINGS_DEQ_EXTENSIONALITY, false, true);
+      {deq}, {deq}, conc, InferenceId::STRINGS_DEQ_EXTENSIONALITY, false, true);
 }
 
 void CoreSolver::addNormalFormPair( Node n1, Node n2 ){

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2064,12 +2064,6 @@ void CoreSolver::processDeq(Node ni, Node nj)
     return;
   }
 
-  if (options().strings.stringsDeqExt)
-  {
-    processDeqExtensionality(ni, nj);
-    return;
-  }
-
   nfi = nfni.d_nf;
   nfj = nfnj.d_nf;
 
@@ -2576,7 +2570,7 @@ void CoreSolver::checkNormalFormsDeq()
     // This is required for model soundness currently, although we could
     // investigate determining cases where the disequality is already
     // satisfied (for optimization).
-    if (options().strings.seqArray != options::SeqArrayMode::NONE)
+    if (options().strings.stringsDeqExt || options().strings.seqArray != options::SeqArrayMode::NONE)
     {
       processDeqExtensionality(eq[0], eq[1]);
       return;

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2574,11 +2574,9 @@ void CoreSolver::checkNormalFormsDeq()
     if (Trace.isOn("strings-solve"))
     {
       Trace("strings-solve") << "- Compare " << eq[0] << ", nf ";
-      utils::printConcatTrace(getNormalForm(eq[0]).d_nf,
-                              "strings-solve");
+      utils::printConcatTrace(getNormalForm(eq[0]).d_nf, "strings-solve");
       Trace("strings-solve") << " against " << eq[1] << ", nf ";
-      utils::printConcatTrace(getNormalForm(eq[1]).d_nf,
-                              "strings-solve");
+      utils::printConcatTrace(getNormalForm(eq[1]).d_nf, "strings-solve");
       Trace("strings-solve") << "..." << std::endl;
     }
     // If using the sequence update solver, we always apply extensionality.
@@ -2592,8 +2590,9 @@ void CoreSolver::checkNormalFormsDeq()
     }
     Node n[2];
     Node l[2];
-    for( size_t i=0; i<2; i++ ){
-      n[i] = ee->getRepresentative( eq[i] );
+    for (size_t i = 0; i < 2; i++)
+    {
+      n[i] = ee->getRepresentative(eq[i]);
     }
     Node deq = n[0].eqNode(n[1]);
     processDeq(n[0], n[1]);

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2528,10 +2528,12 @@ void CoreSolver::checkNormalFormsDeq()
   const context::CDList<Node>& deqs = d_state.getDisequalityList();
 
   NodeManager* nm = NodeManager::currentNM();
+  Trace("str-deq") << "Process disequalites..." << std::endl;
   std::vector<Node> relevantDeqs;
   //for each pair of disequal strings, must determine whether their lengths are equal or disequal
   for (const Node& eq : deqs)
   {
+    Trace("str-deq") << "- disequality " << eq << std::endl;
     Node n[2];
     for( unsigned i=0; i<2; i++ ){
       n[i] = ee->getRepresentative( eq[i] );
@@ -2550,11 +2552,21 @@ void CoreSolver::checkNormalFormsDeq()
       {
         // if they have equal lengths, we must process the disequality below
         relevantDeqs.push_back(eq);
+        Trace("str-deq") << "...relevant" << std::endl;
       }
       else if (!d_state.areDisequal(lt[0], lt[1]))
       {
         d_im.sendSplit(lt[0], lt[1], InferenceId::STRINGS_DEQ_LENGTH_SP);
+        Trace("str-deq") << "...split" << std::endl;
       }
+      else
+      {
+        Trace("str-deq") << "...disequal length" << std::endl;
+      }
+    }
+    else
+    {
+      Trace("str-deq") << "...congruent" << std::endl;
     }
   }
 
@@ -2574,7 +2586,7 @@ void CoreSolver::checkNormalFormsDeq()
         || options().strings.seqArray != options::SeqArrayMode::NONE)
     {
       processDeqExtensionality(eq[0], eq[1]);
-      return;
+      continue;
     }
     // the method below requires representatives
     Node n[2];

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2570,7 +2570,8 @@ void CoreSolver::checkNormalFormsDeq()
     // This is required for model soundness currently, although we could
     // investigate determining cases where the disequality is already
     // satisfied (for optimization).
-    if (options().strings.stringsDeqExt || options().strings.seqArray != options::SeqArrayMode::NONE)
+    if (options().strings.stringsDeqExt
+        || options().strings.seqArray != options::SeqArrayMode::NONE)
     {
       processDeqExtensionality(eq[0], eq[1]);
       return;

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2572,14 +2572,6 @@ void CoreSolver::checkNormalFormsDeq()
   for (const Node& eq : relevantDeqs)
   {
     Assert(!d_state.isInConflict());
-    if (Trace.isOn("strings-solve"))
-    {
-      Trace("strings-solve") << "- Compare " << eq[0] << ", nf ";
-      utils::printConcatTrace(getNormalForm(eq[0]).d_nf, "strings-solve");
-      Trace("strings-solve") << " against " << eq[1] << ", nf ";
-      utils::printConcatTrace(getNormalForm(eq[1]).d_nf, "strings-solve");
-      Trace("strings-solve") << "..." << std::endl;
-    }
     // If using the sequence update solver, we always apply extensionality.
     // This is required for model soundness currently, although we could
     // investigate determining cases where the disequality is already
@@ -2589,11 +2581,19 @@ void CoreSolver::checkNormalFormsDeq()
       processDeqExtensionality(eq[0], eq[1]);
       return;
     }
+    // the method below requires representatives
     Node n[2];
-    Node l[2];
     for (size_t i = 0; i < 2; i++)
     {
       n[i] = ee->getRepresentative(eq[i]);
+    }
+    if (Trace.isOn("strings-solve"))
+    {
+      Trace("strings-solve") << "- Compare " << n[0] << ", nf ";
+      utils::printConcatTrace(getNormalForm(n[0]).d_nf, "strings-solve");
+      Trace("strings-solve") << " against " << n[1] << ", nf ";
+      utils::printConcatTrace(getNormalForm(n[1]).d_nf, "strings-solve");
+      Trace("strings-solve") << "..." << std::endl;
     }
     processDeq(n[0], n[1]);
     if (d_im.hasProcessed())

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2476,6 +2476,7 @@ void CoreSolver::processDeqExtensionality(Node n1, Node n2)
   Node conc = nm->mkNode(OR, lenDeq, nm->mkAnd(concs));
   // A != B => ( seq.len(A) != seq.len(B) or
   //             ( seq.nth(A, d) != seq.nth(B, d) ^ 0 <= d < seq.len(A) ) )
+  // Note that we take A != B verbatim, and do not explain it.
   d_im.sendInference(
       {deq}, {deq}, conc, InferenceId::STRINGS_DEQ_EXTENSIONALITY, false, true);
 }
@@ -2553,7 +2554,7 @@ void CoreSolver::checkNormalFormsDeq()
       }
       if (d_state.areEqual(lt[0], lt[1]))
       {
-        // if they have equal lengths, we must process this below
+        // if they have equal lengths, we must process the disequality below
         relevantDeqs.push_back(eq);
       }
       else if (!d_state.areDisequal(lt[0], lt[1]))
@@ -2594,7 +2595,6 @@ void CoreSolver::checkNormalFormsDeq()
     {
       n[i] = ee->getRepresentative(eq[i]);
     }
-    Node deq = n[0].eqNode(n[1]);
     processDeq(n[0], n[1]);
     if (d_im.hasProcessed())
     {

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -957,10 +957,6 @@ void TheoryStrings::eqNotifyMerge(TNode t1, TNode t2)
   }
 }
 
-void TheoryStrings::eqNotifyDisequal(TNode t1, TNode t2, TNode reason)
-{
-}
-
 void TheoryStrings::addCarePairs(TNodeTrie* t1,
                                  TNodeTrie* t2,
                                  unsigned arity,

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -769,14 +769,23 @@ bool TheoryStrings::preNotifyFact(
     TNode atom, bool pol, TNode fact, bool isPrereg, bool isInternal)
 {
   // this is only required for internal facts, others are already registered
-  if (isInternal && atom.getKind() == EQUAL)
+  if (atom.getKind() == EQUAL)
   {
-    // We must ensure these terms are registered. We register eagerly here for
-    // performance reasons. Alternatively, terms could be registered at full
-    // effort in e.g. BaseSolver::init.
-    for (const Node& t : atom)
+    if (isInternal)
     {
-      d_termReg.registerTerm(t, 0);
+      // We must ensure these terms are registered. We register eagerly here for
+      // performance reasons. Alternatively, terms could be registered at full
+      // effort in e.g. BaseSolver::init.
+      for (const Node& t : atom)
+      {
+        d_termReg.registerTerm(t, 0);
+      }
+    }
+    if (!pol && atom[0].getType().isStringLike())
+    {
+      // store disequalities between strings, may need to check if their lengths
+      // are equal/disequal
+      d_state.addDisequality(atom[0], atom[1]);
     }
   }
   return false;
@@ -950,12 +959,6 @@ void TheoryStrings::eqNotifyMerge(TNode t1, TNode t2)
 
 void TheoryStrings::eqNotifyDisequal(TNode t1, TNode t2, TNode reason)
 {
-  if (t1.getType().isStringLike())
-  {
-    // store disequalities between strings, may need to check if their lengths
-    // are equal/disequal
-    d_state.addDisequality(t1, t2);
-  }
 }
 
 void TheoryStrings::addCarePairs(TNodeTrie* t1,

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -768,9 +768,9 @@ void TheoryStrings::preRegisterTerm(TNode n)
 bool TheoryStrings::preNotifyFact(
     TNode atom, bool pol, TNode fact, bool isPrereg, bool isInternal)
 {
-  // this is only required for internal facts, others are already registered
   if (atom.getKind() == EQUAL)
   {
+    // this is only required for internal facts, others are already registered
     if (isInternal)
     {
       // We must ensure these terms are registered. We register eagerly here for
@@ -781,10 +781,9 @@ bool TheoryStrings::preNotifyFact(
         d_termReg.registerTerm(t, 0);
       }
     }
+    // store disequalities between strings that occur as literals
     if (!pol && atom[0].getType().isStringLike())
     {
-      // store disequalities between strings, may need to check if their lengths
-      // are equal/disequal
       d_state.addDisequality(atom[0], atom[1]);
     }
   }

--- a/src/theory/strings/theory_strings.h
+++ b/src/theory/strings/theory_strings.h
@@ -109,8 +109,6 @@ class TheoryStrings : public Theory {
   void eqNotifyNewClass(TNode t);
   /** Called just after the merge of two equivalence classes */
   void eqNotifyMerge(TNode t1, TNode t2);
-  /** called a disequality is added */
-  void eqNotifyDisequal(TNode t1, TNode t2, TNode reason);
   /** preprocess rewrite */
   TrustNode ppRewrite(TNode atom, std::vector<SkolemLemma>& lems) override;
   /** Collect model values in m based on the relevant terms given by termSet */
@@ -161,8 +159,6 @@ class TheoryStrings : public Theory {
     }
     void eqNotifyDisequal(TNode t1, TNode t2, TNode reason) override
     {
-      Debug("strings") << "NotifyClass::eqNotifyDisequal(" << t1 << ", " << t2 << ", " << reason << std::endl;
-      d_str.eqNotifyDisequal(t1, t2, reason);
     }
 
    private:

--- a/src/theory/theory_model_builder.cpp
+++ b/src/theory/theory_model_builder.cpp
@@ -1133,7 +1133,7 @@ void TheoryEngineModelBuilder::debugCheckModel(TheoryModel* tm)
             << "n: " << n << endl
             << "getValue(n): " << tm->getValue(n) << std::endl
             << "rep: " << rep << std::endl;
-        if (val.isConst() && rep.isConst())
+        if (false && val.isConst() && rep.isConst())
         {
           AlwaysAssert(val == rep) << err.str();
         }

--- a/src/theory/theory_model_builder.cpp
+++ b/src/theory/theory_model_builder.cpp
@@ -1133,7 +1133,7 @@ void TheoryEngineModelBuilder::debugCheckModel(TheoryModel* tm)
             << "n: " << n << endl
             << "getValue(n): " << tm->getValue(n) << std::endl
             << "rep: " << rep << std::endl;
-        if (false && val.isConst() && rep.isConst())
+        if (val.isConst() && rep.isConst())
         {
           AlwaysAssert(val == rep) << err.str();
         }

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1149,6 +1149,7 @@ set(regress_0_tests
   regress0/seq/update-concat-non-atomic2.smt2
   regress0/seq/update-eq.smt2
   regress0/seq/update-eq-unsat.smt2
+  regress0/seq/wrong-model-020322.smt2
   regress0/sets/abt-min.smt2
   regress0/sets/abt-te-exh.smt2
   regress0/sets/abt-te-exh2.smt2

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1150,6 +1150,7 @@ set(regress_0_tests
   regress0/seq/update-eq.smt2
   regress0/seq/update-eq-unsat.smt2
   regress0/seq/wrong-model-020322.smt2
+  regress0/seq/wrong-sat-020322.smt2
   regress0/sets/abt-min.smt2
   regress0/sets/abt-te-exh.smt2
   regress0/sets/abt-te-exh2.smt2

--- a/test/regress/regress0/seq/wrong-model-020322.smt2
+++ b/test/regress/regress0/seq/wrong-model-020322.smt2
@@ -1,0 +1,10 @@
+; COMMAND-LINE: --strings-exp --seq-array=lazy
+; EXPECT: sat
+(set-logic ALL)
+(set-info :status sat)
+(declare-sort E 0)
+(declare-fun k () E)
+(declare-fun s () (Seq E))
+(declare-fun j () Int)
+(assert (distinct (distinct s (str.update s j (seq.unit (seq.nth s 1)))) (distinct s (str.update (str.update s 0 (seq.unit k)) j (seq.unit (seq.nth s 1))))))
+(check-sat)

--- a/test/regress/regress0/seq/wrong-model-020322.smt2
+++ b/test/regress/regress0/seq/wrong-model-020322.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy
+; COMMAND-LINE: --strings-exp --seq-array=lazy -q
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/regress0/seq/wrong-sat-020322.smt2
+++ b/test/regress/regress0/seq/wrong-sat-020322.smt2
@@ -1,6 +1,5 @@
 ; COMMAND-LINE: --strings-exp --seq-array=lazy
-; EXPECT: unsato
-
+; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)
 (declare-sort E 0)

--- a/test/regress/regress0/seq/wrong-sat-020322.smt2
+++ b/test/regress/regress0/seq/wrong-sat-020322.smt2
@@ -1,0 +1,15 @@
+; COMMAND-LINE: --strings-exp --seq-array=lazy
+; EXPECT: unsato
+
+(set-logic ALL)
+(set-info :status unsat)
+(declare-sort E 0)
+(declare-fun k () E)
+(declare-fun s () (Seq E))
+(assert (distinct
+                (distinct s (str.update s 0 (seq.unit (seq.nth s 0))))
+                (distinct s
+                               (str.update (str.update s 0 (seq.unit k))
+                                                   0
+                                                   (seq.unit (seq.nth s 0))))))
+(check-sat)


### PR DESCRIPTION
This simplifies how string disequalities are handled, and fixes a caching bug in our implementation of extensionality.

The simplifications are two-fold:
- We track disequalities via assertions, not via an equality engine callback
- We process disequalities by iterating on the disequality list, not via iterating on pairs of equivalence classes

Extensionality is fixed by not *explaining* disequalities, which leads to being out of sync with the cache (as the previous explanation for the disequality might not hold in another SAT context).

This fixes the last known issues with `--seq-array=X`.

