### PR TITLE
Fix unsoundness in IAND solver

### DIFF
--- a/src/theory/arith/nl/iand_solver.cpp
+++ b/src/theory/arith/nl/iand_solver.cpp
@@ -95,8 +95,8 @@ void IAndSolver::checkInitialRefine()
       Node op = i.getOperator();
       size_t bsize = op.getConst<IntAnd>().d_size;
       Node twok = nm->mkConstInt(Rational(Integer(2).pow(bsize)));
-      Node arg0Mod = nm->mkNode(kind::INTS_MODULUS, i[0],  twok);
-      Node arg1Mod = nm->mkNode(kind::INTS_MODULUS, i[1],  twok);
+      Node arg0Mod = nm->mkNode(kind::INTS_MODULUS, i[0], twok);
+      Node arg1Mod = nm->mkNode(kind::INTS_MODULUS, i[1], twok);
       // initial refinement lemmas
       std::vector<Node> conj;
       // iand(x,y)=iand(y,x) is guaranteed by rewriting

--- a/src/theory/arith/nl/iand_solver.cpp
+++ b/src/theory/arith/nl/iand_solver.cpp
@@ -105,8 +105,11 @@ void IAndSolver::checkInitialRefine()
       conj.push_back(nm->mkNode(LEQ, i, i[0]));
       // iand(x,y)<=y
       conj.push_back(nm->mkNode(LEQ, i, i[1]));
-      // x=y => iand(x,y)=x
-      conj.push_back(nm->mkNode(IMPLIES, i[0].eqNode(i[1]), i.eqNode(i[0])));
+      // x=y => iand(x,y)=mod(x, 2^k)
+      size_t bsize = op.getConst<IntAnd>().d_size;
+      Node twok = nm->mkConstInt(Rational(Integer(2).pow(bsize)));
+      Node argMod = nm->mkNode(kind::INTS_MODULUS, i[0],  twok);
+      conj.push_back(nm->mkNode(IMPLIES, i[0].eqNode(i[1]), i.eqNode(argMod)));
       Node lem = conj.size() == 1 ? conj[0] : nm->mkNode(AND, conj);
       Trace("iand-lemma") << "IAndSolver::Lemma: " << lem << " ; INIT_REFINE"
                           << std::endl;

--- a/src/theory/arith/theory_arith_private.cpp
+++ b/src/theory/arith/theory_arith_private.cpp
@@ -1254,11 +1254,12 @@ void TheoryArithPrivate::releaseArithVar(ArithVar v){
 
 ArithVar TheoryArithPrivate::requestArithVar(TNode x, bool aux, bool internal){
   //TODO : The VarList trick is good enough?
-  Assert(isLeaf(x) || VarList::isMember(x) || x.getKind() == ADD || internal);
-  if (logicInfo().isLinear() && Variable::isDivMember(x))
+  Kind xk = x.getKind();
+  Assert(isLeaf(x) || VarList::isMember(x) || xk == ADD || internal);
+  if (logicInfo().isLinear() && (Variable::isDivMember(x) || xk==IAND || isTranscendentalKind(xk)))
   {
     stringstream ss;
-    ss << "A non-linear fact (involving div/mod/divisibility) was asserted to "
+    ss << "A non-linear fact was asserted to "
           "arithmetic in a linear logic: "
        << x << std::endl;
     throw LogicException(ss.str());

--- a/src/theory/arith/theory_arith_private.cpp
+++ b/src/theory/arith/theory_arith_private.cpp
@@ -1256,7 +1256,8 @@ ArithVar TheoryArithPrivate::requestArithVar(TNode x, bool aux, bool internal){
   //TODO : The VarList trick is good enough?
   Kind xk = x.getKind();
   Assert(isLeaf(x) || VarList::isMember(x) || xk == ADD || internal);
-  if (logicInfo().isLinear() && (Variable::isDivMember(x) || xk==IAND || isTranscendentalKind(xk)))
+  if (logicInfo().isLinear()
+      && (Variable::isDivMember(x) || xk == IAND || isTranscendentalKind(xk)))
   {
     stringstream ss;
     ss << "A non-linear fact was asserted to "

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1873,6 +1873,7 @@ set(regress_1_tests
   regress1/nl/issue3966-conf-coeff.smt2
   regress1/nl/issue4791-llr.smt2
   regress1/nl/issue5372-2-no-m-presolve.smt2
+  regress1/nl/issue5461-iand-init-refine.smt2
   regress1/nl/issue5660-mb-success.smt2
   regress1/nl/issue5662-nl-tc.smt2
   regress1/nl/issue5662-nl-tc-min.smt2

--- a/test/regress/regress1/nl/issue5461-iand-init-refine.smt2
+++ b/test/regress/regress1/nl/issue5461-iand-init-refine.smt2
@@ -1,0 +1,10 @@
+; COMMAND-LINE: --nl-ext-tplanes
+; EXPECT: sat
+(set-logic ALL)
+(declare-fun x () Int)
+(declare-fun y () Int)
+(assert (< x 0))
+(assert (= (* x x) 16))
+(assert (= x y))
+(assert (> ((_ iand 4) x y) 0))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/5461.  The initial lemma schema was assuming arguments were in bounds.

This also modifies the solver so that we throw logic exceptions when encountering iand or transcendentals.