### PR TITLE
Correct search location for CLN libs

### DIFF
--- a/cmake/FindCLN.cmake
+++ b/cmake/FindCLN.cmake
@@ -64,17 +64,17 @@ if(NOT CLN_FOUND_SYSTEM)
       ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> autoreconf -iv
     COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --enable-shared
             --enable-static --with-pic
-    BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libcln.a
-                     <INSTALL_DIR>/lib/libcln${CMAKE_SHARED_LIBRARY_SUFFIX}
+    BUILD_BYPRODUCTS <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/libcln.a
+                     <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/libcln${CMAKE_SHARED_LIBRARY_SUFFIX}
   )
 
   add_dependencies(CLN-EP GMP)
 
   set(CLN_INCLUDE_DIR "${DEPS_BASE}/include/")
   if(BUILD_SHARED_LIBS)
-    set(CLN_LIBRARIES "${DEPS_BASE}/lib/libcln${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    set(CLN_LIBRARIES "${DEPS_BASE}/${CMAKE_INSTALL_LIBDIR}/libcln${CMAKE_SHARED_LIBRARY_SUFFIX}")
   else()
-    set(CLN_LIBRARIES "${DEPS_BASE}/lib/libcln.a")
+    set(CLN_LIBRARIES "${DEPS_BASE}/${CMAKE_INSTALL_LIBDIR}/libcln.a")
   endif()
 endif()
 


### PR DESCRIPTION
On (e.g.,) openSUSE, the default install path (via CMake) for libraries is `lib64` and not `lib`. However, `FindCLN.cmake` is hard-coded to only search in `lib`.

This PR corrects `FindCLN.cmake` such that the build looks in `${CMAKE_INSTALL_LIBDIR}` instead.

Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>