### PR TITLE
Remove superfluous 'lbsd' for Editline

### DIFF
--- a/cmake/FindEditline.cmake
+++ b/cmake/FindEditline.cmake
@@ -42,7 +42,11 @@ if(Editline_INCLUDE_DIRS)
   unset(CMAKE_REQUIRED_INCLUDES)
 
   if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(Editline_LIBRARIES ${Editline_LIBRARIES} bsd tinfo)
+    find_library(BSD_LIBRARIES NAMES bsd)
+    if (BSD_LIBRARIES)
+      set(Editline_LIBRARIES ${Editline_LIBRARIES} bsd)
+    endif()
+    set(Editline_LIBRARIES ${Editline_LIBRARIES} tinfo)
   endif()
 endif()
 


### PR DESCRIPTION
On some systems (e.g., openSUSE), you can link against `editline` *without* having the BSD compatibility libraries. For example, on my machine, I have `libedit-devel` installed without having `libbsd-devel`, which then leads to:

```
: && /usr/bin/c++ -fPIC -fno-inline -Og -Wall -Wsuggest-override -Wnon-virtual-dtor -Wimplicit-fallthrough -Wshadow -fno-extern-tls-init -Wno-class-memaccess -ggdb3 -g -flto -fno-fat-lto-objects   -shared -Wl,-soname,libmain-test.so -o src/main/libmain-test.so src/main/CMakeFiles/main.dir/command_executor.cpp.o src/main/CMakeFiles/main.dir/interactive_shell.cpp.o src/main/CMakeFiles/main.dir/signal_handlers.cpp.o src/main/CMakeFiles/main.dir/time_limit.cpp.o src/main/CMakeFiles/main.dir/options.cpp.o src/main/CMakeFiles/main-test.dir/driver_unified.cpp.o  -Wl,-rpath,/home/avj/clones/cvc5/master/build/src/parser:/home/avj/clones/cvc5/master/build/src:/home/avj/clones/cvc5/master/build/deps/lib64:/home/avj/clones/cvc5/master/build/deps/lib  src/parser/libcvc5parser.so.1  -ledit  -lbsd  -ltinfo  src/libcvc5.so  deps/lib64/libcln.so  deps/lib/libpolyxx.so  deps/lib/libpoly.so  /usr/lib64/libgmp.so && :
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: cannot find -lbsd
collect2: error: ld returned 1 exit status
```

However, there is no requirement that you need `lbsd` when linking `ledit`.

This PR therefore makes it such that `bsd` is only linked when you're using `editline` if you have it.

Signed-off-by: Andrew V. Teylu <andrew@tey.lu>