### PR TITLE
Simplify formalism of introduced arithmetic skolems

### DIFF
--- a/src/theory/arith/operator_elim.cpp
+++ b/src/theory/arith/operator_elim.cpp
@@ -122,8 +122,8 @@ Node OperatorElim::eliminateOperators(Node node,
       // -1 < toIntSkolem - node[0] <= 0
       // 0 <= node[0] - toIntSkolem < 1
       Node pterm = nm->mkNode(TO_INTEGER, node[0]);
-      Node v = sm->mkPurifySkolem(pterm, "toInt",
-                          "a conversion of a Real term to its Integer part");
+      Node v = sm->mkPurifySkolem(
+          pterm, "toInt", "a conversion of a Real term to its Integer part");
       Node one = nm->mkConstReal(Rational(1));
       Node zero = nm->mkConstReal(Rational(0));
       Node diff = nm->mkNode(SUB, node[0], v);
@@ -335,7 +335,9 @@ Node OperatorElim::eliminateOperators(Node node,
       }
       checkNonLinearLogic(node);
       // eliminate inverse functions here
-      Node var = sm->mkPurifySkolem(node, "tfk",
+      Node var = sm->mkPurifySkolem(
+          node,
+          "tfk",
           "Skolem to eliminate a non-standard transcendental function");
       Node lem;
       if (k == SQRT)

--- a/src/theory/arith/operator_elim.cpp
+++ b/src/theory/arith/operator_elim.cpp
@@ -33,31 +33,6 @@ namespace cvc5 {
 namespace theory {
 namespace arith {
 
-/**
- * Attribute used for constructing unique bound variables that are binders
- * for witness terms below. In other words, this attribute maps nodes to
- * the bound variable of a witness term for eliminating that node.
- *
- * Notice we use the same attribute for most bound variables below, since using
- * a node itself is a sufficient cache key for constructing a bound variable.
- * The exception is to_int / is_int, which share a skolem based on their
- * argument.
- */
-struct ArithWitnessVarAttributeId
-{
-};
-using ArithWitnessVarAttribute = expr::Attribute<ArithWitnessVarAttributeId, Node>;
-/**
- * Similar to above, shared for to_int and is_int. This is used for introducing
- * an integer bound variable used to construct the witness term for t in the
- * contexts (to_int t) and (is_int t).
- */
-struct ToIntWitnessVarAttributeId
-{
-};
-using ToIntWitnessVarAttribute
- = expr::Attribute<ToIntWitnessVarAttributeId, Node>;
-
 OperatorElim::OperatorElim(Env& env)
     : EnvObj(env), EagerProofGenerator(d_env.getProofNodeManager())
 {

--- a/src/theory/arith/operator_elim.cpp
+++ b/src/theory/arith/operator_elim.cpp
@@ -154,7 +154,8 @@ Node OperatorElim::eliminateOperators(Node node,
       Node rw = nm->mkNode(k, num, den);
       // we use the purification skolem for div
       Node pterm = nm->mkNode(INTS_DIVISION_TOTAL, node[0], node[1]);
-      Node v = sm->mkPurifySkolem(pterm, "intDiv", "the result of an intdiv-by-k term");
+      Node v = sm->mkPurifySkolem(
+          pterm, "intDiv", "the result of an intdiv-by-k term");
       // make the corresponding lemma
       Node lem;
       Node leqNum = nm->mkNode(LEQ, nm->mkNode(MULT, den, v), num);
@@ -252,7 +253,8 @@ Node OperatorElim::eliminateOperators(Node node,
       }
       checkNonLinearLogic(node);
       Node rw = nm->mkNode(k, num, den);
-      Node v = sm->mkPurifySkolem(rw, "nonlinearDiv", "the result of a non-linear div term");
+      Node v = sm->mkPurifySkolem(
+          rw, "nonlinearDiv", "the result of a non-linear div term");
       Node lem = nm->mkNode(IMPLIES,
                             den.eqNode(nm->mkConstReal(Rational(0))).negate(),
                             nm->mkNode(MULT, den, v).eqNode(num));

--- a/src/theory/arith/operator_elim.cpp
+++ b/src/theory/arith/operator_elim.cpp
@@ -128,10 +128,10 @@ Node OperatorElim::eliminateOperators(Node node,
       Node lem = mkInRange(diff, zero, one);
       Node toIntSkolem =
           mkWitnessSkolem(v,
-                        lem,
-                        "toInt",
-                        "a conversion of a Real term to its Integer part",
-                        lems);
+                          lem,
+                          "toInt",
+                          "a conversion of a Real term to its Integer part",
+                          lems);
       if (k == IS_INTEGER)
       {
         return nm->mkNode(EQUAL, node[0], toIntSkolem);
@@ -223,7 +223,8 @@ Node OperatorElim::eliminateOperators(Node node,
       }
       // we use the purification skolem for div
       Node pterm = nm->mkNode(INTS_DIVISION_TOTAL, node[0], node[1]);
-      Node intVar = mkPurifySkolem(pterm, "intDiv", "the result of an intdiv-by-k term", lems);
+      Node intVar = mkPurifySkolem(
+          pterm, "intDiv", "the result of an intdiv-by-k term", lems);
       if (k == INTS_MODULUS_TOTAL)
       {
         Node nn = nm->mkNode(SUB, num, nm->mkNode(MULT, den, intVar));
@@ -466,10 +467,10 @@ bool OperatorElim::usePartialFunction(SkolemFunId id) const
 }
 
 Node OperatorElim::mkWitnessSkolem(Node v,
-                                 Node pred,
-                                 const std::string& prefix,
-                                 const std::string& comment,
-                                 std::vector<SkolemLemma>& lems)
+                                   Node pred,
+                                   const std::string& prefix,
+                                   const std::string& comment,
+                                   std::vector<SkolemLemma>& lems)
 {
   NodeManager* nm = NodeManager::currentNM();
   SkolemManager* sm = nm->getSkolemManager();
@@ -491,10 +492,10 @@ Node OperatorElim::mkWitnessSkolem(Node v,
 }
 
 Node OperatorElim::mkPurifySkolem(Node t,
-                    Node lem,
-                    const std::string& prefix,
-                    const std::string& comment,
-                    std::vector<SkolemLemma>& lems)
+                                  Node lem,
+                                  const std::string& prefix,
+                                  const std::string& comment,
+                                  std::vector<SkolemLemma>& lems)
 {
   NodeManager* nm = NodeManager::currentNM();
   SkolemManager* sm = nm->getSkolemManager();
@@ -503,8 +504,7 @@ Node OperatorElim::mkPurifySkolem(Node t,
   TrustNode tlem;
   if (d_pnm != nullptr)
   {
-    tlem =
-        mkTrustNode(lem, PfRule::THEORY_PREPROCESS_LEMMA, {}, {lem});
+    tlem = mkTrustNode(lem, PfRule::THEORY_PREPROCESS_LEMMA, {}, {lem});
   }
   else
   {

--- a/src/theory/arith/operator_elim.h
+++ b/src/theory/arith/operator_elim.h
@@ -105,15 +105,6 @@ class OperatorElim : protected EnvObj, public EagerProofGenerator
    */
   Node getArithSkolem(SkolemFunId asi);
   /**
-   * Make the witness term, which creates a witness term based on the skolem
-   * manager with this class as a proof generator.
-   */
-  Node mkWitnessSkolem(Node v,
-                       Node pred,
-                       const std::string& prefix,
-                       const std::string& comment,
-                       std::vector<SkolemLemma>& lems);
-  /**
    * Get the skolem lemma for lem, based on whether we are proof producing.
    * @param lem The lemma that axiomatizing the behavior of k
    * @param k The skolem

--- a/src/theory/arith/operator_elim.h
+++ b/src/theory/arith/operator_elim.h
@@ -109,20 +109,20 @@ class OperatorElim : protected EnvObj, public EagerProofGenerator
    * manager with this class as a proof generator.
    */
   Node mkWitnessSkolem(Node v,
-                     Node pred,
-                     const std::string& prefix,
-                     const std::string& comment,
-                     std::vector<SkolemLemma>& lems);
+                       Node pred,
+                       const std::string& prefix,
+                       const std::string& comment,
+                       std::vector<SkolemLemma>& lems);
   /**
    * Same as above, but makes a purification skolem for t. The lemma lem
    * is what axiomatizes the behavior of t, and is added as a skolem lemma
    * to lems.
    */
   Node mkPurifySkolem(Node t,
-                     Node lem,
-                     const std::string& prefix,
-                     const std::string& comment,
-                     std::vector<SkolemLemma>& lems);
+                      Node lem,
+                      const std::string& prefix,
+                      const std::string& comment,
+                      std::vector<SkolemLemma>& lems);
   /** get arithmetic skolem application
    *
    * By default, this returns the term f( n ), where f is the Skolem function

--- a/src/theory/arith/operator_elim.h
+++ b/src/theory/arith/operator_elim.h
@@ -114,15 +114,12 @@ class OperatorElim : protected EnvObj, public EagerProofGenerator
                        const std::string& comment,
                        std::vector<SkolemLemma>& lems);
   /**
-   * Same as above, but makes a purification skolem for t. The lemma lem
-   * is what axiomatizes the behavior of t, and is added as a skolem lemma
-   * to lems.
+   * Get the skolem lemma for lem, based on whether we are proof producing.
+   * @param lem The lemma that axiomatizing the behavior of k
+   * @param k The skolem
+   * @return the skolem lemma corresponding to lem, annotated with k.
    */
-  Node mkPurifySkolem(Node t,
-                      Node lem,
-                      const std::string& prefix,
-                      const std::string& comment,
-                      std::vector<SkolemLemma>& lems);
+  SkolemLemma mkSkolemLemma(Node lem, Node k);
   /** get arithmetic skolem application
    *
    * By default, this returns the term f( n ), where f is the Skolem function

--- a/src/theory/arith/operator_elim.h
+++ b/src/theory/arith/operator_elim.h
@@ -108,8 +108,18 @@ class OperatorElim : protected EnvObj, public EagerProofGenerator
    * Make the witness term, which creates a witness term based on the skolem
    * manager with this class as a proof generator.
    */
-  Node mkWitnessTerm(Node v,
+  Node mkWitnessSkolem(Node v,
                      Node pred,
+                     const std::string& prefix,
+                     const std::string& comment,
+                     std::vector<SkolemLemma>& lems);
+  /**
+   * Same as above, but makes a purification skolem for t. The lemma lem
+   * is what axiomatizes the behavior of t, and is added as a skolem lemma
+   * to lems.
+   */
+  Node mkPurifySkolem(Node t,
+                     Node lem,
                      const std::string& prefix,
                      const std::string& comment,
                      std::vector<SkolemLemma>& lems);


### PR DESCRIPTION
This ensures that all skolems introduced by arithmetic have concrete terms as witnesses. This avoids introducing witness terms.

This PR is important for ensuring that the "original form" of terms does not contain introduced free variables.  This means that certain features (quantifier elimination, learned literals) are useful to the user.  This was requested by Certora.

This also will improve proof reconstruction for extensions of non-linear arithmetic.
