### PR TITLE
Use witness terms to represent values for large strings in models

### DIFF
--- a/src/options/strings_options.toml
+++ b/src/options/strings_options.toml
@@ -241,3 +241,12 @@ name   = "Strings Theory"
 [[option.mode.NONE]]
   name = "none"
   help = "do not use array-inspired solver for sequence updates"
+
+[[option]]
+  name       = "stringsModelMaxLength"
+  category   = "regular"
+  long       = "strings-model-max-len=N"
+  type       = "uint64_t"
+  default    = "1000"
+  maximum    = "65536"
+  help       = "The maximum size of string values in models"

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -334,7 +334,7 @@ bool TheoryStrings::collectModelInfoType(
     }
     else if (len_value.getConst<Rational>() > String::maxSize())
     {
-      // must throw logic exception if we cannot construct the string
+      // note that we give a warning instead of throwing logic exception if we cannot construct the string, these are then assigned witness terms below
       warning() << "The model was computed to have strings of length "
                 << len_value << ". We only allow strings up to length "
                 << String::maxSize() << std::endl;

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -403,8 +403,17 @@ bool TheoryStrings::collectModelInfoType(
       if (wasOob)
       {
         processed[eqc] = eqc;
-        Trace("strings-model") << "-> length out of bounds" << std::endl;
         Assert(!lenValue.isNull() && lenValue.isConst());
+        // make the abstract value (witness ((x String)) (= (str.len x) lenValue))
+        Node w = utils::mkAbstractStringValueForLength(eqc, lenValue);
+        Trace("strings-model") << "-> length out of bounds, assign abstract " << w << std::endl;
+        if (!m->assertEquality(eqc, w, true))
+        {
+          Unreachable()
+              << "TheoryStrings::collectModelInfoType: Inconsistent abstract equality"
+              << std::endl;
+          return false;
+        }
         continue;
       }
       // ensure we have decided on length value at this point

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -334,7 +334,9 @@ bool TheoryStrings::collectModelInfoType(
     }
     else if (len_value.getConst<Rational>() > String::maxSize())
     {
-      // note that we give a warning instead of throwing logic exception if we cannot construct the string, these are then assigned witness terms below
+      // note that we give a warning instead of throwing logic exception if we
+      // cannot construct the string, these are then assigned witness terms
+      // below
       warning() << "The model was computed to have strings of length "
                 << len_value << ". We only allow strings up to length "
                 << String::maxSize() << std::endl;

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -315,7 +315,8 @@ bool TheoryStrings::collectModelInfoType(
   std::vector< Node > lts_values;
   std::map<std::size_t, Node> values_used;
   std::vector<Node> len_splits;
-  for( size_t i=0, csize = col.size(); i<csize; i++ ) {
+  for (size_t i = 0, csize = col.size(); i < csize; i++)
+  {
     Trace("strings-model") << "Checking length for {" << col[i];
     Trace("strings-model") << " } (length is " << lts[i] << ")" << std::endl;
     Node len_value;
@@ -336,8 +337,8 @@ bool TheoryStrings::collectModelInfoType(
       // must throw logic exception if we cannot construct the string
       std::stringstream ss;
       ss << "The model was computed to have strings of length " << len_value
-          << ". We only allow strings up to length " << String::maxSize();
-      //throw LogicException(ss.str());
+         << ". We only allow strings up to length " << String::maxSize();
+      // throw LogicException(ss.str());
       oobIndices.insert(i);
     }
     else
@@ -368,8 +369,9 @@ bool TheoryStrings::collectModelInfoType(
     conSeq = &d_asolver.getConnectedSequences();
   }
   //step 3 : assign values to equivalence classes that are pure variables
-  for( size_t i=0, csize = col.size(); i<csize; i++ ) {
-    if (oobIndices.find(i)!=oobIndices.end())
+  for (size_t i = 0, csize = col.size(); i < csize; i++)
+  {
+    if (oobIndices.find(i) != oobIndices.end())
     {
       continue;
     }

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -332,14 +332,14 @@ bool TheoryStrings::collectModelInfoType(
     {
       lts_values.push_back(Node::null());
     }
-    else if (len_value.getConst<Rational>() > String::maxSize())
+    else if (len_value.getConst<Rational>() > options().strings.stringsModelMaxLength)
     {
       // note that we give a warning instead of throwing logic exception if we
       // cannot construct the string, these are then assigned witness terms
       // below
       warning() << "The model was computed to have strings of length "
-                << len_value << ". We only allow strings up to length "
-                << String::maxSize() << std::endl;
+                << len_value << ". Based on the current value of option --strings-model-max-len, we only allow strings up to length "
+                << options().strings.stringsModelMaxLength << std::endl;
       oobIndices.insert(i);
       lts_values.push_back(len_value);
     }

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -340,6 +340,7 @@ bool TheoryStrings::collectModelInfoType(
          << ". We only allow strings up to length " << String::maxSize();
       // throw LogicException(ss.str());
       oobIndices.insert(i);
+      lts_values.push_back(Node::null());
     }
     else
     {
@@ -371,10 +372,7 @@ bool TheoryStrings::collectModelInfoType(
   //step 3 : assign values to equivalence classes that are pure variables
   for (size_t i = 0, csize = col.size(); i < csize; i++)
   {
-    if (oobIndices.find(i) != oobIndices.end())
-    {
-      continue;
-    }
+    bool wasOob =  (oobIndices.find(i) != oobIndices.end());
     std::vector< Node > pure_eq;
     Node lenValue = lts_values[i];
     Trace("strings-model") << "Considering (" << col[i].size()
@@ -384,7 +382,7 @@ bool TheoryStrings::collectModelInfoType(
     {
       Trace("strings-model") << "- eqc: " << eqc << std::endl;
       //check if col[i][j] has only variables
-      if (eqc.isConst())
+      if (eqc.isConst() || wasOob)
       {
         processed[eqc] = eqc;
         // Make sure that constants are asserted to the theory model that we

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -335,8 +335,9 @@ bool TheoryStrings::collectModelInfoType(
     else if (len_value.getConst<Rational>() > String::maxSize())
     {
       // must throw logic exception if we cannot construct the string
-      warning() << "The model was computed to have strings of length " << len_value
-         << ". We only allow strings up to length " << String::maxSize() << std::endl;
+      warning() << "The model was computed to have strings of length "
+                << len_value << ". We only allow strings up to length "
+                << String::maxSize() << std::endl;
       oobIndices.insert(i);
       lts_values.push_back(len_value);
     }
@@ -370,7 +371,7 @@ bool TheoryStrings::collectModelInfoType(
   //step 3 : assign values to equivalence classes that are pure variables
   for (size_t i = 0, csize = col.size(); i < csize; i++)
   {
-    bool wasOob =  (oobIndices.find(i) != oobIndices.end());
+    bool wasOob = (oobIndices.find(i) != oobIndices.end());
     std::vector< Node > pure_eq;
     Node lenValue = lts_values[i];
     Trace("strings-model") << "Considering (" << col[i].size()
@@ -389,8 +390,7 @@ bool TheoryStrings::collectModelInfoType(
         // in the term set and, as a result, are skipped when the equality
         // engine is asserted to the theory model.
         m->getEqualityEngine()->addTerm(eqc);
-        Trace("strings-model")
-            << "-> constant" << std::endl;
+        Trace("strings-model") << "-> constant" << std::endl;
         continue;
       }
       NormalForm& nfe = d_csolver.getNormalForm(eqc);
@@ -403,9 +403,8 @@ bool TheoryStrings::collectModelInfoType(
       if (wasOob)
       {
         processed[eqc] = eqc;
-        Trace("strings-model")
-            << "-> length out of bounds" << std::endl;
-        Assert (!lenValue.isNull() && lenValue.isConst());
+        Trace("strings-model") << "-> length out of bounds" << std::endl;
+        Assert(!lenValue.isNull() && lenValue.isConst());
         continue;
       }
       // ensure we have decided on length value at this point

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -404,14 +404,16 @@ bool TheoryStrings::collectModelInfoType(
       {
         processed[eqc] = eqc;
         Assert(!lenValue.isNull() && lenValue.isConst());
-        // make the abstract value (witness ((x String)) (= (str.len x) lenValue))
+        // make the abstract value (witness ((x String)) (= (str.len x)
+        // lenValue))
         Node w = utils::mkAbstractStringValueForLength(eqc, lenValue);
-        Trace("strings-model") << "-> length out of bounds, assign abstract " << w << std::endl;
+        Trace("strings-model")
+            << "-> length out of bounds, assign abstract " << w << std::endl;
         if (!m->assertEquality(eqc, w, true))
         {
-          Unreachable()
-              << "TheoryStrings::collectModelInfoType: Inconsistent abstract equality"
-              << std::endl;
+          Unreachable() << "TheoryStrings::collectModelInfoType: Inconsistent "
+                           "abstract equality"
+                        << std::endl;
           return false;
         }
         continue;

--- a/src/theory/strings/theory_strings_utils.cpp
+++ b/src/theory/strings/theory_strings_utils.cpp
@@ -427,6 +427,7 @@ Node mkAbstractStringValueForLength(Node n, Node len)
   Node v = bvm->mkBoundVar<StringValueForLengthVarAttribute>(
       cacheVal, "s", n.getType());
   Node pred = nm->mkNode(STRING_LENGTH, v).eqNode(len);
+  // return (witness ((v String)) (= (str.len v) len))
   return nm->mkNode(WITNESS, nm->mkNode(BOUND_VAR_LIST, v), pred);
 }
 

--- a/src/theory/strings/theory_strings_utils.cpp
+++ b/src/theory/strings/theory_strings_utils.cpp
@@ -18,8 +18,8 @@
 #include <sstream>
 
 #include "expr/attribute.h"
-#include "expr/skolem_manager.h"
 #include "expr/bound_var_manager.h"
+#include "expr/skolem_manager.h"
 #include "options/strings_options.h"
 #include "theory/quantifiers/fmf/bounded_integers.h"
 #include "theory/rewriter.h"
@@ -410,19 +410,22 @@ Node mkForallInternal(Node bvl, Node body)
 }
 
 /**
- * Mapping to the variable used for binding the witness term for the abstract value below.
+ * Mapping to the variable used for binding the witness term for the abstract
+ * value below.
  */
 struct StringValueForLengthVarAttributeId
 {
 };
-typedef expr::Attribute<StringValueForLengthVarAttributeId, Node> StringValueForLengthVarAttribute;
+typedef expr::Attribute<StringValueForLengthVarAttributeId, Node>
+    StringValueForLengthVarAttribute;
 
 Node mkAbstractStringValueForLength(Node n, Node len)
 {
   NodeManager* nm = NodeManager::currentNM();
   BoundVarManager* bvm = nm->getBoundVarManager();
   Node cacheVal = BoundVarManager::getCacheValue(n, len);
-  Node v = bvm->mkBoundVar<StringValueForLengthVarAttribute>(cacheVal, "s", n.getType());
+  Node v = bvm->mkBoundVar<StringValueForLengthVarAttribute>(
+      cacheVal, "s", n.getType());
   Node pred = nm->mkNode(STRING_LENGTH, v).eqNode(len);
   return nm->mkNode(WITNESS, nm->mkNode(BOUND_VAR_LIST, v), pred);
 }

--- a/src/theory/strings/theory_strings_utils.cpp
+++ b/src/theory/strings/theory_strings_utils.cpp
@@ -19,9 +19,9 @@
 
 #include "expr/attribute.h"
 #include "expr/skolem_manager.h"
+#include "expr/bound_var_manager.h"
 #include "options/strings_options.h"
 #include "theory/quantifiers/fmf/bounded_integers.h"
-#include "theory/quantifiers/quantifiers_attributes.h"
 #include "theory/rewriter.h"
 #include "theory/strings/arith_entail.h"
 #include "theory/strings/strings_entail.h"
@@ -407,6 +407,24 @@ unsigned getLoopMinOccurrences(TNode node)
 Node mkForallInternal(Node bvl, Node body)
 {
   return quantifiers::BoundedIntegers::mkBoundedForall(bvl, body);
+}
+
+/**
+ * Mapping to the variable used for binding the witness term for the abstract value below.
+ */
+struct StringValueForLengthVarAttributeId
+{
+};
+typedef expr::Attribute<StringValueForLengthVarAttributeId, Node> StringValueForLengthVarAttribute;
+
+Node mkAbstractStringValueForLength(Node n, Node len)
+{
+  NodeManager* nm = NodeManager::currentNM();
+  BoundVarManager* bvm = nm->getBoundVarManager();
+  Node cacheVal = BoundVarManager::getCacheValue(n, len);
+  Node v = bvm->mkBoundVar<StringValueForLengthVarAttribute>(cacheVal, "s", n.getType());
+  Node pred = nm->mkNode(STRING_LENGTH, v).eqNode(len);
+  return nm->mkNode(WITNESS, nm->mkNode(BOUND_VAR_LIST, v), pred);
 }
 
 }  // namespace utils

--- a/src/theory/strings/theory_strings_utils.h
+++ b/src/theory/strings/theory_strings_utils.h
@@ -206,7 +206,8 @@ Node mkForallInternal(Node bvl, Node body);
 
 /**
  * Make abstract value for string-like term n whose length is given by len.
- * This is used for constructing models for strings whose lengths are too large to represent in memory.
+ * This is used for constructing models for strings whose lengths are too large
+ * to represent in memory.
  */
 Node mkAbstractStringValueForLength(Node n, Node len);
 

--- a/src/theory/strings/theory_strings_utils.h
+++ b/src/theory/strings/theory_strings_utils.h
@@ -204,6 +204,12 @@ unsigned getLoopMinOccurrences(TNode node);
  */
 Node mkForallInternal(Node bvl, Node body);
 
+/**
+ * Make abstract value for string-like term n whose length is given by len.
+ * This is used for constructing models for strings whose lengths are too large to represent in memory.
+ */
+Node mkAbstractStringValueForLength(Node n, Node len);
+
 }  // namespace utils
 }  // namespace strings
 }  // namespace theory

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -805,8 +805,13 @@ std::string TheoryModel::debugPrintModelEqc() const
 
 bool TheoryModel::isValue(TNode node)
 {
-  return node.isConst() || node.getKind() == Kind::REAL_ALGEBRAIC_NUMBER
-         || node.getKind() == Kind::LAMBDA;
+  if (node.isConst())
+  {
+    return true;
+  }
+  Kind k = node.getKind();
+  return k == kind::REAL_ALGEBRAIC_NUMBER
+         || k == kind::LAMBDA || k == kind::WITNESS;
 }
 
 }  // namespace theory

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -810,8 +810,8 @@ bool TheoryModel::isValue(TNode node)
     return true;
   }
   Kind k = node.getKind();
-  return k == kind::REAL_ALGEBRAIC_NUMBER
-         || k == kind::LAMBDA || k == kind::WITNESS;
+  return k == kind::REAL_ALGEBRAIC_NUMBER || k == kind::LAMBDA
+         || k == kind::WITNESS;
 }
 
 }  // namespace theory

--- a/test/regress/regress0/strings/large-model.smt2
+++ b/test/regress/regress0/strings/large-model.smt2
@@ -1,7 +1,5 @@
-; COMMAND-LINE: --lang=smt2.6 --check-models
-; SCRUBBER: sed -E 's/of length [0-9]+/of length LENGTH/'
-; EXPECT: (error "The model was computed to have strings of length LENGTH. We only allow strings up to length 4294967295")
-; EXIT: 1
+; COMMAND-LINE: -q
+; EXPECT: sat
 (set-logic SLIA)
 (declare-fun x () String)
 (assert (> (str.len x) 100000000000000000000000000000000000000000000000000))


### PR DESCRIPTION
This makes it so that we don't prematurely fail on some Facebook benchmarks.