### PR TITLE
Make model builder robust to multiple value-like terms in the same equivalence class

### DIFF
--- a/src/theory/theory_model_builder.cpp
+++ b/src/theory/theory_model_builder.cpp
@@ -519,7 +519,8 @@ bool TheoryEngineModelBuilder::buildModel(TheoryModel* tm)
         }
         else
         {
-          warning() << "Model values in the same equivalence class " << constRep << " " << n << std::endl;
+          warning() << "Model values in the same equivalence class " << constRep
+                    << " " << n << std::endl;
           if (!constRepBaseModelValue && isBaseValue)
           {
             assignConstRep = true;

--- a/src/theory/theory_model_builder.cpp
+++ b/src/theory/theory_model_builder.cpp
@@ -510,10 +510,12 @@ bool TheoryEngineModelBuilder::buildModel(TheoryModel* tm)
         // higher-order.
         if (tm->isValue(n))
         {
-          // in rare cases, it could be that multiple terms in the same
+          // In rare cases, it could be that multiple terms in the same
           // equivalence class are considered values. We prefer the one that is
-          // a "base" model value (e.g. a constant) here. We throw a debug
-          // failure if there are multiple terms that are considered values.
+          // a "base" model value (e.g. a constant) here. We throw a warning
+          // if there are 2 model values in the same equivalence class, and
+          // a debug failure if there are 2 base values in the same equivalence
+          // class.
           bool assignConstRep = false;
           bool isBaseValue = tm->isBaseModelValue(n);
           if (constRep.isNull())
@@ -524,9 +526,14 @@ bool TheoryEngineModelBuilder::buildModel(TheoryModel* tm)
           {
             warning() << "Model values in the same equivalence class "
                       << constRep << " " << n << std::endl;
-            if (!constRepBaseModelValue && isBaseValue)
+            if (!constRepBaseModelValue)
             {
-              assignConstRep = true;
+              assignConstRep = isBaseValue;
+            }
+            else if (isBaseValue)
+            {
+              Assert(false) << "Base model values in the same equivalence class "
+                        << constRep << " " << n << std::endl;
             }
           }
           if (assignConstRep)

--- a/src/theory/theory_model_builder.cpp
+++ b/src/theory/theory_model_builder.cpp
@@ -500,7 +500,7 @@ bool TheoryEngineModelBuilder::buildModel(TheoryModel* tm)
       addAssignableSubterms(n, tm, assignableCache);
       // model-specific processing of the term
       tm->addTermInternal(n);
-      
+
       // compute whether n is assignable
       if (!isAssignable(n))
       {
@@ -511,9 +511,9 @@ bool TheoryEngineModelBuilder::buildModel(TheoryModel* tm)
         if (tm->isValue(n))
         {
           // in rare cases, it could be that multiple terms in the same
-          // equivalence class are considered values. We prefer the one that is a
-          // "base" model value (e.g. a constant) here. We throw a debug failure
-          // if there are multiple terms that are considered values.
+          // equivalence class are considered values. We prefer the one that is
+          // a "base" model value (e.g. a constant) here. We throw a debug
+          // failure if there are multiple terms that are considered values.
           bool assignConstRep = false;
           bool isBaseValue = tm->isBaseModelValue(n);
           if (constRep.isNull())
@@ -522,8 +522,8 @@ bool TheoryEngineModelBuilder::buildModel(TheoryModel* tm)
           }
           else
           {
-            warning() << "Model values in the same equivalence class " << constRep
-                      << " " << n << std::endl;
+            warning() << "Model values in the same equivalence class "
+                      << constRep << " " << n << std::endl;
             if (!constRepBaseModelValue && isBaseValue)
             {
               assignConstRep = true;
@@ -532,8 +532,8 @@ bool TheoryEngineModelBuilder::buildModel(TheoryModel* tm)
           if (assignConstRep)
           {
             constRep = n;
-            Trace("model-builder")
-                << "    ..ConstRep( " << eqc << " ) = " << constRep << std::endl;
+            Trace("model-builder") << "    ..ConstRep( " << eqc
+                                   << " ) = " << constRep << std::endl;
             constRepBaseModelValue = isBaseValue;
           }
           // if we have a constant representative, nothing else matters

--- a/src/theory/theory_model_builder.cpp
+++ b/src/theory/theory_model_builder.cpp
@@ -532,8 +532,9 @@ bool TheoryEngineModelBuilder::buildModel(TheoryModel* tm)
             }
             else if (isBaseValue)
             {
-              Assert(false) << "Base model values in the same equivalence class "
-                        << constRep << " " << n << std::endl;
+              Assert(false)
+                  << "Base model values in the same equivalence class "
+                  << constRep << " " << n << std::endl;
             }
           }
           if (assignConstRep)

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -2264,6 +2264,8 @@ set(regress_1_tests
   regress1/sep/wand-simp-sat.smt2
   regress1/sep/wand-simp-sat2.smt2
   regress1/sep/wand-simp-unsat.smt2
+	regress1/seq/issue8148-2-const-mv.smt2
+	regress1/seq/issue8148-const-mv.smt2
   regress1/sets/choose.cvc.smt2
   regress1/sets/choose1.smt2
   regress1/sets/choose2.smt2

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -2264,8 +2264,8 @@ set(regress_1_tests
   regress1/sep/wand-simp-sat.smt2
   regress1/sep/wand-simp-sat2.smt2
   regress1/sep/wand-simp-unsat.smt2
-	regress1/seq/issue8148-2-const-mv.smt2
-	regress1/seq/issue8148-const-mv.smt2
+  regress1/seq/issue8148-2-const-mv.smt2
+  regress1/seq/issue8148-const-mv.smt2
   regress1/sets/choose.cvc.smt2
   regress1/sets/choose1.smt2
   regress1/sets/choose2.smt2

--- a/test/regress/regress1/seq/issue8148-2-const-mv.smt2
+++ b/test/regress/regress1/seq/issue8148-2-const-mv.smt2
@@ -1,0 +1,4 @@
+(set-logic ALL)
+(set-info :status sat)
+(assert (forall ((V Int)) (= 0 (seq.nth (seq.unit 0) 1))))
+(check-sat)

--- a/test/regress/regress1/seq/issue8148-2-const-mv.smt2
+++ b/test/regress/regress1/seq/issue8148-2-const-mv.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: --strings-exp -q
+; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)
 (assert (forall ((V Int)) (= 0 (seq.nth (seq.unit 0) 1))))

--- a/test/regress/regress1/seq/issue8148-const-mv.smt2
+++ b/test/regress/regress1/seq/issue8148-const-mv.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: --strings-exp -q
+; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)
 (set-option :re-elim-agg true)

--- a/test/regress/regress1/seq/issue8148-const-mv.smt2
+++ b/test/regress/regress1/seq/issue8148-const-mv.smt2
@@ -1,0 +1,7 @@
+(set-logic ALL)
+(set-info :status sat)
+(set-option :re-elim-agg true)
+(declare-fun e!0 () (Seq Bool))
+(assert (= e!0 seq.empty))
+(assert (seq.nth e!0 0))
+(check-sat)


### PR DESCRIPTION
This changes our policy on handling when two value-like terms are in the same equivalence class. We now give preference to the "base" model value, and either warn or throw a debug exception.

After https://github.com/cvc5/cvc5/commit/f7675b2df9f72ddb7b52dc5d8f3776112a27531b, we can have the situation where e.g. `(seq.nth seq.empty 1)`  is in the same equivalence class as a constant, where  `(seq.nth seq.empty 1)` is considered value-like, despite being unevaluatable.  We now ensure that the constant is taken as the representative of the equivalence class, and not this term.

It also removes assignable terms from consideration when assigning values to equivalence classes.  In particular, `(seq.nth seq.empty 1)` is skipped, so a warning is not even given when the above occurs.

Fixes #8148.