### PR TITLE
Remove approximations infrastructure from model

### DIFF
--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -383,15 +383,6 @@ name   = "SMT Layer"
   name = "none"
   help = "(default) do not print declarations of uninterpreted elements in models."
 
-
-[[option]]
-  name       = "modelWitnessValue"
-  category   = "regular"
-  long       = "model-witness-value"
-  type       = "bool"
-  default    = "false"
-  help       = "in models, use a witness constant for choice functions"
-
 [[option]]
   name       = "foreignTheoryRewrite"
   category   = "regular"

--- a/src/theory/arith/nl/nl_model.cpp
+++ b/src/theory/arith/nl/nl_model.cpp
@@ -1028,7 +1028,6 @@ void NlModel::getModelValueRepair(std::map<Node, Node>& arithModel)
   // recordApproximation method of the model, which overrides the model
   // values for variables that we solved for, using techniques specific to
   // this class.
-  NodeManager* nm = NodeManager::currentNM();
   for (const std::pair<const Node, std::pair<Node, Node>>& cb :
        d_check_model_bounds)
   {

--- a/src/theory/arith/nl/nl_model.cpp
+++ b/src/theory/arith/nl/nl_model.cpp
@@ -1015,8 +1015,7 @@ void NlModel::printModelValue(const char* c, Node n, unsigned prec) const
   }
 }
 
-void NlModel::getModelValueRepair(
-    std::map<Node, Node>& arithModel)
+void NlModel::getModelValueRepair(std::map<Node, Node>& arithModel)
 {
   Trace("nl-model") << "NlModel::getModelValueRepair:" << std::endl;
   // If we extended the model with entries x -> 0 for unconstrained values,
@@ -1038,7 +1037,8 @@ void NlModel::getModelValueRepair(
     Node v = cb.first;
     if (l != u)
     {
-      Trace("nl-model") << v << " is in interval " << l << "..." << u << std::endl;
+      Trace("nl-model") << v << " is in interval " << l << "..." << u
+                        << std::endl;
     }
     else
     {

--- a/src/theory/arith/nl/nl_model.cpp
+++ b/src/theory/arith/nl/nl_model.cpp
@@ -1016,9 +1016,7 @@ void NlModel::printModelValue(const char* c, Node n, unsigned prec) const
 }
 
 void NlModel::getModelValueRepair(
-    std::map<Node, Node>& arithModel,
-    std::map<Node, std::pair<Node, Node>>& approximations,
-    bool witnessToValue)
+    std::map<Node, Node>& arithModel)
 {
   Trace("nl-model") << "NlModel::getModelValueRepair:" << std::endl;
   // If we extended the model with entries x -> 0 for unconstrained values,
@@ -1037,23 +1035,10 @@ void NlModel::getModelValueRepair(
   {
     Node l = cb.second.first;
     Node u = cb.second.second;
-    Node pred;
     Node v = cb.first;
     if (l != u)
     {
-      pred = nm->mkNode(AND, nm->mkNode(GEQ, v, l), nm->mkNode(GEQ, u, v));
-      Trace("nl-model") << v << " approximated as " << pred << std::endl;
-      Node witness;
-      if (witnessToValue)
-      {
-        // witness is the midpoint
-        witness = nm->mkNode(MULT,
-                             nm->mkConst(CONST_RATIONAL, Rational(1, 2)),
-                             nm->mkNode(ADD, l, u));
-        witness = rewrite(witness);
-        Trace("nl-model") << v << " witness is " << witness << std::endl;
-      }
-      approximations[v] = std::pair<Node, Node>(pred, witness);
+      Trace("nl-model") << v << " is in interval " << l << "..." << u << std::endl;
     }
     else
     {

--- a/src/theory/arith/nl/nl_model.h
+++ b/src/theory/arith/nl/nl_model.h
@@ -174,8 +174,7 @@ class NlModel : protected EnvObj
    * The mapping arithModel is updated by this method to map arithmetic terms v
    * to their (exact) value that was computed during checkModel.
    */
-  void getModelValueRepair(
-      std::map<Node, Node>& arithModel);
+  void getModelValueRepair(std::map<Node, Node>& arithModel);
 
  private:
   /** Cache for concrete model values */

--- a/src/theory/arith/nl/nl_model.h
+++ b/src/theory/arith/nl/nl_model.h
@@ -172,15 +172,10 @@ class NlModel : protected EnvObj
    * call to checkModel above.
    *
    * The mapping arithModel is updated by this method to map arithmetic terms v
-   * to their (exact) value that was computed during checkModel; the mapping
-   * approximations is updated to store approximate values in the form of a
-   * pair (P, w), where P is a predicate that describes the possible values of
-   * v and w is a witness point that satisfies this predicate.
+   * to their (exact) value that was computed during checkModel.
    */
   void getModelValueRepair(
-      std::map<Node, Node>& arithModel,
-      std::map<Node, std::pair<Node, Node>>& approximations,
-      bool witnessToValue);
+      std::map<Node, Node>& arithModel);
 
  private:
   /** Cache for concrete model values */

--- a/src/theory/arith/nl/nonlinear_extension.cpp
+++ b/src/theory/arith/nl/nonlinear_extension.cpp
@@ -309,24 +309,6 @@ Node NonlinearExtension::getModelValue(TNode var) const
   return Node::null();
 }
 
-bool NonlinearExtension::assertModel(TheoryModel* tm, TNode var) const
-{
-  if (auto it = d_approximations.find(var); it != d_approximations.end())
-  {
-    const auto& approx = it->second;
-    if (approx.second.isNull())
-    {
-      tm->recordApproximation(var, approx.first);
-    }
-    else
-    {
-      tm->recordApproximation(var, approx.first, approx.second);
-    }
-    return true;
-  }
-  return false;
-}
-
 Result::Sat NonlinearExtension::modelBasedRefinement(const std::set<Node>& termSet)
 {
   ++(d_stats.d_mbrRuns);

--- a/src/theory/arith/nl/nonlinear_extension.cpp
+++ b/src/theory/arith/nl/nonlinear_extension.cpp
@@ -276,37 +276,13 @@ void NonlinearExtension::checkFullEffort(std::map<Node, Node>& arithModel,
   if (res == Result::Sat::SAT)
   {
     Trace("nl-ext") << "interceptModel: do model repair" << std::endl;
-    d_approximations.clear();
     // modify the model values
-    d_model.getModelValueRepair(arithModel,
-                                d_approximations,
-                                options().smt.modelWitnessValue);
-    for (auto& am : arithModel)
-    {
-      Node val = getModelValue(am.first);
-      if (!val.isNull())
-      {
-        am.second = val;
-      }
-    }
+    d_model.getModelValueRepair(arithModel);
   }
   // must post-process model with transcendental solver, to ensure we don't
   // assign values for equivalence classes with transcendental function
   // applications
   d_trSlv.postProcessModel(arithModel, termSet);
-}
-
-Node NonlinearExtension::getModelValue(TNode var) const
-{
-  if (auto it = d_approximations.find(var); it != d_approximations.end())
-  {
-    if (it->second.second.isNull())
-    {
-      return it->second.first;
-    }
-    return Node::null();
-  }
-  return Node::null();
 }
 
 Result::Sat NonlinearExtension::modelBasedRefinement(const std::set<Node>& termSet)

--- a/src/theory/arith/nl/nonlinear_extension.h
+++ b/src/theory/arith/nl/nonlinear_extension.h
@@ -116,10 +116,6 @@ class NonlinearExtension : EnvObj
    * arithmetic term or a witness.
    */
   Node getModelValue(TNode var) const;
-  /**
-   * Assert the model for the given variable to the theory model.
-   */
-  bool assertModel(TheoryModel* tm, TNode var) const;
 
   /** Does this class need a call to check(...) at last call effort? */
   bool hasNlTerms() const { return d_hasNlTerms; }

--- a/src/theory/arith/nl/nonlinear_extension.h
+++ b/src/theory/arith/nl/nonlinear_extension.h
@@ -111,12 +111,6 @@ class NonlinearExtension : EnvObj
   void checkFullEffort(std::map<Node, Node>& arithModel,
                        const std::set<Node>& termSet);
 
-  /**
-   * Retrieve the model value for the given variable. It may be either an
-   * arithmetic term or a witness.
-   */
-  Node getModelValue(TNode var) const;
-
   /** Does this class need a call to check(...) at last call effort? */
   bool hasNlTerms() const { return d_hasNlTerms; }
 
@@ -268,12 +262,6 @@ class NonlinearExtension : EnvObj
 
   /** The strategy for the nonlinear extension. */
   Strategy d_strategy;
-
-  /**
-   * The approximations computed during collectModelInfo. For details, see
-   * NlModel::getModelValueRepair.
-   */
-  std::map<Node, std::pair<Node, Node>> d_approximations;
 }; /* class NonlinearExtension */
 
 }  // namespace nl

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -292,13 +292,6 @@ bool TheoryArith::collectModelValues(TheoryModel* m,
     {
       continue;
     }
-    if (d_nonlinearExtension != nullptr)
-    {
-      if (d_nonlinearExtension->assertModel(m, p.first))
-      {
-        continue;
-      }
-    }
     // maps to constant of comparable type
     Assert(p.first.getType().isComparableTo(p.second.getType()));
     if (m->assertEquality(p.first, p.second, true))

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -14,6 +14,7 @@
  */
 #include "theory/theory_model.h"
 
+#include "expr/attribute.h"
 #include "expr/cardinality_constraint.h"
 #include "expr/node_algorithm.h"
 #include "options/quantifiers_options.h"
@@ -765,15 +766,115 @@ std::string TheoryModel::debugPrintModelEqc() const
   return ss.str();
 }
 
-bool TheoryModel::isValue(TNode node)
+struct IsModelValueTag
 {
-  if (node.isConst())
+};
+struct IsModelValueComputedTag
+{
+};
+/** Attribute true for expressions that are quasi-values */
+using IsModelValueAttr = expr::Attribute<IsModelValueTag, bool>;
+using IsModelValueComputedAttr = expr::Attribute<IsModelValueComputedTag, bool>;
+
+bool TheoryModel::isBaseModelValue(TNode n) const
+{
+  if (n.isConst())
   {
     return true;
   }
-  Kind k = node.getKind();
-  return k == kind::REAL_ALGEBRAIC_NUMBER || k == kind::LAMBDA
-         || k == kind::WITNESS;
+  Kind k = n.getKind();
+  if (k == kind::REAL_ALGEBRAIC_NUMBER || k == kind::LAMBDA
+      || k == kind::WITNESS)
+  {
+    // we are a value if we are one of the above kinds
+    return true;
+  }
+  return false;
+}
+
+bool TheoryModel::isValue(TNode n) const
+{
+  IsModelValueAttr imva;
+  IsModelValueComputedAttr imvca;
+  // The list of nodes we are processing, and the current child index of that
+  // node we are inspecting. This vector always specifies a single path in the
+  // original term n. Notice this index accounts for operators, where the
+  // operator of a term is treated as the first child, and subsequently all
+  // other children are shifted up by one.
+  std::vector<std::pair<TNode, size_t>> visit;
+  // the last computed value of whether a node was a value
+  bool currentReturn = false;
+  visit.emplace_back(n, 0);
+  std::pair<TNode, size_t> v;
+  while (!visit.empty())
+  {
+    v = visit.back();
+    TNode cur = v.first;
+    bool finishedComputing = false;
+    // if we just pushed to the stack, do initial checks
+    if (v.second == 0)
+    {
+      if (cur.getAttribute(imvca))
+      {
+        // already cached
+        visit.pop_back();
+        currentReturn = cur.getAttribute(imva);
+        continue;
+      }
+      if (isBaseModelValue(cur))
+      {
+        finishedComputing = true;
+        currentReturn = true;
+      }
+      else if (cur.getNumChildren() == 0 || rewrite(cur) != cur)
+      {
+        finishedComputing = true;
+        currentReturn = false;
+      }
+    }
+    else if (!currentReturn)
+    {
+      // if the last child was not a value, we are not a value
+      finishedComputing = true;
+    }
+    if (!finishedComputing)
+    {
+      bool hasOperator = cur.hasOperator();
+      size_t nextChildIndex = v.second;
+      if (hasOperator && nextChildIndex > 0)
+      {
+        // if have an operator, we shift the child index we are looking at
+        nextChildIndex--;
+      }
+      if (nextChildIndex == cur.getNumChildren())
+      {
+        // finished, we are a value
+        currentReturn = true;
+      }
+      else
+      {
+        visit.back().second++;
+        if (hasOperator && v.second == 0)
+        {
+          // if we have an operator, process it as the first child
+          visit.emplace_back(cur.getOperator(), 0);
+        }
+        else
+        {
+          Assert(nextChildIndex < cur.getNumChildren());
+          // process the next child, which may be shifted from v.second to
+          // account for the operator
+          visit.emplace_back(cur[nextChildIndex], 0);
+        }
+        continue;
+      }
+    }
+    visit.pop_back();
+    cur.setAttribute(imva, currentReturn);
+    cur.setAttribute(imvca, true);
+  }
+  Assert(n.getAttribute(imvca));
+  return currentReturn;
 }
 
 }  // namespace theory

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -14,7 +14,6 @@
  */
 #include "theory/theory_model.h"
 
-#include "expr/attribute.h"
 #include "expr/cardinality_constraint.h"
 #include "expr/node_algorithm.h"
 #include "options/quantifiers_options.h"
@@ -80,8 +79,6 @@ void TheoryModel::reset(){
   d_modelCache.clear();
   d_sep_heap = Node::null();
   d_sep_nil_eq = Node::null();
-  d_approximations.clear();
-  d_approx_list.clear();
   d_reps.clear();
   d_assignExcSet.clear();
   d_aesMaster.clear();
@@ -108,13 +105,6 @@ bool TheoryModel::getHeapModel(Node& h, Node& neq) const
   h = d_sep_heap;
   neq = d_sep_nil_eq;
   return true;
-}
-
-bool TheoryModel::hasApproximations() const { return !d_approx_list.empty(); }
-
-std::vector<std::pair<Node, Node> > TheoryModel::getApproximations() const
-{
-  return d_approx_list;
 }
 
 std::vector<Node> TheoryModel::getDomainElements(TypeNode tn) const
@@ -276,18 +266,6 @@ Node TheoryModel::getModelValue(TNode n) const
       d_modelCache[n] = ret;
       return ret;
     }
-  }
-  // it might be approximate
-  std::map<Node, Node>::const_iterator ita = d_approximations.find(n);
-  if (ita != d_approximations.end())
-  {
-    // If the value of n is approximate based on predicate P(n), we return
-    // witness z. P(z).
-    Node v = nm->mkBoundVar(n.getType());
-    Node bvl = nm->mkNode(BOUND_VAR_LIST, v);
-    Node answer = nm->mkNode(WITNESS, bvl, ita->second.substitute(n, v));
-    d_modelCache[n] = answer;
-    return answer;
   }
   // must rewrite the term at this point
   ret = rewrite(n);
@@ -588,23 +566,6 @@ bool TheoryModel::hasAssignmentExclusionSets() const
   return !d_assignExcSet.empty();
 }
 
-void TheoryModel::recordApproximation(TNode n, TNode pred)
-{
-  Trace("model-builder-debug")
-      << "Record approximation : " << n << " satisfies the predicate " << pred
-      << std::endl;
-  Assert(d_approximations.find(n) == d_approximations.end());
-  Assert(pred.getType().isBoolean());
-  d_approximations[n] = pred;
-  d_approx_list.push_back(std::pair<Node, Node>(n, pred));
-  // model cache is invalid
-  d_modelCache.clear();
-}
-void TheoryModel::recordApproximation(TNode n, TNode pred, Node witness)
-{
-  Node predDisj = NodeManager::currentNM()->mkNode(OR, n.eqNode(witness), pred);
-  recordApproximation(n, predDisj);
-}
 bool TheoryModel::isUsingModelCore() const { return d_using_model_core; }
 void TheoryModel::setUsingModelCore()
 {
@@ -804,115 +765,15 @@ std::string TheoryModel::debugPrintModelEqc() const
   return ss.str();
 }
 
-struct IsModelValueTag
+bool TheoryModel::isValue(TNode node)
 {
-};
-struct IsModelValueComputedTag
-{
-};
-/** Attribute true for expressions that are quasi-values */
-using IsModelValueAttr = expr::Attribute<IsModelValueTag, bool>;
-using IsModelValueComputedAttr = expr::Attribute<IsModelValueComputedTag, bool>;
-
-bool TheoryModel::isBaseModelValue(TNode n) const
-{
-  if (n.isConst())
+  if (node.isConst())
   {
     return true;
   }
-  Kind k = n.getKind();
-  if (k == kind::REAL_ALGEBRAIC_NUMBER || k == kind::LAMBDA
-      || k == kind::WITNESS)
-  {
-    // we are a value if we are one of the above kinds
-    return true;
-  }
-  return false;
-}
-
-bool TheoryModel::isValue(TNode n) const
-{
-  IsModelValueAttr imva;
-  IsModelValueComputedAttr imvca;
-  // The list of nodes we are processing, and the current child index of that
-  // node we are inspecting. This vector always specifies a single path in the
-  // original term n. Notice this index accounts for operators, where the
-  // operator of a term is treated as the first child, and subsequently all
-  // other children are shifted up by one.
-  std::vector<std::pair<TNode, size_t>> visit;
-  // the last computed value of whether a node was a value
-  bool currentReturn = false;
-  visit.emplace_back(n, 0);
-  std::pair<TNode, size_t> v;
-  while (!visit.empty())
-  {
-    v = visit.back();
-    TNode cur = v.first;
-    bool finishedComputing = false;
-    // if we just pushed to the stack, do initial checks
-    if (v.second == 0)
-    {
-      if (cur.getAttribute(imvca))
-      {
-        // already cached
-        visit.pop_back();
-        currentReturn = cur.getAttribute(imva);
-        continue;
-      }
-      if (isBaseModelValue(cur))
-      {
-        finishedComputing = true;
-        currentReturn = true;
-      }
-      else if (cur.getNumChildren() == 0 || rewrite(cur) != cur)
-      {
-        finishedComputing = true;
-        currentReturn = false;
-      }
-    }
-    else if (!currentReturn)
-    {
-      // if the last child was not a value, we are not a value
-      finishedComputing = true;
-    }
-    if (!finishedComputing)
-    {
-      bool hasOperator = cur.hasOperator();
-      size_t nextChildIndex = v.second;
-      if (hasOperator && nextChildIndex > 0)
-      {
-        // if have an operator, we shift the child index we are looking at
-        nextChildIndex--;
-      }
-      if (nextChildIndex == cur.getNumChildren())
-      {
-        // finished, we are a value
-        currentReturn = true;
-      }
-      else
-      {
-        visit.back().second++;
-        if (hasOperator && v.second == 0)
-        {
-          // if we have an operator, process it as the first child
-          visit.emplace_back(cur.getOperator(), 0);
-        }
-        else
-        {
-          Assert(nextChildIndex < cur.getNumChildren());
-          // process the next child, which may be shifted from v.second to
-          // account for the operator
-          visit.emplace_back(cur[nextChildIndex], 0);
-        }
-        continue;
-      }
-    }
-    visit.pop_back();
-    cur.setAttribute(imva, currentReturn);
-    cur.setAttribute(imvca, true);
-  }
-  Assert(n.getAttribute(imvca));
-  return currentReturn;
+  Kind k = node.getKind();
+  return k == kind::REAL_ALGEBRAIC_NUMBER || k == kind::LAMBDA
+         || k == kind::WITNESS;
 }
 
 }  // namespace theory

--- a/src/theory/theory_model.h
+++ b/src/theory/theory_model.h
@@ -186,35 +186,6 @@ class TheoryModel : protected EnvObj
                                  std::vector<Node>& eset);
   /** have any assignment exclusion sets been created? */
   bool hasAssignmentExclusionSets() const;
-  /** record approximation
-   *
-   * This notifies this model that the value of n was approximated in this
-   * model such that the predicate pred (involving n) holds. For example,
-   * for transcendental functions, we may determine an error bound on the
-   * value of a transcendental function, say c-e <= y <= c+e where
-   * c and e are constants. We call this function with n set to sin( x ) and
-   * pred set to c-e <= sin( x ) <= c+e.
-   *
-   * If recordApproximation is called at least once during the model
-   * construction process, then check-model is not guaranteed to succeed.
-   * However, there are cases where we can establish the input is satisfiable
-   * without constructing an exact model. For example, if x=.77, sin(x)=.7, and
-   * say we have computed c=.7 and e=.01 as an approximation in the above
-   * example, then we may reason that the set of assertions { sin(x)>.6 } is
-   * satisfiable, albiet without establishing an exact (irrational) value for
-   * sin(x).
-   *
-   * This function is simply for bookkeeping, it does not affect the model
-   * construction process.
-   */
-  void recordApproximation(TNode n, TNode pred);
-  /**
-   * Same as above, but with a witness constant. This ensures that the
-   * approximation predicate is of the form (or (= n witness) pred). This
-   * is useful if the user wants to know a possible concrete value in
-   * the range of the predicate.
-   */
-  void recordApproximation(TNode n, TNode pred, Node witness);
   /** set unevaluate/semi-evaluated kind
    *
    * This informs this model how it should interpret applications of terms with
@@ -305,10 +276,6 @@ class TheoryModel : protected EnvObj
   bool getHeapModel(Node& h, Node& neq) const;
   //---------------------------- end separation logic
 
-  /** is the list of approximations non-empty? */
-  bool hasApproximations() const;
-  /** get approximations */
-  std::vector<std::pair<Node, Node> > getApproximations() const;
   /** get domain elements for uninterpreted sort t */
   std::vector<Node> getDomainElements(TypeNode t) const;
   /** get the representative set object */
@@ -374,10 +341,6 @@ class TheoryModel : protected EnvObj
   std::string d_name;
   /** equality engine containing all known equalities/disequalities */
   eq::EqualityEngine* d_equalityEngine;
-  /** approximations (see recordApproximation) */
-  std::map<Node, Node> d_approximations;
-  /** list of all approximations */
-  std::vector<std::pair<Node, Node> > d_approx_list;
   /** a set of kinds that are unevaluated */
   std::unordered_set<Kind, kind::KindHashFunction> d_unevaluated_kinds;
   /** a set of kinds that are semi-evaluated */

--- a/src/theory/theory_model_builder.cpp
+++ b/src/theory/theory_model_builder.cpp
@@ -1124,11 +1124,6 @@ void TheoryEngineModelBuilder::postProcessModel(bool incomplete, TheoryModel* m)
 
 void TheoryEngineModelBuilder::debugCheckModel(TheoryModel* tm)
 {
-  if (tm->hasApproximations())
-  {
-    // models with approximations may fail the assertions below
-    return;
-  }
   eq::EqClassesIterator eqcs_i = eq::EqClassesIterator(tm->d_equalityEngine);
   std::map<Node, Node>::iterator itMap;
   // Check that every term evaluates to its representative in the model

--- a/test/regress/regress1/nl/issue3300-approx-sqrt-witness.smt2
+++ b/test/regress/regress1/nl/issue3300-approx-sqrt-witness.smt2
@@ -1,5 +1,5 @@
 ; SCRUBBER: sed -e 's/((x (_ real_algebraic_number .*/((x (_ real_algebraic_number/'
-; COMMAND-LINE: --produce-models --model-witness-value --no-check-models
+; COMMAND-LINE: --produce-models --no-check-models
 ; REQUIRES: poly
 ; EXPECT: sat
 ; EXPECT: ((x (_ real_algebraic_number


### PR DESCRIPTION
We now allow partial specifications.  Recording approximations is arithmetic specific, and if necessary could be added as a post-processing analysis e.g. during check-model.