### PR TITLE
Consider PI to be a model value

### DIFF
--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -784,7 +784,7 @@ bool TheoryModel::isBaseModelValue(TNode n) const
   }
   Kind k = n.getKind();
   if (k == kind::REAL_ALGEBRAIC_NUMBER || k == kind::LAMBDA
-      || k == kind::WITNESS)
+      || k == kind::WITNESS || k == kind::PI)
   {
     // we are a value if we are one of the above kinds
     return true;

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -792,6 +792,7 @@ set(regress_0_tests
   regress0/nl/nta/issue7938-tf-model.smt2
   regress0/nl/nta/issue8147-unc-model.smt2
   regress0/nl/nta/issue8160-model-purify.smt2
+  regress0/nl/nta/proj-issue460-pi-value.smt2
   regress0/nl/nta/real-pi.smt2
   regress0/nl/nta/sin-sym.smt2
   regress0/nl/nta/sqrt-simple.smt2

--- a/test/regress/regress0/nl/nta/proj-issue460-pi-value.smt2
+++ b/test/regress/regress0/nl/nta/proj-issue460-pi-value.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: -q
+; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)
 (set-option :global-declarations true)

--- a/test/regress/regress0/nl/nta/proj-issue460-pi-value.smt2
+++ b/test/regress/regress0/nl/nta/proj-issue460-pi-value.smt2
@@ -1,0 +1,5 @@
+(set-logic ALL)
+(set-info :status sat)
+(set-option :global-declarations true)
+(set-option :sets-ext true)
+(check-sat-assuming ( (let ((_let0 real.pi))(set.member (- _let0) (set.complement (set.singleton _let0))))))


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5-projects/issues/460.

The special case is necessary due to the node representation of nullary operators, which uses variables internally to represent operators.  The other nullary operators are not model values.