### PR TITLE
Fix special casing for PI in model value

### DIFF
--- a/src/theory/arith/nl/ext_theory_callback.cpp
+++ b/src/theory/arith/nl/ext_theory_callback.cpp
@@ -129,7 +129,7 @@ bool NlExtTheoryCallback::isExtfReduced(
       }
     }
   }
-  return true;
+  return false;
 }
 
 }  // namespace nl

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -784,7 +784,7 @@ bool TheoryModel::isBaseModelValue(TNode n) const
   }
   Kind k = n.getKind();
   if (k == kind::REAL_ALGEBRAIC_NUMBER || k == kind::LAMBDA
-      || k == kind::WITNESS || k == kind::PI)
+      || k == kind::WITNESS)
   {
     // we are a value if we are one of the above kinds
     return true;
@@ -826,8 +826,17 @@ bool TheoryModel::isValue(TNode n) const
         finishedComputing = true;
         currentReturn = true;
       }
-      else if (cur.getNumChildren() == 0 || rewrite(cur) != cur)
+      else if (cur.getNumChildren() == 0)
       {
+        // PI is a (non-base) value. We require it as a special case here
+        // since nullary operators are represented internal as variables.
+        // All other non-constant terms with zero children are not values.
+        finishedComputing = true;
+        currentReturn = (cur.getKind()==kind::PI);
+      }
+      else if (rewrite(cur) != cur)
+      {
+        // non-rewritten terms are never model values
         finishedComputing = true;
         currentReturn = false;
       }

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -832,7 +832,7 @@ bool TheoryModel::isValue(TNode n) const
         // since nullary operators are represented internal as variables.
         // All other non-constant terms with zero children are not values.
         finishedComputing = true;
-        currentReturn = (cur.getKind()==kind::PI);
+        currentReturn = (cur.getKind() == kind::PI);
       }
       else if (rewrite(cur) != cur)
       {

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -792,6 +792,7 @@ set(regress_0_tests
   regress0/nl/nta/issue7938-tf-model.smt2
   regress0/nl/nta/issue8147-unc-model.smt2
   regress0/nl/nta/issue8160-model-purify.smt2
+  regress0/nl/nta/issue8183-tc-pi.smt2
   regress0/nl/nta/proj-issue460-pi-value.smt2
   regress0/nl/nta/real-pi.smt2
   regress0/nl/nta/sin-sym.smt2

--- a/test/regress/regress0/nl/nta/issue8183-tc-pi.smt2
+++ b/test/regress/regress0/nl/nta/issue8183-tc-pi.smt2
@@ -1,0 +1,8 @@
+; COMMAND-LINE: -q
+; EXPECT: sat
+(set-logic ALL)
+(set-info :status sat)
+(declare-fun v () Real)
+(declare-fun a () (Array Real Real))
+(assert (exists ((V Real)) (or (and (= 0 (/ 0 v)) (< 0 (/ 0 v))) (= 1.0 (select (store a (/ (+ 0.0 real.pi) 0.0) 0.0) 0.0)))))
+(check-sat)


### PR DESCRIPTION
PI should be considered a model value but not a "base" model value. This avoid spurious debug assertion failures, which are now treated as warnings.  This makes a difference when another theory e.g. UF says that PI is currently equal to a constant value `c`. Since our lemma schemas are model-based, we may require building a spurious model where PI is c, and refine afterwards.

This also fixes a bug in our extended function rewriting which would mistakenly think that PI was reduced, and hence skip a full effort check if PI was the *only* extended function in the current context.  This was previously causing a final model to be one where PI = 0.0.

Fixes #8183.