### PR TITLE
Fix issue involving dropped purification lemmas for transcendental functions

### DIFF
--- a/src/theory/arith/nl/nonlinear_extension.cpp
+++ b/src/theory/arith/nl/nonlinear_extension.cpp
@@ -301,12 +301,14 @@ Result::Sat NonlinearExtension::modelBasedRefinement(const std::set<Node>& termS
   Trace("nl-ext") << "# false asserts = " << false_asserts.size() << std::endl;
 
   // get the extended terms belonging to this theory
+  std::vector<Node> xtsAll;
+  d_extTheory.getTerms(xtsAll);
   // only consider those that are currently relevant based on the current
   // assertions, i.e. those contained in termSet
   std::vector<Node> xts;
-  for (const Node& x : termSet)
+  for (const Node& x : xtsAll)
   {
-    if (d_extTheory.hasFunctionKind(x.getKind()))
+    if (termSet.find(x) != termSet.end())
     {
       xts.push_back(x);
     }

--- a/src/theory/arith/nl/nonlinear_extension.cpp
+++ b/src/theory/arith/nl/nonlinear_extension.cpp
@@ -301,14 +301,12 @@ Result::Sat NonlinearExtension::modelBasedRefinement(const std::set<Node>& termS
   Trace("nl-ext") << "# false asserts = " << false_asserts.size() << std::endl;
 
   // get the extended terms belonging to this theory
-  std::vector<Node> xtsAll;
-  d_extTheory.getTerms(xtsAll);
   // only consider those that are currently relevant based on the current
   // assertions, i.e. those contained in termSet
   std::vector<Node> xts;
-  for (const Node& x : xtsAll)
+  for (const Node& x : termSet)
   {
-    if (termSet.find(x) != termSet.end())
+    if (d_extTheory.hasFunctionKind(x.getKind()))
     {
       xts.push_back(x);
     }

--- a/src/theory/arith/nl/transcendental/exponential_solver.cpp
+++ b/src/theory/arith/nl/transcendental/exponential_solver.cpp
@@ -44,11 +44,11 @@ ExponentialSolver::ExponentialSolver(Env& env, TranscendentalState* tstate)
 
 ExponentialSolver::~ExponentialSolver() {}
 
-void ExponentialSolver::doPurification(TNode a, TNode new_a, TNode y)
+void ExponentialSolver::doPurification(TNode a, TNode new_a)
 {
   NodeManager* nm = NodeManager::currentNM();
   // do both equalities to ensure that new_a becomes a preregistered term
-  Node lem = nm->mkNode(Kind::AND, a.eqNode(new_a), a[0].eqNode(y));
+  Node lem = nm->mkNode(Kind::AND, a.eqNode(new_a), a[0].eqNode(new_a[0]));
   // note we must do preprocess on this lemma
   Trace("nl-ext-lemma") << "NonlinearExtension::Lemma : purify : " << lem
                         << std::endl;

--- a/src/theory/arith/nl/transcendental/exponential_solver.h
+++ b/src/theory/arith/nl/transcendental/exponential_solver.h
@@ -49,9 +49,9 @@ class ExponentialSolver : protected EnvObj
 
   /**
    * Ensures that new_a is properly registered as a term where new_a is the
-   * purified version of a, y being the new skolem used for purification.
+   * purified version of a, new_a[0] being the new skolem used for purification.
    */
-  void doPurification(TNode a, TNode new_a, TNode y);
+  void doPurification(TNode a, TNode new_a);
 
   /**
    * check initial refine

--- a/src/theory/arith/nl/transcendental/sine_solver.cpp
+++ b/src/theory/arith/nl/transcendental/sine_solver.cpp
@@ -158,8 +158,9 @@ void SineSolver::doReductions()
   }
 }
 
-void SineSolver::doPhaseShift(TNode a, TNode new_a, TNode y)
+void SineSolver::doPhaseShift(TNode a, TNode new_a)
 {
+  TNode y = new_a[0];
   NodeManager* nm = NodeManager::currentNM();
   SkolemManager* sm = nm->getSkolemManager();
   Assert(a.getKind() == Kind::SINE);

--- a/src/theory/arith/nl/transcendental/sine_solver.h
+++ b/src/theory/arith/nl/transcendental/sine_solver.h
@@ -60,9 +60,9 @@ class SineSolver : protected EnvObj
   void doReductions();
   /**
    * Introduces new_a as purified version of a which is also shifted to the main
-   * phase (from -pi to pi). y is the new skolem used for purification.
+   * phase (from -pi to pi). new_a[0] is the new skolem used for purification.
    */
-  void doPhaseShift(TNode a, TNode new_a, TNode y);
+  void doPhaseShift(TNode a, TNode new_a);
 
   /**
    * check initial refine

--- a/src/theory/arith/nl/transcendental/transcendental_solver.cpp
+++ b/src/theory/arith/nl/transcendental/transcendental_solver.cpp
@@ -80,7 +80,7 @@ void TranscendentalSolver::initLastCall(const std::vector<Node>& xts)
         SkolemFunId::TRANSCENDENTAL_PURIFY_ARG, nm->realType(), a);
     Node new_a = nm->mkNode(k, y);
     // should not have processed this already
-    Assert(d_tstate.d_trPurify.find(a) == d_tstate.d_trPurify.end() || d_tstate.d_trPurify[a]==new_a);
+    Assert(d_tstate.d_trPurify.find(a) == d_tstate.d_trPurify.end() || d_tstate.d_trPurify[a].get()==new_a);
     d_tstate.d_trPurify[a] = new_a;
     d_tstate.d_trPurify[new_a] = new_a;
     d_tstate.d_trPurifies[new_a] = a;

--- a/src/theory/arith/nl/transcendental/transcendental_solver.cpp
+++ b/src/theory/arith/nl/transcendental/transcendental_solver.cpp
@@ -74,15 +74,13 @@ void TranscendentalSolver::initLastCall(const std::vector<Node>& xts)
   SkolemManager* sm = nm->getSkolemManager();
   for (const Node& a : needsMaster)
   {
-    // should not have processed this already
-    Assert(d_tstate.d_trPurify.find(a) == d_tstate.d_trPurify.end());
     Kind k = a.getKind();
     Assert(k == Kind::SINE || k == Kind::EXPONENTIAL);
     Node y = sm->mkSkolemFunction(
         SkolemFunId::TRANSCENDENTAL_PURIFY_ARG, nm->realType(), a);
     Node new_a = nm->mkNode(k, y);
-    Assert(d_tstate.d_trPurify.find(new_a) == d_tstate.d_trPurify.end());
-    Assert(d_tstate.d_trPurifies.find(new_a) == d_tstate.d_trPurifies.end());
+    // should not have processed this already
+    Assert(d_tstate.d_trPurify.find(a) == d_tstate.d_trPurify.end() || d_tstate.d_trPurify[a]==new_a);
     d_tstate.d_trPurify[a] = new_a;
     d_tstate.d_trPurify[new_a] = new_a;
     d_tstate.d_trPurifies[new_a] = a;

--- a/src/theory/arith/nl/transcendental/transcendental_solver.cpp
+++ b/src/theory/arith/nl/transcendental/transcendental_solver.cpp
@@ -74,6 +74,11 @@ void TranscendentalSolver::initLastCall(const std::vector<Node>& xts)
     Kind k = a.getKind();
     Assert(k == Kind::SINE || k == Kind::EXPONENTIAL);
     Node new_a = d_tstate.getPurifiedForm(a);
+    // Check if the transcental function application is equal to its purified
+    // form, if so, we already processed the lemma. In rare cases, note that
+    // we may require sending a lemma here even if the purified form above had
+    // already been allocated, e.g. in the case that the purification lemma
+    // below was dropped.
     if (d_astate.areEqual(a, new_a))
     {
       // already processed

--- a/src/theory/arith/nl/transcendental/transcendental_state.cpp
+++ b/src/theory/arith/nl/transcendental/transcendental_state.cpp
@@ -91,6 +91,10 @@ void TranscendentalState::init(const std::vector<Node>& xts,
     if (itp != d_trPurify.end())
     {
       consider = itp->second == a;
+      if (std::find(xts.begin(), xts.end(), itp->second)==xts.end())
+      {
+        needsPurify.push_back(a);
+      }
     }
     else
     {

--- a/src/theory/arith/nl/transcendental/transcendental_state.cpp
+++ b/src/theory/arith/nl/transcendental/transcendental_state.cpp
@@ -15,13 +15,13 @@
 
 #include "theory/arith/nl/transcendental/transcendental_state.h"
 
+#include "expr/skolem_manager.h"
 #include "proof/proof.h"
 #include "theory/arith/arith_utilities.h"
 #include "theory/arith/inference_manager.h"
 #include "theory/arith/nl/nl_model.h"
 #include "theory/arith/nl/transcendental/taylor_generator.h"
 #include "theory/rewriter.h"
-#include "expr/skolem_manager.h"
 
 using namespace cvc5::kind;
 
@@ -460,7 +460,7 @@ Node TranscendentalState::getPurifiedForm(TNode n)
   NodeManager* nm = NodeManager::currentNM();
   SkolemManager* sm = nm->getSkolemManager();
   NodeMap::const_iterator it = d_trPurify.find(n);
-  if (it!=d_trPurify.end())
+  if (it != d_trPurify.end())
   {
     return it->second;
   }

--- a/src/theory/arith/nl/transcendental/transcendental_state.cpp
+++ b/src/theory/arith/nl/transcendental/transcendental_state.cpp
@@ -21,6 +21,7 @@
 #include "theory/arith/nl/nl_model.h"
 #include "theory/arith/nl/transcendental/taylor_generator.h"
 #include "theory/rewriter.h"
+#include "expr/skolem_manager.h"
 
 using namespace cvc5::kind;
 
@@ -91,10 +92,6 @@ void TranscendentalState::init(const std::vector<Node>& xts,
     if (itp != d_trPurify.end())
     {
       consider = itp->second == a;
-      if (std::find(xts.begin(), xts.end(), itp->second)==xts.end())
-      {
-        needsPurify.push_back(a);
-      }
     }
     else
     {
@@ -114,17 +111,17 @@ void TranscendentalState::init(const std::vector<Node>& xts,
           }
         }
       }
-      if (!consider)
-      {
-        // must assign a purified term
-        needsPurify.push_back(a);
-      }
-      else
+      if (consider)
       {
         // assume own purified
         d_trPurify[a] = a;
         d_trPurifies[a] = a;
       }
+    }
+    if (!consider)
+    {
+      // must assign a purified term
+      needsPurify.push_back(a);
     }
     if (ak == Kind::EXPONENTIAL || ak == Kind::SINE)
     {
@@ -456,6 +453,27 @@ void TranscendentalState::doSecantLemmas(const std::pair<Node, Node>& bounds,
 bool TranscendentalState::isPurified(TNode n) const
 {
   return d_trPurifies.find(n) != d_trPurifies.end();
+}
+
+Node TranscendentalState::getPurifiedForm(TNode n)
+{
+  NodeManager* nm = NodeManager::currentNM();
+  SkolemManager* sm = nm->getSkolemManager();
+  NodeMap::const_iterator it = d_trPurify.find(n);
+  if (it!=d_trPurify.end())
+  {
+    return it->second;
+  }
+  Kind k = n.getKind();
+  Assert(k == Kind::SINE || k == Kind::EXPONENTIAL);
+  Node y = sm->mkSkolemFunction(
+      SkolemFunId::TRANSCENDENTAL_PURIFY_ARG, nm->realType(), n);
+  Node new_n = nm->mkNode(k, y);
+  d_trPurify[n] = new_n;
+  d_trPurify[new_n] = new_n;
+  d_trPurifies[new_n] = n;
+  d_trPurifyVars.insert(y);
+  return new_n;
 }
 
 bool TranscendentalState::addModelBoundForPurifyTerm(TNode n, TNode l, TNode u)

--- a/src/theory/arith/nl/transcendental/transcendental_state.h
+++ b/src/theory/arith/nl/transcendental/transcendental_state.h
@@ -167,6 +167,8 @@ class TranscendentalState : protected EnvObj
    * Is term t purified? (See d_trPurify below).
    */
   bool isPurified(TNode n) const;
+  /** get the purified form of node n */
+  Node getPurifiedForm(TNode n);
   /**
    * Add bound for n, and for what (if anything) it purifies
    */

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -772,8 +772,6 @@ set(regress_0_tests
   regress0/nl/issue3971.smt2
   regress0/nl/issue3991.smt2
   regress0/nl/issue4007-rint-uf.smt2
-  regress0/nl/issue4693-inc-purify.smt2
-  regress0/nl/issue4693-5-inc-purify.smt2
   regress0/nl/issue5534-no-assertions.smt2
   regress0/nl/issue5726-downpolys.smt2
   regress0/nl/issue5726-sqfactor.smt2
@@ -792,6 +790,8 @@ set(regress_0_tests
   regress0/nl/nta/exp-n0.5-ub.smt2
   regress0/nl/nta/exp-neg2-unsat-unsound.smt2
   regress0/nl/nta/exp1-ub.smt2
+  regress0/nl/nta/issue4693-inc-purify.smt2
+  regress0/nl/nta/issue4693-5-inc-purify.smt2
   regress0/nl/nta/issue7938-tf-model.smt2
   regress0/nl/nta/issue8147-unc-model.smt2
   regress0/nl/nta/issue8160-model-purify.smt2

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -772,6 +772,8 @@ set(regress_0_tests
   regress0/nl/issue3971.smt2
   regress0/nl/issue3991.smt2
   regress0/nl/issue4007-rint-uf.smt2
+  regress0/nl/issue4693-inc-purify.smt2
+  regress0/nl/issue4693-5-inc-purify.smt2
   regress0/nl/issue5534-no-assertions.smt2
   regress0/nl/issue5726-downpolys.smt2
   regress0/nl/issue5726-sqfactor.smt2

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -791,6 +791,7 @@ set(regress_0_tests
   regress0/nl/nta/exp-neg2-unsat-unsound.smt2
   regress0/nl/nta/exp1-ub.smt2
   regress0/nl/nta/issue4693-inc-purify.smt2
+  regress0/nl/nta/issue4693-4-inc-purify-sat.smt2
   regress0/nl/nta/issue4693-5-inc-purify.smt2
   regress0/nl/nta/issue7938-tf-model.smt2
   regress0/nl/nta/issue8147-unc-model.smt2

--- a/test/regress/regress0/nl/nta/issue4693-4-inc-purify-sat.smt2
+++ b/test/regress/regress0/nl/nta/issue4693-4-inc-purify-sat.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -i -q
+; COMMAND-LINE: -i -q --no-debug-check-models
 ; EXPECT: sat
 ; EXPECT: sat
 (set-logic ALL)

--- a/test/regress/regress0/nl/nta/issue4693-4-inc-purify-sat.smt2
+++ b/test/regress/regress0/nl/nta/issue4693-4-inc-purify-sat.smt2
@@ -1,0 +1,15 @@
+; COMMAND-LINE: -i -q
+; EXPECT: sat
+; EXPECT: sat
+(set-logic ALL)
+(declare-const v0 Bool)
+(declare-const v7 Bool)
+(declare-const v12 Bool)
+(declare-const r11 Real)
+(declare-const bv_17-0 (_ BitVec 17))
+(declare-const r14 Real)
+(assert (xor (>= 98766.0 (cos r11) r14) v12 (= #x1e #x1e #x1e) v0 (= (concat (bvxor (_ bv860 10) (_ bv860 10) (_ bv860 10)) bv_17-0) (concat (bvxor (_ bv860 10) (_ bv860 10) (_ bv860 10)) bv_17-0) (concat (bvxor (_ bv860 10) (_ bv860 10) (_ bv860 10)) bv_17-0)) v7))
+(push 1)
+(check-sat)
+(pop 1)
+(check-sat)

--- a/test/regress/regress0/nl/nta/issue4693-5-inc-purify.smt2
+++ b/test/regress/regress0/nl/nta/issue4693-5-inc-purify.smt2
@@ -1,0 +1,4 @@
+(set-logic ALL)
+(set-info :status unsat)
+(assert (forall ((t Real)) (= 0 (/ t (cos 1.0)))))
+(check-sat)

--- a/test/regress/regress0/nl/nta/issue4693-5-inc-purify.smt2
+++ b/test/regress/regress0/nl/nta/issue4693-5-inc-purify.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: -q
+; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)
 (assert (forall ((t Real)) (= 0 (/ t (cos 1.0)))))

--- a/test/regress/regress0/nl/nta/issue4693-inc-purify.smt2
+++ b/test/regress/regress0/nl/nta/issue4693-inc-purify.smt2
@@ -1,0 +1,10 @@
+; COMMAND-LINE: -i
+; EXPECT: unsat
+; EXPECT: unsat
+(set-logic QF_NRAT)
+(declare-const r0 Real)
+(assert (! (>= (sin 97111.0) r0 r0 r0 97111.0) :named IP_3))
+(push 1)
+(check-sat)
+(pop 1)
+(check-sat)

--- a/test/regress/regress0/nl/nta/issue4693-inc-purify.smt2
+++ b/test/regress/regress0/nl/nta/issue4693-inc-purify.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -i
+; COMMAND-LINE: -i -q
 ; EXPECT: unsat
 ; EXPECT: unsat
 (set-logic QF_NRAT)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/4693.
Fixes https://github.com/cvc5/cvc5/issues/8181 (which now times out).

The issue was caused by purification lemmas being dropped, often in incremental mode.  This meant that we were replacing sin(t) by sin(k) when checking models, but not having any information about sin(k).

We now are more robust and send the purification lemmas for transcendental functions based on checking whether it is necessary to do so.