### PR TITLE
Improve error message when not using strings-exp

### DIFF
--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1272,7 +1272,7 @@ std::string Smt2Printer::smtKindString(Kind k, Variant v)
 std::string Smt2Printer::smtKindStringOf(const Node& n, Variant v)
 {
   Kind k = n.getKind();
-  if (n.getNumChildren()>0 && n[0].getType().isSequence())
+  if (n.getNumChildren() > 0 && n[0].getType().isSequence())
   {
     // this method parallels api::Term::getKind
     switch (k)

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1269,6 +1269,35 @@ std::string Smt2Printer::smtKindString(Kind k, Variant v)
   return kind::kindToString(k);
 }
 
+std::string smtKindStringOf(const Node& n, Variant v = smt2_6_variant)
+{
+  Kind k = n.getKind();
+  if (n.getNumChildren()>0 && n[0].getType().isSequence())
+  {
+    // this method parallels api::Term::getKind
+    switch (k)
+    {
+      case STRING_CONCAT: return "seq.concat";
+      case STRING_LENGTH: return "seq.len";
+      case STRING_SUBSTR: return "seq.extract";
+      case STRING_UPDATE: return "seq.update";
+      case STRING_CHARAT: return "seq.at";
+      case STRING_CONTAINS: return "seq.contains";
+      case STRING_INDEXOF: return "seq.indexof";
+      case STRING_REPLACE: return "seq.replace";
+      case STRING_REPLACE_ALL: return "seq.replace_all";
+      case STRING_REV: return "seq.rev";
+      case STRING_PREFIX: return "seq.prefixof";
+      case STRING_SUFFIX: return "seq.suffixof";
+      default:
+        // fall through to conversion below
+        break;
+    }
+  }
+  // by default
+  return smtKindString(k, v);
+}
+
 void Smt2Printer::toStreamType(std::ostream& out, TypeNode tn) const
 {
   // we currently must call TypeNode::toStream here.

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -953,7 +953,7 @@ void Smt2Printer::toStream(std::ostream& out,
       if(forceBinary && i < n.getNumChildren() - 1) {
         // not going to work properly for parameterized kinds!
         Assert(n.getMetaKind() != kind::metakind::PARAMETERIZED);
-        out << " (" << smtKindString(n.getKind(), d_variant) << ' ';
+        out << " (" << smtKindStringOf(n, d_variant) << ' ';
         parens << ')';
         ++c;
       } else {
@@ -1269,7 +1269,7 @@ std::string Smt2Printer::smtKindString(Kind k, Variant v)
   return kind::kindToString(k);
 }
 
-std::string Smt2Printer::smtKindStringOf(const Node& n, Variant v = smt2_6_variant)
+std::string Smt2Printer::smtKindStringOf(const Node& n, Variant v)
 {
   Kind k = n.getKind();
   if (n.getNumChildren()>0 && n[0].getType().isSequence())

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1277,18 +1277,18 @@ std::string smtKindStringOf(const Node& n, Variant v = smt2_6_variant)
     // this method parallels api::Term::getKind
     switch (k)
     {
-      case STRING_CONCAT: return "seq.concat";
-      case STRING_LENGTH: return "seq.len";
-      case STRING_SUBSTR: return "seq.extract";
-      case STRING_UPDATE: return "seq.update";
-      case STRING_CHARAT: return "seq.at";
-      case STRING_CONTAINS: return "seq.contains";
-      case STRING_INDEXOF: return "seq.indexof";
-      case STRING_REPLACE: return "seq.replace";
-      case STRING_REPLACE_ALL: return "seq.replace_all";
-      case STRING_REV: return "seq.rev";
-      case STRING_PREFIX: return "seq.prefixof";
-      case STRING_SUFFIX: return "seq.suffixof";
+      case kind::STRING_CONCAT: return "seq.concat";
+      case kind::STRING_LENGTH: return "seq.len";
+      case kind::STRING_SUBSTR: return "seq.extract";
+      case kind::STRING_UPDATE: return "seq.update";
+      case kind::STRING_CHARAT: return "seq.at";
+      case kind::STRING_CONTAINS: return "seq.contains";
+      case kind::STRING_INDEXOF: return "seq.indexof";
+      case kind::STRING_REPLACE: return "seq.replace";
+      case kind::STRING_REPLACE_ALL: return "seq.replace_all";
+      case kind::STRING_REV: return "seq.rev";
+      case kind::STRING_PREFIX: return "seq.prefixof";
+      case kind::STRING_SUFFIX: return "seq.suffixof";
       default:
         // fall through to conversion below
         break;

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1269,7 +1269,7 @@ std::string Smt2Printer::smtKindString(Kind k, Variant v)
   return kind::kindToString(k);
 }
 
-std::string smtKindStringOf(const Node& n, Variant v = smt2_6_variant)
+std::string Smt2Printer::smtKindStringOf(const Node& n, Variant v = smt2_6_variant)
 {
   Kind k = n.getKind();
   if (n.getNumChildren()>0 && n[0].getType().isSequence())

--- a/src/printer/smt2/smt2_printer.h
+++ b/src/printer/smt2/smt2_printer.h
@@ -257,6 +257,11 @@ class Smt2Printer : public cvc5::Printer
    */
   static std::string smtKindString(Kind k, Variant v = smt2_6_variant);
   /**
+   * Same as above, but also takes into account the type of the node, which
+   * makes a difference for printing sequences.
+   */
+  static std::string smtKindStringOf(const Node& n, Variant v = smt2_6_variant);
+  /**
    * Get the string corresponding to the sygus datatype t printed as a grammar.
    */
   static std::string sygusGrammarString(const TypeNode& t);

--- a/src/theory/strings/term_registry.cpp
+++ b/src/theory/strings/term_registry.cpp
@@ -18,6 +18,7 @@
 #include "expr/attribute.h"
 #include "options/smt_options.h"
 #include "options/strings_options.h"
+#include "printer/smt2/smt2_printer.h"
 #include "smt/logic_exception.h"
 #include "theory/rewriter.h"
 #include "theory/strings/inference_manager.h"
@@ -26,7 +27,6 @@
 #include "theory/theory.h"
 #include "util/rational.h"
 #include "util/string.h"
-#include "printer/smt2/smt2_printer.h"
 
 using namespace std;
 using namespace cvc5::context;

--- a/src/theory/strings/term_registry.cpp
+++ b/src/theory/strings/term_registry.cpp
@@ -26,6 +26,7 @@
 #include "theory/theory.h"
 #include "util/rational.h"
 #include "util/string.h"
+#include "printer/smt2/smt2_printer.h"
 
 using namespace std;
 using namespace cvc5::context;

--- a/src/theory/strings/term_registry.cpp
+++ b/src/theory/strings/term_registry.cpp
@@ -162,7 +162,7 @@ void TermRegistry::preRegisterTerm(TNode n)
         || k == STRING_UPDATE)
     {
       std::stringstream ss;
-      ss << "Term of kind " << k
+      ss << "Term of kind " << printer::smt2::Smt2Printer::smtKindStringOf(n)
          << " not supported in default mode, try --strings-exp";
       throw LogicException(ss.str());
     }

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1170,6 +1170,7 @@ set(regress_0_tests
   regress0/seq/array/nth-concat.smt2
   regress0/seq/array/update-fallback.smt2
   regress0/seq/array/update-word-eq.smt2
+  regress0/seq/issue6005-no-strings-exp.smt2
   regress0/seq/seq-2var.smt2
   regress0/seq/seq-ex1.smt2
   regress0/seq/seq-ex2.smt2

--- a/test/regress/regress0/seq/issue6005-no-strings-exp.smt2
+++ b/test/regress/regress0/seq/issue6005-no-strings-exp.smt2
@@ -1,0 +1,6 @@
+; EXPECT: (error "Term of kind seq.extract not supported in default mode, try --strings-exp")
+; EXIT: 1
+(set-logic ALL)
+(declare-fun x () (Seq Int))
+(assert (not (= x (seq.extract x 4 7))))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/6005.

Also improves smt2 printing of sequences so that we print the compliant kinds, which is work towards https://github.com/cvc5/cvc5-wishues/issues/106.