### PR TITLE
Add regression for fixed issue

### DIFF
--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1324,6 +1324,7 @@ set(regress_0_tests
   regress0/strings/issue5745-eager-pp.smt2
   regress0/strings/issue5767-eager-pp.smt2
   regress0/strings/issue5771-eager-pp.smt2
+  regress0/strings/issue5815-ndet-string-ent.smt2
   regress0/strings/issue5816-re-kind.smt2
   regress0/strings/issue5915-repl-ctn-rewrite.smt2
   regress0/strings/issue6203-3-unfold-trivial-true.smt2

--- a/test/regress/regress0/strings/issue5815-ndet-string-ent.smt2
+++ b/test/regress/regress0/strings/issue5815-ndet-string-ent.smt2
@@ -1,0 +1,7 @@
+(set-logic ALL)
+(set-info :status sat)
+(declare-fun a () String)
+(assert (= (str.substr (str.substr a (+ (+ 1 0) 1)
+    (- (str.len (str.substr (str.substr (str.substr a 1 (- (+ (str.len a) 1) 1)) 1 (- (+ 1 (+ 1 1)) 1)) 
+    1 (- (str.len a) 1))) 1)) 0 0) a))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/5815.

This adds the regression, in theory I still think it is possible for the assertion to fail, but I don't think it is worth pursuing right now.