### PR TITLE
Rerun failed tests in CI

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -20,7 +20,10 @@ runs:
       shell: bash
       run: |
         make -j${{ env.num_proc }} build-tests
-        ctest -j${{ env.num_proc }} --output-on-failure -LE regress[${{ inputs.regressions-exclude }}]
+        if ! ctest -j${{ env.num_proc }} --output-on-failure -LE regress[${{ inputs.regressions-exclude }}]
+        then
+          ctest --output-on-failure --rerun-failed
+        fi
       env:
         CVC5_REGRESSION_ARGS: --no-early-exit
         RUN_REGRESSION_ARGS: ${{ inputs.regressions-args }}

--- a/test/regress/regress0/wiki.21.cvc.smt2
+++ b/test/regress/regress0/wiki.21.cvc.smt2
@@ -1,4 +1,5 @@
 ; EXPECT: unsat
+; EXPECT: blub
 (set-logic ALL)
 (set-option :incremental false)
 (declare-fun a () Bool)

--- a/test/regress/regress0/wiki.21.cvc.smt2
+++ b/test/regress/regress0/wiki.21.cvc.smt2
@@ -1,5 +1,4 @@
 ; EXPECT: unsat
-; EXPECT: blub
 (set-logic ALL)
 (set-option :incremental false)
 (declare-fun a () Bool)


### PR DESCRIPTION
This PR makes our CI rerun failed tests to have the error output at the bottom of the log. This simplifies retrieving the errors from CI logs.