### PR TITLE
Make one CI job not use libpoly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           - name: ubuntu:production-clang
             os: ubuntu-18.04
             env: CC=clang CXX=clang++
-            config: production --auto-download
+            config: production --auto-download --no-poly
             cache-key: productionclang
             check-examples: true
             exclude_regress: 3-4

--- a/test/regress/regress0/nl/issue8226-ran-refinement.smt2
+++ b/test/regress/regress0/nl/issue8226-ran-refinement.smt2
@@ -1,4 +1,5 @@
 ;; needs --check-models, as --debug-check-models does not trigger the issue
+; REQUIRES: poly
 ; COMMAND-LINE: --check-models
 ; EXPECT: sat
 (set-logic QF_NRA)


### PR DESCRIPTION
This PR fixes a regression that was missing the `REQUIRES: poly` annotation. To avoid these issues in the future, we add `--no-poly` to one of the CI jobs.