### PR TITLE
[CI] Make building static/shared configurable

### DIFF
--- a/.github/actions/configure-and-build/action.yml
+++ b/.github/actions/configure-and-build/action.yml
@@ -7,8 +7,10 @@ inputs:
     default: ""
   build-shared:
     default: true
+    type: boolean
   build-static:
     default: true
+    type: boolean
 outputs:
   shared-build-dir:
     description: build directory of the shared build
@@ -21,10 +23,12 @@ runs:
   steps:
     - name: Shared build
       id: shared-build
+      # Boolean inputs are actually strings:
+      # https://github.com/actions/runner/issues/1483
+      if: inputs.build-shared == '' || inputs.build-shared == 'true'
       shell: bash
       run: |
         echo "::group::Shared build"
-        if [[ "${{ inputs.build-shared }}" != "true" ]]; then exit 0; fi
         ${{ inputs.configure-env }} ./configure.sh ${{ inputs.configure-config }} \
           --prefix=$(pwd)/build-shared/install --werror --name=build-shared
         
@@ -39,10 +43,12 @@ runs:
 
     - name: Static build
       id: static-build
+      # Boolean inputs are actually strings:
+      # https://github.com/actions/runner/issues/1483
+      if: inputs.build-static == '' || inputs.build-static == 'true'
       shell: bash
       run: |
         echo "::group::Static build"
-        if [[ "${{ inputs.build-static }}" != "true" ]]; then exit 0; fi
         ${{ inputs.configure-env }} ./configure.sh ${{ inputs.configure-config }} \
           --prefix=$(pwd)/build-static/install --werror --static --name=build-static --no-java-bindings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
       with:
         configure-env: ${{ matrix.env }}
         configure-config: ${{ matrix.config }}
+        build-shared: ${{ matrix.build-shared }}
+        build-static: ${{ matrix.build-static }}
 
     - name: ccache Statistics
       run: ccache -s


### PR DESCRIPTION
This commit changes our CI workflow to actually pass through
`build-shared` and `build-static` to the `configure-and-build` action
and fixes how the condition is checked there. If we just pass through
the inputs, then the condition `"${{ inputs.build-shared }}" != "true"`
would be `true` (i.e., the step would be skipped) if
`build-shared`/`build-static` are not set explicitly in `ci.yml` because
of the default values for `build-shared`/`build-static` in `ci.yml`.