### PR TITLE
Fix reduction for arc trig functions

### DIFF
--- a/src/theory/arith/operator_elim.cpp
+++ b/src/theory/arith/operator_elim.cpp
@@ -357,11 +357,14 @@ Node OperatorElim::eliminateOperators(Node node,
                             nm->mkNode(LT, var, pi));
         }
         Node cond;
-        if (k == ARCSINE || k == ARCCOSINE || k == ARCSECANT || k == ARCCOSECANT)
+        if (k == ARCSINE || k == ARCCOSINE || k == ARCSECANT
+            || k == ARCCOSECANT)
         {
           // -1 <= x <= 1
-          cond = nm->mkNode(AND, nm->mkNode(GEQ, node[0], nm->mkConstReal(Rational(-1))),
-                                            nm->mkNode(LEQ, node[0], nm->mkConstReal(Rational(1))));
+          cond = nm->mkNode(
+              AND,
+              nm->mkNode(GEQ, node[0], nm->mkConstReal(Rational(-1))),
+              nm->mkNode(LEQ, node[0], nm->mkConstReal(Rational(1))));
           if (k == ARCSECANT || k == ARCCOSECANT)
           {
             cond = cond.notNode();

--- a/src/theory/arith/operator_elim.cpp
+++ b/src/theory/arith/operator_elim.cpp
@@ -356,6 +356,17 @@ Node OperatorElim::eliminateOperators(Node node,
                             nm->mkNode(LEQ, nm->mkConstReal(Rational(0)), var),
                             nm->mkNode(LT, var, pi));
         }
+        Node cond;
+        if (k == ARCSINE || k == ARCCOSINE || k == ARCSECANT || k == ARCCOSECANT)
+        {
+          // -1 <= x <= 1
+          cond = nm->mkNode(AND, nm->mkNode(GEQ, node[0], nm->mkConstReal(Rational(-1))),
+                                            nm->mkNode(LEQ, node[0], nm->mkConstReal(Rational(1))));
+          if (k == ARCSECANT || k == ARCCOSECANT)
+          {
+            cond = cond.notNode();
+          }
+        }
 
         Kind rk =
             k == ARCSINE
@@ -369,6 +380,10 @@ Node OperatorElim::eliminateOperators(Node node,
                                      : (k == ARCSECANT ? SECANT : COTANGENT))));
         Node invTerm = nm->mkNode(rk, var);
         lem = nm->mkNode(AND, rlem, invTerm.eqNode(node[0]));
+        if (!cond.isNull())
+        {
+          lem = nm->mkNode(IMPLIES, cond, lem);
+        }
       }
       Assert(!lem.isNull());
       lems.push_back(mkSkolemLemma(lem, var));

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -810,6 +810,7 @@ set(regress_0_tests
   regress0/nl/nta/proj-issue376.smt2
   regress0/nl/nta/proj-issue403.smt2
   regress0/nl/nta/proj-issue460-pi-value.smt2
+  regress0/nl/nta/proj-issue483-arccos-oob.smt2
   regress0/nl/nta/real-pi.smt2
   regress0/nl/nta/sin-sym.smt2
   regress0/nl/nta/sin-sym-schema.smt2

--- a/test/regress/regress0/nl/nta/proj-issue483-arccos-oob.smt2
+++ b/test/regress/regress0/nl/nta/proj-issue483-arccos-oob.smt2
@@ -1,0 +1,6 @@
+; COMMAND-LINE: -q
+; EXPECT: sat
+(set-logic ALL)
+(set-info :status sat)
+(assert (>= real.pi (arccos real.pi)))
+(check-sat)

--- a/test/regress/regress1/nl/sugar-ident.smt2
+++ b/test/regress/regress1/nl/sugar-ident.smt2
@@ -14,8 +14,8 @@
 (declare-fun a5 () Bool)
 (declare-fun a6 () Bool)
 
-(assert (= a1 (not (= (sin (arcsin x1)) x1))))
-(assert (= a3 (< (arccos x3) 0)))
+(assert (=> (<= (- 1) x1 1) (= a1 (not (= (sin (arcsin x1)) x1)))))
+(assert (= a3 (< (arccos x3) 0.0)))
 (assert (= a4 (> (arctan x4) 1.8)))
 
 (assert (or a1 a3 a4))

--- a/test/regress/regress1/nl/sugar-ident.smt2
+++ b/test/regress/regress1/nl/sugar-ident.smt2
@@ -14,8 +14,8 @@
 (declare-fun a5 () Bool)
 (declare-fun a6 () Bool)
 
-(assert (=> (<= (- 1) x1 1) (= a1 (not (= (sin (arcsin x1)) x1)))))
-(assert (= a3 (< (arccos x3) 0.0)))
+(assert (= a1 (and (<= (- 1) x1 1) (not (= (sin (arcsin x1)) x1)))))
+(assert (= a3 (and (<= (- 1) x3 1) (< (arccos x3) 0))))
 (assert (= a4 (> (arctan x4) 1.8)))
 
 (assert (or a1 a3 a4))


### PR DESCRIPTION
We were not guarding the case where the argument was out of the bounds, e.g. arccos(x) requires -1 <= x <= 1.

Fixes https://github.com/cvc5/cvc5-projects/issues/485.