### PR TITLE
Fixes for skolem definition management

### DIFF
--- a/src/decision/justification_strategy.cpp
+++ b/src/decision/justification_strategy.cpp
@@ -508,6 +508,7 @@ bool JustificationStrategy::needsActiveSkolemDefs() const
 
 void JustificationStrategy::notifyActiveSkolemDefs(std::vector<TNode>& defs)
 {
+  Trace("jh-assert") << "notifyActiveSkolemDefs: " << defs << std::endl;
   Assert(d_jhSkRlvMode == options::JutificationSkolemRlvMode::ASSERT);
   // assertion processed makes all skolems in assertion active,
   // which triggers their definitions to becoming relevant

--- a/src/prop/prop_engine.cpp
+++ b/src/prop/prop_engine.cpp
@@ -267,15 +267,11 @@ void PropEngine::assertLemmasInternal(
     const std::vector<theory::SkolemLemma>& ppLemmas,
     bool removable)
 {
-  if (!trn.isNull())
-  {
-    assertTrustedLemmaInternal(trn, removable);
-  }
-  for (const theory::SkolemLemma& lem : ppLemmas)
-  {
-    assertTrustedLemmaInternal(lem.d_lemma, removable);
-  }
-  // assert to decision engine
+  // Assert to decision engine. Notice this must come before the calls to
+  // assertTrustedLemmaInternal below, since the decision engine requires
+  // setting up information about the relevance of skolems before literals
+  // are potentially asserted to the theory engine, which it listens to for
+  // tracking active skolem definitions.
   if (!removable)
   {
     // also add to the decision engine, where notice we don't need proofs
@@ -288,6 +284,14 @@ void PropEngine::assertLemmasInternal(
     {
       d_theoryProxy->notifyAssertion(lem.getProven(), lem.d_skolem, true);
     }
+  }
+  if (!trn.isNull())
+  {
+    assertTrustedLemmaInternal(trn, removable);
+  }
+  for (const theory::SkolemLemma& lem : ppLemmas)
+  {
+    assertTrustedLemmaInternal(lem.d_lemma, removable);
   }
 }
 

--- a/src/prop/skolem_def_manager.cpp
+++ b/src/prop/skolem_def_manager.cpp
@@ -33,7 +33,7 @@ void SkolemDefManager::notifySkolemDefinition(TNode skolem, Node def)
                    << std::endl;
   // should not have already computed whether the skolem has skolems, or else
   // our computation of hasSkolems is wrong after adding this definition
-  Assert (d_hasSkolems.find(skolem)==d_hasSkolems.end());
+  Assert(d_hasSkolems.find(skolem) == d_hasSkolems.end());
   // in very rare cases, a skolem may be generated twice for terms that are
   // equivalent up to purification
   if (d_skDefs.find(skolem) == d_skDefs.end())
@@ -55,7 +55,8 @@ void SkolemDefManager::notifyAsserted(TNode literal,
 {
   std::unordered_set<Node> skolems;
   getSkolems(literal, skolems);
-  Trace("sk-defs") << "notifyAsserted: " << literal << " has skolems " << skolems << std::endl;
+  Trace("sk-defs") << "notifyAsserted: " << literal << " has skolems "
+                   << skolems << std::endl;
   for (const Node& k : skolems)
   {
     if (d_skActive.find(k) != d_skActive.end())
@@ -136,7 +137,7 @@ bool SkolemDefManager::hasSkolems(TNode n)
         hasSkolem = false;
         for (TNode i : cur)
         {
-          Assert(d_hasSkolems.find(i)!=d_hasSkolems.end());
+          Assert(d_hasSkolems.find(i) != d_hasSkolems.end());
           if (d_hasSkolems[i])
           {
             hasSkolem = true;
@@ -147,12 +148,11 @@ bool SkolemDefManager::hasSkolems(TNode n)
       d_hasSkolems[cur] = hasSkolem;
     }
   } while (!visit.empty());
-  Assert(d_hasSkolems.find(n)!=d_hasSkolems.end());
+  Assert(d_hasSkolems.find(n) != d_hasSkolems.end());
   return d_hasSkolems[n];
 }
 
-void SkolemDefManager::getSkolems(TNode n,
-                                  std::unordered_set<Node>& skolems)
+void SkolemDefManager::getSkolems(TNode n, std::unordered_set<Node>& skolems)
 {
   std::unordered_set<TNode> visited;
   std::unordered_set<TNode>::iterator it;

--- a/src/prop/skolem_def_manager.cpp
+++ b/src/prop/skolem_def_manager.cpp
@@ -83,7 +83,7 @@ void SkolemDefManager::notifyAsserted(TNode literal,
 
 bool SkolemDefManager::hasSkolems(TNode n)
 {
-  Trace("sk-defs") << "Compute has skolems for " << n << std::endl;
+  Trace("sk-defs-debug") << "Compute has skolems for " << n << std::endl;
   std::unordered_set<TNode> visited;
   std::unordered_set<TNode>::iterator it;
   NodeBoolMap::const_iterator itn;

--- a/src/prop/skolem_def_manager.cpp
+++ b/src/prop/skolem_def_manager.cpp
@@ -28,10 +28,12 @@ SkolemDefManager::~SkolemDefManager() {}
 
 void SkolemDefManager::notifySkolemDefinition(TNode skolem, Node def)
 {
-  Assert (d_hasSkolems.find(skolem)==d_hasSkolems.end());
   // Notice that skolem may have kind SKOLEM or BOOLEAN_TERM_VARIABLE
   Trace("sk-defs") << "notifySkolemDefinition: " << def << " for " << skolem
                    << std::endl;
+  // should not have already computed whether the skolem has skolems, or else
+  // our computation of hasSkolems is wrong after adding this definition
+  Assert (d_hasSkolems.find(skolem)==d_hasSkolems.end());
   // in very rare cases, a skolem may be generated twice for terms that are
   // equivalent up to purification
   if (d_skDefs.find(skolem) == d_skDefs.end())

--- a/src/prop/skolem_def_manager.cpp
+++ b/src/prop/skolem_def_manager.cpp
@@ -15,14 +15,12 @@
 
 #include "prop/skolem_def_manager.h"
 
-#include "expr/attribute.h"
-
 namespace cvc5 {
 namespace prop {
 
 SkolemDefManager::SkolemDefManager(context::Context* context,
                                    context::UserContext* userContext)
-    : d_skDefs(userContext), d_skActive(context)
+    : d_skDefs(userContext), d_skActive(context), d_hasSkolems(userContext)
 {
 }
 
@@ -30,6 +28,7 @@ SkolemDefManager::~SkolemDefManager() {}
 
 void SkolemDefManager::notifySkolemDefinition(TNode skolem, Node def)
 {
+  Assert (d_hasSkolems.find(skolem)==d_hasSkolems.end());
   // Notice that skolem may have kind SKOLEM or BOOLEAN_TERM_VARIABLE
   Trace("sk-defs") << "notifySkolemDefinition: " << def << " for " << skolem
                    << std::endl;
@@ -54,6 +53,7 @@ void SkolemDefManager::notifyAsserted(TNode literal,
 {
   std::unordered_set<Node> skolems;
   getSkolems(literal, skolems);
+  Trace("sk-defs") << "notifyAsserted: " << literal << " has skolems " << skolems << std::endl;
   for (const Node& k : skolems)
   {
     if (d_skActive.find(k) != d_skActive.end())
@@ -62,6 +62,7 @@ void SkolemDefManager::notifyAsserted(TNode literal,
       continue;
     }
     d_skActive.insert(k);
+    Trace("sk-defs") << "...activate " << k << std::endl;
     if (useDefs)
     {
       // add its definition to the activated list
@@ -77,28 +78,20 @@ void SkolemDefManager::notifyAsserted(TNode literal,
   }
 }
 
-struct HasSkolemTag
+bool SkolemDefManager::hasSkolems(TNode n)
 {
-};
-struct HasSkolemComputedTag
-{
-};
-/** Attribute true for nodes with skolems in them */
-typedef expr::Attribute<HasSkolemTag, bool> HasSkolemAttr;
-/** Attribute true for nodes where we have computed the above attribute */
-typedef expr::Attribute<HasSkolemComputedTag, bool> HasSkolemComputedAttr;
-
-bool SkolemDefManager::hasSkolems(TNode n) const
-{
+  Trace("sk-defs") << "Compute has skolems for " << n << std::endl;
   std::unordered_set<TNode> visited;
   std::unordered_set<TNode>::iterator it;
+  NodeBoolMap::const_iterator itn;
   std::vector<TNode> visit;
   TNode cur;
   visit.push_back(n);
   do
   {
     cur = visit.back();
-    if (cur.getAttribute(HasSkolemComputedAttr()))
+    itn = d_hasSkolems.find(cur);
+    if (itn != d_hasSkolems.end())
     {
       visit.pop_back();
       // already computed
@@ -116,8 +109,7 @@ bool SkolemDefManager::hasSkolems(TNode n) const
         {
           hasSkolem = (d_skDefs.find(cur) != d_skDefs.end());
         }
-        cur.setAttribute(HasSkolemAttr(), hasSkolem);
-        cur.setAttribute(HasSkolemComputedAttr(), true);
+        d_hasSkolems[cur] = hasSkolem;
       }
       else
       {
@@ -133,7 +125,7 @@ bool SkolemDefManager::hasSkolems(TNode n) const
       visit.pop_back();
       bool hasSkolem;
       if (cur.getMetaKind() == kind::metakind::PARAMETERIZED
-          && cur.getOperator().getAttribute(HasSkolemAttr()))
+          && d_hasSkolems[cur.getOperator()])
       {
         hasSkolem = true;
       }
@@ -142,24 +134,23 @@ bool SkolemDefManager::hasSkolems(TNode n) const
         hasSkolem = false;
         for (TNode i : cur)
         {
-          Assert(i.getAttribute(HasSkolemComputedAttr()));
-          if (i.getAttribute(HasSkolemAttr()))
+          Assert(d_hasSkolems.find(i)!=d_hasSkolems.end());
+          if (d_hasSkolems[i])
           {
             hasSkolem = true;
             break;
           }
         }
       }
-      cur.setAttribute(HasSkolemAttr(), hasSkolem);
-      cur.setAttribute(HasSkolemComputedAttr(), true);
+      d_hasSkolems[cur] = hasSkolem;
     }
   } while (!visit.empty());
-  Assert(n.getAttribute(HasSkolemComputedAttr()));
-  return n.getAttribute(HasSkolemAttr());
+  Assert(d_hasSkolems.find(n)!=d_hasSkolems.end());
+  return d_hasSkolems[n];
 }
 
 void SkolemDefManager::getSkolems(TNode n,
-                                  std::unordered_set<Node>& skolems) const
+                                  std::unordered_set<Node>& skolems)
 {
   std::unordered_set<TNode> visited;
   std::unordered_set<TNode>::iterator it;

--- a/src/prop/skolem_def_manager.cpp
+++ b/src/prop/skolem_def_manager.cpp
@@ -31,13 +31,13 @@ void SkolemDefManager::notifySkolemDefinition(TNode skolem, Node def)
   // Notice that skolem may have kind SKOLEM or BOOLEAN_TERM_VARIABLE
   Trace("sk-defs") << "notifySkolemDefinition: " << def << " for " << skolem
                    << std::endl;
-  // should not have already computed whether the skolem has skolems, or else
-  // our computation of hasSkolems is wrong after adding this definition
-  Assert(d_hasSkolems.find(skolem) == d_hasSkolems.end());
   // in very rare cases, a skolem may be generated twice for terms that are
   // equivalent up to purification
   if (d_skDefs.find(skolem) == d_skDefs.end())
   {
+    // should not have already computed whether the skolem has skolems, or else
+    // our computation of hasSkolems is wrong after adding this definition
+    Assert(d_hasSkolems.find(skolem) == d_hasSkolems.end());
     d_skDefs.insert(skolem, def);
   }
 }

--- a/src/prop/skolem_def_manager.h
+++ b/src/prop/skolem_def_manager.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "context/cdhashset.h"
+#include "context/cdhashmap.h"
 #include "context/cdinsert_hashmap.h"
 #include "context/context.h"
 #include "expr/node.h"
@@ -42,6 +43,7 @@ namespace prop {
 class SkolemDefManager
 {
   using NodeNodeMap = context::CDInsertHashMap<Node, Node>;
+  using NodeBoolMap = context::CDHashMap<Node, bool>;
   using NodeSet = context::CDHashSet<Node>;
 
  public:
@@ -81,15 +83,21 @@ class SkolemDefManager
    * @param n The node to traverse
    * @param skolems The set where the skolems are added
    */
-  void getSkolems(TNode n, std::unordered_set<Node>& skolems) const;
-  /** Does n have skolems having definitions managed by this class? */
-  bool hasSkolems(TNode n) const;
+  void getSkolems(TNode n, std::unordered_set<Node>& skolems);
+  /**
+   * Does n have skolems having definitions managed by this class? Should call
+   * this method *after* notifying skolem definitions for all potential
+   * skolems occurring in n.
+   */
+  bool hasSkolems(TNode n);
 
  private:
   /** skolems to definitions (user-context dependent) */
   NodeNodeMap d_skDefs;
   /** set of active skolems (SAT-context dependent) */
   NodeSet d_skActive;
+  /** Cache for hasSkolems */
+  NodeBoolMap d_hasSkolems;
 };
 
 }  // namespace prop

--- a/src/prop/skolem_def_manager.h
+++ b/src/prop/skolem_def_manager.h
@@ -22,8 +22,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include "context/cdhashset.h"
 #include "context/cdhashmap.h"
+#include "context/cdhashset.h"
 #include "context/cdinsert_hashmap.h"
 #include "context/context.h"
 #include "expr/node.h"

--- a/src/prop/theory_proxy.cpp
+++ b/src/prop/theory_proxy.cpp
@@ -131,6 +131,7 @@ void TheoryProxy::theoryCheck(theory::Theory::Effort effort) {
       // check if this corresponds to a zero-level asserted literal
       d_zll->notifyAsserted(assertion);
     }
+    Trace("ajr-temp") << "assertFact " << assertion << " " << d_dmNeedsActiveDefs << std::endl;
     // now, assert to theory engine
     d_theoryEngine->assertFact(assertion);
     if (d_dmNeedsActiveDefs)

--- a/src/prop/theory_proxy.cpp
+++ b/src/prop/theory_proxy.cpp
@@ -131,7 +131,8 @@ void TheoryProxy::theoryCheck(theory::Theory::Effort effort) {
       // check if this corresponds to a zero-level asserted literal
       d_zll->notifyAsserted(assertion);
     }
-    Trace("ajr-temp") << "assertFact " << assertion << " " << d_dmNeedsActiveDefs << std::endl;
+    Trace("ajr-temp") << "assertFact " << assertion << " "
+                      << d_dmNeedsActiveDefs << std::endl;
     // now, assert to theory engine
     d_theoryEngine->assertFact(assertion);
     if (d_dmNeedsActiveDefs)

--- a/src/prop/theory_proxy.cpp
+++ b/src/prop/theory_proxy.cpp
@@ -131,8 +131,6 @@ void TheoryProxy::theoryCheck(theory::Theory::Effort effort) {
       // check if this corresponds to a zero-level asserted literal
       d_zll->notifyAsserted(assertion);
     }
-    Trace("ajr-temp") << "assertFact " << assertion << " "
-                      << d_dmNeedsActiveDefs << std::endl;
     // now, assert to theory engine
     d_theoryEngine->assertFact(assertion);
     if (d_dmNeedsActiveDefs)

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -575,6 +575,7 @@ set(regress_0_tests
   regress0/decision/error20.delta01.smtv1.smt2
   regress0/decision/error20.smtv1.smt2
   regress0/decision/error3.delta01.smtv1.smt2
+  regress0/decision/issue8296-sk-def-before-assert.smt2
   regress0/decision/pp-regfile.delta01.smtv1.smt2
   regress0/decision/pp-regfile.delta02.smtv1.smt2
   regress0/decision/quant-ex1.smt2

--- a/test/regress/regress0/decision/issue8296-sk-def-before-assert.smt2
+++ b/test/regress/regress0/decision/issue8296-sk-def-before-assert.smt2
@@ -1,0 +1,12 @@
+; COMMAND-LINE: -i
+; EXPECT: sat
+; EXPECT: sat
+(set-logic ALL)
+(set-option :miniscope-quant false)
+(declare-fun i2 () Int)
+(declare-fun v6 () Bool)
+(declare-sort S2 0)
+(assert (exists ((q521 S2)) (exists ((q523 Int)) (exists ((q524 S2)) (forall ((q525 Bool)) (or (= q524 q521) (= q523 (abs i2)) (and v6 (= q525 (= 0 (abs i2))))))))))
+(check-sat)
+(assert (= 1 (abs i2)))
+(check-sat)


### PR DESCRIPTION
Fixes two issues with how we manage skolem definitions (used for tracking which assertions are relevant for the decision engine).

First, the theory proxy must be notified of skolem definitions before we have assertions involving them, or else `hasSkolems` is wrong.  This was previously done incorrectly for lemmas. This PR changes the order in PropEngine::assertLemmasInternal.

Second, skolem definitions are local to a solver instance and should not be managed by attributes, moreover they are user-context dependent. This changes it to a local user-context dependent map in Skolem.

Fixes https://github.com/cvc5/cvc5/issues/8296.