### PR TITLE
Simplify `context::Scope`

### DIFF
--- a/src/context/context.cpp
+++ b/src/context/context.cpp
@@ -370,20 +370,14 @@ Scope::~Scope() {
     d_pContextObjList = d_pContextObjList->restoreAndContinue();
   }
 
-  if (d_garbage) {
-    while (!d_garbage->empty()) {
-      ContextObj* obj = d_garbage->back();
-      d_garbage->pop_back();
-      obj->deleteSelf();
-    }
+  for (ContextObj* obj : d_garbage)
+  {
+    obj->deleteSelf();
   }
 }
 
 void Scope::enqueueToGarbageCollect(ContextObj* obj) {
-  if (!d_garbage) {
-    d_garbage.reset(new std::vector<ContextObj*>);
-  }
-  d_garbage->push_back(obj);
+  d_garbage.push_back(obj);
 }
 
 }  // namespace context

--- a/src/context/context.h
+++ b/src/context/context.h
@@ -257,7 +257,7 @@ class Scope {
    *
    * This is either nullptr or list owned by this scope.
    */
-  std::unique_ptr<std::vector<ContextObj*>> d_garbage;
+  std::vector<ContextObj*> d_garbage;
 
   friend std::ostream& operator<<(std::ostream&, const Scope&);
 


### PR DESCRIPTION
Previously, we were using an `std::unique_ptr<std::vector<ContextObj*>>`
to store the list of `ContextObj`s to be garbage collected before the
destruction of the `Scope`. Lazily allocating that vector is a
micro-optimization that is not worth the trouble.