### PR TITLE
Enable nl-cov-var-elim by default, but disable with proofs

### DIFF
--- a/src/options/arith_options.toml
+++ b/src/options/arith_options.toml
@@ -504,7 +504,7 @@ name   = "Arithmetic Theory"
   category   = "regular"
   long       = "nl-cov-var-elim"
   type       = "bool"
-  default    = "false"
+  default    = "true"
   help       = "whether to eliminate variables using equalities before going into the cylindrical algebraic coverings solver"
 
 [[option]]

--- a/src/options/arith_options.toml
+++ b/src/options/arith_options.toml
@@ -505,7 +505,7 @@ name   = "Arithmetic Theory"
   long       = "nl-cov-var-elim"
   type       = "bool"
   default    = "true"
-  help       = "whether to eliminate variables using equalities before going into the cylindrical algebraic coverings solver"
+  help       = "whether to eliminate variables using equalities before going into the cylindrical algebraic coverings solver. It can not be used when producing proofs right now."
 
 [[option]]
   name       = "nlCovPrune"

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -800,7 +800,6 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
     if (!opts.arith.nlCov && !opts.arith.nlCovWasSetByUser)
     {
       opts.arith.nlCov = true;
-      opts.arith.nlCovVarElim = true;
       if (!opts.arith.nlExtWasSetByUser)
       {
         opts.arith.nlExt = options::NlExtMode::LIGHT;
@@ -817,7 +816,6 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
     if (!opts.arith.nlCov && !opts.arith.nlCovWasSetByUser)
     {
       opts.arith.nlCov = true;
-      opts.arith.nlCovVarElim = true;
       if (!opts.arith.nlExtWasSetByUser)
       {
         opts.arith.nlExt = options::NlExtMode::LIGHT;
@@ -938,6 +936,13 @@ bool SetDefaults::incompatibleWithProofs(Options& opts,
     verbose(1) << "Forcing internal bit-vector solver due to proof production."
                << std::endl;
     opts.bv.bvSolver = options::BVSolver::BITBLAST_INTERNAL;
+  }
+  if (opts.arith.nlCovVarElim && !opts.arith.nlCovVarElimWasSetByUser)
+  {
+    verbose(1)
+        << "Disabling nl-cov-var-elim since it is incompatible with proofs."
+        << std::endl;
+    opts.arith.nlCovVarElim = false;
   }
   return false;
 }


### PR DESCRIPTION
This changes our policy for `--nl-cov-var-elim`. It is now enabled by default (it is only used when the coverings solver is used, though), but then disabled when proofs are enabled. Before, it was forced to be enabled when coverings were enabled in set_defaults.

Fixes cvc5/cvc5-projects#489