### PR TITLE
Remove unused options handler

### DIFF
--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -361,20 +361,6 @@ void OptionsHandler::checkBvSatSolver(const std::string& flag, SatSolverMode m)
   }
 }
 
-void OptionsHandler::setBitblastAig(const std::string& flag, bool arg)
-{
-  if(arg) {
-    if (d_options->bv.bitblastModeWasSetByUser) {
-      if (d_options->bv.bitblastMode != options::BitblastMode::EAGER)
-      {
-        throw OptionException("bitblast-aig must be used with eager bitblaster");
-      }
-    } else {
-      d_options->bv.bitblastMode = options::BitblastMode::EAGER;
-    }
-  }
-}
-
 void OptionsHandler::setDefaultExprDepth(const std::string& flag, int64_t depth)
 {
   ioutils::setDefaultNodeDepth(depth);

--- a/src/options/options_handler.h
+++ b/src/options/options_handler.h
@@ -104,14 +104,8 @@ class OptionsHandler
 
   /******************************* bv options *******************************/
 
-  /** Check that abc is enabled */
-  void abcEnabledBuild(const std::string& flag, bool value);
-  /** Check that abc is enabled */
-  void abcEnabledBuild(const std::string& flag, const std::string& value);
   /** Check that the sat solver mode is compatible with other bv options */
   void checkBvSatSolver(const std::string& flag, SatSolverMode m);
-  /** Check that we use eager bitblasting for aig */
-  void setBitblastAig(const std::string& flag, bool arg);
 
   /******************************* expr options *******************************/
   /** Set ExprSetDepth on all output streams */


### PR DESCRIPTION
The option `--bitblast-aig` was removed in #7455, but the corresponding
options handler was not. This commit removes the options handler.