### PR TITLE
Fix learned literals for top-level AND

### DIFF
--- a/src/prop/zero_level_learner.cpp
+++ b/src/prop/zero_level_learner.cpp
@@ -71,17 +71,22 @@ void ZeroLevelLearner::notifyInputFormulas(
 {
   d_assertNoLearnCount = 0;
   std::unordered_set<TNode> visited;
-  // We consider top level literals of assertions to be the preprocessed
-  // learned literals only, and not the literals tracked by the preprocessor
+  // We consider top level literals of assertions, including those occurring
+  // as children of AND to be the preprocessed learned literals only, and not
+  // the literals tracked by the preprocessor
   // (Preprocessor::getLearnedLiterals). This means that a learned literal from
   // e.g. circuit propagation that is not trivially a top level assertion will
   // be considered an ordinary learned literal.
   // Note that d_pplAtoms and d_ppnAtoms are disjoint
-  for (const Node& lit : assertions)
-  {
-    TNode atom = lit.getKind() == kind::NOT ? lit[0] : lit;
-    if (expr::isBooleanConnective(atom))
+  std::vector<Node> toProcess = assertions;
+  size_t index=0;
+  while (index<toProcess.size())
+   {
+    TNode lit = toProcess[index];
+    index++;
+    if (lit.getKind()==kind::AND)
     {
+      toProcess.insert(toProcess.end(), lit.begin(), lit.end());
       continue;
     }
     visited.insert(atom);


### PR DESCRIPTION
This is important for a deep restart strategy where substitutions may be consolidated by the preprocessor to a single AND.