### PR TITLE
Make uncovered-api-functions.py exit with 1 if something is not covered

### DIFF
--- a/contrib/uncovered-api-functions.py
+++ b/contrib/uncovered-api-functions.py
@@ -3,6 +3,7 @@
 import json
 import re
 import subprocess
+import sys
 
 
 def demangle(name):
@@ -42,3 +43,6 @@ if __name__ == "__main__":
         print('starting in {filename}:{startline}'.format(**nc))
         print('function {function}'.format(**nc))
         print('')
+    if notcovered:
+        sys.exit(1)
+    sys.exit(0)


### PR DESCRIPTION
This simplifies the integration of this script in CI or buildbot jobs. The idea is to automatically check that the whole API is covered by unit tests, and that the language bindings do the same.