### PR TITLE
Update PRs without waiting on successful build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,6 @@ jobs:
   update-pr:
     runs-on: ubuntu-latest
     if: github.repository == 'cvc5/cvc5' && github.event_name == 'push'
-    needs: build
     steps:
       - name: Automatically update PR
         uses: adRise/update-pr-branch@v0.5.1


### PR DESCRIPTION
We automatically update PRs that can be merged automatically in the CI on master. This PR makes it so that this update is done immediately, not only after the CI has run successfully for master.
As we only merge to master if CI works, CI failures on master should only be glitches or issues with the CI itself.
This allows to merge stuff to master twice as fast when using the auto-merge feature.