### PR TITLE
Change output of abduction/interpolation for failed inputs

### DIFF
--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -1953,7 +1953,7 @@ void GetInterpolCommand::printResult(std::ostream& out) const
     }
     else
     {
-      out << "none" << std::endl;
+      out << "fail" << std::endl;
     }
   }
 }
@@ -2020,7 +2020,7 @@ void GetInterpolNextCommand::printResult(std::ostream& out) const
     }
     else
     {
-      out << "none" << std::endl;
+      out << "fail" << std::endl;
     }
   }
 }
@@ -2110,7 +2110,7 @@ void GetAbductCommand::printResult(std::ostream& out) const
     }
     else
     {
-      out << "none" << std::endl;
+      out << "fail" << std::endl;
     }
   }
 }
@@ -2173,7 +2173,7 @@ void GetAbductNextCommand::printResult(std::ostream& out) const
     }
     else
     {
-      out << "none" << std::endl;
+      out << "fail" << std::endl;
     }
   }
 }

--- a/test/regress/cli/regress1/abduction/issue5848-3-trivial-no-abduct.smt2
+++ b/test/regress/cli/regress1/abduction/issue5848-3-trivial-no-abduct.smt2
@@ -1,5 +1,5 @@
 ; COMMAND-LINE: --produce-abducts
-; EXPECT: none
+; EXPECT: fail
 (set-logic ALL)
 (assert (= 0.0 (sqrt 1.0)))
 (get-abduct A false)

--- a/test/regress/cli/regress1/abduction/issue5848-4.smt2
+++ b/test/regress/cli/regress1/abduction/issue5848-4.smt2
@@ -1,5 +1,5 @@
 ; COMMAND-LINE: --produce-abducts
-; EXPECT: none
+; EXPECT: fail
 (set-logic UFLRA)
 (declare-sort S0 0)
 (declare-fun S0-0 () S0)

--- a/test/unit/api/python/test_solver.py
+++ b/test/unit/api/python/test_solver.py
@@ -2468,6 +2468,7 @@ def test_issue7000(solver):
 
 
 def test_mk_sygus_var(solver):
+    solver.setOption("sygus", "true")
     boolSort = solver.getBooleanSort()
     intSort = solver.getIntegerSort()
     funSort = solver.mkFunctionSort(intSort, boolSort)
@@ -2515,7 +2516,7 @@ def test_synth_fun(solver):
     with pytest.raises(RuntimeError):
         solver.synthFun("f6", [x], boolean, g2)
     slv = cvc5.Solver()
-    solver.setOption("sygus", "true")
+    slv.setOption("sygus", "true")
     x2 = slv.mkVar(slv.getBooleanSort())
     slv.synthFun("f1", [x2], slv.getBooleanSort())
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
Changes from "none" to "fail" to be consistent with SyGuS standard.  Note that this means that we don't know if an abduct/interpolant exists.
