### PR TITLE
api: Remove isUninterpretedSortParameterized from header file.

### DIFF
--- a/src/api/cpp/cvc5.h
+++ b/src/api/cpp/cvc5.h
@@ -759,13 +759,6 @@ class CVC5_EXPORT Sort
    */
   Sort getSequenceElementSort() const;
 
-  /* Uninterpreted sort -------------------------------------------------- */
-
-  /**
-   * @return true if an uninterpreted sort is parameterized
-   */
-  bool isUninterpretedSortParameterized() const;
-
   /* Uninterpreted sort constructor sort --------------------------------- */
 
   /**


### PR DESCRIPTION
Method was removed in #8425.