### PR TITLE
ci: Do not cancel jobs on main branch.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,14 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
-    # cancel already running jobs for the same branch/pr/tag
+    # Adapted from https://github.community/t/concurrency-cancel-in-progress-but-not-when-ref-is-master/194707/4
     concurrency:
-      group: build-${{ github.ref }}-${{ matrix.name }}
-      cancel-in-progress: true
+      # group by workflow and ref; the last slightly strange component ensures
+      # that for pull requests, we limit to 1 concurrent job, but for the
+      # main branch we don't
+      group: ${{ github.workflow }}-${{ github.\ref }}-${{ github.ref != 'refs/heads/main' || github.run_number }}
+      # Cancel intermediate builds, but only if it is a pull request build.
+      cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
     steps:
 


### PR DESCRIPTION
This will prevent that jobs on the main branch get cancelled when new PRs are merged in before the previous ones finished on main.