### PR TITLE
Fix `cvc5jar` target namespace

### DIFF
--- a/src/api/java/CMakeLists.txt
+++ b/src/api/java/CMakeLists.txt
@@ -187,7 +187,7 @@ install_jar(cvc5jar DESTINATION share/java)
 
 install_jar_exports(
   TARGETS cvc5jar
-  NAMESPACE cvc5::internal::
+  NAMESPACE cvc5::
   FILE cvc5JavaTargets.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cvc5
 )


### PR DESCRIPTION
This fixes the Java examples. The examples were not able the find the
`cvc5::cvc5jar` target because the namespace had accidentally been
changed to `cvc5::internal::` in commit
bbcd471ed40c813c48957ced5596471cc0ccebe9. This reverts that change.