### PR TITLE
Disable minisat variable elimination when a parametric theory is present

### DIFF
--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -695,11 +695,12 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
       && opts.prop.minisatSimpMode == options::MinisatSimpMode::ALL)
   {
     // cannot use minisat variable elimination for logics where a theory solver
-    // introduces new literals into the search. This includes quantifiers
+    // introduces new literals into the search, or for parametric theories
+    // which may require non-trivial preprocessing. This includes quantifiers
     // (quantifier instantiation), and the lemma schemas used in non-linear
     // and sets. We also can't use it if models are enabled.
     if (logic.isTheoryEnabled(THEORY_SETS) || logic.isTheoryEnabled(THEORY_BAGS)
-        || logic.isQuantified() || opts.smt.produceModels
+        || logic.isTheoryEnabled(THEORY_ARRAYS) ||  logic.isTheoryEnabled(THEORY_STRINGS) || logic.isTheoryEnabled(THEORY_DATATYPES) || logic.isQuantified() || opts.smt.produceModels
         || opts.smt.produceAssignments || opts.smt.checkModels
         || (logic.isTheoryEnabled(THEORY_ARITH) && !logic.isLinear()))
     {

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -700,8 +700,11 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
     // (quantifier instantiation), and the lemma schemas used in non-linear
     // and sets. We also can't use it if models are enabled.
     if (logic.isTheoryEnabled(THEORY_SETS) || logic.isTheoryEnabled(THEORY_BAGS)
-        || logic.isTheoryEnabled(THEORY_ARRAYS) ||  logic.isTheoryEnabled(THEORY_STRINGS) || logic.isTheoryEnabled(THEORY_DATATYPES) || logic.isQuantified() || opts.smt.produceModels
-        || opts.smt.produceAssignments || opts.smt.checkModels
+        || logic.isTheoryEnabled(THEORY_ARRAYS)
+        || logic.isTheoryEnabled(THEORY_STRINGS)
+        || logic.isTheoryEnabled(THEORY_DATATYPES) || logic.isQuantified()
+        || opts.smt.produceModels || opts.smt.produceAssignments
+        || opts.smt.checkModels
         || (logic.isTheoryEnabled(THEORY_ARITH) && !logic.isLinear()))
     {
       opts.prop.minisatSimpMode = options::MinisatSimpMode::CLAUSE_ELIM;

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -132,6 +132,7 @@ set(regress_0_tests
   regress0/arrays/issue7596-define-array-uminus.smt2
   regress0/arrays/issue8103-1-weak-equiv-models.smt2
   regress0/arrays/issue8276-arith-getModelValue.smt2
+  regress0/arrays/proj-issue506-ms-var-elim.smt2
   regress0/arrays/swap_t1_np_nf_ai_00005_007.cvc.smtv1.smt2
   regress0/arrays/x2.smtv1.smt2
   regress0/arrays/x3.smtv1.smt2

--- a/test/regress/cli/regress0/arrays/proj-issue506-ms-var-elim.smt2
+++ b/test/regress/cli/regress0/arrays/proj-issue506-ms-var-elim.smt2
@@ -1,0 +1,6 @@
+(set-logic QF_AX)
+(set-info :status sat)
+(declare-const x (Array Bool Bool))
+(declare-const _x Bool)
+(assert (select (store x _x false) false))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5-projects/issues/506.

It seems there are extremely few cases where it is safe to use this option.