### PR TITLE
Remove support for Python 2.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,6 @@ cvc5_option(USE_EDITLINE      "Use Editline for better interactive support")
 #    > for options where we don't need to detect if set by user (default: OFF)
 option(USE_POLY               "Use LibPoly for polynomial arithmetic")
 option(USE_COCOA              "Use CoCoALib for further polynomial operations")
-option(USE_PYTHON2            "Force Python 2 (deprecated)")
 
 # Custom install directories for dependencies
 # If no directory is provided by the user, we first check if the dependency was
@@ -295,12 +294,7 @@ else()
   endif()
 endif()
 
-if(USE_PYTHON2)
-  find_package(PythonInterp 2.7 REQUIRED)
-else()
-  find_package(PythonInterp 3 REQUIRED)
-endif()
-
+find_package(PythonInterp 3 REQUIRED)
 find_package(GMP 6.1 REQUIRED)
 
 if(ENABLE_ASAN)
@@ -615,7 +609,6 @@ message("")
 print_config("Shared build              " ${BUILD_SHARED_LIBS})
 print_config("Python bindings           " ${BUILD_BINDINGS_PYTHON})
 print_config("Java bindings             " ${BUILD_BINDINGS_JAVA})
-print_config("Python2                   " ${USE_PYTHON2})
 print_config("Interprocedural opt.      " ${ENABLE_IPO})
 message("")
 print_config("CryptoMiniSat             " ${USE_CRYPTOMINISAT} FOUND_SYSTEM ${CryptoMiniSat_FOUND_SYSTEM})

--- a/configure.sh
+++ b/configure.sh
@@ -43,7 +43,6 @@ The following flags enable optional features (disable with --no-<option name>).
   --coverage               support for gcov coverage testing
   --profiling              support for gprof profiling
   --unit-testing           support for unit testing
-  --python2                force Python 2 (deprecated)
   --python-bindings        build Python bindings based on new C++ API
   --java-bindings          build Java bindings based on new C++ API
   --all-bindings           build bindings for all supported languages
@@ -117,7 +116,6 @@ cocoa=default
 muzzle=default
 ninja=default
 profiling=default
-python2=default
 python_bindings=default
 java_bindings=default
 editline=default
@@ -249,9 +247,6 @@ do
     --unit-testing) unit_testing=ON;;
     --no-unit-testing) unit_testing=OFF;;
 
-    --python2) python2=ON;;
-    --no-python2) python2=OFF;;
-
     --python-bindings) python_bindings=ON;;
     --no-python-bindings) python_bindings=OFF;;
 
@@ -343,8 +338,6 @@ fi
   && cmake_opts="$cmake_opts -DENABLE_TRACING=$tracing"
 [ $unit_testing != default ] \
   && cmake_opts="$cmake_opts -DENABLE_UNIT_TESTING=$unit_testing"
-[ $python2 != default ] \
-  && cmake_opts="$cmake_opts -DUSE_PYTHON2=$python2"
 [ $docs != default ] \
   && cmake_opts="$cmake_opts -DBUILD_DOCS=$docs"
 [ $python_bindings != default ] \


### PR DESCRIPTION
This removes support for Python 2.x. We haven't been testing it and
there isn't a good reason to support it.