### PR TITLE
Alethe: Call finalizer on master

### DIFF
--- a/src/proof/alethe/alethe_post_processor.cpp
+++ b/src/proof/alethe/alethe_post_processor.cpp
@@ -1831,7 +1831,7 @@ AletheProofPostprocess::~AletheProofPostprocess() {}
 void AletheProofPostprocess::process(std::shared_ptr<ProofNode> pf)
 {
   // Translate proof node
-  ProofNodeUpdater updater(d_pnm, d_cb, true, false);
+  ProofNodeUpdater updater(d_pnm, d_cb, false, false);
   updater.process(pf->getChildren()[0]);
 
   // In the Alethe proof format the final step has to be (cl). However, after


### PR DESCRIPTION
Up until now the finalizer was not called in master which caused numerous bugs in the checker. The most prevalent being, that a resolution step got arguments which do get deleted in the finalizer unless option proofAletheResPivots is set to true. However, this also causes OR steps being missing from the proof.