### PR TITLE
Fix pypi packaging trigger

### DIFF
--- a/.github/workflows/package_pypi.yml
+++ b/.github/workflows/package_pypi.yml
@@ -1,6 +1,6 @@
 on:
   release:
-    types: [published]
+    types: [created, published]
   schedule:
     - cron: '0 1 * * *'
 


### PR DESCRIPTION
The way we now create releases apparently does not trigger the `release::published` event. It should trigger the `release::created` event, though.