### PR TITLE
Fix pypi packaging trigger again

### DIFF
--- a/.github/actions/store-binary/action.yml
+++ b/.github/actions/store-binary/action.yml
@@ -5,8 +5,10 @@ inputs:
     description: file name of binary
   binary-name:
     description: target name of binary
-  github-token:
-    description: token to upload binary
+  github-token-latest:
+    description: token to upload binary to latest
+  github-token-release:
+    description: token to upload binary to release
 runs:
   using: composite
   steps:
@@ -24,7 +26,7 @@ runs:
       if: github.ref == 'refs/heads/main'
       shell: 'python3 {0}'
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token-latest }}
         BINARY: ${{ inputs.binary-name }}
       run: |
         import datetime
@@ -81,7 +83,7 @@ runs:
       if: startsWith(github.ref, 'refs/tags/')
       shell: 'python3 {0}'
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token-release }}
         BINARY: ${{ inputs.binary-name }}
       run: |
         import os

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,9 @@ jobs:
       with:
         binary: ${{ steps.configure-and-build.outputs.static-build-dir }}/bin/cvc5${{ matrix.binary-ext }}
         binary-name: ${{ matrix.binary-name }}
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        # when using GITHUB_TOKEN, no further workflows are triggered
+        github-token-latest: ${{ secrets.GITHUB_TOKEN }}
+        github-token-release: ${{ secrets.ACTION_USER_TOKEN }}
 
   update-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/package_pypi.yml
+++ b/.github/workflows/package_pypi.yml
@@ -1,6 +1,6 @@
 on:
   release:
-    types: [published]
+    types: [created, published]
   schedule:
     - cron: '0 1 * * *'
 


### PR DESCRIPTION
Further workflows are not triggered when the `GITHUB_TOKEN` is used. This PR creates new releases using the `ACTION_USER_TOKEN` instead...