### PR TITLE
Only run pypi packaging when release is published

### DIFF
--- a/.github/workflows/package_pypi.yml
+++ b/.github/workflows/package_pypi.yml
@@ -1,6 +1,6 @@
 on:
   release:
-    types: [created, published]
+    types: [published]
   schedule:
     - cron: '0 1 * * *'
 


### PR DESCRIPTION
We incorrectly triggered pypi packaging when a release was created or published, i.e. it would run twice.