### PR TITLE
Change CI concurrency policy to not queue on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
     # cancel already running jobs for the same branch/pr/tag
     concurrency:
-      group: build-${{ github.ref }}-${{ matrix.name }}
+      group: build-${{ github.ref }}-${{ matrix.name }}-${{ github.ref != 'refs/heads/main' || github.run_id }}-
       cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
     # cancel already running jobs for the same branch/pr/tag
     concurrency:
-      group: build-${{ github.ref }}-${{ matrix.name }}-${{ github.ref != 'refs/heads/main' || github.run_id }}-
+      group: build-${{ github.ref }}-${{ matrix.name }}-${{ github.ref != 'refs/heads/main' || github.run_id }}
       cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
     steps:


### PR DESCRIPTION
Previously, we would only allow one job per branch/PR and only cancel old jobs on PRs.
This PR changes this policy to allow multiple jobs at once on main.
The way this is done basically follows https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value.