### PR TITLE
Always cancel already running CI runs on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     # cancel already running jobs for the same branch/pr/tag
     concurrency:
       group: build-${{ github.ref }}-${{ matrix.name }}-${{ github.ref != 'refs/heads/main' || github.run_id }}
-      cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+      cancel-in-progress: ${{ github.repository != 'cvc5/cvc5' || startsWith(github.ref, 'refs/pull/') }}
 
     steps:
 


### PR DESCRIPTION
One effect of our changed concurrency policy is that we never cancel runs on forks. This PR changes this, always allowing the concurrency mechanism to cancel on repositories that are not the main repository.