### PR TITLE
Remove variant of mkDatatypeDecl with one sort parameter

### DIFF
--- a/examples/api/cpp/datatypes.cpp
+++ b/examples/api/cpp/datatypes.cpp
@@ -103,8 +103,7 @@ void test(Solver& slv, Sort& consListSort)
   // constructor "cons".
   Sort sort = slv.mkParamSort("T");
   DatatypeDecl paramConsListSpec =
-      slv.mkDatatypeDecl("paramlist",
-                         {sort});  // give the datatype a name
+      slv.mkDatatypeDecl("paramlist", {sort});  // give the datatype a name
   DatatypeConstructorDecl paramCons = slv.mkDatatypeConstructorDecl("cons");
   DatatypeConstructorDecl paramNil = slv.mkDatatypeConstructorDecl("nil");
   paramCons.addSelector("head", sort);

--- a/examples/api/cpp/datatypes.cpp
+++ b/examples/api/cpp/datatypes.cpp
@@ -104,7 +104,7 @@ void test(Solver& slv, Sort& consListSort)
   Sort sort = slv.mkParamSort("T");
   DatatypeDecl paramConsListSpec =
       slv.mkDatatypeDecl("paramlist",
-                         sort);  // give the datatype a name
+                         {sort});  // give the datatype a name
   DatatypeConstructorDecl paramCons = slv.mkDatatypeConstructorDecl("cons");
   DatatypeConstructorDecl paramNil = slv.mkDatatypeConstructorDecl("nil");
   paramCons.addSelector("head", sort);

--- a/examples/api/java/Datatypes.java
+++ b/examples/api/java/Datatypes.java
@@ -96,8 +96,8 @@ public class Datatypes
     // This example builds a simple parameterized list of sort T, with one
     // constructor "cons".
     Sort sort = slv.mkParamSort("T");
-    DatatypeDecl paramConsListSpec = slv.mkDatatypeDecl("paramlist",
-        new Sort[] {sort}); // give the datatype a name
+    DatatypeDecl paramConsListSpec = slv.mkDatatypeDecl(
+        "paramlist", new Sort[] {sort}); // give the datatype a name
     DatatypeConstructorDecl paramCons = slv.mkDatatypeConstructorDecl("cons");
     DatatypeConstructorDecl paramNil = slv.mkDatatypeConstructorDecl("nil");
     paramCons.addSelector("head", sort);

--- a/examples/api/java/Datatypes.java
+++ b/examples/api/java/Datatypes.java
@@ -97,7 +97,7 @@ public class Datatypes
     // constructor "cons".
     Sort sort = slv.mkParamSort("T");
     DatatypeDecl paramConsListSpec = slv.mkDatatypeDecl("paramlist",
-        sort); // give the datatype a name
+        new Sort[] {sort}); // give the datatype a name
     DatatypeConstructorDecl paramCons = slv.mkDatatypeConstructorDecl("cons");
     DatatypeConstructorDecl paramNil = slv.mkDatatypeConstructorDecl("nil");
     paramCons.addSelector("head", sort);

--- a/examples/api/python/datatypes.py
+++ b/examples/api/python/datatypes.py
@@ -82,7 +82,7 @@ def test(slv, consListSort):
     # This example builds a simple parameterized list of sort T, with one
     # constructor "cons".
     sort = slv.mkParamSort("T")
-    paramConsListSpec = slv.mkDatatypeDecl("paramlist", sort)
+    paramConsListSpec = slv.mkDatatypeDecl("paramlist", [sort])
     paramCons = slv.mkDatatypeConstructorDecl("cons")
     paramNil = slv.mkDatatypeConstructorDecl("nil")
     paramCons.addSelector("head", sort)

--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -6081,18 +6081,6 @@ DatatypeDecl Solver::mkDatatypeDecl(const std::string& name, bool isCoDatatype)
 }
 
 DatatypeDecl Solver::mkDatatypeDecl(const std::string& name,
-                                    const Sort& param,
-                                    bool isCoDatatype)
-{
-  CVC5_API_TRY_CATCH_BEGIN;
-  CVC5_API_SOLVER_CHECK_SORT(param);
-  //////// all checks before this line
-  return DatatypeDecl(this, name, param, isCoDatatype);
-  ////////
-  CVC5_API_TRY_CATCH_END;
-}
-
-DatatypeDecl Solver::mkDatatypeDecl(const std::string& name,
                                     const std::vector<Sort>& params,
                                     bool isCoDatatype)
 {

--- a/src/api/cpp/cvc5.h
+++ b/src/api/cpp/cvc5.h
@@ -3686,18 +3686,9 @@ class CVC5_EXPORT Solver
   /**
    * Create a datatype declaration.
    * Create sorts parameter with Solver::mkParamSort().
-   * @param name the name of the datatype
-   * @param param the sort parameter
-   * @param isCoDatatype true if a codatatype is to be constructed
-   * @return the DatatypeDecl
-   */
-  DatatypeDecl mkDatatypeDecl(const std::string& name,
-                              const Sort& param,
-                              bool isCoDatatype = false);
-
-  /**
-   * Create a datatype declaration.
-   * Create sorts parameter with Solver::mkParamSort().
+   *
+   * @warning This method is experimental and may change in future versions.
+   *
    * @param name the name of the datatype
    * @param params a list of sort parameters
    * @param isCoDatatype true if a codatatype is to be constructed

--- a/src/api/cpp/cvc5.h
+++ b/src/api/cpp/cvc5.h
@@ -1835,7 +1835,11 @@ class CVC5_EXPORT DatatypeDecl
   /** Get the number of constructors (so far) for this Datatype declaration. */
   size_t getNumConstructors() const;
 
-  /** Is this Datatype declaration parametric? */
+  /**
+   * Is this Datatype declaration parametric?
+   *
+   * @warning This method is experimental and may change in future versions.
+   */
   bool isParametric() const;
 
   /**

--- a/src/api/java/io/github/cvc5/DatatypeDecl.java
+++ b/src/api/java/io/github/cvc5/DatatypeDecl.java
@@ -51,7 +51,7 @@ public class DatatypeDecl extends AbstractPointer
   private native int getNumConstructors(long pointer);
 
   /**
-   * @return true if this datatype is parametric
+   * @return true if this DatatypeDecl is parametric
    *
    * @api.note This method is experimental and may change in future versions.
    */

--- a/src/api/java/io/github/cvc5/DatatypeDecl.java
+++ b/src/api/java/io/github/cvc5/DatatypeDecl.java
@@ -50,7 +50,11 @@ public class DatatypeDecl extends AbstractPointer
 
   private native int getNumConstructors(long pointer);
 
-  /** @return true if this datatype is parametric */
+  /**
+   * @return true if this datatype is parametric
+   *
+   * @api.note This method is experimental and may change in future versions.
+   */
   public boolean isParametric()
   {
     return isParametric(pointer);

--- a/src/api/java/io/github/cvc5/Solver.java
+++ b/src/api/java/io/github/cvc5/Solver.java
@@ -1442,6 +1442,9 @@ public class Solver implements IPointer, AutoCloseable
   /**
    * Create a datatype declaration.
    * Create sorts parameter with Solver::mkParamSort().
+   *
+   * @api.note This method is experimental and may change in future versions.
+   *
    * @param name the name of the datatype
    * @param params a list of sort parameters
    * @return the DatatypeDecl

--- a/src/api/java/io/github/cvc5/Solver.java
+++ b/src/api/java/io/github/cvc5/Solver.java
@@ -1427,35 +1427,9 @@ public class Solver implements IPointer, AutoCloseable
   /**
    * Create a datatype declaration.
    * Create sorts parameter with Solver::mkParamSort().
-   * @param name the name of the datatype
-   * @param param the sort parameter
-   * @return the DatatypeDecl
-   */
-  public DatatypeDecl mkDatatypeDecl(String name, Sort param)
-  {
-    return mkDatatypeDecl(name, param, false);
-  }
-
-  /**
-   * Create a datatype declaration.
-   * Create sorts parameter with Solver::mkParamSort().
-   * @param name the name of the datatype
-   * @param param the sort parameter
-   * @param isCoDatatype true if a codatatype is to be constructed
-   * @return the DatatypeDecl
-   */
-  public DatatypeDecl mkDatatypeDecl(String name, Sort param, boolean isCoDatatype)
-  {
-    long declPointer = mkDatatypeDecl(pointer, name, param.getPointer(), isCoDatatype);
-    return new DatatypeDecl(this, declPointer);
-  }
-
-  private native long mkDatatypeDecl(
-      long pointer, String name, long paramPointer, boolean isCoDatatype);
-
-  /**
-   * Create a datatype declaration.
-   * Create sorts parameter with Solver::mkParamSort().
+   *
+   * @api.note This method is experimental and may change in future versions.
+   *
    * @param name the name of the datatype
    * @param params a list of sort parameters
    * @return the DatatypeDecl

--- a/src/api/java/jni/solver.cpp
+++ b/src/api/java/jni/solver.cpp
@@ -1478,32 +1478,6 @@ Java_io_github_cvc5_Solver_mkDatatypeDecl__JLjava_lang_String_2Z(
 /*
  * Class:     io_github_cvc5_Solver
  * Method:    mkDatatypeDecl
- * Signature: (JLjava/lang/String;JZ)J
- */
-JNIEXPORT jlong JNICALL
-Java_io_github_cvc5_Solver_mkDatatypeDecl__JLjava_lang_String_2JZ(
-    JNIEnv* env,
-    jobject,
-    jlong pointer,
-    jstring jName,
-    jlong paramPointer,
-    jboolean isCoDatatype)
-{
-  CVC5_JAVA_API_TRY_CATCH_BEGIN;
-  Solver* solver = reinterpret_cast<Solver*>(pointer);
-  const char* s = env->GetStringUTFChars(jName, nullptr);
-  std::string cName(s);
-  Sort* param = reinterpret_cast<Sort*>(paramPointer);
-  DatatypeDecl* retPointer = new DatatypeDecl(
-      solver->mkDatatypeDecl(cName, *param, (bool)isCoDatatype));
-  env->ReleaseStringUTFChars(jName, s);
-  return reinterpret_cast<jlong>(retPointer);
-  CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, 0);
-}
-
-/*
- * Class:     io_github_cvc5_Solver
- * Method:    mkDatatypeDecl
  * Signature: (JLjava/lang/String;[JZ)J
  */
 JNIEXPORT jlong JNICALL

--- a/src/api/python/cvc5.pxd
+++ b/src/api/python/cvc5.pxd
@@ -293,8 +293,6 @@ cdef extern from "api/cpp/cvc5.h" namespace "cvc5":
         DatatypeConstructorDecl mkDatatypeConstructorDecl(const string& name) except +
         DatatypeDecl mkDatatypeDecl(const string& name) except +
         DatatypeDecl mkDatatypeDecl(const string& name, bint isCoDatatype) except +
-        DatatypeDecl mkDatatypeDecl(const string& name, const Sort& param) except +
-        DatatypeDecl mkDatatypeDecl(const string& name, const Sort& param, bint isCoDatatype) except +
         DatatypeDecl mkDatatypeDecl(const string& name, vector[Sort]& params) except +
         DatatypeDecl mkDatatypeDecl(const string& name, vector[Sort]& params, bint isCoDatatype) except +
         # default value for symbol defined in cpp/cvc5.h

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -435,6 +435,9 @@ cdef class DatatypeDecl:
 
     def isParametric(self):
         """
+            .. warning:: This method is experimental and may change in future
+                         versions.
+
             :return: True if this datatype declaration is parametric.
         """
         return self.cdd.isParametric()

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -1600,10 +1600,6 @@ cdef class Solver:
             if isinstance(sorts_or_bool, bool):
                 dd.cdd = self.csolver.mkDatatypeDecl(
                         <const string &> name.encode(), <bint> sorts_or_bool)
-            elif isinstance(sorts_or_bool, Sort):
-                dd.cdd = self.csolver.mkDatatypeDecl(
-                        <const string &> name.encode(),
-                        (<Sort> sorts_or_bool).csort)
             elif isinstance(sorts_or_bool, list):
                 for s in sorts_or_bool:
                     v.push_back((<Sort?> s).csort)
@@ -1614,12 +1610,7 @@ cdef class Solver:
                 raise ValueError("Unhandled second argument type {}"
                                  .format(type(sorts_or_bool)))
         elif sorts_or_bool is not None and isCoDatatype is not None:
-            if isinstance(sorts_or_bool, Sort):
-                dd.cdd = self.csolver.mkDatatypeDecl(
-                        <const string &> name.encode(),
-                        (<Sort> sorts_or_bool).csort,
-                        <bint> isCoDatatype)
-            elif isinstance(sorts_or_bool, list):
+            if isinstance(sorts_or_bool, list):
                 for s in sorts_or_bool:
                     v.push_back((<Sort?> s).csort)
                 dd.cdd = self.csolver.mkDatatypeDecl(

--- a/test/unit/api/cpp/parametric_datatype_black.cpp
+++ b/test/unit/api/cpp/parametric_datatype_black.cpp
@@ -34,7 +34,7 @@ TEST_F(TestApiBlackParametricDatatype, proj_issue387)
   Sort p2 = d_solver.mkParamSort("_x27");
   Sort p3 = d_solver.mkParamSort("_x3");
 
-  DatatypeDecl dtdecl1 = d_solver.mkDatatypeDecl("_x0", p1);
+  DatatypeDecl dtdecl1 = d_solver.mkDatatypeDecl("_x0", {p1});
   DatatypeConstructorDecl ctordecl1 =
       d_solver.mkDatatypeConstructorDecl("_x18");
   ASSERT_THROW(ctordecl1.addSelector("_x17", u2.instantiate({p1, p1})),

--- a/test/unit/api/cpp/solver_black.cpp
+++ b/test/unit/api/cpp/solver_black.cpp
@@ -215,8 +215,8 @@ TEST_F(TestApiBlackSolver, mkDatatypeSorts)
   Sort p1 = d_solver.mkParamSort("p1");
   Sort u0 = d_solver.mkUnresolvedSort("dt0", 1);
   Sort u1 = d_solver.mkUnresolvedSort("dt1", 1);
-  DatatypeDecl dtdecl0 = d_solver.mkDatatypeDecl("dt0", p0);
-  DatatypeDecl dtdecl1 = d_solver.mkDatatypeDecl("dt1", p1);
+  DatatypeDecl dtdecl0 = d_solver.mkDatatypeDecl("dt0", {p0});
+  DatatypeDecl dtdecl1 = d_solver.mkDatatypeDecl("dt1", {p1});
   DatatypeConstructorDecl ctordecl0 = d_solver.mkDatatypeConstructorDecl("c0");
   ctordecl0.addSelector("s0", u1.instantiate({p0}));
   DatatypeConstructorDecl ctordecl1 = d_solver.mkDatatypeConstructorDecl("c1");
@@ -840,7 +840,7 @@ TEST_F(TestApiBlackSolver, mkTermFromOp)
 
   // list datatype
   Sort sort = d_solver.mkParamSort("T");
-  DatatypeDecl listDecl = d_solver.mkDatatypeDecl("paramlist", sort);
+  DatatypeDecl listDecl = d_solver.mkDatatypeDecl("paramlist", {sort});
   DatatypeConstructorDecl cons = d_solver.mkDatatypeConstructorDecl("cons");
   DatatypeConstructorDecl nil = d_solver.mkDatatypeConstructorDecl("nil");
   cons.addSelector("head", sort);
@@ -2964,7 +2964,7 @@ TEST_F(TestApiBlackSolver, proj_issue378)
   Term t7 = d_solver.mkConst(s2, "_x58");
 
   Sort sp = d_solver.mkParamSort("_x178");
-  dtdecl = d_solver.mkDatatypeDecl("_x176", sp);
+  dtdecl = d_solver.mkDatatypeDecl("_x176", {sp});
   cdecl = d_solver.mkDatatypeConstructorDecl("_x184");
   cdecl.addSelector("_x180", s2);
   dtdecl.addConstructor(cdecl);
@@ -2988,7 +2988,7 @@ TEST_F(TestApiBlackSolver, proj_issue379)
   Sort bsort = d_solver.getBooleanSort();
   Sort psort = d_solver.mkParamSort("_x1");
   DatatypeConstructorDecl cdecl;
-  DatatypeDecl dtdecl = d_solver.mkDatatypeDecl("x_0", psort);
+  DatatypeDecl dtdecl = d_solver.mkDatatypeDecl("x_0", {psort});
   cdecl = d_solver.mkDatatypeConstructorDecl("_x8");
   cdecl.addSelector("_x7", bsort);
   dtdecl.addConstructor(cdecl);
@@ -3025,7 +3025,7 @@ TEST_F(TestApiBlackSolver, proj_issue381)
   Sort s1 = d_solver.getBooleanSort();
 
   Sort psort = d_solver.mkParamSort("_x9");
-  DatatypeDecl dtdecl = d_solver.mkDatatypeDecl("_x8", psort);
+  DatatypeDecl dtdecl = d_solver.mkDatatypeDecl("_x8", {psort});
   DatatypeConstructorDecl ctor = d_solver.mkDatatypeConstructorDecl("_x22");
   ctor.addSelector("_x19", s1);
   dtdecl.addConstructor(ctor);
@@ -3051,7 +3051,7 @@ TEST_F(TestApiBlackSolver, proj_issue382)
   Sort psort = d_solver.mkParamSort("_x1");
   DatatypeConstructorDecl ctor = d_solver.mkDatatypeConstructorDecl("_x20");
   ctor.addSelector("_x19", psort);
-  DatatypeDecl dtdecl = d_solver.mkDatatypeDecl("_x0", psort);
+  DatatypeDecl dtdecl = d_solver.mkDatatypeDecl("_x0", {psort});
   dtdecl.addConstructor(ctor);
   Sort s2 = d_solver.mkDatatypeSort(dtdecl);
   Sort s6 = s2.instantiate({s1});

--- a/test/unit/api/cpp/sort_black.cpp
+++ b/test/unit/api/cpp/sort_black.cpp
@@ -37,7 +37,7 @@ class TestApiBlackSort : public TestApi
   Sort create_param_datatype_sort()
   {
     Sort sort = d_solver.mkParamSort("T");
-    DatatypeDecl paramDtypeSpec = d_solver.mkDatatypeDecl("paramlist", sort);
+    DatatypeDecl paramDtypeSpec = d_solver.mkDatatypeDecl("paramlist", {sort});
     DatatypeConstructorDecl paramCons =
         d_solver.mkDatatypeConstructorDecl("cons");
     DatatypeConstructorDecl paramNil =

--- a/test/unit/api/cpp/term_black.cpp
+++ b/test/unit/api/cpp/term_black.cpp
@@ -175,7 +175,7 @@ TEST_F(TestApiBlackTerm, getOp)
 
   // Test Datatypes Ops
   Sort sort = d_solver.mkParamSort("T");
-  DatatypeDecl listDecl = d_solver.mkDatatypeDecl("paramlist", sort);
+  DatatypeDecl listDecl = d_solver.mkDatatypeDecl("paramlist", {sort});
   DatatypeConstructorDecl cons = d_solver.mkDatatypeConstructorDecl("cons");
   DatatypeConstructorDecl nil = d_solver.mkDatatypeConstructorDecl("nil");
   cons.addSelector("head", sort);

--- a/test/unit/api/cpp/term_white.cpp
+++ b/test/unit/api/cpp/term_white.cpp
@@ -50,7 +50,7 @@ TEST_F(TestApiWhiteTerm, getOp)
 
   // Test Datatypes Ops
   Sort sort = d_solver.mkParamSort("T");
-  DatatypeDecl listDecl = d_solver.mkDatatypeDecl("paramlist", sort);
+  DatatypeDecl listDecl = d_solver.mkDatatypeDecl("paramlist", {sort});
   DatatypeConstructorDecl cons = d_solver.mkDatatypeConstructorDecl("cons");
   DatatypeConstructorDecl nil = d_solver.mkDatatypeConstructorDecl("nil");
   cons.addSelector("head", sort);

--- a/test/unit/api/java/SolverTest.java
+++ b/test/unit/api/java/SolverTest.java
@@ -825,7 +825,8 @@ class SolverTest
 
     // list datatype
     Sort sort = d_solver.mkParamSort("T");
-    DatatypeDecl listDecl = d_solver.mkDatatypeDecl("paramlist", new Sort[] {sort});
+    DatatypeDecl listDecl =
+        d_solver.mkDatatypeDecl("paramlist", new Sort[] {sort});
     DatatypeConstructorDecl cons = d_solver.mkDatatypeConstructorDecl("cons");
     DatatypeConstructorDecl nil = d_solver.mkDatatypeConstructorDecl("nil");
     cons.addSelector("head", sort);

--- a/test/unit/api/java/SolverTest.java
+++ b/test/unit/api/java/SolverTest.java
@@ -206,8 +206,8 @@ class SolverTest
     Sort p1 = d_solver.mkParamSort("p1");
     Sort u0 = d_solver.mkUnresolvedSort("dt0", 1);
     Sort u1 = d_solver.mkUnresolvedSort("dt1", 1);
-    DatatypeDecl dtdecl0 = d_solver.mkDatatypeDecl("dt0", p0);
-    DatatypeDecl dtdecl1 = d_solver.mkDatatypeDecl("dt1", p1);
+    DatatypeDecl dtdecl0 = d_solver.mkDatatypeDecl("dt0", new Sort[] {p0});
+    DatatypeDecl dtdecl1 = d_solver.mkDatatypeDecl("dt1", new Sort[] {p1});
     DatatypeConstructorDecl ctordecl0 = d_solver.mkDatatypeConstructorDecl("c0");
     ctordecl0.addSelector("s0", u1.instantiate(new Sort[] {p0}));
     DatatypeConstructorDecl ctordecl1 = d_solver.mkDatatypeConstructorDecl("c1");
@@ -825,7 +825,7 @@ class SolverTest
 
     // list datatype
     Sort sort = d_solver.mkParamSort("T");
-    DatatypeDecl listDecl = d_solver.mkDatatypeDecl("paramlist", sort);
+    DatatypeDecl listDecl = d_solver.mkDatatypeDecl("paramlist", new Sort[] {sort});
     DatatypeConstructorDecl cons = d_solver.mkDatatypeConstructorDecl("cons");
     DatatypeConstructorDecl nil = d_solver.mkDatatypeConstructorDecl("nil");
     cons.addSelector("head", sort);

--- a/test/unit/api/java/SortTest.java
+++ b/test/unit/api/java/SortTest.java
@@ -58,7 +58,7 @@ class SortTest
   Sort create_param_datatype_sort() throws CVC5ApiException
   {
     Sort sort = d_solver.mkParamSort("T");
-    DatatypeDecl paramDtypeSpec = d_solver.mkDatatypeDecl("paramlist", sort);
+    DatatypeDecl paramDtypeSpec = d_solver.mkDatatypeDecl("paramlist", new Sort[] {sort});
     DatatypeConstructorDecl paramCons = d_solver.mkDatatypeConstructorDecl("cons");
     DatatypeConstructorDecl paramNil = d_solver.mkDatatypeConstructorDecl("nil");
     paramCons.addSelector("head", sort);

--- a/test/unit/api/java/SortTest.java
+++ b/test/unit/api/java/SortTest.java
@@ -58,7 +58,8 @@ class SortTest
   Sort create_param_datatype_sort() throws CVC5ApiException
   {
     Sort sort = d_solver.mkParamSort("T");
-    DatatypeDecl paramDtypeSpec = d_solver.mkDatatypeDecl("paramlist", new Sort[] {sort});
+    DatatypeDecl paramDtypeSpec =
+        d_solver.mkDatatypeDecl("paramlist", new Sort[] {sort});
     DatatypeConstructorDecl paramCons = d_solver.mkDatatypeConstructorDecl("cons");
     DatatypeConstructorDecl paramNil = d_solver.mkDatatypeConstructorDecl("nil");
     paramCons.addSelector("head", sort);

--- a/test/unit/api/java/TermTest.java
+++ b/test/unit/api/java/TermTest.java
@@ -210,7 +210,8 @@ class TermTest
 
     // Test Datatypes Ops
     Sort sort = d_solver.mkParamSort("T");
-    DatatypeDecl listDecl = d_solver.mkDatatypeDecl("paramlist", new Sort[] {sort});
+    DatatypeDecl listDecl =
+        d_solver.mkDatatypeDecl("paramlist", new Sort[] {sort});
     DatatypeConstructorDecl cons = d_solver.mkDatatypeConstructorDecl("cons");
     DatatypeConstructorDecl nil = d_solver.mkDatatypeConstructorDecl("nil");
     cons.addSelector("head", sort);

--- a/test/unit/api/java/TermTest.java
+++ b/test/unit/api/java/TermTest.java
@@ -210,7 +210,7 @@ class TermTest
 
     // Test Datatypes Ops
     Sort sort = d_solver.mkParamSort("T");
-    DatatypeDecl listDecl = d_solver.mkDatatypeDecl("paramlist", sort);
+    DatatypeDecl listDecl = d_solver.mkDatatypeDecl("paramlist", new Sort[] {sort});
     DatatypeConstructorDecl cons = d_solver.mkDatatypeConstructorDecl("cons");
     DatatypeConstructorDecl nil = d_solver.mkDatatypeConstructorDecl("nil");
     cons.addSelector("head", sort);

--- a/test/unit/api/python/test_solver.py
+++ b/test/unit/api/python/test_solver.py
@@ -165,8 +165,8 @@ def test_mk_datatype_sorts(solver):
     p1 = solver.mkParamSort("p1")
     u0 = solver.mkUnresolvedSort("dt0", 1)
     u1 = solver.mkUnresolvedSort("dt1", 1)
-    dtdecl0 = solver.mkDatatypeDecl("dt0", p0)
-    dtdecl1 = solver.mkDatatypeDecl("dt1", p1)
+    dtdecl0 = solver.mkDatatypeDecl("dt0", [p0])
+    dtdecl1 = solver.mkDatatypeDecl("dt1", [p1])
     ctordecl0 = solver.mkDatatypeConstructorDecl("c0")
     ctordecl0.addSelector("s0", u1.instantiate({p0}))
     ctordecl1 = solver.mkDatatypeConstructorDecl("c1")
@@ -803,7 +803,7 @@ def test_mk_term_from_op(solver):
 
     # list datatype
     sort = solver.mkParamSort("T")
-    listDecl = solver.mkDatatypeDecl("paramlist", sort)
+    listDecl = solver.mkDatatypeDecl("paramlist", [sort])
     cons = solver.mkDatatypeConstructorDecl("cons")
     nil = solver.mkDatatypeConstructorDecl("nil")
     cons.addSelector("head", sort)

--- a/test/unit/api/python/test_sort.py
+++ b/test/unit/api/python/test_sort.py
@@ -41,7 +41,7 @@ def create_datatype_sort(solver):
 
 def create_param_datatype_sort(solver):
     sort = solver.mkParamSort("T")
-    paramDtypeSpec = solver.mkDatatypeDecl("paramlist", sort)
+    paramDtypeSpec = solver.mkDatatypeDecl("paramlist", [sort])
     paramCons = solver.mkDatatypeConstructorDecl("cons")
     paramNil = solver.mkDatatypeConstructorDecl("nil")
     paramCons.addSelector("head", sort)

--- a/test/unit/api/python/test_term.py
+++ b/test/unit/api/python/test_term.py
@@ -175,7 +175,7 @@ def test_get_op(solver):
 
     # Test Datatypes Ops
     sort = solver.mkParamSort("T")
-    listDecl = solver.mkDatatypeDecl("paramlist", sort)
+    listDecl = solver.mkDatatypeDecl("paramlist", [sort])
     cons = solver.mkDatatypeConstructorDecl("cons")
     nil = solver.mkDatatypeConstructorDecl("nil")
     cons.addSelector("head", sort)


### PR DESCRIPTION
Subsumed by the vector version.

Also marks more methods as experimetnal.