### PR TITLE
Speed up CI by using more cores

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -38,7 +38,7 @@ runs:
         echo "SED=sed" >> $GITHUB_ENV
         echo "CCACHE_CONFIGPATH=/home/runner/.ccache/ccache.conf" >> $GITHUB_ENV
         echo "image_version=$ImageVersion" >> $GITHUB_ENV
-        echo "num_proc=$(nproc)" >> $GITHUB_ENV
+        echo "num_proc=$(( $(nproc) + 1 ))" >> $GITHUB_ENV
         echo "/usr/lib/ccache" >> $GITHUB_PATH
         echo "::endgroup::"
 
@@ -81,7 +81,7 @@ runs:
         echo "SED=gsed" >> $GITHUB_ENV
         echo "CCACHE_CONFIGPATH=/Users/runner/Library/Preferences/ccache/ccache.conf" >> $GITHUB_ENV
         echo "image_version=$ImageVersion" >> $GITHUB_ENV
-        echo "num_proc=$(sysctl -n hw.logicalcpu)" >> $GITHUB_ENV
+        echo "num_proc=$(( $(sysctl -n hw.logicalcpu) + 1 ))" >> $GITHUB_ENV
         echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
         echo "::endgroup::"
 


### PR DESCRIPTION
This PR uses one process more than we have cores in the CI. This speeds up the CI jobs when time is spent waiting on IO instead of actually using the CPU.

---

Timing this is somewhat difficult, but it can reduce the time needed to run the tests significantly. (for example production-clang 4:35 -> 3:22, production-dbg-clang 11:32 -> 10:03) in https://github.com/nafur/cvc5/runs/5796574088 vs https://github.com/nafur/cvc5/runs/5796587767.
