### PR TITLE
Workaround for get-value failure with uninterpreted sorts

### DIFF
--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -733,7 +733,10 @@ void Parser::pushGetValueScope()
     std::vector<cvc5::Term> elements = d_solver->getModelDomainElements(s);
     for (const cvc5::Term& e : elements)
     {
-      defineVar(e.getUninterpretedSortValue(), e);
+      if (e.getKind() == Kind::UNINTERPRETED_SORT_VALUE)
+      {
+        defineVar(e.getUninterpretedSortValue(), e);
+      }
     }
   }
 }


### PR DESCRIPTION
Hey, hope you've all been well! I've attached an `smt2` file generated by a printing backend from `smt-switch`. After upgrading the `cvc5` version in https://github.com/stanford-centaur/smt-switch/pull/284, it failed to get the value of a bit-vector when there are uninterpreted sorts in the original query.

Here is the output as of 145f31d5d0df0019d2a3e6f09776b55bc5d5bffe:
```
unsat
()
sat
(error "Parse Error: ../cvc5-printing.cpp-sample.smt2:22.10: Invalid argument 'groundTerm_1' for '*d_node', expected Term to be an abstract value when calling getUninterpretedSortValue()")
```

I've made _a_ fix for this problem, but I expect it's probably not the _right_ fix. It appears that a node of type `SKOLEM` is included in the model domain elements because it is of uninterpreted sort: https://github.com/cvc5/cvc5/blob/145f31d5d0df0019d2a3e6f09776b55bc5d5bffe/src/parser/parser.cpp#L733

My naive fix was just to check the kind of every element before defining a variable. But perhaps the skolem should not have been included in the first place? Let me know what you think, thanks! (Not sure if I assigned the right person btw, just took the GitHub recommendation haha)

[cvc5-printing.cpp-sample.smt2.tar.gz](https://github.com/cvc5/cvc5/files/8404617/cvc5-printing.cpp-sample.smt2.tar.gz)

