### PR TITLE
Remove duplicate lines in python Kinds documentation

### DIFF
--- a/src/api/python/genenums.py.in
+++ b/src/api/python/genenums.py.in
@@ -79,8 +79,11 @@ comment_repls = {
 
 
 def reformat_comment(comment):
+    # apply replacements from above
     for pat, repl in comment_repls.items():
         comment = re.sub(pat, repl, comment)
+    # remove duplicate lines (e.g. overloads collapse from previous substitutions)
+    comment = re.sub('^(?P<line>.*)$\n^(?P=line)$', '\\g<line>', comment, flags=re.MULTILINE)
     return comment
 
 


### PR DESCRIPTION
We remove the arguments from links to solver methods in the Kinds documentation to turn C++ references into python references. This oftentimes collapses previously different overload of methods (usually `mkTerm()`). This PR generically removes duplicate lines from these comments using some re magic.