### PR TITLE
Maintain symlink to docs for latest release

### DIFF
--- a/.github/workflows/docs_upload.yml
+++ b/.github/workflows/docs_upload.yml
@@ -124,6 +124,9 @@ jobs:
             cp -r docs-new target-releases/$NAME
             cd target-releases/
 
+            rm -f latest
+            ln -s $NAME latest
+
             python3 genversions.py
             git add .
 


### PR DESCRIPTION
This PR creates/updates a symlink called `latest` to the last release. This simplifies permalinks into the documentation.