### PR TITLE
Fix links when converting kinds documentation to python

### DIFF
--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -541,7 +541,7 @@ cdef class DatatypeSelector:
             Similar to selectors, updater terms are a class of function-like
             terms of updater Sort (:py:meth:`Sort.isDatatypeUpdater()`), and
             should be used as the first argument of Terms of kind
-            :py:ob:`APPLY_UPDATER <cvc5.Kind.APPLY_UPDATER>`.
+            :py:obj:`APPLY_UPDATER <Kind.APPLY_UPDATER>`.
 
             :return: The updater term of this datatype selector.
         """

--- a/src/api/python/genenums.py.in
+++ b/src/api/python/genenums.py.in
@@ -62,24 +62,27 @@ class {enum}(Enum):
 ENUMS_ATTR_TEMPLATE = r'''    {name}=c_{enum}.{cpp_name}, """{doc}"""
 '''
 
-comment_repls = {
-    'Term::([a-zA-Z]+)\(([^)]*)\)': ':py:meth:`Term.\\1()`',
-    'Solver::([a-zA-Z]+)\(([^)]*)\) const': ':py:meth:`Solver.\\1()`',
-    'Solver::([a-zA-Z]+)\(([^)]*)\)': ':py:meth:`Solver.\\1()`',
-    'DatatypeConstructor::([a-zA-Z]+)\(([^)]*)\) const': ':py:meth:`DatatypeConstructor.\\1()`',
-    'DatatypeConstructor::([a-zA-Z]+)\(([^)]*)\)': ':py:meth:`DatatypeConstructor.\\1()`',
-    'Datatype::([a-zA-Z]+)\(([^)]*)\) const': ':py:meth:`Datatype.\\1()`',
-    'Datatype::([a-zA-Z]+)\(([^)]*)\)': ':py:meth:`Datatype.\\1()`',
-    'DatatypeSelector::([a-zA-Z]+)\(([^)]*)\) const': ':py:meth:`DatatypeSelector.\\1()`',
-    'DatatypeSelector::([a-zA-Z]+)\(([^)]*)\)': ':py:meth:`DatatypeSelector.\\1()`',
-    ':cpp:func:`(.*?)`': '\\1',
-    ':cpp:enumerator:`(.*?)`': ':py:obj:`\\1`',
-    '\\\\': '\\\\\\\\',
-}
+# list to enforce proper ordering
+comment_repls = [
+    # first remove explicit cpp references
+    (':cpp:func:`(.*?)`', '\\1'),
+    (':cpp:enumerator:`(.*?)`', ':py:obj:`\\1`'),
+    # introduce proper python references
+    ('Term::([a-zA-Z]+)\(([^)]*)\)', ':py:meth:`Term.\\1()`'),
+    ('Solver::([a-zA-Z]+)\(([^)]*)\) const', ':py:meth:`Solver.\\1()`'),
+    ('Solver::([a-zA-Z]+)\(([^)]*)\)', ':py:meth:`Solver.\\1()`'),
+    ('DatatypeConstructor::([a-zA-Z]+)\(([^)]*)\) const', ':py:meth:`DatatypeConstructor.\\1()`'),
+    ('DatatypeConstructor::([a-zA-Z]+)\(([^)]*)\)', ':py:meth:`DatatypeConstructor.\\1()`'),
+    ('Datatype::([a-zA-Z]+)\(([^)]*)\) const', ':py:meth:`Datatype.\\1()`'),
+    ('Datatype::([a-zA-Z]+)\(([^)]*)\)', ':py:meth:`Datatype.\\1()`'),
+    ('DatatypeSelector::([a-zA-Z]+)\(([^)]*)\) const', ':py:meth:`DatatypeSelector.\\1()`'),
+    ('DatatypeSelector::([a-zA-Z]+)\(([^)]*)\)', ':py:meth:`DatatypeSelector.\\1()`'),
+    ('\\\\', '\\\\\\\\'),
+]
 
 
 def reformat_comment(comment):
-    for pat, repl in comment_repls.items():
+    for pat, repl in comment_repls:
         comment = re.sub(pat, repl, comment)
     return comment
 


### PR DESCRIPTION
This PR mainly fixes explicit rst links when we convert the kinds comments to python.