### PR TITLE
Eliminate SmtSolver dependency on SolverEngineState

### DIFF
--- a/src/proof/proof_checker.cpp
+++ b/src/proof/proof_checker.cpp
@@ -93,6 +93,12 @@ ProofChecker::ProofChecker(bool eagerCheck,
 {
 }
 
+void ProofChecker::reset()
+{
+  d_checker.clear();
+  d_plevel.clear();
+}
+
 Node ProofChecker::check(ProofNode* pn, Node expected)
 {
   return check(pn->getRule(), pn->getChildren(), pn->getArguments(), expected);

--- a/src/proof/proof_checker.h
+++ b/src/proof/proof_checker.h
@@ -109,6 +109,8 @@ class ProofChecker
                uint32_t pclevel = 0,
                rewriter::RewriteDb* rdb = nullptr);
   ~ProofChecker() {}
+  /** Reset, which clears the rule checkers */
+  void reset();
   /**
    * Return the formula that is proven by proof node pn, or null if pn is not
    * well-formed. If expected is non-null, then we return null if pn does not

--- a/src/smt/smt_solver.cpp
+++ b/src/smt/smt_solver.cpp
@@ -36,11 +36,9 @@ namespace cvc5::internal {
 namespace smt {
 
 SmtSolver::SmtSolver(Env& env,
-                     SolverEngineState& state,
                      AbstractValues& abs,
                      SolverEngineStatistics& stats)
     : EnvObj(env),
-      d_state(state),
       d_pp(env, abs, stats),
       d_stats(stats),
       d_theoryEngine(nullptr),
@@ -214,7 +212,6 @@ void SmtSolver::processAssertions(Assertions& as)
 {
   TimerStat::CodeTimer paTimer(d_stats.d_processAssertionsTime);
   d_env.getResourceManager()->spendResource(Resource::PreprocessStep);
-  Assert(d_state.isFullyReady());
 
   preprocessing::AssertionPipeline& ap = as.getAssertionPipeline();
 

--- a/src/smt/smt_solver.h
+++ b/src/smt/smt_solver.h
@@ -66,7 +66,6 @@ class SmtSolver : protected EnvObj
 {
  public:
   SmtSolver(Env& env,
-            SolverEngineState& state,
             AbstractValues& abs,
             SolverEngineStatistics& stats);
   ~SmtSolver();
@@ -115,8 +114,6 @@ class SmtSolver : protected EnvObj
   //------------------------------------------ end access methods
 
  private:
-  /** Reference to the state of the SolverEngine */
-  SolverEngineState& d_state;
   /** The preprocessor of this SMT solver */
   Preprocessor d_pp;
   /** Reference to the statistics of SolverEngine */

--- a/src/smt/smt_solver.h
+++ b/src/smt/smt_solver.h
@@ -21,6 +21,8 @@
 #include <vector>
 
 #include "expr/node.h"
+#include "smt/assertions.h"
+#include "smt/env_obj.h"
 #include "smt/preprocessor.h"
 #include "theory/logic_info.h"
 #include "util/result.h"
@@ -43,7 +45,6 @@ class QuantifiersEngine;
 
 namespace smt {
 
-class Assertions;
 class SolverEngineState;
 struct SolverEngineStatistics;
 
@@ -61,7 +62,7 @@ struct SolverEngineStatistics;
  * models) can be queries using other classes that examine the state of the
  * TheoryEngine directly, which can be accessed via getTheoryEngine.
  */
-class SmtSolver
+class SmtSolver : protected EnvObj
 {
  public:
   SmtSolver(Env& env,
@@ -114,8 +115,6 @@ class SmtSolver
   //------------------------------------------ end access methods
 
  private:
-  /** Reference to the environment */
-  Env& d_env;
   /** Reference to the state of the SolverEngine */
   SolverEngineState& d_state;
   /** The preprocessor of this SMT solver */

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -750,17 +750,21 @@ Result SolverEngine::checkSat(const std::vector<Node>& assumptions)
 
 Result SolverEngine::checkSatInternal(const std::vector<Node>& assumptions)
 {
-  Result r;
-
   SolverEngineScope smts(this);
   finishInit();
 
   Trace("smt") << "SolverEngine::checkSat(" << assumptions << ")" << endl;
+  // update the state to indicate we are about to run a check-sat
+  bool hasAssumptions = !assumptions.empty();
+  d_state->notifyCheckSat(hasAssumptions);
+
   // check the satisfiability with the solver object
-  r = d_smtSolver->checkSatisfiability(*d_asserts.get(), assumptions);
+  Result r = d_smtSolver->checkSatisfiability(*d_asserts.get(), assumptions);
 
   Trace("smt") << "SolverEngine::checkSat(" << assumptions << ") => " << r
                << endl;
+  // notify our state of the check-sat result
+  d_state->notifyCheckSatResult(hasAssumptions, r);
 
   // Check that SAT results generate a model correctly.
   if (d_env->getOptions().smt.checkModels)

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -117,7 +117,7 @@ SolverEngine::SolverEngine(NodeManager* nm, const Options* optr)
   // make statistics
   d_stats.reset(new SolverEngineStatistics());
   // make the SMT solver
-  d_smtSolver.reset(new SmtSolver(*d_env, *d_state, *d_absValues, *d_stats));
+  d_smtSolver.reset(new SmtSolver(*d_env, *d_absValues, *d_stats));
   // make the SyGuS solver
   d_sygusSolver.reset(new SygusSolver(*d_env.get(), *d_smtSolver));
   // make the quantifier elimination solver
@@ -752,6 +752,8 @@ Result SolverEngine::checkSatInternal(const std::vector<Node>& assumptions)
 {
   SolverEngineScope smts(this);
   finishInit();
+  // state should be fully ready now
+  Assert(d_state->isFullyReady());
 
   Trace("smt") << "SolverEngine::checkSat(" << assumptions << ")" << endl;
   // update the state to indicate we are about to run a check-sat


### PR DESCRIPTION
This is in preparation for making SmtSolver able to be deep reset (reconstructed) within in a SolverEngine instance.