### PR TITLE
Generalization for sygus verify utility

### DIFF
--- a/src/theory/quantifiers/sygus/synth_verify.cpp
+++ b/src/theory/quantifiers/sygus/synth_verify.cpp
@@ -115,8 +115,7 @@ Result SynthVerify::verify(Node query,
         // went wrong or the answer is unknown (for debugging).
         if (squery.isConst() && !squery.getConst<bool>())
         {
-          Assert(!options().quantifiers.sygusRecFun
-                 || r.getStatus() == Result::UNKNOWN)
+          Assert(r.getStatus() == Result::UNKNOWN)
               << "Expected model from verification step to satisfy query";
         }
       }

--- a/src/theory/quantifiers/sygus/synth_verify.cpp
+++ b/src/theory/quantifiers/sygus/synth_verify.cpp
@@ -116,7 +116,7 @@ Result SynthVerify::verify(Node query,
         if (!squery.isConst() || !squery.getConst<bool>())
         {
           Assert(!options().quantifiers.sygusRecFun
-                  || r.getStatus() == Result::UNKNOWN)
+                 || r.getStatus() == Result::UNKNOWN)
               << "Expected model from verification step to satisfy query";
         }
       }
@@ -159,9 +159,8 @@ Node SynthVerify::preprocessQueryInternal(Node query)
         }
       }
       query = nm->mkAnd(qconj);
-      Trace("cegqi-debug")
-          << "after function definitions, query is " << query
-          << std::endl;
+      Trace("cegqi-debug") << "after function definitions, query is " << query
+                           << std::endl;
     }
   }
   return query;

--- a/src/theory/quantifiers/sygus/synth_verify.cpp
+++ b/src/theory/quantifiers/sygus/synth_verify.cpp
@@ -111,9 +111,9 @@ Result SynthVerify::verify(Node query,
         Trace("cegqi-debug") << "...squery : " << squery << std::endl;
         squery = d_tds->rewriteNode(squery);
         Trace("cegqi-debug") << "...rewrites to : " << squery << std::endl;
-        // if the query did not simplify to true, then something unexpected
+        // if the query simplifies to false, then something
         // went wrong or the answer is unknown (for debugging).
-        if (!squery.isConst() || !squery.getConst<bool>())
+        if (squery.isConst() && !squery.getConst<bool>())
         {
           Assert(!options().quantifiers.sygusRecFun
                  || r.getStatus() == Result::UNKNOWN)

--- a/src/theory/quantifiers/sygus/synth_verify.cpp
+++ b/src/theory/quantifiers/sygus/synth_verify.cpp
@@ -66,26 +66,97 @@ Result SynthVerify::verify(Node query,
                            const std::vector<Node>& vars,
                            std::vector<Node>& mvs)
 {
+  Node queryp = preprocessQueryInternal(query);
+  bool finished;
+  Result r;
+  do
+  {
+    Trace("sygus-engine") << "  *** Verify with subcall..." << std::endl;
+    if (queryp.isConst())
+    {
+      if (!queryp.getConst<bool>())
+      {
+        return Result(Result::UNSAT);
+      }
+      // sat, but we need to get arbtirary model values below
+    }
+    r = checkWithSubsolver(queryp,
+                           vars,
+                           mvs,
+                           d_subOptions,
+                           d_subLogicInfo,
+                           options().quantifiers.sygusVerifyTimeout != 0,
+                           options().quantifiers.sygusVerifyTimeout);
+    finished = true;
+    Trace("sygus-engine") << "  ...got " << r << std::endl;
+    // we try to learn models for "sat" and "unknown" here
+    if (r.getStatus() != Result::UNSAT)
+    {
+      if (TraceIsOn("sygus-engine"))
+      {
+        Trace("sygus-engine") << "  * Verification lemma failed for:\n   ";
+        for (unsigned i = 0, size = vars.size(); i < size; i++)
+        {
+          Trace("sygus-engine") << vars[i] << " -> " << mvs[i] << " ";
+        }
+        Trace("sygus-engine") << std::endl;
+      }
+      // check whether the query is satisfied by the model
+      if (options().quantifiers.oracles || Configuration::isAssertionBuild())
+      {
+        Assert(vars.size() == mvs.size());
+        // the values for the query should be a complete model
+        Node squery =
+            query.substitute(vars.begin(), vars.end(), mvs.begin(), mvs.end());
+        Trace("cegqi-debug") << "...squery : " << squery << std::endl;
+        squery = d_tds->rewriteNode(squery);
+        Trace("cegqi-debug") << "...rewrites to : " << squery << std::endl;
+        // if the query did not simplify to true, then either:
+        // (1) we are using oracles and the value for an oracle function was
+        // not what we expected.
+        // (2) something unexpected went wrong (for debugging).
+        if (!squery.isConst() || !squery.getConst<bool>())
+        {
+          if (options().quantifiers.oracles)
+          {
+            // In this case, we reconstruct the query, which may include more
+            // information about oracles than we had previously. We rerun the
+            // satisfiability check above.
+            Node nextQueryp = preprocessQueryInternal(query);
+            if (nextQueryp != queryp)
+            {
+              queryp = nextQueryp;
+              finished = false;
+            }
+          }
+          else
+          {
+            Assert(!options().quantifiers.sygusRecFun
+                   || r.getStatus() == Result::UNKNOWN)
+                << "Expected model from verification step to satisfy query";
+          }
+        }
+      }
+    }
+  } while (!finished);
+  return r;
+}
+
+Node SynthVerify::preprocessQueryInternal(Node query)
+{
   NodeManager* nm = NodeManager::currentNM();
+  Trace("cegqi-debug") << "pre-rewritten query : " << query << std::endl;
   // simplify the lemma based on the term database sygus utility
   query = d_tds->rewriteNode(query);
   // eagerly unfold applications of evaluation function
-  Trace("cegqi-debug") << "pre-unfold counterexample : " << query << std::endl;
-
-  if (query.isConst())
-  {
-    if (!query.getConst<bool>())
-    {
-      return Result(Result::UNSAT);
-    }
-    // sat, but we need to get arbtirary model values below
-  }
-  else
+  Trace("cegqi-debug") << "post-rewritten query : " << query << std::endl;
+  if (!query.isConst())
   {
     // if non-constant, we may need to add recursive function definitions
     FunDefEvaluator* feval = d_tds->getFunDefEvaluator();
+    OracleChecker* ochecker = d_tds->getOracleChecker();
     const std::vector<Node>& fdefs = feval->getDefinitions();
-    if (!fdefs.empty())
+    if (!fdefs.empty() || (ochecker != nullptr && ochecker->hasOracles()))
     {
       // Get the relevant definitions based on the symbols in the query.
       // Notice in some cases, this may have the effect of making the subcall
@@ -98,50 +169,29 @@ Result SynthVerify::verify(Node query,
       qconj.push_back(query);
       for (const Node& f : syms)
       {
+        // get the function definition
         Node q = feval->getDefinitionFor(f);
         if (!q.isNull())
         {
           qconj.push_back(q);
         }
+        // get the relevant cached oracle calls
+        if (ochecker != nullptr && ochecker->hasOracleCalls(f))
+        {
+          const std::map<Node, Node>& ocalls = ochecker->getOracleCalls(f);
+          for (const std::pair<const Node, Node>& oc : ocalls)
+          {
+            qconj.push_back(oc.first.eqNode(oc.second));
+          }
+        }
       }
       query = nm->mkAnd(qconj);
-      Trace("cegqi-debug") << "query is " << query << std::endl;
+      Trace("cegqi-debug")
+          << "after function definitions + oracle calls, query is " << query
+          << std::endl;
     }
   }
-  Trace("sygus-engine") << "  *** Verify with subcall..." << std::endl;
-  query = rewrite(query);
-  Result r = checkWithSubsolver(query,
-                                vars,
-                                mvs,
-                                d_subOptions,
-                                d_subLogicInfo,
-                                options().quantifiers.sygusVerifyTimeout != 0,
-                                options().quantifiers.sygusVerifyTimeout);
-  Trace("sygus-engine") << "  ...got " << r << std::endl;
-  if (r.getStatus() == Result::SAT)
-  {
-    if (TraceIsOn("sygus-engine"))
-    {
-      Trace("sygus-engine") << "  * Verification lemma failed for:\n   ";
-      for (unsigned i = 0, size = vars.size(); i < size; i++)
-      {
-        Trace("sygus-engine") << vars[i] << " -> " << mvs[i] << " ";
-      }
-      Trace("sygus-engine") << std::endl;
-    }
-    if (Configuration::isAssertionBuild())
-    {
-      // the values for the query should be a complete model
-      Node squery =
-          query.substitute(vars.begin(), vars.end(), mvs.begin(), mvs.end());
-      Trace("cegqi-debug") << "...squery : " << squery << std::endl;
-      squery = rewrite(squery);
-      Trace("cegqi-debug") << "...rewrites to : " << squery << std::endl;
-      Assert(options().quantifiers.sygusRecFun
-             || (squery.isConst() && squery.getConst<bool>()));
-    }
-  }
-  return r;
+  return query;
 }
 
 }  // namespace quantifiers

--- a/src/theory/quantifiers/sygus/synth_verify.h
+++ b/src/theory/quantifiers/sygus/synth_verify.h
@@ -52,7 +52,11 @@ class SynthVerify : protected EnvObj
                 std::vector<Node>& mvs);
 
  private:
-  /** Get query internal */
+  /**
+   * Preprocess query internal. This returns the rewritten form of query
+   * and includes all relevant function definitions, i.e. those that occur
+   * in query.
+   */
   Node preprocessQueryInternal(Node query);
   /** Pointer to the term database sygus */
   TermDbSygus* d_tds;

--- a/src/theory/quantifiers/sygus/synth_verify.h
+++ b/src/theory/quantifiers/sygus/synth_verify.h
@@ -55,7 +55,7 @@ class SynthVerify : protected EnvObj
   /**
    * Preprocess query internal. This returns the rewritten form of query
    * and includes all relevant function definitions, i.e. those that occur
-   * in query.
+   * in query. These are added as top-level conjuncts to the returned formula.
    */
   Node preprocessQueryInternal(Node query);
   /** Pointer to the term database sygus */

--- a/src/theory/quantifiers/sygus/synth_verify.h
+++ b/src/theory/quantifiers/sygus/synth_verify.h
@@ -52,6 +52,8 @@ class SynthVerify : protected EnvObj
                 std::vector<Node>& mvs);
 
  private:
+  /** Get query internal */
+  Node preprocessQueryInternal(Node query);
   /** Pointer to the term database sygus */
   TermDbSygus* d_tds;
   /** The options for subsolver calls */

--- a/src/theory/smt_engine_subsolver.cpp
+++ b/src/theory/smt_engine_subsolver.cpp
@@ -126,7 +126,7 @@ Result checkWithSubsolver(Node query,
   initializeSubsolver(smte, opts, logicInfo, needsTimeout, timeout);
   smte->assertFormula(query);
   r = smte->checkSat();
-  if (r.getStatus() == Result::SAT)
+  if (r.getStatus() == Result::SAT || r.getStatus() == Result::UNKNOWN)
   {
     for (const Node& v : vars)
     {


### PR DESCRIPTION
This is in preparation for synthesis modulo oracles (SyMO), where the verification loop may run multiple times for a given solution. In a follow up PR, the loop introduced in this PR may run multiple times when oracles are present, since the model from the subsolver may trigger further oracle invocations and simplifications to the rewritten form of the specification.

It also makes it so that candidate models are generated for "unknown" results for subsolvers, which is required for SyMO.