### PR TITLE
Properly parse numerals as real when integers are disabled

### DIFF
--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -1704,7 +1704,7 @@ termAtomic[cvc5::Term& atomTerm]
   : INTEGER_LITERAL
     {
       std::string intStr = AntlrInput::tokenText($INTEGER_LITERAL);
-      atomTerm = PARSER_STATE->mkIntOrRealFromNumeral(intStr);
+      atomTerm = PARSER_STATE->mkRealOrIntFromNumeral(intStr);
     }
   | DECIMAL_LITERAL
     {

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -1704,7 +1704,7 @@ termAtomic[cvc5::Term& atomTerm]
   : INTEGER_LITERAL
     {
       std::string intStr = AntlrInput::tokenText($INTEGER_LITERAL);
-      atomTerm = SOLVER->mkInteger(intStr);
+      atomTerm = PARSER_STATE->mkIntOrRealFromNumeral(intStr);
     }
   | DECIMAL_LITERAL
     {

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -841,13 +841,11 @@ bool Smt2::isAbstractValue(const std::string& name)
 
 cvc5::Term Smt2::mkIntOrRealFromNumeral(const std::string& str)
 {
-  // if integers are used, it is an integer
-  if (d_logic.areIntegersUsed())
-  {
-    return d_solver->mkInteger(str);
+  // if arithmetic is enabled, and integers are disabled
+  if(d_logic.isTheoryEnabled(internal::theory::THEORY_ARITH) && !d_logic.areIntegersUsed()) {
+    return d_solver->mkReal(str);
   }
-  // otherwise, numerals specify (integral) reals
-  return d_solver->mkReal(str);
+  return d_solver->mkInteger(str);
 }
 
 void Smt2::parseOpApplyTypeAscription(ParseOp& p, cvc5::Sort type)

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -839,7 +839,7 @@ bool Smt2::isAbstractValue(const std::string& name)
          && name.find_first_not_of("0123456789", 1) == std::string::npos;
 }
 
-cvc5::Term Smt2::mkIntOrRealFromNumeral(const std::string& str)
+cvc5::Term Smt2::mkRealOrIntFromNumeral(const std::string& str)
 {
   // if arithmetic is enabled, and integers are disabled
   if (d_logic.isTheoryEnabled(internal::theory::THEORY_ARITH)

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -842,7 +842,8 @@ bool Smt2::isAbstractValue(const std::string& name)
 cvc5::Term Smt2::mkIntOrRealFromNumeral(const std::string& str)
 {
   // if integers are used, it is an integer
-  if(d_logic.areIntegersUsed()) {
+  if (d_logic.areIntegersUsed())
+  {
     return d_solver->mkInteger(str);
   }
   // otherwise, numerals specify (integral) reals

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -839,6 +839,16 @@ bool Smt2::isAbstractValue(const std::string& name)
          && name.find_first_not_of("0123456789", 1) == std::string::npos;
 }
 
+cvc5::Term Smt2::mkIntOrRealFromNumeral(const std::string& str)
+{
+  // if integers are used, it is an integer
+  if(d_logic.areIntegersUsed()) {
+    return d_solver->mkInteger(str);
+  }
+  // otherwise, numerals specify (integral) reals
+  return d_solver->mkReal(str);
+}
+
 void Smt2::parseOpApplyTypeAscription(ParseOp& p, cvc5::Sort type)
 {
   Trace("parser") << "parseOpApplyTypeAscription : " << p << " " << type

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -842,7 +842,9 @@ bool Smt2::isAbstractValue(const std::string& name)
 cvc5::Term Smt2::mkIntOrRealFromNumeral(const std::string& str)
 {
   // if arithmetic is enabled, and integers are disabled
-  if(d_logic.isTheoryEnabled(internal::theory::THEORY_ARITH) && !d_logic.areIntegersUsed()) {
+  if (d_logic.isTheoryEnabled(internal::theory::THEORY_ARITH)
+      && !d_logic.areIntegersUsed())
+  {
     return d_solver->mkReal(str);
   }
   return d_solver->mkInteger(str);

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -291,13 +291,11 @@ class Smt2 : public Parser
 
   /** Does name denote an abstract value? (of the form '@n' for numeral n). */
   bool isAbstractValue(const std::string& name);
-
-  /** Make abstract value
-   *
-   * Abstract values are used for processing get-value calls. The argument
-   * name should be such that isUninterpretedSortValue(name) is true.
+  
+  /**
+   * Make int or real from numeral string.
    */
-  cvc5::Term mkUninterpretedSortValue(const std::string& name);
+  cvc5::Term mkIntOrRealFromNumeral(const std::string& str);
 
   /**
    * Smt2 parser provides its own checkDeclaration, which does the

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -293,9 +293,12 @@ class Smt2 : public Parser
   bool isAbstractValue(const std::string& name);
 
   /**
-   * Make int or real from numeral string.
+   * Make real or int from numeral string.
+   *
+   * In particular, if arithmetic is enabled, but integers are disabled, then
+   * we construct a real. Otherwise, we construct an integer.
    */
-  cvc5::Term mkIntOrRealFromNumeral(const std::string& str);
+  cvc5::Term mkRealOrIntFromNumeral(const std::string& str);
 
   /**
    * Smt2 parser provides its own checkDeclaration, which does the

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -291,7 +291,7 @@ class Smt2 : public Parser
 
   /** Does name denote an abstract value? (of the form '@n' for numeral n). */
   bool isAbstractValue(const std::string& name);
-  
+
   /**
    * Make int or real from numeral string.
    */


### PR DESCRIPTION
SMT-LIB says numerals are real when integers are not included in the logic.

Due to subtyping, we don't complain internally, although if subtyping is eliminated, this fix is necessary.