### PR TITLE
Make LFSC printer robust to internal types

### DIFF
--- a/src/proof/lfsc/lfsc_node_converter.cpp
+++ b/src/proof/lfsc/lfsc_node_converter.cpp
@@ -538,6 +538,7 @@ TypeNode LfscNodeConverter::postConvertType(TypeNode tn)
   }
   else if (tn.getNumChildren() == 0)
   {
+    // an uninterpreted sort, or an uninstantiatied (maybe parametric) datatype
     d_declTypes.insert(tn);
     // special case: tuples must be distinguished by their arity
     if (tn.isTuple())
@@ -599,7 +600,8 @@ TypeNode LfscNodeConverter::postConvertType(TypeNode tn)
     Node op;
     if (k == PARAMETRIC_DATATYPE)
     {
-      d_declTypes.insert(tn);
+      // note we don't add to declared types here, since the parametric
+      // datatype is traversed and will be declared as a type constructor
       // erase first child, which repeats the datatype
       targs.erase(targs.begin(), targs.begin() + 1);
       types.erase(types.begin(), types.begin() + 1);
@@ -612,7 +614,10 @@ TypeNode LfscNodeConverter::postConvertType(TypeNode tn)
     }
     else if (k == SORT_TYPE)
     {
-      d_declTypes.insert(tn);
+      // Add its uninterpreted sort constructor to the list of declared types.
+      // This is required since the (type) operator is not part of the AST of
+      // the TypeNode.
+      d_declTypes.insert(tn.getUninterpretedSortConstructor());
       TypeNode ftype = nm->mkFunctionType(types, d_sortType);
       std::string name;
       tn.getAttribute(expr::VarNameAttr(), name);

--- a/src/proof/lfsc/lfsc_node_converter.cpp
+++ b/src/proof/lfsc/lfsc_node_converter.cpp
@@ -1227,9 +1227,15 @@ size_t LfscNodeConverter::getOrAssignIndexForVar(Node v)
   return id;
 }
 
-const std::unordered_set<Node>& LfscNodeConverter::getDeclaredSymbols() const { return d_declVars; }
+const std::unordered_set<Node>& LfscNodeConverter::getDeclaredSymbols() const
+{
+  return d_declVars;
+}
 
-const std::unordered_set<TypeNode>& LfscNodeConverter::getDeclaredTypes() const { return d_declTypes; }
+const std::unordered_set<TypeNode>& LfscNodeConverter::getDeclaredTypes() const
+{
+  return d_declTypes;
+}
 
 }  // namespace proof
 }  // namespace cvc5::internal

--- a/src/proof/lfsc/lfsc_node_converter.h
+++ b/src/proof/lfsc/lfsc_node_converter.h
@@ -119,6 +119,7 @@ class LfscNodeConverter : public NodeConverter
   const std::unordered_set<Node>& getDeclaredSymbols() const;
   /** Get the declared types that we have converted */
   const std::unordered_set<TypeNode>& getDeclaredTypes() const;
+
  private:
   /** Should we traverse n? */
   bool shouldTraverse(Node n) override;

--- a/src/proof/lfsc/lfsc_node_converter.h
+++ b/src/proof/lfsc/lfsc_node_converter.h
@@ -115,7 +115,10 @@ class LfscNodeConverter : public NodeConverter
                                         size_t variant = 0);
   /** get name for the name of node v, where v should be a variable */
   std::string getNameForUserNameOf(Node v);
-
+  /** Get the declared symbols (variables) that we have converted */
+  const std::unordered_set<Node>& getDeclaredSymbols() const;
+  /** Get the declared types that we have converted */
+  const std::unordered_set<TypeNode>& getDeclaredTypes() const;
  private:
   /** Should we traverse n? */
   bool shouldTraverse(Node n) override;
@@ -180,6 +183,10 @@ class LfscNodeConverter : public NodeConverter
   std::map<TypeNode, Node> d_typeAsNode;
   /** Used for interpreted builtin parametric sorts */
   std::map<Kind, Node> d_typeKindToNodeCons;
+  /** The set of declared variables */
+  std::unordered_set<Node> d_declVars;
+  /** The set of declared types */
+  std::unordered_set<TypeNode> d_declTypes;
 };
 
 }  // namespace proof

--- a/src/proof/lfsc/lfsc_printer.cpp
+++ b/src/proof/lfsc/lfsc_printer.cpp
@@ -168,7 +168,7 @@ void LfscPrinter::print(std::ostream& out,
     // shared selectors are instance of parametric symbol "sel"
     preamble << "; END DATATYPE " << std::endl;
   }
-  // [4c] user declared sorts
+  // [4c] user declared function symbols
   preamble << preambleSymDecl.str();
 
   // [5] print warnings

--- a/src/proof/lfsc/lfsc_printer.cpp
+++ b/src/proof/lfsc/lfsc_printer.cpp
@@ -26,7 +26,6 @@
 #include "proof/lfsc/lfsc_print_channel.h"
 
 using namespace cvc5::internal::kind;
-using namespace cvc5::internal::rewriter;
 
 namespace cvc5::internal {
 namespace proof {
@@ -178,12 +177,7 @@ void LfscPrinter::print(std::ostream& out,
   }
 
   // [6] print the DSL rewrite rule declarations
-  const std::unordered_set<DslPfRule>& dslrs = lpcp.getDslRewrites();
-  for (DslPfRule dslr : dslrs)
-  {
-    // also computes the format for the rule
-    printDslRule(out, dslr, d_dslFormat[dslr]);
-  }
+  // TODO cvc5-projects #285.
 
   // [7] print the check command and term lets
   out << preamble.str();
@@ -259,12 +253,12 @@ void LfscPrinter::printTypeDefinition(
   }
   else if (tn.isDatatype())
   {
-    const DType& dt = tn.getDType();
     if (tn.getKind() == PARAMETRIC_DATATYPE)
     {
       // skip the instance of a parametric datatype
       return;
     }
+    const DType& dt = tn.getDType();
     if (dt.isTuple())
     {
       const DTypeConstructor& cons = dt[0];

--- a/src/proof/lfsc/lfsc_printer.cpp
+++ b/src/proof/lfsc/lfsc_printer.cpp
@@ -52,7 +52,7 @@ void LfscPrinter::print(std::ostream& out,
 
   // clear the rules we have warned about
   d_trustWarned.clear();
-  
+
   // [1] convert assertions to internal and set up assumption map
   Trace("lfsc-print-debug") << "; print declarations" << std::endl;
   std::vector<Node> iasserts;
@@ -73,7 +73,8 @@ void LfscPrinter::print(std::ostream& out,
   computeProofLetification(pnBody, pletList, pletMap);
 
   // [3] compute the global term letification and declared symbols and types
-  Trace("lfsc-print-debug") << "; compute global term letification and declared symbols" << std::endl;
+  Trace("lfsc-print-debug")
+      << "; compute global term letification and declared symbols" << std::endl;
   LetBinding lbind;
   for (const Node& ia : iasserts)
   {
@@ -98,7 +99,7 @@ void LfscPrinter::print(std::ostream& out,
   }
   // Print the body of the outermost scope0
   printProofInternal(&lpcp, pnBody, emptyLetBind, pletMap, passumeMap);
-  
+
   // [4] print declared sorts and symbols
   // [4a] user declare function symbols
   // Note that this is buffered into an output stream preambleSymDecl and then
@@ -118,7 +119,7 @@ void LfscPrinter::print(std::ostream& out,
     }
     Node si = d_tproc.convert(s);
     preambleSymDecl << "(define " << si << " (var "
-             << d_tproc.getOrAssignIndexForVar(s) << " ";
+                    << d_tproc.getOrAssignIndexForVar(s) << " ";
     printType(preambleSymDecl, st);
     preambleSymDecl << "))" << std::endl;
   }

--- a/src/proof/lfsc/lfsc_printer.cpp
+++ b/src/proof/lfsc/lfsc_printer.cpp
@@ -97,7 +97,7 @@ void LfscPrinter::print(std::ostream& out,
     printProofInternal(&lpcp, p, emptyLetBind, pletMap, passumeMap);
     pletMap[p] = pid;
   }
-  // Print the body of the outermost scope0
+  // Print the body of the outermost scope
   printProofInternal(&lpcp, pnBody, emptyLetBind, pletMap, passumeMap);
 
   // [4] print declared sorts and symbols


### PR DESCRIPTION
This makes the LFSC node converter track the "user declared" symbols and types that it encounters.

It furthermore makes the "dry run" phase of proof printing happen before types and symbols are declared, so that all declared symbols are found before the preamble of LFSC proofs are printed.

These changes are specifically to fix cases where a internal *type* is generated that does not appear in the input. For example, some preprocessing passes may construct auxiliary uninterpreted sorts. 

This fixes 6 more LFSC failures from our regressions.