### PR TITLE
Implement internal support for synthesis modulo oracles

### DIFF
--- a/src/theory/quantifiers/sygus/synth_verify.cpp
+++ b/src/theory/quantifiers/sygus/synth_verify.cpp
@@ -109,6 +109,8 @@ Result SynthVerify::verify(Node query,
         Node squery =
             query.substitute(vars.begin(), vars.end(), mvs.begin(), mvs.end());
         Trace("cegqi-debug") << "...squery : " << squery << std::endl;
+        // Rewrite the node. Notice that if squery contains oracle function
+        // symbols, then this may trigger new calls to oracles.
         squery = d_tds->rewriteNode(squery);
         Trace("cegqi-debug") << "...rewrites to : " << squery << std::endl;
         if (!squery.isConst() || !squery.getConst<bool>())
@@ -125,8 +127,10 @@ Result SynthVerify::verify(Node query,
           if (options().quantifiers.oracles)
           {
             // In this case, we reconstruct the query, which may include more
-            // information about oracles than we had previously. We rerun the
-            // satisfiability check above.
+            // information about oracles than we had previously, due to the
+            // call to rewriteNode above. We rerun the satisfiability check
+            // above, which now may conjoin more I/O pairs to the preprocessed
+            // query.
             Node nextQueryp = preprocessQueryInternal(query);
             if (nextQueryp != queryp)
             {

--- a/src/theory/quantifiers/sygus/synth_verify.cpp
+++ b/src/theory/quantifiers/sygus/synth_verify.cpp
@@ -115,13 +115,6 @@ Result SynthVerify::verify(Node query,
         Trace("cegqi-debug") << "...rewrites to : " << squery << std::endl;
         if (!squery.isConst() || !squery.getConst<bool>())
         {
-          if (squery.isConst())
-          {
-            // simplified to false, the result should have been unknown, or
-            // else this indicates a check-model failure.
-            Assert(r.getStatus() == Result::UNKNOWN)
-                << "Expected model from verification step to satisfy query";
-          }
           // If the query did not simplify to true, then it may be that the
           // value for an oracle function was not what we expected.
           if (options().quantifiers.oracles)
@@ -137,6 +130,14 @@ Result SynthVerify::verify(Node query,
               queryp = nextQueryp;
               finished = false;
             }
+          }
+          else if (squery.isConst())
+          {
+            // simplified to false, the result should have been unknown, or
+            // else this indicates a check-model failure. We check this only
+            // if oracles are disabled.
+            Assert(r.getStatus() == Result::UNKNOWN)
+                << "Expected model from verification step to satisfy query";
           }
         }
       }

--- a/src/theory/quantifiers/sygus/synth_verify.h
+++ b/src/theory/quantifiers/sygus/synth_verify.h
@@ -59,8 +59,8 @@ class SynthVerify : protected EnvObj
    *
    * For each oracle function f in the query, we conjoin equalities f(c) = d
    * where (c, d) is an I/O pair obtained for a call to a oracle. In contrast
-   * to the description Polgreen et al VMCAI 2022, the verification subcall
-   * uses SMT not SMTO. Instead f is treated as an ordinary function symbol,
+   * to the description in Polgreen et al VMCAI 2022, the verification subcall
+   * uses SMT, not SMTO. Instead f is treated as an ordinary function symbol,
    * and its current I/O pairs are communicated explicitly via these conjuncts.
    */
   Node preprocessQueryInternal(Node query);

--- a/src/theory/quantifiers/sygus/synth_verify.h
+++ b/src/theory/quantifiers/sygus/synth_verify.h
@@ -56,6 +56,12 @@ class SynthVerify : protected EnvObj
    * Preprocess query internal. This returns the rewritten form of query
    * and includes all relevant function definitions, i.e. those that occur
    * in query. These are added as top-level conjuncts to the returned formula.
+   *
+   * For each oracle function f in the query, we conjoin equalities f(c) = d
+   * where (c, d) is an I/O pair obtained for a call to a oracle. In contrast
+   * to the description Polgreen et al VMCAI 2022, the verification subcall
+   * uses SMT not SMTO. Instead f is treated as an ordinary function symbol,
+   * and its current I/O pairs are communicated explicitly via these conjuncts.
    */
   Node preprocessQueryInternal(Node query);
   /** Pointer to the term database sygus */


### PR DESCRIPTION
SyMO is implemented as a preprocessor for SMT queries in the verification subsolver of SyGuS.