### PR TITLE
Fix GMP cross-compilation when Wine installed

### DIFF
--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -65,15 +65,24 @@ if(NOT GMP_FOUND_SYSTEM)
     set(GMP_LIBRARIES "${DEPS_BASE}/lib/libgmp.a")
   endif()
 
-
+  # `CC_FOR_BUILD`, `--host`, and `--build` are passed to `configure` to ensure
+  # that cross-compilation works (as suggested in the GMP documentation).
+  # Without the `--build` flag, `configure` may fail for cross-compilation
+  # builds for Windows if Wine is installed.
   ExternalProject_Add(
     GMP-EP
     ${COMMON_EP_CONFIG}
     URL https://gmplib.org/download/gmp/gmp-${GMP_VERSION}.tar.bz2
     URL_HASH SHA1=2dcf34d4a432dbe6cce1475a835d20fe44f75822
     CONFIGURE_COMMAND
-      <SOURCE_DIR>/configure ${LINK_OPTS} --prefix=<INSTALL_DIR>
-      --with-pic --enable-cxx --host=${TOOLCHAIN_PREFIX}
+      ${CMAKE_COMMAND} -E env CC_FOR_BUILD=cc
+        <SOURCE_DIR>/configure
+          ${LINK_OPTS}
+          --prefix=<INSTALL_DIR>
+          --with-pic
+          --enable-cxx
+          --host=${TOOLCHAIN_PREFIX}
+          --build=${CMAKE_HOST_SYSTEM_PROCESSOR}
     BUILD_BYPRODUCTS ${GMP_LIBRARIES}
   )
 endif()


### PR DESCRIPTION
When Wine is installed on the system, our current invocation of GMP's
`configure` fails. To fix the issue, we pass `CC_FOR_BUILD` that is used
to compile build-time programs. When compiling GMP with `--enable-cxx`,
it also seems to be necessary to pass `--build` to make `configure`
pass. Passing `--build` for cross-compilation builds is also recommended
by the [GMP documentation](https://gmplib.org/manual/Build-Options).