### PR TITLE
Properly represent Tuples in the TypeNode AST

### DIFF
--- a/src/expr/node_manager_attributes.h
+++ b/src/expr/node_manager_attributes.h
@@ -33,8 +33,10 @@ namespace attr {
   struct UnresolvedDatatypeTag
   {
   };
-  struct TupleDatatypeTag {};
-}  // namespace attr
+  struct TupleDatatypeTag
+  {
+  };
+  }  // namespace attr
 
 typedef Attribute<attr::VarNameTag, std::string> VarNameAttr;
 typedef Attribute<attr::SortArityTag, uint64_t> SortArityAttr;
@@ -46,7 +48,8 @@ using UnresolvedDatatypeAttr =
     expr::Attribute<expr::attr::UnresolvedDatatypeTag, bool>;
 
 /** Mapping tuples to their datatype type encoding */
-using TupleDatatypeAttr = expr::Attribute<expr::attr::TupleDatatypeTag, TypeNode>;
+using TupleDatatypeAttr =
+    expr::Attribute<expr::attr::TupleDatatypeTag, TypeNode>;
 
 }  // namespace expr
 }  // namespace cvc5::internal

--- a/src/expr/node_manager_attributes.h
+++ b/src/expr/node_manager_attributes.h
@@ -33,7 +33,8 @@ namespace attr {
   struct UnresolvedDatatypeTag
   {
   };
-  }  // namespace attr
+  struct TupleDatatypeTag {};
+}  // namespace attr
 
 typedef Attribute<attr::VarNameTag, std::string> VarNameAttr;
 typedef Attribute<attr::SortArityTag, uint64_t> SortArityAttr;
@@ -43,6 +44,9 @@ typedef expr::Attribute<expr::attr::TypeCheckedTag, bool> TypeCheckedAttr;
 /** Attribute is true for unresolved datatype sorts */
 using UnresolvedDatatypeAttr =
     expr::Attribute<expr::attr::UnresolvedDatatypeTag, bool>;
+
+/** Mapping tuples to their datatype type encoding */
+using TupleDatatypeAttr = expr::Attribute<expr::attr::TupleDatatypeTag, TypeNode>;
 
 }  // namespace expr
 }  // namespace cvc5::internal

--- a/src/expr/node_manager_template.cpp
+++ b/src/expr/node_manager_template.cpp
@@ -626,7 +626,7 @@ std::vector<TypeNode> NodeManager::mkMutualDatatypeTypesInternal(
         TypeNode dtt = typeNode;
         const DTypeConstructor& dc = dt[0];
         std::vector<TypeNode> tupleTypes;
-        for (size_t i=0, nargs = dc.getNumArgs(); i<nargs; i++)
+        for (size_t i = 0, nargs = dc.getNumArgs(); i < nargs; i++)
         {
           // selector should be initialized to the range type, it is not null
           // or unresolved since tuples are not recursive

--- a/src/expr/node_manager_template.cpp
+++ b/src/expr/node_manager_template.cpp
@@ -313,6 +313,7 @@ const DType& NodeManager::getDTypeFor(TypeNode tn) const
   }
   else if (k == kind::TUPLE_TYPE)
   {
+    // lookup its datatype encoding
     TypeNode dtt = getAttribute(tn, expr::TupleDatatypeAttr());
     Assert(!dtt.isNull());
     return getDTypeFor(dtt);
@@ -878,6 +879,8 @@ TypeNode NodeManager::mkTupleType(const std::vector<TypeNode>& types)
   Trace("tuprec-debug") << std::endl;
   Node dtt = d_tt_cache.getTupleType(this, types);
   Node tt = mkTypeNode(kind::TUPLE_TYPE, types);
+  tt.setAttribute(expr::TupleDatatypeAttr(), dtt);
+  // FIXME
   return dtt;
 }
 

--- a/src/expr/node_manager_template.cpp
+++ b/src/expr/node_manager_template.cpp
@@ -314,7 +314,7 @@ const DType& NodeManager::getDTypeFor(TypeNode tn) const
   else if (k == kind::TUPLE_TYPE)
   {
     TypeNode dtt = getAttribute(tn, expr::TupleDatatypeAttr());
-    Assert (!dtt.isNull());
+    Assert(!dtt.isNull());
     return getDTypeFor(dtt);
   }
   Assert(k == kind::PARAMETRIC_DATATYPE);

--- a/src/expr/node_manager_template.cpp
+++ b/src/expr/node_manager_template.cpp
@@ -849,18 +849,18 @@ TypeNode NodeManager::mkFunctionType(const std::vector<TypeNode>& argTypes,
 
 TypeNode NodeManager::mkTupleType(const std::vector<TypeNode>& types)
 {
-  std::vector<TypeNode> ts;
   Trace("tuprec-debug") << "Make tuple type : ";
   for (unsigned i = 0; i < types.size(); ++i)
   {
     CheckArgument(!types[i].isFunctionLike(),
                   types,
                   "cannot put function-like types in tuples");
-    ts.push_back(types[i]);
     Trace("tuprec-debug") << types[i] << " ";
   }
   Trace("tuprec-debug") << std::endl;
-  return d_tt_cache.getTupleType(this, ts);
+  Node dtt = d_tt_cache.getTupleType(this, types);
+  Node tt = mkTypeNode(kind::TUPLE_TYPE, types);
+  return dtt;
 }
 
 TypeNode NodeManager::mkRecordType(const Record& rec)

--- a/src/expr/node_manager_template.cpp
+++ b/src/expr/node_manager_template.cpp
@@ -805,6 +805,7 @@ TypeNode NodeManager::TupleTypeCache::getTupleType(
       }
       dt.addConstructor(c);
       d_data = nm->mkDatatypeType(dt);
+      Assert (d_data.isTuple());
       Trace("tuprec-debug") << "Return type : " << d_data << std::endl;
     }
     return d_data;
@@ -841,6 +842,7 @@ TypeNode NodeManager::RecTypeCache::getRecordType(NodeManager* nm,
       }
       dt.addConstructor(c);
       d_data = nm->mkDatatypeType(dt);
+      Assert (d_data.isRecord());
       Trace("tuprec-debug") << "Return type : " << d_data << std::endl;
     }
     return d_data;

--- a/src/expr/node_manager_template.cpp
+++ b/src/expr/node_manager_template.cpp
@@ -761,9 +761,8 @@ TypeNode NodeManager::mkDatatypeUpdateType(TypeNode domain, TypeNode range)
   return mkTypeNode(kind::UPDATER_TYPE, domain, range);
 }
 
-TypeNode NodeManager::TupleTypeCache::getTupleType(NodeManager* nm,
-                                                   const std::vector<TypeNode>& types,
-                                                   unsigned index)
+TypeNode NodeManager::TupleTypeCache::getTupleType(
+    NodeManager* nm, const std::vector<TypeNode>& types, unsigned index)
 {
   if (index == types.size())
   {

--- a/src/expr/node_manager_template.cpp
+++ b/src/expr/node_manager_template.cpp
@@ -303,6 +303,24 @@ NodeManager::~NodeManager()
   d_attrManager = NULL;
 }
 
+const DType& NodeManager::getDTypeFor(TypeNode tn) const
+{
+  Kind k = tn.getKind();
+  if (k == kind::DATATYPE_TYPE)
+  {
+    DatatypeIndexConstant dic = tn.getConst<DatatypeIndexConstant>();
+    return getDTypeForIndex(dic.getIndex());
+  }
+  else if (k == kind::TUPLE_TYPE)
+  {
+    TypeNode dtt = getAttribute(tn, expr::TupleDatatypeAttr());
+    Assert (!dtt.isNull());
+    return getDTypeFor(dtt);
+  }
+  Assert(k == kind::PARAMETRIC_DATATYPE);
+  return getDTypeFor(tn[0]);
+}
+
 const DType& NodeManager::getDTypeForIndex(size_t index) const
 {
   // if this assertion fails, it is likely due to not managing datatypes

--- a/src/expr/node_manager_template.cpp
+++ b/src/expr/node_manager_template.cpp
@@ -762,7 +762,7 @@ TypeNode NodeManager::mkDatatypeUpdateType(TypeNode domain, TypeNode range)
 }
 
 TypeNode NodeManager::TupleTypeCache::getTupleType(NodeManager* nm,
-                                                   std::vector<TypeNode>& types,
+                                                   const std::vector<TypeNode>& types,
                                                    unsigned index)
 {
   if (index == types.size())
@@ -771,7 +771,8 @@ TypeNode NodeManager::TupleTypeCache::getTupleType(NodeManager* nm,
     {
       std::stringstream sst;
       sst << "__cvc5_tuple";
-      for (unsigned i = 0; i < types.size(); ++i)
+      size_t ntypes = types.size();
+      for (size_t i = 0; i < ntypes; ++i)
       {
         sst << "_" << types[i];
       }
@@ -781,7 +782,7 @@ TypeNode NodeManager::TupleTypeCache::getTupleType(NodeManager* nm,
       ssc << sst.str() << "_ctor";
       std::shared_ptr<DTypeConstructor> c =
           std::make_shared<DTypeConstructor>(ssc.str());
-      for (unsigned i = 0; i < types.size(); ++i)
+      for (size_t i = 0; i < ntypes; ++i)
       {
         std::stringstream ss;
         ss << sst.str() << "_stor_" << i;
@@ -877,8 +878,8 @@ TypeNode NodeManager::mkTupleType(const std::vector<TypeNode>& types)
     Trace("tuprec-debug") << types[i] << " ";
   }
   Trace("tuprec-debug") << std::endl;
-  Node dtt = d_tt_cache.getTupleType(this, types);
-  Node tt = mkTypeNode(kind::TUPLE_TYPE, types);
+  TypeNode dtt = d_tt_cache.getTupleType(this, types);
+  TypeNode tt = mkTypeNode(kind::TUPLE_TYPE, types);
   tt.setAttribute(expr::TupleDatatypeAttr(), dtt);
   // FIXME
   return dtt;

--- a/src/expr/node_manager_template.h
+++ b/src/expr/node_manager_template.h
@@ -172,6 +172,7 @@ class NodeManager
    * would lead to memory leaks. Thus TypeNode are given a DatatypeIndexConstant
    * which is used as an index to retrieve the DType via this call.
    */
+  const DType& getDTypeFor(TypeNode tn) const;
   const DType& getDTypeForIndex(size_t index) const;
 
   /** get the canonical bound variable list for function type tn */

--- a/src/expr/node_manager_template.h
+++ b/src/expr/node_manager_template.h
@@ -840,9 +840,8 @@ class NodeManager
   }; /* struct NodeManager::NVStorage<N> */
 
   /**
-   * A map of tuple types to their corresponding datatype.
-   * Note that the (raw) datatype types are stored in this trie, not the
-   * tuple type itself.
+   * A map of tuple types to their corresponding datatype type, which are
+   * TypeNode of kind TUPLE_TYPE.
    */
   class TupleTypeCache
   {

--- a/src/expr/node_manager_template.h
+++ b/src/expr/node_manager_template.h
@@ -840,7 +840,9 @@ class NodeManager
   }; /* struct NodeManager::NVStorage<N> */
 
   /**
-   * A map of tuple and record types to their corresponding datatype.
+   * A map of tuple types to their corresponding datatype.
+   * Note that the (raw) datatype types are stored in this trie, not the
+   * tuple type itself.
    */
   class TupleTypeCache
   {
@@ -848,9 +850,10 @@ class NodeManager
     std::map<TypeNode, TupleTypeCache> d_children;
     TypeNode d_data;
     TypeNode getTupleType(NodeManager* nm,
-                          std::vector<TypeNode>& types,
+                          const std::vector<TypeNode>& types,
                           unsigned index = 0);
   };
+  /** Same as above, for records */
   class RecTypeCache
   {
    public:

--- a/src/expr/type_node.cpp
+++ b/src/expr/type_node.cpp
@@ -380,6 +380,7 @@ std::vector<TypeNode> TypeNode::getInstantiatedParamTypes() const
 
 bool TypeNode::isTuple() const
 {
+  // FIXME
   return (getKind() == kind::DATATYPE_TYPE && getDType().isTuple());
 }
 
@@ -408,7 +409,7 @@ vector<TypeNode> TypeNode::getTupleTypes() const {
 
 /** Is this an instantiated datatype type */
 bool TypeNode::isInstantiatedDatatype() const {
-  if(getKind() == kind::DATATYPE_TYPE) {
+  if(getKind() == kind::DATATYPE_TYPE || getKind() == kind::TUPLE_TYPE) {
     return true;
   }
   if(getKind() != kind::PARAMETRIC_DATATYPE) {
@@ -527,8 +528,10 @@ bool TypeNode::isBitVector() const { return getKind() == kind::BITVECTOR_TYPE; }
 
 bool TypeNode::isDatatype() const
 {
-  return getKind() == kind::DATATYPE_TYPE
-         || getKind() == kind::PARAMETRIC_DATATYPE;
+  Kind k = getKind();
+  return k== kind::DATATYPE_TYPE
+         || k == kind::PARAMETRIC_DATATYPE ||
+         k == kind::TUPLE_TYPE;
 }
 
 bool TypeNode::isParametricDatatype() const
@@ -582,13 +585,7 @@ std::string TypeNode::toString() const {
 
 const DType& TypeNode::getDType() const
 {
-  if (getKind() == kind::DATATYPE_TYPE)
-  {
-    DatatypeIndexConstant dic = getConst<DatatypeIndexConstant>();
-    return NodeManager::currentNM()->getDTypeForIndex(dic.getIndex());
-  }
-  Assert(getKind() == kind::PARAMETRIC_DATATYPE);
-  return (*this)[0].getDType();
+  return NodeManager::currentNM()->getDTypeForType(*this);
 }
 
 bool TypeNode::isBag() const

--- a/src/expr/type_node.cpp
+++ b/src/expr/type_node.cpp
@@ -378,10 +378,7 @@ std::vector<TypeNode> TypeNode::getInstantiatedParamTypes() const
   return params;
 }
 
-bool TypeNode::isTuple() const
-{
-  return getKind() == kind::TUPLE_TYPE;
-}
+bool TypeNode::isTuple() const { return getKind() == kind::TUPLE_TYPE; }
 
 bool TypeNode::isRecord() const
 {

--- a/src/expr/type_node.cpp
+++ b/src/expr/type_node.cpp
@@ -414,14 +414,14 @@ bool TypeNode::isInstantiatedDatatype() const {
   {
     return true;
   }
-  if(k != kind::PARAMETRIC_DATATYPE) 
+  if (k != kind::PARAMETRIC_DATATYPE)
   {
     return false;
   }
   const DType& dt = (*this)[0].getDType();
   size_t n = dt.getNumParameters();
   Assert(n < getNumChildren());
-  for(size_t i = 0; i < n; ++i)
+  for (size_t i = 0; i < n; ++i)
   {
     if (dt.getParameter(i) == (*this)[i + 1])
     {

--- a/src/expr/type_node.cpp
+++ b/src/expr/type_node.cpp
@@ -409,17 +409,20 @@ vector<TypeNode> TypeNode::getTupleTypes() const {
 
 /** Is this an instantiated datatype type */
 bool TypeNode::isInstantiatedDatatype() const {
-  if (getKind() == kind::DATATYPE_TYPE || getKind() == kind::TUPLE_TYPE)
+  Kind k = getKind();
+  if (k == kind::DATATYPE_TYPE || k == kind::TUPLE_TYPE)
   {
     return true;
   }
-  if(getKind() != kind::PARAMETRIC_DATATYPE) {
+  if(k != kind::PARAMETRIC_DATATYPE) 
+  {
     return false;
   }
   const DType& dt = (*this)[0].getDType();
-  unsigned n = dt.getNumParameters();
+  size_t n = dt.getNumParameters();
   Assert(n < getNumChildren());
-  for(unsigned i = 0; i < n; ++i) {
+  for(size_t i = 0; i < n; ++i)
+  {
     if (dt.getParameter(i) == (*this)[i + 1])
     {
       return false;

--- a/src/expr/type_node.cpp
+++ b/src/expr/type_node.cpp
@@ -588,7 +588,7 @@ std::string TypeNode::toString() const {
 
 const DType& TypeNode::getDType() const
 {
-  return NodeManager::currentNM()->getDTypeForType(*this);
+  return NodeManager::currentNM()->getDTypeFor(*this);
 }
 
 bool TypeNode::isBag() const

--- a/src/expr/type_node.cpp
+++ b/src/expr/type_node.cpp
@@ -409,7 +409,8 @@ vector<TypeNode> TypeNode::getTupleTypes() const {
 
 /** Is this an instantiated datatype type */
 bool TypeNode::isInstantiatedDatatype() const {
-  if(getKind() == kind::DATATYPE_TYPE || getKind() == kind::TUPLE_TYPE) {
+  if (getKind() == kind::DATATYPE_TYPE || getKind() == kind::TUPLE_TYPE)
+  {
     return true;
   }
   if(getKind() != kind::PARAMETRIC_DATATYPE) {
@@ -529,9 +530,8 @@ bool TypeNode::isBitVector() const { return getKind() == kind::BITVECTOR_TYPE; }
 bool TypeNode::isDatatype() const
 {
   Kind k = getKind();
-  return k== kind::DATATYPE_TYPE
-         || k == kind::PARAMETRIC_DATATYPE ||
-         k == kind::TUPLE_TYPE;
+  return k == kind::DATATYPE_TYPE || k == kind::PARAMETRIC_DATATYPE
+         || k == kind::TUPLE_TYPE;
 }
 
 bool TypeNode::isParametricDatatype() const

--- a/src/expr/type_node.cpp
+++ b/src/expr/type_node.cpp
@@ -380,8 +380,7 @@ std::vector<TypeNode> TypeNode::getInstantiatedParamTypes() const
 
 bool TypeNode::isTuple() const
 {
-  // FIXME
-  return (getKind() == kind::DATATYPE_TYPE && getDType().isTuple());
+  return getKind() == kind::TUPLE_TYPE;
 }
 
 bool TypeNode::isRecord() const

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1140,6 +1140,7 @@ std::string Smt2Printer::smtKindString(Kind k, Variant v)
   // datatypes theory
   case kind::APPLY_TESTER: return "is";
   case kind::APPLY_UPDATER: return "update";
+  case kind::TUPLE_TYPE: return "Tuple";
 
   // set theory
   case kind::SET_UNION: return "set.union";

--- a/src/proof/lfsc/lfsc_node_converter.cpp
+++ b/src/proof/lfsc/lfsc_node_converter.cpp
@@ -567,7 +567,7 @@ TypeNode LfscNodeConverter::postConvertType(TypeNode tn)
   }
   else if (tn.getNumChildren() == 0)
   {
-    Assert (!tn.isTuple());
+    Assert(!tn.isTuple());
     // an uninterpreted sort, or an uninstantiatied (maybe parametric) datatype
     d_declTypes.insert(tn);
     if (tnn.isNull())

--- a/src/proof/lfsc/lfsc_node_converter.cpp
+++ b/src/proof/lfsc/lfsc_node_converter.cpp
@@ -540,7 +540,6 @@ TypeNode LfscNodeConverter::postConvertType(TypeNode tn)
   else if (k == TUPLE_TYPE)
   {
     // special case: tuples must be distinguished by their arity
-    const DType& dt = tn.getDType();
     size_t nargs = tn.getNumChildren();
     if (nargs > 0)
     {

--- a/src/proof/lfsc/lfsc_node_converter.cpp
+++ b/src/proof/lfsc/lfsc_node_converter.cpp
@@ -541,13 +541,13 @@ TypeNode LfscNodeConverter::postConvertType(TypeNode tn)
   {
     // special case: tuples must be distinguished by their arity
     const DType& dt = tn.getDType();
-    unsigned int nargs = dt[0].getNumArgs();
+    size_t nargs = tn.getNumChildren();
     if (nargs > 0)
     {
       std::vector<TypeNode> types;
       std::vector<TypeNode> convTypes;
       std::vector<Node> targs;
-      for (unsigned int i = 0; i < nargs; i++)
+      for (size_t i = 0; i < nargs; i++)
       {
         TypeNode tnc = tn[i];
         types.push_back(d_sortType);

--- a/src/theory/datatypes/kinds
+++ b/src/theory/datatypes/kinds
@@ -77,6 +77,19 @@ enumerator PARAMETRIC_DATATYPE \
     "::cvc5::internal::theory::datatypes::DatatypesEnumerator" \
     "theory/datatypes/type_enumerator.h"
 
+operator TUPLE_TYPE 0: "tuple type"
+cardinality TUPLE_TYPE \
+    "%TYPE%.getDType().getCardinality(%TYPE%)" \
+    "expr/dtype.h"
+well-founded TUPLE_TYPE \
+    "%TYPE%.getDType().isWellFounded()" \
+    "%TYPE%.getDType().mkGroundTerm(%TYPE%)" \
+    "expr/dtype.h"
+
+enumerator TUPLE_TYPE \
+    "::cvc5::internal::theory::datatypes::DatatypesEnumerator" \
+    "expr/dtype.h"
+
 parameterized APPLY_TYPE_ASCRIPTION ASCRIPTION_TYPE 1 \
     "type ascription, for datatype constructor applications; first parameter is an ASCRIPTION_TYPE, second is the datatype constructor application being ascribed"
 constant ASCRIPTION_TYPE \

--- a/src/theory/datatypes/theory_datatypes_type_rules.cpp
+++ b/src/theory/datatypes/theory_datatypes_type_rules.cpp
@@ -265,7 +265,7 @@ TypeNode DatatypeAscriptionTypeRule::computeType(NodeManager* nodeManager,
     {
       m.addTypesFromDatatype(childType.getDatatypeConstructorRangeType());
     }
-    else if (childType.getKind() == kind::DATATYPE_TYPE)
+    else if (childType.isDatatype())
     {
       m.addTypesFromDatatype(childType);
     }


### PR DESCRIPTION
This makes it so that Tuple types are properly represented in the AST.

For example, a tuple type over (Int, Int) is now `(TUPLE_TYPE INT INT)` instead of a `DATATYPE_TYPE` constant.

Tuple types behave exactly like datatypes; we can still retrieve their DType as before.

This is in preparation for gradual types and symbolic tuple projections.