### PR TITLE
[Regressions] Use Wine for Windows builds

### DIFF
--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -3203,12 +3203,20 @@ add_custom_target(regress
   DEPENDS build-regress)
 
 macro(cvc5_add_regression_test level file)
+  set(wrapper )
+  if(CMAKE_CROSSCOMPILING AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    # Make wineserver persistent for 60 seconds (this is for better
+    # performance)
+    set(wrapper "wine -p=60")
+  endif()
+
   add_test(${file}
     ${run_regress_script}
     ${RUN_REGRESSION_ARGS}
     --lfsc-binary ${CMAKE_SOURCE_DIR}/deps/bin/lfscc
     --lfsc-sig-dir ${CMAKE_SOURCE_DIR}/proofs/lfsc/signatures
-    ${path_to_cvc5}/cvc5
+    ${wrapper}
+    ${path_to_cvc5}/cvc5${CMAKE_EXECUTABLE_SUFFIX}
     ${CMAKE_CURRENT_LIST_DIR}/${file})
   set_tests_properties(${file} PROPERTIES LABELS "regress${level}")
 

--- a/test/regress/cli/regress0/models-print-2.smt2
+++ b/test/regress/cli/regress0/models-print-2.smt2
@@ -1,9 +1,9 @@
 ; the purpose of this test is to verify that there is a `as` term in the output.
-; the scrubber excludes all lines without "(as @", and replaces this pattern by "AS".
+; the scrubber searches for "(as @a" patterns.
 
-; SCRUBBER: sed -e 's/.*(as @.*/AS/; /sat/d; /cardinality/d; /rep/d; /^($/d; /^)$/d'
-; EXPECT: AS
-; EXPECT: AS
+; SCRUBBER: grep -o "(as @a"
+; EXPECT: (as @a
+; EXPECT: (as @a
 (set-logic QF_UF)
 (set-option :produce-models true)
 (declare-sort Sort0 0)

--- a/test/regress/cli/regress0/options/help.smt2
+++ b/test/regress/cli/regress0/options/help.smt2
@@ -1,5 +1,5 @@
 ; DISABLE-TESTER: dump
 ; COMMAND-LINE: --help
-; SCRUBBER: grep -o "usage: cvc5"
-; EXPECT: usage: cvc5
+; SCRUBBER: grep -o "usage:"
+; EXPECT: usage:
 ; EXIT: 1

--- a/test/regress/cli/run_regression.py
+++ b/test/regress/cli/run_regression.py
@@ -525,8 +525,8 @@ def run_benchmark(benchmark_info):
         output = output.decode()
     if isinstance(error, bytes):
         error = error.decode()
-    output = re.sub(r"^[ \t]*", "", output.strip(), flags=re.MULTILINE)
-    error = re.sub(r"^[ \t]*", "", error.strip(), flags=re.MULTILINE)
+    output = re.sub(r"^[ \t]*|\r", "", output.strip(), flags=re.MULTILINE)
+    error = re.sub(r"^[ \t]*|\r", "", error.strip(), flags=re.MULTILINE)
     # qemu (used for arm nightlies) emits additional error output for non-zero exit codes
     error = re.sub(r"qemu: uncaught target signal.*", "", error).strip()
     return (output, error, exit_status)


### PR DESCRIPTION
This changes our build system to use Wine when we are testing a
cross-compiled Windows build. It updates the post-processing in the
regression script to remove `\r` characters and updates two regressions
to make them compatible with Windows builds.