### PR TITLE
Add option to apply constant propagation for all learned literals

### DIFF
--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -27,7 +27,7 @@ name   = "SMT Layer"
 
 [[option]]
   name       = "simplificationBoolConstProp"
-  category   = "regular"
+  category   = "expert"
   long       = "simplification-bcp"
   type       = "bool"
   default    = "false"

--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -26,6 +26,14 @@ name   = "SMT Layer"
   help = "Save up all ASSERTions; run nonclausal simplification and clausal (MiniSat) propagation for all of them only after reaching a querying command (CHECKSAT or QUERY or predicate SUBTYPE declaration)."
 
 [[option]]
+  name       = "simplificationBoolConstProp"
+  category   = "regular"
+  long       = "simplification-bcp"
+  type       = "bool"
+  default    = "false"
+  help       = "apply Boolean constant propagation as a substituion during simplification"
+
+[[option]]
   name       = "doStaticLearning"
   category   = "regular"
   long       = "static-learning"

--- a/src/preprocessing/passes/non_clausal_simp.cpp
+++ b/src/preprocessing/passes/non_clausal_simp.cpp
@@ -116,7 +116,7 @@ PreprocessingPassResult NonClausalSimp::applyInternal(
       << "Iterate through " << propagator->getLearnedLiterals().size()
       << " learned literals." << std::endl;
   // No conflict, go through the literals and solve them
-  NodeManager * nm = NodeManager::currentNM();
+  NodeManager* nm = NodeManager::currentNM();
   context::Context* u = userContext();
   Rewriter* rw = d_env.getRewriter();
   TrustSubstitutionMap& ttls = d_preprocContext->getTopLevelSubstitutions();
@@ -240,8 +240,8 @@ PreprocessingPassResult NonClausalSimp::applyInternal(
         Assert(top_level_substs.apply(t) == t);
         Assert(nss.apply(t) == t);
         // also add to learned literal
-        ProofGenerator* cpg = constantPropagations->addSubstitutionSolved(
-            t, c, tlearnedLiteral);
+        ProofGenerator* cpg =
+            constantPropagations->addSubstitutionSolved(t, c, tlearnedLiteral);
         // We need to justify (= t c) as a literal, since it is reasserted
         // to the assertion pipeline below. We do this with the proof
         // generator returned by the above call.

--- a/src/preprocessing/passes/non_clausal_simp.cpp
+++ b/src/preprocessing/passes/non_clausal_simp.cpp
@@ -116,6 +116,7 @@ PreprocessingPassResult NonClausalSimp::applyInternal(
       << "Iterate through " << propagator->getLearnedLiterals().size()
       << " learned literals." << std::endl;
   // No conflict, go through the literals and solve them
+  NodeManager * nm = NodeManager::currentNM();
   context::Context* u = userContext();
   Rewriter* rw = d_env.getRewriter();
   TrustSubstitutionMap& ttls = d_preprocContext->getTopLevelSubstitutions();
@@ -173,7 +174,7 @@ PreprocessingPassResult NonClausalSimp::applyInternal(
         Trace("non-clausal-simplify")
             << "conflict with " << learned_literals[i].getNode() << std::endl;
         assertionsToPreprocess->clear();
-        Node n = NodeManager::currentNM()->mkConst<bool>(false);
+        Node n = nm->mkConst<bool>(false);
         assertionsToPreprocess->push_back(n, false, false, d_llpg.get());
         return PreprocessingPassResult::CONFLICT;
       }
@@ -206,7 +207,7 @@ PreprocessingPassResult NonClausalSimp::applyInternal(
         Trace("non-clausal-simplify")
             << "conflict while solving " << learnedLiteral << std::endl;
         assertionsToPreprocess->clear();
-        Node n = NodeManager::currentNM()->mkConst<bool>(false);
+        Node n = nm->mkConst<bool>(false);
         assertionsToPreprocess->push_back(n);
         return PreprocessingPassResult::CONFLICT;
       }
@@ -403,7 +404,7 @@ PreprocessingPassResult NonClausalSimp::applyInternal(
   if (!learnedLitsToConjoin.empty())
   {
     size_t replIndex = assertionsToPreprocess->getRealAssertionsEnd() - 1;
-    Node newConj = NodeManager::currentNM()->mkAnd(learnedLitsToConjoin);
+    Node newConj = nm->mkAnd(learnedLitsToConjoin);
     Trace("non-clausal-simplify")
         << "non-clausal simplification, reassert: " << newConj << std::endl;
     ProofGenerator* pg = nullptr;

--- a/src/preprocessing/passes/non_clausal_simp.cpp
+++ b/src/preprocessing/passes/non_clausal_simp.cpp
@@ -231,6 +231,9 @@ PreprocessingPassResult NonClausalSimp::applyInternal(
         }
         else
         {
+          // From non-equalities, learn the Boolean equality. Notice that
+          // the equality case above is strictly more powerful that this, since
+          // e.g. (= t c) * { t -> c } also simplifies to true.
           bool pol = learnedLiteral.getKind() != kind::NOT;
           c = nm->mkConst(pol);
           t = pol ? learnedLiteral : learnedLiteral[0];

--- a/src/preprocessing/passes/non_clausal_simp.cpp
+++ b/src/preprocessing/passes/non_clausal_simp.cpp
@@ -245,8 +245,8 @@ PreprocessingPassResult NonClausalSimp::applyInternal(
           Assert(top_level_substs.apply(t) == t);
           Assert(nss.apply(t) == t);
           // also add to learned literal
-          ProofGenerator* cpg =
-              constantPropagations->addSubstitutionSolved(t, c, tlearnedLiteral);
+          ProofGenerator* cpg = constantPropagations->addSubstitutionSolved(
+              t, c, tlearnedLiteral);
           // We need to justify (= t c) as a literal, since it is reasserted
           // to the assertion pipeline below. We do this with the proof
           // generator returned by the above call.

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -387,7 +387,8 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
     if (incompatibleWithSeparationLogic(opts, reasonNoSepLogic))
     {
       std::stringstream ss;
-      ss << reasonNoSepLogic.str() << " not supported when using separation logic.";
+      ss << reasonNoSepLogic.str()
+         << " not supported when using separation logic.";
       throw OptionException(ss.str());
     }
   }
@@ -1285,8 +1286,8 @@ bool SetDefaults::incompatibleWithQuantifiers(Options& opts,
   return false;
 }
 
-
-bool SetDefaults::incompatibleWithSeparationLogic(Options& opts, std::ostream& reason) const
+bool SetDefaults::incompatibleWithSeparationLogic(Options& opts,
+                                                  std::ostream& reason) const
 {
   if (options().smt.simplificationBoolConstProp)
   {

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -380,6 +380,17 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
       throw OptionException(ss.str());
     }
   }
+  // check if we have separation logic heap types
+  if (d_env.hasSepHeap())
+  {
+    std::stringstream reasonNoSepLogic;
+    if (incompatibleWithSeparationLogic(opts, reasonNoSepLogic))
+    {
+      std::stringstream ss;
+      ss << reasonNoSepLogic.str() << " not supported when using separation logic.";
+      throw OptionException(ss.str());
+    }
+  }
 }
 
 void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
@@ -1270,6 +1281,22 @@ bool SetDefaults::incompatibleWithQuantifiers(Options& opts,
     // guard). Hence, we throw an option exception if quantifiers are enabled.
     reason << "--nl-ext-rlv";
     return true;
+  }
+  return false;
+}
+
+
+bool SetDefaults::incompatibleWithSeparationLogic(Options& opts, std::ostream& reason) const
+{
+  if (options().smt.simplificationBoolConstProp)
+  {
+    // Spatial formulas in separation logic have a semantics that depends on
+    // their position in the AST (e.g. their nesting beneath separation
+    // conjunctions). Thus, we cannot apply BCP as a substitution for spatial
+    // predicates to the input formula. We disable this option altogether to
+    // ensure this is the case
+    notifyModifyOption("simplification-bcp", "false", "separation logic");
+    options().smt.simplificationBoolConstProp = false;
   }
   return false;
 }

--- a/src/smt/set_defaults.h
+++ b/src/smt/set_defaults.h
@@ -111,6 +111,12 @@ class SetDefaults : protected EnvObj
    * The output stream reason is similar to above.
    */
   bool incompatibleWithQuantifiers(Options& opts, std::ostream& reason) const;
+  /**
+   * Check if incompatible with separation logic. Notice this method may
+   * modify the options to ensure that we are compatible with separation logic.
+   * The output stream reason is similar to above.
+   */
+  bool incompatibleWithSeparationLogic(Options& opts, std::ostream& reason) const;
   //------------------------- options setting, prior finalization of logic
   /**
    * Set defaults pre, which sets all options prior to finalizing the logic.

--- a/src/smt/set_defaults.h
+++ b/src/smt/set_defaults.h
@@ -116,7 +116,8 @@ class SetDefaults : protected EnvObj
    * modify the options to ensure that we are compatible with separation logic.
    * The output stream reason is similar to above.
    */
-  bool incompatibleWithSeparationLogic(Options& opts, std::ostream& reason) const;
+  bool incompatibleWithSeparationLogic(Options& opts,
+                                       std::ostream& reason) const;
   //------------------------- options setting, prior finalization of logic
   /**
    * Set defaults pre, which sets all options prior to finalizing the logic.


### PR DESCRIPTION
Adds `--simplification-bcp`, disabled by default.