### PR TITLE
Fix tuple printing in LFSC

### DIFF
--- a/src/proof/lfsc/lfsc_node_converter.cpp
+++ b/src/proof/lfsc/lfsc_node_converter.cpp
@@ -539,6 +539,7 @@ TypeNode LfscNodeConverter::postConvertType(TypeNode tn)
   }
   else if (k == TUPLE_TYPE)
   {
+    d_declTypes.insert(tn);
     // special case: tuples must be distinguished by their arity
     size_t nargs = tn.getNumChildren();
     if (nargs > 0)

--- a/src/proof/lfsc/lfsc_node_converter.cpp
+++ b/src/proof/lfsc/lfsc_node_converter.cpp
@@ -495,6 +495,18 @@ Node LfscNodeConverter::postConvert(Node n)
   return n;
 }
 
+TypeNode LfscNodeConverter::preConvertType(TypeNode tn)
+{
+  if (tn.getKind() == TUPLE_TYPE)
+  {
+    // Must collect the tuple type here, since at post-order traversal, the
+    // type has been modified and no longer maintains the mapping to its
+    // datatype encoding.
+    d_declTypes.insert(tn);
+  }
+  return tn;
+}
+
 TypeNode LfscNodeConverter::postConvertType(TypeNode tn)
 {
   NodeManager* nm = NodeManager::currentNM();
@@ -539,7 +551,6 @@ TypeNode LfscNodeConverter::postConvertType(TypeNode tn)
   }
   else if (k == TUPLE_TYPE)
   {
-    d_declTypes.insert(tn);
     // special case: tuples must be distinguished by their arity
     size_t nargs = tn.getNumChildren();
     if (nargs > 0)

--- a/src/proof/lfsc/lfsc_node_converter.h
+++ b/src/proof/lfsc/lfsc_node_converter.h
@@ -40,6 +40,8 @@ class LfscNodeConverter : public NodeConverter
   Node preConvert(Node n) override;
   /** convert at post-order traversal */
   Node postConvert(Node n) override;
+  /** convert type at pre-order traversal */
+  TypeNode preConvertType(TypeNode tn) override;
   /** convert type at post-order traversal */
   TypeNode postConvertType(TypeNode tn) override;
   /**


### PR DESCRIPTION
We weren't collecting them as user-defined types after the recent refactor to Tuples.