### PR TITLE
change STATUS to FATAL_ERROR when trying to build python bindings with`--static`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -462,7 +462,7 @@ endif()
 add_subdirectory(src)
 
 if(BUILD_BINDINGS_PYTHON AND NOT BUILD_SHARED_LIBS)
-  message(STATUS "Python bindings can only be built in a shared build.")
+  message(FATAL_ERROR "Python bindings can only be built in a shared build.")
   set(BUILD_BINDINGS_PYTHON OFF)
 endif()
 if(BUILD_BINDINGS_PYTHON)


### PR DESCRIPTION
When running `./configure.sh --static --python-bindings --auto-download` on an M1 mac, the configuration step seems to work, and so does the build step, but python bindings are not created. Only when looking at the logs, we see a message explaining this. 

I suggest failing in this case by using `FATAL_ERROR` instead of `STATUS` (or perhaps at least using `WARNING` to increase visibility).