### PR TITLE
Infrastructure for portfolio solving

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -20,6 +20,8 @@ set(libmain_src_files
   interactive_shell.h
   main.h
   options.h
+  portfolio_driver.cpp
+  portfolio_driver.h
   signal_handlers.cpp
   signal_handlers.h
   time_limit.cpp

--- a/src/main/driver_unified.cpp
+++ b/src/main/driver_unified.cpp
@@ -31,6 +31,7 @@
 #include "main/interactive_shell.h"
 #include "main/main.h"
 #include "main/options.h"
+#include "main/portfolio_driver.h"
 #include "main/signal_handlers.h"
 #include "main/time_limit.h"
 #include "parser/parser.h"
@@ -157,6 +158,7 @@ int runCvc5(int argc, char* argv[], std::unique_ptr<cvc5::Solver>& solver)
   }
 
   int returnValue = 0;
+  cvc5::Result result;
   {
     solver->setInfo("filename", filenameStr);
 
@@ -222,37 +224,8 @@ int runCvc5(int argc, char* argv[], std::unique_ptr<cvc5::Solver>& solver)
             Input::newFileInput(solver->getOption("input-language"), filename));
       }
 
-      bool interrupted = false;
-      while (status)
-      {
-        if (interrupted) {
-          dopts.out() << cvc5::CommandInterrupted();
-          pExecutor->reset();
-          break;
-        }
-        cmd.reset(parser->nextCommand());
-        if (cmd == nullptr) break;
-
-        status = pExecutor->doCommand(cmd);
-        if (cmd->interrupted() && status == 0) {
-          interrupted = true;
-          break;
-        }
-
-        if (dynamic_cast<cvc5::QuitCommand*>(cmd.get()) != nullptr)
-        {
-          break;
-        }
-      }
-    }
-
-    cvc5::Result result;
-    if(status) {
-      result = pExecutor->getResult();
-      returnValue = 0;
-    } else {
-      // there was some kind of error
-      returnValue = 1;
+      PortfolioDriver driver;
+      std::tie(result, returnValue) = driver.execute(pExecutor, parser);
     }
 
 #ifdef CVC5_COMPETITION_MODE

--- a/src/main/portfolio_driver.cpp
+++ b/src/main/portfolio_driver.cpp
@@ -1,0 +1,30 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Morgan Deters, Christopher L. Conway, Gereon Kremer
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2022 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ */
+#include "main/portfolio_driver.h"
+
+namespace cvc5::main {
+
+PortfolioStrategy PortfolioDriver::getStrategy(const std::string& logic)
+{
+	PortfolioStrategy s;
+	if (logic == "QF_NRA")
+	{
+		s.add().set("decision", "justification").timeout(0.5);
+		s.add().set("decision", "internal").set("nl-cad", "false").set("nl-ext", "full").set("nl-ext-tplanes", "true").timeout(0.25);
+		s.add().set("decision", "internal").set("nl-ext", "none");
+	}
+	return s;
+}
+
+}  // namespace cvc5::internal

--- a/src/main/portfolio_driver.h
+++ b/src/main/portfolio_driver.h
@@ -1,0 +1,219 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds, Gereon Kremer, Aina Niemetz
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2022 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * An additional layer between commands and invoking them.
+ */
+
+#ifndef CVC5__MAIN__PORTFOLIO_DRIVER_H
+#define CVC5__MAIN__PORTFOLIO_DRIVER_H
+
+#include <optional>
+
+#include "api/cpp/cvc5.h"
+#include "base/check.h"
+#include "main/command_executor.h"
+#include "parser/parser.h"
+#include "smt/command.h"
+
+namespace cvc5 {
+namespace main {
+
+struct ExecutionContext
+{
+	CommandExecutor* d_executor;
+	cvc5::parser::Parser* d_parser;
+
+	Solver& solver() {
+		return *d_executor->getSolver();
+	}
+};
+
+struct PortfolioConfig
+{
+	PortfolioConfig& set(const std::string& option, const std::string& value)
+	{
+		d_options.emplace_back(option, value);
+		return *this;
+	}
+	/**
+	 * Set timeout as part of the total timeout. The given number should be at most 1.
+	 */
+	PortfolioConfig& timeout(double timeout)
+	{
+		Assert(timeout <= 1) << "The given timeout should be given as part of the total timeout";
+		d_timeout = timeout;
+		return *this;
+	}
+
+	void applyOptions(Solver& solver) const
+	{
+		for (const auto& o: d_options)
+		{
+			solver.setOption(o.first, o.second);
+		}
+	}
+	
+	std::vector<std::pair<std::string,std::string>> d_options;
+	uint64_t d_timeout;
+};
+
+struct PortfolioStrategy
+{
+	PortfolioConfig& add()
+	{
+		d_strategies.emplace_back();
+		return d_strategies.back();
+	}
+
+	std::vector<PortfolioConfig> d_strategies;
+};
+
+
+class PortfolioDriver
+{
+	public:
+		void execute(ExecutionContext& ctx)
+		{
+			Solver& solver = ctx.solver();
+			bool use_portfolio = solver.getOption("use-portfolio") == "true";
+			if (!use_portfolio)
+			{
+				executeContinuous(ctx, false);
+				return;
+			}
+			
+			executeContinuous(ctx, true);
+
+			if (!d_logic)
+			{
+				executeContinuous(ctx, false);
+				return;
+			}
+			
+			PortfolioStrategy strategy = getStrategy(*d_logic);
+			if (strategy.d_strategies.size() == 0)
+			{
+				executeContinuous(ctx, false);
+				return;
+			}
+			if (strategy.d_strategies.size() == 1)
+			{
+				strategy.d_strategies.front().applyOptions(solver);
+				executeContinuous(ctx, false);
+				return;
+			}
+
+			uint64_t total_timeout = ctx.solver().getOptionInfo("tlimit").uintValue();
+			if (total_timeout == 0)
+			{
+				total_timeout == 1200;
+			}
+
+			auto cmds = parseIntoVector(ctx);
+			for (const auto& s: strategy.d_strategies)
+			{
+				// fork
+				// set timeout: s.d_timeout * total_timeout
+				s.applyOptions(solver);
+				execute(ctx, cmds);
+			}
+		}
+	private:
+		PortfolioStrategy getStrategy(const std::string& logic);
+
+		void executeContinuous(ExecutionContext& ctx, bool stopAtSetLogic = false)
+		{
+    		std::unique_ptr<cvc5::Command> cmd;
+			bool interrupted = false;
+			bool status = false;
+			while (status)
+			{
+				if (interrupted) {
+					ctx.solver().getDriverOptions().out() << cvc5::CommandInterrupted();
+					ctx.d_executor->reset();
+					break;
+				}
+				cmd.reset(ctx.d_parser->nextCommand());
+				if (cmd == nullptr) break;
+
+				status = ctx.d_executor->doCommand(cmd);
+				if (cmd->interrupted() && status == 0) {
+					interrupted = true;
+					break;
+				}
+
+				if (dynamic_cast<cvc5::QuitCommand*>(cmd.get()) != nullptr)
+				{
+					break;
+				}
+				if (stopAtSetLogic)
+				{
+					auto* slc = dynamic_cast<cvc5::SetBenchmarkLogicCommand*>(cmd.get());
+					if (slc != nullptr)
+					{
+						d_logic = slc->getLogic();
+						break;
+					}
+				}
+			}
+		}
+
+		std::vector<std::unique_ptr<cvc5::Command>> parseIntoVector(ExecutionContext& ctx)
+		{
+			std::vector<std::unique_ptr<cvc5::Command>> res;
+			while (true)
+			{
+				res.emplace_back(ctx.d_parser->nextCommand());
+				if (!res.back()) break;
+				if (dynamic_cast<cvc5::QuitCommand*>(res.back().get()) != nullptr)
+				{
+					break;
+				}
+			}
+			return res;
+		}
+
+		void execute(ExecutionContext& ctx, std::vector<std::unique_ptr<cvc5::Command>>& cmds)
+		{
+    		bool interrupted = false;
+			bool status = false;
+			auto it = cmds.begin();
+			while (status && it != cmds.end())
+			{
+				if (interrupted) {
+					ctx.solver().getDriverOptions().out() << cvc5::CommandInterrupted();
+					ctx.d_executor->reset();
+					break;
+				}
+
+				Command* cmd = it->get();
+
+				status = ctx.d_executor->doCommand(cmd);
+				if (cmd->interrupted() && status == 0) {
+					interrupted = true;
+					break;
+				}
+
+				if (dynamic_cast<cvc5::QuitCommand*>(cmd) != nullptr)
+				{
+					break;
+				}
+			}
+		}
+
+		std::optional<std::string> d_logic;
+};
+
+}  // namespace main
+}  // namespace cvc5
+
+#endif /* CVC5__MAIN__COMMAND_EXECUTOR_H */

--- a/src/main/portfolio_driver.h
+++ b/src/main/portfolio_driver.h
@@ -115,7 +115,7 @@ class PortfolioDriver
 			uint64_t total_timeout = ctx.solver().getOptionInfo("tlimit").uintValue();
 			if (total_timeout == 0)
 			{
-				total_timeout == 1200;
+				total_timeout = 1200;
 			}
 
 			auto cmds = parseIntoVector(ctx);

--- a/src/options/main_options.toml
+++ b/src/options/main_options.toml
@@ -158,3 +158,11 @@ name   = "Driver"
   type       = "bool"
   default    = "false"
   help       = "Force no CPU limit when dumping models and proofs"
+
+[[option]]
+  name       = "usePortfolio"
+  category   = "expert"
+  long       = "use-portfolio"
+  type       = "bool"
+  default    = "false"
+  help       = "Use internal portfolio mode based on the logic"


### PR DESCRIPTION
We want to replace the set of competition scripts by an internal portfolio mechanism. It seems that this portfolio mechanism is best implemented from scratch in the driver instead of using, e.g., `--tlimit` or `--tlimit-per`.

This PR introduces the infrastructure for that, implementing the following approach:
first parse the input until a logic has been specified; if more than one configuration is to be used, parse the remaining commands into a vector; for every configuration, we fork the main process, and in the child process configure the solver and replay the vectors.

---

This PR is still work in progress, parts are not yet implemented. Please have a look and given some feedback.