### PR TITLE
Update LFSC version

### DIFF
--- a/contrib/get-lfsc-checker
+++ b/contrib/get-lfsc-checker
@@ -24,7 +24,7 @@ LFSC_DIR="$BASE_DIR/lfsc-checker"
 mkdir -p $LFSC_DIR
 
 # download and unpack LFSC
-version="80b6a1b67f819b58f3e80c029a5e22f42d2ab32f"
+version="5f44ffb1241ca81dbb3118807546ba14ab9ea7a5"
 download "https://github.com/cvc5/LFSC/archive/$version.tar.gz" $BASE_DIR/tmp/lfsc.tgz
 tar --strip 1 -xzf $BASE_DIR/tmp/lfsc.tgz -C $LFSC_DIR
 


### PR DESCRIPTION
This updates the `get-lfsc-checker` script to get the latest version of
LFSC, which supports older versions of CMake.