### PR TITLE
Fallback for sequential substitution proof reconstruction

### DIFF
--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -977,22 +977,24 @@ Node ProofPostprocessCallback::expandMacros(PfRule id,
             Node eqo = curr.eqNode(next);
             transChildren.push_back(eqo);
             // ensure the proof for the substitution exists
-            addProofForSubsStep(var, subs, fromList[i], cdp);
+            addProofForSubsStep(var, subs, fromList[ii], cdp);
             // do the single step SUBS, with the same arguments
-            cdp->addStep(eqo, PfRule::SUBS, {var.eqNode(subs)}, args);
+            cdp->addStep(eqo, PfRule::SUBS, {var.eqNode(subs)}, {curr});
             curr = next;
           }
         }
         Assert(curr == ts);
         cdp->addStep(eqq, PfRule::TRANS, transChildren, {});
-        return eqq;
       }
-      Trace("smt-proof-pp-debug")
-          << "resort to TRUST_SUBS" << std::endl
-          << eq << std::endl
-          << eqq << std::endl
-          << "from " << children << " applied to " << t << std::endl;
-      cdp->addStep(eqq, PfRule::TRUST_SUBS, {}, {eqq});
+      else
+      {
+        Trace("smt-proof-pp-debug")
+            << "resort to TRUST_SUBS" << std::endl
+            << eq << std::endl
+            << eqq << std::endl
+            << "from " << children << " applied to " << t << std::endl;
+        cdp->addStep(eqq, PfRule::TRUST_SUBS, {}, {eqq});
+      }
     }
     else
     {

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -987,7 +987,6 @@ Node ProofPostprocessCallback::expandMacros(PfRule id,
         cdp->addStep(eqq, PfRule::TRANS, transChildren, {});
         return eqq;
       }
-      Assert(false);
       Trace("smt-proof-pp-debug")
           << "resort to TRUST_SUBS" << std::endl
           << eq << std::endl

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -962,7 +962,7 @@ Node ProofPostprocessCallback::expandMacros(PfRule id,
       {
         Trace("smt-proof-pp-debug")
             << "resort to sequential reconstruction" << std::endl;
-        // just do the naive sequential substitution,
+        // just do the naive sequential reconstruction,
         // (SUBS F1 ... Fn t) ---> (TRANS (SUBS F1 t) ... (SUBS Fn tn))
         Node curr = t;
         std::vector<Node> transChildren;
@@ -978,7 +978,7 @@ Node ProofPostprocessCallback::expandMacros(PfRule id,
             transChildren.push_back(eqo);
             // ensure the proof for the substitution exists
             addProofForSubsStep(var, subs, fromList[ii], cdp);
-            // do the single step SUBS on curr
+            // do the single step SUBS on curr with the default arguments
             cdp->addStep(eqo, PfRule::SUBS, {var.eqNode(subs)}, {curr});
             curr = next;
           }

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -952,15 +952,42 @@ Node ProofPostprocessCallback::expandMacros(PfRule id,
     Node ts = builtin::BuiltinProofRuleChecker::applySubstitution(
         t, children, ids, ida);
     Node eqq = t.eqNode(ts);
+    // should have the same conclusion, if not, then tcpg does not agree with
+    // the substitution.
     if (eq != eqq)
     {
-      pfn = nullptr;
-    }
-    // should give a proof, if not, then tcpg does not agree with the
-    // substitution.
-    if (pfn == nullptr)
-    {
-      warning() << "resort to TRUST_SUBS" << std::endl
+      // this can happen in very rare cases where e.g. x -> a; f(x) -> b
+      // and t*{x -> a} = t*{x -> a}*{f(x) -> b} != t*{x -> a, f(x) -> b}
+      if (ida==MethodId::SBA_SEQUENTIAL && vsList.size()>1)
+      {
+        Trace("smt-proof-pp-debug") << "resort to sequential reconstruction" << std::endl;
+        // just do the naive sequential substitution,
+        // (SUBS F1 ... Fn t) ---> (TRANS (SUBS F1 t) ... (SUBS Fn tn))
+        Node curr = t;
+        std::vector<Node> transChildren;
+        for (size_t i = 0, nvs = vsList.size(); i < nvs; i++)
+        {
+          size_t ii = nvs-1-i;
+          TNode var = vsList[ii];
+          TNode subs = ssList[ii];
+          Node next = curr.substitute(var, subs);
+          if (next!=curr)
+          {
+            Node eqo = curr.eqNode(next);
+            transChildren.push_back(eqo);
+            // ensure the proof for the substitution exists
+            addProofForSubsStep(var, subs, fromList[i], cdp);
+            // do the single step SUBS, with the same arguments
+            cdp->addStep(eqo, PfRule::SUBS, {var.eqNode(subs)}, args);
+            curr = next;
+          }
+        }
+        Assert (curr==ts);
+        cdp->addStep(eqq, PfRule::TRANS, transChildren, {});
+        return eqq;
+      }
+      Assert (false);
+      Trace("smt-proof-pp-debug") << "resort to TRUST_SUBS" << std::endl
                 << eq << std::endl
                 << eqq << std::endl
                 << "from " << children << " applied to " << t << std::endl;

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -978,7 +978,7 @@ Node ProofPostprocessCallback::expandMacros(PfRule id,
             transChildren.push_back(eqo);
             // ensure the proof for the substitution exists
             addProofForSubsStep(var, subs, fromList[ii], cdp);
-            // do the single step SUBS, with the same arguments
+            // do the single step SUBS on curr
             cdp->addStep(eqo, PfRule::SUBS, {var.eqNode(subs)}, {curr});
             curr = next;
           }

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -958,20 +958,21 @@ Node ProofPostprocessCallback::expandMacros(PfRule id,
     {
       // this can happen in very rare cases where e.g. x -> a; f(x) -> b
       // and t*{x -> a} = t*{x -> a}*{f(x) -> b} != t*{x -> a, f(x) -> b}
-      if (ida==MethodId::SBA_SEQUENTIAL && vsList.size()>1)
+      if (ida == MethodId::SBA_SEQUENTIAL && vsList.size() > 1)
       {
-        Trace("smt-proof-pp-debug") << "resort to sequential reconstruction" << std::endl;
+        Trace("smt-proof-pp-debug")
+            << "resort to sequential reconstruction" << std::endl;
         // just do the naive sequential substitution,
         // (SUBS F1 ... Fn t) ---> (TRANS (SUBS F1 t) ... (SUBS Fn tn))
         Node curr = t;
         std::vector<Node> transChildren;
         for (size_t i = 0, nvs = vsList.size(); i < nvs; i++)
         {
-          size_t ii = nvs-1-i;
+          size_t ii = nvs - 1 - i;
           TNode var = vsList[ii];
           TNode subs = ssList[ii];
           Node next = curr.substitute(var, subs);
-          if (next!=curr)
+          if (next != curr)
           {
             Node eqo = curr.eqNode(next);
             transChildren.push_back(eqo);
@@ -982,15 +983,16 @@ Node ProofPostprocessCallback::expandMacros(PfRule id,
             curr = next;
           }
         }
-        Assert (curr==ts);
+        Assert(curr == ts);
         cdp->addStep(eqq, PfRule::TRANS, transChildren, {});
         return eqq;
       }
-      Assert (false);
-      Trace("smt-proof-pp-debug") << "resort to TRUST_SUBS" << std::endl
-                << eq << std::endl
-                << eqq << std::endl
-                << "from " << children << " applied to " << t << std::endl;
+      Assert(false);
+      Trace("smt-proof-pp-debug")
+          << "resort to TRUST_SUBS" << std::endl
+          << eq << std::endl
+          << eqq << std::endl
+          << "from " << children << " applied to " << t << std::endl;
       cdp->addStep(eqq, PfRule::TRUST_SUBS, {}, {eqq});
     }
     else

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2949,6 +2949,7 @@ set(regress_2_tests
   regress2/strings/cmu-disagree-0707-dd.smt2
   regress2/strings/cmu-prereg-fmf.smt2
   regress2/strings/cmu-repl-len-nterm.smt2
+  regress2/strings/dd.trust-subs.smt2
   regress2/strings/issue3203.smt2
   regress2/strings/issue5381.smt2
   regress2/strings/issue6483.smt2

--- a/test/regress/cli/regress2/strings/dd.trust-subs.smt2
+++ b/test/regress/cli/regress2/strings/dd.trust-subs.smt2
@@ -1,0 +1,7 @@
+; COMMAND-LINE: --strings-exp
+; EXPECT: unsat
+(set-logic ALL)
+(declare-fun x () String)
+(declare-fun y () String)
+(assert (distinct (str.replace (str.replace "B" x y) "A" x) (str.replace "B" x (str.replace y "A" x))))
+(check-sat)


### PR DESCRIPTION
This makes our proof reconstruction fallback to a trivial sequential reconstruction in very rare cases where a sequential substitution fails to reconstruct. This can happen in some rare cases where terms are used in the domain of a substitution that otherwise would be modified by earlier substitutions.  This occurs on 2 QF_SLIA benchmarks, attached is a delta-debugged version.

This also changes a warning message to a trace for this case, as a warning message may cause LFSC proof checking to fail when it should just give a warning for a TRUST_SUBS step, which is the default behavior regardless.