### PR TITLE
Improvements for evaluation in model

### DIFF
--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -122,7 +122,7 @@ void TheoryDatatypes::finishInit()
   // testers are not relevant for model building
   d_valuation.setIrrelevantKind(APPLY_TESTER);
   d_valuation.setIrrelevantKind(DT_SYGUS_BOUND);
-  d_valuation.setSemiEvaluatedKind(APPLY_SELECTOR);
+  d_valuation.setUnevaluatedKind(APPLY_SELECTOR);
 }
 
 TheoryDatatypes::EqcInfo* TheoryDatatypes::getOrMakeEqcInfo( TNode n, bool doMake ){

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -122,6 +122,7 @@ void TheoryDatatypes::finishInit()
   // testers are not relevant for model building
   d_valuation.setIrrelevantKind(APPLY_TESTER);
   d_valuation.setIrrelevantKind(DT_SYGUS_BOUND);
+  // selectors don't always evaluate
   d_valuation.setUnevaluatedKind(APPLY_SELECTOR);
 }
 

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -122,6 +122,7 @@ void TheoryDatatypes::finishInit()
   // testers are not relevant for model building
   d_valuation.setIrrelevantKind(APPLY_TESTER);
   d_valuation.setIrrelevantKind(DT_SYGUS_BOUND);
+  d_valuation.setSemiEvaluatedKind(APPLY_SELECTOR);
 }
 
 TheoryDatatypes::EqcInfo* TheoryDatatypes::getOrMakeEqcInfo( TNode n, bool doMake ){

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -162,6 +162,8 @@ void TheoryStrings::finishInit()
 
   // memberships are not relevant for model building
   d_valuation.setIrrelevantKind(kind::STRING_IN_REGEXP);
+  // seq nth doesn't always evaluate
+  d_valuation.setUnevaluatedKind(SEQ_NTH);
 }
 
 std::string TheoryStrings::identify() const

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -260,7 +260,7 @@ Node TheoryModel::getModelValue(TNode n) const
                         <= cc.getUpperBound());
     }
     // if the value was constant, we return it. If it was non-constant,
-    // we only return it if we an evaluated kind. This can occur if the
+    // we only return it if we are an evaluated kind. This can occur if the
     // children of n failed to evaluate.
     if (ret.isConst() || (
      d_unevaluated_kinds.find(nk) == d_unevaluated_kinds.end()

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -274,7 +274,8 @@ Node TheoryModel::getModelValue(TNode n) const
   }
   // must rewrite the term at this point
   ret = rewrite(n);
-  Trace("model-getvalue-debug") << "Look up " << ret << " in equality engine" << std::endl;
+  Trace("model-getvalue-debug")
+      << "Look up " << ret << " in equality engine" << std::endl;
   // return the representative of the term in the equality engine, if it exists
   TypeNode t = ret.getType();
   if (!logicInfo().isHigherOrder() && (t.isFunction() || t.isPredicate()))

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -262,7 +262,9 @@ Node TheoryModel::getModelValue(TNode n) const
     // if the value was constant, we return it. If it was non-constant,
     // we only return it if we an evaluated kind. This can occur if the
     // children of n failed to evaluate.
-    if (ret.isConst())
+    if (ret.isConst() || (
+     d_unevaluated_kinds.find(nk) == d_unevaluated_kinds.end()
+      && d_semi_evaluated_kinds.find(nk) == d_semi_evaluated_kinds.end()))
     {
       d_modelCache[n] = ret;
       return ret;
@@ -275,7 +277,6 @@ Node TheoryModel::getModelValue(TNode n) const
   }
   // return the representative of the term in the equality engine, if it exists
   TypeNode t = ret.getType();
-  bool eeHasTerm;
   if (!logicInfo().isHigherOrder() && (t.isFunction() || t.isPredicate()))
   {
     // functions are in the equality engine, but *not* as first-class members
@@ -284,13 +285,8 @@ Node TheoryModel::getModelValue(TNode n) const
     // to the equality engine despite hasTerm returning true. However, they are
     // first class members when higher-order is enabled. Hence, the special
     // case here.
-    eeHasTerm = false;
   }
-  else
-  {
-    eeHasTerm = d_equalityEngine->hasTerm(ret);
-  }
-  if (eeHasTerm)
+  else if (d_equalityEngine->hasTerm(ret))
   {
     Trace("model-getvalue-debug")
         << "get value from representative " << ret << "..." << std::endl;

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -269,12 +269,12 @@ Node TheoryModel::getModelValue(TNode n) const
       d_modelCache[n] = ret;
       return ret;
     }
+    // Note that we discard the evaluation of the arguments here
+    Trace("model-getvalue-debug") << "Failed to evaluate " << ret << std::endl;
   }
-  else
-  {
-    // must rewrite the term at this point
-    ret = rewrite(n);
-  }
+  // must rewrite the term at this point
+  ret = rewrite(n);
+  Trace("model-getvalue-debug") << "Look up " << ret << " in equality engine" << std::endl;
   // return the representative of the term in the equality engine, if it exists
   TypeNode t = ret.getType();
   if (!logicInfo().isHigherOrder() && (t.isFunction() || t.isPredicate()))

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -262,16 +262,17 @@ Node TheoryModel::getModelValue(TNode n) const
     // if the value was constant, we return it. If it was non-constant,
     // we only return it if we an evaluated kind. This can occur if the
     // children of n failed to evaluate.
-    if (ret.isConst() || (
-     d_unevaluated_kinds.find(nk) == d_unevaluated_kinds.end()
-      && d_semi_evaluated_kinds.find(nk) == d_semi_evaluated_kinds.end()))
+    if (ret.isConst())
     {
       d_modelCache[n] = ret;
       return ret;
     }
   }
-  // must rewrite the term at this point
-  ret = rewrite(n);
+  else
+  {
+    // must rewrite the term at this point
+    ret = rewrite(n);
+  }
   // return the representative of the term in the equality engine, if it exists
   TypeNode t = ret.getType();
   bool eeHasTerm;

--- a/test/regress/cli/regress0/arith/div.05.smt2
+++ b/test/regress/cli/regress0/arith/div.05.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_NRA)
 (set-info :smt-lib-version 2.6)

--- a/test/regress/cli/regress0/arith/div.05.smt2
+++ b/test/regress/cli/regress0/arith/div.05.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_NRA)
 (set-info :smt-lib-version 2.6)

--- a/test/regress/cli/regress0/arith/issue7984-quant-trans.smt2
+++ b/test/regress/cli/regress0/arith/issue7984-quant-trans.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_NRAT)
 (set-info :status sat)

--- a/test/regress/cli/regress0/arith/issue7984-quant-trans.smt2
+++ b/test/regress/cli/regress0/arith/issue7984-quant-trans.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_NRAT)
 (set-info :status sat)

--- a/test/regress/cli/regress0/arith/projissue469-int-equality.smt2
+++ b/test/regress/cli/regress0/arith/projissue469-int-equality.smt2
@@ -1,5 +1,5 @@
-; COMMAND-LINE: -q
 ; EXPECT: sat
+(set-logic ALL)
 (set-option :nl-ext-ent-conf true)
 (declare-const x Int)
 (assert (> (* x x) (+ x x)))

--- a/test/regress/cli/regress0/cores/issue3455.smt2
+++ b/test/regress/cli/regress0/cores/issue3455.smt2
@@ -1,9 +1,10 @@
-; COMMAND-LINE: -q --incremental
+; COMMAND-LINE: --incremental
 ; EXPECT: sat
 ; EXPECT: sat
 ; EXPECT: unsat
 ; EXPECT: unsat
 ; EXPECT: unsat
+(set-logic ALL)
 (declare-fun x0 () Real)
 (check-sat)
 (assert (<= (* x0 (- 1.0)) 0.0))

--- a/test/regress/cli/regress0/cores/issue3651.smt2
+++ b/test/regress/cli/regress0/cores/issue3651.smt2
@@ -1,9 +1,10 @@
-; COMMAND-LINE: --incremental -q
+; COMMAND-LINE: --incremental
 ; EXPECT: sat
 ; EXPECT: sat
 ; EXPECT: sat
 ; EXPECT: sat
 ; EXPECT: unsat
+(set-logic ALL)
 (declare-fun a () Real)
 (declare-fun b () Real)
 (declare-fun c () Real)

--- a/test/regress/cli/regress0/cores/issue4971-0.smt2
+++ b/test/regress/cli/regress0/cores/issue4971-0.smt2
@@ -1,9 +1,10 @@
-; COMMAND-LINE: --incremental -q --cegqi-full --produce-unsat-cores
+; COMMAND-LINE: --incremental --cegqi-full --produce-unsat-cores
 ; EXPECT: unsat
 ; EXPECT: unsat
 ; EXPECT: (
 ; EXPECT: IP_1
 ; EXPECT: )
+(set-logic ALL)
 (declare-const v1 Bool)
 (declare-const v9 Bool)
 (declare-const v14 Bool)

--- a/test/regress/cli/regress0/cores/issue4971-1.smt2
+++ b/test/regress/cli/regress0/cores/issue4971-1.smt2
@@ -1,7 +1,8 @@
-; COMMAND-LINE: --incremental -q --produce-unsat-cores
-; COMMAND-LINE: --incremental -q --unsat-cores-mode=sat-proof --produce-unsat-cores
+; COMMAND-LINE: --incremental --produce-unsat-cores
+; COMMAND-LINE: --incremental --unsat-cores-mode=sat-proof --produce-unsat-cores
 ; EXPECT: sat
 ; EXPECT: sat
+(set-logic ALL)
 (declare-const i2 Int)
 (declare-const i5 Int)
 (declare-fun st2 () (Set Int))

--- a/test/regress/cli/regress0/cores/issue4971-3.smt2
+++ b/test/regress/cli/regress0/cores/issue4971-3.smt2
@@ -1,8 +1,9 @@
-; COMMAND-LINE: --incremental -q --produce-unsat-cores
+; COMMAND-LINE: --incremental --produce-unsat-cores
 ; EXPECT: sat
 ; EXPECT: sat
 ; EXPECT: sat
 ; EXPECT: sat
+(set-logic ALL)
 (declare-const v1 Bool)
 (declare-const v2 Bool)
 (declare-const v3 Bool)

--- a/test/regress/cli/regress0/cores/issue5902.smt2
+++ b/test/regress/cli/regress0/cores/issue5902.smt2
@@ -1,3 +1,3 @@
-; COMMAND-LINE: -q
 ; EXPECT: unsat
+(set-logic ALL)
 (check-sat-assuming (false))

--- a/test/regress/cli/regress0/cores/issue5908.smt2
+++ b/test/regress/cli/regress0/cores/issue5908.smt2
@@ -1,7 +1,8 @@
-; COMMAND-LINE: -i -q
+; COMMAND-LINE: -i
 ; EXPECT: sat
 ; EXPECT: sat
 ; EXPECT: unsat
+(set-logic ALL)
 (declare-fun a () Int)
 (declare-fun b () Int)
 (declare-fun c () Int)

--- a/test/regress/cli/regress0/datatypes/data-nested-codata.smt2
+++ b/test/regress/cli/regress0/datatypes/data-nested-codata.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_DTLIA)
 (set-info :status sat)

--- a/test/regress/cli/regress0/datatypes/data-nested-codata.smt2
+++ b/test/regress/cli/regress0/datatypes/data-nested-codata.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_DTLIA)
 (set-info :status sat)

--- a/test/regress/cli/regress0/datatypes/datatype1.cvc.smt2
+++ b/test/regress/cli/regress0/datatypes/datatype1.cvc.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-option :incremental false)

--- a/test/regress/cli/regress0/datatypes/datatype1.cvc.smt2
+++ b/test/regress/cli/regress0/datatypes/datatype1.cvc.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-option :incremental false)

--- a/test/regress/cli/regress0/datatypes/datatype3.cvc.smt2
+++ b/test/regress/cli/regress0/datatypes/datatype3.cvc.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-option :incremental false)

--- a/test/regress/cli/regress0/datatypes/datatype3.cvc.smt2
+++ b/test/regress/cli/regress0/datatypes/datatype3.cvc.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-option :incremental false)

--- a/test/regress/cli/regress0/datatypes/issue1433.smt2
+++ b/test/regress/cli/regress0/datatypes/issue1433.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_UFDTLIA)
 (set-info :status sat)

--- a/test/regress/cli/regress0/datatypes/issue1433.smt2
+++ b/test/regress/cli/regress0/datatypes/issue1433.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_UFDTLIA)
 (set-info :status sat)

--- a/test/regress/cli/regress0/datatypes/issue2838.cvc.smt2
+++ b/test/regress/cli/regress0/datatypes/issue2838.cvc.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-option :incremental false)

--- a/test/regress/cli/regress0/datatypes/issue2838.cvc.smt2
+++ b/test/regress/cli/regress0/datatypes/issue2838.cvc.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-option :incremental false)

--- a/test/regress/cli/regress0/datatypes/parametric-alt-list.cvc.smt2
+++ b/test/regress/cli/regress0/datatypes/parametric-alt-list.cvc.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-option :incremental false)

--- a/test/regress/cli/regress0/datatypes/parametric-alt-list.cvc.smt2
+++ b/test/regress/cli/regress0/datatypes/parametric-alt-list.cvc.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-option :incremental false)

--- a/test/regress/cli/regress0/datatypes/v3l60006.cvc.smt2
+++ b/test/regress/cli/regress0/datatypes/v3l60006.cvc.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-option :incremental false)

--- a/test/regress/cli/regress0/datatypes/v3l60006.cvc.smt2
+++ b/test/regress/cli/regress0/datatypes/v3l60006.cvc.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-option :incremental false)

--- a/test/regress/cli/regress0/datatypes/wrong-sel-simp.cvc.smt2
+++ b/test/regress/cli/regress0/datatypes/wrong-sel-simp.cvc.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-option :incremental false)

--- a/test/regress/cli/regress0/datatypes/wrong-sel-simp.cvc.smt2
+++ b/test/regress/cli/regress0/datatypes/wrong-sel-simp.cvc.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-option :incremental false)

--- a/test/regress/cli/regress0/fp/issue3536.smt2
+++ b/test/regress/cli/regress0/fp/issue3536.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_FP)
 (declare-const x (_ FloatingPoint 11 53))

--- a/test/regress/cli/regress0/fp/issue3536.smt2
+++ b/test/regress/cli/regress0/fp/issue3536.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_FP)
 (declare-const x (_ FloatingPoint 11 53))

--- a/test/regress/cli/regress0/fp/issue3619.smt2
+++ b/test/regress/cli/regress0/fp/issue3619.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_FPLRA)
 (set-info :status sat)

--- a/test/regress/cli/regress0/fp/issue3619.smt2
+++ b/test/regress/cli/regress0/fp/issue3619.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_FPLRA)
 (set-info :status sat)

--- a/test/regress/cli/regress0/fp/issue4277-assign-func.smt2
+++ b/test/regress/cli/regress0/fp/issue4277-assign-func.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic HO_ALL)
 (set-option :assign-function-values false)

--- a/test/regress/cli/regress0/fp/issue4277-assign-func.smt2
+++ b/test/regress/cli/regress0/fp/issue4277-assign-func.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic HO_ALL)
 (set-option :assign-function-values false)

--- a/test/regress/cli/regress0/issue5099-model-2.smt2
+++ b/test/regress/cli/regress0/issue5099-model-2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -m -q
+; COMMAND-LINE: -m
 ; EXPECT: sat
 ; EXPECT: ((IP true))
 (set-logic QF_NRA)

--- a/test/regress/cli/regress0/issue5473.smt2
+++ b/test/regress/cli/regress0/issue5473.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 ; EXPECT: ((baz true))
 (set-logic QF_NIRA)

--- a/test/regress/cli/regress0/issue5473.smt2
+++ b/test/regress/cli/regress0/issue5473.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 ; EXPECT: ((baz true))
 (set-logic QF_NIRA)

--- a/test/regress/cli/regress0/issue5736.smt2
+++ b/test/regress/cli/regress0/issue5736.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+(set-logic ALL)
 (set-info :status sat)
 (declare-fun a () (Array (_ BitVec 32) (_ BitVec 32)))
 (declare-fun b () (Array (_ BitVec 32) (_ BitVec 32)))

--- a/test/regress/cli/regress0/issue5743.smt2
+++ b/test/regress/cli/regress0/issue5743.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 (set-logic QF_AUFBV)
 (set-info :status sat)
 (declare-fun bv_22-0 () (_ BitVec 1))

--- a/test/regress/cli/regress0/issue5743.smt2
+++ b/test/regress/cli/regress0/issue5743.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 (set-logic QF_AUFBV)
 (set-info :status sat)
 (declare-fun bv_22-0 () (_ BitVec 1))

--- a/test/regress/cli/regress0/issue5947.smt2
+++ b/test/regress/cli/regress0/issue5947.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 (set-logic QF_UFBVLIA)
 (set-info :status sat)
 (declare-fun f ((_ BitVec 3)) Int)

--- a/test/regress/cli/regress0/issue5947.smt2
+++ b/test/regress/cli/regress0/issue5947.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 (set-logic QF_UFBVLIA)
 (set-info :status sat)
 (declare-fun f ((_ BitVec 3)) Int)

--- a/test/regress/cli/regress0/nl/nta/issue4693-4-inc-purify-sat.smt2
+++ b/test/regress/cli/regress0/nl/nta/issue4693-4-inc-purify-sat.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -i -q --no-debug-check-models
+; COMMAND-LINE: -i --no-debug-check-models
 ; EXPECT: sat
 ; EXPECT: sat
 (set-logic ALL)

--- a/test/regress/cli/regress0/nl/nta/issue4693-5-inc-purify.smt2
+++ b/test/regress/cli/regress0/nl/nta/issue4693-5-inc-purify.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress0/nl/nta/issue4693-5-inc-purify.smt2
+++ b/test/regress/cli/regress0/nl/nta/issue4693-5-inc-purify.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress0/nl/nta/issue4693-inc-purify.smt2
+++ b/test/regress/cli/regress0/nl/nta/issue4693-inc-purify.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -i -q
+; COMMAND-LINE: -i
 ; EXPECT: unsat
 ; EXPECT: unsat
 (set-logic QF_NRAT)

--- a/test/regress/cli/regress0/nl/nta/issue8182-2-exact-mv-keep.smt2
+++ b/test/regress/cli/regress0/nl/nta/issue8182-2-exact-mv-keep.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress0/nl/nta/issue8182-2-exact-mv-keep.smt2
+++ b/test/regress/cli/regress0/nl/nta/issue8182-2-exact-mv-keep.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress0/parser/issue7894-parse-error-assoc.smt2
+++ b/test/regress/cli/regress0/parser/issue7894-parse-error-assoc.smt2
@@ -1,6 +1,6 @@
 ; DISABLE-TESTER: dump
-; COMMAND-LINE: -q
 ; SCRUBBER: grep -o "must have at least 2 children"
 ; EXPECT: must have at least 2 children
 ; EXIT: 1
+(set-logic ALL)
 (assert (= (+ 0)))

--- a/test/regress/cli/regress0/parser/to_fp.smt2
+++ b/test/regress/cli/regress0/parser/to_fp.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strict-parsing -q
+; COMMAND-LINE: --strict-parsing
 ; EXPECT: sat
 (set-logic QF_FP)
 (declare-fun |c::main::main::3::div@1!0&0#1| () (_ FloatingPoint 8 24))

--- a/test/regress/cli/regress0/quantifiers/issue8001-mem-leak.smt2
+++ b/test/regress/cli/regress0/quantifiers/issue8001-mem-leak.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
 ; EXPECT: unknown
+(set-logic ALL)
 (assert (forall ((V (Array Int Int))) (= 0 (select V 0))))
 (check-sat)

--- a/test/regress/cli/regress0/quantifiers/pure_dt_cbqi.smt2
+++ b/test/regress/cli/regress0/quantifiers/pure_dt_cbqi.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --cegqi -q
+; COMMAND-LINE: --cegqi
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress0/seq/mixed-types-seq-nth.smt2
+++ b/test/regress/cli/regress0/seq/mixed-types-seq-nth.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --seq-array=lazy -q
+; COMMAND-LINE: --seq-array=lazy
 
 (set-logic QF_UFSLIA)
 (declare-sort E 0)

--- a/test/regress/cli/regress0/seq/nth-update.smt2
+++ b/test/regress/cli/regress0/seq/nth-update.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy -q
+; COMMAND-LINE: --strings-exp --seq-array=lazy
 ; EXPECT: sat
 (set-logic QF_SLIA)
 (declare-const x (Seq Int))

--- a/test/regress/cli/regress0/seq/seq-expand-defs.smt2
+++ b/test/regress/cli/regress0/seq/seq-expand-defs.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp -q
+; COMMAND-LINE: --strings-exp
 ; EXPECT: sat
 ; EXPECT: (((seq.nth y 7) 404))
 ; EXPECT: (((str.from_code x) "?"))

--- a/test/regress/cli/regress0/seq/seq-expand-defs.smt2
+++ b/test/regress/cli/regress0/seq/seq-expand-defs.smt2
@@ -1,6 +1,6 @@
 ; COMMAND-LINE: --strings-exp -q
 ; EXPECT: sat
-; EXPECT: (((seq.nth y 7) (seq.nth (as seq.empty (Seq Int)) 7)))
+; EXPECT: (((seq.nth y 7) 404))
 ; EXPECT: (((str.from_code x) "?"))
 (set-logic ALL)
 (set-option :produce-models true)

--- a/test/regress/cli/regress0/seq/seq-nth.smt2
+++ b/test/regress/cli/regress0/seq/seq-nth.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp -q
+; COMMAND-LINE: --strings-exp
 ;EXPECT: sat
 (set-logic ALL)
 (declare-fun s () (Seq Int))

--- a/test/regress/cli/regress0/seq/update-concat-non-atomic.smt2
+++ b/test/regress/cli/regress0/seq/update-concat-non-atomic.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy -q
+; COMMAND-LINE: --strings-exp --seq-array=lazy
 ; EXPECT: sat
 (set-logic ALL)
 (declare-sort S 0)

--- a/test/regress/cli/regress0/seq/update-concat-non-atomic2.smt2
+++ b/test/regress/cli/regress0/seq/update-concat-non-atomic2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy -q
+; COMMAND-LINE: --strings-exp --seq-array=lazy
 ; EXPECT: sat
 (set-logic ALL)
 (declare-sort S 0)

--- a/test/regress/cli/regress0/seq/wrong-model-020322.smt2
+++ b/test/regress/cli/regress0/seq/wrong-model-020322.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy -q
+; COMMAND-LINE: --strings-exp --seq-array=lazy
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/bug507.smt2
+++ b/test/regress/cli/regress1/bug507.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/bug507.smt2
+++ b/test/regress/cli/regress1/bug507.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/bug516.smt2
+++ b/test/regress/cli/regress1/bug516.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --finite-model-find --fmf-bound -q
+; COMMAND-LINE: --finite-model-find --fmf-bound
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/cee-bug0909-dd-scope.smt2
+++ b/test/regress/cli/regress1/cee-bug0909-dd-scope.smt2
@@ -1,5 +1,5 @@
-; COMMAND-LINE: --ee-mode=distributed -q
-; COMMAND-LINE: --ee-mode=central -q
+; COMMAND-LINE: --ee-mode=distributed
+; COMMAND-LINE: --ee-mode=central
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/cores/issue5604.smt2
+++ b/test/regress/cli/regress1/cores/issue5604.smt2
@@ -1,5 +1,6 @@
-; COMMAND-LINE: --strings-exp -q
+; COMMAND-LINE: --strings-exp
 ; EXPECT: unsat
+(set-logic ALL)
 (declare-fun a () String)
 (declare-fun b () String)
 (declare-fun c () String)

--- a/test/regress/cli/regress1/datatypes/non-simple-rec-param.smt2
+++ b/test/regress/cli/regress1/datatypes/non-simple-rec-param.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --dt-nested-rec -q
+; COMMAND-LINE: --dt-nested-rec
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/fmf/bug651.smt2
+++ b/test/regress/cli/regress1/fmf/bug651.smt2
@@ -1,5 +1,6 @@
-; COMMAND-LINE: --fmf-fun --fmf-bound -q
+; COMMAND-LINE: --fmf-fun --fmf-bound
 ; EXPECT: sat
+; DISABLE-TESTER: model
 (set-logic UFDTSLIA)
 (set-option :produce-models true)
 

--- a/test/regress/cli/regress1/fmf/cons-sets-bounds.smt2
+++ b/test/regress/cli/regress1/fmf/cons-sets-bounds.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --fmf-bound -q
+; COMMAND-LINE: --fmf-bound
 ; EXPECT: sat
 (set-logic ALL)
 (declare-datatypes ((list 0)) (((cons (head Int) (tail list)) (nil))))

--- a/test/regress/cli/regress1/fmf/jasmin-cdt-crash.smt2
+++ b/test/regress/cli/regress1/fmf/jasmin-cdt-crash.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --finite-model-find --e-matching --uf-ss-fair-monotone -q
+; COMMAND-LINE: --finite-model-find --e-matching --uf-ss-fair-monotone
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/fmf/loopy_coda.smt2
+++ b/test/regress/cli/regress1/fmf/loopy_coda.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --finite-model-find --e-matching --uf-ss-fair-monotone -q
+; COMMAND-LINE: --finite-model-find --e-matching --uf-ss-fair-monotone
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/fmf/lst-no-self-rev-exp.smt2
+++ b/test/regress/cli/regress1/fmf/lst-no-self-rev-exp.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --finite-model-find -q
+; COMMAND-LINE: --finite-model-find
 ; EXPECT: sat
 (set-logic ALL)
 (declare-datatypes ((Nat 0) (Lst 0)) (((succ (pred Nat)) (zero)) ((cons (hd Nat) (tl Lst)) (nil))))

--- a/test/regress/cli/regress1/fmf/nun-0208-to.smt2
+++ b/test/regress/cli/regress1/fmf/nun-0208-to.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --finite-model-find -q
+; COMMAND-LINE: --finite-model-find
 ; EXPECT: sat
 (set-logic ALL)
 (declare-sort b__ 0)

--- a/test/regress/cli/regress1/fmf/pow2-bool.smt2
+++ b/test/regress/cli/regress1/fmf/pow2-bool.smt2
@@ -1,5 +1,6 @@
-; COMMAND-LINE: --fmf-fun -q
+; COMMAND-LINE: --fmf-fun
 ; EXPECT: sat
+; DISABLE-TESTER: model
 (set-logic ALL)
 
 (define-fun-rec p2 ((n Int) (p Int)) Bool (

--- a/test/regress/cli/regress1/nl/transcedental_model_simple.smt2
+++ b/test/regress/cli/regress1/nl/transcedental_model_simple.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --nl-rlv=always -q
+; COMMAND-LINE: --nl-rlv=always
 ; EXPECT: sat
 (set-logic QF_NRAT)
 (set-info :status sat)

--- a/test/regress/cli/regress1/quantifiers/issue5484-qe.smt2
+++ b/test/regress/cli/regress1/quantifiers/issue5484-qe.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; SCRUBBER: sed 's/(.*)/()/g'
 ; EXPECT: ()
 ; EXIT: 0

--- a/test/regress/cli/regress1/quantifiers/issue5484-qe.smt2
+++ b/test/regress/cli/regress1/quantifiers/issue5484-qe.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; SCRUBBER: sed 's/(.*)/()/g'
 ; EXPECT: ()
 ; EXIT: 0

--- a/test/regress/cli/regress1/quantifiers/issue5484b-qe.smt2
+++ b/test/regress/cli/regress1/quantifiers/issue5484b-qe.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; SCRUBBER: sed 's/(.*)/()/g'
 ; EXPECT: ()
 ; EXIT: 0

--- a/test/regress/cli/regress1/quantifiers/issue5484b-qe.smt2
+++ b/test/regress/cli/regress1/quantifiers/issue5484b-qe.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; SCRUBBER: sed 's/(.*)/()/g'
 ; EXPECT: ()
 ; EXIT: 0

--- a/test/regress/cli/regress1/quantifiers/qbv-simple-2vars-vo.smt2
+++ b/test/regress/cli/regress1/quantifiers/qbv-simple-2vars-vo.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --cegqi-bv --cegqi-bv-ineq=keep -q
+; COMMAND-LINE: --cegqi-bv --cegqi-bv-ineq=keep
 ; EXPECT: sat
 (set-logic BV)
 (set-info :status sat)

--- a/test/regress/cli/regress1/quantifiers/qbv-subcall.smt2
+++ b/test/regress/cli/regress1/quantifiers/qbv-subcall.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic BV)
 (set-info :status sat)

--- a/test/regress/cli/regress1/quantifiers/qbv-subcall.smt2
+++ b/test/regress/cli/regress1/quantifiers/qbv-subcall.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic BV)
 (set-info :status sat)

--- a/test/regress/cli/regress1/quantifiers/smtcomp-qbv-053118.smt2
+++ b/test/regress/cli/regress1/quantifiers/smtcomp-qbv-053118.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-info :smt-lib-version 2.6)
 (set-logic BV)

--- a/test/regress/cli/regress1/quantifiers/smtcomp-qbv-053118.smt2
+++ b/test/regress/cli/regress1/quantifiers/smtcomp-qbv-053118.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-info :smt-lib-version 2.6)
 (set-logic BV)

--- a/test/regress/cli/regress1/seq/issue8148-2-const-mv.smt2
+++ b/test/regress/cli/regress1/seq/issue8148-2-const-mv.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp -q
+; COMMAND-LINE: --strings-exp
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/seq/issue8148-const-mv.smt2
+++ b/test/regress/cli/regress1/seq/issue8148-const-mv.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp -q
+; COMMAND-LINE: --strings-exp
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/strings/issue1105.smt2
+++ b/test/regress/cli/regress1/strings/issue1105.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-option :strings-exp true)

--- a/test/regress/cli/regress1/strings/issue1105.smt2
+++ b/test/regress/cli/regress1/strings/issue1105.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-option :strings-exp true)

--- a/test/regress/cli/regress1/strings/issue6913.smt2
+++ b/test/regress/cli/regress1/strings/issue6913.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp -q
+; COMMAND-LINE: --strings-exp
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun a () String)

--- a/test/regress/cli/regress1/wrong-qfabvfp-smtcomp2018.smt2
+++ b/test/regress/cli/regress1/wrong-qfabvfp-smtcomp2018.smt2
@@ -1,5 +1,5 @@
-; COMMAND-LINE: --decision=internal -q
-; COMMAND-LINE: --decision=justification -q
+; COMMAND-LINE: --decision=internal
+; COMMAND-LINE: --decision=justification
 ; EXPECT: sat
 (set-info :smt-lib-version 2.6)
 (set-logic QF_BVFP)

--- a/test/regress/cli/regress2/bug765.smt2
+++ b/test/regress/cli/regress2/bug765.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --incremental --fmf-fun-rlv -q
+; COMMAND-LINE: --incremental --fmf-fun-rlv
 ; DISABLE-TESTER: model
 (set-logic ALL)
 

--- a/test/regress/cli/regress2/bug765.smt2
+++ b/test/regress/cli/regress2/bug765.smt2
@@ -1,4 +1,5 @@
 ; COMMAND-LINE: --incremental --fmf-fun-rlv -q
+; DISABLE-TESTER: model
 (set-logic ALL)
 
 (declare-datatypes ((Color 0)) (

--- a/test/regress/cli/regress2/quantifiers/net-policy-no-time.smt2
+++ b/test/regress/cli/regress2/quantifiers/net-policy-no-time.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic UFDTLIRA)
 (set-option :fmf-bound true)

--- a/test/regress/cli/regress2/quantifiers/net-policy-no-time.smt2
+++ b/test/regress/cli/regress2/quantifiers/net-policy-no-time.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic UFDTLIRA)
 (set-option :fmf-bound true)

--- a/test/regress/cli/regress2/strings/issue6483.smt2
+++ b/test/regress/cli/regress2/strings/issue6483.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic QF_SLIA)
 (declare-fun a () String)

--- a/test/regress/cli/regress2/strings/issue6483.smt2
+++ b/test/regress/cli/regress2/strings/issue6483.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic QF_SLIA)
 (declare-fun a () String)


### PR DESCRIPTION
This marks APPLY_SELECTOR and SEQ_NTH as unevaluatable kinds.

This means that `get-value` applied to applications of them e.g. `(seq.nth t)` will evaluate to `c` if `(seq.nth t)` is in the same equivalence class as constant `c`.  (Note that this could be further improved to reason by congruence for (seq.nth s) where s = t, which I'm considering to do on a followup PR).

This removes many of the required `-q` from the command line arguments of our regressions. This also does some minor cleanup to our regressions to remove `-q` from further regressions.