### PR TITLE
Fix some issues with the Python API tests

### DIFF
--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -2083,7 +2083,7 @@ cdef class Solver:
 
         return term
 
-    def defineFunsRec(self, funs, bound_vars, terms):
+    def defineFunsRec(self, funs, bound_vars, terms, glb = False):
         """
             Define recursive functions.
 
@@ -2098,9 +2098,8 @@ cdef class Solver:
             :param funs: The sorted functions.
             :param bound_vars: The list of parameters to the functions.
             :param terms: The list of function bodies of the functions.
-            :param global: Determines whether this definition is global (i.e.
-                           persists when popping the context).
-            :return: The function.
+            :param glb: Determines whether this definition is global (i.e.
+                        persists when popping the context).
         """
         cdef vector[c_Term] vf
         cdef vector[vector[c_Term]] vbv
@@ -2117,7 +2116,9 @@ cdef class Solver:
             temp.clear()
 
         for t in terms:
-            vf.push_back((<Term?> t).cterm)
+            vt.push_back((<Term?> t).cterm)
+
+        self.csolver.defineFunsRec(vf, vbv, vt, glb)
 
     def getProof(self):
         """

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -2069,7 +2069,7 @@ cdef class Solver:
         for bv in bound_vars:
             v.push_back((<Term?> bv).cterm)
 
-        if t is not None:
+        if isinstance(sym_or_fun, str):
             term.cterm = self.csolver.defineFunRec((<str?> sym_or_fun).encode(),
                                                 <const vector[c_Term] &> v,
                                                 (<Sort?> sort_or_term).csort,

--- a/test/unit/api/python/test_solver.py
+++ b/test/unit/api/python/test_solver.py
@@ -167,19 +167,19 @@ def test_mk_datatype_sorts(solver):
     dtdecl0 = solver.mkDatatypeDecl("dt0", [p0])
     dtdecl1 = solver.mkDatatypeDecl("dt1", [p1])
     ctordecl0 = solver.mkDatatypeConstructorDecl("c0")
-    ctordecl0.addSelector("s0", u1.instantiate({p0}))
+    ctordecl0.addSelector("s0", u1.instantiate(p0))
     ctordecl1 = solver.mkDatatypeConstructorDecl("c1")
-    ctordecl1.addSelector("s1", u0.instantiate({p1}))
+    ctordecl1.addSelector("s1", u0.instantiate(p1))
     dtdecl0.addConstructor(ctordecl0)
     dtdecl1.addConstructor(ctordecl1)
     dt_sorts = solver.mkDatatypeSorts([dtdecl0, dtdecl1])
-    isort1 = dt_sorts[1].instantiate({solver.getBooleanSort()})
+    isort1 = dt_sorts[1].instantiate(solver.getBooleanSort())
     t1 = solver.mkConst(isort1, "t")
     t0 = solver.mkTerm(
         Kind.APPLY_SELECTOR,
         t1.getSort().getDatatype().getSelector("s1").getTerm(),
         t1)
-    assert dt_sorts[0].instantiate({solver.getBooleanSort()}) == t0.getSort()
+    assert dt_sorts[0].instantiate(solver.getBooleanSort()) == t0.getSort()
 
 def test_mk_function_sort(solver):
     funSort = solver.mkFunctionSort(solver.mkUninterpretedSort("u"),\
@@ -1137,12 +1137,12 @@ def test_define_fun_rec_wrong_logic(solver):
 
 def test_define_fun_rec_global(solver):
   bSort = solver.getBooleanSort()
-  fSort = solver.mkFunctionSort({bSort}, bSort)
+  fSort = solver.mkFunctionSort([bSort], bSort)
 
   solver.push()
   bTrue = solver.mkBoolean(True)
   # (define-fun f () Bool true)
-  f = solver.defineFunRec("f", {}, bSort, bTrue, True)
+  f = solver.defineFunRec("f", [], bSort, bTrue, True)
   b = solver.mkVar(bSort, "b")
   gSym = solver.mkConst(fSort, "g")
   # (define-fun g (b Bool) Bool b)

--- a/test/unit/api/python/test_solver.py
+++ b/test/unit/api/python/test_solver.py
@@ -167,19 +167,19 @@ def test_mk_datatype_sorts(solver):
     dtdecl0 = solver.mkDatatypeDecl("dt0", [p0])
     dtdecl1 = solver.mkDatatypeDecl("dt1", [p1])
     ctordecl0 = solver.mkDatatypeConstructorDecl("c0")
-    ctordecl0.addSelector("s0", u1.instantiate(p0))
+    ctordecl0.addSelector("s0", u1.instantiate([p0]))
     ctordecl1 = solver.mkDatatypeConstructorDecl("c1")
-    ctordecl1.addSelector("s1", u0.instantiate(p1))
+    ctordecl1.addSelector("s1", u0.instantiate([p1]))
     dtdecl0.addConstructor(ctordecl0)
     dtdecl1.addConstructor(ctordecl1)
     dt_sorts = solver.mkDatatypeSorts([dtdecl0, dtdecl1])
-    isort1 = dt_sorts[1].instantiate(solver.getBooleanSort())
+    isort1 = dt_sorts[1].instantiate([solver.getBooleanSort()])
     t1 = solver.mkConst(isort1, "t")
     t0 = solver.mkTerm(
         Kind.APPLY_SELECTOR,
         t1.getSort().getDatatype().getSelector("s1").getTerm(),
         t1)
-    assert dt_sorts[0].instantiate(solver.getBooleanSort()) == t0.getSort()
+    assert dt_sorts[0].instantiate([solver.getBooleanSort()]) == t0.getSort()
 
 def test_mk_function_sort(solver):
     funSort = solver.mkFunctionSort(solver.mkUninterpretedSort("u"),\

--- a/test/unit/api/python/test_solver.py
+++ b/test/unit/api/python/test_solver.py
@@ -1641,17 +1641,17 @@ def test_block_model_values5(solver):
     solver.checkSat()
     solver.blockModelValues([x])
 
-def getInstantiations():
+def test_get_instantiations(solver):
     iSort = solver.getIntegerSort()
     boolSort = solver.getBooleanSort()
     p = solver.declareFun("p", [iSort], boolSort)
     x = solver.mkVar(iSort, "x")
-    bvl = solver.mkTerm(Kind.VARIABLE_LIST, [x])
-    app = solver.mkTerm(Kind.APPLY_UF, [p, x])
-    q = solver.mkTerm(Kind.FORALL, [bvl, app]);
+    bvl = solver.mkTerm(Kind.VARIABLE_LIST, x)
+    app = solver.mkTerm(Kind.APPLY_UF, p, x)
+    q = solver.mkTerm(Kind.FORALL, bvl, app)
     solver.assertFormula(q)
     five = solver.mkInteger(5)
-    app2 = solver.mkTerm(Kind.NOT, [solver.mkTerm(Kind.APPLY_UF, [p, five])])
+    app2 = solver.mkTerm(Kind.NOT, solver.mkTerm(Kind.APPLY_UF, p, five))
     solver.assertFormula(app2)
     with pytest.raises(RuntimeError):
         solver.getInstantiations()

--- a/test/unit/api/python/test_solver.py
+++ b/test/unit/api/python/test_solver.py
@@ -1146,7 +1146,7 @@ def test_define_fun_rec_global(solver):
   b = solver.mkVar(bSort, "b")
   gSym = solver.mkConst(fSort, "g")
   # (define-fun g (b Bool) Bool b)
-  g = solver.defineFunRec(gSym, [b], b, True)
+  g = solver.defineFunRec(gSym, [b], b, glbl=True)
 
   # (assert (or (not f) (not (g true))))
   solver.assertFormula(solver.mkTerm(

--- a/test/unit/api/python/test_sort.py
+++ b/test/unit/api/python/test_sort.py
@@ -51,6 +51,10 @@ def create_param_datatype_sort(solver):
     return paramDtypeSort
 
 
+def test_hash(solver):
+    hash(solver.getIntegerSort())
+
+
 def test_operators_comparison(solver):
     solver.getIntegerSort() == Sort(solver)
     solver.getIntegerSort() != Sort(solver)


### PR DESCRIPTION
This PR addresses a few issues in the Python API:
- the implementation of defineFunsRec() lacked the call to the C++ function
- a bunch of tests for defineFunsRec() were missing
- the test for getInstantiations() was incorrectly named and thus not valled.
- add missing test for hashing of Sort