### PR TITLE
Relax an assertion in the evaluator

### DIFF
--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -186,7 +186,7 @@ Node Evaluator::eval(TNode n,
   Assert(((ret.isNull() || !ret.isConst()) && d_rr == nullptr)
          || ret
                 == d_rr->rewrite(n.substitute(
-                    args.begin(), args.end(), vals.begin(), vals.end())));
+                       args.begin(), args.end(), vals.begin(), vals.end())));
   return ret;
 }
 

--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -177,9 +177,9 @@ Node Evaluator::eval(TNode n,
     ret = d_rr->rewrite(itn->second);
   }
   // should be the same as substitution + rewriting, or possibly null if
-  // d_rr is nullptr
-  Assert((ret.isNull() && d_rr == nullptr)
-         || ret
+  // d_rr is nullptr or non-constant
+  AlwaysAssert((ret.isNull() && d_rr == nullptr)
+         || !ret.isConst() || ret
                 == d_rr->rewrite(n.substitute(
                     args.begin(), args.end(), vals.begin(), vals.end())));
   return ret;


### PR DESCRIPTION
In a rare case this can throw after https://github.com/cvc5/cvc5/pull/8740, complaining that `(/ 0.0 0)` and `(/ 0.0 0.0)` are not the same.