### PR TITLE
Eliminate use of subtypes from remainder of type rules

### DIFF
--- a/src/expr/type_matcher.cpp
+++ b/src/expr/type_matcher.cpp
@@ -75,15 +75,13 @@ bool TypeMatcher::doMatching(TypeNode pattern, TypeNode tn)
     if (!d_match[index].isNull())
     {
       Trace("typecheck-idt")
-          << "check subtype " << tn << " " << d_match[index] << std::endl;
-      TypeNode tnn = TypeNode::leastCommonTypeNode(tn, d_match[index]);
-      // recognize subtype relation
-      if (!tnn.isNull())
+          << "check types " << tn << " " << d_match[index] << std::endl;
+      if (tn!=d_match[index])
       {
-        d_match[index] = tnn;
-        return true;
+        return false;
       }
-      return false;
+      d_match[index] = tn;
+      return true;
     }
     d_match[index] = tn;
     return true;

--- a/src/expr/type_matcher.cpp
+++ b/src/expr/type_matcher.cpp
@@ -76,7 +76,7 @@ bool TypeMatcher::doMatching(TypeNode pattern, TypeNode tn)
     {
       Trace("typecheck-idt")
           << "check types " << tn << " " << d_match[index] << std::endl;
-      if (tn!=d_match[index])
+      if (tn != d_match[index])
       {
         return false;
       }

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -94,7 +94,7 @@ static void toStreamRational(std::ostream& out,
   }
   else
   {
-    Assert (isReal);
+    Assert(isReal);
     out << "(/ ";
     if (neg)
     {

--- a/src/theory/arith/theory_arith_type_rules.cpp
+++ b/src/theory/arith/theory_arith_type_rules.cpp
@@ -110,14 +110,10 @@ TypeNode ArithRelationTypeRule::computeType(NodeManager* nodeManager,
   if (check)
   {
     Assert(n.getNumChildren() == 2);
-    for (size_t i = 0; i < 2; i++)
+    if (!n[0].getType(check).isRealOrInt() || !n[1].getType(check).isRealOrInt())
     {
-      TypeNode t = n[i].getType(check);
-      if (!t.isRealOrInt())
-      {
-        throw TypeCheckingExceptionPrivate(
-            n, "expecting an arithmetic term for arithmetic relation");
-      }
+      throw TypeCheckingExceptionPrivate(
+          n, "expecting an arithmetic term for arithmetic relation");
     }
   }
   return nodeManager->booleanType();

--- a/src/theory/arith/theory_arith_type_rules.cpp
+++ b/src/theory/arith/theory_arith_type_rules.cpp
@@ -110,7 +110,8 @@ TypeNode ArithRelationTypeRule::computeType(NodeManager* nodeManager,
   if (check)
   {
     Assert(n.getNumChildren() == 2);
-    if (!n[0].getType(check).isRealOrInt() || !n[1].getType(check).isRealOrInt())
+    if (!n[0].getType(check).isRealOrInt()
+        || !n[1].getType(check).isRealOrInt())
     {
       throw TypeCheckingExceptionPrivate(
           n, "expecting an arithmetic term for arithmetic relation");

--- a/src/theory/arith/theory_arith_type_rules.cpp
+++ b/src/theory/arith/theory_arith_type_rules.cpp
@@ -110,17 +110,14 @@ TypeNode ArithRelationTypeRule::computeType(NodeManager* nodeManager,
   if (check)
   {
     Assert(n.getNumChildren() == 2);
-    TypeNode t1 = n[0].getType(check);
-    if (!t1.isRealOrInt())
+    for (size_t i=0; i<2; i++)
     {
-      throw TypeCheckingExceptionPrivate(
-          n, "expecting an arithmetic term for arithmetic relation");
-    }
-    TypeNode t2 = n[1].getType(check);
-    if (!t1.isComparableTo(t2))
-    {
-      throw TypeCheckingExceptionPrivate(
-          n, "expecting arithmetic terms of comparable type");
+      TypeNode t = n[i].getType(check);
+      if (!t.isRealOrInt())
+      {
+        throw TypeCheckingExceptionPrivate(
+            n, "expecting an arithmetic term for arithmetic relation");
+      }
     }
   }
   return nodeManager->booleanType();

--- a/src/theory/arith/theory_arith_type_rules.cpp
+++ b/src/theory/arith/theory_arith_type_rules.cpp
@@ -110,7 +110,7 @@ TypeNode ArithRelationTypeRule::computeType(NodeManager* nodeManager,
   if (check)
   {
     Assert(n.getNumChildren() == 2);
-    for (size_t i=0; i<2; i++)
+    for (size_t i = 0; i < 2; i++)
     {
       TypeNode t = n[i].getType(check);
       if (!t.isRealOrInt())

--- a/src/theory/arrays/theory_arrays_type_rules.cpp
+++ b/src/theory/arrays/theory_arrays_type_rules.cpp
@@ -40,7 +40,7 @@ TypeNode ArraySelectTypeRule::computeType(NodeManager* nodeManager,
                                          "array select operating on non-array");
     }
     TypeNode indexType = n[1].getType(check);
-    if (indexType!=arrayType.getArrayIndexType())
+    if (indexType != arrayType.getArrayIndexType())
     {
       throw TypeCheckingExceptionPrivate(
           n, "array select not indexed with correct type for array");

--- a/src/theory/arrays/theory_arrays_type_rules.cpp
+++ b/src/theory/arrays/theory_arrays_type_rules.cpp
@@ -40,7 +40,7 @@ TypeNode ArraySelectTypeRule::computeType(NodeManager* nodeManager,
                                          "array select operating on non-array");
     }
     TypeNode indexType = n[1].getType(check);
-    if (!indexType.isSubtypeOf(arrayType.getArrayIndexType()))
+    if (indexType!=arrayType.getArrayIndexType())
     {
       throw TypeCheckingExceptionPrivate(
           n, "array select not indexed with correct type for array");

--- a/src/theory/arrays/theory_arrays_type_rules.cpp
+++ b/src/theory/arrays/theory_arrays_type_rules.cpp
@@ -197,13 +197,13 @@ TypeNode ArrayTableFunTypeRule::computeType(NodeManager* nodeManager,
                                          "array table fun arg 1 is non-array");
     }
     TypeNode indexType = n[2].getType(check);
-    if (indexType!=arrayType.getArrayIndexType())
+    if (indexType != arrayType.getArrayIndexType())
     {
       throw TypeCheckingExceptionPrivate(
           n, "array table fun arg 2 does not match type of array");
     }
     indexType = n[3].getType(check);
-    if (indexType!=arrayType.getArrayIndexType())
+    if (indexType != arrayType.getArrayIndexType())
     {
       throw TypeCheckingExceptionPrivate(
           n, "array table fun arg 3 does not match type of array");

--- a/src/theory/arrays/theory_arrays_type_rules.cpp
+++ b/src/theory/arrays/theory_arrays_type_rules.cpp
@@ -197,13 +197,13 @@ TypeNode ArrayTableFunTypeRule::computeType(NodeManager* nodeManager,
                                          "array table fun arg 1 is non-array");
     }
     TypeNode indexType = n[2].getType(check);
-    if (!indexType.isComparableTo(arrayType.getArrayIndexType()))
+    if (indexType!=arrayType.getArrayIndexType())
     {
       throw TypeCheckingExceptionPrivate(
           n, "array table fun arg 2 does not match type of array");
     }
     indexType = n[3].getType(check);
-    if (!indexType.isComparableTo(arrayType.getArrayIndexType()))
+    if (indexType!=arrayType.getArrayIndexType())
     {
       throw TypeCheckingExceptionPrivate(
           n, "array table fun arg 3 does not match type of array");

--- a/src/theory/bags/theory_bags_type_rules.cpp
+++ b/src/theory/bags/theory_bags_type_rules.cpp
@@ -88,11 +88,8 @@ TypeNode SubBagTypeRule::computeType(NodeManager* nodeManager,
     TypeNode secondBagType = n[1].getType(check);
     if (secondBagType != bagType)
     {
-      if (!bagType.isComparableTo(secondBagType))
-      {
-        throw TypeCheckingExceptionPrivate(
-            n, "BAG_SUBBAG operating on bags of different types");
-      }
+      throw TypeCheckingExceptionPrivate(
+          n, "BAG_SUBBAG operating on bags of different types");
     }
   }
   return nodeManager->booleanType();

--- a/src/theory/bags/theory_bags_type_rules.cpp
+++ b/src/theory/bags/theory_bags_type_rules.cpp
@@ -114,7 +114,7 @@ TypeNode CountTypeRule::computeType(NodeManager* nodeManager,
     TypeNode elementType = n[0].getType(check);
     // e.g. (bag.count 1 (bag (BagMakeOp Real) 1.0 3))) is 3 whereas
     // (bag.count 1.0 (bag (BagMakeOp Int) 1 3)) throws a typing error
-    if (elementType!=bagType.getBagElementType())
+    if (elementType != bagType.getBagElementType())
     {
       std::stringstream ss;
       ss << "member operating on bags of different types:\n"
@@ -143,7 +143,7 @@ TypeNode MemberTypeRule::computeType(NodeManager* nodeManager,
     TypeNode elementType = n[0].getType(check);
     // e.g. (bag.member 1 (bag 1.0 1)) is true whereas
     // (bag.member 1.0 (bag 1 1)) throws a typing error
-    if (elementType!=bagType.getBagElementType())
+    if (elementType != bagType.getBagElementType())
     {
       std::stringstream ss;
       ss << "member operating on bags of different types:\n"
@@ -201,7 +201,7 @@ TypeNode BagMakeTypeRule::computeType(NodeManager* nm, TNode n, bool check)
     TypeNode actualElementType = n[0].getType(check);
     // the type of the element should be a subtype of the type of the operator
     // e.g. (bag (bag_op Real) 1 1) where 1 is an Int
-    if (actualElementType!=expectedElementType)
+    if (actualElementType != expectedElementType)
     {
       std::stringstream ss;
       ss << "The type '" << actualElementType
@@ -486,9 +486,8 @@ TypeNode BagPartitionTypeRule::computeType(NodeManager* nodeManager,
     }
     std::vector<TypeNode> argTypes = functionType.getArgTypes();
     TypeNode rangeType = functionType.getRangeType();
-    if (!(argTypes.size() == 2 && elementType==argTypes[0]
-          && elementType==argTypes[1]
-          && rangeType == nm->booleanType()))
+    if (!(argTypes.size() == 2 && elementType == argTypes[0]
+          && elementType == argTypes[1] && rangeType == nm->booleanType()))
     {
       std::stringstream ss;
       ss << "Operator " << n.getKind() << " expects a function of type  (-> "

--- a/src/theory/bags/theory_bags_type_rules.cpp
+++ b/src/theory/bags/theory_bags_type_rules.cpp
@@ -114,12 +114,12 @@ TypeNode CountTypeRule::computeType(NodeManager* nodeManager,
     TypeNode elementType = n[0].getType(check);
     // e.g. (bag.count 1 (bag (BagMakeOp Real) 1.0 3))) is 3 whereas
     // (bag.count 1.0 (bag (BagMakeOp Int) 1 3)) throws a typing error
-    if (!elementType.isSubtypeOf(bagType.getBagElementType()))
+    if (elementType!=bagType.getBagElementType())
     {
       std::stringstream ss;
       ss << "member operating on bags of different types:\n"
          << "child type:  " << elementType << "\n"
-         << "not subtype: " << bagType.getBagElementType() << "\n"
+         << "not type: " << bagType.getBagElementType() << "\n"
          << "in term : " << n;
       throw TypeCheckingExceptionPrivate(n, ss.str());
     }
@@ -143,12 +143,12 @@ TypeNode MemberTypeRule::computeType(NodeManager* nodeManager,
     TypeNode elementType = n[0].getType(check);
     // e.g. (bag.member 1 (bag 1.0 1)) is true whereas
     // (bag.member 1.0 (bag 1 1)) throws a typing error
-    if (!elementType.isSubtypeOf(bagType.getBagElementType()))
+    if (elementType!=bagType.getBagElementType())
     {
       std::stringstream ss;
       ss << "member operating on bags of different types:\n"
          << "child type:  " << elementType << "\n"
-         << "not subtype: " << bagType.getBagElementType() << "\n"
+         << "not type: " << bagType.getBagElementType() << "\n"
          << "in term : " << n;
       throw TypeCheckingExceptionPrivate(n, ss.str());
     }
@@ -201,11 +201,11 @@ TypeNode BagMakeTypeRule::computeType(NodeManager* nm, TNode n, bool check)
     TypeNode actualElementType = n[0].getType(check);
     // the type of the element should be a subtype of the type of the operator
     // e.g. (bag (bag_op Real) 1 1) where 1 is an Int
-    if (!actualElementType.isSubtypeOf(expectedElementType))
+    if (actualElementType!=expectedElementType)
     {
       std::stringstream ss;
       ss << "The type '" << actualElementType
-         << "' of the element is not a subtype of '" << expectedElementType
+         << "' of the element is not type of '" << expectedElementType
          << "' in term : " << n;
       throw TypeCheckingExceptionPrivate(n, ss.str());
     }
@@ -486,8 +486,8 @@ TypeNode BagPartitionTypeRule::computeType(NodeManager* nodeManager,
     }
     std::vector<TypeNode> argTypes = functionType.getArgTypes();
     TypeNode rangeType = functionType.getRangeType();
-    if (!(argTypes.size() == 2 && elementType.isSubtypeOf(argTypes[0])
-          && elementType.isSubtypeOf(argTypes[1])
+    if (!(argTypes.size() == 2 && elementType==argTypes[0]
+          && elementType==argTypes[1]
           && rangeType == nm->booleanType()))
     {
       std::stringstream ss;

--- a/src/theory/datatypes/theory_datatypes_type_rules.cpp
+++ b/src/theory/datatypes/theory_datatypes_type_rules.cpp
@@ -87,7 +87,7 @@ TypeNode DatatypeConstructorTypeRule::computeType(NodeManager* nodeManager,
         Trace("typecheck-idt") << "typecheck cons arg: " << childType << " "
                                << (*tchild_it) << std::endl;
         TypeNode argumentType = *tchild_it;
-        if (childType!=argumentType)
+        if (childType != argumentType)
         {
           std::stringstream ss;
           ss << "bad type for constructor argument:\n"
@@ -161,7 +161,7 @@ TypeNode DatatypeSelectorTypeRule::computeType(NodeManager* nodeManager,
       Trace("typecheck-idt") << "typecheck sel: " << n << std::endl;
       Trace("typecheck-idt") << "sel type: " << selType << std::endl;
       TypeNode childType = n[0].getType(check);
-      if (selType[0]!=childType)
+      if (selType[0] != childType)
       {
         Trace("typecheck-idt") << "ERROR: " << selType[0].getKind() << " "
                                << childType.getKind() << std::endl;
@@ -203,7 +203,7 @@ TypeNode DatatypeTesterTypeRule::computeType(NodeManager* nodeManager,
     {
       Trace("typecheck-idt") << "typecheck test: " << n << std::endl;
       Trace("typecheck-idt") << "test type: " << testType << std::endl;
-      if (testType[0]!=childType)
+      if (testType[0] != childType)
       {
         throw TypeCheckingExceptionPrivate(n, "bad type for tester argument");
       }
@@ -238,7 +238,7 @@ TypeNode DatatypeUpdateTypeRule::computeType(NodeManager* nodeManager,
               "matching failed for update argument of parameterized datatype");
         }
       }
-      else if (targ!=childType)
+      else if (targ != childType)
       {
         throw TypeCheckingExceptionPrivate(n, "bad type for update argument");
       }
@@ -365,7 +365,7 @@ TypeNode DtSygusEvalTypeRule::computeType(NodeManager* nodeManager,
     {
       TypeNode vtype = svl[i].getType(check);
       TypeNode atype = n[i + 1].getType(check);
-      if (vtype!=atype)
+      if (vtype != atype)
       {
         throw TypeCheckingExceptionPrivate(
             n,

--- a/src/theory/datatypes/theory_datatypes_type_rules.cpp
+++ b/src/theory/datatypes/theory_datatypes_type_rules.cpp
@@ -87,12 +87,12 @@ TypeNode DatatypeConstructorTypeRule::computeType(NodeManager* nodeManager,
         Trace("typecheck-idt") << "typecheck cons arg: " << childType << " "
                                << (*tchild_it) << std::endl;
         TypeNode argumentType = *tchild_it;
-        if (!childType.isSubtypeOf(argumentType))
+        if (childType!=argumentType)
         {
           std::stringstream ss;
           ss << "bad type for constructor argument:\n"
              << "child type:  " << childType << "\n"
-             << "not subtype: " << argumentType << "\n"
+             << "not type: " << argumentType << "\n"
              << "in term : " << n;
           throw TypeCheckingExceptionPrivate(n, ss.str());
         }
@@ -161,7 +161,7 @@ TypeNode DatatypeSelectorTypeRule::computeType(NodeManager* nodeManager,
       Trace("typecheck-idt") << "typecheck sel: " << n << std::endl;
       Trace("typecheck-idt") << "sel type: " << selType << std::endl;
       TypeNode childType = n[0].getType(check);
-      if (!selType[0].isComparableTo(childType))
+      if (selType[0]!=childType)
       {
         Trace("typecheck-idt") << "ERROR: " << selType[0].getKind() << " "
                                << childType.getKind() << std::endl;
@@ -203,7 +203,7 @@ TypeNode DatatypeTesterTypeRule::computeType(NodeManager* nodeManager,
     {
       Trace("typecheck-idt") << "typecheck test: " << n << std::endl;
       Trace("typecheck-idt") << "test type: " << testType << std::endl;
-      if (!testType[0].isComparableTo(childType))
+      if (testType[0]!=childType)
       {
         throw TypeCheckingExceptionPrivate(n, "bad type for tester argument");
       }
@@ -238,12 +238,9 @@ TypeNode DatatypeUpdateTypeRule::computeType(NodeManager* nodeManager,
               "matching failed for update argument of parameterized datatype");
         }
       }
-      else
+      else if (targ!=childType)
       {
-        if (!targ.isComparableTo(childType))
-        {
-          throw TypeCheckingExceptionPrivate(n, "bad type for update argument");
-        }
+        throw TypeCheckingExceptionPrivate(n, "bad type for update argument");
       }
     }
   }
@@ -368,7 +365,7 @@ TypeNode DtSygusEvalTypeRule::computeType(NodeManager* nodeManager,
     {
       TypeNode vtype = svl[i].getType(check);
       TypeNode atype = n[i + 1].getType(check);
-      if (!vtype.isComparableTo(atype))
+      if (vtype!=atype)
       {
         throw TypeCheckingExceptionPrivate(
             n,
@@ -464,14 +461,10 @@ TypeNode MatchTypeRule::computeType(NodeManager* nodeManager,
     {
       retType = currType;
     }
-    else
+    else if (retType != currType)
     {
-      retType = TypeNode::leastCommonTypeNode(retType, currType);
-      if (retType.isNull())
-      {
-        throw TypeCheckingExceptionPrivate(
-            n, "incomparable types in match case list");
-      }
+      throw TypeCheckingExceptionPrivate(
+          n, "incomparable types in match case list");
     }
   }
   // it is mandatory to check this here to ensure the match is exhaustive

--- a/src/theory/sets/theory_sets_type_rules.cpp
+++ b/src/theory/sets/theory_sets_type_rules.cpp
@@ -104,12 +104,12 @@ TypeNode MemberTypeRule::computeType(NodeManager* nodeManager,
     TypeNode elementType = n[0].getType(check);
     // e.g. (member 1 (singleton 1.0)) is true whereas
     // (member 1.0 (singleton 1)) throws a typing error
-    if (!elementType.isSubtypeOf(setType.getSetElementType()))
+    if (elementType!=setType.getSetElementType())
     {
       std::stringstream ss;
       ss << "member operating on sets of different types:\n"
          << "child type:  " << elementType << "\n"
-         << "not subtype: " << setType.getSetElementType() << "\n"
+         << "not type: " << setType.getSetElementType() << "\n"
          << "in term : " << n;
       throw TypeCheckingExceptionPrivate(n, ss.str());
     }

--- a/src/theory/sets/theory_sets_type_rules.cpp
+++ b/src/theory/sets/theory_sets_type_rules.cpp
@@ -104,7 +104,7 @@ TypeNode MemberTypeRule::computeType(NodeManager* nodeManager,
     TypeNode elementType = n[0].getType(check);
     // e.g. (member 1 (singleton 1.0)) is true whereas
     // (member 1.0 (singleton 1)) throws a typing error
-    if (elementType!=setType.getSetElementType())
+    if (elementType != setType.getSetElementType())
     {
       std::stringstream ss;
       ss << "member operating on sets of different types:\n"

--- a/src/theory/sets/theory_sets_type_rules.cpp
+++ b/src/theory/sets/theory_sets_type_rules.cpp
@@ -78,7 +78,7 @@ TypeNode SubsetTypeRule::computeType(NodeManager* nodeManager,
     TypeNode secondSetType = n[1].getType(check);
     if (secondSetType != setType)
     {
-          throw TypeCheckingExceptionPrivate(
+      throw TypeCheckingExceptionPrivate(
           n, "set subset operating on sets of different types");
     }
   }
@@ -128,7 +128,7 @@ TypeNode SingletonTypeRule::computeType(NodeManager* nodeManager,
     TypeNode type2 = n[0].getType(check);
     // the type of the element should be a subtype of the type of the operator
     // e.g. (set.singleton (SetSingletonOp Real) 1) where 1 is an Int
-    if (type1!=type2)
+    if (type1 != type2)
     {
       std::stringstream ss;
       ss << "The type '" << type2 << "' of the element is not a type of '"

--- a/src/theory/sets/theory_sets_type_rules.cpp
+++ b/src/theory/sets/theory_sets_type_rules.cpp
@@ -78,11 +78,8 @@ TypeNode SubsetTypeRule::computeType(NodeManager* nodeManager,
     TypeNode secondSetType = n[1].getType(check);
     if (secondSetType != setType)
     {
-      if (!setType.isComparableTo(secondSetType))
-      {
-        throw TypeCheckingExceptionPrivate(
-            n, "set subset operating on sets of different types");
-      }
+          throw TypeCheckingExceptionPrivate(
+          n, "set subset operating on sets of different types");
     }
   }
   return nodeManager->booleanType();
@@ -129,13 +126,12 @@ TypeNode SingletonTypeRule::computeType(NodeManager* nodeManager,
   if (check)
   {
     TypeNode type2 = n[0].getType(check);
-    TypeNode leastCommonType = TypeNode::leastCommonTypeNode(type1, type2);
     // the type of the element should be a subtype of the type of the operator
     // e.g. (set.singleton (SetSingletonOp Real) 1) where 1 is an Int
-    if (leastCommonType.isNull() || leastCommonType != type1)
+    if (type1!=type2)
     {
       std::stringstream ss;
-      ss << "The type '" << type2 << "' of the element is not a subtype of '"
+      ss << "The type '" << type2 << "' of the element is not a type of '"
          << type1 << "' in term : " << n;
       throw TypeCheckingExceptionPrivate(n, ss.str());
     }

--- a/src/theory/strings/theory_strings_type_rules.cpp
+++ b/src/theory/strings/theory_strings_type_rules.cpp
@@ -336,7 +336,7 @@ TypeNode SeqUnitTypeRule::computeType(NodeManager* nodeManager,
     TypeNode argType = n[0].getType(check);
     // the type of the element should be a subtype of the type of the operator
     // e.g. (seq.unit (SeqUnitOp Real) 1) where 1 is an Int
-    if (argType!=otype)
+    if (argType != otype)
     {
       std::stringstream ss;
       ss << "The type '" << argType << "' of the element is not the type of '"

--- a/src/theory/strings/theory_strings_type_rules.cpp
+++ b/src/theory/strings/theory_strings_type_rules.cpp
@@ -336,10 +336,10 @@ TypeNode SeqUnitTypeRule::computeType(NodeManager* nodeManager,
     TypeNode argType = n[0].getType(check);
     // the type of the element should be a subtype of the type of the operator
     // e.g. (seq.unit (SeqUnitOp Real) 1) where 1 is an Int
-    if (!argType.isSubtypeOf(otype))
+    if (argType!=otype)
     {
       std::stringstream ss;
-      ss << "The type '" << argType << "' of the element is not a subtype of '"
+      ss << "The type '" << argType << "' of the element is not the type of '"
          << otype << "' in term : " << n;
       throw TypeCheckingExceptionPrivate(n, ss.str());
     }

--- a/src/theory/uf/theory_uf_type_rules.cpp
+++ b/src/theory/uf/theory_uf_type_rules.cpp
@@ -131,7 +131,7 @@ TypeNode HoApplyTypeRule::computeType(NodeManager* nodeManager,
   if (check)
   {
     TypeNode aType = n[1].getType(check);
-    if (!aType.isSubtypeOf(fType[0]))
+    if (aType!=fType[0])
     {
       throw TypeCheckingExceptionPrivate(
           n, "argument does not match function type");

--- a/src/theory/uf/theory_uf_type_rules.cpp
+++ b/src/theory/uf/theory_uf_type_rules.cpp
@@ -131,7 +131,7 @@ TypeNode HoApplyTypeRule::computeType(NodeManager* nodeManager,
   if (check)
   {
     TypeNode aType = n[1].getType(check);
-    if (aType!=fType[0])
+    if (aType != fType[0])
     {
       throw TypeCheckingExceptionPrivate(
           n, "argument does not match function type");


### PR DESCRIPTION
This PR should be added before the minor release that advertises our policy change for subtyping.