### PR TITLE
Eliminate subtyping for functions

### DIFF
--- a/src/expr/type_node.cpp
+++ b/src/expr/type_node.cpp
@@ -287,31 +287,6 @@ bool TypeNode::isSubtypeOf(TypeNode t) const {
   {
     return t.isReal();
   }
-  if (isFunction() && t.isFunction())
-  {
-    if (!getRangeType().isSubtypeOf(t.getRangeType()))
-    {
-      // range is not subtype, return false
-      return false;
-    }
-    // must have equal arguments
-    std::vector<TypeNode> t0a = getArgTypes();
-    std::vector<TypeNode> t1a = t.getArgTypes();
-    if (t0a.size() != t1a.size())
-    {
-      // different arities
-      return false;
-    }
-    for (size_t i = 0, nargs = t0a.size(); i < nargs; i++)
-    {
-      if (t0a[i] != t1a[i])
-      {
-        // an argument is different
-        return false;
-      }
-    }
-    return true;
-  }
   // this should only return true for types T1, T2 where we handle equalities between T1 and T2
   // (more cases go here, if we want to support such cases)
   return false;


### PR DESCRIPTION
This was used to ensure certain higher-order constraints involving lambdas that returned reals type checked. Our parsers now respect types and this hack is not necessary.