### PR TITLE
Add a regression for solved issue

### DIFF
--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -277,6 +277,7 @@ set(regress_0_tests
   regress0/bv/bv_to_int_5281.smt2
   regress0/bv/bv_to_int_5293_1.smt2
   regress0/bv/bv_to_int_5293_2.smt2
+  regress0/bv/bv_to_int_8412.smt2
   regress0/bv/bv_to_int_bvmul2.smt2
   regress0/bv/bv_to_int_bvuf_to_intuf.smt2
   regress0/bv/bv_to_int_bvuf_to_intuf_sorts.smt2

--- a/test/regress/cli/regress0/bv/bv_to_int_8412.smt2
+++ b/test/regress/cli/regress0/bv/bv_to_int_8412.smt2
@@ -1,0 +1,7 @@
+; COMMAND-LINE: --solve-bv-as-int=bitwise
+; EXPECT: sat
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 2))
+(assert (distinct true (bvule (bvsdiv (_ bv0 2) x) (_ bv0 2))))
+(check-sat)
+


### PR DESCRIPTION
https://github.com/cvc5/cvc5/issues/8412 is now fixed on `main`. This PR adds a regression from that issue.
closes https://github.com/cvc5/cvc5/issues/8412 .