### PR TITLE
Basic cleanup of sep theory

### DIFF
--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -929,7 +929,7 @@ size_t TheorySep::processAssertion(
 {
   int index = hasPol ? ( pol ? 1 : -1 ) : 0;
   size_t card = 0;
-  std::map< Node, size_t >::iterator it = visited[index].find( n );
+  std::map<Node, size_t>::iterator it = visited[index].find(n);
   if( it==visited[index].end() ){
     Trace("sep-pp-debug") << "process assertion : " << n << ", index = " << index << std::endl;
     if (n.getKind() == SEP_EMP)
@@ -971,7 +971,13 @@ size_t TheorySep::processAssertion(
         bool newHasPol, newPol;
         QuantPhaseReq::getEntailPolarity( n, i, hasPol, pol, newHasPol, newPol );
         int newIndex = newHasPol ? ( newPol ? 1 : -1 ) : 0;
-        size_t ccard = processAssertion( n[i], visited, references, references_strict, newPol, newHasPol, newUnderSpatial );
+        size_t ccard = processAssertion(n[i],
+                                        visited,
+                                        references,
+                                        references_strict,
+                                        newPol,
+                                        newHasPol,
+                                        newUnderSpatial);
         //update cardinality
         if (n.getKind() == SEP_STAR)
         {

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -123,21 +123,6 @@ void TheorySep::preRegisterTerm(TNode n)
   }
 }
 
-Node TheorySep::mkAnd( std::vector< TNode >& assumptions ) {
-  if( assumptions.empty() ){
-    return d_true;
-  }else if( assumptions.size()==1 ){
-    return assumptions[0];
-  }else{
-    return NodeManager::currentNM()->mkNode(AND, assumptions);
-  }
-}
-
-
-/////////////////////////////////////////////////////////////////////////////
-// T-PROPAGATION / REGISTRATION
-/////////////////////////////////////////////////////////////////////////////
-
 bool TheorySep::propagateLit(TNode literal)
 {
   return d_im.propagateLit(literal);
@@ -1129,7 +1114,7 @@ void TheorySep::initializeBounds() {
   SkolemManager* sm = nm->getSkolemManager();
   Trace("sep-bound") << "Initialize bounds for " << d_type_ref << "..."
                      << std::endl;
-  unsigned n_emp = 0;
+  size_t n_emp = 0;
   if (d_bound_kind != bound_invalid)
   {
     n_emp = d_card_max;
@@ -1145,7 +1130,7 @@ void TheorySep::initializeBounds() {
                      << std::endl;
   Trace("sep-bound") << "Constructing " << n_emp << " cardinality constants."
                      << std::endl;
-  for (unsigned r = 0; r < n_emp; r++)
+  for (size_t r = 0; r < n_emp; r++)
   {
     Node e = sm->mkDummySkolem(
         "e", d_type_ref, "cardinality bound element for seplog");

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -50,7 +50,9 @@ TheorySep::TheorySep(Env& env, OutputChannel& out, Valuation valuation)
       d_im(env, *this, d_state, "theory::sep::"),
       d_notify(*this),
       d_reduce(userContext()),
-      d_spatial_assertions(context())
+      d_spatial_assertions(context()),
+      d_bound_kind(bound_invalid),
+      d_card_max(0)
 {
   d_true = NodeManager::currentNM()->mkConst<bool>(true);
   d_false = NodeManager::currentNM()->mkConst<bool>(false);
@@ -605,11 +607,8 @@ void TheorySep::postCheck(Effort level)
     }
   }
   // set up model information based on active assertions
-  for (NodeList::const_iterator i = d_spatial_assertions.begin();
-       i != d_spatial_assertions.end();
-       ++i)
+  for (const Node& fact : d_spatial_assertions)
   {
-    Node fact = (*i);
     bool polarity = fact.getKind() != NOT;
     TNode atom = polarity ? fact : fact[0];
     TNode satom = atom[0];
@@ -623,8 +622,7 @@ void TheorySep::postCheck(Effort level)
   if (TraceIsOn("sep-process"))
   {
     Trace("sep-process") << "--- Current spatial assertions : " << std::endl;
-    for( NodeList::const_iterator i = d_spatial_assertions.begin(); i != d_spatial_assertions.end(); ++i ) {
-      Node fact = (*i);
+    for (const Node& fact : d_spatial_assertions) {
       Trace("sep-process") << "  " << fact;
       if (!assert_active[fact])
       {
@@ -647,11 +645,8 @@ void TheorySep::postCheck(Effort level)
   std::map<Node, bool> active_lbl;
   if (options().sep.sepMinimalRefine)
   {
-    for (NodeList::const_iterator i = d_spatial_assertions.begin();
-         i != d_spatial_assertions.end();
-         ++i)
+    for (const Node& fact : d_spatial_assertions)
     {
-      Node fact = (*i);
       bool polarity = fact.getKind() != NOT;
       TNode atom = polarity ? fact : fact[0];
       TNode satom = atom[0];
@@ -675,11 +670,8 @@ void TheorySep::postCheck(Effort level)
   }
 
   // process spatial assertions
-  for (NodeList::const_iterator i = d_spatial_assertions.begin();
-       i != d_spatial_assertions.end();
-       ++i)
+  for (const Node& fact : d_spatial_assertions)
   {
-    Node fact = (*i);
     bool polarity = fact.getKind() != NOT;
     TNode atom = polarity ? fact : fact[0];
     TNode satom = atom[0];

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -907,7 +907,7 @@ TheorySep::HeapAssertInfo * TheorySep::getOrMakeEqcInfo( Node n, bool doMake ) {
 // Must process assertions at preprocess so that quantified assertions are
 // processed properly.
 void TheorySep::ppNotifyAssertions(const std::vector<Node>& assertions) {
-  std::map<int, std::map<Node, int> > visited;
+  std::map<int, std::map<Node, size_t> > visited;
   std::map<int, std::map<Node, std::vector<Node> > > references;
   std::map<int, std::map<Node, bool> > references_strict;
   for (unsigned i = 0; i < assertions.size(); i++) {
@@ -918,9 +918,9 @@ void TheorySep::ppNotifyAssertions(const std::vector<Node>& assertions) {
 }
 
 //return cardinality
-int TheorySep::processAssertion(
+size_t TheorySep::processAssertion(
     Node n,
-    std::map<int, std::map<Node, int> >& visited,
+    std::map<int, std::map<Node, size_t> >& visited,
     std::map<int, std::map<Node, std::vector<Node> > >& references,
     std::map<int, std::map<Node, bool> >& references_strict,
     bool pol,
@@ -928,8 +928,8 @@ int TheorySep::processAssertion(
     bool underSpatial)
 {
   int index = hasPol ? ( pol ? 1 : -1 ) : 0;
-  int card = 0;
-  std::map< Node, int >::iterator it = visited[index].find( n );
+  size_t card = 0;
+  std::map< Node, size_t >::iterator it = visited[index].find( n );
   if( it==visited[index].end() ){
     Trace("sep-pp-debug") << "process assertion : " << n << ", index = " << index << std::endl;
     if (n.getKind() == SEP_EMP)
@@ -971,7 +971,7 @@ int TheorySep::processAssertion(
         bool newHasPol, newPol;
         QuantPhaseReq::getEntailPolarity( n, i, hasPol, pol, newHasPol, newPol );
         int newIndex = newHasPol ? ( newPol ? 1 : -1 ) : 0;
-        int ccard = processAssertion( n[i], visited, references, references_strict, newPol, newHasPol, newUnderSpatial );
+        size_t ccard = processAssertion( n[i], visited, references, references_strict, newPol, newHasPol, newUnderSpatial );
         //update cardinality
         if (n.getKind() == SEP_STAR)
         {
@@ -1053,7 +1053,7 @@ int TheorySep::processAssertion(
     }
     if( add ){
       //add max cardinality
-      if (card > (int)d_card_max)
+      if (card > d_card_max)
       {
         d_card_max = card;
       }

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -1546,8 +1546,7 @@ Node TheorySep::instantiateLabel(Node n,
         std::map< Node, Node >::iterator it = pto_model.find( vr );
         if( it!=pto_model.end() ){
           if( n[1]!=it->second ){
-            children.push_back(
-                nm->mkNode(EQUAL, n[1], it->second));
+            children.push_back(nm->mkNode(EQUAL, n[1], it->second));
           }
         }else{
           Trace("sep-inst-debug") << "Data for " << vr << " was not specified, do not add condition." << std::endl;

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -1206,18 +1206,19 @@ Node TheorySep::getBaseLabel()
     d_im.lemma(slem, InferenceId::SEP_REF_BOUND);
 
     // symmetry breaking
-    if (d_type_references_card.size() > 1)
+    size_t trcSize = d_type_references_card.size();
+    if (trcSize > 1)
     {
-      std::map<unsigned, Node> lit_mem_map;
-      for (unsigned i = 0; i < d_type_references_card.size(); i++)
+      std::map<size_t, Node> lit_mem_map;
+      for (size_t i = 0; i < trcSize; i++)
       {
         lit_mem_map[i] = nm->mkNode(
             SET_MEMBER, d_type_references_card[i], d_reference_bound_max);
       }
-      for (unsigned i = 0; i < (d_type_references_card.size() - 1); i++)
+      for (size_t i = 0; i < (trcSize - 1); i++)
       {
         std::vector<Node> children;
-        for (unsigned j = (i + 1); j < d_type_references_card.size(); j++)
+        for (size_t j = (i + 1); j < trcSize; j++)
         {
           children.push_back(lit_mem_map[j].negate());
         }
@@ -1546,7 +1547,7 @@ Node TheorySep::instantiateLabel(Node n,
         if( it!=pto_model.end() ){
           if( n[1]!=it->second ){
             children.push_back(
-                NodeManager::currentNM()->mkNode(EQUAL, n[1], it->second));
+                nm->mkNode(EQUAL, n[1], it->second));
           }
         }else{
           Trace("sep-inst-debug") << "Data for " << vr << " was not specified, do not add condition." << std::endl;
@@ -1554,18 +1555,12 @@ Node TheorySep::instantiateLabel(Node n,
       }
       Node singleton = nm->mkNode(SET_SINGLETON, n[0]);
       children.push_back(singleton.eqNode(lbl_v));
-      Node ret = children.empty()
-                     ? NodeManager::currentNM()->mkConst(true)
-                     : (children.size() == 1
-                            ? children[0]
-                            : NodeManager::currentNM()->mkNode(AND, children));
+      Node ret = nm->mkAnd(children);
       Trace("sep-inst-debug") << "Return " << ret << std::endl;
       return ret;
     }
     else if (n.getKind() == SEP_EMP)
     {
-      // return NodeManager::currentNM()->mkConst(
-      // lbl_v.getKind()==SET_EMPTY );
       return lbl_v.eqNode(
           NodeManager::currentNM()->mkConst(EmptySet(lbl_v.getType())));
     }else{
@@ -1679,9 +1674,6 @@ void TheorySep::computeLabelModel( Node lbl ) {
     std::map<Node, Node>::iterator itm = d_tmodel.find(u);
     if (itm == d_tmodel.end())
     {
-      // Trace("sep-process") << "WARNING: could not find symbolic term in model
-      // for " << u << std::endl; Assert( false ); tt = u; TypeNode tn =
-      // u.getType().getRefConstituentType();
       TypeNode tn = u.getType();
       Trace("sep-process")
           << "WARNING: could not find symbolic term in model for " << u

--- a/src/theory/sep/theory_sep.h
+++ b/src/theory/sep/theory_sep.h
@@ -221,29 +221,27 @@ class TheorySep : public Theory {
   //data,ref type (globally fixed)
   TypeNode d_type_ref;
   TypeNode d_type_data;
-  //currently fix one data type for each location type, throw error if using more than one
-  std::map< TypeNode, TypeNode > d_loc_to_data_type;
   //information about types
-  std::map< TypeNode, Node > d_base_label;
-  std::map< TypeNode, Node > d_nil_ref;
+  Node d_base_label;
+  Node d_nil_ref;
   //reference bound
-  std::map< TypeNode, Node > d_reference_bound;
-  std::map< TypeNode, Node > d_reference_bound_max;
-  std::map< TypeNode, std::vector< Node > > d_type_references;
+   Node  d_reference_bound;
+  Node  d_reference_bound_max;
+  std::vector< Node >  d_type_references;
   //kind of bound for reference types
   enum {
     bound_strict,
     bound_default,
     bound_invalid,
   };
-  std::map< TypeNode, unsigned > d_bound_kind;
+  unsigned  d_bound_kind;
 
-  std::map< TypeNode, std::vector< Node > > d_type_references_card;
+ std::vector< Node >  d_type_references_card;
   std::map< Node, unsigned > d_type_ref_card_id;
-  std::map< TypeNode, std::vector< Node > > d_type_references_all;
-  std::map< TypeNode, unsigned > d_card_max;
+  std::vector< Node > d_type_references_all;
+  unsigned  d_card_max;
   //for empty argument
-  std::map< TypeNode, Node > d_emp_arg;
+   Node  d_emp_arg;
   //map from ( atom, label, child index ) -> label
   std::map< Node, std::map< Node, std::map< int, Node > > > d_label_map;
 

--- a/src/theory/sep/theory_sep.h
+++ b/src/theory/sep/theory_sep.h
@@ -65,9 +65,9 @@ class TheorySep : public Theory {
   /** A buffered inference manager */
   InferenceManagerBuffered d_im;
 
-  int processAssertion(
+  size_t processAssertion(
       Node n,
-      std::map<int, std::map<Node, int> >& visited,
+      std::map<int, std::map<Node, size_t> >& visited,
       std::map<int, std::map<Node, std::vector<Node> > >& references,
       std::map<int, std::map<Node, bool> >& references_strict,
       bool pol,

--- a/src/theory/sep/theory_sep.h
+++ b/src/theory/sep/theory_sep.h
@@ -65,8 +65,6 @@ class TheorySep : public Theory {
   /** A buffered inference manager */
   InferenceManagerBuffered d_im;
 
-  Node mkAnd( std::vector< TNode >& assumptions );
-
   int processAssertion(
       Node n,
       std::map<int, std::map<Node, int> >& visited,
@@ -239,7 +237,7 @@ class TheorySep : public Theory {
   std::vector<Node> d_type_references_card;
   std::map< Node, unsigned > d_type_ref_card_id;
   std::vector<Node> d_type_references_all;
-  unsigned d_card_max;
+  size_t d_card_max;
   //for empty argument
   Node d_emp_arg;
   //map from ( atom, label, child index ) -> label

--- a/src/theory/sep/theory_sep.h
+++ b/src/theory/sep/theory_sep.h
@@ -225,23 +225,23 @@ class TheorySep : public Theory {
   Node d_base_label;
   Node d_nil_ref;
   //reference bound
-   Node  d_reference_bound;
-  Node  d_reference_bound_max;
-  std::vector< Node >  d_type_references;
+  Node d_reference_bound;
+  Node d_reference_bound_max;
+  std::vector<Node> d_type_references;
   //kind of bound for reference types
   enum {
     bound_strict,
     bound_default,
     bound_invalid,
   };
-  unsigned  d_bound_kind;
+  unsigned d_bound_kind;
 
- std::vector< Node >  d_type_references_card;
+  std::vector<Node> d_type_references_card;
   std::map< Node, unsigned > d_type_ref_card_id;
-  std::vector< Node > d_type_references_all;
-  unsigned  d_card_max;
+  std::vector<Node> d_type_references_all;
+  unsigned d_card_max;
   //for empty argument
-   Node  d_emp_arg;
+  Node d_emp_arg;
   //map from ( atom, label, child index ) -> label
   std::map< Node, std::map< Node, std::map< int, Node > > > d_label_map;
 

--- a/src/theory/sep/theory_sep.h
+++ b/src/theory/sep/theory_sep.h
@@ -299,9 +299,6 @@ class TheorySep : public Theory {
    * non-null, and compatible with separation logic constraint atom.
    */
   void ensureHeapTypesFor(Node atom) const;
-  // get global reference/data type
-  TypeNode getReferenceType() const;
-  TypeNode getDataType() const;
   /**
    * This is called either when:
    * (A) a declare-heap command is issued with tn1/tn2, and atom is null, or
@@ -312,9 +309,7 @@ class TheorySep : public Theory {
   void registerRefDataTypes(TypeNode tn1, TypeNode tn2, Node atom);
   //get location/data type
   //get the base label for the spatial assertion
-  Node getBaseLabel( TypeNode tn );
-  Node getNilRef( TypeNode tn );
-  void setNilRef( TypeNode tn, Node n );
+  Node getBaseLabel();
   Node getLabel( Node atom, int child, Node lbl );
   /**
    * Apply label lbl to all top-level spatial assertions, recursively, in n.
@@ -336,8 +331,6 @@ class TheorySep : public Theory {
   std::map< Node, HeapInfo > d_label_model;
   // loc -> { data_1, ..., data_n } where (not (pto loc data_1))...(not (pto loc data_n))).
   std::map< Node, std::vector< Node > > d_heap_locs_nptos;
-
-  void debugPrintHeap( HeapInfo& heap, const char * c );
   /**
    * This checks the impact of adding the pto assertion p to heap assert info e,
    * where p has been asserted with the given polarity.


### PR DESCRIPTION
Most of the simplifications are due to the fact that we only handle a single heap type. (The solver was initially designed to potentially handle more than one heap type).