### PR TITLE
Remove spurious assertion in isLegalElimination

### DIFF
--- a/src/theory/theory.cpp
+++ b/src/theory/theory.cpp
@@ -322,8 +322,6 @@ bool Theory::isLegalElimination(TNode x, TNode val)
   }
   if (val.getType() != x.getType())
   {
-    Assert(false) << "isLegalElimination for disequal typed terms " << x
-                  << " -> " << val;
     return false;
   }
   if (!options().smt.produceModels || options().smt.modelVarElimUneval)

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -67,6 +67,7 @@ set(regress_0_tests
   regress0/arith/issue5761-ppr.smt2
   regress0/arith/issue8097-iid.smt2
   regress0/arith/issue8159-rewrite-intreal.smt2
+  regress0/arith/issue8805-mixed-var-elim.smt2
   regress0/arith/ite-lift.smt2
   regress0/arith/leq.01.smtv1.smt2
   regress0/arith/miplib.cvc.smt2

--- a/test/regress/cli/regress0/arith/issue8805-mixed-var-elim.smt2
+++ b/test/regress/cli/regress0/arith/issue8805-mixed-var-elim.smt2
@@ -1,0 +1,6 @@
+(set-logic ALL)
+(set-info :status sat)
+(declare-const a Real) 
+(declare-const b Int) 
+(assert (= (to_real b) (* a a)))
+(check-sat)


### PR DESCRIPTION
Fixes #8805.

The isLegalElimination method correctly catches Int -> Real as an illegal elimination.