### PR TITLE
Fix missing conclusion for sep pto neg prop

### DIFF
--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -1827,6 +1827,8 @@ bool TheorySep::checkPto(HeapAssertInfo* e, Node p, bool polarity)
         // a positive and negative pto
         bool isSat = false;
         std::vector<Node> conc;
+        // based on the lemma below, either the domain or range has to be
+        // disequal. We iterate on each child of the pto
         for (size_t j = 0; j < 2; j++)
         {
           if (areDisequal(p[0][j], q[0][j]))

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -1827,7 +1827,7 @@ bool TheorySep::checkPto(HeapAssertInfo* e, Node p, bool polarity)
         // a positive and negative pto
         bool isSat = false;
         std::vector<Node> conc;
-        for (size_t j=0; j<2; j++)
+        for (size_t j = 0; j < 2; j++)
         {
           if (areDisequal(p[0][j], q[0][j]))
           {
@@ -1855,8 +1855,8 @@ bool TheorySep::checkPto(HeapAssertInfo* e, Node p, bool polarity)
           exp.push_back(neg.notNode());
           Node concn = nm->mkOr(conc);
           Trace("sep-pto") << "prop neg/pos: " << concn << " by " << exp
-                            << std::endl;
-          // (label (pto x y) A) ^ ~(label (pto z w) B) ^ A = B => 
+                           << std::endl;
+          // (label (pto x y) A) ^ ~(label (pto z w) B) ^ A = B =>
           // (x != z or y != w)
           sendLemma(exp, concn, InferenceId::SEP_PTO_NEG_PROP);
         }

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -1825,7 +1825,21 @@ bool TheorySep::checkPto(HeapAssertInfo* e, Node p, bool polarity)
       else if (polarity != pol)
       {
         // a positive and negative pto
-        if (!areDisequal(pval, qval))
+        bool isSat = false;
+        std::vector<Node> conc;
+        for (size_t j=0; j<2; j++)
+        {
+          if (areDisequal(p[0][j], q[0][j]))
+          {
+            isSat = true;
+            break;
+          }
+          if (p[0][j] != q[0][j])
+          {
+            conc.push_back(p[0][j].eqNode(q[0][j]).notNode());
+          }
+        }
+        if (!isSat)
         {
           std::vector<Node> exp;
           if (plbl != qlbl)
@@ -1839,16 +1853,11 @@ bool TheorySep::checkPto(HeapAssertInfo* e, Node p, bool polarity)
           Node neg = polarity ? q : p;
           exp.push_back(pos);
           exp.push_back(neg.notNode());
-          std::vector<Node> conc;
-          if (pval != qval)
-          {
-            conc.push_back(pval.eqNode(qval).notNode());
-          }
           Node concn = nm->mkOr(conc);
           Trace("sep-pto") << "prop neg/pos: " << concn << " by " << exp
-                           << std::endl;
-          // (label (pto x y) A) ^ ~(label (pto z w) B) ^ A = B => y != w
-          // or (label (pto x y) A) ^ ~(label (pto z y) B) ^ A = B => false
+                            << std::endl;
+          // (label (pto x y) A) ^ ~(label (pto z w) B) ^ A = B => 
+          // (x != z or y != w)
           sendLemma(exp, concn, InferenceId::SEP_PTO_NEG_PROP);
         }
       }

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1204,6 +1204,7 @@ set(regress_0_tests
   regress0/sep/issue3720-check-model.smt2
   regress0/sep/issue5343-err.smt2
   regress0/sep/issue8659-wand-diff-heaps.smt2
+  regress0/sep/issue8841-neg-prop.smt2
   regress0/sep/nemp.smt2
   regress0/sep/nil-no-elim.smt2
   regress0/sep/nspatial-simp.smt2

--- a/test/regress/cli/regress0/sep/issue8841-neg-prop.smt2
+++ b/test/regress/cli/regress0/sep/issue8841-neg-prop.smt2
@@ -1,0 +1,13 @@
+; DISABLE-TESTER: model
+(set-logic QF_ALL)
+(set-info :status sat)
+(declare-sort Loc 0)
+(declare-heap (Loc Loc))
+
+(declare-const x1 Loc)
+(declare-const x2 Loc)
+
+(assert (pto x1 x2))
+(assert (not (pto x2 x2)))
+
+(check-sat)


### PR DESCRIPTION
Was introduced in the refactoring in https://github.com/cvc5/cvc5/pull/8768.

Fixes https://github.com/cvc5/cvc5/issues/8841.