### PR TITLE
Disable `lfsc` tester if `proof` tester is disabled.

### DIFF
--- a/test/regress/cli/README.md
+++ b/test/regress/cli/README.md
@@ -124,10 +124,14 @@ excluded by adding the `no-` prefix, e.g. `no-cryptominisat` means that the
 test is not valid for builds that include CryptoMiniSat support.
 
 To disable a specific type of test, the `DISABLE-TESTER` directive can be used.
-The following example disables the proof tester for a regression:
+The following example disables the abduct tester for a regression:
 
 ```
-; DISABLE-TESTER: proof
+; DISABLE-TESTER: abduct
 ```
 
-Multiple testers can be disabled using multiple `DISABLE-TESTER` directives.
+Multiple testers can be disabled using multiple `DISABLE-TESTER` directives. In
+general, each `DISABLE-TESTER` directive disables only the specified tester. The
+only exception to this rule is the proof tester. Disabling the proof tester,
+which directs cvc5 to check generated proofs internally, also disables testers
+that check the printed versions of those proofs (e.g., the lfsc tester).

--- a/test/regress/cli/regress0/deep-restart/dd.fuzz21.smtv1.smt2
+++ b/test/regress/cli/regress0/deep-restart/dd.fuzz21.smtv1.smt2
@@ -2,7 +2,6 @@
 ; EXPECT: unsat
 ; DISABLE-TESTER: unsat-core
 ; DISABLE-TESTER: proof
-; DISABLE-TESTER: lfsc
 (set-logic ALL)
 (declare-const v (_ BitVec 2))
 (declare-const x7 Bool)

--- a/test/regress/cli/regress0/deep-restart/dd.wrong-sat-020322.smt2
+++ b/test/regress/cli/regress0/deep-restart/dd.wrong-sat-020322.smt2
@@ -2,7 +2,6 @@
 ; EXPECT: unsat
 ; DISABLE-TESTER: unsat-core
 ; DISABLE-TESTER: proof
-; DISABLE-TESTER: lfsc
 (set-logic ALL)
 (declare-sort E 0)
 (declare-fun s () (Seq E))

--- a/test/regress/cli/regress0/quantifiers/lra-triv-gn.smt2
+++ b/test/regress/cli/regress0/quantifiers/lra-triv-gn.smt2
@@ -2,7 +2,6 @@
 ; EXPECT: unsat
 ; DISABLE-TESTER: unsat-core
 ; DISABLE-TESTER: proof
-; DISABLE-TESTER: lfsc
 (set-logic LRA)
 (set-info :status unsat)
 (assert (not (exists ((?X Real)) (>= (/ (- 13) 4) ?X))))

--- a/test/regress/cli/regress1/datatypes/dt-param-card4-unsat.smt2
+++ b/test/regress/cli/regress1/datatypes/dt-param-card4-unsat.smt2
@@ -1,4 +1,3 @@
-; DISABLE-TESTER: proof
 ; EXPECT: unsat
 (set-logic QF_ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress1/hole6.cvc.smt2
+++ b/test/regress/cli/regress1/hole6.cvc.smt2
@@ -1,4 +1,3 @@
-; DISABLE-TESTER: proof
 ; EXPECT: unsat
 (set-logic ALL)
 (set-option :incremental false)

--- a/test/regress/cli/regress1/issue3970-nl-ext-purify.smt2
+++ b/test/regress/cli/regress1/issue3970-nl-ext-purify.smt2
@@ -2,7 +2,6 @@
 ; EXPECT: unsat
 ; DISABLE-TESTER: unsat-core
 ; DISABLE-TESTER: proof
-; DISABLE-TESTER: lfsc
 (set-logic QF_UFNRA)
 (set-option :nl-ext-purify true)
 (set-option :sygus-inference true)

--- a/test/regress/cli/regress1/nl/approx-sqrt-unsat.smt2
+++ b/test/regress/cli/regress1/nl/approx-sqrt-unsat.smt2
@@ -1,4 +1,3 @@
-; DISABLE-TESTER: proof
 ; REQUIRES: poly
 ; COMMAND-LINE: --nl-ext-tplanes
 ; EXPECT: unsat

--- a/test/regress/cli/regress1/nl/issue4791-llr.smt2
+++ b/test/regress/cli/regress1/nl/issue4791-llr.smt2
@@ -2,7 +2,6 @@
 ; EXPECT: unsat
 ; DISABLE-TESTER: unsat-core
 ; DISABLE-TESTER: proof
-; DISABLE-TESTER: lfsc
 
 ;
 ;!(a,b,c).( 0<=b & 1<=c & 0<=a & 1<=c

--- a/test/regress/cli/regress1/quantifiers/issue4021-ind-opts.smt2
+++ b/test/regress/cli/regress1/quantifiers/issue4021-ind-opts.smt2
@@ -1,6 +1,5 @@
 ; DISABLE-TESTER: unsat-core
 ; DISABLE-TESTER: proof
-; DISABLE-TESTER: lfsc
 (set-logic HO_ALL)
 (set-option :miniscope-quant agg)
 (set-option :conjecture-gen true)

--- a/test/regress/cli/regress1/sets/sets-disequal.smt2
+++ b/test/regress/cli/regress1/sets/sets-disequal.smt2
@@ -1,4 +1,3 @@
-; DISABLE-TESTER: proof
 ; COMMAND-LINE: --incremental
 ; EXPECT: sat
 ; EXPECT: sat

--- a/test/regress/cli/regress1/sygus/issue3201.smt2
+++ b/test/regress/cli/regress1/sygus/issue3201.smt2
@@ -2,7 +2,6 @@
 ; COMMAND-LINE: --sygus-inference -q
 ; DISABLE-TESTER: unsat-core
 ; DISABLE-TESTER: proof
-; DISABLE-TESTER: lfsc
 (set-logic ALL)
 (declare-fun v () Bool)
 (assert false)

--- a/test/regress/cli/regress1/sygus/issue3247.smt2
+++ b/test/regress/cli/regress1/sygus/issue3247.smt2
@@ -2,7 +2,6 @@
 ; COMMAND-LINE: --sygus-inference --strings-exp -q
 ; DISABLE-TESTER: unsat-core
 ; DISABLE-TESTER: proof
-; DISABLE-TESTER: lfsc
 (set-logic ALL)
 (declare-fun a () String) 
 (declare-fun b () String) 

--- a/test/regress/cli/regress1/sygus/issue3995-fmf-var-op.smt2
+++ b/test/regress/cli/regress1/sygus/issue3995-fmf-var-op.smt2
@@ -2,7 +2,6 @@
 ; COMMAND-LINE: --sygus-inference --fmf-bound
 ; DISABLE-TESTER: unsat-core
 ; DISABLE-TESTER: proof
-; DISABLE-TESTER: lfsc
 (set-logic HO_ALL)
 (declare-fun a () (_ BitVec 1))
 (assert (bvsgt (bvsmod a a) #b0))

--- a/test/regress/cli/regress1/sygus/issue4009-qep.smt2
+++ b/test/regress/cli/regress1/sygus/issue4009-qep.smt2
@@ -2,7 +2,6 @@
 ; COMMAND-LINE: --sygus-inference --sygus-qe-preproc -q
 ; DISABLE-TESTER: unsat-core
 ; DISABLE-TESTER: proof
-; DISABLE-TESTER: lfsc
 (set-logic ALL)
 (declare-fun a () Real)
 (declare-fun b () Real)

--- a/test/regress/cli/regress1/sygus/issue4083-var-shadow.smt2
+++ b/test/regress/cli/regress1/sygus/issue4083-var-shadow.smt2
@@ -2,7 +2,6 @@
 ; EXPECT: unsat
 ; DISABLE-TESTER: unsat-core
 ; DISABLE-TESTER: proof
-; DISABLE-TESTER: lfsc
 (set-logic ALL)
 (set-option :miniscope-quant conj-and-fv)
 (set-option :sygus-inference true)

--- a/test/regress/cli/regress1/sygus/issue4425-sets-sygus-infer.smt2
+++ b/test/regress/cli/regress1/sygus/issue4425-sets-sygus-infer.smt2
@@ -2,7 +2,6 @@
 ; EXPECT: unsat
 ; DISABLE-TESTER: unsat-core
 ; DISABLE-TESTER: proof
-; DISABLE-TESTER: lfsc
 (set-logic ALL)
 (declare-fun a () Int)
 (declare-fun d () Int)

--- a/test/regress/cli/regress1/sygus/proj-issue185.smt2
+++ b/test/regress/cli/regress1/sygus/proj-issue185.smt2
@@ -2,7 +2,6 @@
 ; EXPECT: unsat
 ; DISABLE-TESTER: unsat-core
 ; DISABLE-TESTER: proof
-; DISABLE-TESTER: lfsc
 (set-logic ALL)
 (set-option :sygus-inference true)
 (set-info :status unsat)

--- a/test/regress/cli/regress2/fp/issue7056.smt2
+++ b/test/regress/cli/regress2/fp/issue7056.smt2
@@ -1,6 +1,5 @@
 ; DISABLE-TESTER: unsat-core
 ; DISABLE-TESTER: proof
-; DISABLE-TESTER: lfsc
 ; timeout with unsat cores
 (set-logic ALL)
 (set-info :smt-lib-version 2.6)

--- a/test/regress/cli/regress2/instance_1444.smtv1.smt2
+++ b/test/regress/cli/regress2/instance_1444.smtv1.smt2
@@ -1,4 +1,3 @@
-; DISABLE-TESTER: lfsc
 ; DISABLE-TESTER: proof
 (set-option :incremental false)
 (set-info :status unsat)

--- a/test/regress/cli/regress2/nl/ufnia-factor-open-proof.smt2
+++ b/test/regress/cli/regress2/nl/ufnia-factor-open-proof.smt2
@@ -1,6 +1,5 @@
 ; DISABLE-TESTER: unsat-core
 ; DISABLE-TESTER: proof
-; DISABLE-TESTER: lfsc
 (set-logic QF_UFNIA)
 (set-info :status unsat)
 (declare-fun p2 (Int) Int)

--- a/test/regress/cli/run_regression.py
+++ b/test/regress/cli/run_regression.py
@@ -613,6 +613,8 @@ def run_regression(
                 return EXIT_FAILURE
             if disable_tester in testers:
                 testers.remove(disable_tester)
+                if disable_tester == "proof" and "lfsc" in testers:
+                    testers.remove("lfsc")
 
     expected_output = expected_output.strip()
     expected_error = expected_error.strip()


### PR DESCRIPTION
This PR automatically disables the `lfsc` tester for regressions where `proof` tester is disabled.