### PR TITLE
Add str.unit to LFSC signature

### DIFF
--- a/proofs/lfsc/signatures/theory_def.plf
+++ b/proofs/lfsc/signatures/theory_def.plf
@@ -170,6 +170,8 @@
 (define str.suffixof (# x term (# y term (apply (apply f_str.suffixof x) y))))
 (declare f_str.rev term)
 (define str.rev (# x term (apply f_str.rev x)))
+(declare f_str.unit term)
+(define str.unit (# x term (apply f_str.unit x)))
 (declare f_str.update term)
 (define str.update (# x term (# y term (# z term (apply (apply (apply f_str.update x) y) z)))))
 (declare f_str.to_lower term)


### PR DESCRIPTION
Fixes buildbot failure.