### PR TITLE
[Java API] Do not link JNI libraries

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -78,18 +78,8 @@ add_subdirectory(api/cpp)
 
 if(TARGET cvc5::cvc5jar)
   find_package(Java REQUIRED)
-  find_package(JNI REQUIRED)
   include(UseJava)
-  message(STATUS "JNI_LIBRARIES: ${JNI_LIBRARIES}")
 
-  # get the directories of libraries libjawt.so and libjvm.so
-  set(JNI_LIBRARIES_PATHS "")
-  foreach(LIB ${JNI_LIBRARIES})
-    get_filename_component(LIB_PATH ${LIB} DIRECTORY)
-    set(JNI_LIBRARIES_PATHS "${JNI_LIBRARIES_PATHS}${LIB_PATH}:")
-  endforeach()
-
-  message(STATUS "JNI_LIBRARIES_PATHS: ${JNI_LIBRARIES_PATHS}")
   # get directory build/install/lib where libcvc5jni.so is installed
   get_target_property(CVC5_LIB_FILE cvc5::cvc5 LOCATION)
   get_filename_component(CVC5_JNI_PATH ${CVC5_LIB_FILE} DIRECTORY)
@@ -108,8 +98,6 @@ if(TARGET cvc5::cvc5jar)
         -Djava.library.path=${CVC5_JNI_PATH}
         SimpleVC
   )
-  set_tests_properties(java/SimpleVC PROPERTIES
-    ENVIRONMENT "LD_LIBRARY_PATH=${JNI_LIBRARIES_PATHS}")
   add_subdirectory(api/java)
 endif()
 

--- a/examples/api/java/CMakeLists.txt
+++ b/examples/api/java/CMakeLists.txt
@@ -53,6 +53,4 @@ foreach(example ${EXAMPLES_API_JAVA})
         ${example}
   )
   set_tests_properties(${EXAMPLE_TEST_NAME} PROPERTIES SKIP_RETURN_CODE 77)
-  set_tests_properties(${EXAMPLE_TEST_NAME} PROPERTIES
-    ENVIRONMENT "LD_LIBRARY_PATH=${JNI_LIBRARIES_PATHS}")
 endforeach()

--- a/src/api/java/CMakeLists.txt
+++ b/src/api/java/CMakeLists.txt
@@ -163,7 +163,6 @@ target_include_directories(cvc5jni PUBLIC ${JNI_INCLUDE_DIRS})
 target_include_directories(cvc5jni PUBLIC ${PROJECT_SOURCE_DIR}/src)
 target_include_directories(cvc5jni PUBLIC ${CMAKE_BINARY_DIR}/src/)
 target_include_directories(cvc5jni PUBLIC ${JNI_DIR})
-target_link_libraries(cvc5jni PRIVATE ${JNI_LIBRARIES})
 target_link_libraries(cvc5jni PRIVATE cvc5)
 
 set(CVC5_JAR "cvc5-${CVC5_VERSION}.jar")


### PR DESCRIPTION
Fixes #8869. We are not using `libjawt.so` or `libjvm.so` (we are not
using the Java Invocation API), so we don't need to link `libcvc5jni`
against `JNI_LIBRARIES`. This change allows us to use cvc5 from Java
without linking against the JNI libraries (see changes in the `examples`
folder).