### PR TITLE
[Win64] Use `CC_FOR_BUILD` when compiling GMP

### DIFF
--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -91,11 +91,15 @@ if(NOT GMP_FOUND_SYSTEM)
     set(CONFIGURE_OPTS
       --host=${TOOLCHAIN_PREFIX}
       --build=${CMAKE_HOST_SYSTEM_PROCESSOR})
-  endif()
-  if (CMAKE_CROSSCOMPILING_MACOS)
+
     set(CONFIGURE_ENV ${CMAKE_COMMAND} -E
-      env "CFLAGS=--target=${TOOLCHAIN_PREFIX}"
-      env "LDFLAGS=-arch ${CMAKE_OSX_ARCHITECTURES}")
+      env "CC_FOR_BUILD=cc")
+    if (CMAKE_CROSSCOMPILING_MACOS)
+      set(CONFIGURE_ENV
+        ${CONFIGURE_ENV}
+        env "CFLAGS=--target=${TOOLCHAIN_PREFIX}"
+        env "LDFLAGS=-arch ${CMAKE_OSX_ARCHITECTURES}")
+    endif()
   endif()
 
   # `CC_FOR_BUILD`, `--host`, and `--build` are passed to `configure` to ensure


### PR DESCRIPTION
This restores the use of the `CC_FOR_BUILD` environment variable. It was
(accidentally) removed in 4337cdb8e2a071ded73dbc9236c8bb2f4d42e6e5 after
it was added in b0500dd28ec42d6a1bada80d34b74ce8aea896cc. Without
`CC_FOR_BUILD`, cross-compilation of GMP fails on Arch Linux.