### PR TITLE
[CMake] Fix `install()` commands

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1334,8 +1334,7 @@ target_include_directories(cvc5
 )
 install(TARGETS cvc5
   EXPORT cvc5-targets
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
 include(GenerateExportHeader)

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -120,7 +120,7 @@ set_target_properties(cvc5parser PROPERTIES OUTPUT_NAME cvc5parser)
 target_link_libraries(cvc5parser PRIVATE cvc5)
 target_link_libraries(cvc5parser PRIVATE ANTLR3)
 
-install(TARGETS cvc5parser-objs cvc5parser
+install(TARGETS cvc5parser
   EXPORT cvc5-targets
   DESTINATION ${CMAKE_INSTALL_LIBDIR})
 


### PR DESCRIPTION
This fixes two issues related to `install()` commands:

- It removes the installation of object files from the parser. Before,
  `make install` would add unnecessary object files to the library
  directory.
- It ensures that all artifacts related to the `cvc5` target are
  installed in the library directory. DLL files [count as `RUNTIME`
  artifacts](https://cmake.org/cmake/help/latest/command/install.html),
  so `libcvc5.dll` was not installed in the `lib/` directory with `make
  install`.