### PR TITLE
[Regressions] Disable ASan on slow regression

### DIFF
--- a/test/regress/cli/regress1/arith/issue3480.smt2
+++ b/test/regress/cli/regress1/arith/issue3480.smt2
@@ -1,4 +1,5 @@
 ; COMMAND-LINE: --theoryof-mode=type --quiet --nl-ext-tplanes
+; REQUIRES: no-asan
 (set-logic QF_NIA)
 (declare-fun a () Int)
 (declare-fun b () Int)


### PR DESCRIPTION
This should fix one of our Buildbot failures.