### PR TITLE
Disable parser regression for competition builds

### DIFF
--- a/test/regress/cli/regress0/nl/proj-issue-425.smt2
+++ b/test/regress/cli/regress0/nl/proj-issue-425.smt2
@@ -1,6 +1,7 @@
 ; COMMAND-LINE: --solve-int-as-bv=5524936381719514648
 ; ERROR-SCRUBBER: sed -e '.*Error in option parsing.*/d'
 ; DISABLE-TESTER: dump
+; REQUIRES: no-competition
 ; EXIT: 1
 (set-logic QF_NIA)
 (declare-fun x () Int)


### PR DESCRIPTION
Competition builds do not print parser errors. This leads to a Buildbot
failure on one of our regressions for the competition build. Thus, this
commit changes the failing regression to be skipped for competition
builds.