### PR TITLE
Fix sort inference for equality over finite types

### DIFF
--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -429,7 +429,8 @@ int SortInference::process( Node n, std::map< Node, Node >& var_bound, std::map<
     // we only do this for non-finite types, as finite types have cardinality
     // restrictions.
     if (n.getKind() == kind::EQUAL
-        && !isCardinalityClassFinite(n[0].getType().getCardinalityClass(), false))
+        && !isCardinalityClassFinite(n[0].getType().getCardinalityClass(),
+                                     false))
     {
       Trace("sort-inference-debug") << "For equality " << n << ", set equal types from : " << n[0].getType() << " " << n[1].getType() << std::endl;
       Assert(n[0].getType() == n[1].getType());
@@ -685,7 +686,9 @@ Node SortInference::simplifyNode(
           tnnc = getOrCreateTypeForId( d_op_arg_types[op][i], n[i].getType() );
           Assert(!tnnc.isNull());
         }
-        else if (n.getKind() == kind::EQUAL && !isCardinalityClassFinite(n[0].getType().getCardinalityClass(), false)
+        else if (n.getKind() == kind::EQUAL
+                 && !isCardinalityClassFinite(
+                     n[0].getType().getCardinalityClass(), false)
                  && i == 0)
         {
           Assert(d_equality_types.find(n) != d_equality_types.end());

--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -429,16 +429,9 @@ int SortInference::process( Node n, std::map< Node, Node >& var_bound, std::map<
     if( n.getKind()==kind::EQUAL && !n[0].getType().isBoolean() ){
       Trace("sort-inference-debug") << "For equality " << n << ", set equal types from : " << n[0].getType() << " " << n[1].getType() << std::endl;
       //if original types are mixed (e.g. Int/Real), don't commit type equality in either direction
-      if( n[0].getType()!=n[1].getType() ){
-        //for now, assume the original types
-        for( unsigned i=0; i<2; i++ ){
-          int ct = getIdForType( n[i].getType() );
-          setEqual( child_types[i], ct );
-        }
-      }else{
-        //we only require that the left and right hand side must be equal
-        setEqual( child_types[0], child_types[1] );
-      }
+      Assert (n[0].getType()==n[1].getType());
+      //we only require that the left and right hand side must be equal
+      setEqual( child_types[0], child_types[1] );
       d_equality_types[n] = child_types[0];
       retType = getIdForType( n.getType() );
     }
@@ -880,7 +873,7 @@ bool SortInference::isWellSorted( Node n ) {
   }
 }
 
-bool SortInference::isMonotonic( TypeNode tn ) {
+bool SortInference::isMonotonic( TypeNode tn ) const {
   Assert(tn.isUninterpretedSort());
   return d_non_monotonic_sorts_orig.find( tn )==d_non_monotonic_sorts_orig.end();
 }

--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -428,11 +428,13 @@ int SortInference::process( Node n, std::map< Node, Node >& var_bound, std::map<
     int retType;
     // we only do this for infinite types, as finite types have cardinality
     // restrictions.
-    if( n.getKind()==kind::EQUAL && n[0].getType().getCardinalityClass() == CardinalityClass::INFINITE ){
+    if (n.getKind() == kind::EQUAL
+        && n[0].getType().getCardinalityClass() == CardinalityClass::INFINITE)
+    {
       Trace("sort-inference-debug") << "For equality " << n << ", set equal types from : " << n[0].getType() << " " << n[1].getType() << std::endl;
-      Assert (n[0].getType()==n[1].getType());
-      //we only require that the left and right hand side must be equal
-      setEqual( child_types[0], child_types[1] );
+      Assert(n[0].getType() == n[1].getType());
+      // we only require that the left and right hand side must be equal
+      setEqual(child_types[0], child_types[1]);
       d_equality_types[n] = child_types[0];
       retType = getIdForType( n.getType() );
     }
@@ -874,7 +876,8 @@ bool SortInference::isWellSorted( Node n ) {
   }
 }
 
-bool SortInference::isMonotonic( TypeNode tn ) const {
+bool SortInference::isMonotonic(TypeNode tn) const
+{
   Assert(tn.isUninterpretedSort());
   return d_non_monotonic_sorts_orig.find( tn )==d_non_monotonic_sorts_orig.end();
 }

--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -426,10 +426,10 @@ int SortInference::process( Node n, std::map< Node, Node >& var_bound, std::map<
     Trace("sort-inference-debug") << "...Process " << n << std::endl;
 
     int retType;
-    // we only do this for infinite types, as finite types have cardinality
+    // we only do this for non-finite types, as finite types have cardinality
     // restrictions.
     if (n.getKind() == kind::EQUAL
-        && n[0].getType().getCardinalityClass() == CardinalityClass::INFINITE)
+        && !isCardinalityClassFinite(n[0].getType().getCardinalityClass(), false))
     {
       Trace("sort-inference-debug") << "For equality " << n << ", set equal types from : " << n[0].getType() << " " << n[1].getType() << std::endl;
       Assert(n[0].getType() == n[1].getType());
@@ -685,7 +685,7 @@ Node SortInference::simplifyNode(
           tnnc = getOrCreateTypeForId( d_op_arg_types[op][i], n[i].getType() );
           Assert(!tnnc.isNull());
         }
-        else if (n.getKind() == kind::EQUAL && !n[0].getType().isBoolean()
+        else if (n.getKind() == kind::EQUAL && !isCardinalityClassFinite(n[0].getType().getCardinalityClass(), false)
                  && i == 0)
         {
           Assert(d_equality_types.find(n) != d_equality_types.end());

--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -426,9 +426,10 @@ int SortInference::process( Node n, std::map< Node, Node >& var_bound, std::map<
     Trace("sort-inference-debug") << "...Process " << n << std::endl;
 
     int retType;
-    if( n.getKind()==kind::EQUAL && !n[0].getType().isBoolean() ){
+    // we only do this for infinite types, as finite types have cardinality
+    // restrictions.
+    if( n.getKind()==kind::EQUAL && n[0].getType().getCardinalityClass() == CardinalityClass::INFINITE ){
       Trace("sort-inference-debug") << "For equality " << n << ", set equal types from : " << n[0].getType() << " " << n[1].getType() << std::endl;
-      //if original types are mixed (e.g. Int/Real), don't commit type equality in either direction
       Assert (n[0].getType()==n[1].getType());
       //we only require that the left and right hand side must be equal
       setEqual( child_types[0], child_types[1] );

--- a/src/theory/sort_inference.h
+++ b/src/theory/sort_inference.h
@@ -149,7 +149,7 @@ private:
    */
   void computeMonotonicity(const std::vector<Node>& assertions);
   /** return true if tn was inferred to be monotonic */
-  bool isMonotonic(TypeNode tn);
+  bool isMonotonic(TypeNode tn) const;
   //get sort id for term n
   int getSortId( Node n );
   //get sort id for variable of quantified formula f

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -541,6 +541,7 @@ set(regress_0_tests
   regress0/datatypes/issue2838.cvc.smt2
   regress0/datatypes/issue4393-cdt-model.smt2
   regress0/datatypes/issue5280-no-nrec.smt2
+  regress0/datatypes/issue8883-sort-inf.smt2
   regress0/datatypes/jsat-2.6.smt2
   regress0/datatypes/list-bool.smt2
   regress0/datatypes/list-update.smt2

--- a/test/regress/cli/regress0/datatypes/issue8883-sort-inf.smt2
+++ b/test/regress/cli/regress0/datatypes/issue8883-sort-inf.smt2
@@ -1,0 +1,8 @@
+; COMMAND-LINE: --sort-inference
+; EXPECT: unsat
+(set-logic ALL)
+(declare-datatypes ((Data 1)) ((par (T) ((data)))))
+(declare-fun p2 () (Data Bool))
+(declare-fun p3 () (Data Bool))
+(assert (not (= p2 p3)))
+(check-sat)


### PR DESCRIPTION
Sort inference for equality was not considering equality over some finite types, leading to potential solution soundness.

Fixes #8883.