### PR TITLE
Fix rewrite for `(to_int real.pi)`

### DIFF
--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -793,7 +793,7 @@ RewriteResponse ArithRewriter::rewriteExtIntegerOp(TNode t)
   }
   if (t[0].getKind() == kind::PI)
   {
-    Node ret = isPred ? nm->mkConst(false) : nm->mkConstReal(Rational(3));
+    Node ret = isPred ? nm->mkConst(false) : nm->mkConstInt(Rational(3));
     return returnRewrite(t, ret, Rewrite::INT_EXT_PI);
   }
   else if (t[0].getKind() == kind::TO_REAL)

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -68,6 +68,7 @@ set(regress_0_tests
   regress0/arith/issue8097-iid.smt2
   regress0/arith/issue8159-rewrite-intreal.smt2
   regress0/arith/issue8805-mixed-var-elim.smt2
+  regress0/arith/issue8905-pi-to-int.smt2
   regress0/arith/ite-lift.smt2
   regress0/arith/leq.01.smtv1.smt2
   regress0/arith/miplib.cvc.smt2

--- a/test/regress/cli/regress0/arith/issue8905-pi-to-int.smt2
+++ b/test/regress/cli/regress0/arith/issue8905-pi-to-int.smt2
@@ -1,0 +1,4 @@
+(set-logic QF_ALL)
+(assert (= 3 (to_int real.pi)))
+(set-info :status sat)
+(check-sat)


### PR DESCRIPTION
Fixes #8905. `(to_int real.pi)` was returning a real constant instead of
an integer, making the type of the rewritten term wrong.