### PR TITLE
Move `SymbolManager` and `SymbolTable` to parser

### DIFF
--- a/src/context/cdhashmap.h
+++ b/src/context/cdhashmap.h
@@ -78,7 +78,7 @@
  *     possible.
  */
 
-#include "cvc5_private.h"
+#include "cvc5parser_public.h"
 
 #ifndef CVC5__CONTEXT__CDHASHMAP_H
 #define CVC5__CONTEXT__CDHASHMAP_H

--- a/src/context/cdhashset.h
+++ b/src/context/cdhashset.h
@@ -13,7 +13,7 @@
  * Context-dependent set class.
  */
 
-#include "cvc5_private.h"
+#include "cvc5parser_public.h"
 
 #ifndef CVC5__CONTEXT__CDHASHSET_H
 #define CVC5__CONTEXT__CDHASHSET_H

--- a/src/context/cdinsert_hashmap.h
+++ b/src/context/cdinsert_hashmap.h
@@ -30,6 +30,11 @@
  * - Does not accept TNodes as keys.
  */
 
+#include "cvc5parser_public.h"
+
+#ifndef CVC5__CONTEXT__CDINSERT_HASHMAP_H
+#define CVC5__CONTEXT__CDINSERT_HASHMAP_H
+
 #include <deque>
 #include <functional>
 #include <unordered_map>
@@ -39,12 +44,15 @@
 #include "base/output.h"
 #include "context/cdinsert_hashmap_forward.h"
 #include "context/context.h"
-#include "cvc5_private.h"
-#include "expr/node.h"
 
-#pragma once
+namespace cvc5 {
 
-namespace cvc5::context {
+namespace internal {
+template <bool ref_count>
+class NodeTemplate;
+}
+
+namespace context {
 
 template <class Key, class Data, class HashFcn = std::hash<Key> >
 class InsertHashMap {
@@ -347,7 +355,8 @@ public:
 };/* class CDInsertHashMap<> */
 
 template <class Data, class HashFcn>
-class CDInsertHashMap<internal::TNode, Data, HashFcn> : public ContextObj
+class CDInsertHashMap<internal::NodeTemplate<false>, Data, HashFcn>
+    : public ContextObj
 {
   /* CDInsertHashMap is challenging to get working with TNode.
    * Consider using CDHashMap<TNode,...> instead.
@@ -364,4 +373,7 @@ class CDInsertHashMap<internal::TNode, Data, HashFcn> : public ContextObj
                 "Cannot create a CDInsertHashMap with TNode keys");
 };
 
-}  // namespace cvc5::context
+}  // namespace context
+}  // namespace cvc5
+
+#endif

--- a/src/context/cdlist.h
+++ b/src/context/cdlist.h
@@ -15,7 +15,7 @@
  * simply shortened.
  */
 
-#include "cvc5_private.h"
+#include "cvc5parser_public.h"
 
 #ifndef CVC5__CONTEXT__CDLIST_H
 #define CVC5__CONTEXT__CDLIST_H

--- a/src/context/cdo.h
+++ b/src/context/cdo.h
@@ -13,7 +13,7 @@
  * A context-dependent object.
  */
 
-#include "cvc5_private.h"
+#include "cvc5parser_public.h"
 
 #ifndef CVC5__CONTEXT__CDO_H
 #define CVC5__CONTEXT__CDO_H

--- a/src/context/context.h
+++ b/src/context/context.h
@@ -13,7 +13,7 @@
  * Context class and context manager.
  */
 
-#include "cvc5_private.h"
+#include "cvc5parser_public.h"
 
 #ifndef CVC5__CONTEXT__CONTEXT_H
 #define CVC5__CONTEXT__CONTEXT_H
@@ -62,8 +62,8 @@ std::ostream& operator<<(std::ostream&, const Scope&);
  * ContextMemoryManager.  A copy is stored in each Scope object for quick
  * access.
  */
-class Context {
-
+class CVC5_EXPORT Context
+{
   /**
    * Pointer to the ContextMemoryManager for this Context.
    */
@@ -192,8 +192,7 @@ public:
    */
   void addNotifyObjPost(ContextNotifyObj* pCNO);
 
-};/* class Context */
-
+}; /* class Context */
 
 /**
  * A UserContext is different from a Context only because it's used for
@@ -421,7 +420,8 @@ class Scope {
  *    argument as the special constructor in this class (and pass it
  *    on to all ContextObj instances).
  */
-class ContextObj {
+class CVC5_EXPORT ContextObj
+{
   /**
    * Pointer to Scope in which this object was last modified.
    */
@@ -647,7 +647,7 @@ class ContextObj {
    */
   void enqueueToGarbageCollect();
 
-};/* class ContextObj */
+}; /* class ContextObj */
 
 /**
  * For more flexible context-dependent behavior than that provided by

--- a/src/context/context_mm.h
+++ b/src/context/context_mm.h
@@ -15,7 +15,7 @@
  * Designed for use by ContextManager.
  */
 
-#include "cvc5_private.h"
+#include "cvc5parser_public.h"
 
 #ifndef CVC5__CONTEXT__CONTEXT_MM_H
 #define CVC5__CONTEXT__CONTEXT_MM_H
@@ -39,8 +39,8 @@ namespace cvc5::context {
  * releases the new region and restores the top region from the stack.
  *
  */
-class ContextMemoryManager {
-
+class CVC5_EXPORT ContextMemoryManager
+{
   /**
    * Memory in regions is allocated in chunks.  This is the chunk size
    */
@@ -146,7 +146,7 @@ class ContextMemoryManager {
    */
   void pop();
 
-};/* class ContextMemoryManager */
+}; /* class ContextMemoryManager */
 
 #else /* CVC5_DEBUG_CONTEXT_MEMORY_MANAGER */
 

--- a/src/expr/CMakeLists.txt
+++ b/src/expr/CMakeLists.txt
@@ -72,10 +72,6 @@ libcvc5_add_sources(
   skolem_manager.h
   subtype_elim_node_converter.cpp
   subtype_elim_node_converter.h
-  symbol_manager.cpp
-  symbol_manager.h
-  symbol_table.cpp
-  symbol_table.h
   term_canonize.cpp
   term_canonize.h
   term_context.cpp

--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -29,6 +29,8 @@
 #include "smt/command.h"
 #include "smt/solver_engine.h"
 
+using namespace cvc5::parser;
+
 namespace cvc5::main {
 
 // Function to cancel any (externally-imposed) limit on CPU time.

--- a/src/main/command_executor.h
+++ b/src/main/command_executor.h
@@ -20,7 +20,7 @@
 #include <string>
 
 #include "api/cpp/cvc5.h"
-#include "expr/symbol_manager.h"
+#include "parser/api/cpp/symbol_manager.h"
 
 namespace cvc5 {
 
@@ -46,7 +46,7 @@ class CommandExecutor
    * Certain commands (e.g. reset-assertions) have a specific impact on the
    * symbol manager.
    */
-  std::unique_ptr<SymbolManager> d_symman;
+  std::unique_ptr<parser::SymbolManager> d_symman;
 
   cvc5::Result d_result;
 
@@ -71,7 +71,7 @@ class CommandExecutor
   cvc5::Solver* getSolver() { return d_solver.get(); }
 
   /** Get a pointer to the symbol manager owned by this CommandExecutor */
-  SymbolManager* getSymbolManager() { return d_symman.get(); }
+  parser::SymbolManager* getSymbolManager() { return d_symman.get(); }
 
   cvc5::Result getResult() const { return d_result; }
   void reset();
@@ -106,7 +106,7 @@ private:
 }; /* class CommandExecutor */
 
 bool solverInvoke(cvc5::Solver* solver,
-                  SymbolManager* sm,
+                  parser::SymbolManager* sm,
                   Command* cmd,
                   std::ostream& out);
 

--- a/src/main/interactive_shell.cpp
+++ b/src/main/interactive_shell.cpp
@@ -41,7 +41,7 @@
 #include "api/cpp/cvc5.h"
 #include "base/check.h"
 #include "base/output.h"
-#include "expr/symbol_manager.h"
+#include "parser/api/cpp/symbol_manager.h"
 #include "parser/input.h"
 #include "parser/parser.h"
 #include "parser/parser_builder.h"

--- a/src/main/interactive_shell.h
+++ b/src/main/interactive_shell.h
@@ -24,10 +24,9 @@ namespace cvc5 {
 
 class Solver;
 
-class SymbolManager;
-
 namespace parser {
   class Parser;
+  class SymbolManager;
   }  // namespace parser
 
   class Command;
@@ -38,7 +37,7 @@ namespace parser {
   {
    public:
     InteractiveShell(Solver* solver,
-                     SymbolManager* sm,
+                     parser::SymbolManager* sm,
                      std::istream& in,
                      std::ostream& out);
 

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -27,6 +27,10 @@ set(libcvc5parser_src_files
   antlr_input_imports.cpp
   antlr_line_buffered_input.cpp
   antlr_line_buffered_input.h
+  api/cpp/symbol_manager.cpp
+  api/cpp/symbol_manager.h
+  api/cpp/symbol_table.cpp
+  api/cpp/symbol_table.h
   bounded_token_buffer.cpp
   bounded_token_buffer.h
   bounded_token_factory.cpp

--- a/src/parser/api/cpp/symbol_manager.cpp
+++ b/src/parser/api/cpp/symbol_manager.cpp
@@ -13,7 +13,7 @@
  * The symbol manager.
  */
 
-#include "expr/symbol_manager.h"
+#include "parser/api/cpp/symbol_manager.h"
 
 #include "context/cdhashmap.h"
 #include "context/cdhashset.h"
@@ -22,7 +22,7 @@
 
 using namespace cvc5::context;
 
-namespace cvc5 {
+namespace cvc5::parser {
 
 // ---------------------------------------------- SymbolManager::Implementation
 
@@ -253,7 +253,7 @@ void SymbolManager::Implementation::popScope()
   Trace("sym-manager") << "SymbolManager: popScope" << std::endl;
   if (d_context.getLevel() == 0)
   {
-    throw internal::ScopeException();
+    throw ScopeException();
   }
   d_context.pop();
   Trace("sym-manager-debug")
@@ -308,10 +308,7 @@ SymbolManager::SymbolManager(cvc5::Solver* s)
 
 SymbolManager::~SymbolManager() {}
 
-internal::SymbolTable* SymbolManager::getSymbolTable()
-{
-  return &d_symtabAllocated;
-}
+SymbolTable* SymbolManager::getSymbolTable() { return &d_symtabAllocated; }
 
 NamingResult SymbolManager::setExpressionName(cvc5::Term t,
                                               const std::string& name,
@@ -436,4 +433,4 @@ void SymbolManager::resetAssertions()
   }
 }
 
-}  // namespace cvc5
+}  // namespace cvc5::parser

--- a/src/parser/api/cpp/symbol_manager.h
+++ b/src/parser/api/cpp/symbol_manager.h
@@ -24,9 +24,9 @@
 
 #include "api/cpp/cvc5.h"
 #include "cvc5_export.h"
-#include "expr/symbol_table.h"
+#include "parser/api/cpp/symbol_table.h"
 
-namespace cvc5 {
+namespace cvc5::parser {
 
 /** Represents the result of a call to `setExpressionName()`. */
 enum class NamingResult
@@ -53,7 +53,7 @@ class CVC5_EXPORT SymbolManager
   SymbolManager(cvc5::Solver* s);
   ~SymbolManager();
   /** Get the underlying symbol table */
-  internal::SymbolTable* getSymbolTable();
+  SymbolTable* getSymbolTable();
   //---------------------------- named expressions
   /** Set name of term t to name
    *
@@ -178,7 +178,7 @@ class CVC5_EXPORT SymbolManager
   /**
    * The declaration scope that is "owned" by this symbol manager.
    */
-  internal::SymbolTable d_symtabAllocated;
+  SymbolTable d_symtabAllocated;
   /** The implementation of the symbol manager */
   class Implementation;
   std::unique_ptr<Implementation> d_implementation;
@@ -189,6 +189,6 @@ class CVC5_EXPORT SymbolManager
   bool d_globalDeclarations;
 };
 
-}  // namespace cvc5
+}  // namespace cvc5::parser
 
 #endif /* CVC5__EXPR__SYMBOL_MANAGER_H */

--- a/src/parser/api/cpp/symbol_table.h
+++ b/src/parser/api/cpp/symbol_table.h
@@ -31,9 +31,9 @@ class Sort;
 class Term;
 }  // namespace cvc5
 
-namespace cvc5::internal {
+namespace cvc5::parser {
 
-class CVC5_EXPORT ScopeException : public Exception
+class CVC5_EXPORT ScopeException : public internal::Exception
 {
 };
 
@@ -176,7 +176,7 @@ class CVC5_EXPORT SymbolTable
   /** Get overloaded constant for type.
    * If possible, it returns the defined symbol with name
    * that has type t. Otherwise returns null expression.
-  */
+   */
   cvc5::Term getOverloadedConstantForType(const std::string& name,
                                           cvc5::Sort t) const;
 
@@ -201,6 +201,6 @@ class CVC5_EXPORT SymbolTable
   std::unique_ptr<Implementation> d_implementation;
 }; /* class SymbolTable */
 
-}  // namespace cvc5::internal
+}  // namespace cvc5::parser
 
 #endif /* CVC5__SYMBOL_TABLE_H */

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -25,8 +25,8 @@
 
 #include "api/cpp/cvc5.h"
 #include "cvc5_export.h"
-#include "expr/symbol_manager.h"
-#include "expr/symbol_table.h"
+#include "parser/api/cpp/symbol_manager.h"
+#include "parser/api/cpp/symbol_table.h"
 #include "parser/input.h"
 #include "parser/parse_op.h"
 #include "parser/parser_exception.h"
@@ -117,7 +117,7 @@ private:
  /**
   * This current symbol table used by this parser, from symbol manager.
   */
- internal::SymbolTable* d_symtab;
+ SymbolTable* d_symtab;
 
  /**
   * The level of the assertions in the declaration scope.  Things declared

--- a/src/parser/parser_builder.h
+++ b/src/parser/parser_builder.h
@@ -29,11 +29,11 @@ namespace cvc5 {
 class Solver;
 
 class Options;
-class SymbolManager;
 
 namespace parser {
 
 class Parser;
+class SymbolManager;
 
 /**
  * A builder for input language parsers. <code>build()</code> can be

--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -27,13 +27,13 @@
 #include "base/modal_exception.h"
 #include "base/output.h"
 #include "expr/node.h"
-#include "expr/symbol_manager.h"
 #include "expr/type_node.h"
 #include "options/io_utils.h"
 #include "options/main_options.h"
 #include "options/options.h"
 #include "options/printer_options.h"
 #include "options/smt_options.h"
+#include "parser/api/cpp/symbol_manager.h"
 #include "printer/printer.h"
 #include "proof/unsat_core.h"
 #include "util/smt2_quote_string.h"
@@ -44,6 +44,7 @@ using namespace std;
 namespace cvc5 {
 
 using namespace internal;
+using namespace parser;
 
 std::string sexprToString(cvc5::Term sexpr)
 {

--- a/src/smt/command.h
+++ b/src/smt/command.h
@@ -36,9 +36,12 @@ namespace cvc5 {
 class Solver;
 class Term;
 
-class SymbolManager;
 class Command;
 class CommandStatus;
+
+namespace parser {
+class SymbolManager;
+}
 
 namespace smt {
 class Model;
@@ -144,12 +147,12 @@ class CVC5_EXPORT Command
   /**
    * Invoke the command on the solver and symbol manager sm.
    */
-  virtual void invoke(cvc5::Solver* solver, SymbolManager* sm) = 0;
+  virtual void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) = 0;
   /**
    * Same as above, and prints the result to output stream out.
    */
   virtual void invoke(cvc5::Solver* solver,
-                      SymbolManager* sm,
+                      parser::SymbolManager* sm,
                       std::ostream& out);
 
   virtual void toStream(std::ostream& out) const = 0;
@@ -241,7 +244,7 @@ class CVC5_EXPORT EmptyCommand : public Command
  public:
   EmptyCommand(std::string name = "");
   std::string getName() const;
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 
@@ -256,9 +259,9 @@ class CVC5_EXPORT EchoCommand : public Command
 
   std::string getOutput() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   void invoke(cvc5::Solver* solver,
-              SymbolManager* sm,
+              parser::SymbolManager* sm,
               std::ostream& out) override;
 
   std::string getCommandName() const override;
@@ -278,7 +281,7 @@ class CVC5_EXPORT AssertCommand : public Command
 
   cvc5::Term getTerm() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
 
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
@@ -289,7 +292,7 @@ class CVC5_EXPORT PushCommand : public Command
  public:
   PushCommand(uint32_t nscopes);
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 
@@ -302,7 +305,7 @@ class CVC5_EXPORT PopCommand : public Command
  public:
   PopCommand(uint32_t nscopes);
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 
@@ -318,7 +321,7 @@ class CVC5_EXPORT DeclarationDefinitionCommand : public Command
  public:
   DeclarationDefinitionCommand(const std::string& id);
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override = 0;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override = 0;
   std::string getSymbol() const;
 }; /* class DeclarationDefinitionCommand */
 
@@ -335,7 +338,7 @@ class CVC5_EXPORT DeclareFunctionCommand : public DeclarationDefinitionCommand
   cvc5::Term getFunction() const;
   cvc5::Sort getSort() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 }; /* class DeclareFunctionCommand */
@@ -356,7 +359,7 @@ class CVC5_EXPORT DeclarePoolCommand : public DeclarationDefinitionCommand
   cvc5::Sort getSort() const;
   const std::vector<cvc5::Term>& getInitialValue() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 }; /* class DeclarePoolCommand */
@@ -372,7 +375,7 @@ class CVC5_EXPORT DeclareOracleFunCommand : public Command
   Sort getSort() const;
   const std::string& getBinaryName() const;
 
-  void invoke(Solver* solver, SymbolManager* sm) override;
+  void invoke(Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 
@@ -397,7 +400,7 @@ class CVC5_EXPORT DeclareSortCommand : public DeclarationDefinitionCommand
   size_t getArity() const;
   cvc5::Sort getSort() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 }; /* class DeclareSortCommand */
@@ -417,7 +420,7 @@ class CVC5_EXPORT DefineSortCommand : public DeclarationDefinitionCommand
   const std::vector<cvc5::Sort>& getParameters() const;
   cvc5::Sort getSort() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 }; /* class DefineSortCommand */
@@ -437,7 +440,7 @@ class CVC5_EXPORT DefineFunctionCommand : public DeclarationDefinitionCommand
   cvc5::Sort getSort() const;
   cvc5::Term getFormula() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 
@@ -469,7 +472,7 @@ class CVC5_EXPORT DefineFunctionRecCommand : public Command
   const std::vector<std::vector<cvc5::Term> >& getFormals() const;
   const std::vector<cvc5::Term>& getFormulas() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 
@@ -494,7 +497,7 @@ class CVC5_EXPORT DeclareHeapCommand : public Command
   DeclareHeapCommand(cvc5::Sort locSort, cvc5::Sort dataSort);
   cvc5::Sort getLocationSort() const;
   cvc5::Sort getDataSort() const;
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 
@@ -514,7 +517,7 @@ class CVC5_EXPORT CheckSatCommand : public Command
  public:
   CheckSatCommand();
   cvc5::Result getResult() const;
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out) const override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
@@ -536,7 +539,7 @@ class CVC5_EXPORT CheckSatAssumingCommand : public Command
 
   const std::vector<cvc5::Term>& getTerms() const;
   cvc5::Result getResult() const;
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out) const override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
@@ -564,7 +567,7 @@ class CVC5_EXPORT DeclareSygusVarCommand : public DeclarationDefinitionCommand
    * The declared sygus variable is communicated to the SMT engine in case a
    * synthesis conjecture is built later on.
    */
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   /** returns this command's name */
   std::string getCommandName() const override;
   /** prints this command */
@@ -607,7 +610,7 @@ class CVC5_EXPORT SynthFunCommand : public DeclarationDefinitionCommand
    * The declared function-to-synthesize is communicated to the SMT engine in
    * case a synthesis conjecture is built later on.
    */
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   /** returns this command's name */
   std::string getCommandName() const override;
   /** prints this command */
@@ -638,7 +641,7 @@ class CVC5_EXPORT SygusConstraintCommand : public Command
    * The declared constraint is communicated to the SMT engine in case a
    * synthesis conjecture is built later on.
    */
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   /** returns this command's name */
   std::string getCommandName() const override;
   /** prints this command */
@@ -677,7 +680,7 @@ class CVC5_EXPORT SygusInvConstraintCommand : public Command
    * invariant constraint is built, in case an actual synthesis conjecture is
    * built later on.
    */
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   /** returns this command's name */
   std::string getCommandName() const override;
   /** prints this command */
@@ -707,7 +710,7 @@ class CVC5_EXPORT CheckSynthCommand : public Command
    * and then perform a satisfiability check, whose result is stored in
    * d_result.
    */
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   /** returns this command's name */
   std::string getCommandName() const override;
   /** prints this command */
@@ -736,7 +739,7 @@ class CVC5_EXPORT SimplifyCommand : public Command
 
   cvc5::Term getTerm() const;
   cvc5::Term getResult() const;
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out) const override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
@@ -754,7 +757,7 @@ class CVC5_EXPORT GetValueCommand : public Command
 
   const std::vector<cvc5::Term>& getTerms() const;
   cvc5::Term getResult() const;
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out) const override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
@@ -769,7 +772,7 @@ class CVC5_EXPORT GetAssignmentCommand : public Command
   GetAssignmentCommand();
 
   cvc5::Term getResult() const;
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out) const override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
@@ -779,7 +782,7 @@ class CVC5_EXPORT GetModelCommand : public Command
 {
  public:
   GetModelCommand();
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out) const override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
@@ -795,7 +798,7 @@ class CVC5_EXPORT BlockModelCommand : public Command
  public:
   BlockModelCommand(modes::BlockModelsMode mode);
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 
@@ -811,7 +814,7 @@ class CVC5_EXPORT BlockModelValuesCommand : public Command
   BlockModelValuesCommand(const std::vector<cvc5::Term>& terms);
 
   const std::vector<cvc5::Term>& getTerms() const;
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 
@@ -825,7 +828,7 @@ class CVC5_EXPORT GetProofCommand : public Command
  public:
   GetProofCommand();
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
 
   void printResult(std::ostream& out) const override;
 
@@ -843,7 +846,7 @@ class CVC5_EXPORT GetInstantiationsCommand : public Command
   GetInstantiationsCommand();
 
   static bool isEnabled(cvc5::Solver* solver, const cvc5::Result& res);
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out) const override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
@@ -878,7 +881,7 @@ class CVC5_EXPORT GetInterpolantCommand : public Command
    * query. */
   cvc5::Term getResult() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out) const override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
@@ -905,7 +908,7 @@ class CVC5_EXPORT GetInterpolantNextCommand : public Command
    */
   cvc5::Term getResult() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out) const override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
@@ -945,7 +948,7 @@ class CVC5_EXPORT GetAbductCommand : public Command
    */
   cvc5::Term getResult() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out) const override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
@@ -971,7 +974,7 @@ class CVC5_EXPORT GetAbductNextCommand : public Command
    */
   cvc5::Term getResult() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out) const override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
@@ -996,7 +999,7 @@ class CVC5_EXPORT GetQuantifierEliminationCommand : public Command
 
   cvc5::Term getTerm() const;
   bool getDoFull() const;
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   cvc5::Term getResult() const;
   void printResult(std::ostream& out) const override;
 
@@ -1008,7 +1011,7 @@ class CVC5_EXPORT GetUnsatAssumptionsCommand : public Command
 {
  public:
   GetUnsatAssumptionsCommand();
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::vector<cvc5::Term> getResult() const;
   void printResult(std::ostream& out) const override;
   std::string getCommandName() const override;
@@ -1024,7 +1027,7 @@ class CVC5_EXPORT GetUnsatCoreCommand : public Command
   GetUnsatCoreCommand();
   const std::vector<cvc5::Term>& getUnsatCore() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out) const override;
 
   std::string getCommandName() const override;
@@ -1034,7 +1037,7 @@ class CVC5_EXPORT GetUnsatCoreCommand : public Command
   /** The solver we were invoked with */
   cvc5::Solver* d_solver;
   /** The symbol manager we were invoked with */
-  SymbolManager* d_sm;
+  parser::SymbolManager* d_sm;
   /** the result of the unsat core call */
   std::vector<cvc5::Term> d_result;
 }; /* class GetUnsatCoreCommand */
@@ -1045,7 +1048,7 @@ class CVC5_EXPORT GetDifficultyCommand : public Command
   GetDifficultyCommand();
   const std::map<cvc5::Term, cvc5::Term>& getDifficultyMap() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out) const override;
 
   std::string getCommandName() const override;
@@ -1053,7 +1056,7 @@ class CVC5_EXPORT GetDifficultyCommand : public Command
 
  protected:
   /** The symbol manager we were invoked with */
-  SymbolManager* d_sm;
+  parser::SymbolManager* d_sm;
   /** the result of the get difficulty call */
   std::map<cvc5::Term, cvc5::Term> d_result;
 };
@@ -1064,7 +1067,7 @@ class CVC5_EXPORT GetLearnedLiteralsCommand : public Command
   GetLearnedLiteralsCommand();
   const std::vector<cvc5::Term>& getLearnedLiterals() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out) const override;
 
   std::string getCommandName() const override;
@@ -1083,7 +1086,7 @@ class CVC5_EXPORT GetAssertionsCommand : public Command
  public:
   GetAssertionsCommand();
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getResult() const;
   void printResult(std::ostream& out) const override;
   std::string getCommandName() const override;
@@ -1099,7 +1102,7 @@ class CVC5_EXPORT SetBenchmarkLogicCommand : public Command
   SetBenchmarkLogicCommand(std::string logic);
 
   std::string getLogic() const;
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 }; /* class SetBenchmarkLogicCommand */
@@ -1116,7 +1119,7 @@ class CVC5_EXPORT SetInfoCommand : public Command
   const std::string& getFlag() const;
   const std::string& getValue() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 }; /* class SetInfoCommand */
@@ -1133,7 +1136,7 @@ class CVC5_EXPORT GetInfoCommand : public Command
   std::string getFlag() const;
   std::string getResult() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out) const override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
@@ -1151,7 +1154,7 @@ class CVC5_EXPORT SetOptionCommand : public Command
   const std::string& getFlag() const;
   const std::string& getValue() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 }; /* class SetOptionCommand */
@@ -1168,7 +1171,7 @@ class CVC5_EXPORT GetOptionCommand : public Command
   std::string getFlag() const;
   std::string getResult() const;
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out) const override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
@@ -1184,7 +1187,7 @@ class CVC5_EXPORT DatatypeDeclarationCommand : public Command
 
   DatatypeDeclarationCommand(const std::vector<cvc5::Sort>& datatypes);
   const std::vector<cvc5::Sort>& getDatatypes() const;
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 }; /* class DatatypeDeclarationCommand */
@@ -1193,7 +1196,7 @@ class CVC5_EXPORT ResetCommand : public Command
 {
  public:
   ResetCommand() {}
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 }; /* class ResetCommand */
@@ -1202,7 +1205,7 @@ class CVC5_EXPORT ResetAssertionsCommand : public Command
 {
  public:
   ResetAssertionsCommand() {}
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 }; /* class ResetAssertionsCommand */
@@ -1211,7 +1214,7 @@ class CVC5_EXPORT QuitCommand : public Command
 {
  public:
   QuitCommand() {}
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   std::string getCommandName() const override;
   void toStream(std::ostream& out) const override;
 }; /* class QuitCommand */
@@ -1231,9 +1234,9 @@ class CVC5_EXPORT CommandSequence : public Command
   void addCommand(Command* cmd);
   void clear();
 
-  void invoke(cvc5::Solver* solver, SymbolManager* sm) override;
+  void invoke(cvc5::Solver* solver, parser::SymbolManager* sm) override;
   void invoke(cvc5::Solver* solver,
-              SymbolManager* sm,
+              parser::SymbolManager* sm,
               std::ostream& out) override;
 
   typedef std::vector<Command*>::iterator iterator;


### PR DESCRIPTION
This moves `SymbolManager` and `SymbolTable` to the parser. To do so, it
modifies headers in the `context` package to be public to the parser
(changes `cvc5_private.h` to `cvc5parser_public.h`), because they are
shared between the parser and the main library.