### PR TITLE
[Docs] Update `EnumDocumenter` for newer Sphinx

### DIFF
--- a/docs/ext/autoenum.py
+++ b/docs/ext/autoenum.py
@@ -26,13 +26,12 @@ class EnumDocumenter(ClassDocumenter):
         return isinstance(member, enum.Enum)
 
     def add_content(self,
-                    more_content: Optional[StringList],
-                    no_docstring: bool = False) -> None:
+                    more_content: Optional[StringList]) -> None:
         """Add the docstring for this object."""
 
         # overriding this flag prints __doc__ just as we want to.
         self.doc_as_attr = False
-        super().add_content(more_content, no_docstring)
+        super().add_content(more_content)
         self.doc_as_attr = True
 
 


### PR DESCRIPTION
The `no_docstring` argument of
`sphinx.ext.autodoc.Documenter.add_content()` has been
[deprecated](https://www.sphinx-doc.org/en/master/changes.html) since
Sphinx 3.4.0 (released in December 2020). It seems that newer Sphinx
versions have removed that argument, which breaks our `EnumDocumenter`
(e.g., see the following
[example](https://github.com/cvc5/cvc5/runs/7081097179?check_suite_focus=true)).
This commit updates our use of
`sphinx.ext.autodoc.Documenter.add_content()`.