### PR TITLE
Fix issue 8959

### DIFF
--- a/src/theory/bags/solver_state.cpp
+++ b/src/theory/bags/solver_state.cpp
@@ -39,12 +39,6 @@ void SolverState::registerBag(TNode n)
 {
   Assert(n.getType().isBag());
   d_bags.insert(n);
-  if (n.getKind() == TABLE_GROUP)
-  {
-    std::shared_ptr<context::CDHashSet<Node>> set =
-        std::make_shared<context::CDHashSet<Node>>(d_env.getUserContext());
-    d_partElementSkolems[n] = set;
-  }
 }
 
 void SolverState::registerCountTerm(Node bag, Node element, Node skolem)
@@ -59,6 +53,13 @@ void SolverState::registerCountTerm(Node bag, Node element, Node skolem)
   {
     d_bagElements[bag].push_back(pair);
   }
+}
+
+void SolverState::registerGroupTerm(Node n)
+{
+  std::shared_ptr<context::CDHashSet<Node>> set =
+      std::make_shared<context::CDHashSet<Node>>(d_env.getUserContext());
+  d_partElementSkolems[n] = set;
 }
 
 void SolverState::registerCardinalityTerm(Node n, Node skolem)

--- a/src/theory/bags/solver_state.h
+++ b/src/theory/bags/solver_state.h
@@ -50,6 +50,9 @@ class SolverState : public TheoryState
    */
   void registerCountTerm(Node bag, Node element, Node skolem);
 
+  /** register a table.group term */
+  void registerGroupTerm(Node n);
+
   /**
    * store cardinality term and its skolem in a cahce
    * @param n has the form (bag.card A) where A is a representative

--- a/src/theory/bags/theory_bags.cpp
+++ b/src/theory/bags/theory_bags.cpp
@@ -206,6 +206,10 @@ void TheoryBags::collectBagsAndCountTerms()
       {
         d_ig.registerCardinalityTerm(n);
       }
+      if (k == TABLE_GROUP)
+      {
+        d_state.registerGroupTerm(n);
+      }
       ++it;
     }
     Trace("bags-eqc") << " } " << std::endl;


### PR DESCRIPTION
This PR fixes issue https://github.com/cvc5/cvc5/issues/8959 which happens because group terms that are not representatives are not registered in the solver state. 