### PR TITLE
Get and convert drat proof from cadical in bv solver bitblast

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -159,6 +159,8 @@ libcvc5_add_sources(
   proof/clause_id.h
   proof/dot/dot_printer.cpp
   proof/dot/dot_printer.h
+  proof/drat/drat_proof.cpp
+  proof/drat/drat_proof.h
   proof/eager_proof_generator.cpp
   proof/eager_proof_generator.h
   proof/lazy_proof.cpp

--- a/src/proof/drat/drat_proof.cpp
+++ b/src/proof/drat/drat_proof.cpp
@@ -25,9 +25,9 @@
 namespace cvc5::internal {
 namespace proof {
 
-
 // DratInstruction implementation
-DratInstruction::DratInstruction(DratInstructionKind kind, prop::SatClause clause)
+DratInstruction::DratInstruction(DratInstructionKind kind,
+                                 prop::SatClause clause)
     : d_kind(kind), d_clause(clause)
 {
   // All intialized
@@ -37,27 +37,31 @@ DratInstruction::DratInstruction(DratInstructionKind kind, prop::SatClause claus
 
 DratProof::DratProof() : d_instructions() {}
 
-std::vector<std::string> splitString(std::string s, std::string splitter) {
-    std::vector<std::string> lines;
-    size_t pos = 0;
-    std::string token;
-    while ((pos = s.find(splitter)) != std::string::npos)
-    {
-        token = s.substr(0, pos);
-        s.erase(0, pos + splitter.length());
-        if (token.length() > 0)
-        {
-            lines.push_back(token);
-        }
-    }
+std::vector<std::string> splitString(std::string s, std::string splitter)
+{
+  std::vector<std::string> lines;
+  size_t pos = 0;
+  std::string token;
+  while ((pos = s.find(splitter)) != std::string::npos)
+  {
     token = s.substr(0, pos);
-    if (token.length() > 0) {
-        lines.push_back(token);
+    s.erase(0, pos + splitter.length());
+    if (token.length() > 0)
+    {
+      lines.push_back(token);
     }
-    return lines;
+  }
+  token = s.substr(0, pos);
+  if (token.length() > 0)
+  {
+    lines.push_back(token);
+  }
+  return lines;
 }
 
-void insertSatLiteralIntoClause(prop::SatClause* clause, std::string dratLiteral) {
+void insertSatLiteralIntoClause(prop::SatClause* clause,
+                                std::string dratLiteral)
+{
   int literal = stoi(dratLiteral);
   bool negated = literal < 0;
   if (literal < 0)
@@ -80,9 +84,11 @@ DratProof DratProof::fromPlain(const std::string& s)
     std::string dratColumnSplitter = " ";
     std::vector<std::string> columns = splitString(line, dratColumnSplitter);
     // last line, false derivation
-    if (line == lines[lines.size()-1] && columns.size() == 1 && columns[0] == "0")
+    if (line == lines[lines.size() - 1] && columns.size() == 1
+        && columns[0] == "0")
     {
-      dratProof.d_instructions.emplace_back(ADDITION, prop::SatClause({prop::SatLiteral(0)}));
+      dratProof.d_instructions.emplace_back(
+          ADDITION, prop::SatClause({prop::SatLiteral(0)}));
       break;
     }
     DratInstructionKind kind = ADDITION;
@@ -104,9 +110,8 @@ DratProof DratProof::fromPlain(const std::string& s)
       dratProof.d_instructions.emplace_back(kind, currentClause);
       continue;
     }
-    Unreachable() << "Invalid line in Drat proof: \""
-                  << line
-                  << "\"" << std::endl;
+    Unreachable() << "Invalid line in Drat proof: \"" << line << "\""
+                  << std::endl;
   }
   return dratProof;
 };

--- a/src/proof/drat/drat_proof.cpp
+++ b/src/proof/drat/drat_proof.cpp
@@ -75,7 +75,7 @@ DratProof DratProof::fromPlain(const std::string& s)
   std::string dratLineSplitter = "\n";
   std::vector<std::string> lines = splitString(s, dratLineSplitter);
 
-  for (const std::string line : lines)
+  for (const std::string& line : lines)
   {
     std::string dratColumnSplitter = " ";
     std::vector<std::string> columns = splitString(line, dratColumnSplitter);
@@ -104,11 +104,9 @@ DratProof DratProof::fromPlain(const std::string& s)
       dratProof.d_instructions.emplace_back(kind, currentClause);
       continue;
     }
-    std::ostringstream errmsg;
-    errmsg << "Invalid line in Drat proof: \""
-            << line
-            << "\"";
-    throw InvalidDratProofException(errmsg.str());
+    Unreachable() << "Invalid line in Drat proof: \""
+                  << line
+                  << "\"" << std::endl;
   }
   return dratProof;
 };

--- a/src/proof/drat/drat_proof.cpp
+++ b/src/proof/drat/drat_proof.cpp
@@ -1,0 +1,122 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2022 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Declares C++ types that represent a DRAT proof.
+ * Defines serialization for these types.
+ *
+ * You can find an introduction to DRAT in the drat-trim paper:
+ *    http://www.cs.utexas.edu/~marijn/publications/drat-trim.pdf
+ */
+
+#include "proof/drat/drat_proof.h"
+
+#include <algorithm>
+#include <bitset>
+#include <iostream>
+
+namespace cvc5::internal {
+namespace proof {
+
+
+// DratInstruction implementation
+DratInstruction::DratInstruction(DratInstructionKind kind, prop::SatClause clause)
+    : d_kind(kind), d_clause(clause)
+{
+  // All intialized
+}
+
+// DratProof implementation
+
+DratProof::DratProof() : d_instructions() {}
+
+std::vector<std::string> splitString(std::string s, std::string splitter) {
+    std::vector<std::string> lines;
+    size_t pos = 0;
+    std::string token;
+    while ((pos = s.find(splitter)) != std::string::npos)
+    {
+        token = s.substr(0, pos);
+        s.erase(0, pos + splitter.length());
+        if (token.length() > 0)
+        {
+            lines.push_back(token);
+        }
+    }
+    token = s.substr(0, pos);
+    if (token.length() > 0) {
+        lines.push_back(token);
+    }
+    return lines;
+}
+
+void insertSatLiteralIntoClause(prop::SatClause* clause, std::string dratLiteral) {
+  int literal = stoi(dratLiteral);
+  bool negated = literal < 0;
+  if (literal < 0)
+  {
+    literal *= -1;
+  }
+  clause->emplace_back(prop::SatLiteral((uint64_t)literal, negated));
+}
+
+// See the "binary format" section of
+// https://www.cs.utexas.edu/~marijn/drat-trim/
+DratProof DratProof::fromPlain(const std::string& s)
+{
+  DratProof dratProof;
+  std::string dratLineSplitter = "\n";
+  std::vector<std::string> lines = splitString(s, dratLineSplitter);
+
+  for (const std::string line : lines)
+  {
+    std::string dratColumnSplitter = " ";
+    std::vector<std::string> columns = splitString(line, dratColumnSplitter);
+    // last line, false derivation
+    if (line == lines[lines.size()-1] && columns.size() == 1 && columns[0] == "0")
+    {
+      dratProof.d_instructions.emplace_back(ADDITION, prop::SatClause({prop::SatLiteral(0)}));
+      break;
+    }
+    DratInstructionKind kind = ADDITION;
+    int columnsStart = 0;
+    if (columns[0] == "d")
+    {
+      // last but one column is the literal, last column is 0
+      kind = DELETION;
+      columnsStart = 1;
+    }
+    prop::SatClause currentClause;
+    // last column is 0
+    for (std::size_t i = columnsStart; i < columns.size() - 1; i++)
+    {
+      insertSatLiteralIntoClause(&currentClause, columns[i]);
+    }
+    if (currentClause.size() > 0)
+    {
+      dratProof.d_instructions.emplace_back(kind, currentClause);
+      continue;
+    }
+    std::ostringstream errmsg;
+    errmsg << "Invalid line in Drat proof: \""
+            << line
+            << "\"";
+    throw InvalidDratProofException(errmsg.str());
+  }
+  return dratProof;
+};
+
+const std::vector<DratInstruction>& DratProof::getInstructions() const
+{
+  return d_instructions;
+};
+
+}  // namespace proof
+}  // namespace cvc5::internal

--- a/src/proof/drat/drat_proof.cpp
+++ b/src/proof/drat/drat_proof.cpp
@@ -71,8 +71,6 @@ void insertSatLiteralIntoClause(prop::SatClause* clause,
   clause->emplace_back(prop::SatLiteral((uint64_t)literal, negated));
 }
 
-// See the "binary format" section of
-// https://www.cs.utexas.edu/~marijn/drat-trim/
 DratProof DratProof::fromPlain(const std::string& s)
 {
   DratProof dratProof;
@@ -101,7 +99,7 @@ DratProof DratProof::fromPlain(const std::string& s)
     }
     prop::SatClause currentClause;
     // last column is 0
-    for (std::size_t i = columnsStart; i < columns.size() - 1; i++)
+    for (std::size_t i = columnsStart, size = columns.size() - 1; i < size; i++)
     {
       insertSatLiteralIntoClause(&currentClause, columns[i]);
     }

--- a/src/proof/drat/drat_proof.h
+++ b/src/proof/drat/drat_proof.h
@@ -51,15 +51,16 @@ struct DratInstruction
 /**
  * Class to handle a DRAT proof.
  *
- * A DratProof instance is a sequence of DratInstructions build from a plain
- * (non-binary) DRAT proof.
+ * A DratProof instance is a sequence of DratInstructions built from DRAT
+ * proof.
  */
 class DratProof
 {
  public:
-  DratProof(const DratProof&) = default;
-
-  DratProof(DratProof&&) = default;
+  /**
+   * Create an DRAT proof with no instructions.
+   */
+  DratProof();
 
   ~DratProof() = default;
 
@@ -77,11 +78,6 @@ class DratProof
   const std::vector<DratInstruction>& getInstructions() const;
 
  private:
-  /**
-   * Create an DRAT proof with no instructions.
-   */
-  DratProof();
-
   /**
    * The instructions of the DRAT proof.
    */

--- a/src/proof/drat/drat_proof.h
+++ b/src/proof/drat/drat_proof.h
@@ -1,0 +1,85 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2022 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Declares C++ types that represent a DRAT proof.
+ * Defines serialization for these types.
+ *
+ * You can find an introduction to DRAT in the drat-trim paper:
+ *    http://www.cs.utexas.edu/~marijn/publications/drat-trim.pdf
+ */
+
+#include "cvc5_private.h"
+
+#ifndef CVC5__PROOF__DRAT__DRAT_PROOF_H
+#define CVC5__PROOF__DRAT__DRAT_PROOF_H
+
+#include "prop/sat_solver.h"
+#include "prop/sat_solver_types.h"
+
+namespace cvc5::internal {
+namespace proof {
+
+class InvalidDratProofException : public cvc5::internal::Exception
+{
+ public:
+  InvalidDratProofException() : Exception("Invalid DRAT Proof") {}
+
+  InvalidDratProofException(const std::string& msg) : Exception(msg) {}
+
+  InvalidDratProofException(const char* msg) : Exception(msg) {}
+}; /* class InvalidDratProofException */
+
+enum DratInstructionKind
+{
+  ADDITION,
+  DELETION
+};
+
+struct DratInstruction
+{
+  DratInstruction(DratInstructionKind kind, prop::SatClause clause);
+
+  DratInstructionKind d_kind;
+  prop::SatClause d_clause;
+};
+
+class DratProof
+{
+ public:
+  DratProof(const DratProof&) = default;
+
+  DratProof(DratProof&&) = default;
+
+  ~DratProof() = default;
+
+  static DratProof fromPlain(const std::string& s);
+
+  /**
+   * @return The instructions in this proof
+   */
+  const std::vector<DratInstruction>& getInstructions() const;
+
+ private:
+  /**
+   * Create an DRAT proof with no instructions.
+   */
+  DratProof();
+
+  /**
+   * The instructions of the DRAT proof.
+   */
+  std::vector<DratInstruction> d_instructions;
+};
+
+}  // namespace proof
+}  // namespace cvc5::internal
+
+#endif  // CVC5__PROOF__DRAT__DRAT_PROOF_H

--- a/src/proof/drat/drat_proof.h
+++ b/src/proof/drat/drat_proof.h
@@ -67,10 +67,10 @@ class DratProof
   /**
    * Converts a plain format DRAT proof to a DratProof instance.
    *
-   * @param s string containing the plain DRAT proof.
+   * @param s file stream containing the plain DRAT proof.
    * @return DratProof instance containing the instructions.
    */
-  static DratProof fromPlain(const std::string& s);
+  static DratProof fromPlain(std::ifstream& s);
 
   /**
    * @return The instructions in this proof.

--- a/src/proof/drat/drat_proof.h
+++ b/src/proof/drat/drat_proof.h
@@ -42,7 +42,7 @@ enum DratInstructionKind
  */
 struct DratInstruction
 {
-  DratInstruction(DratInstructionKind kind, prop::SatClause clause);
+  DratInstruction(DratInstructionKind kind, const prop::SatClause& clause);
 
   DratInstructionKind d_kind;
   prop::SatClause d_clause;

--- a/src/proof/drat/drat_proof.h
+++ b/src/proof/drat/drat_proof.h
@@ -51,14 +51,14 @@ struct DratInstruction
 /**
  * Class to handle a DRAT proof.
  *
- * A DratProof instance is a sequence of DratInstructions built from DRAT
+ * A DratProof instance is a sequence of DratInstructions built from a DRAT
  * proof.
  */
 class DratProof
 {
  public:
   /**
-   * Create an DRAT proof with no instructions.
+   * Create a DRAT proof with no instructions.
    */
   DratProof();
 

--- a/src/proof/drat/drat_proof.h
+++ b/src/proof/drat/drat_proof.h
@@ -50,8 +50,9 @@ struct DratInstruction
 
 /**
  * Class to handle a DRAT proof.
- * A plain (non-binary) proof can be interpreted to build it's instructions
- * structures.
+ *
+ * A DratProof instance is a sequence of DratInstructions build from a plain
+ * (non-binary) DRAT proof.
  */
 class DratProof
 {

--- a/src/proof/drat/drat_proof.h
+++ b/src/proof/drat/drat_proof.h
@@ -27,22 +27,19 @@
 namespace cvc5::internal {
 namespace proof {
 
-class InvalidDratProofException : public cvc5::internal::Exception
-{
- public:
-  InvalidDratProofException() : Exception("Invalid DRAT Proof") {}
-
-  InvalidDratProofException(const std::string& msg) : Exception(msg) {}
-
-  InvalidDratProofException(const char* msg) : Exception(msg) {}
-}; /* class InvalidDratProofException */
-
+/**
+ * A DRAT proof has two kinds of instruction, to add and to delete clauses.
+ */
 enum DratInstructionKind
 {
   ADDITION,
   DELETION
 };
 
+/**
+ * Structure to handle a line from the DRAT proof, which is an instruction.
+ * The instruction must have a kind and a clause.
+ */
 struct DratInstruction
 {
   DratInstruction(DratInstructionKind kind, prop::SatClause clause);
@@ -51,6 +48,11 @@ struct DratInstruction
   prop::SatClause d_clause;
 };
 
+/**
+ * Class to handle a DRAT proof.
+ * A plain (non-binary) proof can be interpreted to build it's instructions
+ * structures.
+ */
 class DratProof
 {
  public:
@@ -60,10 +62,16 @@ class DratProof
 
   ~DratProof() = default;
 
+  /**
+   * Converts a plain format DRAT proof to a DratProof instance.
+   *
+   * @param s string containing the plain DRAT proof.
+   * @return DratProof instance containing the instructions.
+   */
   static DratProof fromPlain(const std::string& s);
 
   /**
-   * @return The instructions in this proof
+   * @return The instructions in this proof.
    */
   const std::vector<DratInstruction>& getInstructions() const;
 

--- a/src/proof/proof_rule.cpp
+++ b/src/proof/proof_rule.cpp
@@ -51,6 +51,7 @@ const char* toString(PfRule id)
     case PfRule::TRUST_SUBS_EQ: return "TRUST_SUBS_EQ";
     case PfRule::THEORY_INFERENCE: return "THEORY_INFERENCE";
     case PfRule::SAT_REFUTATION: return "SAT_REFUTATION";
+    case PfRule::DRAT_REFUTATION: return "DRAT_REFUTATION";
     //================================================= Boolean rules
     case PfRule::RESOLUTION: return "RESOLUTION";
     case PfRule::CHAIN_RESOLUTION: return "CHAIN_RESOLUTION";

--- a/src/proof/proof_rule.h
+++ b/src/proof/proof_rule.h
@@ -436,7 +436,29 @@ enum class PfRule : uint32_t
    * SAT solver. \endverbatim
    */
   SAT_REFUTATION,
-
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Boolean -- DRAT Refutation**
+   *
+   * .. math::
+   *   \inferrule{F_1 \dots F_n \mid S_1 \dots S_m}{\bot}
+   *
+   * where assuming a clause set :math:`C` composed of the union of all
+   * :math:`F_i` when viewed as clauses, each :math:`S_i` is a step in the DRAT
+   * proof of :math:`\bot` with one of the following forms:
+   *
+   * - :math:`[l_1, \dots, l_k]` representing the addition to :math:`C` of the
+   *   clause :math:`[l_1, \dots, l_k]`.
+   * - :math:`\mathrm{d}\ [l_1, \dots, l_k]` representing the deletion from
+   *   :math:`C` of the clause :math:`[l_1, \dots, l_k]`.
+   *
+   * Addition proof steps are correct if the clause added to the :math:`C` is
+   * entailed by :math:`C`. Note that :math:`C` is updated after each addition
+   * and deletion.
+   *
+   * The step :math:`S_m` must be of the form :math:`[]`.
+   * \endverbatim
+   */
   DRAT_REFUTATION,
 
   /**

--- a/src/proof/proof_rule.h
+++ b/src/proof/proof_rule.h
@@ -437,6 +437,8 @@ enum class PfRule : uint32_t
    */
   SAT_REFUTATION,
 
+  DRAT_REFUTATION,
+
   /**
    * \verbatim embed:rst:leading-asterisk
    * **Boolean -- Resolution**

--- a/src/prop/cadical.cpp
+++ b/src/prop/cadical.cpp
@@ -206,17 +206,19 @@ bool CadicalSolver::ok() const { return d_inSatMode; }
 
 void CadicalSolver::setDrat()
 {
-  d_dratFile = fopen(tempDratFilePath, "wb");
+  sprintf(d_tempDratFilePath, "dratProof_%d.drat", getpid());
+  d_dratFile = fopen(d_tempDratFilePath, "wb");
   // Currently only non-binary proofs are supported
   d_solver->set_long_option("--no-binary");
-  d_solver->trace_proof(d_dratFile, tempDratFilePath);
+  d_solver->trace_proof(d_dratFile, d_tempDratFilePath);
 }
 
 std::string CadicalSolver::getDrat()
 {
   fclose(d_dratFile);
   d_solver->close_proof_trace();
-  std::ifstream dratFile(tempDratFilePath, std::ios::binary);
+  std::ifstream dratFile(d_tempDratFilePath, std::ios::binary);
+  d_tempDratFilePath[0] = 0;
   std::ostringstream dratFileStringStream;
   dratFileStringStream << dratFile.rdbuf();
   return dratFileStringStream.str();

--- a/src/prop/cadical.cpp
+++ b/src/prop/cadical.cpp
@@ -204,6 +204,23 @@ unsigned CadicalSolver::getAssertionLevel() const
 
 bool CadicalSolver::ok() const { return d_inSatMode; }
 
+void CadicalSolver::setDrat()
+{
+  d_dratFile = fopen(tempDratFilePath, "wb");
+  d_solver->set_long_option("--no-binary");
+  d_solver->trace_proof(d_dratFile, tempDratFilePath);
+}
+
+std::string CadicalSolver::getDrat()
+{
+  fclose(d_dratFile);
+  d_solver->close_proof_trace();
+  std::ifstream dratFile(tempDratFilePath, std::ios::binary);
+  std::ostringstream dratFileStringStream;
+  dratFileStringStream << dratFile.rdbuf();
+  return dratFileStringStream.str();
+}
+
 CadicalSolver::Statistics::Statistics(StatisticsRegistry& registry,
                                       const std::string& prefix)
     : d_numSatCalls(registry.registerInt(prefix + "cadical::calls_to_solve")),

--- a/src/prop/cadical.cpp
+++ b/src/prop/cadical.cpp
@@ -207,6 +207,7 @@ bool CadicalSolver::ok() const { return d_inSatMode; }
 void CadicalSolver::setDrat()
 {
   d_dratFile = fopen(tempDratFilePath, "wb");
+  // Currently only non-binary proofs are supported
   d_solver->set_long_option("--no-binary");
   d_solver->trace_proof(d_dratFile, tempDratFilePath);
 }

--- a/src/prop/cadical.cpp
+++ b/src/prop/cadical.cpp
@@ -17,6 +17,8 @@
 
 #include "prop/cadical.h"
 
+#include <filesystem>
+
 #include "base/check.h"
 #include "util/resource_manager.h"
 #include "util/statistics_registry.h"
@@ -227,7 +229,7 @@ void CadicalSolver::deleteDratFile()
 {
   if (!d_tempDratFilePath.empty())
   {
-    std::remove(d_tempDratFilePath.c_str());
+    std::filesystem::remove(d_tempDratFilePath.c_str());
   }
 }
 

--- a/src/prop/cadical.cpp
+++ b/src/prop/cadical.cpp
@@ -79,7 +79,7 @@ void CadicalSolver::init()
   d_solver->add(0);
 }
 
-CadicalSolver::~CadicalSolver() {}
+CadicalSolver::~CadicalSolver() { deleteDratFile(); }
 
 /**
  * Terminator class that notifies CaDiCaL to terminate when the resource limit
@@ -215,15 +215,20 @@ void CadicalSolver::setDrat()
   d_solver->trace_proof(d_dratFile, d_tempDratFilePath.c_str());
 }
 
-std::string CadicalSolver::getDrat()
+std::ifstream CadicalSolver::getDrat()
 {
   fclose(d_dratFile);
   d_solver->close_proof_trace();
   std::ifstream dratFile(d_tempDratFilePath, std::ios::binary);
-  d_tempDratFilePath[0] = 0;
-  std::ostringstream dratFileStringStream;
-  dratFileStringStream << dratFile.rdbuf();
-  return dratFileStringStream.str();
+  return dratFile;
+}
+
+void CadicalSolver::deleteDratFile()
+{
+  if (!d_tempDratFilePath.empty())
+  {
+    std::remove(d_tempDratFilePath.c_str());
+  }
 }
 
 CadicalSolver::Statistics::Statistics(StatisticsRegistry& registry,

--- a/src/prop/cadical.cpp
+++ b/src/prop/cadical.cpp
@@ -206,11 +206,13 @@ bool CadicalSolver::ok() const { return d_inSatMode; }
 
 void CadicalSolver::setDrat()
 {
-  sprintf(d_tempDratFilePath, "dratProof_%d.drat", getpid());
-  d_dratFile = fopen(d_tempDratFilePath, "wb");
+  std::ostringstream filePathStringStream;
+  filePathStringStream << "dratProof_" << getpid() << ".drat";
+  d_tempDratFilePath = filePathStringStream.str();
+  d_dratFile = fopen(d_tempDratFilePath.c_str(), "wb");
   // Currently only non-binary proofs are supported
   d_solver->set_long_option("--no-binary");
-  d_solver->trace_proof(d_dratFile, d_tempDratFilePath);
+  d_solver->trace_proof(d_dratFile, d_tempDratFilePath.c_str());
 }
 
 std::string CadicalSolver::getDrat()

--- a/src/prop/cadical.h
+++ b/src/prop/cadical.h
@@ -97,7 +97,7 @@ class CadicalSolver : public SatSolver
   SatVariable d_true;
   SatVariable d_false;
   FILE* d_dratFile;
-  char* d_tempDratFilePath;
+  char d_tempDratFilePath[256];
 
   struct Statistics
   {

--- a/src/prop/cadical.h
+++ b/src/prop/cadical.h
@@ -97,7 +97,7 @@ class CadicalSolver : public SatSolver
   SatVariable d_true;
   SatVariable d_false;
   FILE* d_dratFile;
-  char d_tempDratFilePath[256];
+  std::string d_tempDratFilePath;
 
   struct Statistics
   {

--- a/src/prop/cadical.h
+++ b/src/prop/cadical.h
@@ -97,7 +97,7 @@ class CadicalSolver : public SatSolver
   SatVariable d_true;
   SatVariable d_false;
   FILE* d_dratFile;
-  const char* tempDratFilePath = "temp-drat-file.drat";
+  char* d_tempDratFilePath;
 
   struct Statistics
   {

--- a/src/prop/cadical.h
+++ b/src/prop/cadical.h
@@ -64,7 +64,7 @@ class CadicalSolver : public SatSolver
 
   void setDrat() override;
 
-  std::string getDrat() override;
+  std::ifstream getDrat() override;
 
  private:
   /**
@@ -77,6 +77,10 @@ class CadicalSolver : public SatSolver
    * Note: Split out to not call virtual functions in constructor.
    */
   void init();
+  /**
+   * Deletes the generated DRAT proof file.
+   */
+  void deleteDratFile();
 
   /**
    * Set resource limit.

--- a/src/prop/cadical.h
+++ b/src/prop/cadical.h
@@ -62,6 +62,10 @@ class CadicalSolver : public SatSolver
 
   bool ok() const override;
 
+  void setDrat() override;
+
+  std::string getDrat() override;
+
  private:
   /**
    * Private to disallow creation outside of SatSolverFactory.
@@ -92,6 +96,8 @@ class CadicalSolver : public SatSolver
   bool d_inSatMode;
   SatVariable d_true;
   SatVariable d_false;
+  FILE* d_dratFile;
+  const char* tempDratFilePath = "temp-drat-file.drat";
 
   struct Statistics
   {

--- a/src/prop/cnf_stream.cpp
+++ b/src/prop/cnf_stream.cpp
@@ -94,6 +94,11 @@ bool CnfStream::hasLiteral(TNode n) const {
   return find != d_nodeToLiteralMap.end();
 }
 
+bool CnfStream::hasLiteral(const SatLiteral& literal) const
+{
+  return d_literalToNodeMap.contains(literal);
+}
+
 void CnfStream::ensureMappingForLiteral(TNode n)
 {
   SatLiteral lit = getLiteral(n);

--- a/src/prop/cnf_stream.h
+++ b/src/prop/cnf_stream.h
@@ -121,7 +121,7 @@ class CnfStream : protected EnvObj
   bool hasLiteral(TNode node) const;
 
   /**
-   * Returns true iff CNF stream has a mapping for the giving literal
+   * Returns true iff CNF stream has a mapping for the given literal
    * @param literal the literal
    */
   bool hasLiteral(const SatLiteral& literal) const;

--- a/src/prop/cnf_stream.h
+++ b/src/prop/cnf_stream.h
@@ -121,6 +121,12 @@ class CnfStream : protected EnvObj
   bool hasLiteral(TNode node) const;
 
   /**
+   * Returns true iff CNF stream has a mapping for the giving literal
+   * @param literal the literal
+   */
+  bool hasLiteral(const SatLiteral& literal) const;
+
+  /**
    * Ensure that the given node will have a designated SAT literal that is
    * definitionally equal to it.  The result of this function is that the Node
    * can be queried via getSatValue(). Essentially, this is like a "convert-but-

--- a/src/prop/sat_solver.h
+++ b/src/prop/sat_solver.h
@@ -121,10 +121,7 @@ public:
    * Currently it's only possible to save with Cadical solver, which
    * saves the proof in a file.
    */
-  virtual void setDrat()
-  {
-    Unimplemented() << "setDrat not implemented";
-  }
+  virtual void setDrat() { Unimplemented() << "setDrat not implemented"; }
 
   /**
    * Return the previously saved DRAT proof in a string.

--- a/src/prop/sat_solver.h
+++ b/src/prop/sat_solver.h
@@ -114,11 +114,24 @@ public:
     Unimplemented() << "getUnsatAssumptions not implemented";
   }
 
+  /**
+   * Enable saving the DRAT proof.
+   *
+   * The DRAT proof will be saved accordingly to the solver's methods.
+   * Currently it's only possible to save with Cadical solver, which
+   * saves the proof in a file.
+   */
   virtual void setDrat()
   {
     Unimplemented() << "setDrat not implemented";
   }
 
+  /**
+   * Return the previously saved DRAT proof in a string.
+   *
+   * The DRAT proof saving must be enabled, and this method must be
+   * called after the resolution to get the proof.
+   */
   virtual std::string getDrat()
   {
     Unimplemented() << "getDrat not implemented";

--- a/src/prop/sat_solver.h
+++ b/src/prop/sat_solver.h
@@ -114,6 +114,16 @@ public:
     Unimplemented() << "getUnsatAssumptions not implemented";
   }
 
+  virtual void setDrat()
+  {
+    Unimplemented() << "setDrat not implemented";
+  }
+
+  virtual std::string getDrat()
+  {
+    Unimplemented() << "getDrat not implemented";
+  }
+
 };/* class SatSolver */
 
 

--- a/src/prop/sat_solver.h
+++ b/src/prop/sat_solver.h
@@ -115,19 +115,15 @@ public:
   }
 
   /**
-   * Enable saving the DRAT proof.
-   *
-   * The DRAT proof will be saved accordingly to the solver's methods.
-   * Currently it's only possible to save with Cadical solver, which
-   * saves the proof in a file.
+   * Enables the production of a DRAT proof by this SAT solver.
    */
   virtual void setDrat() { Unimplemented() << "setDrat not implemented"; }
 
   /**
-   * Return the previously saved DRAT proof in a string.
+   * Returns the DRAT proof produced by this SAT solver.
    *
-   * The DRAT proof saving must be enabled, and this method must be
-   * called after the resolution to get the proof.
+   * The production of the DRAT proof must have been enabled (via setDrat), and
+   * this method must be called after the solving has finished.
    */
   virtual std::string getDrat()
   {

--- a/src/prop/sat_solver.h
+++ b/src/prop/sat_solver.h
@@ -125,7 +125,7 @@ public:
    * The production of the DRAT proof must have been enabled (via setDrat), and
    * this method must be called after the solving has finished.
    */
-  virtual std::string getDrat()
+  virtual std::ifstream getDrat()
   {
     Unimplemented() << "getDrat not implemented";
   }

--- a/src/prop/sat_solver_factory.cpp
+++ b/src/prop/sat_solver_factory.cpp
@@ -48,9 +48,14 @@ SatSolver* SatSolverFactory::createCryptoMinisat(StatisticsRegistry& registry,
 
 SatSolver* SatSolverFactory::createCadical(StatisticsRegistry& registry,
                                            ResourceManager* resmgr,
-                                           const std::string& name)
+                                           const std::string& name,
+                                           bool produceProofs)
 {
   CadicalSolver* res = new CadicalSolver(registry, name);
+  if (produceProofs)
+  {
+    res->setDrat();
+  }
   res->init();
   res->setResourceLimit(resmgr);
   return res;

--- a/src/prop/sat_solver_factory.h
+++ b/src/prop/sat_solver_factory.h
@@ -41,7 +41,8 @@ class SatSolverFactory
 
   static SatSolver* createCadical(StatisticsRegistry& registry,
                                   ResourceManager* resmgr,
-                                  const std::string& name = "");
+                                  const std::string& name = "",
+                                  bool produceProofs = false);
 
   static SatSolver* createKissat(StatisticsRegistry& registry,
                                  const std::string& name = "");

--- a/src/theory/bv/bv_solver_bitblast.cpp
+++ b/src/theory/bv/bv_solver_bitblast.cpp
@@ -421,7 +421,8 @@ void BVSolverBitblast::handleEagerAtom(TNode fact, bool assertFact)
   registeredAtoms.clear();
 }
 
-std::vector<Node> BVSolverBitblast::convertDratProof(const proof::DratProof& dratProof) const
+std::vector<Node> BVSolverBitblast::convertDratProof(
+    const proof::DratProof& dratProof) const
 {
   NodeManager* nm = NodeManager::currentNM();
   Node cl = nm->mkBoundVar("cl", nm->booleanType());

--- a/src/theory/bv/bv_solver_bitblast.cpp
+++ b/src/theory/bv/bv_solver_bitblast.cpp
@@ -20,7 +20,6 @@
 #include "theory/bv/theory_bv.h"
 #include "theory/bv/theory_bv_utils.h"
 #include "theory/theory_model.h"
-#include "util/rational.h"
 
 namespace cvc5::internal {
 namespace theory {
@@ -328,7 +327,11 @@ bool BVSolverBitblast::collectModelValues(TheoryModel* m,
 
 void BVSolverBitblast::initSatSolver()
 {
-  bool isTheoryProofProducing = d_env.isTheoryProofProducing();
+  // For now we have this always as "false", since the proof tracking it allows
+  // is not used. Once the remaining infrastructure is set up to prove the
+  // theory lemmas from the DRAT proofs, this flag will be initialized with the
+  // value of d_env.isTheoryProofProducing().
+  bool isTheoryProofProducing = false;
   switch (options().bv.bvSatSolver)
   {
     case options::SatSolverMode::CRYPTOMINISAT:
@@ -417,7 +420,7 @@ void BVSolverBitblast::handleEagerAtom(TNode fact, bool assertFact)
   registeredAtoms.clear();
 }
 
-std::vector<Node> BVSolverBitblast::getProofNodes(proof::DratProof dratProof)
+std::vector<Node> BVSolverBitblast::convertDratProof(proof::DratProof dratProof)
 {
   NodeManager* nm = NodeManager::currentNM();
   Node cl = nm->mkBoundVar("cl", nm->booleanType());

--- a/src/theory/bv/bv_solver_bitblast.cpp
+++ b/src/theory/bv/bv_solver_bitblast.cpp
@@ -349,9 +349,9 @@ void BVSolverBitblast::initSatSolver()
       d_satSolver.get(),
       d_bbRegistrar.get(),
       d_nullContext.get(),
-      /** If we are producing proofs for the SAT solver, we need to that all
-       *  literals created in the CNF stream are tracked, which is not the case
-       *  with the FormulaLitPolicy::INTERNAL
+      /** If we are producing proofs for the SAT solver, we need that all
+       * literals created in the CNF stream are tracked, which is not the case
+       * with FormulaLitPolicy::INTERNAL
        */
       isTheoryProofProducing ? prop::FormulaLitPolicy::TRACK
                              : prop::FormulaLitPolicy::INTERNAL,
@@ -426,10 +426,10 @@ std::vector<Node> BVSolverBitblast::getProofNodes(proof::DratProof dratProof)
   prop::SatLiteral zeroLiteral = prop::SatLiteral(0);
 
   std::vector<Node> args;
-  for (const proof::DratInstruction instruction : dratProof.getInstructions())
+  for (const proof::DratInstruction& instruction : dratProof.getInstructions())
   {
-    if (instruction.d_clause.size() == 0
-        || instruction.d_clause[0] == zeroLiteral)
+    Assert(!instruction.d_clause.empty());
+    if (instruction.d_clause[0] == zeroLiteral)
     {
       args.push_back(nm->mkNode(kind::SEXPR, {cl, lastFalseResolution}));
       break;
@@ -437,11 +437,10 @@ std::vector<Node> BVSolverBitblast::getProofNodes(proof::DratProof dratProof)
     std::vector<Node> clauseNodes;
     clauseNodes.emplace_back(
         instruction.d_kind == proof::DratInstructionKind::DELETION ? del : cl);
-    for (const prop::SatLiteral literal : instruction.d_clause)
+    for (const prop::SatLiteral& literal : instruction.d_clause)
     {
-      Node fact = d_cnfStream->getNode(literal);
-      Assert(!fact.isNull());
-      clauseNodes.emplace_back(fact);
+      Assert(d_cnfStream->hasLiteral(literal));
+      clauseNodes.emplace_back(d_cnfStream->getNode(literal));
     }
     args.push_back(nm->mkNode(kind::SEXPR, clauseNodes));
   }

--- a/src/theory/bv/bv_solver_bitblast.cpp
+++ b/src/theory/bv/bv_solver_bitblast.cpp
@@ -345,16 +345,17 @@ void BVSolverBitblast::initSatSolver()
           isTheoryProofProducing));
   }
   d_cnfStream.reset(new prop::CnfStream(
-    d_env,
-    d_satSolver.get(),
-    d_bbRegistrar.get(),
-    d_nullContext.get(),
-    /** If we are producing proofs for the SAT solver, we need to that all
-     *  literals created in the CNF stream are tracked, which is not the case
-     *  with the FormulaLitPolicy::INTERNAL
-     */
-    isTheoryProofProducing ? prop::FormulaLitPolicy::TRACK : prop::FormulaLitPolicy::INTERNAL,
-    "theory::bv::BVSolverBitblast"));
+      d_env,
+      d_satSolver.get(),
+      d_bbRegistrar.get(),
+      d_nullContext.get(),
+      /** If we are producing proofs for the SAT solver, we need to that all
+       *  literals created in the CNF stream are tracked, which is not the case
+       *  with the FormulaLitPolicy::INTERNAL
+       */
+      isTheoryProofProducing ? prop::FormulaLitPolicy::TRACK
+                             : prop::FormulaLitPolicy::INTERNAL,
+      "theory::bv::BVSolverBitblast"));
 }
 
 Node BVSolverBitblast::getValue(TNode node, bool initialize)
@@ -427,7 +428,8 @@ std::vector<Node> BVSolverBitblast::getProofNodes(proof::DratProof dratProof)
   std::vector<Node> args;
   for (const proof::DratInstruction instruction : dratProof.getInstructions())
   {
-    if (instruction.d_clause.size() == 0 || instruction.d_clause[0] == zeroLiteral)
+    if (instruction.d_clause.size() == 0
+        || instruction.d_clause[0] == zeroLiteral)
     {
       args.push_back(nm->mkNode(kind::SEXPR, {cl, lastFalseResolution}));
       break;

--- a/src/theory/bv/bv_solver_bitblast.cpp
+++ b/src/theory/bv/bv_solver_bitblast.cpp
@@ -352,7 +352,8 @@ void BVSolverBitblast::initSatSolver()
       d_satSolver.get(),
       d_bbRegistrar.get(),
       d_nullContext.get(),
-      /** If we are producing proofs for the SAT solver, we need that all
+      /**
+       * If we are producing proofs for the SAT solver, we need that all
        * literals created in the CNF stream are tracked, which is not the case
        * with FormulaLitPolicy::INTERNAL
        */
@@ -420,7 +421,7 @@ void BVSolverBitblast::handleEagerAtom(TNode fact, bool assertFact)
   registeredAtoms.clear();
 }
 
-std::vector<Node> BVSolverBitblast::convertDratProof(proof::DratProof dratProof)
+std::vector<Node> BVSolverBitblast::convertDratProof(const proof::DratProof& dratProof) const
 {
   NodeManager* nm = NodeManager::currentNM();
   Node cl = nm->mkBoundVar("cl", nm->booleanType());

--- a/src/theory/bv/bv_solver_bitblast.h
+++ b/src/theory/bv/bv_solver_bitblast.h
@@ -90,8 +90,12 @@ class BVSolverBitblast : public BVSolver
    */
   void handleEagerAtom(TNode fact, bool assertFact);
 
-  /** Convert drat proof literals to the node literals given to the SAT
-   *  solver
+  /** Converts DRAT proof in terms of SAT literals to the corresponding Node
+   * literals.
+   *
+   * The result is a Node vector where each Node is an s-expression with a
+   * marker of whether it's a clause being added or deleted followed by the
+   * Node-level literals.
    */
   std::vector<Node> getProofNodes(proof::DratProof dratProof);
 

--- a/src/theory/bv/bv_solver_bitblast.h
+++ b/src/theory/bv/bv_solver_bitblast.h
@@ -21,6 +21,7 @@
 #include <unordered_map>
 
 #include "context/cdqueue.h"
+#include "proof/drat/drat_proof.h"
 #include "proof/eager_proof_generator.h"
 #include "prop/cnf_stream.h"
 #include "prop/sat_solver.h"
@@ -88,6 +89,9 @@ class BVSolverBitblast : public BVSolver
    * assumed (false).
    */
   void handleEagerAtom(TNode fact, bool assertFact);
+
+  /** Convert drat proof to proof nodes **/
+  std::vector<Node> getProofNodes(proof::DratProof dratProof);
 
   /** Bit-blaster used to bit-blast atoms/terms. */
   std::unique_ptr<NodeBitblaster> d_bitblaster;

--- a/src/theory/bv/bv_solver_bitblast.h
+++ b/src/theory/bv/bv_solver_bitblast.h
@@ -97,7 +97,7 @@ class BVSolverBitblast : public BVSolver
    * marker of whether it's a clause being added or deleted followed by the
    * Node-level literals.
    */
-  std::vector<Node> convertDratProof(proof::DratProof dratProof);
+  std::vector<Node> convertDratProof(const proof::DratProof& dratProof) const;
 
   /** Bit-blaster used to bit-blast atoms/terms. */
   std::unique_ptr<NodeBitblaster> d_bitblaster;

--- a/src/theory/bv/bv_solver_bitblast.h
+++ b/src/theory/bv/bv_solver_bitblast.h
@@ -90,7 +90,9 @@ class BVSolverBitblast : public BVSolver
    */
   void handleEagerAtom(TNode fact, bool assertFact);
 
-  /** Convert drat proof to proof nodes **/
+  /** Convert drat proof literals to the node literals given to the SAT
+   *  solver
+   */
   std::vector<Node> getProofNodes(proof::DratProof dratProof);
 
   /** Bit-blaster used to bit-blast atoms/terms. */

--- a/src/theory/bv/bv_solver_bitblast.h
+++ b/src/theory/bv/bv_solver_bitblast.h
@@ -97,7 +97,7 @@ class BVSolverBitblast : public BVSolver
    * marker of whether it's a clause being added or deleted followed by the
    * Node-level literals.
    */
-  std::vector<Node> getProofNodes(proof::DratProof dratProof);
+  std::vector<Node> convertDratProof(proof::DratProof dratProof);
 
   /** Bit-blaster used to bit-blast atoms/terms. */
   std::unique_ptr<NodeBitblaster> d_bitblaster;

--- a/test/unit/proof/CMakeLists.txt
+++ b/test/unit/proof/CMakeLists.txt
@@ -16,3 +16,4 @@
 # \todo document this file
 ##
 cvc5_add_unit_test_black(lfsc_node_converter_black proof)
+cvc5_add_unit_test_black(drat_proof_black proof)

--- a/test/unit/proof/drat_proof_black.cpp
+++ b/test/unit/proof/drat_proof_black.cpp
@@ -1,0 +1,58 @@
+#include <string>
+
+#include "proof/drat/drat_proof.h"
+#include "test.h"
+
+namespace cvc5::internal {
+using namespace cvc5::internal::proof;
+
+namespace test {
+
+class TestDratProof : public TestInternal
+{
+};
+
+TEST_F(TestDratProof, ident_sanitize)
+{
+  std::vector<DratInstruction> instructions = {
+      DratInstruction(ADDITION,
+                      prop::SatClause{prop::SatLiteral(14, true),
+                                      prop::SatLiteral(29, true),
+                                      prop::SatLiteral(9, false)}),
+      DratInstruction(ADDITION,
+                      prop::SatClause{prop::SatLiteral(18, true),
+                                      prop::SatLiteral(20, false),
+                                      prop::SatLiteral(30, true),
+                                      prop::SatLiteral(19, false)}),
+      DratInstruction(ADDITION,
+                      prop::SatClause{prop::SatLiteral(28, true),
+                                      prop::SatLiteral(30, false),
+                                      prop::SatLiteral(13, false)}),
+      DratInstruction(ADDITION,
+                      prop::SatClause{prop::SatLiteral(28, true),
+                                      prop::SatLiteral(30, false),
+                                      prop::SatLiteral(13, false)}),
+      DratInstruction(DELETION,
+                      prop::SatClause{prop::SatLiteral(28, true),
+                                      prop::SatLiteral(30, false),
+                                      prop::SatLiteral(13, false)}),
+  };
+  std::string dratStr =
+      "-14 -29 9 0\n-18 20 -30 19 0\n-28 30 13 0\n-28 30 13 0\nd -28 30 13 0";
+  std::string fileName = "temp_drat_unit_test.drat";
+  std::ofstream tempFile(fileName);
+  tempFile << dratStr;
+  tempFile.close();
+  std::ifstream dratFileStream(fileName);
+  DratProof dratProof = DratProof::fromPlain(dratFileStream);
+  for (int i = 0, lenght = instructions.size(); i < lenght; i++)
+  {
+    ASSERT_EQ(instructions[i].d_clause,
+              dratProof.getInstructions()[i].d_clause);
+    ASSERT_EQ(instructions[i].d_kind, dratProof.getInstructions()[i].d_kind);
+  }
+  std::remove(fileName.c_str());
+}
+
+}  // namespace test
+}  // namespace cvc5::internal

--- a/test/unit/proof/drat_proof_black.cpp
+++ b/test/unit/proof/drat_proof_black.cpp
@@ -1,3 +1,4 @@
+#include <filesystem>
 #include <string>
 
 #include "proof/drat/drat_proof.h"
@@ -51,7 +52,7 @@ TEST_F(TestDratProof, ident_sanitize)
               dratProof.getInstructions()[i].d_clause);
     ASSERT_EQ(instructions[i].d_kind, dratProof.getInstructions()[i].d_kind);
   }
-  std::remove(fileName.c_str());
+  std::filesystem::remove(fileName.c_str());
 }
 
 }  // namespace test


### PR DESCRIPTION
Enables to fetch the DRAT proof from cadical sat solver and to convert a plain drat proof's literals to cnf stream nodes.