### PR TITLE
Add 'requirements.txt' listing build/test requirements

### DIFF
--- a/contrib/requirements.txt
+++ b/contrib/requirements.txt
@@ -1,0 +1,9 @@
+# To build cvc5
+toml
+scikit-build
+
+# To build cvc5's Python bindings
+cython
+
+# To test cvc5's Python bindings
+pytest


### PR DESCRIPTION
I don't know if this is reasonable or not, but I "always" forget what are the necessary Python deps for building `cvc5`.

This PR adds a `requirements.txt` file to the `contrib` folder, such that people can just do `pip install -r contrib/requirements.txt` rather than looking in `INSTALL.rst`.

Questions:

- [ ] Should `INSTALL.rst` be updated to document this?
- [ ] Should `requirements.txt` list package versions or are unversioned ones acceptable? If we want versioned, do we have any idea what the minimum versions `cvc5` needs?
- [ ] Where should `requirements.txt` live? The contrib folder feels "a bit wrong", but putting it in the top-level of the repo feels worse.

Signed-off-by: Andrew V. Teylu <andrew@tey.lu>