### PR TITLE
Fix issue with TO_REAL terms in nl model

### DIFF
--- a/src/theory/arith/nl/nl_model.cpp
+++ b/src/theory/arith/nl/nl_model.cpp
@@ -211,7 +211,7 @@ bool NlModel::checkModel(const std::vector<Node>& assertions,
         if (cur.getType().isRealOrInt() && !cur.isConst())
         {
           Kind k = cur.getKind();
-          if (k != MULT && k != ADD && k != NONLINEAR_MULT
+          if (k != MULT && k != ADD && k != NONLINEAR_MULT && k != TO_REAL
               && !isTranscendentalKind(k) && k != IAND && k != POW2)
           {
             // if we have not set an approximate bound for it
@@ -270,6 +270,7 @@ bool NlModel::checkModel(const std::vector<Node>& assertions,
 
 bool NlModel::addSubstitution(TNode v, TNode s)
 {
+  Assert (v.getKind()!=TO_REAL);
   Trace("nl-ext-model") << "* check model substitution : " << v << " -> " << s
                         << std::endl;
   Assert(getSubstitutedForm(s) == s)

--- a/src/theory/arith/nl/nl_model.cpp
+++ b/src/theory/arith/nl/nl_model.cpp
@@ -270,7 +270,7 @@ bool NlModel::checkModel(const std::vector<Node>& assertions,
 
 bool NlModel::addSubstitution(TNode v, TNode s)
 {
-  Assert (v.getKind()!=TO_REAL);
+  Assert(v.getKind() != TO_REAL);
   Trace("nl-ext-model") << "* check model substitution : " << v << " -> " << s
                         << std::endl;
   Assert(getSubstitutedForm(s) == s)

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2063,6 +2063,7 @@ set(regress_1_tests
   regress1/nl/issue8052-iand-rewrite.smt2
   regress1/nl/issue8118-elim-sin.smt2
   regress1/nl/issue8162-drop-pi-bound.smt2
+  regress1/nl/issue8963-to-real-model.smt2
   regress1/nl/learned-rewrite-int-mod-range.smt2
   regress1/nl/metitarski-1025.smt2
   regress1/nl/metitarski-3-4.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2063,6 +2063,7 @@ set(regress_1_tests
   regress1/nl/issue8052-iand-rewrite.smt2
   regress1/nl/issue8118-elim-sin.smt2
   regress1/nl/issue8162-drop-pi-bound.smt2
+  regress1/nl/issue8960-lr-to-real-model.smt2
   regress1/nl/issue8963-to-real-model.smt2
   regress1/nl/learned-rewrite-int-mod-range.smt2
   regress1/nl/metitarski-1025.smt2

--- a/test/regress/cli/regress1/nl/issue8960-lr-to-real-model.smt2
+++ b/test/regress/cli/regress1/nl/issue8960-lr-to-real-model.smt2
@@ -1,0 +1,14 @@
+; COMMAND-LINE: --learned-rewrite
+; EXPECT: sat
+(set-logic ALL)
+(declare-const a Int)
+(declare-const b Int)
+(declare-const c Int)
+(declare-const d Int)
+(declare-const e Int)
+(assert (distinct d 0))
+(assert (distinct b 0))
+(assert (= a (/ e d)))
+(assert (distinct 1 (/ c 0)))
+(assert (= 3 (/ a b b 0 0)))
+(check-sat)

--- a/test/regress/cli/regress1/nl/issue8960-lr-to-real-model.smt2
+++ b/test/regress/cli/regress1/nl/issue8960-lr-to-real-model.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --learned-rewrite
+; COMMAND-LINE: --learned-rewrite -q
 ; EXPECT: sat
 (set-logic ALL)
 (declare-const a Int)

--- a/test/regress/cli/regress1/nl/issue8963-to-real-model.smt2
+++ b/test/regress/cli/regress1/nl/issue8963-to-real-model.smt2
@@ -1,0 +1,8 @@
+; COMMAND-LINE: --decision=internal
+; EXPECT: sat
+(set-logic ALL)
+(declare-fun a () Real)
+(declare-fun r () Int)
+(declare-fun v () Int)
+(assert (exists ((V Real)) (distinct (= (to_real v) (* a a)) (>= 0 (* r v (mod v r))))))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/8963.  That benchmark now times out by default. This PR adds the regression with `--decision=internal` which solves.

Fixes https://github.com/cvc5/cvc5/issues/8960.