### PR TITLE
Revert usage of `seq.nth` in disequality reasoning

### DIFF
--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2428,7 +2428,7 @@ void CoreSolver::processDeqExtensionality(Node n1, Node n2)
   Node deq = eq.negate();
   // we could use seq.nth instead of substr
   Node ss1, ss2;
-   if (n1.getType().isString())
+  if (n1.getType().isString())
   {
     // substring of length 1
     ss1 = nm->mkNode(STRING_SUBSTR, n1, k, d_one);

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2409,12 +2409,14 @@ bool CoreSolver::processSimpleDeq(std::vector<Node>& nfi,
 
 void CoreSolver::processDeqExtensionality(Node n1, Node n2)
 {
+  Trace("strings-deq-ext") << "Processing " << n1 << " != " << n2 << std::endl;
   // hash based on equality
   Node eq = n1 < n2 ? n1.eqNode(n2) : n2.eqNode(n1);
   NodeSet::const_iterator it = d_extDeq.find(eq);
   if (it != d_extDeq.end())
   {
     // already processed
+    Trace("strings-deq-ext") << "- already processed" << std::endl;
     return;
   }
   d_extDeq.insert(eq);
@@ -2424,9 +2426,20 @@ void CoreSolver::processDeqExtensionality(Node n1, Node n2)
   TypeNode intType = nm->integerType();
   Node k = sc->mkSkolemFun(SkolemFunId::STRINGS_DEQ_DIFF, intType, n1, n2);
   Node deq = eq.negate();
-  // use seq.nth instead of substr
-  Node ss1 = nm->mkNode(SEQ_NTH, n1, k);
-  Node ss2 = nm->mkNode(SEQ_NTH, n2, k);
+  // we could use seq.nth instead of substr
+  Node ss1, ss2;
+   if (n1.getType().isString())
+  {
+    // substring of length 1
+    ss1 = nm->mkNode(STRING_SUBSTR, n1, k, d_one);
+    ss2 = nm->mkNode(STRING_SUBSTR, n2, k, d_one);
+  }
+  else
+  {
+    // as an optimization, for sequences, use seq.nth
+    ss1 = nm->mkNode(SEQ_NTH, n1, k);
+    ss2 = nm->mkNode(SEQ_NTH, n2, k);
+  }
 
   // disequality between nth/substr
   Node conc1 = ss1.eqNode(ss2).negate();

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2663,6 +2663,8 @@ set(regress_1_tests
   regress1/strings/issue8975-1.smt2
   regress1/strings/issue8975-2.smt2
   regress1/strings/issue8975-3.smt2
+  regress1/strings/issue8981-strings-deq-ext-nth.smt2
+  regress1/strings/issue8981-2-strings-deq-ext-nth.smt2
   regress1/strings/kaluza-fl.smt2
   regress1/strings/loop002.smt2
   regress1/strings/loop003.smt2

--- a/test/regress/cli/regress1/strings/issue8981-2-strings-deq-ext-nth.smt2
+++ b/test/regress/cli/regress1/strings/issue8981-2-strings-deq-ext-nth.smt2
@@ -1,0 +1,9 @@
+(set-logic QF_S)
+(declare-fun s () String)
+(assert (xor 
+            (str.<= (str.replace_all "FCBEDAC" s s) (str.replace_re "EBDCFAB" re.allchar s)) 
+            (str.in_re (str.replace s "EBDCFAB" "EBDCFAB") (re.union re.allchar re.allchar))
+        )
+)
+(set-info :status sat)
+(check-sat)

--- a/test/regress/cli/regress1/strings/issue8981-strings-deq-ext-nth.smt2
+++ b/test/regress/cli/regress1/strings/issue8981-strings-deq-ext-nth.smt2
@@ -1,0 +1,5 @@
+(set-logic QF_S)
+(declare-fun t () String)
+(assert (str.< t (str.to_lower t)))
+(set-info :status sat)
+(check-sat)


### PR DESCRIPTION
Fixes #8981. Our code for `seq.nth` on strings is not stable yet (see
also #8939). This reverts the use of `seq.nth` when `--strings-deq-ext`
is enabled.