### PR TITLE
[proof] Reintroduce option to print conclusions in internal proof format

### DIFF
--- a/src/options/proof_options.toml
+++ b/src/options/proof_options.toml
@@ -26,6 +26,14 @@ name   = "Proof"
   help       = "Output TPTP proof (work in progress)"
 
 [[option]]
+  name       = "proofPrintConclusion"
+  category   = "expert"
+  long       = "proof-print-conclusion"
+  type       = "bool"
+  default    = "false"
+  help       = "Print conclusion of proof steps when printing AST"
+
+[[option]]
   name       = "proofPedantic"
   category   = "expert"
   long       = "proof-pedantic=N"

--- a/src/proof/proof_node.cpp
+++ b/src/proof/proof_node.cpp
@@ -56,11 +56,11 @@ void ProofNode::setValue(
   d_args = args;
 }
 
-void ProofNode::printDebug(std::ostream& os) const
+void ProofNode::printDebug(std::ostream& os, bool printConclusion) const
 {
   // convert to sexpr and print
   ProofNodeToSExpr pnts;
-  Node ps = pnts.convertToSExpr(this);
+  Node ps = pnts.convertToSExpr(this, printConclusion);
   os << ps;
 }
 

--- a/src/proof/proof_node.h
+++ b/src/proof/proof_node.h
@@ -105,8 +105,12 @@ class ProofNode
    * Returns true if this is a closed proof (i.e. it has no free assumptions).
    */
   bool isClosed();
-  /** Print debug on output strem os */
-  void printDebug(std::ostream& os) const;
+  /** Print debug on output strem os
+   *
+   * @param os the stream to print to
+   * @param printConclusion Whether to print conclusions
+   */
+  void printDebug(std::ostream& os, bool printConclusion = false) const;
 
  private:
   /**

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -212,7 +212,9 @@ void PfManager::printProof(std::ostream& out,
   {
     // otherwise, print using default printer
     out << "(proof\n";
-    out << *fp;
+    // we call the printing method explicitly because we may want to print the
+    // final proof node with conclusions
+    fp->printDebug(out, options().proof.proofPrintConclusion);
     out << "\n)\n";
   }
 }


### PR DESCRIPTION
Does so via a dedicated printing method in proof nodes. For now it is only used for the final proof node.