### PR TITLE
Keep dependencies when resorting to TRUST_SUBS

### DIFF
--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -994,7 +994,7 @@ Node ProofPostprocessCallback::expandMacros(PfRule id,
             << eq << std::endl
             << eqq << std::endl
             << "from " << children << " applied to " << t << std::endl;
-        cdp->addStep(eqq, PfRule::TRUST_SUBS, {}, {eqq});
+        cdp->addStep(eqq, PfRule::TRUST_SUBS, children, {eqq});
       }
     }
     else

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -994,6 +994,7 @@ set(regress_0_tests
   regress0/proj-issue307-get-value-re.smt2
   regress0/proofs/cyclic-ucp.smt2
   regress0/proofs/issue277-circuit-propagator.smt2
+  regress0/proofs/issue8983-trust-subs.smt2
   regress0/proofs/lfsc-test-1.smt2
   regress0/proofs/nomerge-alethe-pf.smt2
   regress0/proofs/open-pf-datatypes.smt2

--- a/test/regress/cli/regress0/proofs/issue8983-trust-subs.smt2
+++ b/test/regress/cli/regress0/proofs/issue8983-trust-subs.smt2
@@ -1,0 +1,7 @@
+; COMMAND-LINE: --proof-granularity=theory-rewrite
+; EXPECT: unsat
+(set-logic ALL)
+(assert (= 0 (div 0 0)))
+(assert (not (= 0 (div 0 0 0))))
+(check-sat)
+


### PR DESCRIPTION
Fixes #8983.

When resorting to TRUST_SUBS, we should keep the original dependencies. 

Separately I will send a PR to ensure we don't rely on TRUST_SUBS in this case.