### PR TITLE
Python API: allow `mkTerm` to accept a list of arguments

### DIFF
--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -1141,8 +1141,17 @@ cdef class Solver:
         if len(args) == 0:
             term.cterm = self.csolver.mkTerm((<Op?> op).cop)
         else:
-            for a in args:
-                v.push_back((<Term?> a).cterm)
+            if len(args) == 1 and isinstance(args[0], list):
+                # if a proper list was given, extract it and
+                # iterate.
+                children = args[0]
+                for a in children:
+                    v.push_back((<Term?> a).cterm)
+            else:
+                # if arguments are comma-separated,
+                # iterate them directly.
+                for a in args:
+                    v.push_back((<Term?> a).cterm)
             term.cterm = self.csolver.mkTerm((<Op?> op).cop, v)
         return term
 

--- a/test/unit/api/python/test_solver.py
+++ b/test/unit/api/python/test_solver.py
@@ -774,6 +774,8 @@ def test_mk_term(solver):
     # Test cases that are nary via the API but have arity = 2 internally
     s_bool = solver.getBooleanSort()
     t_bool = solver.mkConst(s_bool, "t_bool")
+    solver.mkTerm(Kind.AND, t_bool, t_bool, t_bool)
+    solver.mkTerm(Kind.AND, [t_bool, t_bool, t_bool])
     solver.mkTerm(Kind.IMPLIES, t_bool, t_bool, t_bool)
     solver.mkTerm(Kind.XOR, t_bool, t_bool, t_bool)
     solver.mkTerm(solver.mkOp(Kind.XOR), t_bool, t_bool, t_bool)


### PR DESCRIPTION
The `cpp` API supports a list of arguments to `mkTerm`.
The python API supports a varying number of arguments, but not a proper list of arguments.
This PR fixes and tests that.