### PR TITLE
[Cython] Set language level explicitly

### DIFF
--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -64,7 +64,7 @@ set(CYTHON_FLAGS "-X embedsignature=True")
 
 configure_file(genenums.py.in genenums.py)
 
-# Generate cvc5kinds.{pxd,pyx}
+# Generate cvc5kinds.{pxd,pxi}
 set(GENERATED_KINDS_FILES
   "${CMAKE_CURRENT_BINARY_DIR}/cvc5kinds.pxd"
   "${CMAKE_CURRENT_BINARY_DIR}/cvc5kinds.pxi"

--- a/src/api/python/cvc5_python_base.pyx
+++ b/src/api/python/cvc5_python_base.pyx
@@ -1,3 +1,5 @@
+#cython: language_level=3
+
 include "cvc5kinds.pxi"
 include "cvc5types.pxi"
 include "cvc5.pxi"


### PR DESCRIPTION
This fixes a warning when compiling our Python bindings:

```
[...]/python3.10/site-packages/Cython/Compiler/Main.py:346: FutureWarning: Cython directive 'language_level' not set, using '3str' for now (Py3). This has changed from earlier releases! File: [...]/src/api/python/cvc5_python_base.pyx
  tree = Parsing.p_module(s, pxd, full_module_name)
```