### PR TITLE
Fix model block values mode when no terms are specified

### DIFF
--- a/src/smt/model_blocker.cpp
+++ b/src/smt/model_blocker.cpp
@@ -17,10 +17,10 @@
 
 #include "expr/node.h"
 #include "expr/node_algorithm.h"
+#include "theory/logic_info.h"
 #include "theory/quantifiers/term_util.h"
 #include "theory/rewriter.h"
 #include "theory/theory_model.h"
-#include "theory/logic_info.h"
 
 using namespace cvc5::internal::kind;
 
@@ -250,7 +250,8 @@ Node ModelBlocker::getModelBlocker(const std::vector<Node>& assertions,
           // ignore e.g. constructors
           continue;
         }
-        if (!logicInfo().isHigherOrder() && s.getType().getKind() == kind::FUNCTION_TYPE)
+        if (!logicInfo().isHigherOrder()
+            && s.getType().getKind() == kind::FUNCTION_TYPE)
         {
           // ignore functions if not higher-order
           continue;
@@ -281,7 +282,7 @@ Node ModelBlocker::getModelBlocker(const std::vector<Node>& assertions,
       }
     }
     for (const std::pair<const TypeNode, std::vector<Node> >& es :
-          nonClosedEnum)
+         nonClosedEnum)
     {
       size_t nenum = es.second.size();
       for (size_t i = 0; i < nenum; i++)

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2020,6 +2020,7 @@ set(regress_1_tests
   regress1/lemmas/clocksynchro_5clocks.main_invar.base.smtv1.smt2
   regress1/lemmas/pursuit-safety-8.smtv1.smt2
   regress1/minimal_unsat_core.smt2
+  regress1/model-blocker-no-spec-values.smt2
   regress1/model-blocker-simple.smt2
   regress1/model-blocker-values.smt2
   regress1/nl/approx-sqrt.smt2

--- a/test/regress/cli/regress1/model-blocker-no-spec-values.smt2
+++ b/test/regress/cli/regress1/model-blocker-no-spec-values.smt2
@@ -1,0 +1,31 @@
+; EXPECT: sat
+; EXPECT: unsat
+(set-logic ALL)
+(set-option :finite-model-find true)
+(set-option :produce-models true)
+(set-option :incremental true)
+(declare-sort UInt 0)
+(declare-fun intValue (UInt) Int)
+(declare-fun idenInt () (Set (Tuple UInt UInt)))
+
+; Identity relation definition for idenInt
+(assert
+ (forall ((x UInt)(y UInt))
+         (=
+          (set.member
+           (tuple x y) idenInt;
+           )
+          (= x y))))
+
+; intValue is injective
+(assert
+ (forall ((x UInt)(y UInt))
+         (=>
+          (not
+           (= x y))
+          (not
+           (= (intValue x) (intValue y))))))
+
+(check-sat)
+(block-model :values)
+(check-sat)


### PR DESCRIPTION
Previously we were not considering "non-closed enumerable" types when values mode was used without specifying terms.  Also skips non-first-class types.

A code block changed indentation, which is the cause of most of the diff.