### PR TITLE
Use synth verify utility to check side conditions for abduction

### DIFF
--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -600,27 +600,26 @@ bool SynthConjecture::doCheck()
   return true;
 }
 
-bool SynthConjecture::checkSideCondition(const std::vector<Node>& cvals) const
+bool SynthConjecture::checkSideCondition(const std::vector<Node>& cvals)
 {
-  if (!d_embedSideCondition.isNull())
+  if (d_embedSideCondition.isNull())
   {
-    Node sc = d_embedSideCondition;
-    if (!cvals.empty())
-    {
-      sc = sc.substitute(
-        d_candidates.begin(), d_candidates.end(), cvals.begin(), cvals.end());
-    }
-    Trace("sygus-engine") << "Check side condition..." << std::endl;
-    Trace("cegqi-debug") << "Check side condition : " << sc << std::endl;
-    sc = rewrite(sc);
-    Result r = checkWithSubsolver(sc, d_env);
-    Trace("cegqi-debug") << "...got side condition : " << r << std::endl;
-    if (r == Result::UNSAT)
-    {
-      return false;
-    }
-    Trace("sygus-engine") << "...passed side condition" << std::endl;
+    return true;
   }
+  Node sc = d_embedSideCondition;
+  if (!cvals.empty())
+  {
+    sc = sc.substitute(
+      d_candidates.begin(), d_candidates.end(), cvals.begin(), cvals.end());
+  }
+  Trace("sygus-engine") << "Check side condition..." << std::endl;
+  Result r = d_verify.verify(sc);
+  Trace("sygus-engine") << "...result of check side condition : " << r << std::endl;
+  if (r == Result::UNSAT)
+  {
+    return false;
+  }
+  Trace("sygus-engine") << "...passed side condition" << std::endl;
   return true;
 }
 

--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -610,11 +610,12 @@ bool SynthConjecture::checkSideCondition(const std::vector<Node>& cvals)
   if (!cvals.empty())
   {
     sc = sc.substitute(
-      d_candidates.begin(), d_candidates.end(), cvals.begin(), cvals.end());
+        d_candidates.begin(), d_candidates.end(), cvals.begin(), cvals.end());
   }
   Trace("sygus-engine") << "Check side condition..." << std::endl;
   Result r = d_verify.verify(sc);
-  Trace("sygus-engine") << "...result of check side condition : " << r << std::endl;
+  Trace("sygus-engine") << "...result of check side condition : " << r
+                        << std::endl;
   if (r == Result::UNSAT)
   {
     return false;

--- a/src/theory/quantifiers/sygus/synth_conjecture.h
+++ b/src/theory/quantifiers/sygus/synth_conjecture.h
@@ -147,7 +147,7 @@ class SynthConjecture : protected EnvObj
    * satisfy the side condition of the conjecture maintained by this class,
    * if it exists, and true otherwise.
    */
-  bool checkSideCondition(const std::vector<Node>& cvals) const;
+  bool checkSideCondition(const std::vector<Node>& cvals);
 
   /** get a reference to the statistics of parent */
   SygusStatistics& getSygusStatistics() { return d_stats; };

--- a/src/theory/quantifiers/sygus/synth_verify.cpp
+++ b/src/theory/quantifiers/sygus/synth_verify.cpp
@@ -20,11 +20,11 @@
 #include "options/base_options.h"
 #include "options/datatypes_options.h"
 #include "options/quantifiers_options.h"
+#include "smt/set_defaults.h"
 #include "theory/quantifiers/first_order_model.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
 #include "theory/rewriter.h"
 #include "theory/smt_engine_subsolver.h"
-#include "smt/set_defaults.h"
 
 using namespace cvc5::internal::kind;
 using namespace std;

--- a/src/theory/quantifiers/sygus/synth_verify.cpp
+++ b/src/theory/quantifiers/sygus/synth_verify.cpp
@@ -24,6 +24,7 @@
 #include "theory/quantifiers/sygus/term_database_sygus.h"
 #include "theory/rewriter.h"
 #include "theory/smt_engine_subsolver.h"
+#include "smt/set_defaults.h"
 
 using namespace cvc5::internal::kind;
 using namespace std;
@@ -57,6 +58,8 @@ SynthVerify::SynthVerify(Env& env, TermDbSygus* tds)
   d_subOptions.writeDatatypes().dtSharedSelectors =
       options().datatypes.dtSharedSelectors;
   d_subOptions.writeDatatypes().dtSharedSelectorsWasSetByUser = true;
+  // disable checking
+  smt::SetDefaults::disableChecking(d_subOptions);
 }
 
 SynthVerify::~SynthVerify() {}
@@ -76,6 +79,10 @@ Result SynthVerify::verify(Node query,
       if (!queryp.getConst<bool>())
       {
         return Result(Result::UNSAT);
+      }
+      else if (vars.empty())
+      {
+        return Result(Result::SAT);
       }
       // sat, but we need to get arbtirary model values below
     }
@@ -146,6 +153,13 @@ Result SynthVerify::verify(Node query,
     }
   } while (!finished);
   return r;
+}
+
+Result SynthVerify::verify(Node query)
+{
+  std::vector<Node> vars;
+  std::vector<Node> mvs;
+  return verify(query, vars, mvs);
 }
 
 Node SynthVerify::preprocessQueryInternal(Node query)

--- a/src/theory/quantifiers/sygus/synth_verify.h
+++ b/src/theory/quantifiers/sygus/synth_verify.h
@@ -50,6 +50,10 @@ class SynthVerify : protected EnvObj
   Result verify(Node query,
                 const std::vector<Node>& vars,
                 std::vector<Node>& mvs);
+  /**
+   * Same as above, without getting a model.
+   */
+  Result verify(Node query);
 
  private:
   /**

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1730,6 +1730,7 @@ set(regress_1_tests
   regress1/abduction/abd-simple-conj-4.smt2
   regress1/abduction/arjun-global-dec.smt2
   regress1/abduction/arjun-unsat-core-opt.smt2
+  regress1/abduction/dd.abduct-check-sc.smt2
   regress1/abduction/issue5848-2.smt2
   regress1/abduction/issue5848-3-trivial-no-abduct.smt2
   regress1/abduction/issue5848-4.smt2

--- a/test/regress/cli/regress1/abduction/dd.abduct-check-sc.smt2
+++ b/test/regress/cli/regress1/abduction/dd.abduct-check-sc.smt2
@@ -1,3 +1,6 @@
+; COMMAND-LINE: --produce-abducts
+; SCRUBBER: grep -v -E '(\(define-fun)'
+; EXIT: 0
 (set-logic ALL)
 (set-option :produce-unsat-cores true)
 (set-option :produce-abducts true)

--- a/test/regress/cli/regress1/abduction/dd.abduct-check-sc.smt2
+++ b/test/regress/cli/regress1/abduction/dd.abduct-check-sc.smt2
@@ -1,0 +1,5 @@
+(set-logic ALL)
+(set-option :produce-unsat-cores true)
+(set-option :produce-abducts true)
+(declare-const y (_ BitVec 2))
+(get-abduct abd (= y #b00))


### PR DESCRIPTION
Done for consistency (e.g. for special handling recursive functions or oracles), also configures options more consistently, disables checking which caused a spurious option exception when combining unsat cores and abduction.