### PR TITLE
Fix StatisticsRegistry misuse in coverings solver.

### DIFF
--- a/src/theory/arith/nl/coverings/cdcac.cpp
+++ b/src/theory/arith/nl/coverings/cdcac.cpp
@@ -104,7 +104,7 @@ const std::vector<poly::Variable>& CDCAC::getVariableOrdering() const
 std::vector<CACInterval> CDCAC::getUnsatIntervals(std::size_t cur_variable)
 {
   std::vector<CACInterval> res;
-  LazardEvaluation le;
+  LazardEvaluation le(statisticsRegistry());
   prepareRootIsolation(le, cur_variable);
   for (const auto& c : d_constraints.getConstraints())
   {
@@ -429,7 +429,7 @@ CACInterval CDCAC::intervalFromCharacterization(
 
   // Collect -oo, all roots, oo
 
-  LazardEvaluation le;
+  LazardEvaluation le(statisticsRegistry());
   prepareRootIsolation(le, cur_variable);
   std::vector<poly::Value> roots;
   roots.emplace_back(poly::Value::minus_infty());

--- a/src/theory/arith/nl/coverings/lazard_evaluation.cpp
+++ b/src/theory/arith/nl/coverings/lazard_evaluation.cpp
@@ -21,6 +21,7 @@
 
 #include "base/check.h"
 #include "base/output.h"
+#include "util/statistics_registry.h"
 #include "util/statistics_stats.h"
 
 #ifdef CVC5_USE_COCOA
@@ -33,17 +34,14 @@
 
 namespace cvc5::internal::theory::arith::nl::coverings {
 
-struct LazardEvaluationStats
-{
-  IntStat d_directAssignments = statisticsRegistry().registerInt(
-      "theory::arith::coverings::lazard-direct");
-  IntStat d_ranAssignments =
-      statisticsRegistry().registerInt("theory::arith::coverings::lazard-rans");
-  IntStat d_evaluations = statisticsRegistry().registerInt(
-      "theory::arith::coverings::lazard-evals");
-  IntStat d_reductions = statisticsRegistry().registerInt(
-      "theory::arith::coverings::lazard-reduce");
-};
+LazardEvaluationStats::LazardEvaluationStats(StatisticsRegistry& reg)
+    : d_directAssignments(
+        reg.registerInt("theory::arith::coverings::lazard-direct")),
+      d_ranAssignments(
+          reg.registerInt("theory::arith::coverings::lazard-rans")),
+      d_evaluations(reg.registerInt("theory::arith::coverings::lazard-evals")),
+      d_reductions(
+          reg.registerInt("theory::arith::coverings::lazard-reduce")){};
 
 struct LazardEvaluationState;
 std::ostream& operator<<(std::ostream& os, const LazardEvaluationState& state);
@@ -541,6 +539,8 @@ struct LazardEvaluationState
     }
     return res;
   }
+
+  LazardEvaluationState(StatisticsRegistry& reg) : d_stats(reg) {}
 };
 
 std::ostream& operator<<(std::ostream& os, const LazardEvaluationState& state)
@@ -563,8 +563,8 @@ std::ostream& operator<<(std::ostream& os, const LazardEvaluationState& state)
   return os;
 }
 
-LazardEvaluation::LazardEvaluation()
-    : d_state(std::make_unique<LazardEvaluationState>())
+LazardEvaluation::LazardEvaluation(StatisticsRegistry& reg)
+    : d_state(std::make_unique<LazardEvaluationState>(reg))
 {
 }
 
@@ -851,7 +851,7 @@ struct LazardEvaluationState
 {
   poly::Assignment d_assignment;
 };
-LazardEvaluation::LazardEvaluation()
+LazardEvaluation::LazardEvaluation(StatisticsRegistry&)
     : d_state(std::make_unique<LazardEvaluationState>())
 {
 }

--- a/src/theory/arith/nl/coverings/lazard_evaluation.h
+++ b/src/theory/arith/nl/coverings/lazard_evaluation.h
@@ -25,7 +25,18 @@
 
 #include <memory>
 
+#include "util/statistics_stats.h"
+
 namespace cvc5::internal::theory::arith::nl::coverings {
+
+struct LazardEvaluationStats
+{
+  IntStat d_directAssignments;
+  IntStat d_ranAssignments;
+  IntStat d_evaluations;
+  IntStat d_reductions;
+  LazardEvaluationStats(StatisticsRegistry& reg);
+};
 
 struct LazardEvaluationState;
 /**
@@ -73,7 +84,7 @@ struct LazardEvaluationState;
 class LazardEvaluation
 {
  public:
-  LazardEvaluation();
+  LazardEvaluation(StatisticsRegistry& reg);
   ~LazardEvaluation();
 
   /**

--- a/src/theory/arith/nl/coverings_solver.cpp
+++ b/src/theory/arith/nl/coverings_solver.cpp
@@ -24,6 +24,7 @@
 #include "theory/arith/nl/poly_conversion.h"
 #include "theory/inference_id.h"
 #include "theory/theory.h"
+#include "util/rational.h"
 
 namespace cvc5::internal {
 namespace theory {


### PR DESCRIPTION
The build was broken in `--cocoa --poly` configurations. Now it isn't.

Thanks, Shankara Pailoor, for contributing to this. 