### PR TITLE
Optimize arithmetic getEqualityStatus

### DIFF
--- a/src/theory/arith/arith_evaluator.cpp
+++ b/src/theory/arith/arith_evaluator.cpp
@@ -26,7 +26,7 @@ namespace arith {
 std::optional<bool> isExpressionZero(Env& env,
                                      Node expr,
                                      const std::vector<TNode>& nodes,
-  const std::vector<TNode>& repls)
+                                     const std::vector<TNode>& repls)
 {
   // Substitute constants and rewrite
   expr = env.getRewriter()->rewrite(expr);

--- a/src/theory/arith/arith_evaluator.cpp
+++ b/src/theory/arith/arith_evaluator.cpp
@@ -25,24 +25,14 @@ namespace arith {
 
 std::optional<bool> isExpressionZero(Env& env,
                                      Node expr,
-                                     const std::map<Node, Node>& model)
+                                     const std::vector<TNode>& nodes,
+  const std::vector<TNode>& repls)
 {
   // Substitute constants and rewrite
   expr = env.getRewriter()->rewrite(expr);
   if (expr.isConst())
   {
     return expr.getConst<Rational>().isZero();
-  }
-  std::vector<TNode> nodes;
-  std::vector<TNode> repls;
-  for (const auto& [node, repl] : model)
-  {
-    if (repl.getType().isRealOrInt()
-        && Theory::isLeafOf(repl, TheoryId::THEORY_ARITH))
-    {
-      nodes.emplace_back(node);
-      repls.emplace_back(repl);
-    }
   }
   expr =
       expr.substitute(nodes.begin(), nodes.end(), repls.begin(), repls.end());

--- a/src/theory/arith/arith_evaluator.h
+++ b/src/theory/arith/arith_evaluator.h
@@ -39,7 +39,7 @@ namespace arith {
 std::optional<bool> isExpressionZero(Env& env,
                                      Node expr,
                                      const std::vector<TNode>& nodes,
-  const std::vector<TNode>& repls);
+                                     const std::vector<TNode>& repls);
 }
 }  // namespace theory
 }  // namespace cvc5::internal

--- a/src/theory/arith/arith_evaluator.h
+++ b/src/theory/arith/arith_evaluator.h
@@ -29,8 +29,8 @@ namespace arith {
 
 /**
  * Check if the expression `expr` is zero over the given model.
- * The model may contain real algebraic numbers in standard witness form.
- * The environment is used for rewriting.
+ * The model { nodes -> repls } may contain real algebraic numbers in standard
+ * witness form. The environment is used for rewriting.
  *
  * The result is true or false, if the expression could be evaluated. If it
  * could not, possibly in the presence of a transcendental model, the result is
@@ -38,7 +38,8 @@ namespace arith {
  */
 std::optional<bool> isExpressionZero(Env& env,
                                      Node expr,
-                                     const std::map<Node, Node>& model);
+                                     const std::vector<TNode>& nodes,
+  const std::vector<TNode>& repls);
 }
 }  // namespace theory
 }  // namespace cvc5::internal

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -263,6 +263,7 @@ void TheoryArith::postCheck(Effort level)
       updateModelCache(termSet);
     }
     sanityCheckIntegerModel();
+    finalizeModelCache();
   }
 }
 
@@ -428,18 +429,23 @@ void TheoryArith::updateModelCacheInternal(const std::set<Node>& termSet)
     d_arithModelCacheSet = true;
     d_internal->collectModelValues(
         termSet, d_arithModelCache, d_arithModelCacheIllTyped);
-    // make into substitution
-    for (const auto& [node, repl] : d_arithModelCache)
+  }
+}
+
+void TheoryArith::finalizeModelCache()
+{
+  // make into substitution
+  for (const auto& [node, repl] : d_arithModelCache)
+  {
+    Assert(repl.getType().isRealOrInt());
+    if (Theory::isLeafOf(repl, TheoryId::THEORY_ARITH))
     {
-      Assert(repl.getType().isRealOrInt());
-      if (Theory::isLeafOf(repl, TheoryId::THEORY_ARITH))
-      {
-        d_arithModelCacheVars.emplace_back(node);
-        d_arithModelCacheSubs.emplace_back(repl);
-      }
+      d_arithModelCacheVars.emplace_back(node);
+      d_arithModelCacheSubs.emplace_back(repl);
     }
   }
 }
+
 bool TheoryArith::sanityCheckIntegerModel()
 {
   // Double check that the model from the linear solver respects integer types,

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -240,6 +240,8 @@ void TheoryArith::postCheck(Effort level)
   {
     d_arithModelCache.clear();
     d_arithModelCacheIllTyped.clear();
+    d_arithModelCacheVars.clear();
+    d_arithModelCacheSubs.clear();
     d_arithModelCacheSet = false;
     std::set<Node> termSet;
     if (d_nonlinearExtension != nullptr)
@@ -326,7 +328,7 @@ bool TheoryArith::collectModelValues(TheoryModel* m,
     }
   }
 
-  updateModelCache(termSet);
+  updateModelCacheInternal(termSet);
 
   // We are now ready to assert the model.
   for (const std::pair<const Node, Node>& p : d_arithModelCache)
@@ -382,7 +384,7 @@ EqualityStatus TheoryArith::getEqualityStatus(TNode a, TNode b) {
     return d_internal->getEqualityStatus(a,b);
   }
   Node diff = NodeManager::currentNM()->mkNode(Kind::SUB, a, b);
-  std::optional<bool> isZero = isExpressionZero(d_env, diff, d_arithModelCache);
+  std::optional<bool> isZero = isExpressionZero(d_env, diff, d_arithModelCacheVars, d_arithModelCacheSubs);
   if (isZero)
   {
     return *isZero ? EQUALITY_TRUE_IN_MODEL : EQUALITY_FALSE_IN_MODEL;
@@ -414,19 +416,27 @@ void TheoryArith::updateModelCache(std::set<Node>& termSet)
 {
   if (!d_arithModelCacheSet)
   {
-    d_arithModelCacheSet = true;
     collectAssertedTerms(termSet);
-    d_internal->collectModelValues(
-        termSet, d_arithModelCache, d_arithModelCacheIllTyped);
+    updateModelCacheInternal(termSet);
   }
 }
-void TheoryArith::updateModelCache(const std::set<Node>& termSet)
+void TheoryArith::updateModelCacheInternal(const std::set<Node>& termSet)
 {
   if (!d_arithModelCacheSet)
   {
     d_arithModelCacheSet = true;
     d_internal->collectModelValues(
         termSet, d_arithModelCache, d_arithModelCacheIllTyped);
+    // make into substitution
+    for (const auto& [node, repl] : d_arithModelCache)
+    {
+      Assert (repl.getType().isRealOrInt());
+      if (Theory::isLeafOf(repl, TheoryId::THEORY_ARITH))
+      {
+        d_arithModelCacheVars.emplace_back(node);
+        d_arithModelCacheSubs.emplace_back(repl);
+      }
+    }
   }
 }
 bool TheoryArith::sanityCheckIntegerModel()

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -263,6 +263,8 @@ void TheoryArith::postCheck(Effort level)
       updateModelCache(termSet);
     }
     sanityCheckIntegerModel();
+    // Now, finalize the model cache, which constructs a substitution to be
+    // used for getEqualityStatus.
     finalizeModelCache();
   }
 }

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -384,7 +384,8 @@ EqualityStatus TheoryArith::getEqualityStatus(TNode a, TNode b) {
     return d_internal->getEqualityStatus(a,b);
   }
   Node diff = NodeManager::currentNM()->mkNode(Kind::SUB, a, b);
-  std::optional<bool> isZero = isExpressionZero(d_env, diff, d_arithModelCacheVars, d_arithModelCacheSubs);
+  std::optional<bool> isZero = isExpressionZero(
+      d_env, diff, d_arithModelCacheVars, d_arithModelCacheSubs);
   if (isZero)
   {
     return *isZero ? EQUALITY_TRUE_IN_MODEL : EQUALITY_FALSE_IN_MODEL;
@@ -430,7 +431,7 @@ void TheoryArith::updateModelCacheInternal(const std::set<Node>& termSet)
     // make into substitution
     for (const auto& [node, repl] : d_arithModelCache)
     {
-      Assert (repl.getType().isRealOrInt());
+      Assert(repl.getType().isRealOrInt());
       if (Theory::isLeafOf(repl, TheoryId::THEORY_ARITH))
       {
         d_arithModelCacheVars.emplace_back(node);

--- a/src/theory/arith/theory_arith.h
+++ b/src/theory/arith/theory_arith.h
@@ -136,6 +136,8 @@ class TheoryArith : public Theory {
    * termSet.
    */
   void updateModelCacheInternal(const std::set<Node>& termSet);
+  /** Finalized model cache */
+  void finalizeModelCache();
   /**
    * Perform a sanity check on the model that all integer variables are assigned
    * to integer values. If an integer variables is assigned to a non-integer

--- a/src/theory/arith/theory_arith.h
+++ b/src/theory/arith/theory_arith.h
@@ -136,7 +136,11 @@ class TheoryArith : public Theory {
    * termSet.
    */
   void updateModelCacheInternal(const std::set<Node>& termSet);
-  /** Finalized model cache */
+  /**
+   * Finalized model cache. Called after d_arithModelCache is finalized during
+   * a full effort check. It computes d_arithModelCacheSubs/Vars, which are
+   * used during theory combination, for getEqualityStatus.
+   */
   void finalizeModelCache();
   /**
    * Perform a sanity check on the model that all integer variables are assigned

--- a/src/theory/arith/theory_arith.h
+++ b/src/theory/arith/theory_arith.h
@@ -135,7 +135,7 @@ class TheoryArith : public Theory {
    * Update d_arithModelCache (if it is empty right now) using the given
    * termSet.
    */
-  void updateModelCache(const std::set<Node>& termSet);
+  void updateModelCacheInternal(const std::set<Node>& termSet);
   /**
    * Perform a sanity check on the model that all integer variables are assigned
    * to integer values. If an integer variables is assigned to a non-integer
@@ -185,6 +185,9 @@ class TheoryArith : public Theory {
   std::map<Node, Node> d_arithModelCache;
   /** Component of the above that was ill-typed */
   std::map<Node, Node> d_arithModelCacheIllTyped;
+  /** The above model cache, in substitution form. */
+  std::vector<TNode> d_arithModelCacheVars;
+  std::vector<TNode> d_arithModelCacheSubs;
   /** Is the above map computed? */
   bool d_arithModelCacheSet;
 


### PR DESCRIPTION
Previously, we were translating the arithmetic model from a map to 2 vectors for *each* call to `getEqualityStatus`, which for reference is called >1 million times in our regression https://cvc5.stanford.edu/downloads/builds/coverage/cvc5-2022-08-01/buildbot/coverage/build/src/theory/arith/arith_evaluator.cpp.gcov.html.

This caches this conversion at the end of full effort checks.