### PR TITLE
Fix spurious registration lemma for string disequality split

### DIFF
--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2194,7 +2194,6 @@ void CoreSolver::processDeq(Node ni, Node nj)
           Node conc =
               getDecomposeConclusion(ux, uyLen, false, skc, newSkolems);
           Assert(newSkolems.size() == 2);
-          d_termReg.registerTermAtomic(newSkolems[1], LENGTH_GEQ_ONE);
           std::vector<Node> antecLen;
           antecLen.push_back(nm->mkNode(GT, uxLen, uyLen));
           d_im.sendInference(antecLen,

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2669,6 +2669,7 @@ set(regress_1_tests
   regress1/strings/issue8975-3.smt2
   regress1/strings/issue8981-strings-deq-ext-nth.smt2
   regress1/strings/issue8981-2-strings-deq-ext-nth.smt2
+  regress1/strings/issue9003-deq-split.smt2
   regress1/strings/kaluza-fl.smt2
   regress1/strings/loop002.smt2
   regress1/strings/loop003.smt2

--- a/test/regress/cli/regress1/strings/issue9003-deq-split.smt2
+++ b/test/regress/cli/regress1/strings/issue9003-deq-split.smt2
@@ -1,0 +1,9 @@
+; EXPECT: sat
+(set-logic QF_SLIA)
+(declare-fun x () String)
+(declare-fun y () String)
+(declare-fun i () Int)
+(assert (xor (str.<= (str.at y i) (str.update y 0 x)) (= y (str.++ x x))))
+(assert (str.in_re (str.++ x "z" y) (re.++ (re.* (re.++ (str.to_re "b") (str.to_re "z"))) (str.to_re "b"))))
+(assert (str.in_re x (re.* (re.range "a" "u"))))
+(check-sat)


### PR DESCRIPTION
Fixes #9003.

This removes a lemma that said that one of our splitting skolems could be assumed to have length >= 1, introduced here: https://github.com/cvc5/cvc5/pull/4821.
This lemma is unsound, since it assumes the length of a skolem, which can be introduced for other reasons.  In other words, the original form of the lemma is not valid.  I'm disabling this lemma altogether, as I don't think its necessary for performance (we constrain the length of the skolem in the conclusion anyways).