### PR TITLE
Catch logic exception for higher-order relation operators

### DIFF
--- a/src/theory/sets/theory_sets.cpp
+++ b/src/theory/sets/theory_sets.cpp
@@ -159,7 +159,7 @@ TrustNode TheorySets::ppRewrite(TNode n, std::vector<SkolemLemma>& lems)
       throw LogicException(ss.str());
     }
   }
-  if (nk==RELATION_AGGREGATE || nk == RELATION_PROJECT || nk == SET_FOLD)
+  if (nk==RELATION_AGGREGATE || nk == RELATION_PROJECT || nk == SET_MAP || nk == SET_FOLD)
   {
     // requires higher order
     if (!logicInfo().isHigherOrder())

--- a/src/theory/sets/theory_sets.cpp
+++ b/src/theory/sets/theory_sets.cpp
@@ -168,6 +168,17 @@ TrustNode TheorySets::ppRewrite(TNode n, std::vector<SkolemLemma>& lems)
     d_im.lemma(andNode, InferenceId::BAGS_FOLD);
     return TrustNode::mkTrustRewrite(n, ret, nullptr);
   }
+  if (nk==RELATION_AGGREGATE || nk == RELATION_PROJECT)
+  {
+    // requires higher order
+    if (!logicInfo().isHigherOrder())
+    {
+      std::stringstream ss;
+      ss << "Term of kind " << nk << " are only supported with "
+            "higher-order logic. Try adding the logic prefix HO_.";
+      throw LogicException(ss.str());
+    }
+  }
   if (nk == RELATION_AGGREGATE)
   {
     Node ret = SetReduction::reduceAggregateOperator(n);

--- a/src/theory/sets/theory_sets.cpp
+++ b/src/theory/sets/theory_sets.cpp
@@ -159,16 +159,7 @@ TrustNode TheorySets::ppRewrite(TNode n, std::vector<SkolemLemma>& lems)
       throw LogicException(ss.str());
     }
   }
-  if (nk == SET_FOLD)
-  {
-    std::vector<Node> asserts;
-    Node ret = SetReduction::reduceFoldOperator(n, asserts);
-    NodeManager* nm = NodeManager::currentNM();
-    Node andNode = nm->mkNode(AND, asserts);
-    d_im.lemma(andNode, InferenceId::BAGS_FOLD);
-    return TrustNode::mkTrustRewrite(n, ret, nullptr);
-  }
-  if (nk==RELATION_AGGREGATE || nk == RELATION_PROJECT)
+  if (nk==RELATION_AGGREGATE || nk == RELATION_PROJECT || nk == SET_FOLD)
   {
     // requires higher order
     if (!logicInfo().isHigherOrder())
@@ -178,6 +169,15 @@ TrustNode TheorySets::ppRewrite(TNode n, std::vector<SkolemLemma>& lems)
             "higher-order logic. Try adding the logic prefix HO_.";
       throw LogicException(ss.str());
     }
+  }
+  if (nk == SET_FOLD)
+  {
+    std::vector<Node> asserts;
+    Node ret = SetReduction::reduceFoldOperator(n, asserts);
+    NodeManager* nm = NodeManager::currentNM();
+    Node andNode = nm->mkNode(AND, asserts);
+    d_im.lemma(andNode, InferenceId::BAGS_FOLD);
+    return TrustNode::mkTrustRewrite(n, ret, nullptr);
   }
   if (nk == RELATION_AGGREGATE)
   {

--- a/src/theory/sets/theory_sets.cpp
+++ b/src/theory/sets/theory_sets.cpp
@@ -159,13 +159,15 @@ TrustNode TheorySets::ppRewrite(TNode n, std::vector<SkolemLemma>& lems)
       throw LogicException(ss.str());
     }
   }
-  if (nk==RELATION_AGGREGATE || nk == RELATION_PROJECT || nk == SET_MAP || nk == SET_FOLD)
+  if (nk == RELATION_AGGREGATE || nk == RELATION_PROJECT || nk == SET_MAP
+      || nk == SET_FOLD)
   {
     // requires higher order
     if (!logicInfo().isHigherOrder())
     {
       std::stringstream ss;
-      ss << "Term of kind " << nk << " are only supported with "
+      ss << "Term of kind " << nk
+         << " are only supported with "
             "higher-order logic. Try adding the logic prefix HO_.";
       throw LogicException(ss.str());
     }

--- a/src/theory/sets/theory_sets_rewriter.cpp
+++ b/src/theory/sets/theory_sets_rewriter.cpp
@@ -786,10 +786,13 @@ RewriteResponse TheorySetsRewriter::postRewriteAggregate(TNode n)
 RewriteResponse TheorySetsRewriter::postRewriteProject(TNode n)
 {
   Assert(n.getKind() == RELATION_PROJECT);
-  Node ret = SetReduction::reduceProjectOperator(n);
-  if (ret != n)
+  if (n[0].isConst())
   {
-    return RewriteResponse(REWRITE_AGAIN_FULL, ret);
+    Node ret = SetReduction::reduceProjectOperator(n);
+    if (ret != n)
+    {
+      return RewriteResponse(REWRITE_AGAIN_FULL, ret);
+    }
   }
   return RewriteResponse(REWRITE_DONE, n);
 }

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -195,7 +195,7 @@ TrustNode TheoryUF::ppRewrite(TNode node, std::vector<SkolemLemma>& lems)
                       << std::endl;
   Kind k = node.getKind();
   bool isHol = logicInfo().isHigherOrder();
-  if (k == kind::HO_APPLY || (node.isVar() && node.getType().isFunction()))
+  if (k == kind::HO_APPLY || node.getType().isFunction())
   {
     if (!isHol)
     {
@@ -206,7 +206,7 @@ TrustNode TheoryUF::ppRewrite(TNode node, std::vector<SkolemLemma>& lems)
       }
       else
       {
-        ss << "Function variables";
+        ss << "Function terms";
       }
       ss << " are only supported with "
             "higher-order logic. Try adding the logic prefix HO_.";

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2462,6 +2462,7 @@ set(regress_1_tests
   regress1/sets/choose3.smt2
   regress1/sets/choose4.smt2
   regress1/sets/issue5705-cg-subtyping.smt2
+  regress1/sets/issue8987-ho-exception.smt2
   regress1/sets/ListElem.hs.fqout.cvc4.38.smt2
   regress1/sets/ListElts.hs.fqout.cvc4.317.smt2
   regress1/sets/TalkingAboutSets.hs.fqout.cvc4.3577.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2462,6 +2462,7 @@ set(regress_1_tests
   regress1/sets/choose3.smt2
   regress1/sets/choose4.smt2
   regress1/sets/issue5705-cg-subtyping.smt2
+  regress1/sets/issue8987-ho.smt2
   regress1/sets/issue8987-ho-exception.smt2
   regress1/sets/ListElem.hs.fqout.cvc4.38.smt2
   regress1/sets/ListElts.hs.fqout.cvc4.317.smt2

--- a/test/regress/cli/regress1/sets/issue8987-ho-exception.smt2
+++ b/test/regress/cli/regress1/sets/issue8987-ho-exception.smt2
@@ -1,0 +1,8 @@
+; EXPECT: (error "Term of kind rel.project are only supported with higher-order logic. Try adding the logic prefix HO_.")
+; EXIT: 1
+(set-logic ALL)
+(set-option :strings-exp true)
+(declare-fun e () (Relation String))
+(declare-fun v () Int)
+(assert (and (= (str.from_int v) (str.from_int 0)) (= (rel.project e) (rel.project (set.singleton (tuple ""))))))
+(check-sat)

--- a/test/regress/cli/regress1/sets/issue8987-ho.smt2
+++ b/test/regress/cli/regress1/sets/issue8987-ho.smt2
@@ -1,0 +1,8 @@
+; COMMAND-LINE: --uf-lazy-ll
+; EXPECT: sat
+(set-logic HO_ALL)
+(set-option :strings-exp true)
+(declare-fun e () (Relation String))
+(declare-fun v () Int)
+(assert (and (= (str.from_int v) (str.from_int 0)) (= (rel.project e) (rel.project (set.singleton (tuple ""))))))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/8987.

Also strengthens the LogicException check in UF, which erroneously was limited to variables.  

Also makes it so we don't reduce `rel.project` in the rewriter unless its argument is a constant.