### PR TITLE
api: Refactor sort and term (like) objects to not depend on Solver. 

### DIFF
--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -1479,7 +1479,7 @@ Sort Sort::instantiate(const std::vector<Sort>& params) const
 {
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK_NOT_NULL;
-  CVC5_API_CHECK_DOMAIN_SORTS(d_nm, params);
+  CVC5_API_CHECK_DOMAIN_SORTS(params);
   CVC5_API_CHECK(d_type->isParametricDatatype()
                  || d_type->isUninterpretedSortConstructor())
       << "Expected parametric datatype or sort constructor sort.";
@@ -1513,8 +1513,8 @@ Sort Sort::substitute(const Sort& sort, const Sort& replacement) const
 {
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK_NOT_NULL;
-  CVC5_API_CHECK_SORT(d_nm, sort);
-  CVC5_API_CHECK_SORT(d_nm, replacement);
+  CVC5_API_CHECK_SORT(sort);
+  CVC5_API_CHECK_SORT(replacement);
   //////// all checks before this line
   return Sort(
       d_nm, d_type->substitute(sort.getTypeNode(), replacement.getTypeNode()));
@@ -1527,8 +1527,8 @@ Sort Sort::substitute(const std::vector<Sort>& sorts,
 {
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK_NOT_NULL;
-  CVC5_API_CHECK_SORTS(d_nm, sorts);
-  CVC5_API_CHECK_SORTS(d_nm, replacements);
+  CVC5_API_CHECK_SORTS(sorts);
+  CVC5_API_CHECK_SORTS(replacements);
   //////// all checks before this line
 
   std::vector<internal::TypeNode> tSorts = sortVectorToTypeNodes(sorts),
@@ -2369,8 +2369,8 @@ Term Term::substitute(const Term& term, const Term& replacement) const
 {
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK_NOT_NULL;
-  CVC5_API_CHECK_TERM(d_nm, term);
-  CVC5_API_CHECK_TERM(d_nm, replacement);
+  CVC5_API_CHECK_TERM(term);
+  CVC5_API_CHECK_TERM(replacement);
   CVC5_API_CHECK(term.getSort() == replacement.getSort())
       << "Expecting terms of the same sort in substitute";
   //////// all checks before this line
@@ -2388,7 +2388,7 @@ Term Term::substitute(const std::vector<Term>& terms,
   CVC5_API_CHECK_NOT_NULL;
   CVC5_API_CHECK(terms.size() == replacements.size())
       << "Expecting vectors of the same arity in substitute";
-  CVC5_API_TERM_CHECK_TERMS_WITH_TERMS_SORT_EQUAL_TO(d_nm, terms, replacements);
+  CVC5_API_TERM_CHECK_TERMS_WITH_TERMS_SORT_EQUAL_TO(terms, replacements);
   //////// all checks before this line
   std::vector<internal::Node> nodes = Term::termVectorToNodes(terms);
   std::vector<internal::Node> nodeReplacements =
@@ -2491,7 +2491,7 @@ Term Term::andTerm(const Term& t) const
 {
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK_NOT_NULL;
-  CVC5_API_CHECK_TERM(d_nm, t);
+  CVC5_API_CHECK_TERM(t);
   //////// all checks before this line
   internal::Node res = d_node->andNode(*t.d_node);
   (void)res.getType(true); /* kick off type checking */
@@ -2504,7 +2504,7 @@ Term Term::orTerm(const Term& t) const
 {
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK_NOT_NULL;
-  CVC5_API_CHECK_TERM(d_nm, t);
+  CVC5_API_CHECK_TERM(t);
   //////// all checks before this line
   internal::Node res = d_node->orNode(*t.d_node);
   (void)res.getType(true); /* kick off type checking */
@@ -2517,7 +2517,7 @@ Term Term::xorTerm(const Term& t) const
 {
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK_NOT_NULL;
-  CVC5_API_CHECK_TERM(d_nm, t);
+  CVC5_API_CHECK_TERM(t);
   //////// all checks before this line
   internal::Node res = d_node->xorNode(*t.d_node);
   (void)res.getType(true); /* kick off type checking */
@@ -2530,7 +2530,7 @@ Term Term::eqTerm(const Term& t) const
 {
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK_NOT_NULL;
-  CVC5_API_CHECK_TERM(d_nm, t);
+  CVC5_API_CHECK_TERM(t);
   //////// all checks before this line
   internal::Node res = d_node->eqNode(*t.d_node);
   (void)res.getType(true); /* kick off type checking */
@@ -2543,7 +2543,7 @@ Term Term::impTerm(const Term& t) const
 {
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK_NOT_NULL;
-  CVC5_API_CHECK_TERM(d_nm, t);
+  CVC5_API_CHECK_TERM(t);
   //////// all checks before this line
   internal::Node res = d_node->impNode(*t.d_node);
   (void)res.getType(true); /* kick off type checking */
@@ -2556,8 +2556,8 @@ Term Term::iteTerm(const Term& then_t, const Term& else_t) const
 {
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK_NOT_NULL;
-  CVC5_API_CHECK_TERM(d_nm, then_t);
-  CVC5_API_CHECK_TERM(d_nm, else_t);
+  CVC5_API_CHECK_TERM(then_t);
+  CVC5_API_CHECK_TERM(else_t);
   //////// all checks before this line
   internal::Node res = d_node->iteNode(*then_t.d_node, *else_t.d_node);
   (void)res.getType(true); /* kick off type checking */
@@ -3456,7 +3456,7 @@ void DatatypeConstructorDecl::addSelector(const std::string& name,
 {
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK_NOT_NULL;
-  CVC5_API_CHECK_SORT(d_nm, sort);
+  CVC5_API_CHECK_SORT(sort);
   CVC5_API_ARG_CHECK_EXPECTED(!sort.isNull(), sort)
       << "non-null codomain sort for selector";
   //////// all checks before this line
@@ -3572,7 +3572,7 @@ void DatatypeDecl::addConstructor(const DatatypeConstructorDecl& ctor)
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK_NOT_NULL;
   CVC5_API_ARG_CHECK_NOT_NULL(ctor);
-  CVC5_API_ARG_ASSERT_NM(d_nm, "datatype constructor declaration", ctor);
+  CVC5_API_ARG_ASSERT_NM("datatype constructor declaration", ctor);
   //////// all checks before this line
   d_dtype->addConstructor(ctor.d_ctor);
   ////////
@@ -4286,7 +4286,7 @@ std::ostream& operator<<(std::ostream& out, const Datatype& dtype)
 /* -------------------------------------------------------------------------- */
 
 Grammar::Grammar()
-    : d_solver(nullptr),
+    : d_nm(nullptr),
       d_sygusVars(),
       d_ntSyms(),
       d_ntsToTerms(0),
@@ -4296,10 +4296,10 @@ Grammar::Grammar()
 {
 }
 
-Grammar::Grammar(const Solver* slv,
+Grammar::Grammar(internal::NodeManager* nm,
                  const std::vector<Term>& sygusVars,
                  const std::vector<Term>& ntSymbols)
-    : d_solver(slv),
+    : d_nm(nm),
       d_sygusVars(sygusVars),
       d_ntSyms(ntSymbols),
       d_ntsToTerms(ntSymbols.size()),
@@ -4318,8 +4318,8 @@ void Grammar::addRule(const Term& ntSymbol, const Term& rule)
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK(!d_isResolved) << "Grammar cannot be modified after passing "
                                    "it as an argument to synthFun/synthInv";
-  CVC5_API_CHECK_TERM(d_solver->getNodeManager(), ntSymbol);
-  CVC5_API_CHECK_TERM(d_solver->getNodeManager(), rule);
+  CVC5_API_CHECK_TERM(ntSymbol);
+  CVC5_API_CHECK_TERM(rule);
   CVC5_API_ARG_CHECK_EXPECTED(
       d_ntsToTerms.find(ntSymbol) != d_ntsToTerms.cend(), ntSymbol)
       << "ntSymbol to be one of the non-terminal symbols given in the "
@@ -4340,9 +4340,8 @@ void Grammar::addRules(const Term& ntSymbol, const std::vector<Term>& rules)
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK(!d_isResolved) << "Grammar cannot be modified after passing "
                                    "it as an argument to synthFun/synthInv";
-  CVC5_API_CHECK_TERM(d_solver->getNodeManager(), ntSymbol);
-  CVC5_API_CHECK_TERMS_WITH_SORT(
-      d_solver->getNodeManager(), rules, ntSymbol.getSort());
+  CVC5_API_CHECK_TERM(ntSymbol);
+  CVC5_API_CHECK_TERMS_WITH_SORT(rules, ntSymbol.getSort());
   CVC5_API_ARG_CHECK_EXPECTED(
       d_ntsToTerms.find(ntSymbol) != d_ntsToTerms.cend(), ntSymbol)
       << "ntSymbol to be one of the non-terminal symbols given in the "
@@ -4366,7 +4365,7 @@ void Grammar::addAnyConstant(const Term& ntSymbol)
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK(!d_isResolved) << "Grammar cannot be modified after passing "
                                    "it as an argument to synthFun/synthInv";
-  CVC5_API_CHECK_TERM(d_solver->getNodeManager(), ntSymbol);
+  CVC5_API_CHECK_TERM(ntSymbol);
   CVC5_API_ARG_CHECK_EXPECTED(
       d_ntsToTerms.find(ntSymbol) != d_ntsToTerms.cend(), ntSymbol)
       << "ntSymbol to be one of the non-terminal symbols given in the "
@@ -4382,7 +4381,7 @@ void Grammar::addAnyVariable(const Term& ntSymbol)
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK(!d_isResolved) << "Grammar cannot be modified after passing "
                                    "it as an argument to synthFun/synthInv";
-  CVC5_API_CHECK_TERM(d_solver->getNodeManager(), ntSymbol);
+  CVC5_API_CHECK_TERM(ntSymbol);
   CVC5_API_ARG_CHECK_EXPECTED(
       d_ntsToTerms.find(ntSymbol) != d_ntsToTerms.cend(), ntSymbol)
       << "ntSymbol to be one of the non-terminal symbols given in the "
@@ -4477,13 +4476,12 @@ Sort Grammar::resolve()
   d_isResolved = true;
 
   Term bvl;
-  internal::NodeManager* nm = d_solver->getNodeManager();
 
   if (!d_sygusVars.empty())
   {
-    bvl = Term(nm,
-               nm->mkNode(internal::kind::BOUND_VAR_LIST,
-                          Term::termVectorToNodes(d_sygusVars)));
+    bvl = Term(d_nm,
+               d_nm->mkNode(internal::kind::BOUND_VAR_LIST,
+                            Term::termVectorToNodes(d_sygusVars)));
   }
 
   std::unordered_map<Term, Sort> ntsToUnres(d_ntSyms.size());
@@ -4493,7 +4491,7 @@ Sort Grammar::resolve()
     // make the unresolved type, used for referencing the final version of
     // the ntsymbol's datatype
     ntsToUnres[ntsymbol] =
-        Sort(nm, nm->mkUnresolvedDatatypeSort(ntsymbol.toString()));
+        Sort(d_nm, d_nm->mkUnresolvedDatatypeSort(ntsymbol.toString()));
   }
 
   std::vector<internal::DType> datatypes;
@@ -4503,7 +4501,7 @@ Sort Grammar::resolve()
   for (const Term& ntSym : d_ntSyms)
   {
     // make the datatype, which encodes terms generated by this non-terminal
-    DatatypeDecl dtDecl(nm, ntSym.toString());
+    DatatypeDecl dtDecl(d_nm, ntSym.toString());
 
     for (const Term& consTerm : d_ntsToTerms[ntSym])
     {
@@ -4512,7 +4510,7 @@ Sort Grammar::resolve()
 
     if (d_allowVars.find(ntSym) != d_allowVars.cend())
     {
-      addSygusConstructorVariables(dtDecl, Sort(nm, ntSym.d_node->getType()));
+      addSygusConstructorVariables(dtDecl, Sort(d_nm, ntSym.d_node->getType()));
     }
 
     bool aci = d_allowConst.find(ntSym) != d_allowConst.end();
@@ -4530,10 +4528,10 @@ Sort Grammar::resolve()
   }
 
   std::vector<internal::TypeNode> datatypeTypes =
-      nm->mkMutualDatatypeTypes(datatypes);
+      d_nm->mkMutualDatatypeTypes(datatypes);
 
   // return is the first datatype
-  return Sort(nm, datatypeTypes[0]);
+  return Sort(d_nm, datatypeTypes[0]);
   ////////
   CVC5_API_TRY_CATCH_END;
 }
@@ -4544,10 +4542,9 @@ void Grammar::addSygusConstructorTerm(
     const std::unordered_map<Term, Sort>& ntsToUnres) const
 {
   CVC5_API_TRY_CATCH_BEGIN;
-  internal::NodeManager* nm = d_solver->getNodeManager();
-  CVC5_API_CHECK_DTDECL(nm, dt);
-  CVC5_API_CHECK_TERM(nm, term);
-  CVC5_API_CHECK_TERMS_MAP(nm, ntsToUnres);
+  CVC5_API_CHECK_DTDECL(dt);
+  CVC5_API_CHECK_TERM(term);
+  CVC5_API_CHECK_TERMS_MAP(ntsToUnres);
   //////// all checks before this line
 
   // At this point, we should know that dt is well founded, and that its
@@ -4565,11 +4562,12 @@ void Grammar::addSygusConstructorTerm(
   ssCName << op.getKind();
   if (!args.empty())
   {
-    Term lbvl = Term(nm,
-                     nm->mkNode(internal::kind::BOUND_VAR_LIST,
-                                Term::termVectorToNodes(args)));
+    Term lbvl = Term(d_nm,
+                     d_nm->mkNode(internal::kind::BOUND_VAR_LIST,
+                                  Term::termVectorToNodes(args)));
     // its operator is a lambda
-    op = Term(nm, nm->mkNode(internal::kind::LAMBDA, *lbvl.d_node, *op.d_node));
+    op = Term(d_nm,
+              d_nm->mkNode(internal::kind::LAMBDA, *lbvl.d_node, *op.d_node));
   }
   std::vector<internal::TypeNode> cargst = Sort::sortVectorToTypeNodes(cargs);
   dt.d_dtype->addSygusConstructor(*op.d_node, ssCName.str(), cargst);
@@ -4584,17 +4582,16 @@ Term Grammar::purifySygusGTerm(
     const std::unordered_map<Term, Sort>& ntsToUnres) const
 {
   CVC5_API_TRY_CATCH_BEGIN;
-  internal::NodeManager* nm = d_solver->getNodeManager();
-  CVC5_API_CHECK_TERM(nm, term);
-  CVC5_API_CHECK_TERMS(nm, args);
-  CVC5_API_CHECK_SORTS(nm, cargs);
-  CVC5_API_CHECK_TERMS_MAP(nm, ntsToUnres);
+  CVC5_API_CHECK_TERM(term);
+  CVC5_API_CHECK_TERMS(args);
+  CVC5_API_CHECK_SORTS(cargs);
+  CVC5_API_CHECK_TERMS_MAP(ntsToUnres);
   //////// all checks before this line
 
   std::unordered_map<Term, Sort>::const_iterator itn = ntsToUnres.find(term);
   if (itn != ntsToUnres.cend())
   {
-    Term ret = Term(nm, nm->mkBoundVar(term.d_node->getType()));
+    Term ret = Term(d_nm, d_nm->mkBoundVar(term.d_node->getType()));
     args.push_back(ret);
     cargs.push_back(itn->second);
     return ret;
@@ -4603,8 +4600,8 @@ Term Grammar::purifySygusGTerm(
   bool childChanged = false;
   for (unsigned i = 0, nchild = term.d_node->getNumChildren(); i < nchild; i++)
   {
-    Term ptermc =
-        purifySygusGTerm(Term(nm, (*term.d_node)[i]), args, cargs, ntsToUnres);
+    Term ptermc = purifySygusGTerm(
+        Term(d_nm, (*term.d_node)[i]), args, cargs, ntsToUnres);
     pchildren.push_back(ptermc);
     childChanged = childChanged || *ptermc.d_node != (*term.d_node)[i];
   }
@@ -4625,11 +4622,11 @@ Term Grammar::purifySygusGTerm(
   }
   else
   {
-    nret =
-        nm->mkNode(term.d_node->getKind(), Term::termVectorToNodes(pchildren));
+    nret = d_nm->mkNode(term.d_node->getKind(),
+                        Term::termVectorToNodes(pchildren));
   }
 
-  return Term(nm, nret);
+  return Term(d_nm, nret);
   ////////
   CVC5_API_TRY_CATCH_END;
 }
@@ -4638,9 +4635,8 @@ void Grammar::addSygusConstructorVariables(DatatypeDecl& dt,
                                            const Sort& sort) const
 {
   CVC5_API_TRY_CATCH_BEGIN;
-  internal::NodeManager* nm = d_solver->getNodeManager();
-  CVC5_API_CHECK_DTDECL(nm, dt);
-  CVC5_API_CHECK_SORT(nm, sort);
+  CVC5_API_CHECK_DTDECL(dt);
+  CVC5_API_CHECK_SORT(sort);
   //////// all checks before this line
 
   // each variable of appropriate type becomes a sygus constructor in dt.
@@ -7428,7 +7424,7 @@ Grammar Solver::mkGrammar(const std::vector<Term>& boundVars,
   CVC5_API_SOLVER_CHECK_BOUND_VARS(boundVars);
   CVC5_API_SOLVER_CHECK_BOUND_VARS(ntSymbols);
   //////// all checks before this line
-  return Grammar(this, boundVars, ntSymbols);
+  return Grammar(d_nm, boundVars, ntSymbols);
   ////////
   CVC5_API_TRY_CATCH_END;
 }

--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -3562,6 +3562,11 @@ DatatypeDecl::~DatatypeDecl()
   }
 }
 
+bool DatatypeDecl::isResolved() const
+{
+  return d_dtype == nullptr || d_dtype->isResolved();
+}
+
 void DatatypeDecl::addConstructor(const DatatypeConstructorDecl& ctor)
 {
   CVC5_API_TRY_CATCH_BEGIN;

--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -3572,7 +3572,7 @@ void DatatypeDecl::addConstructor(const DatatypeConstructorDecl& ctor)
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK_NOT_NULL;
   CVC5_API_ARG_CHECK_NOT_NULL(ctor);
-  CVC5_API_ARG_CHECK_NM(d_nm, "datatype constructor declaration", ctor);
+  CVC5_API_ARG_ASSERT_NM(d_nm, "datatype constructor declaration", ctor);
   //////// all checks before this line
   d_dtype->addConstructor(ctor.d_ctor);
   ////////

--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -4318,9 +4318,8 @@ void Grammar::addRule(const Term& ntSymbol, const Term& rule)
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK(!d_isResolved) << "Grammar cannot be modified after passing "
                                    "it as an argument to synthFun/synthInv";
-  internal::NodeManager* nm = d_solver->getNodeManager();
-  CVC5_API_CHECK_TERM(nm, ntSymbol);
-  CVC5_API_CHECK_TERM(nm, rule);
+  CVC5_API_CHECK_TERM(d_solver->getNodeManager(), ntSymbol);
+  CVC5_API_CHECK_TERM(d_solver->getNodeManager(), rule);
   CVC5_API_ARG_CHECK_EXPECTED(
       d_ntsToTerms.find(ntSymbol) != d_ntsToTerms.cend(), ntSymbol)
       << "ntSymbol to be one of the non-terminal symbols given in the "
@@ -4341,9 +4340,9 @@ void Grammar::addRules(const Term& ntSymbol, const std::vector<Term>& rules)
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK(!d_isResolved) << "Grammar cannot be modified after passing "
                                    "it as an argument to synthFun/synthInv";
-  internal::NodeManager* nm = d_solver->getNodeManager();
-  CVC5_API_CHECK_TERM(nm, ntSymbol);
-  CVC5_API_CHECK_TERMS_WITH_SORT(nm, rules, ntSymbol.getSort());
+  CVC5_API_CHECK_TERM(d_solver->getNodeManager(), ntSymbol);
+  CVC5_API_CHECK_TERMS_WITH_SORT(
+      d_solver->getNodeManager(), rules, ntSymbol.getSort());
   CVC5_API_ARG_CHECK_EXPECTED(
       d_ntsToTerms.find(ntSymbol) != d_ntsToTerms.cend(), ntSymbol)
       << "ntSymbol to be one of the non-terminal symbols given in the "

--- a/src/api/cpp/cvc5.h
+++ b/src/api/cpp/cvc5.h
@@ -832,15 +832,15 @@ class CVC5_EXPORT Sort
       const std::vector<Sort>& sorts);
   /** Helper to convert a vector of internal TypeNodes to Sorts. */
   std::vector<Sort> static typeNodeVectorToSorts(
-      const Solver* slv, const std::vector<internal::TypeNode>& types);
+      internal::NodeManager* nm, const std::vector<internal::TypeNode>& types);
 
   /**
    * Constructor.
-   * @param slv The associated solver object.
+   * @param nm The associated node manager.
    * @param t The internal type that is to be wrapped by this sort.
    * @return The Sort.
    */
-  Sort(const Solver* slv, const internal::TypeNode& t);
+  Sort(internal::NodeManager* nm, const internal::TypeNode& t);
 
   /**
    * Helper for isNull checks. This prevents calling an API function with
@@ -849,9 +849,9 @@ class CVC5_EXPORT Sort
   bool isNullHelper() const;
 
   /**
-   * The associated solver object.
+   * The associated node manager.
    */
-  const Solver* d_solver;
+  internal::NodeManager* d_nm;
 
   /**
    * The internal type wrapped by this sort.
@@ -918,7 +918,7 @@ class CVC5_EXPORT Op
   /**
    * Syntactic equality operator.
    *
-   * @note Both operators must belong to the same solver object.
+   * @note Both operators must belong to the same node manager.
    *
    * @param t The operator to compare to for equality.
    * @return True if both operators are syntactically identical.
@@ -928,7 +928,7 @@ class CVC5_EXPORT Op
   /**
    * Syntactic disequality operator.
    *
-   * @note Both terms must belong to the same solver object.
+   * @note Both terms must belong to the same node manager.
    *
    * @param t The operator to compare to for disequality.
    * @return True if operators differ syntactically.
@@ -970,19 +970,19 @@ class CVC5_EXPORT Op
  private:
   /**
    * Constructor for a single kind (non-indexed operator).
-   * @param slv The associated solver object.
+   * @param nm The associated node manager.
    * @param k The kind of this Op.
    */
-  Op(const Solver* slv, const Kind k);
+  Op(internal::NodeManager* nm, const Kind k);
 
   /**
    * Constructor.
-   * @param slv The associated solver object.
+   * @param nm The associated node managaer.
    * @param k The kind of this Op.
    * @param n The internal node that is to be wrapped by this term.
    * @return The Term.
    */
-  Op(const Solver* slv, const Kind k, const internal::Node& n);
+  Op(internal::NodeManager* nm, const Kind k, const internal::Node& n);
 
   /**
    * Helper for isNull checks. This prevents calling an API function with
@@ -1015,9 +1015,9 @@ class CVC5_EXPORT Op
   Term getIndexHelper(size_t index) const;
 
   /**
-   * The associated solver object.
+   * The associated node manager.
    */
-  const Solver* d_solver;
+  internal::NodeManager* d_nm;
 
   /** The kind of this operator. */
   Kind d_kind;
@@ -1086,7 +1086,7 @@ class CVC5_EXPORT Term
   /**
    * Syntactic equality operator.
    * Return true if both terms are syntactically identical.
-   * Both terms must belong to the same solver object.
+   * @note Both terms must belong to the same node manager.
    * @param t The term to compare to for equality.
    * @return True if the terms are equal.
    */
@@ -1095,7 +1095,7 @@ class CVC5_EXPORT Term
   /**
    * Syntactic disequality operator.
    * Return true if both terms differ syntactically.
-   * Both terms must belong to the same solver object.
+   * @note Both terms must belong to the same node manager.
    * @param t The term to compare to for disequality.
    * @return True if terms are disequal.
    */
@@ -1309,11 +1309,11 @@ class CVC5_EXPORT Term
 
     /**
      * Constructor
-     * @param slv The associated solver object.
+     * @param nm The associated node manager.
      * @param e A ``std::shared pointer`` to the node that we're iterating over.
      * @param p The position of the iterator (e.g. which child it's on).
      */
-    const_iterator(const Solver* slv,
+    const_iterator(internal::NodeManager* nm,
                    const std::shared_ptr<internal::Node>& e,
                    uint32_t p);
 
@@ -1363,9 +1363,9 @@ class CVC5_EXPORT Term
 
    private:
     /**
-     * The associated solver object.
+     * The associated node manager.
      */
-    const Solver* d_solver;
+    internal::NodeManager* d_nm;
     /** The original node to be iterated over. */
     std::shared_ptr<internal::Node> d_origNode;
     /** Keeps track of the iteration position. */
@@ -1682,37 +1682,37 @@ class CVC5_EXPORT Term
 
  protected:
   /**
-   * The associated solver object.
+   * The associated node manager.
    */
-  const Solver* d_solver;
+  internal::NodeManager* d_nm;
 
  private:
+  /** Helper method to collect all elements of a set. */
+  static void collectSet(std::set<Term>& set,
+                         const internal::Node& node,
+                         internal::NodeManager* nm);
+  /** Helper method to collect all elements of a sequence. */
+  static void collectSequence(std::vector<Term>& seq,
+                              const internal::Node& node,
+                              internal::NodeManager* nm);
+
+  /**
+   * Constructor.
+   * @param nm The associated node manager.
+   * @param n The internal node that is to be wrapped by this term.
+   * @return The Term.
+   */
+  Term(internal::NodeManager* nm, const internal::Node& n);
+
+  /** @return The internal wrapped Node of this term. */
+  const internal::Node& getNode(void) const;
+
   /** Helper to convert a vector of Terms to internal Nodes. */
   std::vector<internal::Node> static termVectorToNodes(
       const std::vector<Term>& terms);
   /** Helper to convert a vector of internal Nodes to Terms. */
   std::vector<Term> static nodeVectorToTerms(
-      const Solver* slv, const std::vector<internal::Node>& nodes);
-
-  /** Helper method to collect all elements of a set. */
-  static void collectSet(std::set<Term>& set,
-                         const internal::Node& node,
-                         const Solver* slv);
-  /** Helper method to collect all elements of a sequence. */
-  static void collectSequence(std::vector<Term>& seq,
-                              const internal::Node& node,
-                              const Solver* slv);
-
-  /**
-   * Constructor.
-   * @param slv The associated solver object.
-   * @param n The internal node that is to be wrapped by this term.
-   * @return The Term.
-   */
-  Term(const Solver* slv, const internal::Node& n);
-
-  /** @return The internal wrapped Node of this term. */
-  const internal::Node& getNode(void) const;
+      internal::NodeManager* nm, const std::vector<internal::Node>& nodes);
 
   /**
    * Helper for isNull checks. This prevents calling an API function with
@@ -1873,11 +1873,11 @@ class CVC5_EXPORT DatatypeConstructorDecl
  private:
   /**
    * Constructor.
-   * @param slv The associated solver object.
+   * @param nm The associated node manager.
    * @param name The name of the datatype constructor.
    * @return The DatatypeConstructorDecl.
    */
-  DatatypeConstructorDecl(const Solver* slv, const std::string& name);
+  DatatypeConstructorDecl(internal::NodeManager* nm, const std::string& name);
 
   /**
    * Helper for isNull checks. This prevents calling an API function with
@@ -1892,9 +1892,9 @@ class CVC5_EXPORT DatatypeConstructorDecl
   bool isResolved() const;
 
   /**
-   * The associated solver object.
+   * The associated node manager.
    */
-  const Solver* d_solver;
+  internal::NodeManager* d_nm;
 
   /**
    * The internal (intermediate) datatype constructor wrapped by this
@@ -1966,24 +1966,24 @@ class CVC5_EXPORT DatatypeDecl
  private:
   /**
    * Constructor.
-   * @param slv The associated solver object.
+   * @param nm The associated node manager.
    * @param name The name of the datatype.
    * @param isCoDatatype True if a codatatype is to be constructed.
    * @return The DatatypeDecl.
    */
-  DatatypeDecl(const Solver* slv,
+  DatatypeDecl(internal::NodeManager* nm,
                const std::string& name,
                bool isCoDatatype = false);
 
   /**
    * Constructor for parameterized datatype declaration.
    * Create sorts parameter with Solver::mkParamSort().
-   * @param slv The associated solver object.
+   * @param nm The associated node manager.
    * @param name The name of the datatype.
    * @param params A list of sort parameters.
    * @param isCoDatatype True if a codatatype is to be constructed.
    */
-  DatatypeDecl(const Solver* slv,
+  DatatypeDecl(internal::NodeManager* nm,
                const std::string& name,
                const std::vector<Sort>& params,
                bool isCoDatatype = false);
@@ -1998,9 +1998,9 @@ class CVC5_EXPORT DatatypeDecl
   bool isNullHelper() const;
 
   /**
-   * The associated solver object.
+   * The associated node manager.
    */
-  const Solver* d_solver;
+  internal::NodeManager* d_nm;
 
   /**
    * The internal (intermediate) datatype wrapped by this datatype
@@ -2072,11 +2072,12 @@ class CVC5_EXPORT DatatypeSelector
  private:
   /**
    * Constructor.
-   * @param slv The associated solver object.
+   * @param nm The associated node manager.
    * @param stor The internal datatype selector to be wrapped.
    * @return The DatatypeSelector.
    */
-  DatatypeSelector(const Solver* slv, const internal::DTypeSelector& stor);
+  DatatypeSelector(internal::NodeManager* nm,
+                   const internal::DTypeSelector& stor);
 
   /**
    * Helper for isNull checks. This prevents calling an API function with
@@ -2085,9 +2086,9 @@ class CVC5_EXPORT DatatypeSelector
   bool isNullHelper() const;
 
   /**
-   * The associated solver object.
+   * The associated node manager.
    */
-  const Solver* d_solver;
+  internal::NodeManager* d_nm;
 
   /**
    * The internal datatype selector wrapped by this datatype selector.
@@ -2302,18 +2303,18 @@ class CVC5_EXPORT DatatypeConstructor
    private:
     /**
      * Constructor.
-     * @param slv The associated Solver object.
+     * @param nm The associated node manager.
      * @param ctor The internal datatype constructor to iterate over.
      * @param begin True if this is a `begin()` iterator.
      */
-    const_iterator(const Solver* slv,
+    const_iterator(internal::NodeManager* nm,
                    const internal::DTypeConstructor& ctor,
                    bool begin);
 
     /**
-     * The associated solver object.
+     * The associated node manager.
      */
-    const Solver* d_solver;
+    internal::NodeManager* d_nm;
 
     /**
      * A pointer to the list of selectors of the internal datatype
@@ -2342,11 +2343,11 @@ class CVC5_EXPORT DatatypeConstructor
  private:
   /**
    * Constructor.
-   * @param slv The associated solver instance.
+   * @param nm The associated node manager.
    * @param ctor The internal datatype constructor to be wrapped.
    * @return The DatatypeConstructor.
    */
-  DatatypeConstructor(const Solver* slv,
+  DatatypeConstructor(internal::NodeManager* nm,
                       const internal::DTypeConstructor& ctor);
 
   /**
@@ -2363,9 +2364,9 @@ class CVC5_EXPORT DatatypeConstructor
   bool isNullHelper() const;
 
   /**
-   * The associated solver object.
+   * The associated node manager.
    */
-  const Solver* d_solver;
+  internal::NodeManager* d_nm;
 
   /**
    * The internal datatype constructor wrapped by this datatype constructor.
@@ -2554,16 +2555,18 @@ class CVC5_EXPORT Datatype
    private:
     /**
      * Constructor.
-     * @param slv The associated Solver object.
+     * @param nm The associated node manager.
      * @param dtype The internal datatype to iterate over.
      * @param begin True if this is a begin() iterator.
      */
-    const_iterator(const Solver* slv, const internal::DType& dtype, bool begin);
+    const_iterator(internal::NodeManager* nm,
+                   const internal::DType& dtype,
+                   bool begin);
 
     /**
-     * The associated solver object.
+     * The associated node manager.
      */
-    const Solver* d_solver;
+    internal::NodeManager* d_nm;
 
     /**
      * A pointer to the list of constructors of the internal datatype
@@ -2592,11 +2595,11 @@ class CVC5_EXPORT Datatype
  private:
   /**
    * Constructor.
-   * @param slv The associated solver instance.
+   * @param nm The associated node manager.
    * @param dtype The internal datatype to be wrapped.
    * @return The Datatype.
    */
-  Datatype(const Solver* slv, const internal::DType& dtype);
+  Datatype(internal::NodeManager* nm, const internal::DType& dtype);
 
   /**
    * Return constructor for name.
@@ -2619,9 +2622,9 @@ class CVC5_EXPORT Datatype
   bool isNullHelper() const;
 
   /**
-   * The associated solver object.
+   * The associated node manager.
    */
-  const Solver* d_solver;
+  internal::NodeManager* d_nm;
 
   /**
    * The internal datatype wrapped by this datatype.
@@ -3211,13 +3214,6 @@ class CVC5_EXPORT Solver
   friend class main::CommandExecutor;
   friend class Sort;
   friend class Term;
-
- private:
-  /*
-   * Constructs a solver with the given original options. This should only be
-   * used internally when the Solver is reset.
-   */
-  Solver(std::unique_ptr<internal::Options>&& original);
 
  public:
   /* .................................................................... */
@@ -5002,6 +4998,29 @@ class CVC5_EXPORT Solver
   std::ostream& getOutput(const std::string& tag) const;
 
  private:
+  /**
+   * Helper for mk-functions that call d_nm->mkConst().
+   * @param nm The associated node manager.
+   * @pram t The value.
+   */
+  template <typename T>
+  static Term mkValHelper(internal::NodeManager* nm, const T& t);
+  /**
+   * Helper for creating rational values.
+   * @param nm The associated node manager.
+   * @param r The value (either int or real).
+   * @param isInt True to create an integer value.
+   */
+  static Term mkRationalValHelper(internal::NodeManager*,
+                                  const internal::Rational&,
+                                  bool);
+
+  /*
+   * Constructs a solver with the given original options. This should only be
+   * used internally when the Solver is reset.
+   */
+  Solver(std::unique_ptr<internal::Options>&& original);
+
   /** @return The node manager of this solver */
   internal::NodeManager* getNodeManager(void) const;
   /** Reset the API statistics */
@@ -5012,12 +5031,6 @@ class CVC5_EXPORT Solver
   /** Helper for creating operators. */
   template <typename T>
   Op mkOpHelper(Kind kind, const T& t) const;
-  /** Helper for mk-functions that call d_nodeMgr->mkConst(). */
-  template <typename T>
-  Term mkValHelper(const T& t) const;
-  /** Helper for making rational values. */
-  Term mkRationalValHelper(const internal::Rational& r,
-                           bool isInt = true) const;
   /** Helper for mkReal functions that take a string as argument. */
   Term mkRealOrIntegerFromStrHelper(const std::string& s,
                                     bool isInt = true) const;
@@ -5104,7 +5117,7 @@ class CVC5_EXPORT Solver
   /** Keep a copy of the original option settings (for resets). */
   std::unique_ptr<internal::Options> d_originalOptions;
   /** The node manager of this solver. */
-  internal::NodeManager* d_nodeMgr;
+  internal::NodeManager* d_nm;
   /** The statistics collected on the Api level. */
   std::unique_ptr<APIStatistics> d_stats;
   /** The SMT engine of this solver. */

--- a/src/api/cpp/cvc5.h
+++ b/src/api/cpp/cvc5.h
@@ -1951,6 +1951,12 @@ class CVC5_EXPORT DatatypeDecl
   bool isParametric() const;
 
   /**
+   * Is this datatype declaration resolved (i.e,. has it been used to declare
+   * a datatype already)?
+   */
+  bool isResolved() const;
+
+  /**
    * @return True if this DatatypeDecl is a null object.
    */
   bool isNull() const;

--- a/src/api/cpp/cvc5.h
+++ b/src/api/cpp/cvc5.h
@@ -2754,7 +2754,7 @@ class CVC5_EXPORT Grammar
    * @param sygusVars The input variables to synth-fun/synth-var.
    * @param ntSymbols The non-terminals of this grammar.
    */
-  Grammar(const Solver* slv,
+  Grammar(internal::NodeManager* nm,
           const std::vector<Term>& sygusVars,
           const std::vector<Term>& ntSymbols);
 
@@ -2826,8 +2826,8 @@ class CVC5_EXPORT Grammar
    */
   bool containsFreeVariables(const Term& rule) const;
 
-  /** The solver that created this grammar. */
-  const Solver* d_solver;
+  /** The node manager associated with this grammar. */
+  internal::NodeManager* d_nm;
   /** Input variables to the corresponding function/invariant to synthesize.*/
   std::vector<Term> d_sygusVars;
   /** The non-terminal symbols of this grammar. */

--- a/src/api/cpp/cvc5_checks.h
+++ b/src/api/cpp/cvc5_checks.h
@@ -171,12 +171,14 @@ namespace cvc5 {
  * Node manager check for member functions of classes other than class Solver.
  * Check if given node manager matches the node manager this solver object is
  * associated with.
+ *
+ * @note This is an assertion rather than an API guard since all Solver
+ *       instances in a thread share the same NodeManager instance.
  */
-#define CVC5_API_ARG_CHECK_NM(nm, what, arg)              \
-  CVC5_API_CHECK(nm == arg.d_nm)                          \
-      << "Given " << (what)                               \
-      << " is not associated with the node manager this " \
-      << "object is associated with";
+#define CVC5_API_ARG_ASSERT_NM(nm, what, arg)                                \
+  Assert(nm == arg.d_nm) << "Given " << (what)                               \
+                         << " is not associated with the node manager this " \
+                         << "object is associated with";
 
 /* -------------------------------------------------------------------------- */
 /* Sort checks.                                                               */
@@ -187,11 +189,11 @@ namespace cvc5 {
  * Check if given sort is not null and associated with the node manager this
  * object is associated with.
  */
-#define CVC5_API_CHECK_SORT(nm, sort)        \
-  do                                         \
-  {                                          \
-    CVC5_API_ARG_CHECK_NOT_NULL(sort);       \
-    CVC5_API_ARG_CHECK_NM(nm, "sort", sort); \
+#define CVC5_API_CHECK_SORT(nm, sort)         \
+  do                                          \
+  {                                           \
+    CVC5_API_ARG_CHECK_NOT_NULL(sort);        \
+    CVC5_API_ARG_ASSERT_NM(nm, "sort", sort); \
   } while (0)
 
 /**
@@ -245,11 +247,11 @@ namespace cvc5 {
  * Check if given term is not null and associated with the node manager this
  * object is associated with.
  */
-#define CVC5_API_CHECK_TERM(nm, term)        \
-  do                                         \
-  {                                          \
-    CVC5_API_ARG_CHECK_NOT_NULL(term);       \
-    CVC5_API_ARG_CHECK_NM(nm, "term", term); \
+#define CVC5_API_CHECK_TERM(nm, term)         \
+  do                                          \
+  {                                           \
+    CVC5_API_ARG_CHECK_NOT_NULL(term);        \
+    CVC5_API_ARG_ASSERT_NM(nm, "term", term); \
   } while (0)
 
 /**

--- a/src/api/cpp/cvc5_checks.h
+++ b/src/api/cpp/cvc5_checks.h
@@ -164,17 +164,18 @@ namespace cvc5 {
                 << (idx) << ", expected "
 
 /* -------------------------------------------------------------------------- */
-/* Solver checks.                                                             */
+/* Node manager check.                                                        */
 /* -------------------------------------------------------------------------- */
 
 /**
- * Solver check for member functions of classes other than class Solver.
- * Check if given solver matches the solver object this object is associated
- * with.
+ * Node manager check for member functions of classes other than class Solver.
+ * Check if given node manager matches the node manager this solver object is
+ * associated with.
  */
-#define CVC5_API_ARG_CHECK_SOLVER(what, arg)                              \
-  CVC5_API_CHECK(this->d_solver == arg.d_solver)                          \
-      << "Given " << (what) << " is not associated with the solver this " \
+#define CVC5_API_ARG_CHECK_NM(nm, what, arg)              \
+  CVC5_API_CHECK(nm == arg.d_nm)                          \
+      << "Given " << (what)                               \
+      << " is not associated with the node manager this " \
       << "object is associated with";
 
 /* -------------------------------------------------------------------------- */
@@ -183,57 +184,56 @@ namespace cvc5 {
 
 /**
  * Sort check for member functions of classes other than class Solver.
- * Check if given sort is not null and associated with the solver object this
+ * Check if given sort is not null and associated with the node manager this
  * object is associated with.
  */
-#define CVC5_API_CHECK_SORT(sort)            \
+#define CVC5_API_CHECK_SORT(nm, sort)        \
   do                                         \
   {                                          \
     CVC5_API_ARG_CHECK_NOT_NULL(sort);       \
-    CVC5_API_ARG_CHECK_SOLVER("sort", sort); \
+    CVC5_API_ARG_CHECK_NM(nm, "sort", sort); \
   } while (0)
 
 /**
  * Sort check for member functions of classes other than class Solver.
  * Check if each sort in the given container of sorts is not null and
- * associated with the solver object this object is associated with.
+ * associated with the node manager this object is associated with.
  */
-#define CVC5_API_CHECK_SORTS(sorts)                                         \
-  do                                                                        \
-  {                                                                         \
-    size_t i = 0;                                                           \
-    for (const auto& s : sorts)                                             \
-    {                                                                       \
-      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("sort", s, sorts, i);            \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                 \
-          this->d_solver == s.d_solver, "sort", sorts, i)                   \
-          << "a sort associated with the solver this object is associated " \
-             "with";                                                        \
-      i += 1;                                                               \
-    }                                                                       \
+#define CVC5_API_CHECK_SORTS(nm, sorts)                                       \
+  do                                                                          \
+  {                                                                           \
+    size_t i = 0;                                                             \
+    for (const auto& s : sorts)                                               \
+    {                                                                         \
+      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("sort", s, sorts, i);              \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(nm == s.d_nm, "sort", sorts, i)    \
+          << "a sort associated with node manager this object is associated " \
+             "with";                                                          \
+      i += 1;                                                                 \
+    }                                                                         \
   } while (0)
 
 /**
  * Sort check for member functions of classes other than class Solver.
  * Check if each sort in the given container of sorts is not null, is
- * associated with the solver object this object is associated with, and is a
+ * associated with the node manager this object is associated with, and is a
  * first-class sort.
  */
-#define CVC5_API_CHECK_DOMAIN_SORTS(sorts)                                  \
-  do                                                                        \
-  {                                                                         \
-    size_t i = 0;                                                           \
-    for (const auto& s : sorts)                                             \
-    {                                                                       \
-      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("sort", s, sorts, i);            \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                 \
-          this->d_solver == s.d_solver, "sort", sorts, i)                   \
-          << "a sort associated with the solver this object is associated " \
-             "with";                                                        \
-      CVC5_API_ARG_CHECK_EXPECTED(s.getTypeNode().isFirstClass(), s)        \
-          << "first-class sort as domain sort";                             \
-      i += 1;                                                               \
-    }                                                                       \
+#define CVC5_API_CHECK_DOMAIN_SORTS(nm, sorts)                             \
+  do                                                                       \
+  {                                                                        \
+    size_t i = 0;                                                          \
+    for (const auto& s : sorts)                                            \
+    {                                                                      \
+      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("sort", s, sorts, i);           \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(nm == s.d_nm, "sort", sorts, i) \
+          << "a sort associated with the node manager this object is "     \
+             "associated "                                                 \
+             "with";                                                       \
+      CVC5_API_ARG_CHECK_EXPECTED(s.getTypeNode().isFirstClass(), s)       \
+          << "first-class sort as domain sort";                            \
+      i += 1;                                                              \
+    }                                                                      \
   } while (0)
 
 /* -------------------------------------------------------------------------- */
@@ -242,77 +242,78 @@ namespace cvc5 {
 
 /**
  * Term check for member functions of classes other than class Solver.
- * Check if given term is not null and associated with the solver object this
+ * Check if given term is not null and associated with the node manager this
  * object is associated with.
  */
-#define CVC5_API_CHECK_TERM(term)            \
+#define CVC5_API_CHECK_TERM(nm, term)        \
   do                                         \
   {                                          \
     CVC5_API_ARG_CHECK_NOT_NULL(term);       \
-    CVC5_API_ARG_CHECK_SOLVER("term", term); \
+    CVC5_API_ARG_CHECK_NM(nm, "term", term); \
   } while (0)
 
 /**
  * Term check for member functions of classes other than class Solver.
  * Check if each term in the given container of terms is not null and
- * associated with the solver object this object is associated with.
+ * associated with the node manager this object is associated with.
  */
-#define CVC5_API_CHECK_TERMS(terms)                                         \
-  do                                                                        \
-  {                                                                         \
-    size_t i = 0;                                                           \
-    for (const auto& s : terms)                                             \
-    {                                                                       \
-      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("term", s, terms, i);            \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                 \
-          this->d_solver == s.d_solver, "term", terms, i)                   \
-          << "a term associated with the solver this object is associated " \
-             "with";                                                        \
-      i += 1;                                                               \
-    }                                                                       \
+#define CVC5_API_CHECK_TERMS(nm, terms)                                    \
+  do                                                                       \
+  {                                                                        \
+    size_t i = 0;                                                          \
+    for (const auto& s : terms)                                            \
+    {                                                                      \
+      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("term", s, terms, i);           \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(nm == s.d_nm, "term", terms, i) \
+          << "a term associated with the node manager this object is "     \
+             "associated "                                                 \
+             "with";                                                       \
+      i += 1;                                                              \
+    }                                                                      \
   } while (0)
 
 /**
  * Term check for member functions of classes other than class Solver.
  * Check if each term and sort in the given map (which maps terms to sorts) is
- * not null and associated with the solver object this object is associated
+ * not null and associated with the node manager this object is associated
  * with.
  */
-#define CVC5_API_CHECK_TERMS_MAP(map)                                       \
-  do                                                                        \
-  {                                                                         \
-    size_t i = 0;                                                           \
-    for (const auto& p : map)                                               \
-    {                                                                       \
-      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("term", p.first, map, i);        \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                 \
-          this->d_solver == p.first.d_solver, "term", map, i)               \
-          << "a term associated with the solver this object is associated " \
-             "with";                                                        \
-      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("sort", p.second, map, i);       \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                 \
-          this->d_solver == p.second.d_solver, "sort", map, i)              \
-          << "a sort associated with the solver this object is associated " \
-             "with";                                                        \
-      i += 1;                                                               \
-    }                                                                       \
+#define CVC5_API_CHECK_TERMS_MAP(nm, map)                                      \
+  do                                                                           \
+  {                                                                            \
+    size_t i = 0;                                                              \
+    for (const auto& p : map)                                                  \
+    {                                                                          \
+      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("term", p.first, map, i);           \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(nm == p.first.d_nm, "term", map, i) \
+          << "a term associated with the node manager this object is "         \
+             "associated "                                                     \
+             "with";                                                           \
+      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("sort", p.second, map, i);          \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                    \
+          nm == p.second.d_nm, "sort", map, i)                                 \
+          << "a sort associated with the node manager this object is "         \
+             "associated "                                                     \
+             "with";                                                           \
+      i += 1;                                                                  \
+    }                                                                          \
   } while (0)
 
 /**
  * Term check for member functions of classes other than class Solver.
  * Check if each term in the given container is not null, associated with the
- * solver object this object is associated with, and of the given sort.
+ * node manager object this object is associated with, and of the given sort.
  */
-#define CVC5_API_CHECK_TERMS_WITH_SORT(terms, sort)                            \
+#define CVC5_API_CHECK_TERMS_WITH_SORT(nm, terms, sort)                        \
   do                                                                           \
   {                                                                            \
     size_t i = 0;                                                              \
     for (const auto& t : terms)                                                \
     {                                                                          \
       CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("term", t, terms, i);               \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                    \
-          this->d_solver == t.d_solver, "term", terms, i)                      \
-          << "a term associated with the solver this object is associated "    \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(nm == t.d_nm, "term", terms, i)     \
+          << "a term associated with the node manager this object is "         \
+             "associated "                                                     \
              "with";                                                           \
       CVC5_API_CHECK(t.getSort() == sort)                                      \
           << "Expected term with sort " << sort << " at index " << i << " in " \
@@ -324,30 +325,30 @@ namespace cvc5 {
 /**
  * Term check for member functions of classes other than class Solver.
  * Check if each term in both the given container is not null, associated with
- * the solver object this object is associated with, and their sorts are
+ * the node manager this object is associated with, and their sorts are
  * pairwise equal.
  */
-#define CVC5_API_TERM_CHECK_TERMS_WITH_TERMS_SORT_EQUAL_TO(terms1, terms2)  \
-  do                                                                        \
-  {                                                                         \
-    size_t i = 0;                                                           \
-    for (const auto& t1 : terms1)                                           \
-    {                                                                       \
-      const auto& t2 = terms2[i];                                           \
-      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("term", t1, terms1, i);          \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                 \
-          this->d_solver == t1.d_solver, "term", terms1, i)                 \
-          << "a term associated with the solver this object is associated " \
-             "with";                                                        \
-      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("term", t2, terms2, i);          \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                 \
-          this->d_solver == t2.d_solver, "term", terms2, i)                 \
-          << "a term associated with the solver this object is associated " \
-             "with";                                                        \
-      CVC5_API_CHECK(t1.getSort() == t2.getSort())                          \
-          << "Expecting terms of the same sort at index " << i;             \
-      i += 1;                                                               \
-    }                                                                       \
+#define CVC5_API_TERM_CHECK_TERMS_WITH_TERMS_SORT_EQUAL_TO(nm, terms1, terms2) \
+  do                                                                           \
+  {                                                                            \
+    size_t i = 0;                                                              \
+    for (const auto& t1 : terms1)                                              \
+    {                                                                          \
+      const auto& t2 = terms2[i];                                              \
+      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("term", t1, terms1, i);             \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(nm == t1.d_nm, "term", terms1, i)   \
+          << "a term associated with the node manager this object is "         \
+             "associated "                                                     \
+             "with";                                                           \
+      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("term", t2, terms2, i);             \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(nm == t2.d_nm, "term", terms2, i)   \
+          << "a term associated with the node manager this object is "         \
+             "associated "                                                     \
+             "with";                                                           \
+      CVC5_API_CHECK(t1.getSort() == t2.getSort())                             \
+          << "Expecting terms of the same sort at index " << i;                \
+      i += 1;                                                                  \
+    }                                                                          \
   } while (0)
 
 /* -------------------------------------------------------------------------- */
@@ -357,13 +358,16 @@ namespace cvc5 {
 /**
  * DatatypeDecl check for member functions of classes other than class Solver.
  * Check if given datatype declaration is not null and associated with the
- * solver object this DatatypeDecl object is associated with.
+ * node manager this DatatypeDecl object is associated with.
  */
-#define CVC5_API_CHECK_DTDECL(decl)                          \
-  do                                                         \
-  {                                                          \
-    CVC5_API_ARG_CHECK_NOT_NULL(decl);                       \
-    CVC5_API_ARG_CHECK_SOLVER("datatype declaration", decl); \
+#define CVC5_API_CHECK_DTDECL(nm, decl)                                  \
+  do                                                                     \
+  {                                                                      \
+    CVC5_API_ARG_CHECK_NOT_NULL(decl);                                   \
+    CVC5_API_CHECK(nm == decl.d_nm)                                      \
+        << "Given datatype declaration is not associated with the node " \
+           "manager this "                                               \
+        << "object is associated with";                                  \
   } while (0)
 
 /* -------------------------------------------------------------------------- */
@@ -374,124 +378,124 @@ namespace cvc5 {
 
 /**
  * Sort checks for member functions of class Solver.
- * Check if given sort is not null and associated with this solver.
+ * Check if given sort is not null and associated with the node manager of this
+ * solver.
  */
-#define CVC5_API_SOLVER_CHECK_SORT(sort)                    \
-  do                                                        \
-  {                                                         \
-    CVC5_API_ARG_CHECK_NOT_NULL(sort);                      \
-    CVC5_API_CHECK(this == sort.d_solver)                   \
-        << "Given sort is not associated with this solver"; \
+#define CVC5_API_SOLVER_CHECK_SORT(sort)                                      \
+  do                                                                          \
+  {                                                                           \
+    CVC5_API_ARG_CHECK_NOT_NULL(sort);                                        \
+    CVC5_API_CHECK(d_nm == sort.d_nm) << "Given sort is not associated with " \
+                                         "the node manager of this solver";   \
   } while (0)
 
 /**
  * Sort checks for member functions of class Solver.
  * Check if each sort in the given container of sorts is not null and
- * associated with this solver.
+ * associated with the node manager of this solver.
  */
-#define CVC5_API_SOLVER_CHECK_SORTS(sorts)                        \
-  do                                                              \
-  {                                                               \
-    size_t i = 0;                                                 \
-    for (const auto& s : sorts)                                   \
-    {                                                             \
-      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("sorts", s, sorts, i); \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                       \
-          this == s.d_solver, "sort", sorts, i)                   \
-          << "a sort associated with this solver";                \
-      i += 1;                                                     \
-    }                                                             \
+#define CVC5_API_SOLVER_CHECK_SORTS(sorts)                                   \
+  do                                                                         \
+  {                                                                          \
+    size_t i = 0;                                                            \
+    for (const auto& s : sorts)                                              \
+    {                                                                        \
+      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("sorts", s, sorts, i);            \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(d_nm == s.d_nm, "sort", sorts, i) \
+          << "a sort associated with the node manager of this solver";       \
+      i += 1;                                                                \
+    }                                                                        \
   } while (0)
 
 /**
  * Domain sort check for member functions of class Solver.
- * Check if domain sort is not null, associated with this solver, and a
- * first-class sort.
+ * Check if domain sort is not null, associated with the node manager of this
+ * solver, and a first-class sort.
  */
-#define CVC5_API_SOLVER_CHECK_DOMAIN_SORT(sort)                          \
-  do                                                                     \
-  {                                                                      \
-    CVC5_API_ARG_CHECK_NOT_NULL(sort);                                   \
-    CVC5_API_CHECK(this == sort.d_solver)                                \
-        << "Given sort is not associated with this solver";              \
-    CVC5_API_ARG_CHECK_EXPECTED(sort.getTypeNode().isFirstClass(), sort) \
-        << "first-class sort as domain sort";                            \
+#define CVC5_API_SOLVER_CHECK_DOMAIN_SORT(sort)                               \
+  do                                                                          \
+  {                                                                           \
+    CVC5_API_ARG_CHECK_NOT_NULL(sort);                                        \
+    CVC5_API_CHECK(d_nm == sort.d_nm) << "Given sort is not associated with " \
+                                         "the node manager of this solver";   \
+    CVC5_API_ARG_CHECK_EXPECTED(sort.getTypeNode().isFirstClass(), sort)      \
+        << "first-class sort as domain sort";                                 \
   } while (0)
 
 /**
  * Domain sort checks for member functions of class Solver.
  * Check if each domain sort in the given container of sorts is not null,
- * associated with this solver, and a first-class sort.
+ * associated with the node manager of this solver, and a first-class sort.
  */
-#define CVC5_API_SOLVER_CHECK_DOMAIN_SORTS(sorts)                       \
-  do                                                                    \
-  {                                                                     \
-    size_t i = 0;                                                       \
-    for (const auto& s : sorts)                                         \
-    {                                                                   \
-      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("domain sort", s, sorts, i); \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                             \
-          this == s.d_solver, "domain sort", sorts, i)                  \
-          << "a sort associated with this solver object";               \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                             \
-          s.getTypeNode().isFirstClass(), "domain sort", sorts, i)      \
-          << "first-class sort as domain sort";                         \
-      i += 1;                                                           \
-    }                                                                   \
+#define CVC5_API_SOLVER_CHECK_DOMAIN_SORTS(sorts)                             \
+  do                                                                          \
+  {                                                                           \
+    size_t i = 0;                                                             \
+    for (const auto& s : sorts)                                               \
+    {                                                                         \
+      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("domain sort", s, sorts, i);       \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                   \
+          d_nm == s.d_nm, "domain sort", sorts, i)                            \
+          << "a sort associated with the node manager of this solver object"; \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                   \
+          s.getTypeNode().isFirstClass(), "domain sort", sorts, i)            \
+          << "first-class sort as domain sort";                               \
+      i += 1;                                                                 \
+    }                                                                         \
   } while (0)
 
 /**
  * Codomain sort check for member functions of class Solver.
- * Check if codomain sort is not null, associated with this solver, and a
- * first-class, non-function sort.
+ * Check if codomain sort is not null, associated with the node manager of this
+ * solver, and a first-class, non-function sort.
  */
-#define CVC5_API_SOLVER_CHECK_CODOMAIN_SORT(sort)           \
-  do                                                        \
-  {                                                         \
-    CVC5_API_ARG_CHECK_NOT_NULL(sort);                      \
-    CVC5_API_CHECK(this == sort.d_solver)                   \
-        << "Given sort is not associated with this solver"; \
-    CVC5_API_ARG_CHECK_EXPECTED(!sort.isFunction(), sort)   \
-        << "function sort as codomain sort";                \
+#define CVC5_API_SOLVER_CHECK_CODOMAIN_SORT(sort)                             \
+  do                                                                          \
+  {                                                                           \
+    CVC5_API_ARG_CHECK_NOT_NULL(sort);                                        \
+    CVC5_API_CHECK(d_nm == sort.d_nm) << "Given sort is not associated with " \
+                                         "the node manager of this solver";   \
+    CVC5_API_ARG_CHECK_EXPECTED(!sort.isFunction(), sort)                     \
+        << "function sort as codomain sort";                                  \
   } while (0)
 
 /* Term checks. ------------------------------------------------------------- */
 
 /**
  * Term checks for member functions of class Solver.
- * Check if given term is not null and associated with this solver.
+ * Check if given term is not null and associated with the node manager of this
+ * solver.
  */
-#define CVC5_API_SOLVER_CHECK_TERM(term)                    \
-  do                                                        \
-  {                                                         \
-    CVC5_API_ARG_CHECK_NOT_NULL(term);                      \
-    CVC5_API_CHECK(this == term.d_solver)                   \
-        << "Given term is not associated with this solver"; \
+#define CVC5_API_SOLVER_CHECK_TERM(term)                                      \
+  do                                                                          \
+  {                                                                           \
+    CVC5_API_ARG_CHECK_NOT_NULL(term);                                        \
+    CVC5_API_CHECK(d_nm == term.d_nm) << "Given term is not associated with " \
+                                         "the node manager of this solver";   \
   } while (0)
 
 /**
  * Term checks for member functions of class Solver.
  * Check if each term in the given container of terms is not null and
- * associated with this solver.
+ * associated with the node manager of this solver.
  */
-#define CVC5_API_SOLVER_CHECK_TERMS(terms)                        \
-  do                                                              \
-  {                                                               \
-    size_t i = 0;                                                 \
-    for (const auto& t : terms)                                   \
-    {                                                             \
-      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("terms", t, terms, i); \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                       \
-          this == t.d_solver, "term", terms, i)                   \
-          << "a term associated with this solver";                \
-      i += 1;                                                     \
-    }                                                             \
+#define CVC5_API_SOLVER_CHECK_TERMS(terms)                                   \
+  do                                                                         \
+  {                                                                          \
+    size_t i = 0;                                                            \
+    for (const auto& t : terms)                                              \
+    {                                                                        \
+      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("terms", t, terms, i);            \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(d_nm == t.d_nm, "term", terms, i) \
+          << "a term associated with the node manager of this solver";       \
+      i += 1;                                                                \
+    }                                                                        \
   } while (0)
 
 /**
  * Term checks for member functions of class Solver.
- * Check if given term is not null, associated with this solver, and of given
- * sort.
+ * Check if given term is not null, associated with the node manager of this
+ * solver, and of given sort.
  */
 #define CVC5_API_SOLVER_CHECK_TERM_WITH_SORT(term, sort) \
   do                                                     \
@@ -503,8 +507,8 @@ namespace cvc5 {
 
 /**
  * Term checks for member functions of class Solver.
- * Check if each term in the given container is not null, associated with this
- * solver, and of the given sort.
+ * Check if each term in the given container is not null, associated with the
+ * node manager of this solver, and of the given sort.
  */
 #define CVC5_API_SOLVER_CHECK_TERMS_WITH_SORT(terms, sort)                     \
   do                                                                           \
@@ -513,9 +517,8 @@ namespace cvc5 {
     for (const auto& t : terms)                                                \
     {                                                                          \
       CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("term", t, terms, i);               \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                    \
-          this == t.d_solver, "term", terms, i)                                \
-          << "a term associated with this solver";                             \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(d_nm == t.d_nm, "term", terms, i)   \
+          << "a term associated with the node manager of this solver";         \
       CVC5_API_CHECK(t.getSort() == sort)                                      \
           << "Expected term with sort " << sort << " at index " << i << " in " \
           << #terms;                                                           \
@@ -525,36 +528,36 @@ namespace cvc5 {
 
 /**
  * Bound variable checks for member functions of class Solver.
- * Check if each term in the given container is not null, associated with this
- * solver, and a bound variable.
+ * Check if each term in the given container is not null, associated with the
+ * node manager of this solver, and a bound variable.
  */
-#define CVC5_API_SOLVER_CHECK_BOUND_VARS(bound_vars)            \
-  do                                                            \
-  {                                                             \
-    size_t i = 0;                                               \
-    for (const auto& bv : bound_vars)                           \
-    {                                                           \
-      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL(                     \
-          "bound variable", bv, bound_vars, i);                 \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                     \
-          this == bv.d_solver, "bound variable", bound_vars, i) \
-          << "a term associated with this solver object";       \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                     \
-          bv.d_node->getKind() == cvc5::internal::Kind::BOUND_VARIABLE,   \
-          "bound variable",                                     \
-          bound_vars,                                           \
-          i)                                                    \
-          << "a bound variable";                                \
-      i += 1;                                                   \
-    }                                                           \
+#define CVC5_API_SOLVER_CHECK_BOUND_VARS(bound_vars)                          \
+  do                                                                          \
+  {                                                                           \
+    size_t i = 0;                                                             \
+    for (const auto& bv : bound_vars)                                         \
+    {                                                                         \
+      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL(                                   \
+          "bound variable", bv, bound_vars, i);                               \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                   \
+          d_nm == bv.d_nm, "bound variable", bound_vars, i)                   \
+          << "a term associated with the node manager of this solver object"; \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                   \
+          bv.d_node->getKind() == cvc5::internal::Kind::BOUND_VARIABLE,       \
+          "bound variable",                                                   \
+          bound_vars,                                                         \
+          i)                                                                  \
+          << "a bound variable";                                              \
+      i += 1;                                                                 \
+    }                                                                         \
   } while (0)
 
 /**
  * Bound variable checks for member functions of class Solver that define
  * functions.
- * Check if each term in the given container is not null, associated with this
- * solver, a bound variable, matches theh corresponding sort in 'domain_sorts',
- * and is a first-class term.
+ * Check if each term in the given container is not null, associated with the
+ * node manager of this solver, a bound variable, matches theh corresponding
+ * sort in 'domain_sorts', and is a first-class term.
  */
 #define CVC5_API_SOLVER_CHECK_BOUND_VARS_DEF_FUN(                             \
     fun, bound_vars, domain_sorts)                                            \
@@ -569,10 +572,10 @@ namespace cvc5 {
       CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL(                                   \
           "bound variable", bv, bound_vars, i);                               \
       CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                   \
-          this == bv.d_solver, "bound variable", bound_vars, i)               \
-          << "a term associated with this solver object";                     \
+          d_nm == bv.d_nm, "bound variable", bound_vars, i)                   \
+          << "a term associated with the node manager of this solver object"; \
       CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                   \
-          bv.d_node->getKind() == cvc5::internal::Kind::BOUND_VARIABLE,                 \
+          bv.d_node->getKind() == cvc5::internal::Kind::BOUND_VARIABLE,       \
           "bound variable",                                                   \
           bound_vars,                                                         \
           i)                                                                  \
@@ -596,79 +599,83 @@ namespace cvc5 {
 
 /**
  * Op checks for member functions of class Solver.
- * Check if given operator is not null and associated with this solver.
+ * Check if given operator is not null and associated with the node manager of
+ * this solver.
  */
-#define CVC5_API_SOLVER_CHECK_OP(op)                            \
-  do                                                            \
-  {                                                             \
-    CVC5_API_ARG_CHECK_NOT_NULL(op);                            \
-    CVC5_API_CHECK(this == op.d_solver)                         \
-        << "Given operator is not associated with this solver"; \
+#define CVC5_API_SOLVER_CHECK_OP(op)                                           \
+  do                                                                           \
+  {                                                                            \
+    CVC5_API_ARG_CHECK_NOT_NULL(op);                                           \
+    CVC5_API_CHECK(d_nm == op.d_nm) << "Given operator is not associated "     \
+                                       "with the node manager of this solver"; \
   } while (0)
 
 /* Datatype checks. --------------------------------------------------------- */
 
 /**
  * DatatypeDecl checks for member functions of class Solver.
- * Check if given datatype declaration is not null and associated with this
- * solver.
+ * Check if given datatype declaration is not null and associated with the node
+ * manager of this solver.
  */
-#define CVC5_API_SOLVER_CHECK_DTDECL(decl)                                  \
-  do                                                                        \
-  {                                                                         \
-    CVC5_API_ARG_CHECK_NOT_NULL(decl);                                      \
-    CVC5_API_CHECK(this == decl.d_solver)                                   \
-        << "Given datatype declaration is not associated with this solver"; \
-    CVC5_API_ARG_CHECK_EXPECTED(                                            \
-        dtypedecl.getDatatype().getNumConstructors() > 0, dtypedecl)        \
-        << "a datatype declaration with at least one constructor";          \
+#define CVC5_API_SOLVER_CHECK_DTDECL(decl)                               \
+  do                                                                     \
+  {                                                                      \
+    CVC5_API_ARG_CHECK_NOT_NULL(decl);                                   \
+    CVC5_API_CHECK(d_nm == decl.d_nm)                                    \
+        << "Given datatype declaration is not associated with the node " \
+           "manager of this solver";                                     \
+    CVC5_API_ARG_CHECK_EXPECTED(                                         \
+        dtypedecl.getDatatype().getNumConstructors() > 0, dtypedecl)     \
+        << "a datatype declaration with at least one constructor";       \
   } while (0)
 
 /**
  * DatatypeDecl checks for member functions of class Solver.
  * Check if each datatype declaration in the given container of declarations is
- * not null and associated with this solver.
+ * not null and associated with the node manager of this solver.
  */
-#define CVC5_API_SOLVER_CHECK_DTDECLS(decls)                         \
-  do                                                                 \
-  {                                                                  \
-    size_t i = 0;                                                    \
-    for (const auto& d : decls)                                      \
-    {                                                                \
-      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL(                          \
-          "datatype declaration", d, decls, i);                      \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                          \
-          this == d.d_solver, "datatype declaration", decls, i)      \
-          << "a datatype declaration associated with this solver";   \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                          \
-          d.getDatatype().getNumConstructors() > 0,                  \
-          "datatype declaration",                                    \
-          decls,                                                     \
-          i)                                                         \
-          << "a datatype declaration with at least one constructor"; \
-      i += 1;                                                        \
-    }                                                                \
+#define CVC5_API_SOLVER_CHECK_DTDECLS(decls)                               \
+  do                                                                       \
+  {                                                                        \
+    size_t i = 0;                                                          \
+    for (const auto& d : decls)                                            \
+    {                                                                      \
+      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL(                                \
+          "datatype declaration", d, decls, i);                            \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                \
+          d_nm == d.d_nm, "datatype declaration", decls, i)                \
+          << "a datatype declaration associated with the node manager of " \
+             "this solver";                                                \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                \
+          d.getDatatype().getNumConstructors() > 0,                        \
+          "datatype declaration",                                          \
+          decls,                                                           \
+          i)                                                               \
+          << "a datatype declaration with at least one constructor";       \
+      i += 1;                                                              \
+    }                                                                      \
   } while (0)
 
 /**
  * DatatypeConstructorDecl checks for member functions of class Solver.
  * Check if each datatype constructor declaration in the given container of
- * declarations is not null and associated with this solver.
+ * declarations is not null and associated with the node manager of this solver.
  */
-#define CVC5_API_SOLVER_CHECK_DTCTORDECLS(decls)                               \
-  do                                                                           \
-  {                                                                            \
-    size_t i = 0;                                                              \
-    for (const auto& d : decls)                                                \
-    {                                                                          \
-      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL(                                    \
-          "datatype constructor declaration", d, decls, i);                    \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                    \
-          this == d.d_solver, "datatype constructor declaration", decls, i)    \
-          << "a datatype constructor declaration associated with this solver " \
-             "object";                                                         \
-      i += 1;                                                                  \
-    }                                                                          \
+#define CVC5_API_SOLVER_CHECK_DTCTORDECLS(decls)                            \
+  do                                                                        \
+  {                                                                         \
+    size_t i = 0;                                                           \
+    for (const auto& d : decls)                                             \
+    {                                                                       \
+      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL(                                 \
+          "datatype constructor declaration", d, decls, i);                 \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                 \
+          d_nm == d.d_nm, "datatype constructor declaration", decls, i)     \
+          << "a datatype constructor declaration associated with the node " \
+             "manager of this solver "                                      \
+             "object";                                                      \
+      i += 1;                                                               \
+    }                                                                       \
   } while (0)
 
 /**

--- a/src/api/cpp/cvc5_checks.h
+++ b/src/api/cpp/cvc5_checks.h
@@ -175,10 +175,10 @@ namespace cvc5 {
  * @note This is an assertion rather than an API guard since all Solver
  *       instances in a thread share the same NodeManager instance.
  */
-#define CVC5_API_ARG_ASSERT_NM(nm, what, arg)                                \
-  Assert(nm == arg.d_nm) << "Given " << (what)                               \
-                         << " is not associated with the node manager this " \
-                         << "object is associated with";
+#define CVC5_API_ARG_ASSERT_NM(what, arg)                                      \
+  Assert(d_nm == arg.d_nm) << "Given " << (what)                               \
+                           << " is not associated with the node manager this " \
+                           << "object is associated with";
 
 /* -------------------------------------------------------------------------- */
 /* Sort checks.                                                               */
@@ -189,11 +189,11 @@ namespace cvc5 {
  * Check if given sort is not null and associated with the node manager this
  * object is associated with.
  */
-#define CVC5_API_CHECK_SORT(nm, sort)         \
-  do                                          \
-  {                                           \
-    CVC5_API_ARG_CHECK_NOT_NULL(sort);        \
-    CVC5_API_ARG_ASSERT_NM(nm, "sort", sort); \
+#define CVC5_API_CHECK_SORT(sort)         \
+  do                                      \
+  {                                       \
+    CVC5_API_ARG_CHECK_NOT_NULL(sort);    \
+    CVC5_API_ARG_ASSERT_NM("sort", sort); \
   } while (0)
 
 /**
@@ -201,14 +201,14 @@ namespace cvc5 {
  * Check if each sort in the given container of sorts is not null and
  * associated with the node manager this object is associated with.
  */
-#define CVC5_API_CHECK_SORTS(nm, sorts)                                       \
+#define CVC5_API_CHECK_SORTS(sorts)                                           \
   do                                                                          \
   {                                                                           \
     size_t i = 0;                                                             \
     for (const auto& s : sorts)                                               \
     {                                                                         \
       CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("sort", s, sorts, i);              \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(nm == s.d_nm, "sort", sorts, i)    \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(d_nm == s.d_nm, "sort", sorts, i)  \
           << "a sort associated with node manager this object is associated " \
              "with";                                                          \
       i += 1;                                                                 \
@@ -221,21 +221,21 @@ namespace cvc5 {
  * associated with the node manager this object is associated with, and is a
  * first-class sort.
  */
-#define CVC5_API_CHECK_DOMAIN_SORTS(nm, sorts)                             \
-  do                                                                       \
-  {                                                                        \
-    size_t i = 0;                                                          \
-    for (const auto& s : sorts)                                            \
-    {                                                                      \
-      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("sort", s, sorts, i);           \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(nm == s.d_nm, "sort", sorts, i) \
-          << "a sort associated with the node manager this object is "     \
-             "associated "                                                 \
-             "with";                                                       \
-      CVC5_API_ARG_CHECK_EXPECTED(s.getTypeNode().isFirstClass(), s)       \
-          << "first-class sort as domain sort";                            \
-      i += 1;                                                              \
-    }                                                                      \
+#define CVC5_API_CHECK_DOMAIN_SORTS(sorts)                                   \
+  do                                                                         \
+  {                                                                          \
+    size_t i = 0;                                                            \
+    for (const auto& s : sorts)                                              \
+    {                                                                        \
+      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("sort", s, sorts, i);             \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(d_nm == s.d_nm, "sort", sorts, i) \
+          << "a sort associated with the node manager this object is "       \
+             "associated "                                                   \
+             "with";                                                         \
+      CVC5_API_ARG_CHECK_EXPECTED(s.getTypeNode().isFirstClass(), s)         \
+          << "first-class sort as domain sort";                              \
+      i += 1;                                                                \
+    }                                                                        \
   } while (0)
 
 /* -------------------------------------------------------------------------- */
@@ -247,11 +247,11 @@ namespace cvc5 {
  * Check if given term is not null and associated with the node manager this
  * object is associated with.
  */
-#define CVC5_API_CHECK_TERM(nm, term)         \
-  do                                          \
-  {                                           \
-    CVC5_API_ARG_CHECK_NOT_NULL(term);        \
-    CVC5_API_ARG_ASSERT_NM(nm, "term", term); \
+#define CVC5_API_CHECK_TERM(term)         \
+  do                                      \
+  {                                       \
+    CVC5_API_ARG_CHECK_NOT_NULL(term);    \
+    CVC5_API_ARG_ASSERT_NM("term", term); \
   } while (0)
 
 /**
@@ -259,19 +259,19 @@ namespace cvc5 {
  * Check if each term in the given container of terms is not null and
  * associated with the node manager this object is associated with.
  */
-#define CVC5_API_CHECK_TERMS(nm, terms)                                    \
-  do                                                                       \
-  {                                                                        \
-    size_t i = 0;                                                          \
-    for (const auto& s : terms)                                            \
-    {                                                                      \
-      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("term", s, terms, i);           \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(nm == s.d_nm, "term", terms, i) \
-          << "a term associated with the node manager this object is "     \
-             "associated "                                                 \
-             "with";                                                       \
-      i += 1;                                                              \
-    }                                                                      \
+#define CVC5_API_CHECK_TERMS(terms)                                          \
+  do                                                                         \
+  {                                                                          \
+    size_t i = 0;                                                            \
+    for (const auto& s : terms)                                              \
+    {                                                                        \
+      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("term", s, terms, i);             \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(d_nm == s.d_nm, "term", terms, i) \
+          << "a term associated with the node manager this object is "       \
+             "associated "                                                   \
+             "with";                                                         \
+      i += 1;                                                                \
+    }                                                                        \
   } while (0)
 
 /**
@@ -280,25 +280,26 @@ namespace cvc5 {
  * not null and associated with the node manager this object is associated
  * with.
  */
-#define CVC5_API_CHECK_TERMS_MAP(nm, map)                                      \
-  do                                                                           \
-  {                                                                            \
-    size_t i = 0;                                                              \
-    for (const auto& p : map)                                                  \
-    {                                                                          \
-      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("term", p.first, map, i);           \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(nm == p.first.d_nm, "term", map, i) \
-          << "a term associated with the node manager this object is "         \
-             "associated "                                                     \
-             "with";                                                           \
-      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("sort", p.second, map, i);          \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                                    \
-          nm == p.second.d_nm, "sort", map, i)                                 \
-          << "a sort associated with the node manager this object is "         \
-             "associated "                                                     \
-             "with";                                                           \
-      i += 1;                                                                  \
-    }                                                                          \
+#define CVC5_API_CHECK_TERMS_MAP(map)                                  \
+  do                                                                   \
+  {                                                                    \
+    size_t i = 0;                                                      \
+    for (const auto& p : map)                                          \
+    {                                                                  \
+      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("term", p.first, map, i);   \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                            \
+          d_nm == p.first.d_nm, "term", map, i)                        \
+          << "a term associated with the node manager this object is " \
+             "associated "                                             \
+             "with";                                                   \
+      CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("sort", p.second, map, i);  \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(                            \
+          d_nm == p.second.d_nm, "sort", map, i)                       \
+          << "a sort associated with the node manager this object is " \
+             "associated "                                             \
+             "with";                                                   \
+      i += 1;                                                          \
+    }                                                                  \
   } while (0)
 
 /**
@@ -306,14 +307,14 @@ namespace cvc5 {
  * Check if each term in the given container is not null, associated with the
  * node manager object this object is associated with, and of the given sort.
  */
-#define CVC5_API_CHECK_TERMS_WITH_SORT(nm, terms, sort)                        \
+#define CVC5_API_CHECK_TERMS_WITH_SORT(terms, sort)                            \
   do                                                                           \
   {                                                                            \
     size_t i = 0;                                                              \
     for (const auto& t : terms)                                                \
     {                                                                          \
       CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("term", t, terms, i);               \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(nm == t.d_nm, "term", terms, i)     \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(d_nm == t.d_nm, "term", terms, i)   \
           << "a term associated with the node manager this object is "         \
              "associated "                                                     \
              "with";                                                           \
@@ -330,7 +331,7 @@ namespace cvc5 {
  * the node manager this object is associated with, and their sorts are
  * pairwise equal.
  */
-#define CVC5_API_TERM_CHECK_TERMS_WITH_TERMS_SORT_EQUAL_TO(nm, terms1, terms2) \
+#define CVC5_API_TERM_CHECK_TERMS_WITH_TERMS_SORT_EQUAL_TO(terms1, terms2)     \
   do                                                                           \
   {                                                                            \
     size_t i = 0;                                                              \
@@ -338,12 +339,12 @@ namespace cvc5 {
     {                                                                          \
       const auto& t2 = terms2[i];                                              \
       CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("term", t1, terms1, i);             \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(nm == t1.d_nm, "term", terms1, i)   \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(d_nm == t1.d_nm, "term", terms1, i) \
           << "a term associated with the node manager this object is "         \
              "associated "                                                     \
              "with";                                                           \
       CVC5_API_ARG_AT_INDEX_CHECK_NOT_NULL("term", t2, terms2, i);             \
-      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(nm == t2.d_nm, "term", terms2, i)   \
+      CVC5_API_ARG_AT_INDEX_CHECK_EXPECTED(d_nm == t2.d_nm, "term", terms2, i) \
           << "a term associated with the node manager this object is "         \
              "associated "                                                     \
              "with";                                                           \
@@ -362,11 +363,11 @@ namespace cvc5 {
  * Check if given datatype declaration is not null and associated with the
  * node manager this DatatypeDecl object is associated with.
  */
-#define CVC5_API_CHECK_DTDECL(nm, decl)                                  \
+#define CVC5_API_CHECK_DTDECL(decl)                                      \
   do                                                                     \
   {                                                                      \
     CVC5_API_ARG_CHECK_NOT_NULL(decl);                                   \
-    CVC5_API_CHECK(nm == decl.d_nm)                                      \
+    CVC5_API_CHECK(d_nm == decl.d_nm)                                    \
         << "Given datatype declaration is not associated with the node " \
            "manager this "                                               \
         << "object is associated with";                                  \

--- a/src/api/cpp/cvc5_checks.h
+++ b/src/api/cpp/cvc5_checks.h
@@ -617,16 +617,19 @@ namespace cvc5 {
  * Check if given datatype declaration is not null and associated with the node
  * manager of this solver.
  */
-#define CVC5_API_SOLVER_CHECK_DTDECL(decl)                               \
-  do                                                                     \
-  {                                                                      \
-    CVC5_API_ARG_CHECK_NOT_NULL(decl);                                   \
-    CVC5_API_CHECK(d_nm == decl.d_nm)                                    \
-        << "Given datatype declaration is not associated with the node " \
-           "manager of this solver";                                     \
-    CVC5_API_ARG_CHECK_EXPECTED(                                         \
-        dtypedecl.getDatatype().getNumConstructors() > 0, dtypedecl)     \
-        << "a datatype declaration with at least one constructor";       \
+#define CVC5_API_SOLVER_CHECK_DTDECL(decl)                                \
+  do                                                                      \
+  {                                                                       \
+    CVC5_API_ARG_CHECK_NOT_NULL(decl);                                    \
+    CVC5_API_CHECK(d_nm == decl.d_nm)                                     \
+        << "Given datatype declaration is not associated with the node "  \
+           "manager of this solver";                                      \
+    CVC5_API_CHECK(!decl.isResolved())                                    \
+        << "Given datatype declaration is already resolved (has already " \
+        << "been used to create a datatype sort";                         \
+    CVC5_API_ARG_CHECK_EXPECTED(                                          \
+        dtypedecl.getDatatype().getNumConstructors() > 0, dtypedecl)      \
+        << "a datatype declaration with at least one constructor";        \
   } while (0)
 
 /**

--- a/src/smt/sygus_solver.cpp
+++ b/src/smt/sygus_solver.cpp
@@ -312,7 +312,8 @@ bool SygusSolver::getSynthSolutions(std::map<Node, Node>& solMap)
   if (usingSygusSubsolver())
   {
     // use the call to get the synth solutions from the subsolver
-    return d_subsolver->getSubsolverSynthSolutions(solMap);
+    return d_subsolver ? d_subsolver->getSubsolverSynthSolutions(solMap)
+                       : false;
   }
   return getSubsolverSynthSolutions(solMap);
 }

--- a/test/unit/api/cpp/op_white.cpp
+++ b/test/unit/api/cpp/op_white.cpp
@@ -25,7 +25,7 @@ class TestApiWhiteOp : public TestApi
 
 TEST_F(TestApiWhiteOp, opFromKind)
 {
-  Op plus(&d_solver, ADD);
+  Op plus(d_solver.getNodeManager(), ADD);
   ASSERT_FALSE(plus.isIndexed());
   ASSERT_EQ(0, plus.getNumIndices());
   ASSERT_EQ(plus, d_solver.mkOp(ADD));

--- a/test/unit/api/cpp/solver_black.cpp
+++ b/test/unit/api/cpp/solver_black.cpp
@@ -186,6 +186,7 @@ TEST_F(TestApiBlackSolver, mkDatatypeSort)
   dtypeSpec.addConstructor(nil);
   ASSERT_NO_THROW(d_solver.mkDatatypeSort(dtypeSpec));
 
+  // FIXME: https://github.com/cvc5/cvc5-projects/issues/522
   // Solver slv;
   // ASSERT_THROW(slv.mkDatatypeSort(dtypeSpec), CVC5ApiException);
 
@@ -212,6 +213,7 @@ TEST_F(TestApiBlackSolver, mkDatatypeSorts)
   std::vector<DatatypeDecl> decls = {dtypeSpec1, dtypeSpec2};
   ASSERT_NO_THROW(d_solver.mkDatatypeSorts(decls));
 
+  // FIXME: https://github.com/cvc5/cvc5-projects/issues/522
   // ASSERT_THROW(slv.mkDatatypeSorts(decls), CVC5ApiException);
 
   DatatypeDecl throwsDtypeSpec = d_solver.mkDatatypeDecl("list");
@@ -230,6 +232,7 @@ TEST_F(TestApiBlackSolver, mkDatatypeSorts)
   std::vector<DatatypeDecl> udecls = {ulist};
   ASSERT_NO_THROW(d_solver.mkDatatypeSorts(udecls));
 
+  // FIXME: https://github.com/cvc5/cvc5-projects/issues/522
   // ASSERT_THROW(slv.mkDatatypeSorts(udecls), CVC5ApiException);
 
   /* mutually recursive with unresolved parameterized sorts */

--- a/test/unit/api/cpp/solver_black.cpp
+++ b/test/unit/api/cpp/solver_black.cpp
@@ -160,7 +160,7 @@ TEST_F(TestApiBlackSolver, mkArraySort)
   ASSERT_NO_THROW(d_solver.mkArraySort(bvSort, fpSort));
 
   Solver slv;
-  ASSERT_THROW(slv.mkArraySort(boolSort, boolSort), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkArraySort(boolSort, boolSort));
 }
 
 TEST_F(TestApiBlackSolver, mkBitVectorSort)

--- a/test/unit/api/cpp/solver_black.cpp
+++ b/test/unit/api/cpp/solver_black.cpp
@@ -186,8 +186,8 @@ TEST_F(TestApiBlackSolver, mkDatatypeSort)
   dtypeSpec.addConstructor(nil);
   ASSERT_NO_THROW(d_solver.mkDatatypeSort(dtypeSpec));
 
-  Solver slv;
-  ASSERT_THROW(slv.mkDatatypeSort(dtypeSpec), CVC5ApiException);
+  // Solver slv;
+  // ASSERT_THROW(slv.mkDatatypeSort(dtypeSpec), CVC5ApiException);
 
   DatatypeDecl throwsDtypeSpec = d_solver.mkDatatypeDecl("list");
   ASSERT_THROW(d_solver.mkDatatypeSort(throwsDtypeSpec), CVC5ApiException);
@@ -212,7 +212,7 @@ TEST_F(TestApiBlackSolver, mkDatatypeSorts)
   std::vector<DatatypeDecl> decls = {dtypeSpec1, dtypeSpec2};
   ASSERT_NO_THROW(d_solver.mkDatatypeSorts(decls));
 
-  ASSERT_THROW(slv.mkDatatypeSorts(decls), CVC5ApiException);
+  // ASSERT_THROW(slv.mkDatatypeSorts(decls), CVC5ApiException);
 
   DatatypeDecl throwsDtypeSpec = d_solver.mkDatatypeDecl("list");
   std::vector<DatatypeDecl> throwsDecls = {throwsDtypeSpec};
@@ -230,7 +230,7 @@ TEST_F(TestApiBlackSolver, mkDatatypeSorts)
   std::vector<DatatypeDecl> udecls = {ulist};
   ASSERT_NO_THROW(d_solver.mkDatatypeSorts(udecls));
 
-  ASSERT_THROW(slv.mkDatatypeSorts(udecls), CVC5ApiException);
+  // ASSERT_THROW(slv.mkDatatypeSorts(udecls), CVC5ApiException);
 
   /* mutually recursive with unresolved parameterized sorts */
   Sort p0 = d_solver.mkParamSort("p0");
@@ -286,21 +286,17 @@ TEST_F(TestApiBlackSolver, mkFunctionSort)
                CVC5ApiException);
 
   Solver slv;
-  ASSERT_THROW(slv.mkFunctionSort({d_solver.mkUninterpretedSort("u")},
-                                  d_solver.getIntegerSort()),
-               CVC5ApiException);
-  ASSERT_THROW(slv.mkFunctionSort({slv.mkUninterpretedSort("u")},
-                                  d_solver.getIntegerSort()),
-               CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkFunctionSort({d_solver.mkUninterpretedSort("u")},
+                                     d_solver.getIntegerSort()));
+  ASSERT_NO_THROW(slv.mkFunctionSort({slv.mkUninterpretedSort("u")},
+                                     d_solver.getIntegerSort()));
   std::vector<Sort> sorts1 = {d_solver.getBooleanSort(),
                               slv.getIntegerSort(),
                               d_solver.getIntegerSort()};
   std::vector<Sort> sorts2 = {slv.getBooleanSort(), slv.getIntegerSort()};
   ASSERT_NO_THROW(slv.mkFunctionSort(sorts2, slv.getIntegerSort()));
-  ASSERT_THROW(slv.mkFunctionSort(sorts1, slv.getIntegerSort()),
-               CVC5ApiException);
-  ASSERT_THROW(slv.mkFunctionSort(sorts2, d_solver.getIntegerSort()),
-               CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkFunctionSort(sorts1, slv.getIntegerSort()));
+  ASSERT_NO_THROW(slv.mkFunctionSort(sorts2, d_solver.getIntegerSort()));
 }
 
 TEST_F(TestApiBlackSolver, mkParamSort)
@@ -320,8 +316,7 @@ TEST_F(TestApiBlackSolver, mkPredicateSort)
       d_solver.mkPredicateSort({d_solver.getIntegerSort(), funSort}));
 
   Solver slv;
-  ASSERT_THROW(slv.mkPredicateSort({d_solver.getIntegerSort()}),
-               CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkPredicateSort({d_solver.getIntegerSort()}));
 }
 
 TEST_F(TestApiBlackSolver, mkRecordSort)
@@ -337,7 +332,7 @@ TEST_F(TestApiBlackSolver, mkRecordSort)
   ASSERT_NO_THROW(recSort.getDatatype());
 
   Solver slv;
-  ASSERT_THROW(slv.mkRecordSort(fields), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkRecordSort(fields));
 }
 
 TEST_F(TestApiBlackSolver, mkSetSort)
@@ -346,7 +341,7 @@ TEST_F(TestApiBlackSolver, mkSetSort)
   ASSERT_NO_THROW(d_solver.mkSetSort(d_solver.getIntegerSort()));
   ASSERT_NO_THROW(d_solver.mkSetSort(d_solver.mkBitVectorSort(4)));
   Solver slv;
-  ASSERT_THROW(slv.mkSetSort(d_solver.mkBitVectorSort(4)), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkSetSort(d_solver.mkBitVectorSort(4)));
 }
 
 TEST_F(TestApiBlackSolver, mkBagSort)
@@ -355,7 +350,7 @@ TEST_F(TestApiBlackSolver, mkBagSort)
   ASSERT_NO_THROW(d_solver.mkBagSort(d_solver.getIntegerSort()));
   ASSERT_NO_THROW(d_solver.mkBagSort(d_solver.mkBitVectorSort(4)));
   Solver slv;
-  ASSERT_THROW(slv.mkBagSort(d_solver.mkBitVectorSort(4)), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkBagSort(d_solver.mkBitVectorSort(4)));
 }
 
 TEST_F(TestApiBlackSolver, mkSequenceSort)
@@ -364,7 +359,7 @@ TEST_F(TestApiBlackSolver, mkSequenceSort)
   ASSERT_NO_THROW(d_solver.mkSequenceSort(
       d_solver.mkSequenceSort(d_solver.getIntegerSort())));
   Solver slv;
-  ASSERT_THROW(slv.mkSequenceSort(d_solver.getIntegerSort()), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkSequenceSort(d_solver.getIntegerSort()));
 }
 
 TEST_F(TestApiBlackSolver, mkUninterpretedSort)
@@ -397,7 +392,7 @@ TEST_F(TestApiBlackSolver, mkTupleSort)
   ASSERT_NO_THROW(d_solver.mkTupleSort({d_solver.getIntegerSort(), funSort}));
 
   Solver slv;
-  ASSERT_THROW(slv.mkTupleSort({d_solver.getIntegerSort()}), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkTupleSort({d_solver.getIntegerSort()}));
 }
 
 TEST_F(TestApiBlackSolver, mkBitVector)
@@ -460,7 +455,7 @@ TEST_F(TestApiBlackSolver, mkVar)
   ASSERT_THROW(d_solver.mkVar(Sort()), CVC5ApiException);
   ASSERT_THROW(d_solver.mkVar(Sort(), "a"), CVC5ApiException);
   Solver slv;
-  ASSERT_THROW(slv.mkVar(boolSort, "x"), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkVar(boolSort, "x"));
 }
 
 TEST_F(TestApiBlackSolver, mkBoolean)
@@ -500,7 +495,7 @@ TEST_F(TestApiBlackSolver, mkFloatingPoint)
   ASSERT_THROW(d_solver.mkFloatingPoint(3, 5, t2), CVC5ApiException);
 
   Solver slv;
-  ASSERT_THROW(slv.mkFloatingPoint(3, 5, t1), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkFloatingPoint(3, 5, t1));
 }
 
 TEST_F(TestApiBlackSolver, mkCardinalityConstraint)
@@ -511,38 +506,39 @@ TEST_F(TestApiBlackSolver, mkCardinalityConstraint)
   ASSERT_THROW(d_solver.mkCardinalityConstraint(si, 3), CVC5ApiException);
   ASSERT_THROW(d_solver.mkCardinalityConstraint(su, 0), CVC5ApiException);
   Solver slv;
-  ASSERT_THROW(slv.mkCardinalityConstraint(su, 3), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkCardinalityConstraint(su, 3));
 }
 
 TEST_F(TestApiBlackSolver, mkEmptySet)
 {
-  Solver slv;
   Sort s = d_solver.mkSetSort(d_solver.getBooleanSort());
   ASSERT_NO_THROW(d_solver.mkEmptySet(Sort()));
   ASSERT_NO_THROW(d_solver.mkEmptySet(s));
   ASSERT_THROW(d_solver.mkEmptySet(d_solver.getBooleanSort()),
                CVC5ApiException);
-  ASSERT_THROW(slv.mkEmptySet(s), CVC5ApiException);
+  Solver slv;
+  ASSERT_NO_THROW(slv.mkEmptySet(s));
 }
 
 TEST_F(TestApiBlackSolver, mkEmptyBag)
 {
-  Solver slv;
   Sort s = d_solver.mkBagSort(d_solver.getBooleanSort());
   ASSERT_NO_THROW(d_solver.mkEmptyBag(Sort()));
   ASSERT_NO_THROW(d_solver.mkEmptyBag(s));
   ASSERT_THROW(d_solver.mkEmptyBag(d_solver.getBooleanSort()),
                CVC5ApiException);
-  ASSERT_THROW(slv.mkEmptyBag(s), CVC5ApiException);
+  Solver slv;
+  ASSERT_NO_THROW(slv.mkEmptyBag(s));
 }
 
 TEST_F(TestApiBlackSolver, mkEmptySequence)
 {
-  Solver slv;
   Sort s = d_solver.mkSequenceSort(d_solver.getBooleanSort());
   ASSERT_NO_THROW(d_solver.mkEmptySequence(s));
   ASSERT_NO_THROW(d_solver.mkEmptySequence(d_solver.getBooleanSort()));
-  ASSERT_THROW(slv.mkEmptySequence(s), CVC5ApiException);
+
+  Solver slv;
+  ASSERT_NO_THROW(slv.mkEmptySequence(s));
 }
 
 TEST_F(TestApiBlackSolver, mkFalse)
@@ -718,7 +714,7 @@ TEST_F(TestApiBlackSolver, mkSepNil)
   ASSERT_NO_THROW(d_solver.mkSepNil(d_solver.getBooleanSort()));
   ASSERT_THROW(d_solver.mkSepNil(Sort()), CVC5ApiException);
   Solver slv;
-  ASSERT_THROW(slv.mkSepNil(d_solver.getIntegerSort()), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkSepNil(d_solver.getIntegerSort()));
 }
 
 TEST_F(TestApiBlackSolver, mkString)
@@ -771,7 +767,7 @@ TEST_F(TestApiBlackSolver, mkTerm)
       d_solver.mkTerm(BAG_MAKE, {d_solver.mkTrue(), d_solver.mkInteger(1)}));
   ASSERT_THROW(d_solver.mkTerm(NOT, {Term()}), CVC5ApiException);
   ASSERT_THROW(d_solver.mkTerm(NOT, {a}), CVC5ApiException);
-  ASSERT_THROW(slv.mkTerm(NOT, {d_solver.mkTrue()}), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkTerm(NOT, {d_solver.mkTrue()}));
 
   // mkTerm(Kind kind, Term child1, Term child2) const
   ASSERT_NO_THROW(d_solver.mkTerm(EQUAL, {a, b}));
@@ -779,7 +775,7 @@ TEST_F(TestApiBlackSolver, mkTerm)
   ASSERT_THROW(d_solver.mkTerm(EQUAL, {a, Term()}), CVC5ApiException);
   ASSERT_THROW(d_solver.mkTerm(EQUAL, {a, d_solver.mkTrue()}),
                CVC5ApiException);
-  ASSERT_THROW(slv.mkTerm(EQUAL, {a, b}), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkTerm(EQUAL, {a, b}));
 
   // mkTerm(Kind kind, Term child1, Term child2, Term child3) const
   ASSERT_NO_THROW(d_solver.mkTerm(
@@ -795,10 +791,8 @@ TEST_F(TestApiBlackSolver, mkTerm)
       CVC5ApiException);
   ASSERT_THROW(d_solver.mkTerm(ITE, {d_solver.mkTrue(), d_solver.mkTrue(), b}),
                CVC5ApiException);
-  ASSERT_THROW(
-      slv.mkTerm(ITE,
-                 {d_solver.mkTrue(), d_solver.mkTrue(), d_solver.mkTrue()}),
-      CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkTerm(
+      ITE, {d_solver.mkTrue(), d_solver.mkTrue(), d_solver.mkTrue()}));
 
   // mkTerm(Kind kind, const std::vector<Term>& children) const
   ASSERT_NO_THROW(d_solver.mkTerm(EQUAL, {v1}));
@@ -890,7 +884,7 @@ TEST_F(TestApiBlackSolver, mkTermFromOp)
   ASSERT_THROW(d_solver.mkTerm(opterm1), CVC5ApiException);
   ASSERT_THROW(d_solver.mkTerm(APPLY_SELECTOR, {headTerm}), CVC5ApiException);
   ASSERT_THROW(d_solver.mkTerm(opterm1), CVC5ApiException);
-  ASSERT_THROW(slv.mkTerm(APPLY_CONSTRUCTOR, {nilTerm}), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkTerm(APPLY_CONSTRUCTOR, {nilTerm}));
 
   // mkTerm(Op op, Term child) const
   ASSERT_NO_THROW(d_solver.mkTerm(opterm1, {a}));
@@ -902,7 +896,7 @@ TEST_F(TestApiBlackSolver, mkTermFromOp)
   ASSERT_THROW(
       d_solver.mkTerm(APPLY_CONSTRUCTOR, {consTerm, d_solver.mkInteger(0)}),
       CVC5ApiException);
-  ASSERT_THROW(slv.mkTerm(opterm1, {a}), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkTerm(opterm1, {a}));
 
   // mkTerm(Op op, Term child1, Term child2) const
   ASSERT_NO_THROW(
@@ -918,11 +912,10 @@ TEST_F(TestApiBlackSolver, mkTermFromOp)
                CVC5ApiException);
   ASSERT_THROW(d_solver.mkTerm(opterm2, {Term(), d_solver.mkInteger(1)}),
                CVC5ApiException);
-  ASSERT_THROW(slv.mkTerm(APPLY_CONSTRUCTOR,
-                          {consTerm,
-                           d_solver.mkInteger(0),
-                           d_solver.mkTerm(APPLY_CONSTRUCTOR, {nilTerm})}),
-               CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkTerm(APPLY_CONSTRUCTOR,
+                             {consTerm,
+                              d_solver.mkInteger(0),
+                              d_solver.mkTerm(APPLY_CONSTRUCTOR, {nilTerm})}));
 
   // mkTerm(Op op, Term child1, Term child2, Term child3) const
   ASSERT_THROW(d_solver.mkTerm(opterm1, {a, b, a}), CVC5ApiException);
@@ -936,7 +929,7 @@ TEST_F(TestApiBlackSolver, mkTermFromOp)
   ASSERT_THROW(d_solver.mkTerm(opterm2, {v1}), CVC5ApiException);
   ASSERT_THROW(d_solver.mkTerm(opterm2, {v2}), CVC5ApiException);
   ASSERT_THROW(d_solver.mkTerm(opterm2, {v3}), CVC5ApiException);
-  ASSERT_THROW(slv.mkTerm(opterm2, {v4}), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkTerm(opterm2, {v4}));
 }
 
 TEST_F(TestApiBlackSolver, mkTrue)
@@ -962,12 +955,10 @@ TEST_F(TestApiBlackSolver, mkTuple)
       d_solver.mkTuple({d_solver.getIntegerSort()}, {d_solver.mkReal("5.3")}),
       CVC5ApiException);
   Solver slv;
-  ASSERT_THROW(slv.mkTuple({d_solver.mkBitVectorSort(3)},
-                           {slv.mkBitVector(3, "101", 2)}),
-               CVC5ApiException);
-  ASSERT_THROW(slv.mkTuple({slv.mkBitVectorSort(3)},
-                           {d_solver.mkBitVector(3, "101", 2)}),
-               CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkTuple({d_solver.mkBitVectorSort(3)},
+                              {slv.mkBitVector(3, "101", 2)}));
+  ASSERT_NO_THROW(slv.mkTuple({slv.mkBitVectorSort(3)},
+                              {d_solver.mkBitVector(3, "101", 2)}));
 }
 
 TEST_F(TestApiBlackSolver, mkUniverseSet)
@@ -975,7 +966,7 @@ TEST_F(TestApiBlackSolver, mkUniverseSet)
   ASSERT_NO_THROW(d_solver.mkUniverseSet(d_solver.getBooleanSort()));
   ASSERT_THROW(d_solver.mkUniverseSet(Sort()), CVC5ApiException);
   Solver slv;
-  ASSERT_THROW(slv.mkUniverseSet(d_solver.getBooleanSort()), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkUniverseSet(d_solver.getBooleanSort()));
 }
 
 TEST_F(TestApiBlackSolver, mkConst)
@@ -993,7 +984,7 @@ TEST_F(TestApiBlackSolver, mkConst)
   ASSERT_THROW(d_solver.mkConst(Sort(), "a"), CVC5ApiException);
 
   Solver slv;
-  ASSERT_THROW(slv.mkConst(boolSort), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkConst(boolSort));
 }
 
 TEST_F(TestApiBlackSolver, mkConstArray)
@@ -1012,8 +1003,8 @@ TEST_F(TestApiBlackSolver, mkConstArray)
   Solver slv;
   Term zero2 = slv.mkInteger(0);
   Sort arrSort2 = slv.mkArraySort(slv.getIntegerSort(), slv.getIntegerSort());
-  ASSERT_THROW(slv.mkConstArray(arrSort2, zero), CVC5ApiException);
-  ASSERT_THROW(slv.mkConstArray(arrSort, zero2), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkConstArray(arrSort2, zero));
+  ASSERT_NO_THROW(slv.mkConstArray(arrSort, zero2));
 }
 
 TEST_F(TestApiBlackSolver, declareDatatype)
@@ -1046,7 +1037,6 @@ TEST_F(TestApiBlackSolver, declareDatatype)
   Sort s3 = d_solver.declareDatatype(std::string("_x17"), {ctor1, ctor2});
   ASSERT_THROW(d_solver.declareDatatype(std::string("_x86"), {ctor1, ctor2}),
                CVC5ApiException);
-  // constructor belongs to different solver instance
   Solver slv;
   ASSERT_THROW(slv.declareDatatype(std::string("a"), ctors1), CVC5ApiException);
 }
@@ -1065,7 +1055,7 @@ TEST_F(TestApiBlackSolver, declareFun)
   ASSERT_THROW(d_solver.declareFun("f5", {bvSort, bvSort}, funSort),
                CVC5ApiException);
   Solver slv;
-  ASSERT_THROW(slv.declareFun("f1", {}, bvSort), CVC5ApiException);
+  ASSERT_NO_THROW(slv.declareFun("f1", {}, bvSort));
 }
 
 TEST_F(TestApiBlackSolver, declareSort)
@@ -1113,12 +1103,12 @@ TEST_F(TestApiBlackSolver, defineFun)
   Term v12 = slv.mkConst(bvSort2, "v1");
   Term b12 = slv.mkVar(bvSort2, "b1");
   Term b22 = slv.mkVar(slv.getIntegerSort(), "b2");
-  ASSERT_THROW(slv.defineFun("f", {}, bvSort, v12), CVC5ApiException);
-  ASSERT_THROW(slv.defineFun("f", {}, bvSort2, v1), CVC5ApiException);
-  ASSERT_THROW(slv.defineFun("ff", {b1, b22}, bvSort2, v12), CVC5ApiException);
-  ASSERT_THROW(slv.defineFun("ff", {b12, b2}, bvSort2, v12), CVC5ApiException);
-  ASSERT_THROW(slv.defineFun("ff", {b12, b22}, bvSort, v12), CVC5ApiException);
-  ASSERT_THROW(slv.defineFun("ff", {b12, b22}, bvSort2, v1), CVC5ApiException);
+  ASSERT_NO_THROW(slv.defineFun("f", {}, bvSort, v12));
+  ASSERT_NO_THROW(slv.defineFun("f", {}, bvSort2, v1));
+  ASSERT_NO_THROW(slv.defineFun("ff", {b1, b22}, bvSort2, v12));
+  ASSERT_NO_THROW(slv.defineFun("ff", {b12, b2}, bvSort2, v12));
+  ASSERT_NO_THROW(slv.defineFun("ff", {b12, b22}, bvSort, v12));
+  ASSERT_NO_THROW(slv.defineFun("ff", {b12, b22}, bvSort2, v1));
 }
 
 TEST_F(TestApiBlackSolver, defineFunGlobal)
@@ -1183,16 +1173,12 @@ TEST_F(TestApiBlackSolver, defineFunRec)
   Term b22 = slv.mkVar(slv.getIntegerSort(), "b2");
   ASSERT_NO_THROW(slv.defineFunRec("f", {}, bvSort2, v12));
   ASSERT_NO_THROW(slv.defineFunRec("ff", {b12, b22}, bvSort2, v12));
-  ASSERT_THROW(slv.defineFunRec("f", {}, bvSort, v12), CVC5ApiException);
-  ASSERT_THROW(slv.defineFunRec("f", {}, bvSort2, v1), CVC5ApiException);
-  ASSERT_THROW(slv.defineFunRec("ff", {b1, b22}, bvSort2, v12),
-               CVC5ApiException);
-  ASSERT_THROW(slv.defineFunRec("ff", {b12, b2}, bvSort2, v12),
-               CVC5ApiException);
-  ASSERT_THROW(slv.defineFunRec("ff", {b12, b22}, bvSort, v12),
-               CVC5ApiException);
-  ASSERT_THROW(slv.defineFunRec("ff", {b12, b22}, bvSort2, v1),
-               CVC5ApiException);
+  ASSERT_NO_THROW(slv.defineFunRec("f", {}, bvSort, v12));
+  ASSERT_NO_THROW(slv.defineFunRec("f", {}, bvSort2, v1));
+  ASSERT_NO_THROW(slv.defineFunRec("ff", {b1, b22}, bvSort2, v12));
+  ASSERT_NO_THROW(slv.defineFunRec("ff", {b12, b2}, bvSort2, v12));
+  ASSERT_NO_THROW(slv.defineFunRec("ff", {b12, b22}, bvSort, v12));
+  ASSERT_NO_THROW(slv.defineFunRec("ff", {b12, b22}, bvSort2, v1));
 }
 
 TEST_F(TestApiBlackSolver, defineFunRecWrongLogic)
@@ -1277,20 +1263,20 @@ TEST_F(TestApiBlackSolver, defineFunsRec)
   Term f22 = slv.mkConst(funSort22, "f2");
   ASSERT_NO_THROW(
       slv.defineFunsRec({f12, f22}, {{b12, b112}, {b42}}, {v12, v22}));
-  ASSERT_THROW(slv.defineFunsRec({f1, f22}, {{b12, b112}, {b42}}, {v12, v22}),
-               CVC5ApiException);
+  ASSERT_NO_THROW(
+      slv.defineFunsRec({f1, f22}, {{b12, b112}, {b42}}, {v12, v22}));
   ASSERT_THROW(slv.defineFunsRec({f12, f2}, {{b12, b112}, {b42}}, {v12, v22}),
                CVC5ApiException);
-  ASSERT_THROW(slv.defineFunsRec({f12, f22}, {{b1, b112}, {b42}}, {v12, v22}),
-               CVC5ApiException);
-  ASSERT_THROW(slv.defineFunsRec({f12, f22}, {{b12, b11}, {b42}}, {v12, v22}),
-               CVC5ApiException);
+  ASSERT_NO_THROW(
+      slv.defineFunsRec({f12, f22}, {{b1, b112}, {b42}}, {v12, v22}));
+  ASSERT_NO_THROW(
+      slv.defineFunsRec({f12, f22}, {{b12, b11}, {b42}}, {v12, v22}));
   ASSERT_THROW(slv.defineFunsRec({f12, f22}, {{b12, b112}, {b4}}, {v12, v22}),
                CVC5ApiException);
-  ASSERT_THROW(slv.defineFunsRec({f12, f22}, {{b12, b112}, {b42}}, {v1, v22}),
-               CVC5ApiException);
-  ASSERT_THROW(slv.defineFunsRec({f12, f22}, {{b12, b112}, {b42}}, {v12, v2}),
-               CVC5ApiException);
+  ASSERT_NO_THROW(
+      slv.defineFunsRec({f12, f22}, {{b12, b112}, {b42}}, {v1, v22}));
+  ASSERT_NO_THROW(
+      slv.defineFunsRec({f12, f22}, {{b12, b112}, {b42}}, {v12, v2}));
 }
 
 TEST_F(TestApiBlackSolver, defineFunsRecWrongLogic)
@@ -2314,8 +2300,7 @@ TEST_F(TestApiBlackSolver, blockModelValues1)
   d_solver.checkSat();
   ASSERT_THROW(d_solver.blockModelValues({}), CVC5ApiException);
   ASSERT_THROW(d_solver.blockModelValues({Term()}), CVC5ApiException);
-  ASSERT_THROW(d_solver.blockModelValues({Solver().mkBoolean(false)}),
-               CVC5ApiException);
+  ASSERT_NO_THROW(d_solver.blockModelValues({Solver().mkBoolean(false)}));
 }
 
 TEST_F(TestApiBlackSolver, blockModelValues2)
@@ -2428,7 +2413,7 @@ TEST_F(TestApiBlackSolver, simplify)
   ASSERT_NE(d_solver.mkTrue(), x_eq_b);
   ASSERT_NE(d_solver.mkTrue(), d_solver.simplify(x_eq_b));
   Solver slv;
-  ASSERT_THROW(slv.simplify(x), CVC5ApiException);
+  ASSERT_NO_THROW(slv.simplify(x));
 
   Term i1 = d_solver.mkConst(d_solver.getIntegerSort(), "i1");
   ASSERT_NO_THROW(d_solver.simplify(i1));
@@ -2477,7 +2462,7 @@ TEST_F(TestApiBlackSolver, assertFormula)
   ASSERT_NO_THROW(d_solver.assertFormula(d_solver.mkTrue()));
   ASSERT_THROW(d_solver.assertFormula(Term()), CVC5ApiException);
   Solver slv;
-  ASSERT_THROW(slv.assertFormula(d_solver.mkTrue()), CVC5ApiException);
+  ASSERT_NO_THROW(slv.assertFormula(d_solver.mkTrue()));
 }
 
 TEST_F(TestApiBlackSolver, checkSat)
@@ -2493,7 +2478,7 @@ TEST_F(TestApiBlackSolver, checkSatAssuming)
   ASSERT_NO_THROW(d_solver.checkSatAssuming(d_solver.mkTrue()));
   ASSERT_THROW(d_solver.checkSatAssuming(d_solver.mkTrue()), CVC5ApiException);
   Solver slv;
-  ASSERT_THROW(slv.checkSatAssuming(d_solver.mkTrue()), CVC5ApiException);
+  ASSERT_NO_THROW(slv.checkSatAssuming(d_solver.mkTrue()));
 }
 
 TEST_F(TestApiBlackSolver, checkSatAssuming1)
@@ -2508,7 +2493,7 @@ TEST_F(TestApiBlackSolver, checkSatAssuming1)
   ASSERT_NO_THROW(d_solver.checkSatAssuming(d_solver.mkTrue()));
   ASSERT_NO_THROW(d_solver.checkSatAssuming(z));
   Solver slv;
-  ASSERT_THROW(slv.checkSatAssuming(d_solver.mkTrue()), CVC5ApiException);
+  ASSERT_NO_THROW(slv.checkSatAssuming(d_solver.mkTrue()));
 }
 
 TEST_F(TestApiBlackSolver, checkSatAssuming2)
@@ -2558,7 +2543,7 @@ TEST_F(TestApiBlackSolver, checkSatAssuming2)
       d_solver.checkSatAssuming({n, d_solver.mkTerm(DISTINCT, {x, y})}),
       CVC5ApiException);
   Solver slv;
-  ASSERT_THROW(slv.checkSatAssuming(d_solver.mkTrue()), CVC5ApiException);
+  ASSERT_NO_THROW(slv.checkSatAssuming(d_solver.mkTrue()));
 }
 
 TEST_F(TestApiBlackSolver, setLogic)
@@ -2627,8 +2612,8 @@ TEST_F(TestApiBlackSolver, mkGrammar)
   Term boolVar2 = slv.mkVar(slv.getBooleanSort());
   Term intVar2 = slv.mkVar(slv.getIntegerSort());
   ASSERT_NO_THROW(slv.mkGrammar({boolVar2}, {intVar2}));
-  ASSERT_THROW(slv.mkGrammar({boolVar}, {intVar2}), CVC5ApiException);
-  ASSERT_THROW(slv.mkGrammar({boolVar2}, {intVar}), CVC5ApiException);
+  ASSERT_NO_THROW(slv.mkGrammar({boolVar}, {intVar2}));
+  ASSERT_NO_THROW(slv.mkGrammar({boolVar2}, {intVar}));
 }
 
 TEST_F(TestApiBlackSolver, synthFun)
@@ -2661,10 +2646,8 @@ TEST_F(TestApiBlackSolver, synthFun)
   slv.setOption("sygus", "true");
   Term x2 = slv.mkVar(slv.getBooleanSort());
   ASSERT_NO_THROW(slv.synthFun("f1", {x2}, slv.getBooleanSort()));
-  ASSERT_THROW(slv.synthFun("", {}, d_solver.getBooleanSort()),
-               CVC5ApiException);
-  ASSERT_THROW(slv.synthFun("f1", {x}, d_solver.getBooleanSort()),
-               CVC5ApiException);
+  ASSERT_NO_THROW(slv.synthFun("", {}, d_solver.getBooleanSort()));
+  ASSERT_NO_THROW(slv.synthFun("f1", {x}, d_solver.getBooleanSort()));
 }
 
 TEST_F(TestApiBlackSolver, synthInv)
@@ -2706,7 +2689,7 @@ TEST_F(TestApiBlackSolver, addSygusConstraint)
 
   Solver slv;
   slv.setOption("sygus", "true");
-  ASSERT_THROW(slv.addSygusConstraint(boolTerm), CVC5ApiException);
+  ASSERT_NO_THROW(slv.addSygusConstraint(boolTerm));
 }
 
 TEST_F(TestApiBlackSolver, addSygusAssume)
@@ -2722,7 +2705,7 @@ TEST_F(TestApiBlackSolver, addSygusAssume)
 
   Solver slv;
   slv.setOption("sygus", "true");
-  ASSERT_THROW(slv.addSygusAssume(boolTerm), CVC5ApiException);
+  ASSERT_NO_THROW(slv.addSygusAssume(boolTerm));
 }
 
 TEST_F(TestApiBlackSolver, addSygusInvConstraint)
@@ -2787,14 +2770,10 @@ TEST_F(TestApiBlackSolver, addSygusInvConstraint)
   Term trans22 = slv.declareFun("trans", {real2, real2}, boolean2);
   Term post22 = slv.declareFun("post", {real2}, boolean2);
   ASSERT_NO_THROW(slv.addSygusInvConstraint(inv22, pre22, trans22, post22));
-  ASSERT_THROW(slv.addSygusInvConstraint(inv, pre22, trans22, post22),
-               CVC5ApiException);
-  ASSERT_THROW(slv.addSygusInvConstraint(inv22, pre, trans22, post22),
-               CVC5ApiException);
-  ASSERT_THROW(slv.addSygusInvConstraint(inv22, pre22, trans, post22),
-               CVC5ApiException);
-  ASSERT_THROW(slv.addSygusInvConstraint(inv22, pre22, trans22, post),
-               CVC5ApiException);
+  ASSERT_NO_THROW(slv.addSygusInvConstraint(inv, pre22, trans22, post22));
+  ASSERT_NO_THROW(slv.addSygusInvConstraint(inv22, pre, trans22, post22));
+  ASSERT_NO_THROW(slv.addSygusInvConstraint(inv22, pre22, trans, post22));
+  ASSERT_NO_THROW(slv.addSygusInvConstraint(inv22, pre22, trans22, post));
 }
 
 TEST_F(TestApiBlackSolver, checkSynth)

--- a/test/unit/api/cpp/solver_white.cpp
+++ b/test/unit/api/cpp/solver_white.cpp
@@ -45,9 +45,10 @@ TEST_F(TestApiWhiteSolver, getOp)
                                    {consTerm, d_solver.mkInteger(1), listnil});
   Term listhead = d_solver.mkTerm(APPLY_SELECTOR, {headTerm, listcons1});
 
-  ASSERT_EQ(listnil.getOp(), Op(&d_solver, APPLY_CONSTRUCTOR));
-  ASSERT_EQ(listcons1.getOp(), Op(&d_solver, APPLY_CONSTRUCTOR));
-  ASSERT_EQ(listhead.getOp(), Op(&d_solver, APPLY_SELECTOR));
+  ASSERT_EQ(listnil.getOp(), Op(d_solver.getNodeManager(), APPLY_CONSTRUCTOR));
+  ASSERT_EQ(listcons1.getOp(),
+            Op(d_solver.getNodeManager(), APPLY_CONSTRUCTOR));
+  ASSERT_EQ(listhead.getOp(), Op(d_solver.getNodeManager(), APPLY_SELECTOR));
 }
 
 }  // namespace test

--- a/test/unit/api/cpp/term_white.cpp
+++ b/test/unit/api/cpp/term_white.cpp
@@ -38,14 +38,14 @@ TEST_F(TestApiWhiteTerm, getOp)
   Op ext = d_solver.mkOp(BITVECTOR_EXTRACT, {4, 0});
   Term extb = d_solver.mkTerm(ext, {b});
 
-  ASSERT_EQ(ab.getOp(), Op(&d_solver, SELECT));
+  ASSERT_EQ(ab.getOp(), Op(d_solver.getNodeManager(), SELECT));
   // can compare directly to a Kind (will invoke Op constructor)
-  ASSERT_EQ(ab.getOp(), Op(&d_solver, SELECT));
+  ASSERT_EQ(ab.getOp(), Op(d_solver.getNodeManager(), SELECT));
 
   Term f = d_solver.mkConst(funsort, "f");
   Term fx = d_solver.mkTerm(APPLY_UF, {f, x});
 
-  ASSERT_EQ(fx.getOp(), Op(&d_solver, APPLY_UF));
+  ASSERT_EQ(fx.getOp(), Op(d_solver.getNodeManager(), APPLY_UF));
   // testing rebuild from op and children
 
   // Test Datatypes Ops
@@ -74,10 +74,10 @@ TEST_F(TestApiWhiteTerm, getOp)
   Term headTerm = d_solver.mkTerm(APPLY_SELECTOR, {headOpTerm, consTerm});
   Term tailTerm = d_solver.mkTerm(APPLY_SELECTOR, {tailOpTerm, consTerm});
 
-  ASSERT_EQ(nilTerm.getOp(), Op(&d_solver, APPLY_CONSTRUCTOR));
-  ASSERT_EQ(consTerm.getOp(), Op(&d_solver, APPLY_CONSTRUCTOR));
-  ASSERT_EQ(headTerm.getOp(), Op(&d_solver, APPLY_SELECTOR));
-  ASSERT_EQ(tailTerm.getOp(), Op(&d_solver, APPLY_SELECTOR));
+  ASSERT_EQ(nilTerm.getOp(), Op(d_solver.getNodeManager(), APPLY_CONSTRUCTOR));
+  ASSERT_EQ(consTerm.getOp(), Op(d_solver.getNodeManager(), APPLY_CONSTRUCTOR));
+  ASSERT_EQ(headTerm.getOp(), Op(d_solver.getNodeManager(), APPLY_SELECTOR));
+  ASSERT_EQ(tailTerm.getOp(), Op(d_solver.getNodeManager(), APPLY_SELECTOR));
 }
 }  // namespace test
 }  // namespace cvc5::internal

--- a/test/unit/api/java/SolverTest.java
+++ b/test/unit/api/java/SolverTest.java
@@ -149,6 +149,7 @@ class SolverTest
     dtypeSpec.addConstructor(nil);
     assertDoesNotThrow(() -> d_solver.mkDatatypeSort(dtypeSpec));
 
+    // FIXME: https://github.com/cvc5/cvc5-projects/issues/522
     // Solver slv = new Solver();
     // assertThrows(CVC5ApiException.class, () -> slv.mkDatatypeSort(dtypeSpec));
     // slv.close();
@@ -177,6 +178,7 @@ class SolverTest
     DatatypeDecl[] decls = {dtypeSpec1, dtypeSpec2};
     assertDoesNotThrow(() -> d_solver.mkDatatypeSorts(decls));
 
+    // FIXME: https://github.com/cvc5/cvc5-projects/issues/522
     // assertThrows(CVC5ApiException.class, () -> slv.mkDatatypeSorts(decls));
 
     DatatypeDecl throwsDtypeSpec = d_solver.mkDatatypeDecl("list");
@@ -195,6 +197,7 @@ class SolverTest
     DatatypeDecl[] udecls = new DatatypeDecl[] {ulist};
     assertDoesNotThrow(() -> d_solver.mkDatatypeSorts(udecls));
 
+    // FIXME: https://github.com/cvc5/cvc5-projects/issues/522
     // assertThrows(CVC5ApiException.class, () -> slv.mkDatatypeSorts(udecls));
     slv.close();
 

--- a/test/unit/api/java/SolverTest.java
+++ b/test/unit/api/java/SolverTest.java
@@ -119,7 +119,7 @@ class SolverTest
     assertDoesNotThrow(() -> d_solver.mkArraySort(bvSort, fpSort));
 
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class, () -> slv.mkArraySort(boolSort, boolSort));
+    assertDoesNotThrow(() -> slv.mkArraySort(boolSort, boolSort));
     slv.close();
   }
 
@@ -150,7 +150,7 @@ class SolverTest
     assertDoesNotThrow(() -> d_solver.mkDatatypeSort(dtypeSpec));
 
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class, () -> slv.mkDatatypeSort(dtypeSpec));
+    assertDoesNotThrow(() -> slv.mkDatatypeSort(dtypeSpec));
 
     DatatypeDecl throwsDtypeSpec = d_solver.mkDatatypeDecl("list");
     assertThrows(CVC5ApiException.class, () -> d_solver.mkDatatypeSort(throwsDtypeSpec));

--- a/test/unit/api/java/SolverTest.java
+++ b/test/unit/api/java/SolverTest.java
@@ -149,12 +149,12 @@ class SolverTest
     dtypeSpec.addConstructor(nil);
     assertDoesNotThrow(() -> d_solver.mkDatatypeSort(dtypeSpec));
 
-    Solver slv = new Solver();
-    assertDoesNotThrow(() -> slv.mkDatatypeSort(dtypeSpec));
+    // Solver slv = new Solver();
+    // assertThrows(CVC5ApiException.class, () -> slv.mkDatatypeSort(dtypeSpec));
+    // slv.close();
 
     DatatypeDecl throwsDtypeSpec = d_solver.mkDatatypeDecl("list");
     assertThrows(CVC5ApiException.class, () -> d_solver.mkDatatypeSort(throwsDtypeSpec));
-    slv.close();
   }
 
   @Test
@@ -177,7 +177,7 @@ class SolverTest
     DatatypeDecl[] decls = {dtypeSpec1, dtypeSpec2};
     assertDoesNotThrow(() -> d_solver.mkDatatypeSorts(decls));
 
-    assertThrows(CVC5ApiException.class, () -> slv.mkDatatypeSorts(decls));
+    // assertThrows(CVC5ApiException.class, () -> slv.mkDatatypeSorts(decls));
 
     DatatypeDecl throwsDtypeSpec = d_solver.mkDatatypeDecl("list");
     DatatypeDecl[] throwsDecls = new DatatypeDecl[] {throwsDtypeSpec};
@@ -195,7 +195,7 @@ class SolverTest
     DatatypeDecl[] udecls = new DatatypeDecl[] {ulist};
     assertDoesNotThrow(() -> d_solver.mkDatatypeSorts(udecls));
 
-    assertThrows(CVC5ApiException.class, () -> slv.mkDatatypeSorts(udecls));
+    // assertThrows(CVC5ApiException.class, () -> slv.mkDatatypeSorts(udecls));
     slv.close();
 
     /* mutually recursive with unresolved parameterized sorts */
@@ -258,19 +258,18 @@ class SolverTest
                 funSort2));
 
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class,
+    assertDoesNotThrow(
         () -> slv.mkFunctionSort(d_solver.mkUninterpretedSort("u"), d_solver.getIntegerSort()));
 
-    assertThrows(CVC5ApiException.class,
+    assertDoesNotThrow(
         () -> slv.mkFunctionSort(slv.mkUninterpretedSort("u"), d_solver.getIntegerSort()));
 
     Sort[] sorts1 =
         new Sort[] {d_solver.getBooleanSort(), slv.getIntegerSort(), d_solver.getIntegerSort()};
     Sort[] sorts2 = new Sort[] {slv.getBooleanSort(), slv.getIntegerSort()};
     assertDoesNotThrow(() -> slv.mkFunctionSort(sorts2, slv.getIntegerSort()));
-    assertThrows(CVC5ApiException.class, () -> slv.mkFunctionSort(sorts1, slv.getIntegerSort()));
-    assertThrows(
-        CVC5ApiException.class, () -> slv.mkFunctionSort(sorts2, d_solver.getIntegerSort()));
+    assertDoesNotThrow(() -> slv.mkFunctionSort(sorts1, slv.getIntegerSort()));
+    assertDoesNotThrow(() -> slv.mkFunctionSort(sorts2, d_solver.getIntegerSort()));
     slv.close();
   }
 
@@ -293,8 +292,7 @@ class SolverTest
         () -> d_solver.mkPredicateSort(new Sort[] {d_solver.getIntegerSort(), funSort}));
 
     Solver slv = new Solver();
-    assertThrows(
-        CVC5ApiException.class, () -> slv.mkPredicateSort(new Sort[] {d_solver.getIntegerSort()}));
+    assertDoesNotThrow(() -> slv.mkPredicateSort(new Sort[] {d_solver.getIntegerSort()}));
     slv.close();
   }
 
@@ -311,7 +309,7 @@ class SolverTest
     assertDoesNotThrow(() -> recSort.getDatatype());
 
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class, () -> slv.mkRecordSort(fields));
+    assertDoesNotThrow(() -> slv.mkRecordSort(fields));
     slv.close();
   }
 
@@ -322,7 +320,7 @@ class SolverTest
     assertDoesNotThrow(() -> d_solver.mkSetSort(d_solver.getIntegerSort()));
     assertDoesNotThrow(() -> d_solver.mkSetSort(d_solver.mkBitVectorSort(4)));
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class, () -> slv.mkSetSort(d_solver.mkBitVectorSort(4)));
+    assertDoesNotThrow(() -> slv.mkSetSort(d_solver.mkBitVectorSort(4)));
     slv.close();
   }
 
@@ -333,7 +331,7 @@ class SolverTest
     assertDoesNotThrow(() -> d_solver.mkBagSort(d_solver.getIntegerSort()));
     assertDoesNotThrow(() -> d_solver.mkBagSort(d_solver.mkBitVectorSort(4)));
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class, () -> slv.mkBagSort(d_solver.mkBitVectorSort(4)));
+    assertDoesNotThrow(() -> slv.mkBagSort(d_solver.mkBitVectorSort(4)));
     slv.close();
   }
 
@@ -344,7 +342,7 @@ class SolverTest
     assertDoesNotThrow(
         () -> d_solver.mkSequenceSort(d_solver.mkSequenceSort(d_solver.getIntegerSort())));
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class, () -> slv.mkSequenceSort(d_solver.getIntegerSort()));
+    assertDoesNotThrow(() -> slv.mkSequenceSort(d_solver.getIntegerSort()));
     slv.close();
   }
 
@@ -381,8 +379,7 @@ class SolverTest
     assertDoesNotThrow(() -> d_solver.mkTupleSort(new Sort[] {d_solver.getIntegerSort(), funSort}));
 
     Solver slv = new Solver();
-    assertThrows(
-        CVC5ApiException.class, () -> slv.mkTupleSort(new Sort[] {d_solver.getIntegerSort()}));
+    assertDoesNotThrow(() -> slv.mkTupleSort(new Sort[] {d_solver.getIntegerSort()}));
     slv.close();
   }
 
@@ -443,7 +440,7 @@ class SolverTest
     assertThrows(CVC5ApiException.class, () -> d_solver.mkVar(d_solver.getNullSort()));
     assertThrows(CVC5ApiException.class, () -> d_solver.mkVar(d_solver.getNullSort(), "a"));
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class, () -> slv.mkVar(boolSort, "x"));
+    assertDoesNotThrow(() -> slv.mkVar(boolSort, "x"));
     slv.close();
   }
 
@@ -485,7 +482,7 @@ class SolverTest
     assertThrows(CVC5ApiException.class, () -> d_solver.mkFloatingPoint(3, 5, t2));
 
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class, () -> slv.mkFloatingPoint(3, 5, t1));
+    assertDoesNotThrow(() -> slv.mkFloatingPoint(3, 5, t1));
     slv.close();
   }
 
@@ -498,7 +495,7 @@ class SolverTest
     assertThrows(CVC5ApiException.class, () -> d_solver.mkCardinalityConstraint(si, 3));
     assertThrows(CVC5ApiException.class, () -> d_solver.mkCardinalityConstraint(su, 0));
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class, () -> slv.mkCardinalityConstraint(su, 3));
+    assertDoesNotThrow(() -> slv.mkCardinalityConstraint(su, 3));
     slv.close();
   }
 
@@ -510,7 +507,7 @@ class SolverTest
     assertDoesNotThrow(() -> d_solver.mkEmptySet(d_solver.getNullSort()));
     assertDoesNotThrow(() -> d_solver.mkEmptySet(s));
     assertThrows(CVC5ApiException.class, () -> d_solver.mkEmptySet(d_solver.getBooleanSort()));
-    assertThrows(CVC5ApiException.class, () -> slv.mkEmptySet(s));
+    assertDoesNotThrow(() -> slv.mkEmptySet(s));
     slv.close();
   }
 
@@ -523,7 +520,7 @@ class SolverTest
     assertDoesNotThrow(() -> d_solver.mkEmptyBag(s));
     assertThrows(CVC5ApiException.class, () -> d_solver.mkEmptyBag(d_solver.getBooleanSort()));
 
-    assertThrows(CVC5ApiException.class, () -> slv.mkEmptyBag(s));
+    assertDoesNotThrow(() -> slv.mkEmptyBag(s));
     slv.close();
   }
 
@@ -534,7 +531,7 @@ class SolverTest
     Sort s = d_solver.mkSequenceSort(d_solver.getBooleanSort());
     assertDoesNotThrow(() -> d_solver.mkEmptySequence(s));
     assertDoesNotThrow(() -> d_solver.mkEmptySequence(d_solver.getBooleanSort()));
-    assertThrows(CVC5ApiException.class, () -> slv.mkEmptySequence(s));
+    assertDoesNotThrow(() -> slv.mkEmptySequence(s));
     slv.close();
   }
 
@@ -730,7 +727,7 @@ class SolverTest
     assertDoesNotThrow(() -> d_solver.mkSepNil(d_solver.getBooleanSort()));
     assertThrows(CVC5ApiException.class, () -> d_solver.mkSepNil(d_solver.getNullSort()));
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class, () -> slv.mkSepNil(d_solver.getIntegerSort()));
+    assertDoesNotThrow(() -> slv.mkSepNil(d_solver.getIntegerSort()));
     slv.close();
   }
 
@@ -767,14 +764,14 @@ class SolverTest
     assertDoesNotThrow(() -> d_solver.mkTerm(NOT, d_solver.mkTrue()));
     assertThrows(CVC5ApiException.class, () -> d_solver.mkTerm(NOT, d_solver.getNullTerm()));
     assertThrows(CVC5ApiException.class, () -> d_solver.mkTerm(NOT, a));
-    assertThrows(CVC5ApiException.class, () -> slv.mkTerm(NOT, d_solver.mkTrue()));
+    assertDoesNotThrow(() -> slv.mkTerm(NOT, d_solver.mkTrue()));
 
     // mkTerm(Kind kind, Term child1, Term child2) const
     assertDoesNotThrow(() -> d_solver.mkTerm(EQUAL, a, b));
     assertThrows(CVC5ApiException.class, () -> d_solver.mkTerm(EQUAL, d_solver.getNullTerm(), b));
     assertThrows(CVC5ApiException.class, () -> d_solver.mkTerm(EQUAL, a, d_solver.getNullTerm()));
     assertThrows(CVC5ApiException.class, () -> d_solver.mkTerm(EQUAL, a, d_solver.mkTrue()));
-    assertThrows(CVC5ApiException.class, () -> slv.mkTerm(EQUAL, a, b));
+    assertDoesNotThrow(() -> slv.mkTerm(EQUAL, a, b));
 
     // mkTerm(Kind kind, Term child1, Term child2, Term child3) const
     assertDoesNotThrow(
@@ -791,7 +788,7 @@ class SolverTest
     assertThrows(CVC5ApiException.class,
         () -> d_solver.mkTerm(ITE, d_solver.mkTrue(), d_solver.mkTrue(), b));
 
-    assertThrows(CVC5ApiException.class,
+    assertDoesNotThrow(
         () -> slv.mkTerm(ITE, d_solver.mkTrue(), d_solver.mkTrue(), d_solver.mkTrue()));
 
     // mkTerm(Kind kind, const Term[]& children) const
@@ -846,7 +843,7 @@ class SolverTest
     assertThrows(CVC5ApiException.class, () -> d_solver.mkTerm(opterm1));
     assertThrows(CVC5ApiException.class, () -> d_solver.mkTerm(APPLY_SELECTOR, headTerm));
     assertThrows(CVC5ApiException.class, () -> d_solver.mkTerm(opterm1));
-    assertThrows(CVC5ApiException.class, () -> slv.mkTerm(APPLY_CONSTRUCTOR, nilTerm));
+    assertDoesNotThrow(() -> slv.mkTerm(APPLY_CONSTRUCTOR, nilTerm));
 
     // mkTerm(Op op, Term child) const
     assertDoesNotThrow(() -> d_solver.mkTerm(opterm1, a));
@@ -858,7 +855,7 @@ class SolverTest
     assertThrows(CVC5ApiException.class,
         () -> d_solver.mkTerm(APPLY_CONSTRUCTOR, consTerm, d_solver.mkInteger(0)));
 
-    assertThrows(CVC5ApiException.class, () -> slv.mkTerm(opterm1, a));
+    assertDoesNotThrow(() -> slv.mkTerm(opterm1, a));
 
     // mkTerm(Op op, Term child1, Term child2) const
     assertDoesNotThrow(()
@@ -876,12 +873,11 @@ class SolverTest
     assertThrows(CVC5ApiException.class,
         () -> d_solver.mkTerm(opterm2, d_solver.getNullTerm(), d_solver.mkInteger(1)));
 
-    assertThrows(CVC5ApiException.class,
-        ()
-            -> slv.mkTerm(APPLY_CONSTRUCTOR,
-                consTerm,
-                d_solver.mkInteger(0),
-                d_solver.mkTerm(APPLY_CONSTRUCTOR, nilTerm)));
+    assertDoesNotThrow(()
+                           -> slv.mkTerm(APPLY_CONSTRUCTOR,
+                               consTerm,
+                               d_solver.mkInteger(0),
+                               d_solver.mkTerm(APPLY_CONSTRUCTOR, nilTerm)));
 
     // mkTerm(Op op, Term child1, Term child2, Term child3) const
     assertThrows(CVC5ApiException.class, () -> d_solver.mkTerm(opterm1, a, b, a));
@@ -895,7 +891,7 @@ class SolverTest
     assertThrows(CVC5ApiException.class, () -> d_solver.mkTerm(opterm2, v1));
     assertThrows(CVC5ApiException.class, () -> d_solver.mkTerm(opterm2, v2));
     assertThrows(CVC5ApiException.class, () -> d_solver.mkTerm(opterm2, v3));
-    assertThrows(CVC5ApiException.class, () -> slv.mkTerm(opterm2, v4));
+    assertDoesNotThrow(() -> slv.mkTerm(opterm2, v4));
     slv.close();
   }
 
@@ -931,15 +927,13 @@ class SolverTest
                 new Sort[] {d_solver.getIntegerSort()}, new Term[] {d_solver.mkReal("5.3")}));
 
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class,
-        ()
-            -> slv.mkTuple(new Sort[] {d_solver.mkBitVectorSort(3)},
-                new Term[] {slv.mkBitVector(3, "101", 2)}));
+    assertDoesNotThrow(()
+                           -> slv.mkTuple(new Sort[] {d_solver.mkBitVectorSort(3)},
+                               new Term[] {slv.mkBitVector(3, "101", 2)}));
 
-    assertThrows(CVC5ApiException.class,
-        ()
-            -> slv.mkTuple(new Sort[] {slv.mkBitVectorSort(3)},
-                new Term[] {d_solver.mkBitVector(3, "101", 2)}));
+    assertDoesNotThrow(()
+                           -> slv.mkTuple(new Sort[] {slv.mkBitVectorSort(3)},
+                               new Term[] {d_solver.mkBitVector(3, "101", 2)}));
     slv.close();
   }
 
@@ -949,7 +943,7 @@ class SolverTest
     assertDoesNotThrow(() -> d_solver.mkUniverseSet(d_solver.getBooleanSort()));
     assertThrows(CVC5ApiException.class, () -> d_solver.mkUniverseSet(d_solver.getNullSort()));
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class, () -> slv.mkUniverseSet(d_solver.getBooleanSort()));
+    assertDoesNotThrow(() -> slv.mkUniverseSet(d_solver.getBooleanSort()));
     slv.close();
   }
 
@@ -969,7 +963,7 @@ class SolverTest
     assertThrows(CVC5ApiException.class, () -> d_solver.mkConst(d_solver.getNullSort(), "a"));
 
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class, () -> slv.mkConst(boolSort));
+    assertDoesNotThrow(() -> slv.mkConst(boolSort));
     slv.close();
   }
 
@@ -992,8 +986,8 @@ class SolverTest
     Solver slv = new Solver();
     Term zero2 = slv.mkInteger(0);
     Sort arrSort2 = slv.mkArraySort(slv.getIntegerSort(), slv.getIntegerSort());
-    assertThrows(CVC5ApiException.class, () -> slv.mkConstArray(arrSort2, zero));
-    assertThrows(CVC5ApiException.class, () -> slv.mkConstArray(arrSort, zero2));
+    assertDoesNotThrow(() -> slv.mkConstArray(arrSort2, zero));
+    assertDoesNotThrow(() -> slv.mkConstArray(arrSort, zero2));
     slv.close();
   }
 
@@ -1037,7 +1031,7 @@ class SolverTest
         () -> d_solver.declareFun("f5", new Sort[] {bvSort, bvSort}, funSort));
 
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class, () -> slv.declareFun("f1", new Sort[] {}, bvSort));
+    assertDoesNotThrow(() -> slv.declareFun("f1", new Sort[] {}, bvSort));
     slv.close();
   }
 
@@ -1094,16 +1088,12 @@ class SolverTest
     Term v12 = slv.mkConst(bvSort2, "v1");
     Term b12 = slv.mkVar(bvSort2, "b1");
     Term b22 = slv.mkVar(slv.getIntegerSort(), "b2");
-    assertThrows(CVC5ApiException.class, () -> slv.defineFun("f", new Term[] {}, bvSort, v12));
-    assertThrows(CVC5ApiException.class, () -> slv.defineFun("f", new Term[] {}, bvSort2, v1));
-    assertThrows(
-        CVC5ApiException.class, () -> slv.defineFun("ff", new Term[] {b1, b22}, bvSort2, v12));
-    assertThrows(
-        CVC5ApiException.class, () -> slv.defineFun("ff", new Term[] {b12, b2}, bvSort2, v12));
-    assertThrows(
-        CVC5ApiException.class, () -> slv.defineFun("ff", new Term[] {b12, b22}, bvSort, v12));
-    assertThrows(
-        CVC5ApiException.class, () -> slv.defineFun("ff", new Term[] {b12, b22}, bvSort2, v1));
+    assertDoesNotThrow(() -> slv.defineFun("f", new Term[] {}, bvSort, v12));
+    assertDoesNotThrow(() -> slv.defineFun("f", new Term[] {}, bvSort2, v1));
+    assertDoesNotThrow(() -> slv.defineFun("ff", new Term[] {b1, b22}, bvSort2, v12));
+    assertDoesNotThrow(() -> slv.defineFun("ff", new Term[] {b12, b2}, bvSort2, v12));
+    assertDoesNotThrow(() -> slv.defineFun("ff", new Term[] {b12, b22}, bvSort, v12));
+    assertDoesNotThrow(() -> slv.defineFun("ff", new Term[] {b12, b22}, bvSort2, v1));
     slv.close();
   }
 
@@ -1174,19 +1164,15 @@ class SolverTest
     Term b22 = slv.mkVar(slv.getIntegerSort(), "b2");
     assertDoesNotThrow(() -> slv.defineFunRec("f", new Term[] {}, bvSort2, v12));
     assertDoesNotThrow(() -> slv.defineFunRec("ff", new Term[] {b12, b22}, bvSort2, v12));
-    assertThrows(CVC5ApiException.class, () -> slv.defineFunRec("f", new Term[] {}, bvSort, v12));
-    assertThrows(CVC5ApiException.class, () -> slv.defineFunRec("f", new Term[] {}, bvSort2, v1));
-    assertThrows(
-        CVC5ApiException.class, () -> slv.defineFunRec("ff", new Term[] {b1, b22}, bvSort2, v12));
+    assertDoesNotThrow(() -> slv.defineFunRec("f", new Term[] {}, bvSort, v12));
+    assertDoesNotThrow(() -> slv.defineFunRec("f", new Term[] {}, bvSort2, v1));
+    assertDoesNotThrow(() -> slv.defineFunRec("ff", new Term[] {b1, b22}, bvSort2, v12));
 
-    assertThrows(
-        CVC5ApiException.class, () -> slv.defineFunRec("ff", new Term[] {b12, b2}, bvSort2, v12));
+    assertDoesNotThrow(() -> slv.defineFunRec("ff", new Term[] {b12, b2}, bvSort2, v12));
 
-    assertThrows(
-        CVC5ApiException.class, () -> slv.defineFunRec("ff", new Term[] {b12, b22}, bvSort, v12));
+    assertDoesNotThrow(() -> slv.defineFunRec("ff", new Term[] {b12, b22}, bvSort, v12));
 
-    assertThrows(
-        CVC5ApiException.class, () -> slv.defineFunRec("ff", new Term[] {b12, b22}, bvSort2, v1));
+    assertDoesNotThrow(() -> slv.defineFunRec("ff", new Term[] {b12, b22}, bvSort2, v1));
     slv.close();
   }
 
@@ -1290,7 +1276,7 @@ class SolverTest
         ()
             -> slv.defineFunsRec(
                 new Term[] {f12, f22}, new Term[][] {{b12, b112}, {b42}}, new Term[] {v12, v22}));
-    assertThrows(CVC5ApiException.class,
+    assertDoesNotThrow(
         ()
             -> slv.defineFunsRec(
                 new Term[] {f1, f22}, new Term[][] {{b12, b112}, {b42}}, new Term[] {v12, v22}));
@@ -1298,11 +1284,11 @@ class SolverTest
         ()
             -> slv.defineFunsRec(
                 new Term[] {f12, f2}, new Term[][] {{b12, b112}, {b42}}, new Term[] {v12, v22}));
-    assertThrows(CVC5ApiException.class,
+    assertDoesNotThrow(
         ()
             -> slv.defineFunsRec(
                 new Term[] {f12, f22}, new Term[][] {{b1, b112}, {b42}}, new Term[] {v12, v22}));
-    assertThrows(CVC5ApiException.class,
+    assertDoesNotThrow(
         ()
             -> slv.defineFunsRec(
                 new Term[] {f12, f22}, new Term[][] {{b12, b11}, {b42}}, new Term[] {v12, v22}));
@@ -1310,11 +1296,11 @@ class SolverTest
         ()
             -> slv.defineFunsRec(
                 new Term[] {f12, f22}, new Term[][] {{b12, b112}, {b4}}, new Term[] {v12, v22}));
-    assertThrows(CVC5ApiException.class,
+    assertDoesNotThrow(
         ()
             -> slv.defineFunsRec(
                 new Term[] {f12, f22}, new Term[][] {{b12, b112}, {b42}}, new Term[] {v1, v22}));
-    assertThrows(CVC5ApiException.class,
+    assertDoesNotThrow(
         ()
             -> slv.defineFunsRec(
                 new Term[] {f12, f22}, new Term[][] {{b12, b112}, {b42}}, new Term[] {v12, v2}));
@@ -2337,8 +2323,7 @@ class SolverTest
     assertThrows(CVC5ApiException.class,
         () -> d_solver.blockModelValues(new Term[] {d_solver.getNullTerm()}));
     Solver slv = new Solver();
-    assertThrows(
-        CVC5ApiException.class, () -> d_solver.blockModelValues(new Term[] {slv.mkBoolean(false)}));
+    assertDoesNotThrow(() -> d_solver.blockModelValues(new Term[] {slv.mkBoolean(false)}));
     slv.close();
   }
 
@@ -2459,7 +2444,7 @@ class SolverTest
     assertNotEquals(d_solver.mkTrue(), x_eq_b);
     assertNotEquals(d_solver.mkTrue(), d_solver.simplify(x_eq_b));
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class, () -> slv.simplify(x));
+    assertDoesNotThrow(() -> slv.simplify(x));
 
     Term i1 = d_solver.mkConst(d_solver.getIntegerSort(), "i1");
     assertDoesNotThrow(() -> d_solver.simplify(i1));
@@ -2508,7 +2493,7 @@ class SolverTest
     assertDoesNotThrow(() -> d_solver.assertFormula(d_solver.mkTrue()));
     assertThrows(CVC5ApiException.class, () -> d_solver.assertFormula(d_solver.getNullTerm()));
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class, () -> slv.assertFormula(d_solver.mkTrue()));
+    assertDoesNotThrow(() -> slv.assertFormula(d_solver.mkTrue()));
     slv.close();
   }
 
@@ -2527,7 +2512,7 @@ class SolverTest
     assertDoesNotThrow(() -> d_solver.checkSatAssuming(d_solver.mkTrue()));
     assertThrows(CVC5ApiException.class, () -> d_solver.checkSatAssuming(d_solver.mkTrue()));
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class, () -> slv.checkSatAssuming(d_solver.mkTrue()));
+    assertDoesNotThrow(() -> slv.checkSatAssuming(d_solver.mkTrue()));
     slv.close();
   }
 
@@ -2544,7 +2529,7 @@ class SolverTest
     assertDoesNotThrow(() -> d_solver.checkSatAssuming(d_solver.mkTrue()));
     assertDoesNotThrow(() -> d_solver.checkSatAssuming(z));
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class, () -> slv.checkSatAssuming(d_solver.mkTrue()));
+    assertDoesNotThrow(() -> slv.checkSatAssuming(d_solver.mkTrue()));
     slv.close();
   }
 
@@ -2596,7 +2581,7 @@ class SolverTest
         () -> d_solver.checkSatAssuming(new Term[] {n, d_solver.mkTerm(DISTINCT, x, y)}));
 
     Solver slv = new Solver();
-    assertThrows(CVC5ApiException.class, () -> slv.checkSatAssuming(d_solver.mkTrue()));
+    assertDoesNotThrow(() -> slv.checkSatAssuming(d_solver.mkTrue()));
     slv.close();
   }
 
@@ -2653,7 +2638,7 @@ class SolverTest
 
     Solver slv = new Solver();
     slv.setOption("sygus", "true");
-    assertThrows(CVC5ApiException.class, () -> slv.declareSygusVar("", boolSort));
+    assertDoesNotThrow(() -> slv.declareSygusVar("", boolSort));
     slv.close();
   }
 
@@ -2682,10 +2667,8 @@ class SolverTest
     Term intVar2 = slv.mkVar(slv.getIntegerSort());
     assertDoesNotThrow(() -> slv.mkGrammar(new Term[] {boolVar2}, new Term[] {intVar2}));
 
-    assertThrows(
-        CVC5ApiException.class, () -> slv.mkGrammar(new Term[] {boolVar}, new Term[] {intVar2}));
-    assertThrows(
-        CVC5ApiException.class, () -> slv.mkGrammar(new Term[] {boolVar2}, new Term[] {intVar}));
+    assertDoesNotThrow(() -> slv.mkGrammar(new Term[] {boolVar}, new Term[] {intVar2}));
+    assertDoesNotThrow(() -> slv.mkGrammar(new Term[] {boolVar2}, new Term[] {intVar}));
     slv.close();
   }
 
@@ -2723,10 +2706,8 @@ class SolverTest
     Term x2 = slv.mkVar(slv.getBooleanSort());
     assertDoesNotThrow(() -> slv.synthFun("f1", new Term[] {x2}, slv.getBooleanSort()));
 
-    assertThrows(
-        CVC5ApiException.class, () -> slv.synthFun("", new Term[] {}, d_solver.getBooleanSort()));
-    assertThrows(CVC5ApiException.class,
-        () -> slv.synthFun("f1", new Term[] {x}, d_solver.getBooleanSort()));
+    assertDoesNotThrow(() -> slv.synthFun("", new Term[] {}, d_solver.getBooleanSort()));
+    assertDoesNotThrow(() -> slv.synthFun("f1", new Term[] {x}, d_solver.getBooleanSort()));
     slv.close();
   }
 
@@ -2771,7 +2752,7 @@ class SolverTest
 
     Solver slv = new Solver();
     slv.setOption("sygus", "true");
-    assertThrows(CVC5ApiException.class, () -> slv.addSygusConstraint(boolTerm));
+    assertDoesNotThrow(() -> slv.addSygusConstraint(boolTerm));
     slv.close();
   }
 
@@ -2789,7 +2770,7 @@ class SolverTest
 
     Solver slv = new Solver();
     slv.setOption("sygus", "true");
-    assertThrows(CVC5ApiException.class, () -> slv.addSygusAssume(boolTerm));
+    assertDoesNotThrow(() -> slv.addSygusAssume(boolTerm));
     slv.close();
   }
 
@@ -2850,14 +2831,10 @@ class SolverTest
     Term post22 = slv.declareFun("post", new Sort[] {real2}, boolean2);
     assertDoesNotThrow(() -> slv.addSygusInvConstraint(inv22, pre22, trans22, post22));
 
-    assertThrows(
-        CVC5ApiException.class, () -> slv.addSygusInvConstraint(inv, pre22, trans22, post22));
-    assertThrows(
-        CVC5ApiException.class, () -> slv.addSygusInvConstraint(inv22, pre, trans22, post22));
-    assertThrows(
-        CVC5ApiException.class, () -> slv.addSygusInvConstraint(inv22, pre22, trans, post22));
-    assertThrows(
-        CVC5ApiException.class, () -> slv.addSygusInvConstraint(inv22, pre22, trans22, post));
+    assertDoesNotThrow(() -> slv.addSygusInvConstraint(inv, pre22, trans22, post22));
+    assertDoesNotThrow(() -> slv.addSygusInvConstraint(inv22, pre, trans22, post22));
+    assertDoesNotThrow(() -> slv.addSygusInvConstraint(inv22, pre22, trans, post22));
+    assertDoesNotThrow(() -> slv.addSygusInvConstraint(inv22, pre22, trans22, post));
     slv.close();
   }
 

--- a/test/unit/api/python/test_solver.py
+++ b/test/unit/api/python/test_solver.py
@@ -106,8 +106,10 @@ def test_mk_datatype_sort(solver):
     dtypeSpec.addConstructor(nil)
     solver.mkDatatypeSort(dtypeSpec)
 
+    # FIXME: https://github.com/cvc5/cvc5-projects/issues/522
     #slv = cvc5.Solver()
-    #slv.mkDatatypeSort(dtypeSpec)
+    #with pytest.raises(RuntimeError):
+    #    slv.mkDatatypeSort(dtypeSpec)
 
     throwsDtypeSpec = solver.mkDatatypeDecl("list")
     with pytest.raises(RuntimeError):
@@ -134,6 +136,7 @@ def test_mk_datatype_sorts(solver):
     decls = [dtypeSpec1, dtypeSpec2]
     solver.mkDatatypeSorts(decls)
 
+    # FIXME: https://github.com/cvc5/cvc5-projects/issues/522
     #with pytest.raises(RuntimeError):
     #    slv.mkDatatypeSorts(decls)
 
@@ -154,6 +157,7 @@ def test_mk_datatype_sorts(solver):
     udecls = [ulist]
 
     solver.mkDatatypeSorts(udecls)
+    # FIXME: https://github.com/cvc5/cvc5-projects/issues/522
     #with pytest.raises(RuntimeError):
     #    slv.mkDatatypeSorts(udecls)
 

--- a/test/unit/api/python/test_solver.py
+++ b/test/unit/api/python/test_solver.py
@@ -80,8 +80,7 @@ def test_mk_array_sort(solver):
     solver.mkArraySort(bvSort, fpSort)
 
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.mkArraySort(boolSort, boolSort)
+    slv.mkArraySort(boolSort, boolSort)
 
 
 def test_mk_bit_vector_sort(solver):
@@ -108,8 +107,7 @@ def test_mk_datatype_sort(solver):
     solver.mkDatatypeSort(dtypeSpec)
 
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.mkDatatypeSort(dtypeSpec)
+    slv.mkDatatypeSort(dtypeSpec)
 
     throwsDtypeSpec = solver.mkDatatypeDecl("list")
     with pytest.raises(RuntimeError):

--- a/test/unit/api/python/test_solver.py
+++ b/test/unit/api/python/test_solver.py
@@ -106,8 +106,8 @@ def test_mk_datatype_sort(solver):
     dtypeSpec.addConstructor(nil)
     solver.mkDatatypeSort(dtypeSpec)
 
-    slv = cvc5.Solver()
-    slv.mkDatatypeSort(dtypeSpec)
+    #slv = cvc5.Solver()
+    #slv.mkDatatypeSort(dtypeSpec)
 
     throwsDtypeSpec = solver.mkDatatypeDecl("list")
     with pytest.raises(RuntimeError):
@@ -134,8 +134,8 @@ def test_mk_datatype_sorts(solver):
     decls = [dtypeSpec1, dtypeSpec2]
     solver.mkDatatypeSorts(decls)
 
-    with pytest.raises(RuntimeError):
-        slv.mkDatatypeSorts(decls)
+    #with pytest.raises(RuntimeError):
+    #    slv.mkDatatypeSorts(decls)
 
     throwsDtypeSpec = solver.mkDatatypeDecl("list")
     throwsDecls = [throwsDtypeSpec]
@@ -154,8 +154,8 @@ def test_mk_datatype_sorts(solver):
     udecls = [ulist]
 
     solver.mkDatatypeSorts(udecls)
-    with pytest.raises(RuntimeError):
-        slv.mkDatatypeSorts(udecls)
+    #with pytest.raises(RuntimeError):
+    #    slv.mkDatatypeSorts(udecls)
 
     # mutually recursive with unresolved parameterized sorts
     p0 = solver.mkParamSort("p0")
@@ -209,21 +209,17 @@ def test_mk_function_sort(solver):
                 funSort2)
 
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.mkFunctionSort(solver.mkUninterpretedSort("u"),\
-                solver.getIntegerSort())
-    with pytest.raises(RuntimeError):
-        slv.mkFunctionSort(slv.mkUninterpretedSort("u"),\
-                solver.getIntegerSort())
+    slv.mkFunctionSort(solver.mkUninterpretedSort("u"),\
+            solver.getIntegerSort())
+    slv.mkFunctionSort(slv.mkUninterpretedSort("u"),\
+            solver.getIntegerSort())
     sorts1 = [solver.getBooleanSort(),\
             slv.getIntegerSort(),\
             solver.getIntegerSort()]
     sorts2 = [slv.getBooleanSort(), slv.getIntegerSort()]
     slv.mkFunctionSort(sorts2, slv.getIntegerSort())
-    with pytest.raises(RuntimeError):
-        slv.mkFunctionSort(sorts1, slv.getIntegerSort())
-    with pytest.raises(RuntimeError):
-        slv.mkFunctionSort(sorts2, solver.getIntegerSort())
+    slv.mkFunctionSort(sorts1, slv.getIntegerSort())
+    slv.mkFunctionSort(sorts2, solver.getIntegerSort())
 
 
 def test_mk_param_sort(solver):
@@ -242,8 +238,7 @@ def test_mk_predicate_sort(solver):
     solver.mkPredicateSort(solver.getIntegerSort(), funSort)
 
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.mkPredicateSort(solver.getIntegerSort())
+    slv.mkPredicateSort(solver.getIntegerSort())
 
 
 def test_mk_record_sort(solver):
@@ -261,8 +256,7 @@ def test_mk_set_sort(solver):
     solver.mkSetSort(solver.getIntegerSort())
     solver.mkSetSort(solver.mkBitVectorSort(4))
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.mkSetSort(solver.mkBitVectorSort(4))
+    slv.mkSetSort(solver.mkBitVectorSort(4))
 
 
 def test_mk_bag_sort(solver):
@@ -270,8 +264,7 @@ def test_mk_bag_sort(solver):
     solver.mkBagSort(solver.getIntegerSort())
     solver.mkBagSort(solver.mkBitVectorSort(4))
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.mkBagSort(solver.mkBitVectorSort(4))
+    slv.mkBagSort(solver.mkBitVectorSort(4))
 
 
 def test_mk_sequence_sort(solver):
@@ -279,8 +272,7 @@ def test_mk_sequence_sort(solver):
     solver.mkSequenceSort(\
             solver.mkSequenceSort(solver.getIntegerSort()))
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.mkSequenceSort(solver.getIntegerSort())
+    slv.mkSequenceSort(solver.getIntegerSort())
 
 
 def test_mk_uninterpreted_sort(solver):
@@ -309,8 +301,7 @@ def test_mk_tuple_sort(solver):
     solver.mkTupleSort(solver.getIntegerSort(), funSort)
 
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.mkTupleSort(solver.getIntegerSort())
+    slv.mkTupleSort(solver.getIntegerSort())
 
 
 def test_mk_bit_vector(solver):
@@ -392,8 +383,7 @@ def test_mk_var(solver):
     with pytest.raises(RuntimeError):
         solver.mkVar(cvc5.Sort(solver), "a")
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.mkVar(boolSort, "x")
+    slv.mkVar(boolSort, "x")
 
 
 def test_mk_boolean(solver):
@@ -432,8 +422,7 @@ def test_mk_floating_point(solver):
         solver.mkFloatingPoint(3, 5, t2)
 
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.mkFloatingPoint(3, 5, t1)
+    slv.mkFloatingPoint(3, 5, t1)
 
 
 def test_mk_cardinality_constraint(solver):
@@ -445,8 +434,7 @@ def test_mk_cardinality_constraint(solver):
     with pytest.raises(RuntimeError):
         solver.mkEmptySet(solver.mkCardinalityConstraint(su, 0))
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.mkCardinalityConstraint(su, 3)
+    slv.mkCardinalityConstraint(su, 3)
 
 
 def test_mk_empty_set(solver):
@@ -456,8 +444,7 @@ def test_mk_empty_set(solver):
     solver.mkEmptySet(s)
     with pytest.raises(RuntimeError):
         solver.mkEmptySet(solver.getBooleanSort())
-    with pytest.raises(RuntimeError):
-        slv.mkEmptySet(s)
+    slv.mkEmptySet(s)
 
 
 def test_mk_empty_bag(solver):
@@ -467,8 +454,7 @@ def test_mk_empty_bag(solver):
     solver.mkEmptyBag(s)
     with pytest.raises(RuntimeError):
         solver.mkEmptyBag(solver.getBooleanSort())
-    with pytest.raises(RuntimeError):
-        slv.mkEmptyBag(s)
+    slv.mkEmptyBag(s)
 
 
 def test_mk_empty_sequence(solver):
@@ -476,8 +462,7 @@ def test_mk_empty_sequence(solver):
     s = solver.mkSequenceSort(solver.getBooleanSort())
     solver.mkEmptySequence(s)
     solver.mkEmptySequence(solver.getBooleanSort())
-    with pytest.raises(RuntimeError):
-        slv.mkEmptySequence(s)
+    slv.mkEmptySequence(s)
 
 
 def test_mk_false(solver):
@@ -691,8 +676,7 @@ def test_mk_sep_nil(solver):
     with pytest.raises(RuntimeError):
         solver.mkSepNil(cvc5.Sort(solver))
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.mkSepNil(solver.getIntegerSort())
+    slv.mkSepNil(solver.getIntegerSort())
 
 
 def test_mk_string(solver):
@@ -730,8 +714,7 @@ def test_mk_term(solver):
         solver.mkTerm(Kind.NOT, cvc5.Term(solver))
     with pytest.raises(RuntimeError):
         solver.mkTerm(Kind.NOT, a)
-    with pytest.raises(RuntimeError):
-        slv.mkTerm(Kind.NOT, solver.mkTrue())
+    slv.mkTerm(Kind.NOT, solver.mkTrue())
 
     # mkTerm(Kind kind, Term child1, Term child2) const
     solver.mkTerm(Kind.EQUAL, a, b)
@@ -741,8 +724,7 @@ def test_mk_term(solver):
         solver.mkTerm(Kind.EQUAL, a, cvc5.Term(solver))
     with pytest.raises(RuntimeError):
         solver.mkTerm(Kind.EQUAL, a, solver.mkTrue())
-    with pytest.raises(RuntimeError):
-        slv.mkTerm(Kind.EQUAL, a, b)
+    slv.mkTerm(Kind.EQUAL, a, b)
 
     # mkTerm(Kind kind, Term child1, Term child2, Term child3) const
     solver.mkTerm(Kind.ITE, solver.mkTrue(), solver.mkTrue(), solver.mkTrue())
@@ -757,9 +739,8 @@ def test_mk_term(solver):
                       cvc5.Term(solver))
     with pytest.raises(RuntimeError):
         solver.mkTerm(Kind.ITE, solver.mkTrue(), solver.mkTrue(), b)
-    with pytest.raises(RuntimeError):
-        slv.mkTerm(Kind.ITE, solver.mkTrue(), solver.mkTrue(),
-                   solver.mkTrue())
+    slv.mkTerm(Kind.ITE, solver.mkTrue(), solver.mkTrue(),
+               solver.mkTrue())
 
     solver.mkTerm(Kind.EQUAL, a, b)
     with pytest.raises(RuntimeError):
@@ -846,8 +827,7 @@ def test_mk_term_from_op(solver):
         solver.mkTerm(Kind.APPLY_SELECTOR, headTerm)
     with pytest.raises(RuntimeError):
         solver.mkTerm(opterm1)
-    with pytest.raises(RuntimeError):
-        slv.mkTerm(Kind.APPLY_CONSTRUCTOR, nilTerm)
+    slv.mkTerm(Kind.APPLY_CONSTRUCTOR, nilTerm)
 
     # mkTerm(Op op, Term child) const
     solver.mkTerm(opterm1, a)
@@ -860,8 +840,7 @@ def test_mk_term_from_op(solver):
         solver.mkTerm(opterm1, cvc5.Term(solver))
     with pytest.raises(RuntimeError):
         solver.mkTerm(Kind.APPLY_CONSTRUCTOR, consTerm, solver.mkInteger(0))
-    with pytest.raises(RuntimeError):
-        slv.mkTerm(opterm1, a)
+    slv.mkTerm(opterm1, a)
 
     # mkTerm(Op op, Term child1, Term child2) const
     solver.mkTerm(Kind.APPLY_CONSTRUCTOR, consTerm, solver.mkInteger(0),
@@ -874,11 +853,10 @@ def test_mk_term_from_op(solver):
         solver.mkTerm(opterm2, solver.mkInteger(1), cvc5.Term(solver))
     with pytest.raises(RuntimeError):
         solver.mkTerm(opterm2, cvc5.Term(solver), solver.mkInteger(1))
-    with pytest.raises(RuntimeError):
-        slv.mkTerm(Kind.APPLY_CONSTRUCTOR,\
-                        consTerm,\
-                        solver.mkInteger(0),\
-                        solver.mkTerm(Kind.APPLY_CONSTRUCTOR, nilTerm))
+    slv.mkTerm(Kind.APPLY_CONSTRUCTOR,\
+                    consTerm,\
+                    solver.mkInteger(0),\
+                    solver.mkTerm(Kind.APPLY_CONSTRUCTOR, nilTerm))
 
     # mkTerm(Op op, Term child1, Term child2, Term child3) const
     with pytest.raises(RuntimeError):
@@ -894,8 +872,7 @@ def test_mk_term_from_op(solver):
         solver.mkTerm(opterm2, solver.mkInteger(1), cvc5.Term(solver))
     with pytest.raises(RuntimeError):
         solver.mkTerm(opterm2)
-    with pytest.raises(RuntimeError):
-        slv.mkTerm(opterm2, solver.mkInteger(5))
+    slv.mkTerm(opterm2, solver.mkInteger(5))
 
 
 def test_mk_true(solver):
@@ -917,12 +894,10 @@ def test_mk_tuple(solver):
     with pytest.raises(RuntimeError):
         solver.mkTuple([solver.getIntegerSort()], [solver.mkReal("5.3")])
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.mkTuple([solver.mkBitVectorSort(3)],
-                    [slv.mkBitVector(3, "101", 2)])
-    with pytest.raises(RuntimeError):
-        slv.mkTuple([slv.mkBitVectorSort(3)],
-                    [solver.mkBitVector(3, "101", 2)])
+    slv.mkTuple([solver.mkBitVectorSort(3)],
+                [slv.mkBitVector(3, "101", 2)])
+    slv.mkTuple([slv.mkBitVectorSort(3)],
+                [solver.mkBitVector(3, "101", 2)])
 
 
 def test_mk_universe_set(solver):
@@ -930,8 +905,7 @@ def test_mk_universe_set(solver):
     with pytest.raises(RuntimeError):
         solver.mkUniverseSet(cvc5.Sort(solver))
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.mkUniverseSet(solver.getBooleanSort())
+    slv.mkUniverseSet(solver.getBooleanSort())
 
 
 def test_mk_const(solver):
@@ -950,8 +924,7 @@ def test_mk_const(solver):
         solver.mkConst(cvc5.Sort(solver), "a")
 
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.mkConst(boolSort)
+    slv.mkConst(boolSort)
 
 
 def test_mk_const_array(solver):
@@ -972,10 +945,8 @@ def test_mk_const_array(solver):
     slv = cvc5.Solver()
     zero2 = slv.mkInteger(0)
     arrSort2 = slv.mkArraySort(slv.getIntegerSort(), slv.getIntegerSort())
-    with pytest.raises(RuntimeError):
-        slv.mkConstArray(arrSort2, zero)
-    with pytest.raises(RuntimeError):
-        slv.mkConstArray(arrSort, zero2)
+    slv.mkConstArray(arrSort2, zero)
+    slv.mkConstArray(arrSort, zero2)
 
 
 def test_declare_fun(solver):
@@ -991,8 +962,7 @@ def test_declare_fun(solver):
     with pytest.raises(RuntimeError):
         solver.declareFun("f5", [bvSort, bvSort], funSort)
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.declareFun("f1", [], bvSort)
+    slv.declareFun("f1", [], bvSort)
 
 
 def test_declare_sort(solver):
@@ -1026,18 +996,12 @@ def test_define_fun(solver):
     v12 = slv.mkConst(bvSort2, "v1")
     b12 = slv.mkVar(bvSort2, "b1")
     b22 = slv.mkVar(slv.getIntegerSort(), "b2")
-    with pytest.raises(RuntimeError):
-        slv.defineFun("f", [], bvSort, v12)
-    with pytest.raises(RuntimeError):
-        slv.defineFun("f", [], bvSort2, v1)
-    with pytest.raises(RuntimeError):
-        slv.defineFun("ff", [b1, b22], bvSort2, v12)
-    with pytest.raises(RuntimeError):
-        slv.defineFun("ff", [b12, b2], bvSort2, v12)
-    with pytest.raises(RuntimeError):
-        slv.defineFun("ff", [b12, b22], bvSort, v12)
-    with pytest.raises(RuntimeError):
-        slv.defineFun("ff", [b12, b22], bvSort2, v1)
+    slv.defineFun("f", [], bvSort, v12)
+    slv.defineFun("f", [], bvSort2, v1)
+    slv.defineFun("ff", [b1, b22], bvSort2, v12)
+    slv.defineFun("ff", [b12, b2], bvSort2, v12)
+    slv.defineFun("ff", [b12, b22], bvSort, v12)
+    slv.defineFun("ff", [b12, b22], bvSort2, v1)
 
 
 def test_define_fun_global(solver):
@@ -1107,18 +1071,12 @@ def test_define_fun_rec(solver):
     b22 = slv.mkVar(slv.getIntegerSort(), "b2")
     slv.defineFunRec("f", [], bvSort2, v12)
     slv.defineFunRec("ff", [b12, b22], bvSort2, v12)
-    with pytest.raises(RuntimeError):
-        slv.defineFunRec("f", [], bvSort, v12)
-    with pytest.raises(RuntimeError):
-        slv.defineFunRec("f", [], bvSort2, v1)
-    with pytest.raises(RuntimeError):
-        slv.defineFunRec("ff", [b1, b22], bvSort2, v12)
-    with pytest.raises(RuntimeError):
-        slv.defineFunRec("ff", [b12, b2], bvSort2, v12)
-    with pytest.raises(RuntimeError):
-        slv.defineFunRec("ff", [b12, b22], bvSort, v12)
-    with pytest.raises(RuntimeError):
-        slv.defineFunRec("ff", [b12, b22], bvSort2, v1)
+    slv.defineFunRec("f", [], bvSort, v12)
+    slv.defineFunRec("f", [], bvSort2, v1)
+    slv.defineFunRec("ff", [b1, b22], bvSort2, v12)
+    slv.defineFunRec("ff", [b12, b2], bvSort2, v12)
+    slv.defineFunRec("ff", [b12, b22], bvSort, v12)
+    slv.defineFunRec("ff", [b12, b22], bvSort2, v1)
 
 
 def test_define_fun_rec_wrong_logic(solver):
@@ -1199,23 +1157,18 @@ def test_define_funs_rec(solver):
   v22 = slv.mkConst(slv.getIntegerSort(), "v2")
   f12 = slv.mkConst(funSort12, "f1")
   f22 = slv.mkConst(funSort22, "f2")
-  
+
   slv.defineFunsRec([f12, f22], [[b12, b112], [b42]], [v12, v22])
-  
-  with pytest.raises(RuntimeError):
-    slv.defineFunsRec([f1, f22], [[b12, b112], [b42]], [v12, v22])
+  slv.defineFunsRec([f1, f22], [[b12, b112], [b42]], [v12, v22])
+  slv.defineFunsRec([f12, f22], [[b1, b112], [b42]], [v12, v22])
+  slv.defineFunsRec([f12, f22], [[b12, b11], [b42]], [v12, v22])
+  slv.defineFunsRec([f12, f22], [[b12, b112], [b42]], [v1, v22])
+  slv.defineFunsRec([f12, f22], [[b12, b112], [b42]], [v12, v2])
+
   with pytest.raises(RuntimeError):
     slv.defineFunsRec([f12, f2], [[b12, b112], [b42]], [v12, v22])
   with pytest.raises(RuntimeError):
-    slv.defineFunsRec([f12, f22], [[b1, b112], [b42]], [v12, v22])
-  with pytest.raises(RuntimeError):
-    slv.defineFunsRec([f12, f22], [[b12, b11], [b42]], [v12, v22])
-  with pytest.raises(RuntimeError):
     slv.defineFunsRec([f12, f22], [[b12, b112], [b4]], [v12, v22])
-  with pytest.raises(RuntimeError):
-    slv.defineFunsRec([f12, f22], [[b12, b112], [b42]], [v1, v22])
-  with pytest.raises(RuntimeError):
-    slv.defineFunsRec([f12, f22], [[b12, b112], [b42]], [v12, v2])
 
 
 def test_define_funs_rec_wrong_logic(solver):
@@ -1752,8 +1705,7 @@ def test_block_model_values1(solver):
         solver.blockModelValues([])
     with pytest.raises(RuntimeError):
         solver.blockModelValues([cvc5.Term(solver)])
-    with pytest.raises(RuntimeError):
-        solver.blockModelValues([cvc5.Solver().mkBoolean(False)])
+    solver.blockModelValues([cvc5.Solver().mkBoolean(False)])
 
 def test_block_model_values2(solver):
     solver.setOption("produce-models", "true")
@@ -1880,8 +1832,7 @@ def test_simplify(solver):
     assert solver.mkTrue() != x_eq_b
     assert solver.mkTrue() != solver.simplify(x_eq_b)
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.simplify(x)
+    slv.simplify(x)
 
     i1 = solver.mkConst(solver.getIntegerSort(), "i1")
     solver.simplify(i1)
@@ -1933,8 +1884,7 @@ def test_assert_formula(solver):
     with pytest.raises(RuntimeError):
         solver.assertFormula(cvc5.Term(solver))
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.assertFormula(solver.mkTrue())
+    slv.assertFormula(solver.mkTrue())
 
 
 def test_check_sat(solver):
@@ -1950,8 +1900,7 @@ def test_check_sat_assuming(solver):
     with pytest.raises(RuntimeError):
         solver.checkSatAssuming(solver.mkTrue())
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.checkSatAssuming(solver.mkTrue())
+    slv.checkSatAssuming(solver.mkTrue())
 
 
 def test_check_sat_assuming1(solver):
@@ -1966,8 +1915,7 @@ def test_check_sat_assuming1(solver):
     solver.checkSatAssuming(solver.mkTrue())
     solver.checkSatAssuming(z)
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.checkSatAssuming(solver.mkTrue())
+    slv.checkSatAssuming(solver.mkTrue())
 
 
 def test_check_sat_assuming2(solver):
@@ -2016,8 +1964,7 @@ def test_check_sat_assuming2(solver):
     with pytest.raises(RuntimeError):
         solver.checkSatAssuming(n, solver.mkTerm(Kind.DISTINCT, x, y))
     slv = cvc5.Solver()
-    with pytest.raises(RuntimeError):
-        slv.checkSatAssuming(solver.mkTrue())
+    slv.checkSatAssuming(solver.mkTrue())
 
 
 def test_set_logic(solver):
@@ -2072,10 +2019,8 @@ def test_mk_sygus_grammar(solver):
     boolVar2 = slv.mkVar(slv.getBooleanSort())
     intVar2 = slv.mkVar(slv.getIntegerSort())
     slv.mkGrammar([boolVar2], [intVar2])
-    with pytest.raises(RuntimeError):
-        slv.mkGrammar([boolVar], [intVar2])
-    with pytest.raises(RuntimeError):
-        slv.mkGrammar([boolVar2], [intVar])
+    slv.mkGrammar([boolVar], [intVar2])
+    slv.mkGrammar([boolVar2], [intVar])
 
 
 def test_synth_inv(solver):
@@ -2197,14 +2142,10 @@ def test_add_sygus_inv_constraint(solver):
     trans22 = slv.declareFun("trans", [real2, real2], boolean2)
     post22 = slv.declareFun("post", [real2], boolean2)
     slv.addSygusInvConstraint(inv22, pre22, trans22, post22)
-    with pytest.raises(RuntimeError):
-        slv.addSygusInvConstraint(inv, pre22, trans22, post22)
-    with pytest.raises(RuntimeError):
-        slv.addSygusInvConstraint(inv22, pre, trans22, post22)
-    with pytest.raises(RuntimeError):
-        slv.addSygusInvConstraint(inv22, pre22, trans, post22)
-    with pytest.raises(RuntimeError):
-        slv.addSygusInvConstraint(inv22, pre22, trans22, post)
+    slv.addSygusInvConstraint(inv, pre22, trans22, post22)
+    slv.addSygusInvConstraint(inv22, pre, trans22, post22)
+    slv.addSygusInvConstraint(inv22, pre22, trans, post22)
+    slv.addSygusInvConstraint(inv22, pre22, trans22, post)
 
 
 def test_check_synth(solver):
@@ -2701,10 +2642,8 @@ def test_synth_fun(solver):
     slv.setOption("sygus", "true")
     x2 = slv.mkVar(slv.getBooleanSort())
     slv.synthFun("f1", [x2], slv.getBooleanSort())
-    with pytest.raises(RuntimeError):
-        slv.synthFun("", [], solver.getBooleanSort())
-    with pytest.raises(RuntimeError):
-        slv.synthFun("f1", [x], solver.getBooleanSort())
+    slv.synthFun("", [], solver.getBooleanSort())
+    slv.synthFun("f1", [x], solver.getBooleanSort())
 
 
 def test_tuple_project(solver):


### PR DESCRIPTION
This refactors Sort, Term, Op and datatype objects to not maintain a
reference (and depend) on Solver, but an associated NodeManager. This
allows to share node managers between solver instances.