### PR TITLE
Disable checking on subsolvers when doing sygus rewrite rule synthesis

### DIFF
--- a/src/smt/process_assertions.cpp
+++ b/src/smt/process_assertions.cpp
@@ -117,7 +117,7 @@ bool ProcessAssertions::apply(Assertions& as)
     // nothing to do
     return true;
   }
-  
+
   // this must be applied to assertions before they are preprocessed, so that
   // we do not synthesize rewrite rules for internally generated symbols.
   if (options().quantifiers.sygusRewSynthInput)
@@ -130,7 +130,7 @@ bool ProcessAssertions::apply(Assertions& as)
   {
     applyPass("bv-gauss", as);
   }
-  
+
   // Add dummy assertion in last position - to be used as a
   // placeholder for any new assertions to get added
   assertions.push_back(d_true);

--- a/src/smt/process_assertions.cpp
+++ b/src/smt/process_assertions.cpp
@@ -117,12 +117,20 @@ bool ProcessAssertions::apply(Assertions& as)
     // nothing to do
     return true;
   }
+  
+  // this must be applied to assertions before they are preprocessed, so that
+  // we do not synthesize rewrite rules for internally generated symbols.
+  if (options().quantifiers.sygusRewSynthInput)
+  {
+    // do candidate rewrite rule synthesis
+    applyPass("synth-rr", as);
+  }
 
   if (options().bv.bvGaussElim)
   {
     applyPass("bv-gauss", as);
   }
-
+  
   // Add dummy assertion in last position - to be used as a
   // placeholder for any new assertions to get added
   assertions.push_back(d_true);
@@ -254,11 +262,6 @@ bool ProcessAssertions::apply(Assertions& as)
   if (options().quantifiers.sygusInference)
   {
     applyPass("sygus-infer", as);
-  }
-  else if (options().quantifiers.sygusRewSynthInput)
-  {
-    // do candidate rewrite rule synthesis
-    applyPass("synth-rr", as);
   }
 
   Trace("smt-proc") << "ProcessAssertions::processAssertions() : pre-simplify"

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -1801,6 +1801,7 @@ void SetDefaults::disableChecking(Options& opts)
   opts.writeSmt().checkUnsatCores = false;
   opts.writeSmt().produceProofs = false;
   opts.writeSmt().checkProofs = false;
+  opts.writeSmt().debugCheckModels = false;
   opts.writeSmt().checkModels = false;
 }
 

--- a/src/theory/quantifiers/candidate_rewrite_database.cpp
+++ b/src/theory/quantifiers/candidate_rewrite_database.cpp
@@ -192,7 +192,7 @@ Node CandidateRewriteDatabase::addTerm(Node sol,
           // add the solution again
           // by construction of the above point, we should be unique now
           eq_sol = d_sampler->registerTerm(sol);
-          Assert(eq_sol == sol);
+          Assert(eq_sol == sol) << "Model failed to distinguish terms " << eq_sol << " and " << sol;
         }
         else
         {

--- a/src/theory/quantifiers/candidate_rewrite_database.cpp
+++ b/src/theory/quantifiers/candidate_rewrite_database.cpp
@@ -16,8 +16,9 @@
 #include "theory/quantifiers/candidate_rewrite_database.h"
 
 #include "options/base_options.h"
+#include "options/quantifiers_options.h"
 #include "printer/printer.h"
-#include "smt/solver_engine.h"
+#include "smt/set_defaults.h"
 #include "theory/datatypes/sygus_datatype_utils.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
 #include "theory/quantifiers/term_util.h"
@@ -43,6 +44,11 @@ CandidateRewriteDatabase::CandidateRewriteDatabase(
       d_using_sygus(false),
       d_crewrite_filter(env)
 {
+  // determine the options to use for the verification subsolvers we spawn
+  // we start with the provided options
+  d_subOptions.copyValues(options());
+  // disable checking
+  smt::SetDefaults::disableChecking(d_subOptions);
 }
 void CandidateRewriteDatabase::initialize(const std::vector<Node>& vars,
                                           SygusSampler* ss)
@@ -141,8 +147,9 @@ Node CandidateRewriteDatabase::addTerm(Node sol,
         // Notice we don't set produce-models. rrChecker takes the same
         // options as the SolverEngine we belong to, where we ensure that
         // produce-models is set.
+        SubsolverSetupInfo ssi(d_env, d_subOptions);
         std::unique_ptr<SolverEngine> rrChecker;
-        initializeChecker(rrChecker, crr);
+        initializeChecker(rrChecker, crr, ssi);
         Result r = rrChecker->checkSat();
         Trace("rr-check") << "...result : " << r << std::endl;
         if (r.getStatus() == Result::SAT)

--- a/src/theory/quantifiers/candidate_rewrite_database.cpp
+++ b/src/theory/quantifiers/candidate_rewrite_database.cpp
@@ -192,7 +192,8 @@ Node CandidateRewriteDatabase::addTerm(Node sol,
           // add the solution again
           // by construction of the above point, we should be unique now
           eq_sol = d_sampler->registerTerm(sol);
-          Assert(eq_sol == sol) << "Model failed to distinguish terms " << eq_sol << " and " << sol;
+          Assert(eq_sol == sol) << "Model failed to distinguish terms "
+                                << eq_sol << " and " << sol;
         }
         else
         {

--- a/src/theory/quantifiers/candidate_rewrite_database.h
+++ b/src/theory/quantifiers/candidate_rewrite_database.h
@@ -23,6 +23,7 @@
 #include "theory/quantifiers/candidate_rewrite_filter.h"
 #include "theory/quantifiers/expr_miner.h"
 #include "theory/quantifiers/sygus_sampler.h"
+#include "options/options.h"
 
 namespace cvc5::internal {
 namespace theory {
@@ -128,6 +129,8 @@ class CandidateRewriteDatabase : public ExprMiner
   CandidateRewriteFilter d_crewrite_filter;
   /** the cache for results of addTerm */
   std::unordered_map<Node, Node> d_add_term_cache;
+  /** The options for subsolver calls */
+  Options d_subOptions;
 };
 
 }  // namespace quantifiers

--- a/src/theory/quantifiers/candidate_rewrite_database.h
+++ b/src/theory/quantifiers/candidate_rewrite_database.h
@@ -20,10 +20,10 @@
 
 #include <vector>
 
+#include "options/options.h"
 #include "theory/quantifiers/candidate_rewrite_filter.h"
 #include "theory/quantifiers/expr_miner.h"
 #include "theory/quantifiers/sygus_sampler.h"
-#include "options/options.h"
 
 namespace cvc5::internal {
 namespace theory {

--- a/src/theory/quantifiers/expr_miner.cpp
+++ b/src/theory/quantifiers/expr_miner.cpp
@@ -75,9 +75,8 @@ void ExprMiner::initializeChecker(std::unique_ptr<SolverEngine>& checker,
   {
     initializeSubsolver(checker, info);
   }
-  // also set the options
+  // disable options that would lead to infinite loops
   checker->setOption("sygus-rr-synth-input", "false");
-  checker->setOption("input-language", "smt2");
   // Convert bound variables to skolems. This ensures the satisfiability
   // check is ground.
   Node squery = convertToSkolem(query);

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2666,6 +2666,7 @@ set(regress_1_tests
   regress1/strings/issue8918-str-nth-crange-red.smt2
   regress1/strings/issue8932-cmi-unit.smt2
   regress1/strings/issue8944-sygus-inst.smt2
+  regress1/strings/issue8956-1.smt2
   regress1/strings/issue8970-strip-sym-len.smt2
   regress1/strings/issue8975-1.smt2
   regress1/strings/issue8975-2.smt2
@@ -2850,6 +2851,7 @@ set(regress_1_tests
   regress1/sygus/issue4425-sets-sygus-infer.smt2
   regress1/sygus/issue7925-dt-share-config.sy
   regress1/sygus/issue8216-rr-input-re.smt2
+  regress1/sygus/issue8956-2.smt2
   regress1/sygus/large-const-simp.sy
   regress1/sygus/let-bug-simp.sy
   regress1/sygus/list-head-x.sy

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2852,6 +2852,7 @@ set(regress_1_tests
   regress1/sygus/issue7925-dt-share-config.sy
   regress1/sygus/issue8216-rr-input-re.smt2
   regress1/sygus/issue8956-2.smt2
+  regress1/sygus/issue8976-interp-check.smt2
   regress1/sygus/large-const-simp.sy
   regress1/sygus/let-bug-simp.sy
   regress1/sygus/list-head-x.sy

--- a/test/regress/cli/regress1/strings/issue8956-1.smt2
+++ b/test/regress/cli/regress1/strings/issue8956-1.smt2
@@ -1,0 +1,8 @@
+; COMMAND-LINE: --no-strings-lazy-pp
+; EXPECT: sat
+(set-logic QF_SLIA)
+(declare-fun s () String)
+(assert (> (- (str.len s) (+ 1 1) 1 1) 0))
+(assert (= "0" (str.substr s (+ 1 1 1 1) 1)))
+(assert (> (- (str.len s) (str.len (str.update (str.++ "9" "0") (str.to_int "0") s)) (+ 1 1) (+ (+ 1 1) 1)) 0))
+(check-sat)

--- a/test/regress/cli/regress1/sygus/issue8956-2.smt2
+++ b/test/regress/cli/regress1/sygus/issue8956-2.smt2
@@ -1,0 +1,10 @@
+; COMMAND-LINE: --sygus-rr-synth-input
+; SCRUBBER: grep -v -E '\(define-fun'
+; EXPECT: unknown
+(set-logic QF_S)
+(declare-fun s () String)
+(declare-fun i () String)
+(declare-fun x () String)
+(assert (or (= x i) (= x s)))
+(assert (str.in_re x (re.* (re.++ re.allchar re.allchar))))
+(check-sat)

--- a/test/regress/cli/regress1/sygus/issue8956-2.smt2
+++ b/test/regress/cli/regress1/sygus/issue8956-2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --sygus-rr-synth-input --tlimit-per=500
+; COMMAND-LINE: --sygus-rr-synth-input --tlimit-per=500 --check-models
 ; SCRUBBER: grep -v -E '\('
 ; EXPECT: unknown
 (set-logic QF_S)

--- a/test/regress/cli/regress1/sygus/issue8956-2.smt2
+++ b/test/regress/cli/regress1/sygus/issue8956-2.smt2
@@ -1,5 +1,5 @@
-; COMMAND-LINE: --sygus-rr-synth-input
-; SCRUBBER: grep -v -E '\(define-fun'
+; COMMAND-LINE: --sygus-rr-synth-input --tlimit-per=500
+; SCRUBBER: grep -v -E '\('
 ; EXPECT: unknown
 (set-logic QF_S)
 (declare-fun s () String)

--- a/test/regress/cli/regress1/sygus/issue8976-interp-check.smt2
+++ b/test/regress/cli/regress1/sygus/issue8976-interp-check.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --produce-interpolants -q --check-models
+; COMMAND-LINE: --produce-interpolants -q --strings-exp --check-models
 ; EXPECT: fail
 (set-logic ALL)
 (declare-fun a () String)                                                       

--- a/test/regress/cli/regress1/sygus/issue8976-interp-check.smt2
+++ b/test/regress/cli/regress1/sygus/issue8976-interp-check.smt2
@@ -1,0 +1,8 @@
+; COMMAND-LINE: --produce-interpolants -q --check-models
+; EXPECT: fail
+(set-logic ALL)
+(declare-fun a () String)                                                       
+(declare-fun b () Int)                                                          
+(assert (not (= 0 (ite (str.contains (str.at a 0) "O") 1 0))))                  
+(get-interpolant c (not (= 1 b)) ((d Bool) (e Int))                             
+                 ((d Bool ((< e e))) (e Int (2 (mod e e))))) 


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/8956.

Also adds the first benchmark from that issue, which was likely fixed due to the disabling of `str.nth`.

Also adds regression from https://github.com/cvc5/cvc5/issues/8976, which was failing for a similar reason for interpolants, which has already been fixed. Fixes https://github.com/cvc5/cvc5/issues/8976.