### PR TITLE
Strengthen check for when  

### DIFF
--- a/src/theory/theory.cpp
+++ b/src/theory/theory.cpp
@@ -515,20 +515,31 @@ bool Theory::areCareDisequal(TNode x, TNode y)
   Assert(d_equalityEngine != nullptr);
   Assert(d_equalityEngine->hasTerm(x));
   Assert(d_equalityEngine->hasTerm(y));
-  if (d_equalityEngine->areDisequal(x,y,false))
+  if (x.isConst() && y.isConst())
   {
     return true;
   }
   if (!d_equalityEngine->isTriggerTerm(x, d_id)
       || !d_equalityEngine->isTriggerTerm(y, d_id))
   {
+    // just check if they are disequal, which is the used in the case for
+    // non-shared terms.
+    if (d_equalityEngine->areDisequal(x,y,false))
+    {
+      return true;
+    }
     return false;
   }
   TNode x_shared = d_equalityEngine->getTriggerTermRepresentative(x, d_id);
   TNode y_shared = d_equalityEngine->getTriggerTermRepresentative(y, d_id);
   EqualityStatus eqStatus = d_valuation.getEqualityStatus(x_shared, y_shared);
-  return eqStatus == EQUALITY_FALSE_AND_PROPAGATED || eqStatus == EQUALITY_FALSE
-         || eqStatus == EQUALITY_FALSE_IN_MODEL;
+  if ( eqStatus == EQUALITY_FALSE_AND_PROPAGATED || eqStatus == EQUALITY_FALSE
+         || eqStatus == EQUALITY_FALSE_IN_MODEL)
+  {
+    return true;
+  }
+  Assert (!d_equalityEngine->areDisequal(x,y,false));
+  return false;
 }
 
 void Theory::getCareGraph(CareGraph* careGraph) {

--- a/src/theory/theory.cpp
+++ b/src/theory/theory.cpp
@@ -524,7 +524,7 @@ bool Theory::areCareDisequal(TNode x, TNode y)
   {
     // just check if they are disequal, which is the used in the case for
     // non-shared terms.
-    if (d_equalityEngine->areDisequal(x,y,false))
+    if (d_equalityEngine->areDisequal(x, y, false))
     {
       return true;
     }
@@ -533,12 +533,12 @@ bool Theory::areCareDisequal(TNode x, TNode y)
   TNode x_shared = d_equalityEngine->getTriggerTermRepresentative(x, d_id);
   TNode y_shared = d_equalityEngine->getTriggerTermRepresentative(y, d_id);
   EqualityStatus eqStatus = d_valuation.getEqualityStatus(x_shared, y_shared);
-  if ( eqStatus == EQUALITY_FALSE_AND_PROPAGATED || eqStatus == EQUALITY_FALSE
-         || eqStatus == EQUALITY_FALSE_IN_MODEL)
+  if (eqStatus == EQUALITY_FALSE_AND_PROPAGATED || eqStatus == EQUALITY_FALSE
+      || eqStatus == EQUALITY_FALSE_IN_MODEL)
   {
     return true;
   }
-  Assert (!d_equalityEngine->areDisequal(x,y,false));
+  Assert(!d_equalityEngine->areDisequal(x, y, false));
   return false;
 }
 

--- a/src/theory/theory.cpp
+++ b/src/theory/theory.cpp
@@ -515,6 +515,10 @@ bool Theory::areCareDisequal(TNode x, TNode y)
   Assert(d_equalityEngine != nullptr);
   Assert(d_equalityEngine->hasTerm(x));
   Assert(d_equalityEngine->hasTerm(y));
+  if (d_equalityEngine->areDisequal(x,y,false))
+  {
+    return true;
+  }
   if (!d_equalityEngine->isTriggerTerm(x, d_id)
       || !d_equalityEngine->isTriggerTerm(y, d_id))
   {


### PR DESCRIPTION
This should lead to slightly smaller care graphs for some theories like sets where care pairs are computed for operators that have both shared and non-shared children. For example, `(set.member x A)` where `x` is shared and `A` is not.

This PR modifies a callback that checks whether two terms do not need to be cared about.  Two terms `(f t1 ... tn)` and `(f s1 ... sn)` do not generate care pairs if we know some `ti != si`.

Previously, we were assuming that all arguments of a function to test where shared, and thus were insisting that they were trigger terms. However, we failed to recognize when non-shared terms were disequal.  This adds this check. It furthermore catches the case of disequal constants (which are trivially disequal, but not explicitly disequal in the equality engine).

This issue was found by @mudathirmahgoub when comparing the standard implementation of compute care graphs with the array implementation.

FYI @barrettcw 