### PR TITLE
[CMake] Minor updates related to build configs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,25 +87,21 @@ cvc5_option(ENABLE_AUTO_DOWNLOAD  "Enable automatic download of dependencies")
 cvc5_option(ENABLE_IPO            "Enable interprocedural optimization")
 # >> 2-valued: ON OFF
 #    > for options where we don't need to detect if set by user (default: OFF)
-option(ENABLE_BEST             "Enable dependencies known to give best performance")
 option(ENABLE_COVERAGE         "Enable support for gcov coverage testing")
 option(ENABLE_DEBUG_CONTEXT_MM "Enable the debug context memory manager")
 option(ENABLE_PROFILING        "Enable support for gprof profiling")
 
 # Optional dependencies
 #
-# >> 3-valued: IGNORE ON OFF
-#    > allows to detect if set by user (default: IGNORE)
-#    > only necessary for options set for ENABLE_BEST
-cvc5_option(USE_CLN           "Use CLN instead of GMP")
-cvc5_option(USE_CRYPTOMINISAT "Use CryptoMiniSat SAT solver")
-cvc5_option(USE_GLPK          "Use GLPK simplex solver")
-cvc5_option(USE_KISSAT        "Use Kissat SAT solver")
-cvc5_option(USE_EDITLINE      "Use Editline for better interactive support")
 # >> 2-valued: ON OFF
 #    > for options where we don't need to detect if set by user (default: OFF)
-option(USE_POLY               "Use LibPoly for polynomial arithmetic")
-option(USE_COCOA              "Use CoCoALib for further polynomial operations")
+option(USE_CLN           "Use CLN instead of GMP")
+option(USE_COCOA         "Use CoCoALib for further polynomial operations")
+option(USE_CRYPTOMINISAT "Use CryptoMiniSat SAT solver")
+option(USE_EDITLINE      "Use Editline for better interactive support")
+option(USE_GLPK          "Use GLPK simplex solver")
+option(USE_KISSAT        "Use Kissat SAT solver")
+option(USE_POLY          "Use LibPoly for polynomial arithmetic")
 
 # Custom install directories for dependencies
 # If no directory is provided by the user, we first check if the dependency was
@@ -588,9 +584,6 @@ else()
   print_config("Build profile             " "${CVC5_BUILD_PROFILE_STRING}")
 endif()
 message("")
-print_config("GPL                       " ${ENABLE_GPL})
-print_config("Best configuration        " ${ENABLE_BEST})
-message("")
 print_config("Assertions                " ${ENABLE_ASSERTIONS})
 print_config("Debug symbols             " ${ENABLE_DEBUG_SYMBOLS})
 print_config("Debug context mem mgr     " ${ENABLE_DEBUG_CONTEXT_MM})
@@ -655,7 +648,7 @@ if(GPL_LIBS)
   "\n"
   "If you prefer to license cvc5 under those terms, please configure cvc5 to"
   "\n"
-  "disable all optional GPLed library dependencies (-DENABLE_BSD_ONLY=ON)."
+  "disable all optional GPLed library dependencies."
   )
 else()
   message(
@@ -666,9 +659,9 @@ else()
   "\n"
   "it is covered by the (modified) BSD license.  To build against GPL'ed"
   "\n"
-  "libraries which can improve cvc5's performance on arithmetic and bitvector"
+  "libraries which can improve cvc5's performance on arithmetic and bit-vector"
   "\n"
-  "logics, re-configure with '-DENABLE_GPL -DENABLE_BEST'."
+  "logics, use the 'configure.sh' script to re-configure with '--best --gpl'."
   )
 endif()
 

--- a/configure.sh
+++ b/configure.sh
@@ -163,11 +163,11 @@ do
 
     # Best configuration
     --best)
-      ipo=ON
       cln=ON
       cryptominisat=ON
-      glpk=ON
       editline=ON
+      glpk=ON
+      ipo=ON
       ;;
 
     --prefix) die "missing argument to $1 (try -h)" ;;


### PR DESCRIPTION
Commit 27fb04bc96999e101b45458c549345e864e085e9 moved the handling of
the "best" build configuration from the main `CMakeLists.txt` file to
our `configure.sh` script. This commit makes several updates related to
the build configuration:

- It removes the mention of `-DENABLE_BSD_ONLY=ON`, which does not seem
  to exist anymore.
- It removes the `ENABLE_BEST` option, which, after the commit mentioned
  above, was only used to print whether the current build is a "best"
  build or not (but the flag was not being used by `configure.sh`
  anyway).
- It updates the configuration message to say that `--best --gpl` should
  be passed to `configure.sh` to enable the best optional dependencies.
- It makes all the options for optional dependencies two-valued, because
  `ENABLE_BEST` is not used anymore.
- In the configuration summary, it omits printing the `ENABLE_GPL`
  variable since the license of the binary is printed anyway.