### PR TITLE
[FP] Do not attempt to word blast within closures

### DIFF
--- a/src/theory/fp/fp_word_blaster.cpp
+++ b/src/theory/fp/fp_word_blaster.cpp
@@ -868,6 +868,13 @@ Node FpWordBlaster::wordBlast(TNode node)
       continue;
     }
 
+    if (cur.isClosure())
+    {
+      // We ignore closures. For closures (e.g., set comprehension), we rely on
+      // the reduction of the closures to handle the body.
+      continue;
+    }
+
     auto it = visited.find(cur);
     if (it == visited.end())
     {

--- a/src/theory/fp/theory_fp.cpp
+++ b/src/theory/fp/theory_fp.cpp
@@ -808,16 +808,23 @@ bool TheoryFp::collectModelValues(TheoryModel* m,
     TNode current = working.back();
     working.pop_back();
 
-    if (visited.find(current) != visited.end())
+    if (visited.find(current) != visited.end() || current.isClosure())
     {
-      // Ignore things that have already been explored
+      // Ignore things that have already been explored and closures. For
+      // variables in closures (e.g., set comprehension), we rely on the
+      // reduction of the closures to handle the body.
       continue;
     }
+
     visited.insert(current);
 
     TypeNode t = current.getType();
 
-    if ((t.isRoundingMode() || t.isFloatingPoint()) && this->isLeaf(current))
+    // We do not attempt to compute a model for bound variables. It can happen
+    // that a relevant term contains a bound variable if it for example
+    // contains a set comprehension.
+    if ((t.isRoundingMode() || t.isFloatingPoint()) && this->isLeaf(current)
+        && current.getKind() != BOUND_VARIABLE)
     {
       relevantVariables.insert(current);
     }

--- a/src/theory/fp/theory_fp.cpp
+++ b/src/theory/fp/theory_fp.cpp
@@ -820,11 +820,7 @@ bool TheoryFp::collectModelValues(TheoryModel* m,
 
     TypeNode t = current.getType();
 
-    // We do not attempt to compute a model for bound variables. It can happen
-    // that a relevant term contains a bound variable if it for example
-    // contains a set comprehension.
-    if ((t.isRoundingMode() || t.isFloatingPoint()) && this->isLeaf(current)
-        && current.getKind() != BOUND_VARIABLE)
+    if ((t.isRoundingMode() || t.isFloatingPoint()) && this->isLeaf(current))
     {
       relevantVariables.insert(current);
     }

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -1300,7 +1300,8 @@ void TheoryEngine::lemma(TrustNode tlemma,
   Node node = tlemma.getNode();
   Node lemma = tlemma.getProven();
 
-  Assert(!expr::hasFreeVar(lemma));
+  Assert(!expr::hasFreeVar(lemma))
+      << "Lemma " << lemma << " from " << from << " has a free variable";
 
   // when proofs are enabled, we ensure the trust node has a generator by
   // adding a trust step to the lazy proof maintained by this class

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -663,6 +663,7 @@ set(regress_0_tests
   regress0/fp/ext-rew-test.smt2
   regress0/fp/from_ubv.smt2
   regress0/fp/from_sbv.smt2
+  regress0/fp/fp-set-comprehension-basic.smt2
   regress0/fp/issue-5524.smt2
   regress0/fp/issue3536.smt2
   regress0/fp/issue3582.smt2
@@ -674,6 +675,8 @@ set(regress_0_tests
   regress0/fp/issue7002.smt2
   regress0/fp/issue7569.smt2
   regress0/fp/proj-issue329-prereg-context.smt2
+  regress0/fp/proj-issue477-fp-set-comprehension.smt2
+  regress0/fp/proj-issue509-fp-set-comprehension.smt2
   regress0/fp/rti_3_5_bug.smt2
   regress0/fp/simple.smt2
   regress0/fp/word-blast.smt2

--- a/test/regress/cli/regress0/fp/fp-set-comprehension-basic.smt2
+++ b/test/regress/cli/regress0/fp/fp-set-comprehension-basic.smt2
@@ -1,0 +1,7 @@
+; EXPECT: unknown
+(set-logic ALL)
+(set-option :sets-ext true)
+(declare-const S (Set Float32))
+(declare-const x Float32)
+(assert (not (= x (set.choose (set.comprehension ((_x14 Float32)) false _x14)))))
+(check-sat)

--- a/test/regress/cli/regress0/fp/proj-issue477-fp-set-comprehension.smt2
+++ b/test/regress/cli/regress0/fp/proj-issue477-fp-set-comprehension.smt2
@@ -1,0 +1,6 @@
+; EXPECT: unknown
+(set-logic ALL)
+(set-option :strings-exp true)
+(set-option :sets-ext true)
+(assert (= (seq.nth (seq.unit false) (bag.count (_ NaN 11 53) (bag (_ +zero 11 53) 1))) (seq.nth (seq.extract (seq.unit false) (bag.count (_ NaN 11 53) (bag (_ +zero 11 53) 1)) (bag.count (set.choose (set.comprehension ((_x14 Float64)) false _x14)) (bag (_ +zero 11 53) 1))) 0)))
+(check-sat)

--- a/test/regress/cli/regress0/fp/proj-issue509-fp-set-comprehension.smt2
+++ b/test/regress/cli/regress0/fp/proj-issue509-fp-set-comprehension.smt2
@@ -1,0 +1,6 @@
+(set-logic ALL)
+(set-option :sets-ext true)
+(declare-datatype d ((c (s RoundingMode))))
+(assert (set.member (set.choose (set.comprehension ((_x18 d)) false (s _x18))) (set.comprehension ((_x18 d)) false (s _x18))))
+(set-info :status unsat)
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5-projects/issues/477. Fixes
https://github.com/cvc5/cvc5-projects/issues/509. It can happen that
certain closures such as set comprehension appear within a
floating-point term. Currently, the word blaster descends into the
closure and tries to word blast the body of the closure including bound
variables, which leads to the issues mentioned. This commit changes the
behavior to prevent the FP solver from descending into closures (both
for word blasting and computing models). Instead, we rely on the theory
responsible for the closure to reduce it in an appropriate manner.