### PR TITLE
Use assertions instead of (Pretty)CheckArgument in integer_*_imp.

### DIFF
--- a/src/util/integer_cln_imp.cpp
+++ b/src/util/integer_cln_imp.cpp
@@ -164,7 +164,7 @@ void Integer::setBit(uint32_t i, bool value)
 
 Integer Integer::oneExtend(uint32_t size, uint32_t amount) const
 {
-  DebugCheckArgument((*this) < Integer(1).multiplyByPow2(size), size);
+  Assert((*this) < Integer(1).multiplyByPow2(size));
   cln::cl_byte range(amount, size);
   cln::cl_I allones = (cln::cl_I(1) << (size + amount)) - 1;  // 2^size - 1
   Integer temp(allones);
@@ -260,7 +260,7 @@ Integer Integer::euclidianDivideRemainder(const Integer& y) const
 
 Integer Integer::exactQuotient(const Integer& y) const
 {
-  DebugCheckArgument(y.divides(*this), y);
+  Assert(y.divides(*this));
   return Integer(cln::exquo(d_value, y.d_value));
 }
 
@@ -318,7 +318,7 @@ Integer Integer::modMultiply(const Integer& y, const Integer& m) const
 
 Integer Integer::modInverse(const Integer& m) const
 {
-  PrettyCheckArgument(m > 0, m, "m must be greater than zero");
+  Assert(m > 0) << "m must be greater than zero";
   cln::cl_modint_ring ry = cln::find_modint_ring(m.d_value);
   cln::cl_MI xm = ry->canonhom(d_value);
   /* normalize to modulo m for coprime check */
@@ -470,41 +470,34 @@ bool Integer::fitsUnsignedInt() const
 signed int Integer::getSignedInt() const
 {
   // ensure there isn't overflow
-  CheckArgument(
-      fitsSignedInt(), this, "Overflow detected in Integer::getSignedInt()");
+  Assert(fitsSignedInt()) << "Overflow detected in Integer::getSignedInt()";
   return cln::cl_I_to_int(d_value);
 }
 
 unsigned int Integer::getUnsignedInt() const
 {
   // ensure there isn't overflow
-  CheckArgument(fitsUnsignedInt(),
-                this,
-                "Overflow detected in Integer::getUnsignedInt()");
+  Assert(fitsUnsignedInt()) << "Overflow detected in Integer::getUnsignedInt()";
   return cln::cl_I_to_uint(d_value);
 }
 
 long Integer::getLong() const
 {
   // ensure there isn't overflow
-  CheckArgument(d_value <= std::numeric_limits<long>::max(),
-                this,
-                "Overflow detected in Integer::getLong()");
-  CheckArgument(d_value >= std::numeric_limits<long>::min(),
-                this,
-                "Overflow detected in Integer::getLong()");
+  Assert(d_value <= std::numeric_limits<long>::max())
+      << "Overflow detected in Integer::getLong()";
+  Assert(d_value >= std::numeric_limits<long>::min())
+      << "Overflow detected in Integer::getLong()";
   return cln::cl_I_to_long(d_value);
 }
 
 unsigned long Integer::getUnsignedLong() const
 {
   // ensure there isn't overflow
-  CheckArgument(d_value <= std::numeric_limits<unsigned long>::max(),
-                this,
-                "Overflow detected in Integer::getUnsignedLong()");
-  CheckArgument(d_value >= std::numeric_limits<unsigned long>::min(),
-                this,
-                "Overflow detected in Integer::getUnsignedLong()");
+  Assert(d_value <= std::numeric_limits<unsigned long>::max())
+      << "Overflow detected in Integer::getUnsignedLong()";
+  Assert(d_value >= std::numeric_limits<unsigned long>::min())
+      << "Overflow detected in Integer::getUnsignedLong()";
   return cln::cl_I_to_ulong(d_value);
 }
 
@@ -522,12 +515,10 @@ int64_t Integer::getSigned64() const
       return getLong();
     }
     // ensure there isn't overflow
-    CheckArgument(d_value <= std::numeric_limits<int64_t>::max(),
-                  this,
-                  "Overflow detected in Integer::getSigned64()");
-    CheckArgument(d_value >= std::numeric_limits<int64_t>::min(),
-                  this,
-                  "Overflow detected in Integer::getSigned64()");
+    Assert(d_value <= std::numeric_limits<int64_t>::max())
+        << "Overflow detected in Integer::getSigned64()";
+    Assert(d_value >= std::numeric_limits<int64_t>::min())
+        << "Overflow detected in Integer::getSigned64()";
     return std::stoll(toString());
   }
 }
@@ -545,12 +536,10 @@ uint64_t Integer::getUnsigned64() const
       return getUnsignedLong();
     }
     // ensure there isn't overflow
-    CheckArgument(d_value <= std::numeric_limits<uint64_t>::max(),
-                  this,
-                  "Overflow detected in Integer::getSigned64()");
-    CheckArgument(d_value >= std::numeric_limits<uint64_t>::min(),
-                  this,
-                  "Overflow detected in Integer::getSigned64()");
+    Assert(d_value <= std::numeric_limits<uint64_t>::max())
+        << "Overflow detected in Integer::getSigned64()";
+    Assert(d_value >= std::numeric_limits<uint64_t>::min())
+        << "Overflow detected in Integer::getSigned64()";
     return std::stoull(toString());
   }
 }

--- a/src/util/integer_gmp_imp.cpp
+++ b/src/util/integer_gmp_imp.cpp
@@ -187,7 +187,7 @@ bool Integer::isBitSet(uint32_t i) const
 Integer Integer::oneExtend(uint32_t size, uint32_t amount) const
 {
   // check that the size is accurate
-  DebugCheckArgument((*this) < Integer(1).multiplyByPow2(size), size);
+  Assert((*this) < Integer(1).multiplyByPow2(size));
   mpz_class res = d_value;
 
   for (unsigned i = size; i < size + amount; ++i)
@@ -304,7 +304,7 @@ Integer Integer::euclidianDivideRemainder(const Integer& y) const
 
 Integer Integer::exactQuotient(const Integer& y) const
 {
-  DebugCheckArgument(y.divides(*this), y);
+  Assert(y.divides(*this));
   mpz_class q;
   mpz_divexact(q.get_mpz_t(), d_value.get_mpz_t(), y.d_value.get_mpz_t());
   return Integer(q);
@@ -378,7 +378,7 @@ Integer Integer::modMultiply(const Integer& y, const Integer& m) const
 
 Integer Integer::modInverse(const Integer& m) const
 {
-  PrettyCheckArgument(m > 0, m, "m must be greater than zero");
+  Assert(m > 0) << "m must be greater than zero";
   mpz_class res;
   if (mpz_invert(res.get_mpz_t(), d_value.get_mpz_t(), m.d_value.get_mpz_t())
       == 0)
@@ -405,46 +405,38 @@ bool Integer::fitsUnsignedInt() const { return d_value.fits_uint_p(); }
 signed int Integer::getSignedInt() const
 {
   // ensure there isn't overflow
-  CheckArgument(d_value <= std::numeric_limits<int>::max(),
-                this,
-                "Overflow detected in Integer::getSignedInt().");
-  CheckArgument(d_value >= std::numeric_limits<int>::min(),
-                this,
-                "Overflow detected in Integer::getSignedInt().");
-  CheckArgument(
-      fitsSignedInt(), this, "Overflow detected in Integer::getSignedInt().");
+  Assert(d_value <= std::numeric_limits<int>::max())
+      << "Overflow detected in Integer::getSignedInt().";
+  Assert(d_value >= std::numeric_limits<int>::min())
+      << "Overflow detected in Integer::getSignedInt().";
+  Assert(fitsSignedInt()) << "Overflow detected in Integer::getSignedInt().";
   return (signed int)d_value.get_si();
 }
 
 unsigned int Integer::getUnsignedInt() const
 {
   // ensure there isn't overflow
-  CheckArgument(d_value <= std::numeric_limits<unsigned int>::max(),
-                this,
-                "Overflow detected in Integer::getUnsignedInt()");
-  CheckArgument(d_value >= std::numeric_limits<unsigned int>::min(),
-                this,
-                "Overflow detected in Integer::getUnsignedInt()");
-  CheckArgument(
-      fitsUnsignedInt(), this, "Overflow detected in Integer::getUnsignedInt()");
+  Assert(d_value <= std::numeric_limits<unsigned int>::max())
+      << "Overflow detected in Integer::getUnsignedInt()";
+  Assert(d_value >= std::numeric_limits<unsigned int>::min())
+      << "Overflow detected in Integer::getUnsignedInt()";
+  Assert(fitsUnsignedInt()) << "Overflow detected in Integer::getUnsignedInt()";
   return (unsigned int)d_value.get_ui();
 }
 
 long Integer::getLong() const
 {
   // ensure there it fits
-  CheckArgument(mpz_fits_slong_p(d_value.get_mpz_t()) != 0,
-                this,
-                "Overflow detected in Integer::getLong().");
+  Assert(mpz_fits_slong_p(d_value.get_mpz_t()) != 0)
+      << "Overflow detected in Integer::getLong().";
   return d_value.get_si();
 }
 
 unsigned long Integer::getUnsignedLong() const
 {
   // ensure that it fits
-  CheckArgument(mpz_fits_ulong_p(d_value.get_mpz_t()) != 0,
-                this,
-                "Overflow detected in Integer::getUnsignedLong().");
+  Assert(mpz_fits_ulong_p(d_value.get_mpz_t()) != 0)
+      << "Overflow detected in Integer::getUnsignedLong().";
   return d_value.get_ui();
 }
 
@@ -466,8 +458,7 @@ int64_t Integer::getSigned64() const
     }
     catch (const std::exception& e)
     {
-      CheckArgument(
-          false, this, "Overflow detected in Integer::getSigned64().");
+      Assert(false) << "Overflow detected in Integer::getSigned64().";
     }
   }
   return 0;
@@ -486,14 +477,12 @@ uint64_t Integer::getUnsigned64() const
     }
     try
     {
-      CheckArgument(
-          sgn() >= 0, this, "Overflow detected in Integer::getUnsigned64().");
+      Assert(sgn() >= 0) << "Overflow detected in Integer::getUnsigned64().";
       return std::stoull(toString());
     }
     catch (const std::exception& e)
     {
-      CheckArgument(
-          false, this, "Overflow detected in Integer::getUnsigned64().");
+      Assert(false) << "Overflow detected in Integer::getUnsigned64().";
     }
   }
   return 0;

--- a/test/unit/util/integer_black.cpp
+++ b/test/unit/util/integer_black.cpp
@@ -344,7 +344,7 @@ TEST_F(TestUtilBlackInteger, overly_long_signed)
   ASSERT_NO_THROW(i.getSigned64());
   ASSERT_EQ(i.getSigned64(), sl);
   i = i + 1;
-  ASSERT_THROW(i.getSigned64(), IllegalArgumentException);
+  ASSERT_DEATH(i.getSigned64(), "gmpz_fits_slong");
 }
 
 TEST_F(TestUtilBlackInteger, overly_long_unsigned)
@@ -355,13 +355,13 @@ TEST_F(TestUtilBlackInteger, overly_long_unsigned)
   {
     ASSERT_EQ(i.getUnsignedLong(), ul);
   }
-  ASSERT_THROW(i.getLong(), IllegalArgumentException);
+  ASSERT_DEATH(i.getLong(), "gmpz_fits_slong");
   ASSERT_NO_THROW(i.getUnsigned64());
   ASSERT_EQ(i.getUnsigned64(), ul);
   uint64_t ulplus1 = ul + 1;
   ASSERT_EQ(ulplus1, 0);
   i = i + 1;
-  ASSERT_THROW(i.getUnsignedLong(), IllegalArgumentException);
+  ASSERT_DEATH(i.getUnsignedLong(), "gmpz_fits_ulong");
 }
 
 TEST_F(TestUtilBlackInteger, getSigned64)
@@ -369,14 +369,14 @@ TEST_F(TestUtilBlackInteger, getSigned64)
   {
     int64_t i = std::numeric_limits<int64_t>::max();
     Integer a(i);
-    EXPECT_EQ(a.getSigned64(), i);
-    EXPECT_THROW((a + 1).getSigned64(), IllegalArgumentException);
+    ASSERT_EQ(a.getSigned64(), i);
+    ASSERT_DEATH((a + 1).getSigned64(), "gmpz_fits_slong");
   }
   {
     int64_t i = std::numeric_limits<int64_t>::min();
     Integer a(i);
-    EXPECT_EQ(a.getSigned64(), i);
-    EXPECT_THROW((a - 1).getSigned64(), IllegalArgumentException);
+    ASSERT_EQ(a.getSigned64(), i);
+    ASSERT_DEATH((a - 1).getSigned64(), "gmpz_fits_slong");
   }
 }
 
@@ -385,14 +385,14 @@ TEST_F(TestUtilBlackInteger, getUnsigned64)
   {
     uint64_t i = std::numeric_limits<uint64_t>::max();
     Integer a(i);
-    EXPECT_EQ(a.getUnsigned64(), i);
-    EXPECT_THROW((a + 1).getUnsigned64(), IllegalArgumentException);
+    ASSERT_EQ(a.getUnsigned64(), i);
+    ASSERT_DEATH((a + 1).getUnsigned64(), "gmpz_fits_ulong");
   }
   {
     uint64_t i = std::numeric_limits<uint64_t>::min();
     Integer a(i);
-    EXPECT_EQ(a.getUnsigned64(), i);
-    EXPECT_THROW((a - 1).getUnsigned64(), IllegalArgumentException);
+    ASSERT_EQ(a.getUnsigned64(), i);
+    ASSERT_DEATH((a - 1).getUnsigned64(), "gmpz_fits_ulong");
   }
 }
 


### PR DESCRIPTION
This is in preparation for getting rid of IllegalArgumentException.
This exception was originally used for guards in the old API and is now
obsolete.