### PR TITLE
Use assertions instead of (Pretty)CheckArgument in symbol_(table|manager).

### DIFF
--- a/src/parser/api/cpp/symbol_manager.cpp
+++ b/src/parser/api/cpp/symbol_manager.cpp
@@ -247,8 +247,8 @@ void SymbolManager::Implementation::pushScope(bool isUserContext)
 {
   Trace("sym-manager") << "SymbolManager: pushScope, isUserContext = "
                        << isUserContext << std::endl;
-  PrettyCheckArgument(!d_hasPushedScope.get() || !isUserContext,
-                      "cannot push a user context within a scope context");
+  Assert(!d_hasPushedScope.get() || !isUserContext)
+      << "cannot push a user context within a scope context";
   d_context.push();
   if (!isUserContext)
   {

--- a/src/parser/symbol_table.cpp
+++ b/src/parser/symbol_table.cpp
@@ -22,6 +22,7 @@
 #include <utility>
 
 #include "api/cpp/cvc5.h"
+#include "base/check.h"
 #include "context/cdhashmap.h"
 #include "context/cdhashset.h"
 #include "context/context.h"
@@ -414,7 +415,7 @@ bool SymbolTable::Implementation::bind(const string& name,
                                        cvc5::Term obj,
                                        bool doOverload)
 {
-  PrettyCheckArgument(!obj.isNull(), obj, "cannot bind to a null cvc5::Term");
+  Assert(!obj.isNull()) << "cannot bind to a null cvc5::Term";
   Trace("sym-table") << "SymbolTable: bind " << name << " to " << obj
                      << ", doOverload=" << doOverload << std::endl;
   if (doOverload)
@@ -482,12 +483,9 @@ cvc5::Sort SymbolTable::Implementation::lookupType(const string& name) const
 {
   std::pair<std::vector<cvc5::Sort>, cvc5::Sort> p =
       (*d_typeMap.find(name)).second;
-  PrettyCheckArgument(p.first.size() == 0,
-                      name,
-                      "type constructor arity is wrong: "
-                      "`%s' requires %u parameters but was provided 0",
-                      name.c_str(),
-                      p.first.size());
+  Assert(p.first.size() == 0)
+      << "type constructor arity is wrong: `" << name << "' requires "
+      << p.first.size() << " parameters but was provided 0";
   return p.second;
 }
 
@@ -496,23 +494,18 @@ cvc5::Sort SymbolTable::Implementation::lookupType(
 {
   std::pair<std::vector<cvc5::Sort>, cvc5::Sort> p =
       (*d_typeMap.find(name)).second;
-  PrettyCheckArgument(p.first.size() == params.size(),
-                      params,
-                      "type constructor arity is wrong: "
-                      "`%s' requires %u parameters but was provided %u",
-                      name.c_str(),
-                      p.first.size(),
-                      params.size());
+  Assert(p.first.size() == params.size())
+      << "type constructor arity is wrong: `" << name.c_str() << "' requires "
+      << p.first.size() << " parameters but was provided " << params.size();
   if (p.first.size() == 0)
   {
-    PrettyCheckArgument(p.second.isUninterpretedSort(), name.c_str());
+    Assert(p.second.isUninterpretedSort());
     return p.second;
   }
   if (p.second.isDatatype())
   {
-    PrettyCheckArgument(p.second.getDatatype().isParametric(),
-                        name,
-                        "expected parametric datatype");
+    Assert(p.second.getDatatype().isParametric())
+        << "expected parametric datatype";
     return p.second.instantiate(params);
   }
   bool isUninterpretedSortConstructor =


### PR DESCRIPTION
This is in preparation for getting rid of IllegalArgumentException.
This exception was originally used for guards in the old API and is now
obsolete.