### PR TITLE
Use assertions instead of (Pretty)CheckArgument in expr and smt.

### DIFF
--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -5861,8 +5861,9 @@ Term Solver::mkConstArray(const Sort& sort, const Term& val) const
   CVC5_API_ARG_CHECK_EXPECTED(sort.isArray(), sort) << "an array sort";
   CVC5_API_CHECK(val.getSort() == sort.getArrayElementSort())
       << "Value does not match element sort";
-  //////// all checks before this line
   internal::Node n = *val.d_node;
+  CVC5_API_ARG_CHECK_EXPECTED(n.isConst(), val) << "a value";
+  //////// all checks before this line
   Term res = mkValHelper(d_nm, internal::ArrayStoreAll(*sort.d_type, n));
   return res;
   ////////

--- a/src/expr/array_store_all.cpp
+++ b/src/expr/array_store_all.cpp
@@ -32,21 +32,16 @@ ArrayStoreAll::ArrayStoreAll(const TypeNode& type, const Node& value)
   // this check is stronger than the assertion check in the expr manager that
   // ArrayTypes are actually array types
   // because this check is done in production builds too
-  PrettyCheckArgument(
-      type.isArray(), type,
-      "array store-all constants can only be created for array types, not `%s'",
-      type.toString().c_str());
-
-  PrettyCheckArgument(
-      value.getType() == type.getArrayConstituentType(),
-      value,
-      "expr type `%s' does not match constituent type of array type `%s'",
-      value.getType().toString().c_str(),
-      type.toString().c_str());
+  Assert(type.isArray())
+      << "array store-all constants can only be created for array types, not `"
+      << type.toString().c_str() << "'";
+  Assert(value.getType() == type.getArrayConstituentType())
+      << "expr type `" << value.getType().toString().c_str()
+      << "' does not match constituent type of array type `"
+      << type.toString().c_str() << "'";
   Trace("arrays") << "constructing constant array of type: '" << type
                   << "' and value: '" << value << "'" << std::endl;
-  PrettyCheckArgument(
-      value.isConst(), value, "ArrayStoreAll requires a constant expression");
+  Assert(value.isConst()) << "ArrayStoreAll requires a constant expression";
 
   // Delay allocation until the checks above have been performed. If these
   // fail, the memory for d_type and d_value should not leak. The alternative

--- a/src/expr/codatatype_bound_variable.cpp
+++ b/src/expr/codatatype_bound_variable.cpp
@@ -31,16 +31,13 @@ CodatatypeBoundVariable::CodatatypeBoundVariable(const TypeNode& type,
                                                  Integer index)
     : d_type(new TypeNode(type)), d_index(index)
 {
-  PrettyCheckArgument(type.isCodatatype(),
-                      type,
-                      "codatatype bound variables can only be created for "
-                      "codatatype sorts, not `%s'",
-                      type.toString().c_str());
-  PrettyCheckArgument(
-      index >= 0,
-      index,
-      "index >= 0 required for codatatype bound variable index, not `%s'",
-      index.toString().c_str());
+  Assert(type.isCodatatype())
+      << "codatatype bound variables can only be created for "
+         "codatatype sorts, not `"
+      << type.toString().c_str() << "'";
+  Assert(index >= 0)
+      << "index >= 0 required for codatatype bound variable index, not `"
+      << index.toString().c_str() << "'";
 }
 
 CodatatypeBoundVariable::~CodatatypeBoundVariable() {}

--- a/src/expr/mkexpr
+++ b/src/expr/mkexpr
@@ -229,7 +229,7 @@ template <> $2 const & Expr::getConst< $2 >() const;
 "
   getConst_implementations="${getConst_implementations}
 template <> $2 const & Expr::getConst() const {
-  PrettyCheckArgument(getKind() == ::cvc5::internal::kind::$1, *this, \"Improper kind for getConst<$2>()\");
+Assert(getKind() == ::cvc5::internal::kind::$1) << \"Improper kind for getConst<$2>()\";
   return d_node->getConst< $2 >();
 }
 "

--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -1217,8 +1217,7 @@ GetValueCommand::GetValueCommand(cvc5::Term term) : d_terms()
 GetValueCommand::GetValueCommand(const std::vector<cvc5::Term>& terms)
     : d_terms(terms)
 {
-  PrettyCheckArgument(
-      terms.size() >= 1, terms, "cannot get-value of an empty set of terms");
+  Assert(terms.size() >= 1) << "cannot get-value of an empty set of terms";
 }
 
 const std::vector<cvc5::Term>& GetValueCommand::getTerms() const
@@ -1400,9 +1399,8 @@ BlockModelValuesCommand::BlockModelValuesCommand(
     const std::vector<cvc5::Term>& terms)
     : d_terms(terms)
 {
-  PrettyCheckArgument(terms.size() >= 1,
-                      terms,
-                      "cannot block-model-values of an empty set of terms");
+  Assert(terms.size() >= 1)
+      << "cannot block-model-values of an empty set of terms";
 }
 
 const std::vector<cvc5::Term>& BlockModelValuesCommand::getTerms() const

--- a/test/unit/api/cpp/term_black.cpp
+++ b/test/unit/api/cpp/term_black.cpp
@@ -857,6 +857,10 @@ TEST_F(TestApiBlackTerm, getConstArrayBase)
 
   ASSERT_TRUE(constarr.isConstArray());
   ASSERT_EQ(one, constarr.getConstArrayBase());
+
+  Term a = d_solver.mkConst(arrsort, "a");
+  ASSERT_THROW(a.getConstArrayBase(), CVC5ApiException);
+  ASSERT_THROW(one.getConstArrayBase(), CVC5ApiException);
 }
 
 TEST_F(TestApiBlackTerm, getBoolean)
@@ -1109,7 +1113,12 @@ TEST_F(TestApiBlackTerm, constArray)
   Sort arrsort = d_solver.mkArraySort(intsort, intsort);
   Term a = d_solver.mkConst(arrsort, "a");
   Term one = d_solver.mkInteger(1);
+  Term two = d_solver.mkBitVector(2, 2);
+  Term iconst = d_solver.mkConst(intsort);
   Term constarr = d_solver.mkConstArray(arrsort, one);
+
+  ASSERT_THROW(d_solver.mkConstArray(arrsort, two), CVC5ApiException);
+  ASSERT_THROW(d_solver.mkConstArray(arrsort, iconst), CVC5ApiException);
 
   ASSERT_EQ(constarr.getKind(), CONST_ARRAY);
   ASSERT_EQ(constarr.getConstArrayBase(), one);

--- a/test/unit/api/java/TermTest.java
+++ b/test/unit/api/java/TermTest.java
@@ -824,6 +824,10 @@ class TermTest
 
     assertTrue(constarr.isConstArray());
     assertEquals(one, constarr.getConstArrayBase());
+
+    Term a = d_solver.mkConst(arrsort, "a");
+    assertThrows(CVC5ApiException.class, () -> a.getConstArrayBase());
+    assertThrows(CVC5ApiException.class, () -> one.getConstArrayBase());
   }
 
   @Test
@@ -1109,14 +1113,19 @@ class TermTest
     Sort arrsort = d_solver.mkArraySort(intsort, intsort);
     Term a = d_solver.mkConst(arrsort, "a");
     Term one = d_solver.mkInteger(1);
+    Term two = d_solver.mkBitVector(2, 2);
+    Term iconst = d_solver.mkConst(intsort);
     Term constarr = d_solver.mkConstArray(arrsort, one);
+
+    assertThrows(CVC5ApiException.class, () -> d_solver.mkConstArray(arrsort, two));
+    assertThrows(CVC5ApiException.class, () -> d_solver.mkConstArray(arrsort, iconst));
 
     assertEquals(constarr.getKind(), CONST_ARRAY);
     assertEquals(constarr.getConstArrayBase(), one);
     assertThrows(CVC5ApiException.class, () -> a.getConstArrayBase());
 
-    arrsort = d_solver.mkArraySort(d_solver.getRealSort(), d_solver.getRealSort());
-    Term zero_array = d_solver.mkConstArray(arrsort, d_solver.mkReal(0));
+    Sort arrsort2 = d_solver.mkArraySort(d_solver.getRealSort(), d_solver.getRealSort());
+    Term zero_array = d_solver.mkConstArray(arrsort2, d_solver.mkReal(0));
     Term stores = d_solver.mkTerm(STORE, zero_array, d_solver.mkReal(1), d_solver.mkReal(2));
     stores = d_solver.mkTerm(STORE, stores, d_solver.mkReal(2), d_solver.mkReal(3));
     stores = d_solver.mkTerm(STORE, stores, d_solver.mkReal(4), d_solver.mkReal(5));

--- a/test/unit/api/python/test_term.py
+++ b/test/unit/api/python/test_term.py
@@ -958,6 +958,13 @@ def test_get_const_array_base(solver):
     assert constarr.isConstArray()
     assert one == constarr.getConstArrayBase()
 
+    with pytest.raises(RuntimeError):
+        one.getConstArrayBase()
+
+    a = solver.mkConst(arrsort, "a")
+    with pytest.raises(RuntimeError):
+        a.getConstArrayBase()
+
 
 def test_get_uninterpreted_sort_value(solver):
     solver.setOption("produce-models", "true")
@@ -1264,7 +1271,14 @@ def test_const_array(solver):
     arrsort = solver.mkArraySort(intsort, intsort)
     a = solver.mkConst(arrsort, "a")
     one = solver.mkInteger(1)
+    two = solver.mkBitVector(2, 2)
+    iconst = solver.mkConst(intsort)
     constarr = solver.mkConstArray(arrsort, one)
+
+    with pytest.raises(RuntimeError):
+        solver.mkConstArray(arrsort, two)
+    with pytest.raises(RuntimeError):
+        solver.mkConstArray(arrsort, iconst)
 
     assert constarr.getKind() == Kind.CONST_ARRAY
     assert constarr.getConstArrayBase() == one

--- a/test/unit/util/array_store_all_white.cpp
+++ b/test/unit/util/array_store_all_white.cpp
@@ -45,42 +45,42 @@ TEST_F(TestUtilWhiteArrayStoreAll, store_all)
 
 TEST_F(TestUtilWhiteArrayStoreAll, type_errors)
 {
-  ASSERT_THROW(ArrayStoreAll(d_nodeManager->integerType(),
+  ASSERT_DEATH(ArrayStoreAll(d_nodeManager->integerType(),
                              d_nodeManager->mkConst(UninterpretedSortValue(
                                  d_nodeManager->mkSort("U"), 0))),
-               IllegalArgumentException);
-  ASSERT_THROW(ArrayStoreAll(d_nodeManager->integerType(),
+               "can only be created for array types");
+  ASSERT_DEATH(ArrayStoreAll(d_nodeManager->integerType(),
                              d_nodeManager->mkConstReal(Rational(9, 2))),
-               IllegalArgumentException);
-  ASSERT_THROW(
+               "can only be created for array types");
+  ASSERT_DEATH(
       ArrayStoreAll(d_nodeManager->mkArrayType(d_nodeManager->integerType(),
                                                d_nodeManager->mkSort("U")),
                     d_nodeManager->mkConstReal(Rational(9, 2))),
-      IllegalArgumentException);
-  ASSERT_THROW(ArrayStoreAll(
-      d_nodeManager->mkArrayType(d_nodeManager->mkBitVectorType(8),
-                                 d_nodeManager->realType()),
-      d_nodeManager->mkConstInt(Rational(0))),
-      IllegalArgumentException);
+      "does not match constituent type of array type");
+  ASSERT_DEATH(ArrayStoreAll(
+                   d_nodeManager->mkArrayType(d_nodeManager->mkBitVectorType(8),
+                                              d_nodeManager->realType()),
+                   d_nodeManager->mkConstInt(Rational(0))),
+               "does not match constituent type of array type");
 }
 
 TEST_F(TestUtilWhiteArrayStoreAll, const_error)
 {
   TypeNode usort = d_nodeManager->mkSort("U");
-  ASSERT_THROW(ArrayStoreAll(d_nodeManager->mkArrayType(
+  ASSERT_DEATH(ArrayStoreAll(d_nodeManager->mkArrayType(
                                  d_nodeManager->mkSort("U"), usort),
                              d_nodeManager->mkVar(usort)),
-               IllegalArgumentException);
-  ASSERT_THROW(
+               "requires a constant expression");
+  ASSERT_DEATH(
       ArrayStoreAll(d_nodeManager->integerType(),
                     d_nodeManager->mkVar("x", d_nodeManager->integerType())),
-      IllegalArgumentException);
-  ASSERT_THROW(ArrayStoreAll(d_nodeManager->integerType(),
+      "array store-all constants can only be created for array types");
+  ASSERT_DEATH(ArrayStoreAll(d_nodeManager->integerType(),
                              d_nodeManager->mkNode(
                                  kind::ADD,
                                  d_nodeManager->mkConstInt(Rational(1)),
                                  d_nodeManager->mkConstInt(Rational(0)))),
-               IllegalArgumentException);
+               "array store-all constants can only be created for array types");
 }
 }  // namespace test
 }  // namespace cvc5::internal


### PR DESCRIPTION
This is in preparation for getting rid of IllegalArgumentException.
This exception was originally used for guards in the old API and is now
obsolete.