### PR TITLE
Remove re-inter-mode=all mode

### DIFF
--- a/src/options/strings_options.toml
+++ b/src/options/strings_options.toml
@@ -147,15 +147,9 @@ name   = "Strings Theory"
   default    = "CONSTANT"
   help       = "determines which regular expressions intersections to compute"
   help_mode  = "Regular expression intersection modes."
-[[option.mode.ALL]]
-  name = "all"
-  help = "Compute intersections for all regular expressions."
 [[option.mode.CONSTANT]]
   name = "constant"
   help = "Compute intersections only between regular expressions that do not contain re.allchar or re.range."
-[[option.mode.ONE_CONSTANT]]
-  name = "one-constant"
-  help = "Compute intersections only between regular expressions such that at least one side does not contain re.allchar or re.range."
 [[option.mode.NONE]]
   name = "none"
   help = "Do not compute intersections for regular expressions."

--- a/src/theory/strings/regexp_solver.cpp
+++ b/src/theory/strings/regexp_solver.cpp
@@ -471,7 +471,6 @@ bool RegExpSolver::checkEqcIntersect(const std::vector<Node>& mems)
   }
   // the initial regular expression membership and its constant type
   Node mi;
-  RegExpConstType rcti = RE_C_UNKNOWN;
   NodeManager* nm = NodeManager::currentNM();
   for (const Node& m : mems)
   {
@@ -482,30 +481,16 @@ bool RegExpSolver::checkEqcIntersect(const std::vector<Node>& mems)
       continue;
     }
     RegExpConstType rct = d_regexp_opr.getRegExpConstType(m[1]);
-    if (rct == RE_C_VARIABLE
-        || (options().strings.stringRegExpInterMode
-                == options::RegExpInterMode::CONSTANT
-            && rct != RE_C_CONRETE_CONSTANT))
+    if (rct != RE_C_CONRETE_CONSTANT)
     {
-      // cannot do intersection on RE with variables, or with re.allchar based
-      // on option.
+      // cannot do intersection on RE with variables, or with re.allchar,
+      // or re.complement
       continue;
-    }
-    if (options().strings.stringRegExpInterMode
-        == options::RegExpInterMode::ONE_CONSTANT)
-    {
-      if (!mi.isNull() && rcti >= RE_C_CONSTANT && rct >= RE_C_CONSTANT)
-      {
-        // if both have re.allchar, do not do intersection if the
-        // options::RegExpInterMode::ONE_CONSTANT option is set.
-        continue;
-      }
     }
     if (mi.isNull())
     {
       // first regular expression seen
       mi = m;
-      rcti = rct;
       continue;
     }
     Node resR = d_regexp_opr.intersect(mi[1], m[1]);

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2684,6 +2684,7 @@ set(regress_1_tests
   regress1/strings/issue8981-strings-deq-ext-nth.smt2
   regress1/strings/issue8981-2-strings-deq-ext-nth.smt2
   regress1/strings/issue9003-deq-split.smt2
+  regress1/strings/issue9040-re-inter-all.smt2
   regress1/strings/kaluza-fl.smt2
   regress1/strings/loop002.smt2
   regress1/strings/loop003.smt2

--- a/test/regress/cli/regress1/strings/issue9040-re-inter-all.smt2
+++ b/test/regress/cli/regress1/strings/issue9040-re-inter-all.smt2
@@ -1,0 +1,6 @@
+; COMMAND-LINE: --strings-exp
+; EXPECT: sat
+(set-logic ALL)
+(declare-fun e () String)
+(assert (distinct (str.in_re e (re.* (str.to_re "b"))) (ite (str.in_re e (re.* (re.comp (str.to_re "")))) (= e "") false)))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/9040.

The code is not robust for non-concrete regular expressions. Moreover it is probably never a good idea to ever call methods for intersection for non-concrete RE.