### PR TITLE
Disable LFSC tester on regression that uses sets

### DIFF
--- a/test/regress/cli/regress0/fp/proj-issue509-fp-set-comprehension.smt2
+++ b/test/regress/cli/regress0/fp/proj-issue509-fp-set-comprehension.smt2
@@ -1,3 +1,4 @@
+; DISABLE-TESTER: lfsc
 (set-logic ALL)
 (set-option :sets-ext true)
 (declare-datatype d ((c (s RoundingMode))))


### PR DESCRIPTION
We currently have no signature for sets in LFSC, so this commit disables
a regression that includes sets.