### PR TITLE
Ensure that facts are rewritten

### DIFF
--- a/src/theory/inference_manager_buffered.cpp
+++ b/src/theory/inference_manager_buffered.cpp
@@ -81,6 +81,7 @@ void InferenceManagerBuffered::addPendingFact(Node conc,
                                               ProofGenerator* pg)
 {
   // make a simple theory internal fact
+  Assert(conc == rewrite(conc));
   Assert(conc.getKind() != AND && conc.getKind() != OR);
   d_pendingFact.emplace_back(new SimpleTheoryInternalFact(id, conc, exp, pg));
 }

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -167,6 +167,9 @@ void InferenceManager::sendInference(InferInfo& ii, bool asLemma)
   Assert(!ii.isTrivial());
   // set that this inference manager will be processing this inference
   ii.d_sim = this;
+  // ensure that the conclusion is rewritten to accurately determine whether
+  // this inference can be sent as a fact
+  ii.d_conc = rewrite(ii.d_conc);
   Trace("strings-infer-debug")
       << "sendInference: " << ii << ", asLemma = " << asLemma << std::endl;
   // check if we should send a conflict, lemma or a fact


### PR DESCRIPTION
Currently, we do not ensure that facts are rewritten. This can lead to
terms being added to the equality engine in their unrewritten and
rewritten form:

```
...
  [(+ i (* (- 1) (str.len z_6)))]
    SKOLEM_FUN_STRINGS_DEQ_DIFF_56
    SKOLEM_FUN_STRINGS_DEQ_DIFF_16
    (+ i (* (- 1) (str.len y1)))
  [(- i (str.len z_6))]
...
```

This commit adds an assertion that facts must be rewritten. It also
modifies the inference manager for the theory of strings to rewrite an
inference before determining whether an inference can be treated as a
fact.