### PR TITLE
Add SMT driver class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -345,6 +345,8 @@ libcvc5_add_sources(
   smt/solver_engine_state.h
   smt/solver_engine_stats.cpp
   smt/solver_engine_stats.h
+  smt/smt_driver.cpp
+  smt/smt_driver.h
   smt/smt_mode.cpp
   smt/smt_mode.h
   smt/smt_solver.cpp

--- a/src/smt/smt_driver.cpp
+++ b/src/smt/smt_driver.cpp
@@ -1,0 +1,115 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds, Aina Niemetz, Morgan Deters
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2022 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The solver for SMT queries in an SolverEngine.
+ */
+
+#include "smt/smt_driver.h"
+
+#include "options/base_options.h"
+#include "options/main_options.h"
+#include "options/smt_options.h"
+#include "prop/prop_engine.h"
+#include "smt/context_manager.h"
+#include "smt/env.h"
+#include "smt/logic_exception.h"
+#include "smt/smt_solver.h"
+
+namespace cvc5::internal {
+namespace smt {
+
+SmtDriver::SmtDriver(Env& env, SmtSolver& smt, ContextManager* ctx)
+    : EnvObj(env), d_smt(smt), d_ctx(ctx)
+{
+}
+
+Result SmtDriver::checkSatisfiability(const std::vector<Node>& assumptions)
+{
+  Assertions& as = d_smt.getAssertions();
+  Result result;
+  try
+  {
+    // then, initialize the assertions
+    as.setAssumptions(assumptions);
+
+    // make the check, where notice smt engine should be fully inited by now
+
+    Trace("smt") << "SmtSolver::check()" << std::endl;
+
+    ResourceManager* rm = d_env.getResourceManager();
+    if (rm->out())
+    {
+      UnknownExplanation why = rm->outOfResources()
+                                   ? UnknownExplanation::RESOURCEOUT
+                                   : UnknownExplanation::TIMEOUT;
+      result = Result(Result::UNKNOWN, why);
+    }
+    else
+    {
+      rm->beginCall();
+
+      bool checkAgain = true;
+      while (checkAgain)
+      {
+        checkAgain = false;
+        // check sat based on the driver strategy
+        result = checkSatNext(checkAgain);
+        // if we were asked to check again
+        if (checkAgain)
+        {
+          Assert(d_ctx != nullptr);
+          as.clearCurrent();
+          d_ctx->notifyResetAssertions();
+          // get the next assertions based on the driver strategy
+          getNextAssertions(as);
+          // finish init to construct new theory/prop engine
+          d_smt.finishInit();
+          // setup
+          d_ctx->setup();
+        }
+      }
+
+      rm->endCall();
+      Trace("limit") << "SmtSolver::check(): cumulative millis "
+                     << rm->getTimeUsage() << ", resources "
+                     << rm->getResourceUsage() << std::endl;
+    }
+  }
+  catch (const LogicException& e)
+  {
+    // The exception may have been throw during solving, backtrack to reset the
+    // decision level to the level expected after this method finishes
+    d_smt.getPropEngine()->resetTrail();
+    throw;
+  }
+
+  return result;
+}
+
+SmtDriverSingleCall::SmtDriverSingleCall(Env& env, SmtSolver& smt)
+    : SmtDriver(env, smt, nullptr)
+{
+}
+
+Result SmtDriverSingleCall::checkSatNext(bool& checkAgain)
+{
+  Assertions& as = d_smt.getAssertions();
+  d_smt.preprocess(as);
+  d_smt.assertToInternal(as);
+  Result result = d_smt.checkSatInternal();
+  return result;
+}
+
+void SmtDriverSingleCall::getNextAssertions(Assertions& as) { Assert(false); }
+
+}  // namespace smt
+}  // namespace cvc5::internal

--- a/src/smt/smt_driver.h
+++ b/src/smt/smt_driver.h
@@ -1,0 +1,106 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2022 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The solver for SMT queries in an SolverEngine.
+ */
+
+#include "cvc5_private.h"
+
+#ifndef CVC5__SMT__SMT_DRIVER_H
+#define CVC5__SMT__SMT_DRIVER_H
+
+#include <vector>
+
+#include "expr/node.h"
+#include "smt/assertions.h"
+#include "smt/env_obj.h"
+#include "util/result.h"
+
+namespace cvc5::internal {
+namespace smt {
+
+class SmtSolver;
+class ContextManager;
+
+/**
+ * SMT driver class.
+ *
+ * The purpose of this class is to define algorithms for checking
+ * satisfiability beyond a single call to the underlying SMT solver. The
+ * default implementation, SmtDriverSingleCall, is used for invoking a
+ * single call to the SMT solver only.
+ */
+class SmtDriver : protected EnvObj
+{
+ public:
+  SmtDriver(Env& env, SmtSolver& smt, ContextManager* ctx);
+
+  /**
+   * Check satisfiability. This invokes the algorithm given by this driver
+   * for checking satisfiability.
+   *
+   * @param assumptions The assumptions for this check-sat call, which are
+   * temporary assertions.
+   */
+  Result checkSatisfiability(const std::vector<Node>& assumptions);
+
+ protected:
+  /**
+   * Check satisfiability next, return the result.
+   *
+   * If checkAgain is set to true, then this driver will be called to
+   * getNextAssertions as described below.
+   *
+   * If checkAgain is not set or set to false, then the returned result
+   * is the final one returned by the checkSatisfiability method above.
+   */
+  virtual Result checkSatNext(bool& checkAgain) = 0;
+  /**
+   * Get the next assertions. This is called immediately after checkSatNext
+   * where checkAgain has been set to true. This populates assertions with
+   * those that will be checked on the next call to checkSatNext.
+   *
+   * Note that `as` is always the assertions of the underlying solver d_smt
+   * currently.
+   */
+  virtual void getNextAssertions(Assertions& as) = 0;
+  /** The underlying SMT solver */
+  SmtSolver& d_smt;
+  /**
+   * The underlying context manager. This is only required to be provided
+   * if the checkSatNext method ever sets checkAgain to true.
+   */
+  ContextManager* d_ctx;
+};
+
+/**
+ * The default SMT driver, which makes a single call to the underlying
+ * SMT solver.
+ *
+ * Notice this class does not require ContextManager.
+ */
+class SmtDriverSingleCall : public SmtDriver
+{
+ public:
+  SmtDriverSingleCall(Env& env, SmtSolver& smt);
+
+ protected:
+  /** Check sat next, does not set checkAgain to true */
+  Result checkSatNext(bool& checkAgain) override;
+  /** Never called */
+  void getNextAssertions(Assertions& as) override;
+};
+
+}  // namespace smt
+}  // namespace cvc5::internal
+
+#endif


### PR DESCRIPTION
This introduces the SMT driver class, which is layer between SolverEngine and SmtSolver.  It will be used for satisfiability algorithms that may require multiple check-sat calls, or other interactions between SmtSolver and e.g. the preprocessor.

Followup PRs will connect it to SolverEngine and refactor the code for deep restarts to fit into this framework.