### PR TITLE
unit: Fix integer_black unit tests.

### DIFF
--- a/test/unit/util/integer_black.cpp
+++ b/test/unit/util/integer_black.cpp
@@ -344,7 +344,7 @@ TEST_F(TestUtilBlackInteger, overly_long_signed)
   ASSERT_NO_THROW(i.getSigned64());
   ASSERT_EQ(i.getSigned64(), sl);
   i = i + 1;
-  ASSERT_DEATH(i.getSigned64(), "gmpz_fits_slong");
+  ASSERT_DEATH(i.getSigned64(), "Overflow detected");
 }
 
 TEST_F(TestUtilBlackInteger, overly_long_unsigned)
@@ -355,13 +355,13 @@ TEST_F(TestUtilBlackInteger, overly_long_unsigned)
   {
     ASSERT_EQ(i.getUnsignedLong(), ul);
   }
-  ASSERT_DEATH(i.getLong(), "gmpz_fits_slong");
+  ASSERT_DEATH(i.getLong(), "Overflow detected");
   ASSERT_NO_THROW(i.getUnsigned64());
   ASSERT_EQ(i.getUnsigned64(), ul);
   uint64_t ulplus1 = ul + 1;
   ASSERT_EQ(ulplus1, 0);
   i = i + 1;
-  ASSERT_DEATH(i.getUnsignedLong(), "gmpz_fits_ulong");
+  ASSERT_DEATH(i.getUnsignedLong(), "Overflow detected");
 }
 
 TEST_F(TestUtilBlackInteger, getSigned64)
@@ -370,13 +370,13 @@ TEST_F(TestUtilBlackInteger, getSigned64)
     int64_t i = std::numeric_limits<int64_t>::max();
     Integer a(i);
     ASSERT_EQ(a.getSigned64(), i);
-    ASSERT_DEATH((a + 1).getSigned64(), "gmpz_fits_slong");
+    ASSERT_DEATH((a + 1).getSigned64(), "Overflow detected");
   }
   {
     int64_t i = std::numeric_limits<int64_t>::min();
     Integer a(i);
     ASSERT_EQ(a.getSigned64(), i);
-    ASSERT_DEATH((a - 1).getSigned64(), "gmpz_fits_slong");
+    ASSERT_DEATH((a - 1).getSigned64(), "Overflow detected");
   }
 }
 
@@ -386,13 +386,13 @@ TEST_F(TestUtilBlackInteger, getUnsigned64)
     uint64_t i = std::numeric_limits<uint64_t>::max();
     Integer a(i);
     ASSERT_EQ(a.getUnsigned64(), i);
-    ASSERT_DEATH((a + 1).getUnsigned64(), "gmpz_fits_ulong");
+    ASSERT_DEATH((a + 1).getUnsigned64(), "Overflow detected");
   }
   {
     uint64_t i = std::numeric_limits<uint64_t>::min();
     Integer a(i);
     ASSERT_EQ(a.getUnsigned64(), i);
-    ASSERT_DEATH((a - 1).getUnsigned64(), "gmpz_fits_ulong");
+    ASSERT_DEATH((a - 1).getUnsigned64(), "Overflow detected");
   }
 }
 


### PR DESCRIPTION
Due to different (old) glibc versions, DEATH was triggered in different
places on the cluster and on CI. This generalizes the DEATH message to
match on in the unit tests.