### PR TITLE
bv: Change sort of reduction operators to (_ BitVec 1).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@ This file contains a summary of important user-visible changes.
 
 **Changes**
 
+- The sort for (non-standard) bit-vector operators BITVECTOR_REDAND and
+  BITVECTOR_REDOR is now (_ BitVec 1) (was Boolean), following the definition
+  of reduction operators in Verilog (their origin).
 - API: Previously, it was not possible to share Sort, Term, Op, Grammar and
        datatype objects between Solver instances. This is now allowed.
 

--- a/src/theory/bv/kinds
+++ b/src/theory/bv/kinds
@@ -208,8 +208,8 @@ typerule BITVECTOR_SLTBV ::cvc5::internal::theory::bv::BitVectorBVPredTypeRule
 typerule BITVECTOR_ITE ::cvc5::internal::theory::bv::BitVectorITETypeRule
 
 ## reduction kinds
-typerule BITVECTOR_REDAND ::cvc5::internal::theory::bv::BitVectorUnaryPredicateTypeRule
-typerule BITVECTOR_REDOR ::cvc5::internal::theory::bv::BitVectorUnaryPredicateTypeRule
+typerule BITVECTOR_REDAND ::cvc5::internal::theory::bv::BitVectorRedTypeRule
+typerule BITVECTOR_REDOR ::cvc5::internal::theory::bv::BitVectorRedTypeRule
 
 ## internal kinds
 typerule BITVECTOR_ACKERMANNIZE_UDIV ::cvc5::internal::theory::bv::BitVectorAckermanizationUdivTypeRule

--- a/src/theory/bv/theory_bv_rewrite_rules_operator_elimination.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_operator_elimination.h
@@ -649,11 +649,14 @@ inline bool RewriteRule<RedorEliminate>::applies(TNode node)
 template <>
 inline Node RewriteRule<RedorEliminate>::apply(TNode node)
 {
-  Trace("bv-rewrite") << "RewriteRule<RedorEliminate>(" << node << ")" << std::endl;
+  Trace("bv-rewrite") << "RewriteRule<RedorEliminate>(" << node << ")"
+                      << std::endl;
   TNode a = node[0];
-  unsigned size = utils::getSize(node[0]); 
-  Node result = NodeManager::currentNM()->mkNode(kind::EQUAL, a, utils::mkConst( size, 0 ) );
-  return result.negate();
+  unsigned size = utils::getSize(node[0]);
+  NodeManager* nm = NodeManager::currentNM();
+  return nm->mkNode(
+      kind::BITVECTOR_NOT,
+      nm->mkNode(kind::BITVECTOR_COMP, a, utils::mkConst(size, 0)));
 }
 
 template <>
@@ -665,13 +668,14 @@ inline bool RewriteRule<RedandEliminate>::applies(TNode node)
 template <>
 inline Node RewriteRule<RedandEliminate>::apply(TNode node)
 {
-  Trace("bv-rewrite") << "RewriteRule<RedandEliminate>(" << node << ")" << std::endl;
+  Trace("bv-rewrite") << "RewriteRule<RedandEliminate>(" << node << ")"
+                      << std::endl;
   TNode a = node[0];
-  unsigned size = utils::getSize(node[0]); 
-  Node result = NodeManager::currentNM()->mkNode(kind::EQUAL, a, utils::mkOnes( size ) );
+  unsigned size = utils::getSize(node[0]);
+  Node result = NodeManager::currentNM()->mkNode(
+      kind::BITVECTOR_COMP, a, utils::mkOnes(size));
   return result;
 }
-
 }
 }
 }  // namespace cvc5::internal

--- a/src/theory/bv/theory_bv_rewriter.cpp
+++ b/src/theory/bv/theory_bv_rewriter.cpp
@@ -618,20 +618,20 @@ RewriteResponse TheoryBVRewriter::RewriteRotateLeft(TNode node, bool prerewrite)
   return RewriteResponse(REWRITE_AGAIN_FULL, resultNode); 
 }
 
-RewriteResponse TheoryBVRewriter::RewriteRedor(TNode node, bool prerewrite){
-  Node resultNode = LinearRewriteStrategy
-    < RewriteRule<RedorEliminate>
-    >::apply(node);
-  
-  return RewriteResponse(REWRITE_AGAIN_FULL, resultNode); 
+RewriteResponse TheoryBVRewriter::RewriteRedor(TNode node, bool prerewrite)
+{
+  Node resultNode =
+      LinearRewriteStrategy<RewriteRule<RedorEliminate>>::apply(node);
+
+  return RewriteResponse(REWRITE_AGAIN_FULL, resultNode);
 }
 
-RewriteResponse TheoryBVRewriter::RewriteRedand(TNode node, bool prerewrite){
-  Node resultNode = LinearRewriteStrategy
-    < RewriteRule<RedandEliminate>
-    >::apply(node);
-  
-  return RewriteResponse(REWRITE_AGAIN_FULL, resultNode); 
+RewriteResponse TheoryBVRewriter::RewriteRedand(TNode node, bool prerewrite)
+{
+  Node resultNode =
+      LinearRewriteStrategy<RewriteRule<RedandEliminate>>::apply(node);
+
+  return RewriteResponse(REWRITE_AGAIN_FULL, resultNode);
 }
 
 RewriteResponse TheoryBVRewriter::RewriteEqual(TNode node, bool prerewrite) {

--- a/src/theory/bv/theory_bv_type_rules.cpp
+++ b/src/theory/bv/theory_bv_type_rules.cpp
@@ -98,19 +98,19 @@ TypeNode BitVectorPredicateTypeRule::computeType(NodeManager* nodeManager,
   return nodeManager->booleanType();
 }
 
-TypeNode BitVectorUnaryPredicateTypeRule::computeType(NodeManager* nodeManager,
-                                                      TNode n,
-                                                      bool check)
+TypeNode BitVectorRedTypeRule::computeType(NodeManager* nodeManager,
+                                           TNode n,
+                                           bool check)
 {
   if (check)
   {
     TypeNode type = n[0].getType(check);
     if (!type.isBitVector())
     {
-      throw TypeCheckingExceptionPrivate(n, "expecting bit-vector terms");
+      throw TypeCheckingExceptionPrivate(n, "expecting bit-vector term");
     }
   }
-  return nodeManager->booleanType();
+  return nodeManager->mkBitVectorType(1);
 }
 
 TypeNode BitVectorBVPredTypeRule::computeType(NodeManager* nodeManager,

--- a/src/theory/bv/theory_bv_type_rules.h
+++ b/src/theory/bv/theory_bv_type_rules.h
@@ -59,7 +59,7 @@ class BitVectorPredicateTypeRule
   static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
 };
 
-class BitVectorUnaryPredicateTypeRule
+class BitVectorRedTypeRule
 {
  public:
   static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -477,6 +477,8 @@ set(regress_0_tests
   regress0/bv/pr4993-bvugt-bvurem-b.smt2
   regress0/bv/proj-issue343.smt2
   regress0/bv/proj-issue438-prerewrite-fixed-point.smt2
+  regress0/bv/redand.smt2
+  regress0/bv/redor.smt2
   regress0/bv/reset-assertions-assert-input.smt2
   regress0/bv/sizecheck.cvc.smt2
   regress0/bv/smtcompbug.smtv1.smt2

--- a/test/regress/cli/regress0/bv/redand.smt2
+++ b/test/regress/cli/regress0/bv/redand.smt2
@@ -1,0 +1,6 @@
+; EXPECT: sat
+(set-logic QF_BV)
+(declare-const x (_ BitVec 3))
+(declare-const y (_ BitVec 3))
+(assert (= #b1 (bvor (bvredand x) (bvredand y))))
+(check-sat)

--- a/test/regress/cli/regress0/bv/redor.smt2
+++ b/test/regress/cli/regress0/bv/redor.smt2
@@ -1,0 +1,7 @@
+; EXPECT: sat
+(set-logic QF_BV)
+(declare-const x (_ BitVec 3))
+(declare-const y (_ BitVec 3))
+(assert (= #b1 (bvand (bvredor x) (bvredor y))))
+(check-sat)
+


### PR DESCRIPTION
This fixes the sort of (non-standard) bit-vector reduction operators
from Boolean to (_ BitVec 1) (corresponding to their definition in
Verilog, the origin of these operators).