### PR TITLE
test: Require no-competition from expectedly failing DT parser tests.

### DIFF
--- a/test/regress/cli/regress0/parser/non_well_founded_dt.smt2
+++ b/test/regress/cli/regress0/parser/non_well_founded_dt.smt2
@@ -1,3 +1,4 @@
+; REQUIRES: no-competition
 ; EXPECT: (error "Parse Error: non_well_founded_dt.smt2:10.77: Datatype sort _dt5 is not well-founded
 ; EXPECT: 
 ; EXPECT: ... (_sel33 Bool) (_sel34 _dt5) (_sel35 _dt5))))

--- a/test/regress/cli/regress0/parser/non_well_founded_dt.smt2
+++ b/test/regress/cli/regress0/parser/non_well_founded_dt.smt2
@@ -1,5 +1,5 @@
 ; REQUIRES: no-competition
-; EXPECT: (error "Parse Error: non_well_founded_dt.smt2:10.77: Datatype sort _dt5 is not well-founded
+; EXPECT: (error "Parse Error: non_well_founded_dt.smt2:11.77: Datatype sort _dt5 is not well-founded
 ; EXPECT: 
 ; EXPECT: ... (_sel33 Bool) (_sel34 _dt5) (_sel35 _dt5))))
 ; EXPECT: ^

--- a/test/regress/cli/regress0/parser/non_well_founded_dts.smt2
+++ b/test/regress/cli/regress0/parser/non_well_founded_dts.smt2
@@ -1,3 +1,4 @@
+; REQUIRES: no-competition
 ; EXPECT: (error "Parse Error: non_well_founded_dts.smt2:6.490: Datatype sort _dt5 is not well-founded")
 ; EXIT: 1
 ; DISABLE-TESTER: dump

--- a/test/regress/cli/regress0/parser/non_well_founded_dts.smt2
+++ b/test/regress/cli/regress0/parser/non_well_founded_dts.smt2
@@ -1,5 +1,5 @@
 ; REQUIRES: no-competition
-; EXPECT: (error "Parse Error: non_well_founded_dts.smt2:6.490: Datatype sort _dt5 is not well-founded")
+; EXPECT: (error "Parse Error: non_well_founded_dts.smt2:7.490: Datatype sort _dt5 is not well-founded")
 ; EXIT: 1
 ; DISABLE-TESTER: dump
 (set-option :global-declarations true)


### PR DESCRIPTION
Fixes the currently failing nightly competition build.