### PR TITLE
Remove infrastructure for `Debug()`

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -50,25 +50,17 @@ file(GLOB_RECURSE source_files
      ${PROJECT_SOURCE_DIR}/src/*.g)
 
 add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/Debug_tags.h
-  COMMAND ${PYTHON_EXECUTABLE} ${collect_tags_script} ${CMAKE_CURRENT_BINARY_DIR}/ Debug ${PROJECT_SOURCE_DIR}/src
-  DEPENDS ${collect_tags_script} ${source_files}
-)
-
-add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/Trace_tags.h
-  COMMAND ${PYTHON_EXECUTABLE} ${collect_tags_script} ${CMAKE_CURRENT_BINARY_DIR}/ Trace ${PROJECT_SOURCE_DIR}/src
+  COMMAND ${PYTHON_EXECUTABLE} ${collect_tags_script} ${CMAKE_CURRENT_BINARY_DIR}/ ${PROJECT_SOURCE_DIR}/src
   DEPENDS ${collect_tags_script} ${source_files}
 )
 
 add_custom_target(gen-tags
   DEPENDS
-    ${CMAKE_CURRENT_BINARY_DIR}/Debug_tags.h
     ${CMAKE_CURRENT_BINARY_DIR}/Trace_tags.h
 )
 
 set_source_files_properties(
-  ${CMAKE_CURRENT_BINARY_DIR}/Debug_tags.h
   ${CMAKE_CURRENT_BINARY_DIR}/Trace_tags.h
   PROPERTIES GENERATED TRUE
 )

--- a/src/base/collect_tags.py
+++ b/src/base/collect_tags.py
@@ -24,7 +24,6 @@ def parse_args():
     """Parse command line arguments and return them."""
     ap = argparse.ArgumentParser(description='collect debug and trace tags')
     ap.add_argument('destdir', help='where to put the results')
-    ap.add_argument('type', choices=['Debug', 'Trace'], help='which tags to collect')
     ap.add_argument('basedir', help='where to look for source file')
     return ap.parse_args()
 
@@ -57,16 +56,11 @@ def collect_tags(basedir):
     return sorted(tags)
 
 
-def write_file(filename, type, tags):
+def write_file(filename, tags):
     """Render the header file to the given filename."""
     with open(filename, 'w') as out:
-        out.write('static const std::vector<std::string> {}_tags = {{\n'.format(type))
-        if type == 'Debug':
-            out.write('#if defined(CVC5_DEBUG) && defined(CVC5_TRACING)\n')
-        elif type == 'Trace':
-            out.write('#if defined(CVC5_TRACING)\n')
-        else:
-            raise 'type is neither Debug nor Trace: {}'.format(type)
+        out.write('static const std::vector<std::string> Trace_tags = {\n')
+        out.write('#if defined(CVC5_TRACING)\n')
         for t in tags:
             out.write('"{}",\n'.format(t))
         out.write('#endif\n')
@@ -76,14 +70,14 @@ def write_file(filename, type, tags):
 if __name__ == '__main__':
     # setup
     opts = parse_args()
-    RE_PAT = re.compile('{}(?:\\.isOn)?\\("([^"]+)"\\)'.format(opts.type))
-    FILENAME_TMP = '{}/{}_tags.tmp'.format(opts.destdir, opts.type)
-    FILENAME_DEST = '{}/{}_tags.h'.format(opts.destdir, opts.type)
+    RE_PAT = re.compile('Trace(?:\\.isOn)?\\("([^"]+)"\\)')
+    FILENAME_TMP = '{}/Trace_tags.tmp'.format(opts.destdir)
+    FILENAME_DEST = '{}/Trace_tags.h'.format(opts.destdir)
 
     # collect tags
     tags = collect_tags(opts.basedir)
     # write header file
-    write_file(FILENAME_TMP, opts.type, tags)
+    write_file(FILENAME_TMP, tags)
 
     if not os.path.isfile(FILENAME_DEST):
         # file does not exist yet

--- a/src/base/configuration.cpp
+++ b/src/base/configuration.cpp
@@ -22,7 +22,6 @@
 #include <sstream>
 #include <string>
 
-#include "base/Debug_tags.h"
 #include "base/Trace_tags.h"
 #include "base/configuration_private.h"
 #include "base/cvc5config.h"
@@ -222,17 +221,6 @@ bool Configuration::isBuiltWithPoly()
   return IS_POLY_BUILD;
 }
 bool Configuration::isBuiltWithCoCoA() { return IS_COCOA_BUILD; }
-
-const std::vector<std::string>& Configuration::getDebugTags()
-{
-  return Debug_tags;
-}
-
-bool Configuration::isDebugTag(const std::string& tag)
-{
-  return std::find(Debug_tags.begin(), Debug_tags.end(), tag)
-         != Debug_tags.end();
-}
 
 const std::vector<std::string>& Configuration::getTraceTags()
 {

--- a/src/base/configuration.h
+++ b/src/base/configuration.h
@@ -109,11 +109,6 @@ public:
 
   static bool isBuiltWithCoCoA();
 
-  /* Return a sorted array of the debug tags name */
-  static const std::vector<std::string>& getDebugTags();
-  /* Test if the given argument is a known debug tag name */
-  static bool isDebugTag(const std::string& tag);
-
   /* Return a sorted array of the trace tags name */
   static const std::vector<std::string>& getTraceTags();
   /* Test if the given argument is a known trace tag name */

--- a/src/main/driver_unified.cpp
+++ b/src/main/driver_unified.cpp
@@ -79,7 +79,6 @@ int runCvc5(int argc, char* argv[], std::unique_ptr<cvc5::Solver>& solver)
   }
   for (const auto& name : {"show-config",
                            "copyright",
-                           "show-debug-tags",
                            "show-trace-tags",
                            "version"})
   {

--- a/src/options/base_options.toml
+++ b/src/options/base_options.toml
@@ -141,14 +141,6 @@ name   = "Base"
   help       = "trace something (e.g. -t pushpop), can repeat and may contain wildcards like (e.g. -t theory::*)"
 
 [[option]]
-  category   = "regular"
-  short      = "d"
-  long       = "debug=TAG"
-  type       = "std::string"
-  predicates = ["enableDebugTag"]
-  help       = "debug something (e.g. -d arith), can repeat"
-
-[[option]]
   short      = "o"
   category   = "common"
   long       = "output=TAG"

--- a/src/options/main_options.toml
+++ b/src/options/main_options.toml
@@ -52,16 +52,6 @@ name   = "Driver"
   help       = "seed for random number generator"
 
 [[option]]
-  name       = "showDebugTags"
-  category   = "expert"
-  long       = "show-debug-tags"
-  type       = "bool"
-  default    = "false"
-  predicates = ["showDebugTags"]
-  alternate  = false
-  help       = "show all available tags for debugging"
-
-[[option]]
   name       = "showTraceTags"
   category   = "expert"
   long       = "show-trace-tags"

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -251,36 +251,6 @@ void OptionsHandler::enableTraceTag(const std::string& flag,
   }
 }
 
-void OptionsHandler::enableDebugTag(const std::string& flag,
-                                    const std::string& optarg)
-{
-  if (!Configuration::isDebugBuild())
-  {
-    throw OptionException("debug tags not available in non-debug builds");
-  }
-  else if (!Configuration::isTracingBuild())
-  {
-    throw OptionException("debug tags not available in non-tracing builds");
-  }
-
-  if (!Configuration::isDebugTag(optarg) && !Configuration::isTraceTag(optarg))
-  {
-    if (optarg == "help")
-    {
-      d_options->writeDriver().showDebugTags = true;
-      showDebugTags("", true);
-      return;
-    }
-
-    throw OptionException(std::string("debug tag ") + optarg
-                          + std::string(" not available.")
-                          + suggestTags(Configuration::getDebugTags(),
-                                        optarg,
-                                        Configuration::getTraceTags()));
-  }
-  TraceChannel.on(optarg);
-}
-
 void OptionsHandler::enableOutputTag(const std::string& flag,
                                      OutputTag optarg)
 {
@@ -419,20 +389,6 @@ void OptionsHandler::showVersion(const std::string& flag, bool value)
 {
   if (!value) return;
   d_options->base.out << Configuration::about() << std::endl;
-}
-
-void OptionsHandler::showDebugTags(const std::string& flag, bool value)
-{
-  if (!value) return;
-  if (!Configuration::isDebugBuild())
-  {
-    throw OptionException("debug tags not available in non-debug builds");
-  }
-  else if (!Configuration::isTracingBuild())
-  {
-    throw OptionException("debug tags not available in non-tracing builds");
-  }
-  printTags(Configuration::getDebugTags());
 }
 
 void OptionsHandler::showTraceTags(const std::string& flag, bool value)

--- a/src/options/options_handler.h
+++ b/src/options/options_handler.h
@@ -91,8 +91,6 @@ class OptionsHandler
   void setStatsDetail(const std::string& flag, bool value);
   /** Enable a particular trace tag */
   void enableTraceTag(const std::string& flag, const std::string& optarg);
-  /** Enable a particular debug tag */
-  void enableDebugTag(const std::string& flag, const std::string& optarg);
   /** Enable a particular output tag */
   void enableOutputTag(const std::string& flag, OutputTag optarg);
   /** Pass the resource weight specification to the resource manager */
@@ -110,8 +108,6 @@ class OptionsHandler
   void showCopyright(const std::string& flag, bool value);
   /** Show version information and exit */
   void showVersion(const std::string& flag, bool value);
-  /** Show all debug tags and exit */
-  void showDebugTags(const std::string& flag, bool value);
   /** Show all trace tags and exit */
   void showTraceTags(const std::string& flag, bool value);
 


### PR DESCRIPTION
Commit 8f7952bc092d252a4d0c04c87636c443536833b3 removed all uses of
`Debug()`. This commit removes the infrastructure to support `Debug()`.