### PR TITLE
Add debug output -o lemmas

### DIFF
--- a/src/options/base_options.toml
+++ b/src/options/base_options.toml
@@ -211,10 +211,10 @@ name   = "Base"
   help = "print reason why cvc5 answers unknown for any given check-sat query"
   description = "With ``-o incomplete``, cvc5 prints reason for why it answers unknown for any given check-sat query."
   example-file = "regress0/printer/incomplete.smt2"
-[[option.mode.SAT_LEMMAS]]
-  name = "sat-lemmas"
+[[option.mode.LEMMAS]]
+  name = "lemmas"
   help = "print lemmas as they are added to the SAT solver"
-  description = "With ``-o sat-lemmas``, cvc5 prints lemmas as they are added to the SAT solver."
+  description = "With ``-o lemmas``, cvc5 prints lemmas as they are added to the SAT solver."
   example-file = "regress0/printer/print_sat_lemmas.smt2"
 
 # Stores then enabled output tags.

--- a/src/options/base_options.toml
+++ b/src/options/base_options.toml
@@ -200,6 +200,7 @@ name   = "Base"
   name = "pre-asserts"
   help = "print a benchmark corresponding to the assertions of the input problem before preprocessing"
   description = "With ``-o pre-asserts``, cvc5 prints a benchmark corresponding to the assertions of the input problem before preprocessing."
+  example-file = "regress0/printer/pre-asserts-output.smt2"
 [[option.mode.DEEP_RESTART]]
   name = "deep-restart"
   help = "print when cvc5 performs a deep restart along with the literals it has learned"
@@ -210,6 +211,11 @@ name   = "Base"
   help = "print reason why cvc5 answers unknown for any given check-sat query"
   description = "With ``-o incomplete``, cvc5 prints reason for why it answers unknown for any given check-sat query."
   example-file = "regress0/printer/incomplete.smt2"
+[[option.mode.SAT_LEMMAS]]
+  name = "sat-lemmas"
+  help = "print lemmas as they are added to the SAT solver"
+  description = "With ``-o sat-lemmas``, cvc5 prints lemmas as they are added to the SAT solver."
+  example-file = "regress0/printer/print_sat_lemmas.smt2"
 
 # Stores then enabled output tags.
 [[option]]

--- a/src/prop/prop_engine.cpp
+++ b/src/prop/prop_engine.cpp
@@ -234,6 +234,13 @@ void PropEngine::assertTrustedLemmaInternal(TrustNode trn, bool removable)
 {
   Node node = trn.getNode();
   Trace("prop::lemmas") << "assertLemma(" << node << ")" << std::endl;
+  if (isOutputOn(OutputTag::PROP_LEMMA))
+  {
+    output(OutputTag::PROP_LEMMA) << "(prop-lemma ";
+    // use original form of the lemma here
+    output(OutputTag::PROP_LEMMA) << SkolemManager::getOriginalForm(node);
+    output(OutputTag::PROP_LEMMA) << ")" << std::endl;
+  }
   bool negated = trn.getKind() == TrustNodeKind::CONFLICT;
   // should have a proof generator if the theory engine is proof producing
   Assert(!d_env.isTheoryProofProducing() || trn.getGenerator() != nullptr);

--- a/src/prop/prop_engine.cpp
+++ b/src/prop/prop_engine.cpp
@@ -234,12 +234,12 @@ void PropEngine::assertTrustedLemmaInternal(TrustNode trn, bool removable)
 {
   Node node = trn.getNode();
   Trace("prop::lemmas") << "assertLemma(" << node << ")" << std::endl;
-  if (isOutputOn(OutputTag::PROP_LEMMA))
+  if (isOutputOn(OutputTag::LEMMAS))
   {
-    output(OutputTag::PROP_LEMMA) << "(prop-lemma ";
+    output(OutputTag::LEMMAS) << "(lemma ";
     // use original form of the lemma here
-    output(OutputTag::PROP_LEMMA) << SkolemManager::getOriginalForm(node);
-    output(OutputTag::PROP_LEMMA) << ")" << std::endl;
+    output(OutputTag::LEMMAS) << SkolemManager::getOriginalForm(node);
+    output(OutputTag::LEMMAS) << ")" << std::endl;
   }
   bool negated = trn.getKind() == TrustNodeKind::CONFLICT;
   // should have a proof generator if the theory engine is proof producing

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1002,6 +1002,7 @@ set(regress_0_tests
   regress0/printer/let_shadowing.smt2
   regress0/printer/post-asserts-output.smt2
   regress0/printer/pre-asserts-output.smt2
+  regress0/printer/print_sat_lemmas.smt2
   regress0/printer/print_subs.smt2
   regress0/printer/symbol_starting_w_digit.smt2
   regress0/printer/tuples_and_records.cvc.smt2

--- a/test/regress/cli/regress0/printer/deep-restart-output.smt2
+++ b/test/regress/cli/regress0/printer/deep-restart-output.smt2
@@ -2,6 +2,7 @@
 ; EXPECT: (deep-restart ((= f k)))
 ; EXPECT: sat
 (set-logic ALL)
+(set-option :deep-restart input)
 (declare-const x Bool)
 (declare-fun b () Int)
 (declare-fun f () String)

--- a/test/regress/cli/regress0/printer/print_sat_lemmas.smt2
+++ b/test/regress/cli/regress0/printer/print_sat_lemmas.smt2
@@ -1,0 +1,8 @@
+; COMMAND-LINE: -o sat-lemmas
+; SCRUBBER: grep -E '\(assert'
+; EXPECT: (sat-lemma (=> (forall ((x Int)) (P x)) (P 5)))
+(set-logic ALL)
+(declare-fun P (Int) Bool)
+(assert (forall ((x Int)) (P x)))
+(assert (not (P 5)))
+(check-sat)

--- a/test/regress/cli/regress0/printer/print_sat_lemmas.smt2
+++ b/test/regress/cli/regress0/printer/print_sat_lemmas.smt2
@@ -1,6 +1,6 @@
-; COMMAND-LINE: -o sat-lemmas
-; SCRUBBER: grep -E '\(assert'
-; EXPECT: (sat-lemma (=> (forall ((x Int)) (P x)) (P 5)))
+; COMMAND-LINE: -o lemmas
+; SCRUBBER: grep -E '\(lemma'
+; EXPECT: (lemma (=> (forall ((x Int)) (P x)) (P 5)))
 (set-logic ALL)
 (declare-fun P (Int) Bool)
 (assert (forall ((x Int)) (P x)))


### PR DESCRIPTION
Prints all lemmas that enter the SAT solver.

This PR also corrects some documentation issues with other output options.