### PR TITLE
bv: Only force BITBLAST_INTERNAL if full proofs are required.

### DIFF
--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -966,7 +966,8 @@ bool SetDefaults::incompatibleWithProofs(Options& opts,
   }
   // If proofs are required and the user did not specify a specific BV solver,
   // we make sure to use the proof producing BITBLAST_INTERNAL solver.
-  if (opts.bv.bvSolver != options::BVSolver::BITBLAST_INTERNAL
+  if (opts.smt.proofMode == options::ProofMode::FULL
+      && opts.bv.bvSolver != options::BVSolver::BITBLAST_INTERNAL
       && !opts.bv.bvSolverWasSetByUser)
   {
     verbose(1) << "Forcing internal bit-vector solver due to proof production."

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -470,6 +470,7 @@ set(regress_0_tests
   regress0/bv/issue8159-1-rewrite-bvneg.smt2
   regress0/bv/issue8240-rewrite-bvnot.smt2
   regress0/bv/issue8654-bitblast-quant-exc.smt2
+  regress0/bv/issue9101-unsat-cores.smt2
   regress0/bv/mul-neg-unsat.smt2
   regress0/bv/mul-negpow2.smt2
   regress0/bv/mult-pow2-negative.smt2

--- a/test/regress/cli/regress0/bv/issue9101-unsat-cores.smt2
+++ b/test/regress/cli/regress0/bv/issue9101-unsat-cores.smt2
@@ -1,0 +1,8 @@
+(set-option :produce-models true)
+(set-option :produce-unsat-cores true)
+(set-logic QF_BV)
+(set-info :status sat)
+(declare-fun a () (_ BitVec 59))
+(declare-fun b () (_ BitVec 46))
+(assert (bvule (bvmul a #b10110010010100110100010010000100101001100001010010001100101) (concat (bvshl b #b1111110001100111010100001110111111110101011100) #b0001101010101)))
+(check-sat)


### PR DESCRIPTION
Fixes #9101.