### PR TITLE
Fix push/pop with quantifier elimination solver

### DIFF
--- a/src/api/java/jni/solver.cpp
+++ b/src/api/java/jni/solver.cpp
@@ -13,8 +13,6 @@
  * The cvc5 Java API.
  */
 
-#include <iostream>
-
 #include "api/cpp/cvc5.h"
 #include "api_utilities.h"
 #include "io_github_cvc5_Solver.h"

--- a/src/api/java/jni/solver.cpp
+++ b/src/api/java/jni/solver.cpp
@@ -13,6 +13,8 @@
  * The cvc5 Java API.
  */
 
+#include <iostream>
+
 #include "api/cpp/cvc5.h"
 #include "api_utilities.h"
 #include "io_github_cvc5_Solver.h"

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1704,8 +1704,12 @@ bool SolverEngine::getSubsolverSynthSolutions(std::map<Node, Node>& solMap)
 Node SolverEngine::getQuantifierElimination(Node q, bool doFull)
 {
   finishInit();
-  return d_quantElimSolver->getQuantifierElimination(
+  d_ctxManager->doPendingPops();
+  d_ctxManager->notifyCheckSat(true);
+  Node result = d_quantElimSolver->getQuantifierElimination(
       q, doFull, d_isInternalSubsolver);
+  d_ctxManager->notifyCheckSatResult(true);
+  return result;
 }
 
 Node SolverEngine::getInterpolant(const Node& conj, const TypeNode& grammarType)

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1121,6 +1121,7 @@ set(regress_0_tests
   regress0/quantifiers/issue8466-syqi-bool.smt2
   regress0/quantifiers/issue8609-subtype-assert.smt2
   regress0/quantifiers/issue8821-enum-interleave-types.smt2
+  regress0/quantifiers/issue8923-qe-push-pop.smt2
   regress0/quantifiers/lra-triv-gn.smt2
   regress0/quantifiers/macro-back-subs-sat.smt2
   regress0/quantifiers/macros-int-real.smt2

--- a/test/regress/cli/regress0/quantifiers/issue8923-qe-push-pop.smt2
+++ b/test/regress/cli/regress0/quantifiers/issue8923-qe-push-pop.smt2
@@ -1,0 +1,19 @@
+; COMMAND-LINE: --incremental
+; SCRUBBER: sed 's/(.*)/()/g'
+; EXPECT: ()
+; EXPECT: ()
+; EXIT: 0
+(set-logic ALL)
+
+(push)
+(declare-const a Int)
+(declare-const b Int)
+(get-qe (exists ((a Int)) (and (= b 0) (= a 1))))
+(pop)
+
+(push)
+(declare-const x Int)
+(declare-const y Int)
+(declare-const z Int)
+(get-qe (exists ((y Int)) (and (= x y) (= y z))))
+(pop)


### PR DESCRIPTION
Fixes #8923. This adds calls to the context manager when the quantifier
elimination solver is called. Note that we may want to consider further
refactoring based on the changes in this commit.