### PR TITLE
Minor simplification to interface to prepreprocess

### DIFF
--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -35,10 +35,8 @@ namespace cvc5::internal {
 namespace smt {
 
 Preprocessor::Preprocessor(Env& env,
-                           AbstractValues& abs,
                            SolverEngineStatistics& stats)
     : EnvObj(env),
-      d_absValues(abs),
       d_propagator(env, true, true),
       d_assertionsProcessed(env.getUserContext(), false),
       d_processor(env, stats)
@@ -111,44 +109,17 @@ std::vector<Node> Preprocessor::getLearnedLiterals() const
 
 void Preprocessor::cleanup() { d_processor.cleanup(); }
 
-Node Preprocessor::applySubstitutions(const Node& n)
+Node Preprocessor::applySubstitutions(const Node& node)
 {
-  std::unordered_map<Node, Node> cache;
-  return applySubstitutions(n, cache);
-}
-
-Node Preprocessor::applySubstitutions(const Node& node,
-                                      std::unordered_map<Node, Node>& cache)
-{
-  Trace("smt") << "SMT applySubstitutions(" << node << ")" << endl;
-  // Substitute out any abstract values in node.
-  Node n = d_absValues.substituteAbstractValues(node);
-  if (options().expr.typeChecking)
-  {
-    // Ensure node is type-checked at this point.
-    n.getType(true);
-  }
-  // apply substitutions here (without rewriting), before expanding definitions
-  n = d_env.getTopLevelSubstitutions().apply(n);
-  Trace("smt-debug") << "...after top-level subs: " << n << std::endl;
-  return n;
+  return d_env.getTopLevelSubstitutions().apply(node);
 }
 
 void Preprocessor::applySubstitutions(std::vector<Node>& ns)
 {
-  std::unordered_map<Node, Node> cache;
   for (size_t i = 0, nasserts = ns.size(); i < nasserts; i++)
   {
-    ns[i] = applySubstitutions(ns[i], cache);
+    ns[i] = applySubstitutions(ns[i]);
   }
-}
-
-Node Preprocessor::simplify(const Node& node)
-{
-  Trace("smt") << "SMT simplify(" << node << ")" << endl;
-  Node ret = applySubstitutions(node);
-  ret = rewrite(ret);
-  return ret;
 }
 
 void Preprocessor::enableProofs(PreprocessProofGenerator* pppg)

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -52,7 +52,7 @@ class PreprocessProofGenerator;
 class Preprocessor : protected EnvObj
 {
  public:
-  Preprocessor(Env& env, AbstractValues& abs, SolverEngineStatistics& stats);
+  Preprocessor(Env& env, SolverEngineStatistics& stats);
   ~Preprocessor();
   /**
    * Finish initialization
@@ -78,25 +78,13 @@ class Preprocessor : protected EnvObj
    */
   void cleanup();
   /**
-   * Simplify a formula without doing "much" work.  Does not involve
-   * the SAT Engine in the simplification, but uses the current
-   * definitions, assertions, and the current partial model, if one
-   * has been constructed.  It also involves theory normalization.
-   *
-   * @param n The node to simplify
-   * @return The simplified term.
-   */
-  Node simplify(const Node& n);
-  /**
    * Apply top-level substitutions and eliminate abstract values in a term or
    * formula n.  No other simplification or normalization is done.
    *
-   * @param n The node to expand
-   * @return The expanded term.
+   * @param n The node to subsitute
+   * @return The term after substitution.
    */
   Node applySubstitutions(const Node& n);
-  /** Same as above, with a cache of previous results. */
-  Node applySubstitutions(const Node& n, std::unordered_map<Node, Node>& cache);
   /** Same as above, for a list of assertions, updating in place */
   void applySubstitutions(std::vector<Node>& ns);
   /**
@@ -109,8 +97,6 @@ class Preprocessor : protected EnvObj
   void enableProofs(PreprocessProofGenerator* pppg);
 
  private:
-  /** Reference to the abstract values utility */
-  AbstractValues& d_absValues;
   /**
    * A circuit propagator for non-clausal propositional deduction.
    */

--- a/src/smt/smt_solver.cpp
+++ b/src/smt/smt_solver.cpp
@@ -36,11 +36,10 @@ namespace cvc5::internal {
 namespace smt {
 
 SmtSolver::SmtSolver(Env& env,
-                     AbstractValues& abs,
                      Assertions& asserts,
                      SolverEngineStatistics& stats)
     : EnvObj(env),
-      d_pp(env, abs, stats),
+      d_pp(env, stats),
       d_asserts(asserts),
       d_stats(stats),
       d_theoryEngine(nullptr),

--- a/src/smt/smt_solver.h
+++ b/src/smt/smt_solver.h
@@ -66,7 +66,6 @@ class SmtSolver : protected EnvObj
 {
  public:
   SmtSolver(Env& env,
-            AbstractValues& abs,
             Assertions& asserts,
             SolverEngineStatistics& stats);
   ~SmtSolver();

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -108,7 +108,7 @@ SolverEngine::SolverEngine(const Options* optr)
   // make statistics
   d_stats.reset(new SolverEngineStatistics(d_env->getStatisticsRegistry()));
   // make the SMT solver
-  d_smtSolver.reset(new SmtSolver(*d_env, *d_absValues, *d_asserts, *d_stats));
+  d_smtSolver.reset(new SmtSolver(*d_env, *d_asserts, *d_stats));
   // make the context manager
   d_ctxManager.reset(new ContextManager(*d_env.get(), *d_state, *d_smtSolver));
   // make the SyGuS solver
@@ -952,10 +952,11 @@ Node SolverEngine::simplify(const Node& t)
   // ensure we've processed assertions
   d_smtSolver->processAssertions(*d_asserts);
   // Substitute out any abstract values in node.
-  Node tt = d_absValues.substituteAbstractValues(t);
+  Node tt = d_absValues->substituteAbstractValues(t);
+  // apply substitutions
   tt = d_smtSolver->getPreprocessor()->applySubstitutions(tt);
   // now rewrite
-  return rewrite(tt);
+  return d_env->getRewriter()->rewrite(tt);
 }
 
 Node SolverEngine::getValue(const Node& t) const
@@ -965,7 +966,7 @@ Node SolverEngine::getValue(const Node& t) const
   TypeNode expectedType = t.getType();
 
   // Substitute out any abstract values in node.
-  Node tt = d_absValues.substituteAbstractValues(t);
+  Node tt = d_absValues->substituteAbstractValues(t);
   
   // We must expand definitions here, which replaces certain subterms of t
   // by the form that is used internally. This is necessary for some corner

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -967,7 +967,7 @@ Node SolverEngine::getValue(const Node& t) const
 
   // Substitute out any abstract values in node.
   Node tt = d_absValues->substituteAbstractValues(t);
-  
+
   // We must expand definitions here, which replaces certain subterms of t
   // by the form that is used internally. This is necessary for some corner
   // cases of get-value to be accurate, e.g., when getting the value of


### PR DESCRIPTION
Apply substitutions is used by internal methods and thus should not do things for processing user terms (e.g. substituting abstract values).

Also moves simplify entirely to SolverEngine.