### PR TITLE
Fix care graph for bv2nat of different widths

### DIFF
--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -641,7 +641,7 @@ void TheoryUF::computeCareGraph() {
           for (const Node& c : app)
           {
             Node happ = nm->mkNode(kind::HO_APPLY, curr, c);
-            Assert (curr.getType().isFunction());
+            Assert(curr.getType().isFunction());
             typeIndex[curr.getType()].addTerm(happ, {curr, c});
             curr = happ;
             keep.push_back(happ);

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -641,6 +641,7 @@ void TheoryUF::computeCareGraph() {
           for (const Node& c : app)
           {
             Node happ = nm->mkNode(kind::HO_APPLY, curr, c);
+            Assert (curr.getType().isFunction());
             typeIndex[curr.getType()].addTerm(happ, {curr, c});
             curr = happ;
             keep.push_back(happ);
@@ -650,7 +651,8 @@ void TheoryUF::computeCareGraph() {
       else if (k == kind::HO_APPLY || k == kind::BITVECTOR_TO_NAT)
       {
         // add it to the typeIndex for the function type if HO_APPLY, or the
-        // bitvector type if bv2nat
+        // bitvector type if bv2nat. The latter ensures that we compute
+        // care pairs based on bv2nat only for bitvectors of the same width.
         typeIndex[app[0].getType()].addTerm(app, reps);
       }
       else

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -674,10 +674,13 @@ void TheoryUF::computeCareGraph() {
   }
   for (std::pair<const TypeNode, TNodeTrie>& tt : typeIndex)
   {
+    // functions for HO_APPLY which has arity 2, bitvectors for bv2nat which
+    // has arity one
+    size_t a = tt.first.isFunction() ? 2 : 1;
     Trace("uf::sharing") << "TheoryUf::computeCareGraph(): Process ho index "
                          << tt.first << "..." << std::endl;
     // the arity of HO_APPLY is always two
-    nodeTriePathPairProcess(&tt.second, 2, d_cpacb);
+    nodeTriePathPairProcess(&tt.second, a, d_cpacb);
   }
   Trace("uf::sharing") << "TheoryUf::computeCareGraph(): finished."
                        << std::endl;

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2047,6 +2047,7 @@ set(regress_1_tests
   regress1/issue8852-interpol-no-var.smt2
   regress1/issue8958-bv2nat-lazy.smt2
   regress1/issue9057-block-m-lit.smt2
+  regress1/issue9112-bv2nat-cg.smt2
   regress1/lemmas/clocksynchro_5clocks.main_invar.base.smtv1.smt2
   regress1/lemmas/pursuit-safety-8.smtv1.smt2
   regress1/minimal_unsat_core.smt2

--- a/test/regress/cli/regress1/issue9112-bv2nat-cg.smt2
+++ b/test/regress/cli/regress1/issue9112-bv2nat-cg.smt2
@@ -1,0 +1,7 @@
+(set-logic ALL)
+(set-info :status sat)
+(declare-fun a () Int)
+(declare-fun v () (_ BitVec 1))
+(assert (= 1 (bv2nat v)))
+(assert (forall ((V Int)) (= (_ bv0 1) ((_ extract 0 0) ((_ int2bv 1) (bv2nat ((_ int2bv 3) a)))))))
+(check-sat)


### PR DESCRIPTION
We are currently (spuriously) comparing bv2nat terms whose arguments have different bitwidth.

Fixes #9112.