### PR TITLE
Fix `NEWS.md`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,21 +2,28 @@ This file contains a summary of important user-visible changes.
 
 **New Features**
 
-- API: New API function getVersion(), returns a string representation of
-       the solver version.
+- API: New API function `Solver::getVersion()`, returns a string representation
+       of the solver version.
 
 **Changes**
 
-- The (non-standard) operators BITVECTOR_TO_NAT and INT_TO_BITVECTOR now
+- The (non-standard) operators `BITVECTOR_TO_NAT` and `INT_TO_BITVECTOR` now
   belong to the UF theory. A logic that includes UF is required to use them.
-- The sort for (non-standard) bit-vector operators BITVECTOR_REDAND and
-  BITVECTOR_REDOR is now (_ BitVec 1) (was Boolean), following the definition
-  of reduction operators in Verilog (their origin).
-- API: Previously, it was not possible to share Sort, Term, Op, Grammar and
-       datatype objects between Solver instances. This is now allowed.
+- The sort for (non-standard) bit-vector operators `BITVECTOR_REDAND` and
+  `BITVECTOR_REDOR` is now `(_ BitVec 1)` (was Boolean), following the
+  definition of reduction operators in Verilog (their origin).
 - Reenable functionality that allows `(get-model)` commands after answering
   `unknown` when `:produce-models` is set to `true`. Note that there is no
   guarantee that building a model succeeds in this case.
+
+cvc5 1.0.2
+==========
+
+**Changes**
+
+- API: Previously, it was not possible to share Sort, Term, Op, Grammar and
+       datatype objects between Solver instances. This is now allowed for
+       solvers that belong to the same thread.
 
 cvc5 1.0.1
 ==========


### PR DESCRIPTION
After our release of cvc5 1.0.2, we started to mix news for cvc5 1.0.2 and features/changes currently only on `main`. This commit adds a cvc5 1.0.2 section and fixes some minor formatting issues.