### PR TITLE
Remove mention of `ENTAILED`/`NOT_ENTAILED`

### DIFF
--- a/src/api/cpp/cvc5.h
+++ b/src/api/cpp/cvc5.h
@@ -4664,7 +4664,7 @@ class CVC5_EXPORT Solver
 
   /**
    * Block the current model values of (at least) the values in terms. Can be
-   * called only if immediately preceded by a SAT or NOT_ENTAILED query.
+   * called only if immediately preceded by a SAT query.
    *
    * SMT-LIB:
    *

--- a/src/api/java/io/github/cvc5/Solver.java
+++ b/src/api/java/io/github/cvc5/Solver.java
@@ -2491,7 +2491,7 @@ public class Solver implements IPointer, AutoCloseable
   /**
    * Block the current model values of (at least) the values in terms.
    *
-   * Can be called only if immediately preceded by a SAT or NOT_ENTAILED query.
+   * Can be called only if immediately preceded by a SAT query.
    *
    * SMT-LIB:
    * {@code

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -2854,8 +2854,7 @@ cdef class Solver:
     def blockModelValues(self, terms):
         """
            Block the current model values of (at least) the values in terms.
-           Can be called only if immediately preceded by a SAT or NOT_ENTAILED
-           query.
+           Can be called only if immediately preceded by a SAT query.
 
            SMT-LIB:
 

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -648,8 +648,7 @@ TheoryModel* SolverEngine::getAvailableModel(const char* c) const
   {
     std::stringstream ss;
     ss << "Cannot " << c
-       << " unless immediately preceded by SAT/NOT_ENTAILED or UNKNOWN "
-          "response.";
+       << " unless immediately preceded by SAT or UNKNOWN response.";
     throw RecoverableModalException(ss.str().c_str());
   }
 
@@ -807,7 +806,7 @@ std::vector<Node> SolverEngine::getUnsatAssumptions(void)
   {
     throw RecoverableModalException(
         "Cannot get unsat assumptions unless immediately preceded by "
-        "UNSAT/ENTAILED.");
+        "UNSAT.");
   }
   finishInit();
   UnsatCore core = getUnsatCoreInternal();
@@ -1318,7 +1317,7 @@ UnsatCore SolverEngine::getUnsatCoreInternal()
   {
     throw RecoverableModalException(
         "Cannot get an unsat core unless immediately preceded by "
-        "UNSAT/ENTAILED response.");
+        "UNSAT response.");
   }
   // generate with new proofs
   PropEngine* pe = getPropEngine();
@@ -1523,7 +1522,7 @@ std::string SolverEngine::getProof(modes::ProofComponent c)
   {
     throw RecoverableModalException(
         "Cannot get a proof unless immediately preceded by "
-        "UNSAT/ENTAILED response.");
+        "UNSAT response.");
   }
   // determine if we should get the full proof from the SAT solver
   PropEngine* pe = getPropEngine();

--- a/src/smt/solver_engine.h
+++ b/src/smt/solver_engine.h
@@ -221,10 +221,10 @@ class CVC5_EXPORT SolverEngine
   void blockModel(modes::BlockModelsMode mode);
 
   /**
-   * Block the current model values of (at least) the values in exprs.
-   * Can be called only if immediately preceded by a SAT or NOT_ENTAILED query.
-   * Only permitted if produce-models is on, and the block-models option is set
-   * to a mode other than "none".
+   * Block the current model values of (at least) the values in exprs. Can be
+   * called only if immediately preceded by a SAT query. Only permitted if
+   * produce-models is on, and the block-models option is set to a mode other
+   * than "none".
    *
    * This adds an assertion to the assertion stack of the form:
    *  (or (not (= exprs[0] M0)) ... (not (= exprs[n] Mn)))
@@ -475,8 +475,8 @@ class CVC5_EXPORT SolverEngine
 
   /**
    * Get the assigned value of an expr (only if immediately preceded by a SAT
-   * or NOT_ENTAILED query).  Only permitted if the SolverEngine is set to
-   * operate interactively and produce-models is on.
+   * query). Only permitted if the SolverEngine is set to operate interactively
+   * and produce-models is on.
    *
    * @throw ModalException, TypeCheckingException, LogicException
    */
@@ -670,22 +670,23 @@ class CVC5_EXPORT SolverEngine
    * Get instantiation term vectors, which maps each instantiated quantified
    * formula to the list of instantiations for that quantified formula. This
    * list is minimized if proofs are enabled, and this call is immediately
-   * preceded by an UNSAT or ENTAILED query
+   * preceded by an UNSAT query.
    */
   void getInstantiationTermVectors(
       std::map<Node, std::vector<std::vector<Node>>>& insts);
 
   /**
-   * Get an unsatisfiable core (only if immediately preceded by an UNSAT or
-   * ENTAILED query).  Only permitted if cvc5 was built with unsat-core support
-   * and produce-unsat-cores is on.
+   * Get an unsatisfiable core (only if immediately preceded by an UNSAT
+   * query). Only permitted if cvc5 was built with unsat-core support and
+   * produce-unsat-cores is on.
    */
   UnsatCore getUnsatCore();
 
   /**
-   * Get a refutation proof (only if immediately preceded by an UNSAT or
-   * ENTAILED query). Only permitted if cvc5 was built with proof support and
-   * the proof option is on. */
+   * Get a refutation proof (only if immediately preceded by an UNSAT query).
+   * Only permitted if cvc5 was built with proof support and the proof option
+   * is on.
+   */
   std::string getProof(modes::ProofComponent c = modes::PROOF_COMPONENT_FULL);
 
   /**
@@ -867,9 +868,8 @@ class CVC5_EXPORT SolverEngine
 
   /**
    * Internal method to get an unsatisfiable core (only if immediately preceded
-   * by an UNSAT or ENTAILED query). Only permitted if cvc5 was built with
-   * unsat-core support and produce-unsat-cores is on. Does not dump the
-   * command.
+   * by an UNSAT query). Only permitted if cvc5 was built with unsat-core
+   * support and produce-unsat-cores is on. Does not dump the command.
    */
   UnsatCore getUnsatCoreInternal();
 


### PR DESCRIPTION
PRs #8260 and #8313 got rid of methods/enum values for entailment checks. This commit updates the corresponding documentation.