### PR TITLE
Check whether theories are enabled during ppRewrite

### DIFF
--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -757,7 +757,7 @@ TrustNode TheoryEngine::ppRewrite(TNode term,
     ss << "The logic was specified as " << logicInfo().getLogicString()
        << ", which doesn't include " << tid
        << ", but got a preprocessing-time term for that theory." << std::endl
-       << "The term:" << endl
+       << "The term:" << std::endl
        << term;
     throw LogicException(ss.str());
   }

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -732,16 +732,9 @@ theory::Theory::PPAssertStatus TheoryEngine::solve(
   Trace("theory::solve") << "TheoryEngine::solve(" << literal << "): solving with " << theoryOf(atom)->getId() << endl;
 
   theory::TheoryId tid = d_env.theoryOf(atom);
-  if (!isTheoryEnabled(tid) && tid != THEORY_SAT_SOLVER)
-  {
-    stringstream ss;
-    ss << "The logic was specified as " << logicInfo().getLogicString()
-       << ", which doesn't include " << tid
-       << ", but got a preprocessing-time fact for that theory." << endl
-       << "The fact:" << endl
-       << literal;
-    throw LogicException(ss.str());
-  }
+  // This should be implied by the check during ppRewrite, in particular
+  // literal should have been passed to ppRewrite.
+  Assert (isTheoryEnabled(tid) || tid== THEORY_SAT_SOLVER);
 
   Theory::PPAssertStatus solveStatus =
       theoryOf(atom)->ppAssert(tliteral, substitutionOut);
@@ -754,6 +747,20 @@ TrustNode TheoryEngine::ppRewrite(TNode term,
 {
   Assert(lems.empty());
   TheoryId tid = d_env.theoryOf(term);
+  // We check whether the theory is enabled here (instead of during solve),
+  // since there are corner cases where facts may involve terms that belong
+  // to other theories, e.g. equalities between variables belong to UF when
+  // theoryof-mode is `term`.
+  if (!isTheoryEnabled(tid) && tid != THEORY_SAT_SOLVER)
+  {
+    stringstream ss;
+    ss << "The logic was specified as " << logicInfo().getLogicString()
+       << ", which doesn't include " << tid
+       << ", but got a preprocessing-time term for that theory." << std::endl
+       << "The term:" << endl
+       << term;
+    throw LogicException(ss.str());
+  }
   TrustNode trn = d_theoryTable[tid]->ppRewrite(term, lems);
   // should never introduce a skolem to eliminate an equality
   Assert(lems.empty() || term.getKind() != kind::EQUAL);

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -734,7 +734,7 @@ theory::Theory::PPAssertStatus TheoryEngine::solve(
   theory::TheoryId tid = d_env.theoryOf(atom);
   // This should be implied by the check during ppRewrite, in particular
   // literal should have been passed to ppRewrite.
-  Assert (isTheoryEnabled(tid) || tid== THEORY_SAT_SOLVER);
+  Assert(isTheoryEnabled(tid) || tid == THEORY_SAT_SOLVER);
 
   Theory::PPAssertStatus solveStatus =
       theoryOf(atom)->ppAssert(tliteral, substitutionOut);

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -731,10 +731,9 @@ theory::Theory::PPAssertStatus TheoryEngine::solve(
   TNode atom = literal.getKind() == kind::NOT ? literal[0] : literal;
   Trace("theory::solve") << "TheoryEngine::solve(" << literal << "): solving with " << theoryOf(atom)->getId() << endl;
 
-  theory::TheoryId tid = d_env.theoryOf(atom);
   // This should be implied by the check during ppRewrite, in particular
   // literal should have been passed to ppRewrite.
-  Assert(isTheoryEnabled(tid) || tid == THEORY_SAT_SOLVER);
+  Assert(isTheoryEnabled(d_env.theoryOf(atom)) || d_env.theoryOf(atom) == THEORY_SAT_SOLVER);
 
   Theory::PPAssertStatus solveStatus =
       theoryOf(atom)->ppAssert(tliteral, substitutionOut);

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -733,7 +733,8 @@ theory::Theory::PPAssertStatus TheoryEngine::solve(
 
   // This should be implied by the check during ppRewrite, in particular
   // literal should have been passed to ppRewrite.
-  Assert(isTheoryEnabled(d_env.theoryOf(atom)) || d_env.theoryOf(atom) == THEORY_SAT_SOLVER);
+  Assert(isTheoryEnabled(d_env.theoryOf(atom))
+         || d_env.theoryOf(atom) == THEORY_SAT_SOLVER);
 
   Theory::PPAssertStatus solveStatus =
       theoryOf(atom)->ppAssert(tliteral, substitutionOut);

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -775,6 +775,7 @@ set(regress_0_tests
   regress0/issue8807-model-core-partial.smt2
   regress0/issue8833-interpol-no-shared-var.smt2
   regress0/issue8834-model-core-nconst.smt2
+  regress0/issue9121-theoryof-no-enabled.smt2
   regress0/ite_arith.smt2
   regress0/ite_real_int_type.smtv1.smt2
   regress0/ite_real_valid.smtv1.smt2

--- a/test/regress/cli/regress0/issue9121-theoryof-no-enabled.smt2
+++ b/test/regress/cli/regress0/issue9121-theoryof-no-enabled.smt2
@@ -1,0 +1,12 @@
+; EXPECT: (error "The logic was specified as AUF, which doesn't include THEORY_DATATYPES, but got a preprocessing-time term for that theory.
+; EXPECT: The term:
+; EXPECT: (e x)")
+(set-logic AUF)
+(declare-datatypes ((l 0) (t 0)) (
+((n) (c (e t) (d l)))
+((m (f l)))
+))
+(declare-fun x () l)
+(declare-fun y () t)
+(assert (distinct y (e x)))
+(check-sat)

--- a/test/regress/cli/regress0/issue9121-theoryof-no-enabled.smt2
+++ b/test/regress/cli/regress0/issue9121-theoryof-no-enabled.smt2
@@ -1,6 +1,7 @@
 ; EXPECT: (error "The logic was specified as AUF, which doesn't include THEORY_DATATYPES, but got a preprocessing-time term for that theory.
 ; EXPECT: The term:
 ; EXPECT: (e x)")
+; EXIT: 1
 (set-logic AUF)
 (declare-datatypes ((l 0) (t 0)) (
 ((n) (c (e t) (d l)))


### PR DESCRIPTION
Fixes #9121.

In that regression, we failed to realize that the datatypes theory was disabled, since equalities involving variables are sent to UF in the `AUF` logic. This makes our logic check more strict to check theories are enabled for *terms* instead of literals.