### PR TITLE
Do not traverse beneath non-standard closures when selecting patterns

### DIFF
--- a/src/theory/quantifiers/ematching/pattern_term_selector.cpp
+++ b/src/theory/quantifiers/ematching/pattern_term_selector.cpp
@@ -268,7 +268,7 @@ void PatternTermSelector::collectTermsInternal(
       << "Collect pat terms " << n << " " << pol << " " << hasPol << " " << epol
       << " " << hasEPol << std::endl;
   Kind nk = n.getKind();
-  if (nk == FORALL || nk == INST_CONSTANT)
+  if (n.isClosure() || nk == INST_CONSTANT)
   {
     // do not traverse beneath quantified formulas
     return;

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2360,6 +2360,7 @@ set(regress_1_tests
   regress1/quantifiers/proj-issue151-2.smt2
   regress1/quantifiers/proj-issue155.smt2
   regress1/quantifiers/proj-issue295.smt2
+  regress1/quantifiers/proj-issue532-set-comp-fv-trigger.smt2
   regress1/quantifiers/psyco-001-bv.smt2
   regress1/quantifiers/psyco-107-bv.smt2
   regress1/quantifiers/psyco-196.smt2

--- a/test/regress/cli/regress1/quantifiers/proj-issue532-set-comp-fv-trigger.smt2
+++ b/test/regress/cli/regress1/quantifiers/proj-issue532-set-comp-fv-trigger.smt2
@@ -1,0 +1,3 @@
+; EXPECT: unknown
+(set-logic ALL)
+(check-sat-assuming ((forall ((x RoundingMode) (_x RoundingMode)) (set.choose (set.comprehension ((_x16 RoundingMode)) (set.is_singleton (set.singleton x)) (set.is_singleton (set.insert x _x16 (set.singleton _x))))))))


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5-projects/issues/532.