### PR TITLE
Fix computation of cardinality class

### DIFF
--- a/src/util/cardinality.h
+++ b/src/util/cardinality.h
@@ -155,16 +155,14 @@ class Cardinality
   bool isCountable() const { return isFinite() || d_card == s_intCard; }
 
   /**
-   * In the case that this cardinality is finite, return its
-   * cardinality.  (If this cardinality is infinite, this function
-   * throws an IllegalArgumentException.)
+   * Return a finite cardinality as an integer. This method can only be called
+   * on finite cardinalities.
    */
   Integer getFiniteCardinality() const;
 
   /**
-   * In the case that this cardinality is infinite, return its Beth
-   * number.  (If this cardinality is finite, this function throws an
-   * IllegalArgumentException.)
+   * Return the Beth number of an infinite cardinality. This method can only be
+   * called on infinite cardinalities.
    */
   Integer getBethNumber() const;
 

--- a/src/util/cardinality_class.cpp
+++ b/src/util/cardinality_class.cpp
@@ -39,13 +39,19 @@ std::ostream& operator<<(std::ostream& out, CardinalityClass c)
   return out;
 }
 
-CardinalityClass minCardinalityClass(CardinalityClass c1, CardinalityClass c2)
-{
-  return c1 < c2 ? c1 : c2;
-}
-
 CardinalityClass maxCardinalityClass(CardinalityClass c1, CardinalityClass c2)
 {
+  // If one of the classes is interpreted one and the other finite, then the
+  // result should be interpreted finite: the type is finite under the
+  // assumption that uninterpreted sorts have cardinality one, but infinite
+  // otherwise.
+  if ((c1 == CardinalityClass::INTERPRETED_ONE
+       && c2 == CardinalityClass::FINITE)
+      || (c1 == CardinalityClass::FINITE
+          && c2 == CardinalityClass::INTERPRETED_ONE))
+  {
+    return CardinalityClass::INTERPRETED_FINITE;
+  }
   return c1 > c2 ? c1 : c2;
 }
 

--- a/src/util/cardinality_class.h
+++ b/src/util/cardinality_class.h
@@ -80,8 +80,6 @@ const char* toString(CardinalityClass c);
  */
 std::ostream& operator<<(std::ostream& out, CardinalityClass c);
 
-/** Take the min class of c1 and c2 */
-CardinalityClass minCardinalityClass(CardinalityClass c1, CardinalityClass c2);
 /** Take the max class of c1 and c2 */
 CardinalityClass maxCardinalityClass(CardinalityClass c1, CardinalityClass c2);
 /**

--- a/test/unit/api/cpp/solver_black.cpp
+++ b/test/unit/api/cpp/solver_black.cpp
@@ -41,6 +41,28 @@ TEST_F(TestApiBlackSolver, proj_issue416)
   slv.checkSat();
 }
 
+TEST_F(TestApiBlackSolver, proj_issue435)
+{
+  Solver slv;
+  slv.setOption("strings-exp", "true");
+  Sort s1 = slv.mkUninterpretedSort("_u0");
+  Sort s3 = slv.getBooleanSort();
+  Sort _p7 = slv.mkParamSort("_p7");
+  DatatypeDecl _dt5 = slv.mkDatatypeDecl("_dt5", {_p7});
+  DatatypeConstructorDecl _cons33 = slv.mkDatatypeConstructorDecl("_cons33");
+  _cons33.addSelector("_sel31", s1);
+  _cons33.addSelector("_sel32", _p7);
+  _dt5.addConstructor(_cons33);
+  std::vector<Sort> _s6 = slv.mkDatatypeSorts({_dt5});
+  Sort s6 = _s6[0];
+  Sort s21 = s6.instantiate({s3});
+  Sort s42 = slv.mkSequenceSort(s21);
+  Term t40 = slv.mkConst(s42, "_x64");
+  Term t75 = slv.mkTerm(Kind::SEQ_REV, {t40});
+  Term t91 = slv.mkTerm(Kind::SEQ_PREFIX, {t75, t40});
+  slv.checkSatAssuming({t91});
+}
+
 TEST_F(TestApiBlackSolver, pow2Large1)
 {
   // Based on https://github.com/cvc5/cvc5-projects/issues/371


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5-projects/issues/435. To compute the cardinality class of constructors, we compute the maximum of the cardinality of the arguments. However, we considered the result of `max(INTERPRETED_ONE, FINITE)` to be `FINITE`. This is not accurate when finite model finding is turned off. This led to issues in the sequences solver, because we considered a constructor with an argument of an uninterpreted sort as finite and tried to retrieve that cardinality. This commit fixes the issue by making the result of `max(INTERPRETED_ONE, FINITE)` be `FINITE_INTERPRETED`.

Note in the original issue, the following assertion failure:

```
Fatal failure within void cvc5::Minisat::Solver::pop() at src/prop/minisat/core/Solver.cc:1971
Check failure

 decisionLevel() == 0
```

occurred because of an `IllegalArgumentException` was being thrown (calling `Cardinality::getFiniteCardinality()` on a sort with an non-finite cardinality). This exception then lead to an unexpected decision level (similar to the issue with uncaught `TypeCheckingExceptionPrivate` exceptions fixed in c4be9f55771b4babbaddf60f9ff215695562efde). There is an on-going effort to get rid of `IllegalArgumentException`, so it is not worth adding a fix for this. For example, commit
f8306b27c11abf4f758fbe78e40481494e05ee22 changed the code in `cardinality.cpp` that was throwing the exception in this case.