### PR TITLE
Stabilize numbering of bound and free vars in LFSC proofs.

### DIFF
--- a/src/proof/lfsc/lfsc_node_converter.cpp
+++ b/src/proof/lfsc/lfsc_node_converter.cpp
@@ -162,7 +162,7 @@ Node LfscNodeConverter::postConvert(Node n)
     TypeNode intType = nm->integerType();
     TypeNode varType = nm->mkFunctionType({intType, d_sortType}, tn);
     Node var = mkInternalSymbol("var", varType);
-    Node index = nm->mkConstInt(Rational(getOrAssignIndexForVar(n)));
+    Node index = nm->mkConstInt(Rational(getOrAssignIndexForFVar(n)));
     Node tc = typeAsNode(convertType(tn));
     return nm->mkNode(APPLY_UF, var, index, tc);
   }
@@ -1267,29 +1267,29 @@ Node LfscNodeConverter::getOperatorOfBoundVar(Node cop, Node v)
   return nm->mkNode(APPLY_UF, cop, x, tc);
 }
 
-size_t LfscNodeConverter::getOrAssignIndexForVar(Node v)
+size_t LfscNodeConverter::getOrAssignIndexForFVar(Node fv)
 {
-  Assert(v.isVar());
-  std::map<Node, size_t>::iterator it = d_varIndex.find(v);
-  if (it != d_varIndex.end())
+  Assert(fv.isVar());
+  std::map<Node, size_t>::iterator it = d_fvarIndex.find(fv);
+  if (it != d_fvarIndex.end())
   {
     return it->second;
   }
-  size_t id = d_varIndex.size();
-  d_varIndex[v] = id;
+  size_t id = d_fvarIndex.size();
+  d_fvarIndex[fv] = id;
   return id;
 }
 
-size_t LfscNodeConverter::getOrAssignIndexForBVar(Node v)
+size_t LfscNodeConverter::getOrAssignIndexForBVar(Node bv)
 {
-  Assert(v.isVar());
-  std::map<Node, size_t>::iterator it = d_bvarIndex.find(v);
+  Assert(bv.isVar());
+  std::map<Node, size_t>::iterator it = d_bvarIndex.find(bv);
   if (it != d_bvarIndex.end())
   {
     return it->second;
   }
   size_t id = d_bvarIndex.size();
-  d_bvarIndex[v] = id;
+  d_bvarIndex[bv] = id;
   return id;
 }
 

--- a/src/proof/lfsc/lfsc_node_converter.cpp
+++ b/src/proof/lfsc/lfsc_node_converter.cpp
@@ -109,7 +109,7 @@ Node LfscNodeConverter::postConvert(Node n)
     }
     // bound variable v is (bvar x T)
     TypeNode intType = nm->integerType();
-    Node x = nm->mkConstInt(Rational(getOrAssignIndexForVar(n)));
+    Node x = nm->mkConstInt(Rational(getOrAssignIndexForBVar(n)));
     Node tc = typeAsNode(convertType(tn));
     TypeNode ftype = nm->mkFunctionType({intType, d_sortType}, tn);
     Node bvarOp = getSymbolInternal(k, ftype, "bvar");
@@ -1262,7 +1262,7 @@ Node LfscNodeConverter::getOperatorOfClosure(Node q,
 Node LfscNodeConverter::getOperatorOfBoundVar(Node cop, Node v)
 {
   NodeManager* nm = NodeManager::currentNM();
-  Node x = nm->mkConstInt(Rational(getOrAssignIndexForVar(v)));
+  Node x = nm->mkConstInt(Rational(getOrAssignIndexForBVar(v)));
   Node tc = typeAsNode(convertType(v.getType()));
   return nm->mkNode(APPLY_UF, cop, x, tc);
 }
@@ -1277,6 +1277,19 @@ size_t LfscNodeConverter::getOrAssignIndexForVar(Node v)
   }
   size_t id = d_varIndex.size();
   d_varIndex[v] = id;
+  return id;
+}
+
+size_t LfscNodeConverter::getOrAssignIndexForBVar(Node v)
+{
+  Assert(v.isVar());
+  std::map<Node, size_t>::iterator it = d_bvarIndex.find(v);
+  if (it != d_bvarIndex.end())
+  {
+    return it->second;
+  }
+  size_t id = d_bvarIndex.size();
+  d_bvarIndex[v] = id;
   return id;
 }
 

--- a/src/proof/lfsc/lfsc_node_converter.h
+++ b/src/proof/lfsc/lfsc_node_converter.h
@@ -191,9 +191,9 @@ class LfscNodeConverter : public NodeConverter
   TypeNode d_sortType;
   /** Used for getting unique index for free variable */
   std::map<Node, size_t> d_fvarIndex;
-  // We use different maps for free and bound variables to ensure that the order
-  // of bound variables appearing in definitions does not depend on the order in
-  // which free variables appear in assertions/proof.
+  // We use different maps for free and bound variables to ensure that the
+  // indices of bound variables appearing in definitions do not depend on the
+  // order in which free variables appear in assertions/proof.
   /** Used for getting unique index for bound variable */
   std::map<Node, size_t> d_bvarIndex;
   /** Cache for typeAsNode */

--- a/src/proof/lfsc/lfsc_node_converter.h
+++ b/src/proof/lfsc/lfsc_node_converter.h
@@ -90,15 +90,15 @@ class LfscNodeConverter : public NodeConverter
    */
   Node getOperatorOfBoundVar(Node cop, Node v);
   /**
-   * Get the variable index for variable v, or assign a fresh index if it is
-   * not yet assigned.
+   * Get the variable index for free variable fv, or assign a fresh index if it
+   * is not yet assigned.
    */
-  size_t getOrAssignIndexForBVar(Node v);
+  size_t getOrAssignIndexForFVar(Node fv);
   /**
-   * Get the variable index for variable v, or assign a fresh index if it is
-   * not yet assigned.
+   * Get the variable index for bound variable bv, or assign a fresh index if it
+   * is not yet assigned.
    */
-  size_t getOrAssignIndexForVar(Node v);
+  size_t getOrAssignIndexForBVar(Node bv);
   /**
    * Make an internal symbol with custom name. This is a BOUND_VARIABLE that
    * has a distinguished status so that it is *not* printed as (bvar ...). The
@@ -189,8 +189,8 @@ class LfscNodeConverter : public NodeConverter
   TypeNode d_arrow;
   /** the type of LFSC sorts, which can appear in terms */
   TypeNode d_sortType;
-  /** Used for getting unique index for variable */
-  std::map<Node, size_t> d_varIndex;
+  /** Used for getting unique index for free variable */
+  std::map<Node, size_t> d_fvarIndex;
   /** Used for getting unique index for bound variable */
   std::map<Node, size_t> d_bvarIndex;
   /** Cache for typeAsNode */

--- a/src/proof/lfsc/lfsc_node_converter.h
+++ b/src/proof/lfsc/lfsc_node_converter.h
@@ -93,6 +93,11 @@ class LfscNodeConverter : public NodeConverter
    * Get the variable index for variable v, or assign a fresh index if it is
    * not yet assigned.
    */
+  size_t getOrAssignIndexForBVar(Node v);
+  /**
+   * Get the variable index for variable v, or assign a fresh index if it is
+   * not yet assigned.
+   */
   size_t getOrAssignIndexForVar(Node v);
   /**
    * Make an internal symbol with custom name. This is a BOUND_VARIABLE that
@@ -186,6 +191,8 @@ class LfscNodeConverter : public NodeConverter
   TypeNode d_sortType;
   /** Used for getting unique index for variable */
   std::map<Node, size_t> d_varIndex;
+  /** Used for getting unique index for bound variable */
+  std::map<Node, size_t> d_bvarIndex;
   /** Cache for typeAsNode */
   std::map<TypeNode, Node> d_typeAsNode;
   /** Used for interpreted builtin parametric sorts */

--- a/src/proof/lfsc/lfsc_node_converter.h
+++ b/src/proof/lfsc/lfsc_node_converter.h
@@ -191,6 +191,9 @@ class LfscNodeConverter : public NodeConverter
   TypeNode d_sortType;
   /** Used for getting unique index for free variable */
   std::map<Node, size_t> d_fvarIndex;
+  // We use different maps for free and bound variables to ensure that the order
+  // of bound variables appearing in definitions does not depend on the order in
+  // which free variables appear in assertions/proof.
   /** Used for getting unique index for bound variable */
   std::map<Node, size_t> d_bvarIndex;
   /** Cache for typeAsNode */

--- a/src/proof/lfsc/lfsc_post_processor.cpp
+++ b/src/proof/lfsc/lfsc_post_processor.cpp
@@ -84,7 +84,14 @@ bool LfscProofPostprocessCallback::update(Node res,
         // The arguments of the outer scope are definitions.
         if (d_numIgnoredScopes == 0)
         {
-          d_defs.insert(args.cbegin(), args.cend());
+          for (const Node& arg : args)
+          {
+            d_defs.insert(arg);
+            // Some declarations only appear inside definitions and don't show
+            // up in assertions. We need to keep track of those declarations and
+            // print them with other declarations.
+            d_tproc.convert(arg);
+          }
         }
         d_numIgnoredScopes++;
         // Note that we do not want to modify the top-most SCOPEs.

--- a/src/proof/lfsc/lfsc_post_processor.cpp
+++ b/src/proof/lfsc/lfsc_post_processor.cpp
@@ -92,9 +92,9 @@ bool LfscProofPostprocessCallback::update(Node res,
             // up in assertions. To ensure that those declarations are printed,
             // we need to process the definitions.
             // - We process the definitions here before the rest of the proof to
-            // keep the indicies of bound variables consistant between different
+            // keep the indices of bound variables consistant between different
             // queries that share the same definitions (e.g., incremental mode).
-            // Otherwise, bound variables will be assigned indicies according to
+            // Otherwise, bound variables will be assigned indices according to
             // the order in which they appear in the proof.
             d_tproc.convert(arg);
           }

--- a/src/proof/lfsc/lfsc_post_processor.cpp
+++ b/src/proof/lfsc/lfsc_post_processor.cpp
@@ -87,9 +87,15 @@ bool LfscProofPostprocessCallback::update(Node res,
           for (const Node& arg : args)
           {
             d_defs.insert(arg);
-            // Some declarations only appear inside definitions and don't show
-            // up in assertions. We need to keep track of those declarations and
-            // print them with other declarations.
+            // Notes:
+            // - Some declarations only appear inside definitions and don't show
+            // up in assertions. To ensure that those declarations are printed,
+            // we need to process the definitions.
+            // - We process the definitions here before the rest of the proof to
+            // keep the indicies of bound variables consistant between different
+            // queries that share the same definitions (e.g., incremental mode).
+            // Otherwise, bound variables will be assigned indicies according to
+            // the order in which they appear in the proof.
             d_tproc.convert(arg);
           }
         }

--- a/src/proof/lfsc/lfsc_printer.cpp
+++ b/src/proof/lfsc/lfsc_printer.cpp
@@ -51,10 +51,6 @@ void LfscPrinter::print(std::ostream& out, const ProofNode* pn)
   for (const Node& n : definitions)
   {
     definedSymbols.insert(n[0]);
-    // Some declarations only appear inside definitions and don't show up in
-    // assertions. We need to keep track of those declarations and print them
-    // with other declarations.
-    d_tproc.convert(n);
   }
   const std::vector<Node>& assertions = pn->getChildren()[0]->getArguments();
   const ProofNode* pnBody = pn->getChildren()[0]->getChildren()[0].get();

--- a/src/proof/lfsc/lfsc_printer.cpp
+++ b/src/proof/lfsc/lfsc_printer.cpp
@@ -212,7 +212,7 @@ void LfscPrinter::print(std::ostream& out, const ProofNode* pn)
   for (size_t i = 0, nasserts = iasserts.size(); i < nasserts; i++)
   {
     Node ia = iasserts[i];
-    out << "(% ";
+    out << "(# ";
     LfscPrintChannelOut::printAssumeId(out, i);
     out << " (holds ";
     printInternal(out, ia, lbind);

--- a/src/proof/lfsc/lfsc_printer.cpp
+++ b/src/proof/lfsc/lfsc_printer.cpp
@@ -127,7 +127,7 @@ void LfscPrinter::print(std::ostream& out, const ProofNode* pn)
     }
     Node si = d_tproc.convert(s);
     preambleSymDecl << "(define " << si << " (var "
-                    << d_tproc.getOrAssignIndexForVar(s) << " ";
+                    << d_tproc.getOrAssignIndexForFVar(s) << " ";
     printType(preambleSymDecl, st);
     preambleSymDecl << "))" << std::endl;
   }


### PR DESCRIPTION
This PR makes 3 changes to the LFSC printer to make Kind 2 proofs go through:
- Separate the counters for free and bound variables.
- Assign indices to bound variables appearing in definitions first.
- Replace `%` lambda binders (which is not allowed in definitions) with `#` binder.