### PR TITLE
Fix getEqualityStatus for non-linear arithmetic terms

### DIFF
--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -380,19 +380,26 @@ EqualityStatus TheoryArith::getEqualityStatus(TNode a, TNode b) {
   Trace("arith") << "TheoryArith::getEqualityStatus(" << a << ", " << b << ")" << std::endl;
   if (a == b)
   {
+    Trace("arith") << "...return (trivial) true" << std::endl;
     return EQUALITY_TRUE_IN_MODEL;
   }
   if (d_arithModelCache.empty())
   {
-    return d_internal->getEqualityStatus(a,b);
+    EqualityStatus es = d_internal->getEqualityStatus(a,b);
+    Trace("arith") << "...return (from linear) " << es << std::endl;
+    return es;
   }
+  Trace("arith") << "Evaluate under " << d_arithModelCacheVars << " / " << d_arithModelCacheSubs << std::endl;
   Node diff = NodeManager::currentNM()->mkNode(Kind::SUB, a, b);
   std::optional<bool> isZero = isExpressionZero(
       d_env, diff, d_arithModelCacheVars, d_arithModelCacheSubs);
   if (isZero)
   {
-    return *isZero ? EQUALITY_TRUE_IN_MODEL : EQUALITY_FALSE_IN_MODEL;
+    EqualityStatus es = *isZero ? EQUALITY_TRUE_IN_MODEL : EQUALITY_FALSE_IN_MODEL;
+    Trace("arith") << "...return (from evaluate) " << es << std::endl;
+    return es;
   }
+  Trace("arith") << "...return unknown" << std::endl;
   return EQUALITY_UNKNOWN;
 }
 
@@ -440,7 +447,10 @@ void TheoryArith::finalizeModelCache()
   for (const auto& [node, repl] : d_arithModelCache)
   {
     Assert(repl.getType().isRealOrInt());
-    if (Theory::isLeafOf(repl, TheoryId::THEORY_ARITH))
+    // we only keep the domain of the substitution that is for leafs of
+    // arithmetic; otherwise we are using the value of the abstraction of
+    // non-linear term from the linear solver, which can be incorrect.
+    if (Theory::isLeafOf(node, TheoryId::THEORY_ARITH))
     {
       d_arithModelCacheVars.emplace_back(node);
       d_arithModelCacheSubs.emplace_back(repl);

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -385,17 +385,19 @@ EqualityStatus TheoryArith::getEqualityStatus(TNode a, TNode b) {
   }
   if (d_arithModelCache.empty())
   {
-    EqualityStatus es = d_internal->getEqualityStatus(a,b);
+    EqualityStatus es = d_internal->getEqualityStatus(a, b);
     Trace("arith") << "...return (from linear) " << es << std::endl;
     return es;
   }
-  Trace("arith") << "Evaluate under " << d_arithModelCacheVars << " / " << d_arithModelCacheSubs << std::endl;
+  Trace("arith") << "Evaluate under " << d_arithModelCacheVars << " / "
+                 << d_arithModelCacheSubs << std::endl;
   Node diff = NodeManager::currentNM()->mkNode(Kind::SUB, a, b);
   std::optional<bool> isZero = isExpressionZero(
       d_env, diff, d_arithModelCacheVars, d_arithModelCacheSubs);
   if (isZero)
   {
-    EqualityStatus es = *isZero ? EQUALITY_TRUE_IN_MODEL : EQUALITY_FALSE_IN_MODEL;
+    EqualityStatus es =
+        *isZero ? EQUALITY_TRUE_IN_MODEL : EQUALITY_FALSE_IN_MODEL;
     Trace("arith") << "...return (from evaluate) " << es << std::endl;
     return es;
   }

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2104,6 +2104,7 @@ set(regress_1_tests
   regress1/nl/issue8162-drop-pi-bound.smt2
   regress1/nl/issue8960-lr-to-real-model.smt2
   regress1/nl/issue8963-to-real-model.smt2
+  regress1/nl/issue9113-iand-cg.smt2
   regress1/nl/learned-rewrite-int-mod-range.smt2
   regress1/nl/metitarski-1025.smt2
   regress1/nl/metitarski-3-4.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2104,6 +2104,7 @@ set(regress_1_tests
   regress1/nl/issue8162-drop-pi-bound.smt2
   regress1/nl/issue8960-lr-to-real-model.smt2
   regress1/nl/issue8963-to-real-model.smt2
+  regress1/nl/issue9113-1-iand-cg.smt2
   regress1/nl/issue9113-iand-cg.smt2
   regress1/nl/learned-rewrite-int-mod-range.smt2
   regress1/nl/metitarski-1025.smt2

--- a/test/regress/cli/regress1/nl/issue9113-1-iand-cg.smt2
+++ b/test/regress/cli/regress1/nl/issue9113-1-iand-cg.smt2
@@ -1,0 +1,10 @@
+; COMMAND-LINE: -i
+; EXPECT: sat
+; EXPECT: sat
+(set-logic ALL)
+(declare-fun a (Int) Int)
+(declare-fun b (Int) Int)
+(assert (= 1 (a (- 1))))
+(check-sat)
+(assert (= (b 0) ((_ iand 3) 1 (a (- 1)))))
+(check-sat)

--- a/test/regress/cli/regress1/nl/issue9113-iand-cg.smt2
+++ b/test/regress/cli/regress1/nl/issue9113-iand-cg.smt2
@@ -1,0 +1,7 @@
+(set-logic ALL)
+(set-info :status sat)
+(declare-fun a () Int)
+(declare-fun b (Int) Bool)
+(assert (b ((_ iand 1) a (- 1))))
+(assert (not (b 1)))
+(check-sat)


### PR DESCRIPTION
Fixes the 1st and 3rd benchmarks on #9113.

Previously we were using substitutions that involve non-linear terms, e.g. applications of `iand` would assume the value assigned to them by the linear arithmetic solver.

This changes a check when computing the model substitution to check whether the *domain* of the substitution is leaf. Previously, we were checking the range, likely by mistake.