### PR TITLE
Add instantiation evaluator manager

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -817,6 +817,8 @@ libcvc5_add_sources(
   theory/quantifiers/ieval/free_var_info.h
   theory/quantifiers/ieval/inst_evaluator.cpp
   theory/quantifiers/ieval/inst_evaluator.h
+  theory/quantifiers/ieval/inst_evaluator_manager.cpp
+  theory/quantifiers/ieval/inst_evaluator_manager.h
   theory/quantifiers/ieval/pattern_term_info.cpp
   theory/quantifiers/ieval/pattern_term_info.h
   theory/quantifiers/ieval/quant_info.cpp

--- a/src/theory/quantifiers/ieval/inst_evaluator_manager.cpp
+++ b/src/theory/quantifiers/ieval/inst_evaluator_manager.cpp
@@ -1,0 +1,80 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2022 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Inst evaluator manager class.
+ */
+
+#include "theory/quantifiers/ieval/inst_evaluator_manager.h"
+
+#include "options/quantifiers_options.h"
+
+namespace cvc5::internal {
+namespace theory {
+namespace quantifiers {
+namespace ieval {
+
+InstEvaluatorManager::InstEvaluatorManager(Env& env,
+                                           QuantifiersState& qs,
+                                           TermDb& tdb)
+    : QuantifiersUtil(env), d_qstate(qs), d_tdb(tdb)
+{
+}
+
+bool InstEvaluatorManager::reset(Theory::Effort effort)
+{
+  for (std::pair<const QuantEvPair, std::unique_ptr<InstEvaluator> >& e :
+       d_evals)
+  {
+    // ensure the information is completely cleared
+    e.second->resetAll(false);
+  }
+  return true;
+}
+
+std::string InstEvaluatorManager::identify() const
+{
+  return "InstEvaluatorManager";
+}
+
+InstEvaluator* InstEvaluatorManager::getEvaluator(Node q, TermEvaluatorMode tev)
+{
+  if (tev == ieval::TermEvaluatorMode::NONE)
+  {
+    // no evaluation specified
+    return nullptr;
+  }
+  // NOTE: will guard here based on option setting
+  QuantEvPair key(q, tev);
+  std::map<QuantEvPair, std::unique_ptr<InstEvaluator> >::iterator it =
+      d_evals.find(key);
+  if (it != d_evals.end())
+  {
+    // already constructed
+    return it->second.get();
+  }
+  // don't use canonization or trackAssignments, use generalized learning if
+  // option specifies it
+  // NOTE: will be based on option setting
+  bool genLearning = false;
+  d_evals[key].reset(
+      new InstEvaluator(d_env, d_qstate, d_tdb, tev, genLearning));
+  InstEvaluator* ret = d_evals[key].get();
+  // set that we are watching quantified formula q
+  ret->watch(q);
+  // return
+  return ret;
+}
+
+}  // namespace ieval
+}  // namespace quantifiers
+}  // namespace theory
+}  // namespace cvc5::internal

--- a/src/theory/quantifiers/ieval/inst_evaluator_manager.h
+++ b/src/theory/quantifiers/ieval/inst_evaluator_manager.h
@@ -1,0 +1,70 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2022 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Inst evaluator manager class.
+ */
+
+#include "cvc5_private.h"
+
+#ifndef CVC5__THEORY__QUANTIFIERS__IEVAL__INST_EVALUATOR_MANAGER_H
+#define CVC5__THEORY__QUANTIFIERS__IEVAL__INST_EVALUATOR_MANAGER_H
+
+#include <vector>
+
+#include "expr/node.h"
+#include "smt/env_obj.h"
+#include "theory/quantifiers/ieval/inst_evaluator.h"
+#include "theory/quantifiers/quant_util.h"
+
+namespace cvc5::internal {
+namespace theory {
+namespace quantifiers {
+
+class TermDb;
+
+namespace ieval {
+
+/**
+ * Inst evaluator manager, used for allocating InstEvaluators.
+ *
+ * It ensures that all allocated inst evaluators that are allocated are
+ * hard-reset during the beginning of each instantiation round. This is to
+ * ensure that the evaluation of terms based on the term database is correct.
+ */
+class InstEvaluatorManager : public QuantifiersUtil
+{
+  using QuantEvPair = std::pair<Node, TermEvaluatorMode>;
+
+ public:
+  InstEvaluatorManager(Env& env, QuantifiersState& qs, TermDb& tdb);
+  /** reset (calculate which terms are active) */
+  bool reset(Theory::Effort effort) override;
+  /** identify */
+  std::string identify() const override;
+  /** Get evaluator for quantified formula q in evaluation mode tev */
+  InstEvaluator* getEvaluator(Node q, TermEvaluatorMode tev);
+
+ private:
+  /** Reference to quantifiers state */
+  QuantifiersState& d_qstate;
+  /** Reference to term database */
+  TermDb& d_tdb;
+  /** Maps to the evaluators */
+  std::map<QuantEvPair, std::unique_ptr<InstEvaluator> > d_evals;
+};
+
+}  // namespace ieval
+}  // namespace quantifiers
+}  // namespace theory
+}  // namespace cvc5::internal
+
+#endif /* CVC5__THEORY__QUANTIFIERS__IEVAL__INST_EVALUATOR_MANAGER_H */

--- a/src/theory/quantifiers/term_registry.cpp
+++ b/src/theory/quantifiers/term_registry.cpp
@@ -45,6 +45,7 @@ TermRegistry::TermRegistry(Env& env,
       d_sygusTdb(nullptr),
       d_ochecker(nullptr),
       d_vtsCache(new VtsTermCache(env)),
+      d_ievalMan(new ieval::InstEvaluatorManager(env, qs, *d_termDb.get())),
       d_qmodel(nullptr)
 {
   if (options().quantifiers.oracles)
@@ -160,6 +161,17 @@ TermEnumeration* TermRegistry::getTermEnumeration() const
 TermPools* TermRegistry::getTermPools() const { return d_termPools.get(); }
 
 VtsTermCache* TermRegistry::getVtsTermCache() const { return d_vtsCache.get(); }
+
+ieval::InstEvaluatorManager* TermRegistry::getInstEvaluatorManager() const
+{
+  return d_ievalMan.get();
+}
+
+ieval::InstEvaluator* TermRegistry::getEvaluator(Node q,
+                                                 ieval::TermEvaluatorMode tev)
+{
+  return d_ievalMan->getEvaluator(q, tev);
+}
 
 FirstOrderModel* TermRegistry::getModel() const { return d_qmodel; }
 

--- a/src/theory/quantifiers/term_registry.h
+++ b/src/theory/quantifiers/term_registry.h
@@ -25,6 +25,7 @@
 #include "smt/env_obj.h"
 #include "theory/quantifiers/cegqi/vts_term_cache.h"
 #include "theory/quantifiers/entailment_check.h"
+#include "theory/quantifiers/ieval/inst_evaluator_manager.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
 #include "theory/quantifiers/term_database.h"
 #include "theory/quantifiers/term_enumeration.h"
@@ -96,6 +97,20 @@ class TermRegistry : protected EnvObj
   TermPools* getTermPools() const;
   /** get the virtual term substitution term cache utility */
   VtsTermCache* getVtsTermCache() const;
+  /** get the instantiation evaluator manager */
+  ieval::InstEvaluatorManager* getInstEvaluatorManager() const;
+  /**
+   * Get evaluator for quantified formula q and evaluator mode tev. We require
+   * that an evaluator is only used by one user at a time. The user of an
+   * evaluator has the responsibility to ensure it is cleaned (via a soft
+   * resetAll or push) when it is finished using it.
+   *
+   * Note the returned inst evaluator can be assumed to be watching quantified
+   * formula q only. It may or may not be initialized (i.e. such that the
+   * evaluation of ground terms is already computed), although the InstEvaluator
+   * interface automatically manages this initialization internally.
+   */
+  ieval::InstEvaluator* getEvaluator(Node q, ieval::TermEvaluatorMode tev);
   /** get the model utility */
   FirstOrderModel* getModel() const;
 
@@ -120,6 +135,8 @@ class TermRegistry : protected EnvObj
   std::unique_ptr<OracleChecker> d_ochecker;
   /** virtual term substitution term cache for arithmetic instantiation */
   std::unique_ptr<VtsTermCache> d_vtsCache;
+  /** the instantiation evaluator manager */
+  std::unique_ptr<ieval::InstEvaluatorManager> d_ievalMan;
   /** extended model object */
   FirstOrderModel* d_qmodel;
 };


### PR DESCRIPTION
This utility is a centralized module for allocating and maintaining instantiation evaluator utilities.  This PR adds the methods for retrieving evaluators per quantified formula into the quantifiers term registry.