### PR TITLE
NM: Initialize NodeManager on construction.

### DIFF
--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -4939,7 +4939,6 @@ std::ostream& operator<<(std::ostream& out, const Statistics& stats)
 Solver::Solver(std::unique_ptr<internal::Options>&& original)
 {
   d_nm = internal::NodeManager::currentNM();
-  d_nm->init();
   d_originalOptions = std::move(original);
   d_slv.reset(new internal::SolverEngine(d_originalOptions.get()));
   d_slv->setSolver(this);

--- a/src/expr/node_manager_template.cpp
+++ b/src/expr/node_manager_template.cpp
@@ -85,7 +85,7 @@ struct NVReclaim {
 
   ~NVReclaim() {
     Trace("gc") << "<< clearing NVRECLAIM field\n";
-    d_deletionField = NULL;
+    d_deletionField = nullptr;
   }
 };
 
@@ -108,12 +108,22 @@ typedef expr::Attribute<attr::LambdaBoundVarListTag, Node>
 NodeManager::NodeManager()
     : d_skManager(new SkolemManager),
       d_bvManager(new BoundVarManager),
-      d_initialized(false),
       d_nextId(0),
       d_attrManager(new expr::attr::AttributeManager()),
       d_nodeUnderDeletion(nullptr),
       d_inReclaimZombies(false)
 {
+  poolInsert(&expr::NodeValue::null());
+
+  for (uint32_t i = 0; i < uint32_t (kind::LAST_KIND); ++i)
+  {
+    Kind k = Kind(i);
+
+    if (hasOperator(k))
+    {
+      d_operators[i] = mkConst(Kind(k));
+    }
+  }
 }
 
 NodeManager* NodeManager::currentNM()
@@ -202,30 +212,6 @@ TypeNode NodeManager::mkFloatingPointType(FloatingPointSize fs)
   return mkTypeConst<FloatingPointSize>(fs);
 }
 
-void NodeManager::init()
-{
-  if (d_initialized)
-  {
-    return;
-  }
-  d_initialized = true;
-
-  // Note: This code cannot be part of the constructor because it indirectly
-  // calls `NodeManager::currentNM()`, which is where the `NodeManager` is
-  // being constructed.
-  poolInsert(&expr::NodeValue::null());
-
-  for (unsigned i = 0; i < unsigned(kind::LAST_KIND); ++i)
-  {
-    Kind k = Kind(i);
-
-    if (hasOperator(k))
-    {
-      d_operators[i] = mkConst(Kind(k));
-    }
-  }
-}
-
 NodeManager::~NodeManager()
 {
   // Destroy skolem and bound var manager before cleaning up attributes and
@@ -283,10 +269,7 @@ NodeManager::~NodeManager()
     }
   }
 
-  if (d_initialized)
-  {
-    poolRemove(&expr::NodeValue::null());
-  }
+  poolRemove(&expr::NodeValue::null());
 
   if (TraceIsOn("gc:leaks"))
   {

--- a/src/expr/node_manager_template.h
+++ b/src/expr/node_manager_template.h
@@ -109,14 +109,6 @@ class NodeManager
    */
   static bool hasOperator(Kind k);
 
-  /**
-   * Initialize the node manager by adding a null node to the pool and filling
-   * the caches for `operatorOf()`. This method must be called before using the
-   * NodeManager. This method may be called multiple times. Subsequent calls to
-   * this method have no effect.
-   */
-  void init();
-
   /** Get this node manager's skolem manager */
   SkolemManager* getSkolemManager() { return d_skManager.get(); }
   /** Get this node manager's bound variable manager */
@@ -883,14 +875,6 @@ class NodeManager
   void poolRemove(expr::NodeValue* nv);
 
   /**
-   * Determine if nv is currently being deleted by the NodeManager.
-   */
-  inline bool isCurrentlyDeleting(const expr::NodeValue* nv) const
-  {
-    return d_nodeUnderDeletion == nv;
-  }
-
-  /**
    * Register a NodeValue as a zombie.
    */
   inline void markForDeletion(expr::NodeValue* nv)
@@ -968,8 +952,6 @@ class NodeManager
   std::unique_ptr<BoundVarManager> d_bvManager;
 
   NodeValuePool d_nodeValuePool;
-
-  bool d_initialized;
 
   /** The next node identifier */
   size_t d_nextId;
@@ -1059,14 +1041,14 @@ inline expr::NodeValue* NodeManager::poolLookup(expr::NodeValue* nv) const {
 inline void NodeManager::poolInsert(expr::NodeValue* nv) {
   Assert(d_nodeValuePool.find(nv) == d_nodeValuePool.end())
       << "NodeValue already in the pool!";
-  d_nodeValuePool.insert(nv);// FIXME multithreading
+  d_nodeValuePool.insert(nv);
 }
 
 inline void NodeManager::poolRemove(expr::NodeValue* nv) {
   Assert(d_nodeValuePool.find(nv) != d_nodeValuePool.end())
       << "NodeValue is not in the pool!";
 
-  d_nodeValuePool.erase(nv);// FIXME multithreading
+  d_nodeValuePool.erase(nv);
 }
 
 inline Kind NodeManager::operatorToKind(TNode n) {

--- a/src/expr/node_value.cpp
+++ b/src/expr/node_value.cpp
@@ -113,11 +113,5 @@ void NodeValue::markForDeletion()
   NodeManager::currentNM()->markForDeletion(this);
 }
 
-bool NodeValue::isBeingDeleted() const
-{
-  return NodeManager::currentNM() != NULL
-         && NodeManager::currentNM()->isCurrentlyDeleting(this);
-}
-
 }  // namespace expr
 }  // namespace cvc5::internal

--- a/src/expr/node_value.h
+++ b/src/expr/node_value.h
@@ -93,7 +93,7 @@ class CVC5_EXPORT NodeValue
     using pointer = T*;
     using reference = T;
 
-    iterator() : d_i(NULL) {}
+    iterator() : d_i(nullptr) {}
     explicit iterator(const_nv_iterator i) : d_i(i) {}
 
     /** Conversion of a TNode iterator to a Node iterator. */
@@ -294,10 +294,6 @@ class CVC5_EXPORT NodeValue
 
   void inc()
   {
-    Assert(!isBeingDeleted())
-        << "NodeValue is currently being deleted "
-           "and increment is being called on it. Don't Do That!";
-    // FIXME multithreading
     if (__builtin_expect((d_rc < MAX_RC - 1), true))
     {
       ++d_rc;
@@ -327,8 +323,6 @@ class CVC5_EXPORT NodeValue
 
   /** Decrement ref counts of children */
   inline void decrRefCounts();
-
-  bool isBeingDeleted() const;
 
   /** Returns true if the reference count is maximized. */
   inline bool HasMaximizedReferenceCount() { return d_rc == MAX_RC; }

--- a/test/unit/test_node.h
+++ b/test/unit/test_node.h
@@ -30,7 +30,6 @@ class TestNode : public TestInternal
   void SetUp() override
   {
     d_nodeManager = NodeManager::currentNM();
-    d_nodeManager->init();
     d_skolemManager = d_nodeManager->getSkolemManager();
     d_boolTypeNode.reset(new TypeNode(d_nodeManager->booleanType()));
     d_bvTypeNode.reset(new TypeNode(d_nodeManager->mkBitVectorType(2)));

--- a/test/unit/test_smt.h
+++ b/test/unit/test_smt.h
@@ -43,7 +43,6 @@ class TestSmt : public TestInternal
   void SetUp() override
   {
     d_nodeManager = NodeManager::currentNM();
-    d_nodeManager->init();
     d_skolemManager = d_nodeManager->getSkolemManager();
     d_slvEngine.reset(new SolverEngine);
     d_slvEngine->finishInit();
@@ -60,7 +59,6 @@ class TestSmtNoFinishInit : public TestInternal
   void SetUp() override
   {
     d_nodeManager = NodeManager::currentNM();
-    d_nodeManager->init();
     d_skolemManager = d_nodeManager->getSkolemManager();
     d_slvEngine.reset(new SolverEngine);
   }


### PR DESCRIPTION
The NodeManager is a true singleton and thus only a single instance ever exists. Thus it should be initialized on construction.
This removes an assertion in `NodeValue::inc()`, which implicitly calls `NodeManager::currentNM()` and thus causes infinite recursion when the NodeManager is initialized on construction due to the insertion of the null node into the node value pool. @ajreynol and I suspect that this assertion was for previous incarnations of multi-threading support, which makes this assertion obsolete.