### PR TITLE
Fix print benchmark utility for dependencies in the body of ordinary define-fun

### DIFF
--- a/src/smt/print_benchmark.cpp
+++ b/src/smt/print_benchmark.cpp
@@ -231,14 +231,14 @@ void PrintBenchmark::getConnectedDefinitions(
   {
     // a recursively defined symbol
     recDefs.push_back(n);
-    // get the symbols in the body
-    std::unordered_set<Node> symsBody;
-    expr::getSymbols(it->second.second, symsBody, visited);
-    for (const Node& s : symsBody)
-    {
-      getConnectedDefinitions(
-          s, recDefs, ordinaryDefs, syms, defMap, processedDefs, visited);
-    }
+  }
+  // get the symbols in the body
+  std::unordered_set<Node> symsBody;
+  expr::getSymbols(it->second.second, symsBody, visited);
+  for (const Node& s : symsBody)
+  {
+    getConnectedDefinitions(
+        s, recDefs, ordinaryDefs, syms, defMap, processedDefs, visited);
   }
 }
 


### PR DESCRIPTION
We previously were only tracing dependencies for define-fun-rec, and not define-fun. This would lead to invalid orders on benchmarks with define-fun with bodies that had other references to declarations.