### PR TITLE
api: Associate nullary constructors with currentNM().

### DIFF
--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -1116,14 +1116,15 @@ Sort::Sort(internal::NodeManager* nm, const internal::TypeNode& t)
 {
 }
 
-Sort::Sort() : d_nm(nullptr), d_type(new internal::TypeNode()) {}
+Sort::Sort()
+    : d_nm(internal::NodeManager::currentNM()), d_type(new internal::TypeNode())
+{
+}
 
 Sort::~Sort()
 {
-  if (d_nm != nullptr)
-  {
-    d_type.reset();
-  }
+  Assert(d_nm != nullptr);
+  d_type.reset();
 }
 
 std::vector<internal::TypeNode> Sort::sortVectorToTypeNodes(
@@ -1850,7 +1851,12 @@ bool Sort::isNullHelper() const { return d_type->isNull(); }
 /* Op                                                                     */
 /* -------------------------------------------------------------------------- */
 
-Op::Op() : d_nm(nullptr), d_kind(NULL_TERM), d_node(new internal::Node()) {}
+Op::Op()
+    : d_nm(internal::NodeManager::currentNM()),
+      d_kind(NULL_TERM),
+      d_node(new internal::Node())
+{
+}
 
   Op::Op(internal::NodeManager* nm, const Kind k)
     : d_nm(nm), d_kind(k), d_node(new internal::Node())
@@ -1864,12 +1870,8 @@ Op::Op(internal::NodeManager* nm, const Kind k, const internal::Node& n)
 
 Op::~Op()
 {
-  if (d_nm != nullptr)
-  {
-    // Ensure that the correct node manager is in scope when the type node is
-    // destroyed.
-    d_node.reset();
-  }
+  Assert(d_nm != nullptr);
+  d_node.reset();
 }
 
 /* Public methods                                                             */
@@ -2189,10 +2191,7 @@ std::string Op::toString() const
   {
     CVC5_API_CHECK(!d_node->isNull())
         << "Expecting a non-null internal expression";
-    if (d_nm != nullptr)
-    {
-      return d_node->toString();
-    }
+    Assert(d_nm != nullptr);
     return d_node->toString();
   }
   ////////
@@ -2222,7 +2221,10 @@ bool Op::isIndexedHelper() const { return !d_node->isNull(); }
 /* Term                                                                       */
 /* -------------------------------------------------------------------------- */
 
-Term::Term() : d_nm(nullptr), d_node(new internal::Node()) {}
+Term::Term()
+    : d_nm(internal::NodeManager::currentNM()), d_node(new internal::Node())
+{
+}
 
 Term::Term(internal::NodeManager* nm, const internal::Node& n) : d_nm(nm)
 {
@@ -2231,10 +2233,8 @@ Term::Term(internal::NodeManager* nm, const internal::Node& n) : d_nm(nm)
 
 Term::~Term()
 {
-  if (d_nm != nullptr)
-  {
-    d_node.reset();
-  }
+  Assert(d_nm != nullptr);
+  d_node.reset();
 }
 
 bool Term::operator==(const Term& t) const
@@ -2576,7 +2576,7 @@ std::string Term::toString() const
 }
 
 Term::const_iterator::const_iterator()
-    : d_nm(nullptr), d_origNode(nullptr), d_pos(0)
+    : d_nm(internal::NodeManager::currentNM()), d_origNode(nullptr), d_pos(0)
 {
 }
 
@@ -2588,7 +2588,7 @@ Term::const_iterator::const_iterator(internal::NodeManager* nm,
 }
 
 Term::const_iterator::const_iterator(const const_iterator& it)
-    : d_nm(nullptr), d_origNode(nullptr)
+    : d_nm(internal::NodeManager::currentNM()), d_origNode(nullptr)
 {
   if (it.d_origNode != nullptr)
   {
@@ -3435,7 +3435,7 @@ Kind Term::getKindHelper() const
 /* DatatypeConstructorDecl -------------------------------------------------- */
 
 DatatypeConstructorDecl::DatatypeConstructorDecl()
-    : d_nm(nullptr), d_ctor(nullptr)
+    : d_nm(internal::NodeManager::currentNM()), d_ctor(nullptr)
 {
 }
 
@@ -3533,7 +3533,10 @@ bool DatatypeConstructorDecl::isResolved() const
 
 /* DatatypeDecl ------------------------------------------------------------- */
 
-DatatypeDecl::DatatypeDecl() : d_nm(nullptr), d_dtype(nullptr) {}
+DatatypeDecl::DatatypeDecl()
+    : d_nm(internal::NodeManager::currentNM()), d_dtype(nullptr)
+{
+}
 
 DatatypeDecl::DatatypeDecl(internal::NodeManager* nm,
                            const std::string& name,
@@ -3661,7 +3664,10 @@ internal::DType& DatatypeDecl::getDatatype(void) const { return *d_dtype; }
 
 /* DatatypeSelector --------------------------------------------------------- */
 
-DatatypeSelector::DatatypeSelector() : d_nm(nullptr), d_stor(nullptr) {}
+DatatypeSelector::DatatypeSelector()
+    : d_nm(internal::NodeManager::currentNM()), d_stor(nullptr)
+{
+}
 
 DatatypeSelector::DatatypeSelector(internal::NodeManager* nm,
                                    const internal::DTypeSelector& stor)
@@ -3748,7 +3754,10 @@ bool DatatypeSelector::isNullHelper() const { return d_stor == nullptr; }
 
 /* DatatypeConstructor ------------------------------------------------------ */
 
-DatatypeConstructor::DatatypeConstructor() : d_nm(nullptr), d_ctor(nullptr) {}
+DatatypeConstructor::DatatypeConstructor()
+    : d_nm(internal::NodeManager::currentNM()), d_ctor(nullptr)
+{
+}
 
 DatatypeConstructor::DatatypeConstructor(internal::NodeManager* nm,
                                          const internal::DTypeConstructor& ctor)
@@ -3884,7 +3893,7 @@ DatatypeConstructor::const_iterator::const_iterator(
 }
 
 DatatypeConstructor::const_iterator::const_iterator()
-    : d_nm(nullptr), d_int_stors(nullptr), d_idx(0)
+    : d_nm(internal::NodeManager::currentNM()), d_int_stors(nullptr), d_idx(0)
 {
 }
 
@@ -4001,7 +4010,10 @@ Datatype::Datatype(internal::NodeManager* nm, const internal::DType& dtype)
   CVC5_API_CHECK(d_dtype->isResolved()) << "Expected resolved datatype";
 }
 
-Datatype::Datatype() : d_nm(nullptr), d_dtype(nullptr) {}
+Datatype::Datatype()
+    : d_nm(internal::NodeManager::currentNM()), d_dtype(nullptr)
+{
+}
 
 Datatype::~Datatype()
 {
@@ -4246,7 +4258,7 @@ Datatype::const_iterator::const_iterator(internal::NodeManager* nm,
 }
 
 Datatype::const_iterator::const_iterator()
-    : d_nm(nullptr), d_int_ctors(nullptr), d_idx(0)
+    : d_nm(internal::NodeManager::currentNM()), d_int_ctors(nullptr), d_idx(0)
 {
 }
 
@@ -4307,7 +4319,7 @@ std::ostream& operator<<(std::ostream& out, const Datatype& dtype)
 /* -------------------------------------------------------------------------- */
 
 Grammar::Grammar()
-    : d_nm(nullptr),
+    : d_nm(internal::NodeManager::currentNM()),
       d_sygusVars(),
       d_ntSyms(),
       d_ntsToTerms(0),

--- a/src/api/python/cvc5.pxd
+++ b/src/api/python/cvc5.pxd
@@ -206,7 +206,6 @@ cdef extern from "api/cpp/cvc5.h" namespace "cvc5":
         Solver() except +
         Sort getBooleanSort() except +
         Sort getIntegerSort() except +
-        Sort getNullSort() except +
         Sort getRealSort() except +
         Sort getRegExpSort() except +
         Sort getRoundingModeSort() except +

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -259,9 +259,9 @@ cdef class DatatypeConstructor:
         return self.cdc.getName().decode()
 
     def getTerm(self):
-        """   
+        """
             Get the constructor term of this datatype constructor.
-            
+
             Datatype constructors are a special class of function-like terms
             whose sort is datatype constructor
             (:py:meth:`Sort.isDatatypeConstructor()`). All datatype
@@ -834,14 +834,6 @@ cdef class Solver:
         """
         cdef Sort sort = Sort(self)
         sort.csort = self.csolver.getIntegerSort()
-        return sort
-
-    def getNullSort(self):
-        """
-            :return: A null sort object.
-        """
-        cdef Sort sort = Sort(self)
-        sort.csort = self.csolver.getNullSort()
         return sort
 
     def getRealSort(self):

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -645,7 +645,7 @@ Command* Smt2::setLogic(std::string name, bool fromCommand)
 
   if (d_logic.isTheoryEnabled(internal::theory::THEORY_SETS))
   {
-    defineVar("set.empty", d_solver->mkEmptySet(d_solver->getNullSort()));
+    defineVar("set.empty", d_solver->mkEmptySet(Sort()));
     // the Boolean sort is a placeholder here since we don't have type info
     // without type annotation
     defineVar("set.universe",
@@ -675,7 +675,7 @@ Command* Smt2::setLogic(std::string name, bool fromCommand)
 
   if (d_logic.isTheoryEnabled(internal::theory::THEORY_BAGS))
   {
-    defineVar("bag.empty", d_solver->mkEmptyBag(d_solver->getNullSort()));
+    defineVar("bag.empty", d_solver->mkEmptyBag(Sort()));
     addOperator(cvc5::BAG_UNION_MAX, "bag.union_max");
     addOperator(cvc5::BAG_UNION_DISJOINT, "bag.union_disjoint");
     addOperator(cvc5::BAG_INTER_MIN, "bag.inter_min");

--- a/test/unit/api/cpp/solver_black.cpp
+++ b/test/unit/api/cpp/solver_black.cpp
@@ -139,11 +139,6 @@ TEST_F(TestApiBlackSolver, getIntegerSort)
   ASSERT_NO_THROW(d_solver.getIntegerSort());
 }
 
-TEST_F(TestApiBlackSolver, getNullSort)
-{
-  ASSERT_NO_THROW(d_solver.getNullSort());
-}
-
 TEST_F(TestApiBlackSolver, getRealSort)
 {
   ASSERT_NO_THROW(d_solver.getRealSort());
@@ -2617,8 +2612,7 @@ TEST_F(TestApiBlackSolver, declareSygusVar)
   ASSERT_NO_THROW(d_solver.declareSygusVar("", funSort));
   ASSERT_NO_THROW(d_solver.declareSygusVar(std::string("b"), boolSort));
   ASSERT_THROW(d_solver.declareSygusVar("", Sort()), CVC5ApiException);
-  ASSERT_THROW(d_solver.declareSygusVar("a", d_solver.getNullSort()),
-               CVC5ApiException);
+  ASSERT_THROW(d_solver.declareSygusVar("a", Sort()), CVC5ApiException);
   Solver slv;
   ASSERT_THROW(slv.declareSygusVar("", boolSort), CVC5ApiException);
 }
@@ -2647,7 +2641,7 @@ TEST_F(TestApiBlackSolver, mkGrammar)
 TEST_F(TestApiBlackSolver, synthFun)
 {
   d_solver.setOption("sygus", "true");
-  Sort null = d_solver.getNullSort();
+  Sort null;
   Sort boolean = d_solver.getBooleanSort();
   Sort integer = d_solver.getIntegerSort();
 

--- a/test/unit/api/python/test_solver.py
+++ b/test/unit/api/python/test_solver.py
@@ -43,10 +43,6 @@ def test_get_integer_sort(solver):
     solver.getIntegerSort()
 
 
-def test_get_null_sort(solver):
-    solver.getNullSort()
-
-
 def test_get_real_sort(solver):
     solver.getRealSort()
 
@@ -2614,8 +2610,6 @@ def test_mk_sygus_var(solver):
     solver.declareSygusVar("b", boolSort)
     with pytest.raises(RuntimeError):
         solver.declareSygusVar("", cvc5.Sort(solver))
-    with pytest.raises(RuntimeError):
-        solver.declareSygusVar("a", solver.getNullSort())
     slv = cvc5.Solver()
     solver.setOption("sygus", "true")
     with pytest.raises(RuntimeError):
@@ -2624,7 +2618,7 @@ def test_mk_sygus_var(solver):
 
 def test_synth_fun(solver):
     solver.setOption("sygus", "true")
-    null = solver.getNullSort()
+    null = cvc5.Sort(solver)
     boolean = solver.getBooleanSort()
     integer = solver.getIntegerSort()
 


### PR DESCRIPTION
This makes Solver::getNullarySort() obsolete and refactors everything related to this function on the C++ and Python level. We still have to keep it (temporarily) in the C++ API until the Java API is also refactored accordingly.