### PR TITLE
test: Use correct Python interpreter for run_regression.py.

### DIFF
--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -3386,6 +3386,7 @@ macro(cvc5_add_regression_test level file)
   endif()
 
   add_test(${file}
+    ${PYTHON_EXECUTABLE}
     ${run_regress_script}
     ${RUN_REGRESSION_ARGS}
     --lfsc-binary ${CMAKE_SOURCE_DIR}/deps/bin/lfscc


### PR DESCRIPTION
Use the Python interpreter found by CMake to run the regression script.

This fixes the unicode encoding errors in the nightlies.