### PR TITLE
Allow SyGuS solver to answer infeasible

### DIFF
--- a/src/smt/sygus_solver.cpp
+++ b/src/smt/sygus_solver.cpp
@@ -303,6 +303,11 @@ SynthResult SygusSolver::checkSynth(bool isNext)
       checkSynthSolution(as, sol_map);
     }
   }
+  else if (r.getStatus() == Result::UNSAT)
+  {
+    // unsat means no solution
+    sr = SynthResult(SynthResult::NO_SOLUTION);
+  }
   else
   {
     // otherwise, we return "unknown"

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -521,7 +521,6 @@ bool Cegis::getRefinementEvalLemmas(const std::vector<Node>& vs,
                                << " against current model." << std::endl;
       Trace("sygus-cref-eval2") << "Check refinement lemma conjunct " << lem
                                 << " against current model." << std::endl;
-      Node cre_lem;
       Node lemcs = lem.substitute(vs.begin(), vs.end(), ms.begin(), ms.end());
       Trace("sygus-cref-eval2")
           << "...under substitution it is : " << lemcs << std::endl;
@@ -641,7 +640,6 @@ bool Cegis::sampleAddRefinementLemma(const std::vector<Node>& candidates,
   sbody = rewrite(sbody);
   Trace("cegis-sample") << "Sample (after rewriting): " << sbody << std::endl;
 
-  NodeManager* nm = NodeManager::currentNM();
   for (unsigned i = 0, size = d_cegis_sampler.getNumSamplePoints(); i < size;
        i++)
   {

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -480,13 +480,10 @@ void Cegis::registerRefinementLemma(const std::vector<Node>& vars, Node lem)
       && options().quantifiers.sygusEvalUnfoldMode
              != options::SygusEvalUnfoldMode::NONE)
   {
-    // Make the refinement lemma and add it to lems.
-    // This lemma is guarded by the parent's guard, which has the semantics
-    // "this conjecture has a solution", hence this lemma states:
-    // if the parent conjecture has a solution, it satisfies the specification
-    // for the given concrete point.
-    Node rlem = lem;
-    d_qim.addPendingLemma(rlem, InferenceId::QUANTIFIERS_SYGUS_CEGIS_REFINE);
+    // Make the refinement lemma and add it to lems. This lemma states:
+    // the parent conjecture satisfies the specification for the given
+    // concrete point.
+    d_qim.addPendingLemma(lem, InferenceId::QUANTIFIERS_SYGUS_CEGIS_REFINE);
   }
 }
 

--- a/src/theory/quantifiers/sygus/cegis_unif.cpp
+++ b/src/theory/quantifiers/sygus/cegis_unif.cpp
@@ -394,8 +394,8 @@ void CegisUnif::registerRefinementLemma(const std::vector<Node>& vars, Node lem)
       d_u_enum_manager.registerEvalPts(ep.second, n);
     }
   }
-  // Make the refinement lemma and add it to lems. This lemma states: it
-  // satisfies the specification for the given concrete point.
+  // Make the refinement lemma and add it to lems. This lemma states: the
+  // parent conjecture satisfies the specification for the given concrete point.
   d_qim.addPendingLemma(plem,
                         InferenceId::QUANTIFIERS_SYGUS_UNIF_PI_REFINEMENT);
 }

--- a/src/theory/quantifiers/sygus/cegis_unif.cpp
+++ b/src/theory/quantifiers/sygus/cegis_unif.cpp
@@ -394,13 +394,9 @@ void CegisUnif::registerRefinementLemma(const std::vector<Node>& vars, Node lem)
       d_u_enum_manager.registerEvalPts(ep.second, n);
     }
   }
-  // Make the refinement lemma and add it to lems. This lemma is guarded by the
-  // parent's guard, which has the semantics "this conjecture has a solution",
-  // hence this lemma states: if the parent conjecture has a solution, it
+  // Make the refinement lemma and add it to lems. This lemma states: it
   // satisfies the specification for the given concrete point.
-  Node rlem =
-      NodeManager::currentNM()->mkNode(OR, d_parent->getGuard().negate(), plem);
-  d_qim.addPendingLemma(rlem,
+  d_qim.addPendingLemma(plem,
                         InferenceId::QUANTIFIERS_SYGUS_UNIF_PI_REFINEMENT);
 }
 

--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -76,8 +76,7 @@ SynthConjecture::SynthConjecture(Env& env,
       d_ceg_cegisUnif(new CegisUnif(env, qs, qim, d_tds, this)),
       d_sygus_ccore(new CegisCoreConnective(env, qs, qim, d_tds, this)),
       d_master(nullptr),
-      d_repair_index(0),
-      d_guarded_stream_exc(false)
+      d_repair_index(0)
 {
   if (options().datatypes.sygusSymBreakPbe
       || options().quantifiers.sygusUnifPbe)
@@ -125,12 +124,6 @@ void SynthConjecture::assign(Node q)
   d_quant = q;
   NodeManager* nm = NodeManager::currentNM();
   SkolemManager* sm = nm->getSkolemManager();
-
-  // initialize the guard
-  d_feasible_guard = sm->mkDummySkolem("G", nm->booleanType());
-  d_feasible_guard = rewrite(d_feasible_guard);
-  d_feasible_guard = d_qstate.getValuation().ensureLiteral(d_feasible_guard);
-  AlwaysAssert(!d_feasible_guard.isNull());
 
   // pre-simplify the quantified formula based on the process utility
   d_simp_quant = d_ceg_proc->preSimplify(d_quant);
@@ -250,7 +243,7 @@ void SynthConjecture::assign(Node q)
   if (d_exampleInfer!=nullptr && !d_exampleInfer->initialize(conjForExamples, d_candidates))
   {
     // there is a contradictory example pair, the conjecture is infeasible.
-    Node infLem = d_feasible_guard.negate();
+    Node infLem = nm->mkConst(false);
     d_qim.lemma(infLem, InferenceId::QUANTIFIERS_SYGUS_EXAMPLE_INFER_CONTRA);
     // we don't need to continue initialization in this case
     return;
@@ -274,21 +267,10 @@ void SynthConjecture::assign(Node q)
 
   Assert(d_qreg.getQuantAttributes().isSygus(q));
 
-  // register the strategy
-  d_feasible_strategy.reset(new DecisionStrategySingleton(
-      d_env, "sygus_feasible", d_feasible_guard, d_qstate.getValuation()));
-  d_qim.getDecisionManager()->registerStrategy(
-      DecisionManager::STRAT_QUANT_SYGUS_FEASIBLE, d_feasible_strategy.get());
-  // this must be called, both to ensure that the feasible guard is
-  // decided on with true polariy, but also to ensure that output channel
-  // has been used on this call to check.
-  d_qim.requirePhase(d_feasible_guard, true);
-
   Trace("cegqi") << "...finished, single invocation = " << isSingleInvocation()
                  << std::endl;
 }
 
-Node SynthConjecture::getGuard() const { return d_feasible_guard; }
 
 bool SynthConjecture::isSingleInvocation() const
 {
@@ -297,30 +279,6 @@ bool SynthConjecture::isSingleInvocation() const
 
 bool SynthConjecture::needsCheck()
 {
-  bool value;
-  Assert(!d_feasible_guard.isNull());
-  // non or fully single invocation : look at guard only
-  if (d_qstate.getValuation().hasSatValue(d_feasible_guard, value))
-  {
-    if (!value)
-    {
-      Trace("sygus-engine-debug") << "Conjecture is infeasible." << std::endl;
-      warning() << "Warning : the SyGuS conjecture may be infeasible"
-                << std::endl;
-      return false;
-    }
-    else
-    {
-      Trace("sygus-engine-debug") << "Feasible guard " << d_feasible_guard
-                                  << " assigned true." << std::endl;
-    }
-  }
-  else
-  {
-    Trace("cegqi-warn") << "WARNING: Guard " << d_feasible_guard
-                        << " is not assigned!" << std::endl;
-    Assert(false);
-  }
   return true;
 }
 
@@ -790,11 +748,6 @@ void SynthConjecture::excludeCurrentSolution(const std::vector<Node>& values)
   }
   if (!exp.empty())
   {
-    if (!d_guarded_stream_exc)
-    {
-      d_guarded_stream_exc = true;
-      exp.push_back(d_feasible_guard);
-    }
     Node exc_lem = exp.size() == 1
                        ? exp[0]
                        : NodeManager::currentNM()->mkNode(kind::AND, exp);

--- a/src/theory/quantifiers/sygus/synth_conjecture.h
+++ b/src/theory/quantifiers/sygus/synth_conjecture.h
@@ -101,11 +101,6 @@ class SynthConjecture : protected EnvObj
    *   f -> (lambda x. x+1)
    */
   bool getSynthSolutions(std::map<Node, std::map<Node, Node> >& sol_map);
-  /**
-   * The feasible guard whose semantics are "this conjecture is feasiable".
-   * This is "G" in Figure 3 of Reynolds et al CAV 2015.
-   */
-  Node getGuard() const;
   /** is ground */
   bool isGround() const { return d_innerVars.empty(); }
   /** are we using single invocation techniques */
@@ -186,8 +181,6 @@ class SynthConjecture : protected EnvObj
   TermDbSygus* d_tds;
   /** The synthesis verify utility */
   SynthVerify d_verify;
-  /** The feasible guard. */
-  Node d_feasible_guard;
   /**
    * Do we have a solution in this solve context? This flag is reset to false
    * on every call to presolve.
@@ -338,12 +331,6 @@ class SynthConjecture : protected EnvObj
   //-------------------------------- sygus stream
   /** exclude the current solution { enums -> values } */
   void excludeCurrentSolution(const std::vector<Node>& values);
-  /**
-   * Whether we have guarded a stream exclusion lemma when using sygusStream.
-   * This is an optimization that allows us to guard only the first stream
-   * exclusion lemma.
-   */
-  bool d_guarded_stream_exc;
   //-------------------------------- end sygus stream
   /** expression miner managers for each function-to-synthesize
    *

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1538,6 +1538,7 @@ set(regress_0_tests
   regress0/sygus/hd-05-d1-prog-nogrammar.sy
   regress0/sygus/ho-occ-synth-fun.sy
   regress0/sygus/incremental-modify-ex.sy
+  regress0/sygus/infeasible-constraint.sy
   regress0/sygus/inv-different-var-order.sy
   regress0/sygus/issue3356-syg-inf-usort.smt2
   regress0/sygus/issue3624.sy

--- a/test/regress/cli/regress0/sygus/infeasible-constraint.sy
+++ b/test/regress/cli/regress0/sygus/infeasible-constraint.sy
@@ -1,0 +1,15 @@
+; COMMAND-LINE: --sygus-out=status 
+; EXPECT: infeasible
+(set-logic NIA)
+(synth-fun p ((a Int)) Bool
+    ( (B Bool) (I Int))
+    (
+        (B Bool ((and B B) (or B B) (<= I I) (< I I)))
+        (I Int (a (+ I I) (* I I)))
+    )
+)
+(declare-var x Int)
+; common mistake of making a constraint for an assumption
+(constraint (> x 0))
+(constraint (= (p x) (> x 0)))
+(check-synth)

--- a/test/regress/cli/regress0/sygus/pbe-pred-contra.sy
+++ b/test/regress/cli/regress0/sygus/pbe-pred-contra.sy
@@ -1,5 +1,5 @@
-; COMMAND-LINE: --lang=sygus2 --sygus-si=none --sygus-out=status -q
-; EXPECT: fail
+; COMMAND-LINE: --lang=sygus2 --sygus-si=none --sygus-out=status
+; EXPECT: infeasible
 (set-logic LIA)
 (synth-fun P ((x Int)) Bool)
 (constraint (P 54))

--- a/test/regress/cli/regress0/sygus/univ_3-long-repeat-conflict.sy
+++ b/test/regress/cli/regress0/sygus/univ_3-long-repeat-conflict.sy
@@ -1,4 +1,4 @@
-; EXPECT: fail
+; EXPECT: infeasible
 ; COMMAND-LINE: --lang=sygus2 --sygus-out=status -q
 (set-logic SLIA)
 


### PR DESCRIPTION
Due to previous refactoring, the SMT solver called by the SyGuS solver no longer answers unsat when the synthesis problem is feasible.  

This PR makes it so that unsat from the underlying SMT solver is now interpreted as "infeasible" and is officially returned as such by the SyGuS solver.  Note that we return unsat when e.g. a CEGIS refinement lemma is equivalent to false. On the other hand, we do not yet answer unsat when we run out of terms (e.g. for finite grammars), as this is still guarded.  A followup PR will address this.

This further removes the "feasible guard" from the internal sygus solver, which was used as a way to prevent unsat due to the infeasibility of CEGIS refinement lemmas.