### PR TITLE
Guard CoCoA in unit/theory/theory_ff_model_black

### DIFF
--- a/test/unit/theory/theory_ff_core_black.cpp
+++ b/test/unit/theory/theory_ff_core_black.cpp
@@ -21,7 +21,6 @@
 #include <CoCoA/SparsePolyRing.H>
 #include <CoCoA/ring.H>
 #include <CoCoA/symbol.H>
-#endif  // CVC5_USE_COCOA
 
 #include <memory>
 #include <utility>
@@ -37,8 +36,6 @@ using namespace context;
 using namespace theory;
 
 namespace test {
-
-#ifdef CVC5_USE_COCOA
 
 class TestTheoryFfRootsBlack : public TestSmt
 {

--- a/test/unit/theory/theory_ff_model_black.cpp
+++ b/test/unit/theory/theory_ff_model_black.cpp
@@ -13,6 +13,7 @@
  * Black box testing of ff model construction.
  */
 
+#ifdef CVC5_USE_COCOA
 #include <CoCoA/BigInt.H>
 #include <CoCoA/QuotientRing.H>
 #include <CoCoA/RingZZ.H>
@@ -20,6 +21,7 @@
 #include <CoCoA/SparsePolyRing.H>
 #include <CoCoA/ring.H>
 #include <CoCoA/symbol.H>
+#endif  // CVC5_USE_COCOA
 
 #include <memory>
 #include <utility>
@@ -35,6 +37,8 @@ using namespace context;
 using namespace theory;
 
 namespace test {
+
+#ifdef CVC5_USE_COCOA
 
 class TestTheoryFfModelBlack : public TestSmt
 {
@@ -236,6 +240,8 @@ TEST_F(TestTheoryFfModelBlack, CommonRootCosntraints)
   EXPECT_EQ(values[0] * values[0], values[1]);
   EXPECT_EQ(values[1] * values[2], z + 1);
 }
+
+#endif  // CVC5_USE_COCOA
 
 }  // namespace test
 }  // namespace cvc5::internal

--- a/test/unit/theory/theory_ff_model_black.cpp
+++ b/test/unit/theory/theory_ff_model_black.cpp
@@ -21,7 +21,6 @@
 #include <CoCoA/SparsePolyRing.H>
 #include <CoCoA/ring.H>
 #include <CoCoA/symbol.H>
-#endif  // CVC5_USE_COCOA
 
 #include <memory>
 #include <utility>
@@ -37,8 +36,6 @@ using namespace context;
 using namespace theory;
 
 namespace test {
-
-#ifdef CVC5_USE_COCOA
 
 class TestTheoryFfModelBlack : public TestSmt
 {

--- a/test/unit/theory/theory_ff_roots_black.cpp
+++ b/test/unit/theory/theory_ff_roots_black.cpp
@@ -21,7 +21,6 @@
 #include <CoCoA/SparsePolyRing.H>
 #include <CoCoA/ring.H>
 #include <CoCoA/symbol.H>
-#endif  // CVC5_USE_COCOA
 
 #include <memory>
 #include <utility>
@@ -37,8 +36,6 @@ using namespace context;
 using namespace theory;
 
 namespace test {
-
-#ifdef CVC5_USE_COCOA
 
 class TestTheoryFfRootsBlack : public TestSmt
 {


### PR DESCRIPTION
Without the guards, we break the `--no-cocoa` build.