### PR TITLE
Use str.nth in reductions, eliminate in preprocessing

### DIFF
--- a/src/theory/strings/array_solver.cpp
+++ b/src/theory/strings/array_solver.cpp
@@ -227,6 +227,11 @@ void ArraySolver::checkTerm(Node t, bool checkInv)
         }
         else
         {
+          if (d_state.areDisequal(t[1], d_zero))
+          {
+            // n is known to be disequal from zero, skip
+            return;
+          }
           Assert(k == SEQ_NTH);
           Node val;
           if (cIsConst)

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -1239,6 +1239,7 @@ TrustNode TheoryStrings::ppRewrite(TNode atom, std::vector<SkolemLemma>& lems)
   {
     if (ak == STRING_TO_CODE)
     {
+      // If we are eliminating code, convert it to nth.
       // str.to_code(t) ---> ite(str.len(t) = 1, str.nth(t,0), -1)
       NodeManager* nm = NodeManager::currentNM();
       Node t = atom[0];
@@ -1250,6 +1251,8 @@ TrustNode TheoryStrings::ppRewrite(TNode atom, std::vector<SkolemLemma>& lems)
   }
   else if (ak == SEQ_NTH && atom[0].getType().isString())
   {
+    // If we are not eliminating code, we are eliminating nth (over strings);
+    // convert it to code.
     // (seq.nth x n) ---> (str.to_code (str.substr x n 1))
     NodeManager* nm = NodeManager::currentNM();
     Node ret = nm->mkNode(

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -1243,7 +1243,8 @@ TrustNode TheoryStrings::ppRewrite(TNode atom, std::vector<SkolemLemma>& lems)
       NodeManager* nm = NodeManager::currentNM();
       Node t = atom[0];
       Node cond = nm->mkNode(EQUAL, nm->mkNode(STRING_LENGTH, t), d_one);
-      Node ret = nm->mkNode(ITE, cond, nm->mkNode(SEQ_NTH, t, d_zero), d_neg_one);
+      Node ret =
+          nm->mkNode(ITE, cond, nm->mkNode(SEQ_NTH, t, d_zero), d_neg_one);
       return TrustNode::mkTrustRewrite(atom, ret, nullptr);
     }
   }
@@ -1253,8 +1254,9 @@ TrustNode TheoryStrings::ppRewrite(TNode atom, std::vector<SkolemLemma>& lems)
     NodeManager* nm = NodeManager::currentNM();
     Node ret = nm->mkNode(
         STRING_TO_CODE,
-        nm->mkNode(STRING_SUBSTR, atom[0], atom[1], nm->mkConstInt(Rational(1))));
-      return TrustNode::mkTrustRewrite(atom, ret, nullptr);
+        nm->mkNode(
+            STRING_SUBSTR, atom[0], atom[1], nm->mkConstInt(Rational(1))));
+    return TrustNode::mkTrustRewrite(atom, ret, nullptr);
   }
 
   TrustNode ret;

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -1235,14 +1235,26 @@ TrustNode TheoryStrings::ppRewrite(TNode atom, std::vector<SkolemLemma>& lems)
     lems.push_back(SkolemLemma(tnk, k));
     return TrustNode::mkTrustRewrite(atom, k, nullptr);
   }
-  else if (ak == STRING_TO_CODE && options().strings.stringsCodeElim)
+  if (options().strings.stringsCodeElim)
   {
-    // str.to_code(t) ---> ite(str.len(t) = 1, str.nth(t,0), -1)
+    if (ak == STRING_TO_CODE)
+    {
+      // str.to_code(t) ---> ite(str.len(t) = 1, str.nth(t,0), -1)
+      NodeManager* nm = NodeManager::currentNM();
+      Node t = atom[0];
+      Node cond = nm->mkNode(EQUAL, nm->mkNode(STRING_LENGTH, t), d_one);
+      Node ret = nm->mkNode(ITE, cond, nm->mkNode(SEQ_NTH, t, d_zero), d_neg_one);
+      return TrustNode::mkTrustRewrite(atom, ret, nullptr);
+    }
+  }
+  else if (ak == SEQ_NTH && atom[0].getType().isString())
+  {
+    // (seq.nth x n) ---> (str.to_code (str.substr x n 1))
     NodeManager* nm = NodeManager::currentNM();
-    Node t = atom[0];
-    Node cond = nm->mkNode(EQUAL, nm->mkNode(STRING_LENGTH, t), d_one);
-    Node ret = nm->mkNode(ITE, cond, nm->mkNode(SEQ_NTH, t, d_zero), d_neg_one);
-    return TrustNode::mkTrustRewrite(atom, ret, nullptr);
+    Node ret = nm->mkNode(
+        STRING_TO_CODE,
+        nm->mkNode(STRING_SUBSTR, atom[0], atom[1], nm->mkConstInt(Rational(1))));
+      return TrustNode::mkTrustRewrite(atom, ret, nullptr);
   }
 
   TrustNode ret;

--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -1078,12 +1078,11 @@ Node StringsPreprocess::simplifyRec(Node t, std::vector<Node>& asserts)
 }
 Node StringsPreprocess::mkCodePointAtIndex(Node x, Node i)
 {
-  // we could use (SEQ_NTH, x, i) instead of
-  // (STRING_TO_CODE, (STRING_SUBSTR, x, i, 1))
+  // We use (SEQ_NTH, x, i) instead of
+  // (STRING_TO_CODE, (STRING_SUBSTR, x, i, 1)) here. The former may be
+  // converted to the latter during preprocessing based on our options.
   NodeManager* nm = NodeManager::currentNM();
-  return nm->mkNode(
-      STRING_TO_CODE,
-      nm->mkNode(STRING_SUBSTR, x, i, nm->mkConstInt(Rational(1))));
+  return nm->mkNode(SEQ_NTH, x, i);
 }
 
 Node StringsPreprocess::processAssertion(Node n, std::vector<Node>& asserts)

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1507,6 +1507,7 @@ set(regress_0_tests
   regress0/strings/replaceall-eval.smt2
   regress0/strings/rewrites-re-concat.smt2
   regress0/strings/rewrites-v2.smt2
+  regress0/strings/simple-nth-fail.smt2
   regress0/strings/std2.6.1.smt2
   regress0/strings/str_unsound_ext_rew_eq.smt2
   regress0/strings/str-rev-simple.smt2

--- a/test/regress/cli/regress0/strings/simple-nth-fail.smt2
+++ b/test/regress/cli/regress0/strings/simple-nth-fail.smt2
@@ -1,0 +1,8 @@
+(set-logic QF_SLIA)
+(set-info :status sat)
+(declare-const i Int)
+(declare-const n Int)
+(assert (>= n 0))
+(assert (= i (str.to_int (str.from_code n))))
+(assert (>= i 0))
+(check-sat)


### PR DESCRIPTION
This clarifies the relationship between str.nth and str.to_code; one is rewritten to another and they are never combined.

In preparation for using str.nth by default, this updates the string reductions to use str.nth, which is now rewritten to its previous value during preprocessing.  Thus, this PR does not change behavior.

It also includes a fix to the sequences array solver discovered during testing this change, where tautological lemmas were being sent.