### PR TITLE
Fix cache issue for OOB split inference for str.unit

### DIFF
--- a/src/theory/strings/base_solver.cpp
+++ b/src/theory/strings/base_solver.cpp
@@ -354,6 +354,7 @@ bool BaseSolver::processConstantLike(Node a, Node b)
       if (!d_state.areDisequal(s, t))
       {
         d_im.sendSplit(s, t, InferenceId::STRINGS_UNIT_SPLIT);
+        Trace("strings-base") << "...split" << std::endl;
       }
       else if (d_strUnitOobEq.find(eq) == d_strUnitOobEq.end())
       {
@@ -374,7 +375,17 @@ bool BaseSolver::processConstantLike(Node a, Node b)
         // s or t may be concrete integers corresponding to code
         // points of string constants, and thus are not guaranteed to
         // be terms in the equality engine.
-        d_im.sendInference(exp, exp, conc, InferenceId::STRINGS_UNIT_INJ_OOB);
+        NodeManager * nm = NodeManager::currentNM();
+        // We must send this lemma immediately, since otherwise if buffered,
+        // this lemma may be dropped if there is a fact or conflict that
+        // preempts it. 
+        Node lem = nm->mkNode(IMPLIES, nm->mkAnd(exp), conc);
+        d_im.lemma(lem, InferenceId::STRINGS_UNIT_INJ_OOB);
+        Trace("strings-base") << "...oob split" << std::endl;
+      }
+      else
+      {
+        Trace("strings-base") << "...already sent oob" << std::endl;
       }
     }
     else
@@ -382,7 +393,12 @@ bool BaseSolver::processConstantLike(Node a, Node b)
       // (seq.unit x) = (seq.unit y) => x=y, or
       // (seq.unit x) = (seq.unit c) => x=c
       d_im.sendInference(exp, eq, InferenceId::STRINGS_UNIT_INJ);
+      Trace("strings-base") << "...inj seq" << std::endl;
     }
+  }
+  else
+  {
+    Trace("strings-base") << "...equal" << std::endl;
   }
   return false;
 }

--- a/src/theory/strings/base_solver.cpp
+++ b/src/theory/strings/base_solver.cpp
@@ -375,10 +375,10 @@ bool BaseSolver::processConstantLike(Node a, Node b)
         // s or t may be concrete integers corresponding to code
         // points of string constants, and thus are not guaranteed to
         // be terms in the equality engine.
-        NodeManager * nm = NodeManager::currentNM();
+        NodeManager* nm = NodeManager::currentNM();
         // We must send this lemma immediately, since otherwise if buffered,
         // this lemma may be dropped if there is a fact or conflict that
-        // preempts it. 
+        // preempts it.
         Node lem = nm->mkNode(IMPLIES, nm->mkAnd(exp), conc);
         d_im.lemma(lem, InferenceId::STRINGS_UNIT_INJ_OOB);
         Trace("strings-base") << "...oob split" << std::endl;

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2811,6 +2811,7 @@ set(regress_1_tests
   regress1/strings/str006.smt2
   regress1/strings/str007.smt2
   regress1/strings/string-unsound-sem.smt2
+  regress1/strings/strings-code-elim-min.smt2 
   regress1/strings/strings-index-empty.smt2
   regress1/strings/strings-leq-trans-unsat.smt2
   regress1/strings/strings-lt-len5.smt2

--- a/test/regress/cli/regress0/strings/simple-nth-fail.smt2
+++ b/test/regress/cli/regress0/strings/simple-nth-fail.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: --no-strings-code-elim
+; COMMAND-LINE: --strings-code-elim
 (set-logic QF_SLIA)
 (set-info :status sat)
 (declare-const i Int)

--- a/test/regress/cli/regress1/strings/issue8975-3.smt2
+++ b/test/regress/cli/regress1/strings/issue8975-3.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --decision=internal
+; COMMAND-LINE: --decision=internal -q
 ; EXPECT: sat
 (set-logic QF_SLIA)
 (declare-const x Int)

--- a/test/regress/cli/regress1/strings/strings-code-elim-min.smt2
+++ b/test/regress/cli/regress1/strings/strings-code-elim-min.smt2
@@ -1,0 +1,14 @@
+; COMMAND-LINE: --decision=internal --strings-code-elim
+; EXPECT: sat
+(set-logic QF_SLIA)
+(declare-fun s () String)
+(assert (= "0" (str.substr s 2 1)))
+(assert (distinct 1 (str.len (str.substr s 2 2))))
+(assert (= 1 (str.len (str.substr s 1 1))))
+(assert (= 1 (str.len (str.substr s 0 1))))
+(assert (= "0" (str.at (str.substr s 3 (- (str.len s) 3)) 0)))
+(assert (distinct 1 (str.len (str.substr "00000" 3 (- (str.len s) 3)))))
+(assert (str.in_re s (re.++ (re.range "0" "9") (re.* (re.range "0" "9")))))
+(assert (> (str.len s) 3))
+(assert (<= (str.len s) 5))
+(check-sat)


### PR DESCRIPTION
This fixes the current known issues with using str.nth instead of str.to_code in string reductions (`--strings-code-elim`).