### PR TITLE
Fix PBE symmetry breaking for multiple sygus types for the same builtin type

### DIFF
--- a/src/theory/quantifiers/sygus/sygus_enumerator_callback.cpp
+++ b/src/theory/quantifiers/sygus/sygus_enumerator_callback.cpp
@@ -100,7 +100,7 @@ bool SygusEnumeratorCallbackDefault::addTermInternal(Node n, Node bn, Node bnr)
       ++(d_stats->d_enumTermsExampleEval);
     }
     // Is it equivalent under examples?
-    Node bne = d_eec->addSearchVal(d_tn, bnr);
+    Node bne = d_eec->addSearchVal(n.getType(), bnr);
     if (!bne.isNull())
     {
       if (bnr != bne)

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1558,6 +1558,7 @@ set(regress_0_tests
   regress0/sygus/issue6298-par.sy
   regress0/sygus/let-ringer.sy
   regress0/sygus/let-simp.sy
+  regress0/sygus/nl-c-grammar-div-pbe.sy
   regress0/sygus/no-logic.sy
   regress0/sygus/no-syntax-test-bool.sy
   regress0/sygus/no-syntax-test.sy

--- a/test/regress/cli/regress0/sygus/nl-c-grammar-div-pbe.sy
+++ b/test/regress/cli/regress0/sygus/nl-c-grammar-div-pbe.sy
@@ -1,3 +1,5 @@
+; COMMAND-LINE: --sygus-out=status
+; EXPECT: feasible
 (set-logic NIA)
 (synth-fun f ((x Int) (y Int)) Int
   ((Start Int) (StartC Int))

--- a/test/regress/cli/regress0/sygus/nl-c-grammar-div-pbe.sy
+++ b/test/regress/cli/regress0/sygus/nl-c-grammar-div-pbe.sy
@@ -1,0 +1,10 @@
+(set-logic NIA)
+(synth-fun f ((x Int) (y Int)) Int
+  ((Start Int) (StartC Int))
+  (
+  (Start Int (x y (div x StartC)))
+  (StartC Int (2 3))
+  )
+)
+(constraint (= (f 4 5) 2))
+(check-synth)


### PR DESCRIPTION
Was mistakenly using the same cache, meaning that a term could be discarded if a term from another sygus type was already enumerated.