### PR TITLE
[proofs] [uf] Make EqProof conversion robust to fickle rewriting of n-ary kinds

### DIFF
--- a/src/proof/proof_rule.cpp
+++ b/src/proof/proof_rule.cpp
@@ -45,6 +45,7 @@ const char* toString(PfRule id)
     case PfRule::THEORY_EXPAND_DEF: return "THEORY_EXPAND_DEF";
     case PfRule::WITNESS_AXIOM: return "WITNESS_AXIOM";
     case PfRule::TRUST_REWRITE: return "TRUST_REWRITE";
+    case PfRule::TRUST_FLATTENING_REWRITE: return "TRUST_FLATTENING_REWRITE";
     case PfRule::TRUST_SUBS: return "TRUST_SUBS";
     case PfRule::TRUST_SUBS_MAP: return "TRUST_SUBS_MAP";
     case PfRule::TRUST_SUBS_EQ: return "TRUST_SUBS_EQ";

--- a/src/proof/proof_rule.h
+++ b/src/proof/proof_rule.h
@@ -368,6 +368,18 @@ enum class PfRule : uint32_t
   TRUST_REWRITE,
   /**
    * \verbatim embed:rst:leading-asterisk
+   * **Trusted rules -- Non-supported flattening rewrite **
+   *
+   * .. math::
+   *   \inferrule{- \mid F}{F}
+   *
+   * where :math:`F` is an equality `t = t'` where both `t` and `t'` are
+   * applications of associative operators but the rewriter does not support
+   * flattening them to the same normal form. \endverbatim
+   */
+  TRUST_FLATTENING_REWRITE,
+  /**
+   * \verbatim embed:rst:leading-asterisk
    * **Trusted rules -- Non-replayable substitution**
    *
    * .. math::

--- a/src/theory/builtin/proof_checker.cpp
+++ b/src/theory/builtin/proof_checker.cpp
@@ -57,6 +57,7 @@ void BuiltinProofRuleChecker::registerTo(ProofChecker* pc)
   pc->registerTrustedChecker(PfRule::THEORY_EXPAND_DEF, this, 3);
   pc->registerTrustedChecker(PfRule::WITNESS_AXIOM, this, 3);
   pc->registerTrustedChecker(PfRule::TRUST_REWRITE, this, 1);
+  pc->registerTrustedChecker(PfRule::TRUST_FLATTENING_REWRITE, this, 1);
   pc->registerTrustedChecker(PfRule::TRUST_SUBS, this, 1);
   pc->registerTrustedChecker(PfRule::TRUST_SUBS_MAP, this, 1);
   pc->registerTrustedChecker(PfRule::TRUST_SUBS_EQ, this, 3);
@@ -386,6 +387,7 @@ Node BuiltinProofRuleChecker::checkInternal(PfRule id,
            || id == PfRule::THEORY_PREPROCESS_LEMMA
            || id == PfRule::THEORY_EXPAND_DEF || id == PfRule::WITNESS_AXIOM
            || id == PfRule::THEORY_LEMMA || id == PfRule::THEORY_REWRITE
+           || id == PfRule::TRUST_FLATTENING_REWRITE
            || id == PfRule::TRUST_REWRITE || id == PfRule::TRUST_SUBS
            || id == PfRule::TRUST_SUBS_MAP || id == PfRule::TRUST_SUBS_EQ
            || id == PfRule::THEORY_INFERENCE)

--- a/src/theory/uf/eq_proof.cpp
+++ b/src/theory/uf/eq_proof.cpp
@@ -1463,7 +1463,7 @@ Node EqProof::addToProof(CDProof* p,
         PfRule::MACRO_SR_PRED_TRANSFORM,
         {conclusion},
         {d_node},
-        d_node,
+        Node::null(),
         "eqproof-conv");
     if (res.isNull())
     {

--- a/src/theory/uf/eq_proof.cpp
+++ b/src/theory/uf/eq_proof.cpp
@@ -1466,12 +1466,12 @@ Node EqProof::addToProof(CDProof* p,
         Node::null(),
         "eqproof-conv");
     // If rewriting was not able to flatten the rebuilt conclusion into the
-    // original one, we give up and use a TRUST_REWRITE step, generating a proof
-    // for the original conclusion d_node such as
+    // original one, we give up and use a TRUST_FLATTENING_REWRITE step,
+    // generating a proof for the original conclusion d_node such as
     //
     //     Converted EqProof
-    //  ----------------------         ----------------------- TRUST_REWRITE
-    //     conclusion                    conclusion = d_node
+    //  ----------------------      ------------------- TRUST_FLATTENING_REWRITE
+    //     conclusion               conclusion = d_node
     // ------------------------------------------------------- EQ_RESOLVE
     //                       d_node
     //
@@ -1480,10 +1480,10 @@ Node EqProof::addToProof(CDProof* p,
     if (res.isNull())
     {
       Trace("eqproof-conv")
-          << "EqProof::addToProof: adding a trust rewrite step\n";
+          << "EqProof::addToProof: adding a trust flattening rewrite step\n";
       Node bridgeEq = conclusion.eqNode(d_node);
       p->addStep(bridgeEq,
-                 PfRule::TRUST_REWRITE,
+                 PfRule::TRUST_FLATTENING_REWRITE,
                  {},
                  {bridgeEq});
       p->addStep(d_node,

--- a/src/theory/uf/eq_proof.cpp
+++ b/src/theory/uf/eq_proof.cpp
@@ -1455,9 +1455,9 @@ Node EqProof::addToProof(CDProof* p,
   // rewriting
   if (!CDProof::isSame(conclusion, d_node))
   {
-    Trace("eqproof-conv") << "EqProof::addToProof: add "
+    Trace("eqproof-conv") << "EqProof::addToProof: try to flatten via a"
                           << PfRule::MACRO_SR_PRED_TRANSFORM
-                          << " step to flatten rebuilt conclusion "
+                          << " step the rebuilt conclusion "
                           << conclusion << " into " << d_node << "\n";
     Node res = p->getManager()->getChecker()->checkDebug(
         PfRule::MACRO_SR_PRED_TRANSFORM,
@@ -1465,6 +1465,18 @@ Node EqProof::addToProof(CDProof* p,
         {d_node},
         Node::null(),
         "eqproof-conv");
+    // If rewriting was not able to flatten the rebuilt conclusion into the
+    // original one, we give up and use a TRUST_REWRITE step, generating a proof
+    // for the original conclusion d_node such as
+    //
+    //     Converted EqProof
+    //  ----------------------         ----------------------- TRUST_REWRITE
+    //     conclusion                    conclusion = d_node
+    // ------------------------------------------------------- EQ_RESOLVE
+    //                       d_node
+    //
+    //
+    //  If rewriting was able to do it, however, we just add the macro step.
     if (res.isNull())
     {
       Trace("eqproof-conv")

--- a/src/theory/uf/eq_proof.h
+++ b/src/theory/uf/eq_proof.h
@@ -246,7 +246,7 @@ class EqProof
   bool buildTransitivityChain(Node conclusion,
                               std::vector<Node>& premises) const;
 
-  /** Reduce the a congruence EqProof into a transitivity matrix
+  /** Reduce a congruence EqProof into a transitivity matrix
    *
    * Given a congruence EqProof of (= (f a0 ... an-1) (f b0 ... bn-1)), reduce
    * its justification into a matrix
@@ -298,25 +298,26 @@ class EqProof
    *
    * where when the first child of CONG is a transitivity step
    * - the premises that are CONG steps are recursively reduced with *the same*
-       argument i
+   *   argument i
    * - the other premises are processed with addToProof and added to the i row
    *   in the matrix
    *
-   * In the above example the to which the transitivity matrix is
+   * In the above example the corresponding transitivity matrix is
    *   [0] -> (= a0 c), (= b0 c)
    *   [1] -> (= a1 b1)
    *
-   * The remaining complication is that when conclusion is an equality of n-ary
-   * applications of *different* arities, there is, necessarily, a transitivity
-   * step as a first child a CONG step whose conclusion is an equality of n-ary
-   * applications of different arities. For example
+   * The remaining complication is when the conclusion is an equality of n-ary
+   * applications of *different* arities. Then there necessarily is a
+   * transitivity step as a first child a CONG step whose conclusion is an
+   * equality of n-ary applications of different arities. For example
+   *
    *             P0                              P1
    * -------------------------- EQP::TRANS  -----------
    *     (= (f a0 a1) (f b0))                (= a2 b1)
    * -------------------------------------------------- EQP::CONG
    *              (= (f a0 a1 a2) (f b0 b1))
    *
-   * will be first reduced with i = 2 (maximal arity amorg the original
+   * will be first reduced with i = 2 (maximal arity among the original
    * conclusion's applications), adding (= a2 b1) to row 2 after processing
    * P1. The first child is reduced with i = 1. Since it is a TRANS step whose
    * conclusion is an equality of n-ary applications with mismatching arity, P0

--- a/src/theory/uf/equality_engine.cpp
+++ b/src/theory/uf/equality_engine.cpp
@@ -1088,7 +1088,10 @@ void EqualityEngine::buildEqConclusion(EqualityNodeId id1,
   if (!eq[0].isNull() && !eq[1].isNull())
   {
     eqp->d_node = eq[0].eqNode(eq[1]);
+    Trace("equality") << "buildEqConclusion: Built equality " << eqp->d_node << "\n";
+    return;
   }
+  Trace("equality") << "buildEqConclusion: Did not build equality\n";
 }
 
 void EqualityEngine::explainEquality(TNode t1, TNode t2, bool polarity,

--- a/src/theory/uf/equality_engine.h
+++ b/src/theory/uf/equality_engine.h
@@ -416,7 +416,7 @@ class EqualityEngine : public context::ContextNotifyObj, protected EnvObj
   /** Are we in propagate */
   bool d_inPropagate;
 
-  /** Proof-new specific construction of equality conclusions for EqProofs
+  /** Construction of equality conclusions for EqProofs
    *
    * Given two equality node ids, build an equality between the nodes they
    * correspond to and add it as a conclusion to the given EqProof.

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1033,6 +1033,7 @@ set(regress_0_tests
   regress0/proofs/issue277-circuit-propagator.smt2
   regress0/proofs/issue8983-trust-subs.smt2
   regress0/proofs/issue9200-lfsc-inst-sorts.smt2
+  regress0/proofs/issue9205-eqProofNary.smt2
   regress0/proofs/lfsc-test-1.smt2
   regress0/proofs/nomerge-alethe-pf.smt2
   regress0/proofs/open-pf-datatypes.smt2
@@ -2821,7 +2822,7 @@ set(regress_1_tests
   regress1/strings/str006.smt2
   regress1/strings/str007.smt2
   regress1/strings/string-unsound-sem.smt2
-  regress1/strings/strings-code-elim-min.smt2 
+  regress1/strings/strings-code-elim-min.smt2
   regress1/strings/strings-index-empty.smt2
   regress1/strings/strings-leq-trans-unsat.smt2
   regress1/strings/strings-lt-len5.smt2

--- a/test/regress/cli/regress0/proofs/issue9205-eqProofNary.smt2
+++ b/test/regress/cli/regress0/proofs/issue9205-eqProofNary.smt2
@@ -1,0 +1,12 @@
+; EXPECT: unsat
+(set-logic QF_UFBVLIA)
+(declare-fun to (Int) Bool)
+(declare-fun top (Int) (_ BitVec 32))
+(declare-fun t (Int) Bool)
+(declare-fun p (Int) (_ BitVec 32))
+(declare-fun p. (Int) (_ BitVec 32))
+(declare-fun op. (Int) (_ BitVec 32))
+(declare-fun op (Int) (_ BitVec 32))
+(declare-fun o (Int) (_ BitVec 32))
+(assert (and (to 1) (not (t 1)) (= (op 1) (op 0)) (= (op. 1) (op. 0)) (= (p. 1) (p. 0)) (= (p 0) (bvadd (bvadd (p. 0) (op. 0)) (op 0) (o 0))) (= (top 1) (bvadd (bvadd (p. 1) (op. 1)) (op 1) (o 1))) (= (o 1) (ite (to 1) (o 0) (bvadd (o 0) (op 0)))) (= (t 1) (= (p 0) (bvadd (bvadd (p. 1) (op. 1)) (op 1) (o 1))))))
+(check-sat)


### PR DESCRIPTION
Since the equality engine reasons modulo AC for n-ary kinds, the EqProof conversion into ProofNode must account for this implicit reasoning. One of the things it relies on is that via rewriting it'll be able to convert an equality such as 
  `(= (f (f t1 t2 t3) t4) (f (f t5 t6) t7))`
into
  `(= (f t1 t2 t3 t4) (f t5 t6 t7))`

However whether the rewriter will always be able to do so depends on the theory: the strings one can, the BV one not.

This commit makes the conversion robust to this issue by testing whether the rewriter would get it and otherwise adding a TRUST_REWRITE step.

Fixes #9205