### PR TITLE
Fix mkmetakind script for spurious replacements in bash >=5.2

### DIFF
--- a/src/expr/mkexpr
+++ b/src/expr/mkexpr
@@ -14,6 +14,9 @@
 #
 # Output is to standard out.
 #
+# Required to disable this option for bash >=5.2 to avoid automatically
+# replacing & by the substituted text.
+shopt -u patsub_replacement
 
 copyright=2010-2022
 

--- a/src/expr/mkkind
+++ b/src/expr/mkkind
@@ -13,6 +13,9 @@
 #
 # Output is to standard out.
 #
+# Required to disable this option for bash >=5.2 to avoid automatically
+# replacing & by the substituted text.
+shopt -u patsub_replacement
 
 copyright=2010-2022
 

--- a/src/expr/mkmetakind
+++ b/src/expr/mkmetakind
@@ -16,6 +16,8 @@
 #
 # Output is to standard out.
 #
+# Required to disable this option for bash >=5.2 to avoid automatically
+# replacing & by the substituted text.
 shopt -u patsub_replacement
 
 copyright=2010-2022

--- a/src/expr/mkmetakind
+++ b/src/expr/mkmetakind
@@ -264,7 +264,7 @@ $2 ${class};"
 #pragma GCC diagnostic ignored \"-Wstrict-aliasing\"
 
 template <>
-${class} const& NodeValue::getConst< ${class} >() const {
+${class} const\& NodeValue::getConst< ${class} >() const {
   //AssertArgument(getKind() == ::cvc5::internal::kind::$1, *this,
   //               \"Improper kind for getConst<${class}>()\");
   // To support non-inlined CONSTANT-kinded NodeValues (those that are
@@ -284,20 +284,20 @@ ${class} const& NodeValue::getConst< ${class} >() const {
   if [ "${skip_const_map}" != true ]; then
     metakind_mkConst="${metakind_mkConst}
 template<>
-Node NodeManager::mkConst<${class}>(const ${class}& val)
+Node NodeManager::mkConst<${class}>(const ${class}\& val)
 {
   return mkConstInternal<Node, ${class}>(::cvc5::internal::kind::$1, val);
 }
 
 template<>
-TypeNode NodeManager::mkTypeConst<${class}>(const ${class}& val)
+TypeNode NodeManager::mkTypeConst<${class}>(const ${class}\& val)
 {
   return mkConstInternal<TypeNode, ${class}>(::cvc5::internal::kind::$1, val);
 }
 "
     metakind_mkConst="${metakind_mkConst}
 template<>
-Node NodeManager::mkConst(Kind k, const ${class}& val)
+Node NodeManager::mkConst(Kind k, const ${class}\& val)
 {
   return mkConstInternal<Node, ${class}>(k, val);
 }
@@ -305,11 +305,11 @@ Node NodeManager::mkConst(Kind k, const ${class}& val)
   elif [[ "${payload_seen}" != true ]]; then
     metakind_mkConstDelete="${metakind_mkConstDelete}
 template<>
-Node NodeManager::mkConst<${class}>(const ${class}& val) = delete;
+Node NodeManager::mkConst<${class}>(const ${class}\& val) = delete;
 "
     metakind_mkConst="${metakind_mkConst}
 template<>
-Node NodeManager::mkConst(Kind k, const ${class}& val)
+Node NodeManager::mkConst(Kind k, const ${class}\& val)
 {
   return mkConstInternal<Node, ${class}>(k, val);
 }

--- a/src/expr/mkmetakind
+++ b/src/expr/mkmetakind
@@ -16,6 +16,7 @@
 #
 # Output is to standard out.
 #
+shopt -u patsub_replacement
 
 copyright=2010-2022
 
@@ -264,7 +265,7 @@ $2 ${class};"
 #pragma GCC diagnostic ignored \"-Wstrict-aliasing\"
 
 template <>
-${class} const\& NodeValue::getConst< ${class} >() const {
+${class} const& NodeValue::getConst< ${class} >() const {
   //AssertArgument(getKind() == ::cvc5::internal::kind::$1, *this,
   //               \"Improper kind for getConst<${class}>()\");
   // To support non-inlined CONSTANT-kinded NodeValues (those that are
@@ -284,20 +285,20 @@ ${class} const\& NodeValue::getConst< ${class} >() const {
   if [ "${skip_const_map}" != true ]; then
     metakind_mkConst="${metakind_mkConst}
 template<>
-Node NodeManager::mkConst<${class}>(const ${class}\& val)
+Node NodeManager::mkConst<${class}>(const ${class}& val)
 {
   return mkConstInternal<Node, ${class}>(::cvc5::internal::kind::$1, val);
 }
 
 template<>
-TypeNode NodeManager::mkTypeConst<${class}>(const ${class}\& val)
+TypeNode NodeManager::mkTypeConst<${class}>(const ${class}& val)
 {
   return mkConstInternal<TypeNode, ${class}>(::cvc5::internal::kind::$1, val);
 }
 "
     metakind_mkConst="${metakind_mkConst}
 template<>
-Node NodeManager::mkConst(Kind k, const ${class}\& val)
+Node NodeManager::mkConst(Kind k, const ${class}& val)
 {
   return mkConstInternal<Node, ${class}>(k, val);
 }
@@ -305,11 +306,11 @@ Node NodeManager::mkConst(Kind k, const ${class}\& val)
   elif [[ "${payload_seen}" != true ]]; then
     metakind_mkConstDelete="${metakind_mkConstDelete}
 template<>
-Node NodeManager::mkConst<${class}>(const ${class}\& val) = delete;
+Node NodeManager::mkConst<${class}>(const ${class}& val) = delete;
 "
     metakind_mkConst="${metakind_mkConst}
 template<>
-Node NodeManager::mkConst(Kind k, const ${class}\& val)
+Node NodeManager::mkConst(Kind k, const ${class}& val)
 {
   return mkConstInternal<Node, ${class}>(k, val);
 }


### PR DESCRIPTION
Fixes my local build for bash >=5.2, which has a distinguished meaning for `&` in text replacement.  See `patsub_replacement` in https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00012.html.