### PR TITLE
Use separate subsolver for synthesizing rewrite rules from input

### DIFF
--- a/src/preprocessing/passes/synth_rew_rules.cpp
+++ b/src/preprocessing/passes/synth_rew_rules.cpp
@@ -26,7 +26,6 @@
 #include "preprocessing/assertion_pipeline.h"
 #include "printer/printer.h"
 #include "printer/smt2/smt2_printer.h"
-#include "smt/logic_exception.h"
 #include "smt/set_defaults.h"
 #include "theory/quantifiers/candidate_rewrite_database.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
@@ -501,7 +500,7 @@ PreprocessingPassResult SynthRewRulesPass::applyInternal(
   // Note that typically the above call will be non-terminating, as it will
   // enumerate rewrite rules ad infinitum, but it is possible to reach this
   // line if a finite grammar is inferred above.
-  throw LogicException("Finished synthesizing rewrite rules.");
+  throw Exception("Finished synthesizing rewrite rules.");
 
   return PreprocessingPassResult::NO_CONFLICT;
 }

--- a/src/preprocessing/passes/synth_rew_rules.cpp
+++ b/src/preprocessing/passes/synth_rew_rules.cpp
@@ -21,15 +21,19 @@
 #include "expr/sygus_datatype.h"
 #include "expr/term_canonize.h"
 #include "options/base_options.h"
+#include "options/datatypes_options.h"
 #include "options/quantifiers_options.h"
 #include "preprocessing/assertion_pipeline.h"
 #include "printer/printer.h"
 #include "printer/smt2/smt2_printer.h"
+#include "smt/logic_exception.h"
+#include "smt/set_defaults.h"
 #include "theory/quantifiers/candidate_rewrite_database.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
 #include "theory/quantifiers/sygus/sygus_grammar_cons.h"
 #include "theory/quantifiers/sygus/sygus_utils.h"
 #include "theory/quantifiers/term_util.h"
+#include "theory/smt_engine_subsolver.h"
 
 using namespace std;
 using namespace cvc5::internal::kind;
@@ -476,11 +480,28 @@ PreprocessingPassResult SynthRewRulesPass::applyInternal(
   Trace("srs-input") << "got : " << res << std::endl;
   Trace("srs-input") << "...finished." << std::endl;
 
-  assertionsToPreprocess->replace(0, res);
-  for (unsigned i = 1, size = assertionsToPreprocess->size(); i < size; ++i)
+  // use a separate subsolver
+  Options subOptions;
+  subOptions.copyValues(d_env.getOptions());
+  subOptions.writeQuantifiers().sygus = true;
+  subOptions.writeQuantifiers().sygusRewSynthInput = false;
+  subOptions.writeQuantifiers().sygusRewSynth = true;
+  // we should not use the extended rewriter, since we are interested
+  // in rewrites that are not in the main rewriter
+  if (!subOptions.datatypes.sygusRewriterWasSetByUser)
   {
-    assertionsToPreprocess->replace(i, trueNode);
+    subOptions.writeDatatypes().sygusRewriter =
+        options::SygusRewriterMode::BASIC;
   }
+  smt::SetDefaults::disableChecking(subOptions);
+  theory::SubsolverSetupInfo ssi(d_env, subOptions);
+  theory::checkWithSubsolver(res, ssi);
+
+  // If we terminate the above check, then we throw a logic exception now.
+  // Note that typically the above call will be non-terminating, as it will
+  // enumerate rewrite rules ad infinitum, but it is possible to reach this
+  // line if a finite grammar is inferred above.
+  throw LogicException("Finished synthesizing rewrite rules.");
 
   return PreprocessingPassResult::NO_CONFLICT;
 }

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -888,8 +888,7 @@ bool SetDefaults::isSygus(const Options& opts) const
   if (!d_isInternalSubsolver)
   {
     if (opts.smt.produceAbducts || opts.smt.produceInterpolants
-        || opts.quantifiers.sygusInference
-        || opts.quantifiers.sygusRewSynthInput)
+        || opts.quantifiers.sygusInference)
     {
       // since we are trying to recast as sygus, we assume the input is sygus
       return true;
@@ -1650,19 +1649,6 @@ void SetDefaults::setDefaultsSygus(Options& opts) const
   {
     // should use full effort cbqi for single invocation and repair const
     opts.writeQuantifiers().cegqiFullEffort = true;
-  }
-  if (opts.quantifiers.sygusRewSynthInput)
-  {
-    // If we are using synthesis rewrite rules from input, we use
-    // sygusRewSynth after preprocessing. See passes/synth_rew_rules.h for
-    // details on this technique.
-    opts.writeQuantifiers().sygusRewSynth = true;
-    // we should not use the extended rewriter, since we are interested
-    // in rewrites that are not in the main rewriter
-    if (!opts.datatypes.sygusRewriterWasSetByUser)
-    {
-      opts.writeDatatypes().sygusRewriter = options::SygusRewriterMode::BASIC;
-    }
   }
   // Whether we must use "basic" sygus algorithms. A non-basic sygus algorithm
   // is one that is specialized for returning a single solution. Non-basic

--- a/test/api/cpp/proj-issue445.cpp
+++ b/test/api/cpp/proj-issue445.cpp
@@ -37,5 +37,13 @@ int main(void)
   Term t279 = slv.mkTerm(Kind::SEQ_REPLACE_ALL, {t141, t229, t141});
   Term t289 = slv.mkTerm(Kind::SEQ_PREFIX, {t279, t229});
   slv.assertFormula({t289});
-  (void)slv.simplify(t7);
+  try
+  {
+    (void)slv.simplify(t7);
+  }
+  catch (const CVC5ApiException& e)
+  {
+    // currently simplify triggers rewrite rule synthesis which terminates
+    // with an exception
+  }
 }

--- a/test/api/cpp/proj-issue445.cpp
+++ b/test/api/cpp/proj-issue445.cpp
@@ -25,7 +25,7 @@ int main(void)
   Solver slv;
   slv.setOption("sygus-rr-synth-input", "true");
   slv.setOption("strings-exp", "true");
-  slv.setOption("tlimit", "100");
+  slv.setOption("sygus-abort-size", "1");
   Sort s1 = slv.mkUninterpretedSort("_u0");
   Sort s5 = slv.mkUninterpretedSort("_u1");
   Sort s6 = slv.mkUninterpretedSort("_u2");

--- a/test/api/cpp/proj-issue445.cpp
+++ b/test/api/cpp/proj-issue445.cpp
@@ -39,11 +39,7 @@ int main(void)
   Term t279 = slv.mkTerm(Kind::SEQ_REPLACE_ALL, {t141, t229, t141});
   Term t289 = slv.mkTerm(Kind::SEQ_PREFIX, {t279, t229});
   slv.assertFormula({t289});
-  try
-  {
-    (void)slv.simplify(t7);
-  }
-  catch (cvc5::CVC5ApiException& e)
-  {
-  }
+  // should terminate with an exception indicating we are done enumerating
+  // rewrite rules.
+  ASSERT_THROW((void)slv.simplify(t7));
 }

--- a/test/api/cpp/proj-issue445.cpp
+++ b/test/api/cpp/proj-issue445.cpp
@@ -25,7 +25,7 @@ int main(void)
   Solver slv;
   slv.setOption("sygus-rr-synth-input", "true");
   slv.setOption("strings-exp", "true");
-  slv.setOption("tlimit", 100);
+  slv.setOption("tlimit", "100");
   Sort s1 = slv.mkUninterpretedSort("_u0");
   Sort s5 = slv.mkUninterpretedSort("_u1");
   Sort s6 = slv.mkUninterpretedSort("_u2");

--- a/test/api/cpp/proj-issue445.cpp
+++ b/test/api/cpp/proj-issue445.cpp
@@ -39,5 +39,11 @@ int main(void)
   Term t279 = slv.mkTerm(Kind::SEQ_REPLACE_ALL, {t141, t229, t141});
   Term t289 = slv.mkTerm(Kind::SEQ_PREFIX, {t279, t229});
   slv.assertFormula({t289});
-  (void)slv.simplify(t7);
+  try
+  {
+    (void)slv.simplify(t7);
+  }
+  catch (cvc5::CVC5ApiException& e)
+  {
+  }
 }

--- a/test/api/cpp/proj-issue445.cpp
+++ b/test/api/cpp/proj-issue445.cpp
@@ -24,6 +24,8 @@ int main(void)
 {
   Solver slv;
   slv.setOption("sygus-rr-synth-input", "true");
+  slv.setOption("strings-exp", "true");
+  slv.setOption("tlimit", 100);
   Sort s1 = slv.mkUninterpretedSort("_u0");
   Sort s5 = slv.mkUninterpretedSort("_u1");
   Sort s6 = slv.mkUninterpretedSort("_u2");
@@ -37,13 +39,5 @@ int main(void)
   Term t279 = slv.mkTerm(Kind::SEQ_REPLACE_ALL, {t141, t229, t141});
   Term t289 = slv.mkTerm(Kind::SEQ_PREFIX, {t279, t229});
   slv.assertFormula({t289});
-  try
-  {
-    (void)slv.simplify(t7);
-  }
-  catch (const CVC5ApiException& e)
-  {
-    // currently simplify triggers rewrite rule synthesis which terminates
-    // with an exception
-  }
+  (void)slv.simplify(t7);
 }

--- a/test/api/cpp/proj-issue445.cpp
+++ b/test/api/cpp/proj-issue445.cpp
@@ -41,5 +41,11 @@ int main(void)
   slv.assertFormula({t289});
   // should terminate with an exception indicating we are done enumerating
   // rewrite rules.
-  ASSERT_THROW((void)slv.simplify(t7));
+  try
+  {
+    (void)slv.simplify(t7);
+  }
+  catch (cvc5::CVC5ApiException& e)
+  {
+  }
 }

--- a/test/regress/cli/regress1/sygus/issue8956-2.smt2
+++ b/test/regress/cli/regress1/sygus/issue8956-2.smt2
@@ -1,6 +1,8 @@
 ; COMMAND-LINE: --sygus-rr-synth-input --tlimit-per=500 --check-models
 ; SCRUBBER: grep -v -E '\('
-; EXPECT: unknown
+; EXIT: 1
+; In this example, a finite grammar is inferred as the set of possible terms in rewrites.
+; We terminate with an exception to indicate that the rewrite rule synthesis finished.
 (set-logic QF_S)
 (declare-fun s () String)
 (declare-fun i () String)

--- a/test/unit/api/cpp/solver_black.cpp
+++ b/test/unit/api/cpp/solver_black.cpp
@@ -3378,7 +3378,7 @@ TEST_F(TestApiBlackSolver, proj_issue422)
   Term t300 = slv.mkTerm(Kind::BITVECTOR_SLT, {t276, t276});
   Term t301 = slv.mkTerm(Kind::EQUAL, {t288, t300});
   slv.assertFormula({t301});
-  slv.push(4);
+  ASSERT_THROW(slv.push(4), CVC5ApiException);
 }
 
 TEST_F(TestApiBlackSolver, proj_issue423)

--- a/test/unit/api/cpp/solver_black.cpp
+++ b/test/unit/api/cpp/solver_black.cpp
@@ -3378,6 +3378,8 @@ TEST_F(TestApiBlackSolver, proj_issue422)
   Term t300 = slv.mkTerm(Kind::BITVECTOR_SLT, {t276, t276});
   Term t301 = slv.mkTerm(Kind::EQUAL, {t288, t300});
   slv.assertFormula({t301});
+  // should terminate with an exception indicating we are done enumerating
+  // rewrite rules.
   ASSERT_THROW(slv.push(4), CVC5ApiException);
 }
 

--- a/test/unit/api/cpp/solver_black.cpp
+++ b/test/unit/api/cpp/solver_black.cpp
@@ -3346,6 +3346,8 @@ TEST_F(TestApiBlackSolver, proj_issue422)
 {
   Solver slv;
   slv.setOption("sygus-rr-synth-input", "true");
+  slv.setOption("strings-exp", "true");
+  slv.setOption("sygus-abort-size", "1");
   Sort s1 = slv.mkBitVectorSort(36);
   Sort s2 = slv.getStringSort();
   Term t1 = slv.mkConst(s2, "_x0");


### PR DESCRIPTION
This experimental option causes cvc5 to synthesize rewrite rules based on the input. The code for this is a preprocessing pass which used to rewrite the input to a sygus conjecture. This is confusing since it changes the semantics of the input. We now call a separate subsolver.

This also cleans up set defaults. The options required for synthesizing rewrite rules are now applied locally to the subsolver spawned by the preprocessing pass.

We now terminate with an exception in the rare case when rewrite rule synthesis terminates.

This is required for further enhancements to the sygus solver for answering `infeasible`.