### PR TITLE
[proof] [prop] Cache prop proof per check-sat

### DIFF
--- a/src/prop/prop_proof_manager.cpp
+++ b/src/prop/prop_proof_manager.cpp
@@ -29,6 +29,8 @@ PropPfManager::PropPfManager(Env& env,
                              CDCLTSatSolverInterface* satSolver,
                              ProofCnfStream* cnfProof)
     : EnvObj(env),
+      d_satSkoletonProofNode(userContext),
+      d_fullPropProofNode(userContext),
       d_pfpp(new ProofPostprocess(env, cnfProof)),
       d_satSolver(satSolver),
       d_assertions(userContext),
@@ -98,6 +100,14 @@ std::vector<std::shared_ptr<ProofNode>> PropPfManager::getProofLeaves(
 
 std::shared_ptr<ProofNode> PropPfManager::getProof(bool connectCnf)
 {
+  if (connectCnf && d_fullPropProofNode.get())
+  {
+    return d_fullPropProofNode.get();
+  }
+  if (!connectCnf && d_satSkoletonProofNode.get())
+  {
+    return d_satSkoletonProofNode.get();
+  }
   // retrieve the SAT solver's refutation proof
   Trace("sat-proof")
       << "PropPfManager::getProof: Getting resolution proof of false\n";
@@ -120,6 +130,7 @@ std::shared_ptr<ProofNode> PropPfManager::getProof(bool connectCnf)
   }
   if (!connectCnf)
   {
+    d_satSkoletonProofNode = conflictProof;
     return conflictProof;
   }
   // connect it with CNF proof
@@ -142,6 +153,7 @@ std::shared_ptr<ProofNode> PropPfManager::getProof(bool connectCnf)
     Trace("sat-proof-debug")
         << "PropPfManager::getProof: proof is " << *conflictProof.get() << "\n";
   }
+  d_fullPropProofNode = conflictProof;
   return conflictProof;
 }
 

--- a/src/prop/prop_proof_manager.cpp
+++ b/src/prop/prop_proof_manager.cpp
@@ -29,8 +29,7 @@ PropPfManager::PropPfManager(Env& env,
                              CDCLTSatSolverInterface* satSolver,
                              ProofCnfStream* cnfProof)
     : EnvObj(env),
-      d_satSkoletonProofNode(userContext),
-      d_fullPropProofNode(userContext),
+      d_propProofs(userContext),
       d_pfpp(new ProofPostprocess(env, cnfProof)),
       d_satSolver(satSolver),
       d_assertions(userContext),
@@ -100,13 +99,10 @@ std::vector<std::shared_ptr<ProofNode>> PropPfManager::getProofLeaves(
 
 std::shared_ptr<ProofNode> PropPfManager::getProof(bool connectCnf)
 {
-  if (connectCnf && d_fullPropProofNode.get())
+  auto it = d_propProofs.find(connectCnf);
+  if (it != d_propProofs.end())
   {
-    return d_fullPropProofNode.get();
-  }
-  if (!connectCnf && d_satSkoletonProofNode.get())
-  {
-    return d_satSkoletonProofNode.get();
+    return it->second;
   }
   // retrieve the SAT solver's refutation proof
   Trace("sat-proof")
@@ -130,7 +126,7 @@ std::shared_ptr<ProofNode> PropPfManager::getProof(bool connectCnf)
   }
   if (!connectCnf)
   {
-    d_satSkoletonProofNode = conflictProof;
+    d_propProofs[connectCnf] = conflictProof;
     return conflictProof;
   }
   // connect it with CNF proof
@@ -153,7 +149,7 @@ std::shared_ptr<ProofNode> PropPfManager::getProof(bool connectCnf)
     Trace("sat-proof-debug")
         << "PropPfManager::getProof: proof is " << *conflictProof.get() << "\n";
   }
-  d_fullPropProofNode = conflictProof;
+  d_propProofs[connectCnf] = conflictProof;
   return conflictProof;
 }
 

--- a/src/prop/prop_proof_manager.h
+++ b/src/prop/prop_proof_manager.h
@@ -19,7 +19,6 @@
 #define CVC5__PROP_PROOF_MANAGER_H
 
 #include "api/cpp/cvc5_types.h"
-
 #include "context/cdlist.h"
 #include "context/cdo.h"
 #include "proof/proof.h"

--- a/src/prop/prop_proof_manager.h
+++ b/src/prop/prop_proof_manager.h
@@ -21,6 +21,7 @@
 #include "api/cpp/cvc5_types.h"
 
 #include "context/cdlist.h"
+#include "context/cdo.h"
 #include "proof/proof.h"
 #include "proof/proof_node_manager.h"
 #include "prop/proof_post_processor.h"
@@ -92,6 +93,14 @@ class PropPfManager : protected EnvObj
   void checkProof(const context::CDList<Node>& assertions);
 
  private:
+  /** The proofs of this proof manager, which are saved once requested (note the
+   * request may require or not the full proof).
+   *
+   * The proofs are kept in a (user)context-dependent manner because between
+   * satisfiability checks we should discard them.
+   */
+  context::CDO<std::shared_ptr<ProofNode>> d_satSkoletonProofNode;
+  context::CDO<std::shared_ptr<ProofNode>> d_fullPropProofNode;
   /** The proof post-processor */
   std::unique_ptr<prop::ProofPostprocess> d_pfpp;
   /**

--- a/src/prop/prop_proof_manager.h
+++ b/src/prop/prop_proof_manager.h
@@ -93,13 +93,12 @@ class PropPfManager : protected EnvObj
 
  private:
   /** The proofs of this proof manager, which are saved once requested (note the
-   * request may require or not the full proof).
+   * cache is for both the request of the full proof (true) or not (false)).
    *
    * The proofs are kept in a (user)context-dependent manner because between
    * satisfiability checks we should discard them.
    */
-  context::CDO<std::shared_ptr<ProofNode>> d_satSkoletonProofNode;
-  context::CDO<std::shared_ptr<ProofNode>> d_fullPropProofNode;
+  context::CDHashMap<bool, std::shared_ptr<ProofNode>> d_propProofs;
   /** The proof post-processor */
   std::unique_ptr<prop::ProofPostprocess> d_pfpp;
   /**

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1032,6 +1032,7 @@ set(regress_0_tests
   regress0/proofs/cyclic-ucp.smt2
   regress0/proofs/issue277-circuit-propagator.smt2
   regress0/proofs/issue8983-trust-subs.smt2
+  regress0/proofs/issue9156-doublePropProof.smt2
   regress0/proofs/issue9200-lfsc-inst-sorts.smt2
   regress0/proofs/lfsc-test-1.smt2
   regress0/proofs/nomerge-alethe-pf.smt2
@@ -2821,7 +2822,7 @@ set(regress_1_tests
   regress1/strings/str006.smt2
   regress1/strings/str007.smt2
   regress1/strings/string-unsound-sem.smt2
-  regress1/strings/strings-code-elim-min.smt2 
+  regress1/strings/strings-code-elim-min.smt2
   regress1/strings/strings-index-empty.smt2
   regress1/strings/strings-leq-trans-unsat.smt2
   regress1/strings/strings-lt-len5.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1033,6 +1033,7 @@ set(regress_0_tests
   regress0/proofs/issue277-circuit-propagator.smt2
   regress0/proofs/issue8983-trust-subs.smt2
   regress0/proofs/issue9156-doublePropProof.smt2
+  regress0/proofs/issue9172-doublePropProof.smt2
   regress0/proofs/issue9200-lfsc-inst-sorts.smt2
   regress0/proofs/lfsc-test-1.smt2
   regress0/proofs/nomerge-alethe-pf.smt2

--- a/test/regress/cli/regress0/proofs/issue9156-doublePropProof.smt2
+++ b/test/regress/cli/regress0/proofs/issue9156-doublePropProof.smt2
@@ -1,0 +1,7 @@
+; COMMAND-LINE: --strings-exp --check-proofs --check-unsat-cores
+; EXPECT: unsat
+(set-logic QF_SLIA)
+(declare-fun a () String)
+(assert (= (str.len a) 0))
+(assert (str.contains (str.substr a 0 (- 1 0)) "G"))
+(check-sat)

--- a/test/regress/cli/regress0/proofs/issue9172-doublePropProof.smt2
+++ b/test/regress/cli/regress0/proofs/issue9172-doublePropProof.smt2
@@ -1,0 +1,9 @@
+; COMMAND-LINE: --strings-exp --check-proofs --check-unsat-cores
+; EXPECT: unsat
+(set-logic QF_SLIA)
+(declare-fun b () String)
+(assert (> (ite (str.prefixof "-" b) 1 0) 1))
+(assert (ite (str.prefixof "-" b) false (ite (= 0 (str.to_int (str.at b
+            (+ (str.len b) (- 1))))) false true)))
+(assert (= (str.len b) 1))
+(check-sat)


### PR DESCRIPTION
Avoids potential issues when requesting to build the prop engine proof twice in the same check-sat call. This is done by caching the computed proof nodes. Note it's two proof nodes since a prop engine proof may be requested connecting the SAT proof or not to the proofs of its leaves stored in the ProofCnfStream.

Fixes #9156 and its duplicate #9172.
