### PR TITLE
Enable SyGuS grammar tokens when produce-abducts is true

### DIFF
--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -2245,7 +2245,7 @@ ASSUME_TOK : { PARSER_STATE->sygus()}?'assume';
 INV_CONSTRAINT_TOK : { PARSER_STATE->sygus()}?'inv-constraint';
 SET_FEATURE_TOK : { PARSER_STATE->sygus() }? 'set-feature';
 SYGUS_CONSTANT_TOK : { PARSER_STATE->hasGrammars() }? 'Constant';
-SYGUS_VARIABLE_TOK : { PARSER_STATE->hasGrammars() }? 'Variable';
+SYGUS_VARIABLE_TOK : { PARSER_STATE->sygus() }? 'Variable';
 
 // attributes
 ATTRIBUTE_PATTERN_TOK : ':pattern';

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -2244,8 +2244,8 @@ CONSTRAINT_TOK : { PARSER_STATE->sygus()}?'constraint';
 ASSUME_TOK : { PARSER_STATE->sygus()}?'assume';
 INV_CONSTRAINT_TOK : { PARSER_STATE->sygus()}?'inv-constraint';
 SET_FEATURE_TOK : { PARSER_STATE->sygus() }? 'set-feature';
-SYGUS_CONSTANT_TOK : { PARSER_STATE->sygus() }? 'Constant';
-SYGUS_VARIABLE_TOK : { PARSER_STATE->sygus() }? 'Variable';
+SYGUS_CONSTANT_TOK : { PARSER_STATE->hasGrammars() }? 'Constant';
+SYGUS_VARIABLE_TOK : { PARSER_STATE->hasGrammars() }? 'Variable';
 
 // attributes
 ATTRIBUTE_PATTERN_TOK : ':pattern';

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -791,7 +791,7 @@ bool Smt2::sygus() const
 
 bool Smt2::hasGrammars() const
 {
-  return sygus() || d_solver->getOption("produce-abducts");
+  return sygus() || d_solver->getOption("produce-abducts") == "true";
 }
 
 void Smt2::checkThatLogicIsSet()

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -791,7 +791,7 @@ bool Smt2::sygus() const
 
 bool Smt2::hasGrammars() const
 {
-  return sygus() || d_solver->getOption("produce-abducts") == "true";
+  return sygus() || d_solver->getOption("produce-abducts") == "true"  || d_solver->getOption("produce-interpolants") == "true";
 }
 
 void Smt2::checkThatLogicIsSet()

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -791,7 +791,8 @@ bool Smt2::sygus() const
 
 bool Smt2::hasGrammars() const
 {
-  return sygus() || d_solver->getOption("produce-abducts") == "true"  || d_solver->getOption("produce-interpolants") == "true";
+  return sygus() || d_solver->getOption("produce-abducts") == "true"
+         || d_solver->getOption("produce-interpolants") == "true";
 }
 
 void Smt2::checkThatLogicIsSet()

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -789,6 +789,11 @@ bool Smt2::sygus() const
   return d_solver->getOption("input-language") == "LANG_SYGUS_V2";
 }
 
+bool Smt2::hasGrammars() const
+{
+  return sygus() || d_solver->getOption("produce-abducts");
+}
+
 void Smt2::checkThatLogicIsSet()
 {
   if (!logicIsSet())

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -234,7 +234,7 @@ class Smt2 : public Parser
 
   /** Are we using a sygus language? */
   bool sygus() const;
-  
+
   /** Has grammars? */
   bool hasGrammars() const;
 

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -237,8 +237,8 @@ class Smt2 : public Parser
 
   /**
    * Are we using SyGuS grammars? This is true if the input is the SyGuS
-   * language or if produce-abducts is true. Enables grammar-specific tokens
-   * `Constant` and `Variable`.
+   * language or if produce-abducts or produce-interpolants is true. Enables
+   * grammar-specific token `Constant`.
    */
   bool hasGrammars() const;
 

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -234,6 +234,9 @@ class Smt2 : public Parser
 
   /** Are we using a sygus language? */
   bool sygus() const;
+  
+  /** Has grammars? */
+  bool hasGrammars() const;
 
   void checkThatLogicIsSet();
 

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -235,7 +235,11 @@ class Smt2 : public Parser
   /** Are we using a sygus language? */
   bool sygus() const;
 
-  /** Has grammars? */
+  /**
+   * Are we using SyGuS grammars? This is true if the input is the SyGuS
+   * language or if produce-abducts is true. Enables grammar-specific tokens
+   * `Constant` and `Variable`.
+   */
   bool hasGrammars() const;
 
   void checkThatLogicIsSet();

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1784,6 +1784,7 @@ set(regress_1_tests
   regress1/abduction/abd-simple-conj-4.smt2
   regress1/abduction/arjun-global-dec.smt2
   regress1/abduction/arjun-unsat-core-opt.smt2
+  regress1/abduction/constant-in-grammar.smt2
   regress1/abduction/dd.abduct-check-sc.smt2
   regress1/abduction/issue5848-2.smt2
   regress1/abduction/issue5848-3-trivial-no-abduct.smt2

--- a/test/regress/cli/regress1/abduction/constant-in-grammar.smt2
+++ b/test/regress/cli/regress1/abduction/constant-in-grammar.smt2
@@ -1,3 +1,6 @@
+; COMMAND-LINE: --produce-abducts
+; SCRUBBER: grep -v -E '(\(define-fun)'
+; EXIT: 0
 (set-logic ALL)
 (declare-fun x () Int)
 (get-abduct A (> x 0) 

--- a/test/regress/cli/regress1/abduction/constant-in-grammar.smt2
+++ b/test/regress/cli/regress1/abduction/constant-in-grammar.smt2
@@ -1,0 +1,6 @@
+(set-logic ALL)
+(declare-fun x () Int)
+(get-abduct A (> x 0) 
+  ((Start Bool) (StartC Int)) (
+    (Start Bool ((> x StartC))) 
+    (StartC Int ((Constant Int)))))


### PR DESCRIPTION
We currently reject the token `Constant` in grammars for `get-abduct` and `get-interpolant`. This corrects the issue.

FYI @arjunvish 