### PR TITLE
Move ownership of preprocess proof generator to preprocessor

### DIFF
--- a/src/smt/assertions.cpp
+++ b/src/smt/assertions.cpp
@@ -199,10 +199,5 @@ void Assertions::enableProofs(smt::PreprocessProofGenerator* pppg)
   d_assertions.enableProofs(pppg);
 }
 
-bool Assertions::isProofEnabled() const
-{
-  return d_assertions.isProofEnabled();
-}
-
 }  // namespace smt
 }  // namespace cvc5::internal

--- a/src/smt/assertions.h
+++ b/src/smt/assertions.h
@@ -113,8 +113,6 @@ class Assertions : protected EnvObj
    * @param pppg The preprocess proof generator of the proof manager.
    */
   void enableProofs(smt::PreprocessProofGenerator* pppg);
-  /** Is proof enabled? */
-  bool isProofEnabled() const;
   //------------------------------------ end for proofs
  private:
   /**

--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -55,7 +55,7 @@ void Preprocessor::finishInit(TheoryEngine* te, prop::PropEngine* pe)
         d_env, userContext(), "smt::PreprocessProofGenerator");
     d_propagator.enableProofs(userContext(), d_pppg.get());
   }
-  
+
   d_ppContext.reset(new preprocessing::PreprocessingPassContext(
       d_env, te, pe, &d_propagator));
 
@@ -132,7 +132,7 @@ void Preprocessor::applySubstitutions(std::vector<Node>& ns)
   }
 }
 
-PreprocessProofGenerator * Preprocessor::getPreprocessProofGenerator()
+PreprocessProofGenerator* Preprocessor::getPreprocessProofGenerator()
 {
   return d_pppg.get();
 }

--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -70,11 +70,6 @@ bool Preprocessor::process(preprocessing::AssertionPipeline& ap)
     // nothing to do
     return true;
   }
-  // enable proofs if necessary
-  if (d_pppg)
-  {
-    ap.enableProofs(d_pppg.get());
-  }
   if (d_assertionsProcessed && options().base.incrementalSolving)
   {
     // TODO(b/1255): Substitutions in incremental mode should be managed with a

--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -53,7 +53,7 @@ void Preprocessor::finishInit(TheoryEngine* te, prop::PropEngine* pe)
     // now construct preprocess proof generator
     d_pppg = std::make_unique<PreprocessProofGenerator>(
         d_env, userContext(), "smt::PreprocessProofGenerator");
-    d_propagator.enableProofs(userContext(), pppg);
+    d_propagator.enableProofs(userContext(), d_pppg.get());
   }
   
   d_ppContext.reset(new preprocessing::PreprocessingPassContext(

--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -47,10 +47,9 @@ Preprocessor::~Preprocessor() {}
 
 void Preprocessor::finishInit(TheoryEngine* te, prop::PropEngine* pe)
 {
+  // set up the preprocess proof generator, if necessary
   if (options().smt.produceProofs)
   {
-    // set up the preprocess proof generator, if necessary
-    // now construct preprocess proof generator
     d_pppg = std::make_unique<PreprocessProofGenerator>(
         d_env, userContext(), "smt::PreprocessProofGenerator");
     d_propagator.enableProofs(userContext(), d_pppg.get());

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -88,7 +88,7 @@ class Preprocessor : protected EnvObj
   /** Same as above, for a list of assertions, updating in place */
   void applySubstitutions(std::vector<Node>& ns);
   /** Get the preprocess proof generator */
-  PreprocessProofGenerator * getPreprocessProofGenerator();
+  PreprocessProofGenerator* getPreprocessProofGenerator();
 
  private:
   /** The preprocess proof generator. */

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -87,16 +87,12 @@ class Preprocessor : protected EnvObj
   Node applySubstitutions(const Node& n);
   /** Same as above, for a list of assertions, updating in place */
   void applySubstitutions(std::vector<Node>& ns);
-  /**
-   * Enable proofs for this preprocessor. This must be called
-   * explicitly since we construct the preprocessor before we know
-   * whether proofs are enabled.
-   *
-   * @param pppg The preprocess proof generator of the proof manager.
-   */
-  void enableProofs(PreprocessProofGenerator* pppg);
+  /** Get the preprocess proof generator */
+  PreprocessProofGenerator * getPreprocessProofGenerator();
 
  private:
+  /** The preprocess proof generator. */
+  std::unique_ptr<PreprocessProofGenerator> d_pppg;
   /**
    * A circuit propagator for non-clausal propositional deduction.
    */

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -44,12 +44,8 @@ PfManager::PfManager(Env& env)
           static_cast<uint32_t>(options().proof.proofPedantic))),
       d_pnm(new ProofNodeManager(
           env.getOptions(), env.getRewriter(), d_pchecker.get())),
-      d_pppg(nullptr),
       d_pfpp(nullptr)
 {
-  // now construct preprocess proof generator
-  d_pppg = std::make_unique<PreprocessProofGenerator>(
-      env, env.getUserContext(), "smt::PreprocessProofGenerator");
   // Now, initialize the proof postprocessor with the environment.
   // By default the post-processor will update all assumptions, which
   // can lead to SCOPE subproofs of the form
@@ -69,7 +65,6 @@ PfManager::PfManager(Env& env)
   // assumptions (which would disable the update of B1 in this case).
   d_pfpp = std::make_unique<ProofPostprocess>(
       env,
-      d_pppg.get(),
       nullptr,
       options().proof.proofFormatMode != options::ProofFormatMode::ALETHE);
 
@@ -118,8 +113,10 @@ constexpr typename std::vector<T, Alloc>::size_type erase_if(
 }
 
 std::shared_ptr<ProofNode> PfManager::connectProofToAssertions(
-    std::shared_ptr<ProofNode> pfn, Assertions& as, ProofScopeMode scopeMode)
+    std::shared_ptr<ProofNode> pfn, SmtSolver& smt, ProofScopeMode scopeMode)
 {
+  Assertions& as = smt.getAssertions();
+  PreprocessProofGenerator * pppg = smt.getPreprocessor().getPreprocessProofGenerator();
   // Note this assumes that connectProofToAssertions is only called once per
   // unsat response. This method would need to cache its result otherwise.
   Trace("smt-proof")
@@ -161,7 +158,7 @@ std::shared_ptr<ProofNode> PfManager::connectProofToAssertions(
   Trace("smt-proof")
       << "SolverEngine::connectProofToAssertions(): postprocess...\n";
   Assert(d_pfpp != nullptr);
-  d_pfpp->process(pfn);
+  d_pfpp->process(pfn, pppg);
 
   switch (scopeMode)
   {
@@ -272,7 +269,7 @@ void PfManager::printProof(std::ostream& out,
 }
 
 void PfManager::translateDifficultyMap(std::map<Node, Node>& dmap,
-                                       Assertions& as)
+                                       SmtSolver& smt)
 {
   Trace("difficulty-proc") << "Translate difficulty start" << std::endl;
   Trace("difficulty") << "PfManager::translateDifficultyMap" << std::endl;
@@ -301,7 +298,7 @@ void PfManager::translateDifficultyMap(std::map<Node, Node>& dmap,
   cdp.addStep(fnode, PfRule::SAT_REFUTATION, ppAsserts, {});
   std::shared_ptr<ProofNode> pf = cdp.getProofFor(fnode);
   Trace("difficulty-proc") << "Get final proof" << std::endl;
-  std::shared_ptr<ProofNode> fpf = connectProofToAssertions(pf, as);
+  std::shared_ptr<ProofNode> fpf = connectProofToAssertions(pf, smt);
   Trace("difficulty-debug") << "Final proof is " << *fpf.get() << std::endl;
   Assert(fpf->getRule() == PfRule::SCOPE);
   fpf = fpf->getChildren()[0];
@@ -337,11 +334,6 @@ ProofChecker* PfManager::getProofChecker() const { return d_pchecker.get(); }
 ProofNodeManager* PfManager::getProofNodeManager() const { return d_pnm.get(); }
 
 rewriter::RewriteDb* PfManager::getRewriteDatabase() const { return nullptr; }
-
-smt::PreprocessProofGenerator* PfManager::getPreprocessProofGenerator() const
-{
-  return d_pppg.get();
-}
 
 void PfManager::getAssertions(Assertions& as, std::vector<Node>& assertions)
 {

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -32,6 +32,7 @@
 #include "smt/env.h"
 #include "smt/preprocess_proof_generator.h"
 #include "smt/proof_post_processor.h"
+#include "smt/smt_solver.h"
 
 namespace cvc5::internal {
 namespace smt {
@@ -116,7 +117,7 @@ std::shared_ptr<ProofNode> PfManager::connectProofToAssertions(
     std::shared_ptr<ProofNode> pfn, SmtSolver& smt, ProofScopeMode scopeMode)
 {
   Assertions& as = smt.getAssertions();
-  PreprocessProofGenerator * pppg = smt.getPreprocessor().getPreprocessProofGenerator();
+  PreprocessProofGenerator * pppg = smt.getPreprocessor()->getPreprocessProofGenerator();
   // Note this assumes that connectProofToAssertions is only called once per
   // unsat response. This method would need to cache its result otherwise.
   Trace("smt-proof")

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -117,7 +117,8 @@ std::shared_ptr<ProofNode> PfManager::connectProofToAssertions(
     std::shared_ptr<ProofNode> pfn, SmtSolver& smt, ProofScopeMode scopeMode)
 {
   Assertions& as = smt.getAssertions();
-  PreprocessProofGenerator * pppg = smt.getPreprocessor()->getPreprocessProofGenerator();
+  PreprocessProofGenerator* pppg =
+      smt.getPreprocessor()->getPreprocessProofGenerator();
   // Note this assumes that connectProofToAssertions is only called once per
   // unsat response. This method would need to cache its result otherwise.
   Trace("smt-proof")

--- a/src/smt/proof_manager.h
+++ b/src/smt/proof_manager.h
@@ -110,7 +110,8 @@ class PfManager : protected EnvObj
    * assumption is the "source" of an assertion.
    *
    * @param dmap Map estimating the difficulty of preprocessed assertions
-   * @param as The input assertions
+   * @param smt The SMT solver that owns the assertions and the preprocess
+   * proof generator.
    */
   void translateDifficultyMap(std::map<Node, Node>& dmap, SmtSolver& smt);
 

--- a/src/smt/proof_manager.h
+++ b/src/smt/proof_manager.h
@@ -37,6 +37,7 @@ class RewriteDb;
 namespace smt {
 
 class Assertions;
+class SmtSolver;
 class PreprocessProofGenerator;
 class ProofPostprocess;
 

--- a/src/smt/proof_manager.h
+++ b/src/smt/proof_manager.h
@@ -111,7 +111,7 @@ class PfManager : protected EnvObj
    * @param dmap Map estimating the difficulty of preprocessed assertions
    * @param as The input assertions
    */
-  void translateDifficultyMap(std::map<Node, Node>& dmap, Assertions& as);
+  void translateDifficultyMap(std::map<Node, Node>& dmap, SmtSolver& smt);
 
   /**
    * Connect proof to assertions
@@ -126,7 +126,7 @@ class PfManager : protected EnvObj
    */
   std::shared_ptr<ProofNode> connectProofToAssertions(
       std::shared_ptr<ProofNode> pfn,
-      Assertions& as,
+      SmtSolver& smt,
       ProofScopeMode scopeMode = ProofScopeMode::UNIFIED);
   //--------------------------- access to utilities
   /** Get a pointer to the ProofChecker owned by this. */
@@ -135,8 +135,6 @@ class PfManager : protected EnvObj
   ProofNodeManager* getProofNodeManager() const;
   /** Get the rewrite database, containing definitions of rewrites from DSL. */
   rewriter::RewriteDb* getRewriteDatabase() const;
-  /** Get the proof generator for proofs of preprocessing. */
-  smt::PreprocessProofGenerator* getPreprocessProofGenerator() const;
   //--------------------------- end access to utilities
  private:
   /**
@@ -155,8 +153,6 @@ class PfManager : protected EnvObj
   std::unique_ptr<ProofChecker> d_pchecker;
   /** A proof node manager based on the above checker */
   std::unique_ptr<ProofNodeManager> d_pnm;
-  /** The preprocess proof generator. */
-  std::unique_ptr<smt::PreprocessProofGenerator> d_pppg;
   /** The proof post-processor */
   std::unique_ptr<smt::ProofPostprocess> d_pfpp;
 }; /* class SolverEngine */

--- a/src/smt/proof_manager.h
+++ b/src/smt/proof_manager.h
@@ -118,7 +118,8 @@ class PfManager : protected EnvObj
    * Connect proof to assertions
    *
    * Replaces the free assumptions of pfn that correspond to preprocessed
-   * assertions in as with their corresponding proof of preprocessing.
+   * assertions maintained by smt with their corresponding proof of
+   * preprocessing, which is obtained from the preprocessor of smt.
    *
    * Throws an assertion failure if pg cannot provide a closed proof with
    * respect to assertions in as. Note this includes equalities of the form

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -1276,7 +1276,8 @@ ProofPostprocess::ProofPostprocess(Env& env,
 
 ProofPostprocess::~ProofPostprocess() {}
 
-void ProofPostprocess::process(std::shared_ptr<ProofNode> pf, ProofGenerator* pppg)
+void ProofPostprocess::process(std::shared_ptr<ProofNode> pf,
+                               ProofGenerator* pppg)
 {
   // Initialize the callback, which computes necessary static information about
   // how to process, including how to process assumptions in pf.

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -36,19 +36,19 @@ namespace cvc5::internal {
 namespace smt {
 
 ProofPostprocessCallback::ProofPostprocessCallback(Env& env,
-                                                   ProofGenerator* pppg,
                                                    rewriter::RewriteDb* rdb,
                                                    bool updateScopedAssumptions)
     : EnvObj(env),
-      d_pppg(pppg),
+      d_pppg(nullptr),
       d_wfpm(env),
       d_updateScopedAssumptions(updateScopedAssumptions)
 {
   d_true = NodeManager::currentNM()->mkConst(true);
 }
 
-void ProofPostprocessCallback::initializeUpdate()
+void ProofPostprocessCallback::initializeUpdate(ProofGenerator* pppg)
 {
+  d_pppg = pppg;
   d_assumpToProof.clear();
   d_wfAssumptions.clear();
 }
@@ -1263,11 +1263,10 @@ bool ProofPostprocessCallback::addToTransChildren(Node eq,
 }
 
 ProofPostprocess::ProofPostprocess(Env& env,
-                                   ProofGenerator* pppg,
                                    rewriter::RewriteDb* rdb,
                                    bool updateScopedAssumptions)
     : EnvObj(env),
-      d_cb(env, pppg, rdb, updateScopedAssumptions),
+      d_cb(env, rdb, updateScopedAssumptions),
       // the update merges subproofs
       d_updater(env, d_cb, options().proof.proofPpMerge),
       d_finalCb(env),
@@ -1277,11 +1276,11 @@ ProofPostprocess::ProofPostprocess(Env& env,
 
 ProofPostprocess::~ProofPostprocess() {}
 
-void ProofPostprocess::process(std::shared_ptr<ProofNode> pf)
+void ProofPostprocess::process(std::shared_ptr<ProofNode> pf, ProofGenerator* pppg)
 {
   // Initialize the callback, which computes necessary static information about
   // how to process, including how to process assumptions in pf.
-  d_cb.initializeUpdate();
+  d_cb.initializeUpdate(pppg);
   // now, process
   d_updater.process(pf);
   // take stats and check pedantic

--- a/src/smt/proof_post_processor.h
+++ b/src/smt/proof_post_processor.h
@@ -51,6 +51,9 @@ class ProofPostprocessCallback : public ProofNodeUpdaterCallback, protected EnvO
   /**
    * Initialize, called once for each new ProofNode to process. This initializes
    * static information to be used by successive calls to update.
+   * 
+   * @param pppg The proof generator that has proofs of preprocessed assertions
+   * (derived from input assertions).
    */
   void initializeUpdate(ProofGenerator* pppg);
   /**
@@ -247,7 +250,6 @@ class ProofPostprocess : protected EnvObj
  public:
   /**
    * @param env The environment we are using
-   * @param pppg The proof generator for pre-processing proofs
    * @param updateScopedAssumptions Whether we post-process assumptions in
    * scope. Since doing so is sound and only problematic depending on who is
    * consuming the proof, it's true by default.
@@ -256,7 +258,11 @@ class ProofPostprocess : protected EnvObj
                    rewriter::RewriteDb* rdb,
                    bool updateScopedAssumptions = true);
   ~ProofPostprocess();
-  /** post-process */
+  /** post-process 
+   * 
+   * @param pf The proof to process.
+   * @param pppg The proof generator for pre-processing proofs.
+   */
   void process(std::shared_ptr<ProofNode> pf, ProofGenerator* pppg);
   /** set eliminate rule */
   void setEliminateRule(PfRule rule);

--- a/src/smt/proof_post_processor.h
+++ b/src/smt/proof_post_processor.h
@@ -51,7 +51,7 @@ class ProofPostprocessCallback : public ProofNodeUpdaterCallback, protected EnvO
   /**
    * Initialize, called once for each new ProofNode to process. This initializes
    * static information to be used by successive calls to update.
-   * 
+   *
    * @param pppg The proof generator that has proofs of preprocessed assertions
    * (derived from input assertions).
    */
@@ -258,8 +258,8 @@ class ProofPostprocess : protected EnvObj
                    rewriter::RewriteDb* rdb,
                    bool updateScopedAssumptions = true);
   ~ProofPostprocess();
-  /** post-process 
-   * 
+  /** post-process
+   *
    * @param pf The proof to process.
    * @param pppg The proof generator for pre-processing proofs.
    */

--- a/src/smt/proof_post_processor.h
+++ b/src/smt/proof_post_processor.h
@@ -45,7 +45,6 @@ class ProofPostprocessCallback : public ProofNodeUpdaterCallback, protected EnvO
 {
  public:
   ProofPostprocessCallback(Env& env,
-                           ProofGenerator* pppg,
                            rewriter::RewriteDb* rdb,
                            bool updateScopedAssumptions);
   ~ProofPostprocessCallback() {}
@@ -53,7 +52,7 @@ class ProofPostprocessCallback : public ProofNodeUpdaterCallback, protected EnvO
    * Initialize, called once for each new ProofNode to process. This initializes
    * static information to be used by successive calls to update.
    */
-  void initializeUpdate();
+  void initializeUpdate(ProofGenerator* pppg);
   /**
    * Set eliminate rule, which adds rule to the list of rules we will eliminate
    * during update. This adds rule to d_elimRules. Supported rules for
@@ -259,7 +258,7 @@ class ProofPostprocess : protected EnvObj
                    bool updateScopedAssumptions = true);
   ~ProofPostprocess();
   /** post-process */
-  void process(std::shared_ptr<ProofNode> pf);
+  void process(std::shared_ptr<ProofNode> pf, ProofGenerator* pppg);
   /** set eliminate rule */
   void setEliminateRule(PfRule rule);
 

--- a/src/smt/proof_post_processor.h
+++ b/src/smt/proof_post_processor.h
@@ -253,7 +253,6 @@ class ProofPostprocess : protected EnvObj
    * consuming the proof, it's true by default.
    */
   ProofPostprocess(Env& env,
-                   ProofGenerator* pppg,
                    rewriter::RewriteDb* rdb,
                    bool updateScopedAssumptions = true);
   ~ProofPostprocess();

--- a/src/smt/smt_solver.cpp
+++ b/src/smt/smt_solver.cpp
@@ -82,6 +82,11 @@ void SmtSolver::finishInit()
   d_propEngine->finishInit();
 
   d_pp.finishInit(d_theoryEngine.get(), d_propEngine.get());
+  
+  if (options().smt.produceProofs)
+  {
+    d_asserts.enableProofs(d_pp.getPreprocessProofGenerator());
+  }
 }
 
 void SmtSolver::resetAssertions()

--- a/src/smt/smt_solver.cpp
+++ b/src/smt/smt_solver.cpp
@@ -82,7 +82,6 @@ void SmtSolver::finishInit()
   d_propEngine->finishInit();
 
   d_pp.finishInit(d_theoryEngine.get(), d_propEngine.get());
-
   if (options().smt.produceProofs)
   {
     d_asserts.enableProofs(d_pp.getPreprocessProofGenerator());
@@ -104,6 +103,10 @@ void SmtSolver::resetAssertions()
   d_propEngine->finishInit();
   // must reset the preprocessor as well
   d_pp.finishInit(d_theoryEngine.get(), d_propEngine.get());
+  if (options().smt.produceProofs)
+  {
+    d_asserts.enableProofs(d_pp.getPreprocessProofGenerator());
+  }
 }
 
 void SmtSolver::interrupt()

--- a/src/smt/smt_solver.cpp
+++ b/src/smt/smt_solver.cpp
@@ -80,7 +80,6 @@ void SmtSolver::finishInit()
   Trace("smt-debug") << "Finishing init for theory engine..." << std::endl;
   d_theoryEngine->finishInit();
   d_propEngine->finishInit();
-
   d_pp.finishInit(d_theoryEngine.get(), d_propEngine.get());
   if (options().smt.produceProofs)
   {

--- a/src/smt/smt_solver.cpp
+++ b/src/smt/smt_solver.cpp
@@ -82,7 +82,7 @@ void SmtSolver::finishInit()
   d_propEngine->finishInit();
 
   d_pp.finishInit(d_theoryEngine.get(), d_propEngine.get());
-  
+
   if (options().smt.produceProofs)
   {
     d_asserts.enableProofs(d_pp.getPreprocessProofGenerator());

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1567,7 +1567,8 @@ std::string SolverEngine::getProof(modes::ProofComponent c)
     for (std::shared_ptr<ProofNode>& p : ps)
     {
       Assert(p != nullptr);
-      p = d_pfManager->connectProofToAssertions(p, *d_smtSolver.get(), scopeMode);
+      p = d_pfManager->connectProofToAssertions(
+          p, *d_smtSolver.get(), scopeMode);
     }
   }
   // print all proofs

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -173,10 +173,6 @@ void SolverEngine::finishInit()
     PreprocessProofGenerator* pppg = d_pfManager->getPreprocessProofGenerator();
     // start the unsat core manager
     d_ucManager.reset(new UnsatCoreManager());
-    // enable it in the assertions pipeline
-    d_smtSolver->getAssertions().enableProofs(pppg);
-    // enabled proofs in the preprocessor
-    d_smtSolver->getPreprocessor()->enableProofs(pppg);
     pnm = d_pfManager->getProofNodeManager();
   }
   // enable proof support in the environment/rewriter
@@ -1277,8 +1273,7 @@ void SolverEngine::checkProof()
   if (d_env->getOptions().smt.checkProofs)
   {
     // connect proof to assertions, which will fail if the proof is malformed
-    Assertions& as = d_smtSolver->getAssertions();
-    d_pfManager->connectProofToAssertions(pePfn, as);
+    d_pfManager->connectProofToAssertions(pePfn, *d_smtSolver.get());
   }
 }
 
@@ -1315,9 +1310,8 @@ UnsatCore SolverEngine::getUnsatCoreInternal()
   std::shared_ptr<ProofNode> pepf = cdp.getProofFor(fnode);
 
   Assert(pepf != nullptr);
-  Assertions& as = d_smtSolver->getAssertions();
   std::shared_ptr<ProofNode> pfn =
-      d_pfManager->connectProofToAssertions(pepf, as);
+      d_pfManager->connectProofToAssertions(pepf, *d_smtSolver.get());
   std::vector<Node> core;
   d_ucManager->getUnsatCore(pfn, as, core);
   if (options().smt.minimalUnsatCores)
@@ -1566,7 +1560,6 @@ std::string SolverEngine::getProof(modes::ProofComponent c)
   // connect proofs to preprocessing, if specified
   if (connectToPreprocess)
   {
-    Assertions& as = d_smtSolver->getAssertions();
     ProofScopeMode scopeMode =
         connectMkOuterScope ? mode == options::ProofFormatMode::LFSC
                                   ? ProofScopeMode::DEFINITIONS_AND_ASSERTIONS
@@ -1575,7 +1568,7 @@ std::string SolverEngine::getProof(modes::ProofComponent c)
     for (std::shared_ptr<ProofNode>& p : ps)
     {
       Assert(p != nullptr);
-      p = d_pfManager->connectProofToAssertions(p, as, scopeMode);
+      p = d_pfManager->connectProofToAssertions(p, *d_smtSolver.get(), scopeMode);
     }
   }
   // print all proofs

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -170,7 +170,6 @@ void SolverEngine::finishInit()
     NodeManager::currentNM()->getBoundVarManager()->enableKeepCacheValues();
     // make the proof manager
     d_pfManager.reset(new PfManager(*d_env.get()));
-    PreprocessProofGenerator* pppg = d_pfManager->getPreprocessProofGenerator();
     // start the unsat core manager
     d_ucManager.reset(new UnsatCoreManager());
     pnm = d_pfManager->getProofNodeManager();
@@ -1313,7 +1312,7 @@ UnsatCore SolverEngine::getUnsatCoreInternal()
   std::shared_ptr<ProofNode> pfn =
       d_pfManager->connectProofToAssertions(pepf, *d_smtSolver.get());
   std::vector<Node> core;
-  d_ucManager->getUnsatCore(pfn, as, core);
+  d_ucManager->getUnsatCore(pfn, d_smtSolver->getAssertions(), core);
   if (options().smt.minimalUnsatCores)
   {
     core = reduceUnsatCore(core);
@@ -1828,8 +1827,7 @@ void SolverEngine::getDifficultyMap(std::map<Node, Node>& dmap)
   TheoryEngine* te = d_smtSolver->getTheoryEngine();
   te->getDifficultyMap(dmap);
   // then ask proof manager to translate dmap in terms of the input
-  Assertions& as = d_smtSolver->getAssertions();
-  d_pfManager->translateDifficultyMap(dmap, as);
+  d_pfManager->translateDifficultyMap(dmap, *d_smtSolver.get());
 }
 
 void SolverEngine::push()


### PR DESCRIPTION
This simplifies initialization and is work towards allowing more flexibility in our infrastructure (e.g. using multiple SmtSolver / preprocessor instances).