### PR TITLE
Do not report infeasible for smart enumeration + any-constant constructors

### DIFF
--- a/src/smt/sygus_solver.cpp
+++ b/src/smt/sygus_solver.cpp
@@ -434,7 +434,8 @@ void SygusSolver::initializeSygusSubsolver(std::unique_ptr<SolverEngine>& se,
   std::unordered_set<Node> processed;
   // if we did not spawn a subsolver for the main check, the overall SyGuS
   // conjecture has been added as an assertion. Do not add it here, which
-  // is important for check-synth-sol.
+  // is important for check-synth-sol. Adding this also has no impact
+  // when spawning a subsolver for the main check.
   processed.insert(d_conj);
   // carry the ordinary define-fun definitions
   const context::CDList<Node>& alistDefs = as.getAssertionListDefinitions();

--- a/src/smt/sygus_solver.cpp
+++ b/src/smt/sygus_solver.cpp
@@ -431,9 +431,13 @@ void SygusSolver::initializeSygusSubsolver(std::unique_ptr<SolverEngine>& se,
                                            Assertions& as)
 {
   initializeSubsolver(se, d_env);
+  std::unordered_set<Node> processed;
+  // if we did not spawn a subsolver for the main check, the overall SyGuS
+  // conjecture has been added as an assertion. Do not add it here, which
+  // is important for check-synth-sol.
+  processed.insert(d_conj);
   // carry the ordinary define-fun definitions
   const context::CDList<Node>& alistDefs = as.getAssertionListDefinitions();
-  std::unordered_set<Node> processed;
   for (const Node& def : alistDefs)
   {
     // only consider define-fun, represented as (= f (lambda ...)).

--- a/src/theory/incomplete_id.cpp
+++ b/src/theory/incomplete_id.cpp
@@ -29,6 +29,8 @@ const char* toString(IncompleteId i)
     case IncompleteId::QUANTIFIERS: return "QUANTIFIERS";
     case IncompleteId::QUANTIFIERS_SYGUS_NO_VERIFY:
       return "QUANTIFIERS_SYGUS_NO_VERIFY";
+    case IncompleteId::QUANTIFIERS_SYGUS_SMART_BLOCK_ANY_CONSTANT:
+      return "QUANTIFIERS_SYGUS_SMART_BLOCK_ANY_CONSTANT";
     case IncompleteId::QUANTIFIERS_CEGQI: return "QUANTIFIERS_CEGQI";
     case IncompleteId::QUANTIFIERS_FMF: return "QUANTIFIERS_FMF";
     case IncompleteId::QUANTIFIERS_RECORDED_INST:

--- a/src/theory/incomplete_id.h
+++ b/src/theory/incomplete_id.h
@@ -38,8 +38,12 @@ enum class IncompleteId
   ARITH_NL,
   // incomplete due to lack of a complete quantifiers strategy
   QUANTIFIERS,
-  // we failed to verify the correctness of a candidate solution in SyGuS
+  // (refutation unsound) we failed to verify the correctness of a candidate
+  // solution in SyGuS and blocked it to make progress
   QUANTIFIERS_SYGUS_NO_VERIFY,
+  // (refutation unsound) we are generalizing any-constants when blocking with
+  // smart enumeration
+  QUANTIFIERS_SYGUS_SMART_BLOCK_ANY_CONSTANT,
   // incomplete due to counterexample-guided instantiation not being complete
   QUANTIFIERS_CEGQI,
   // incomplete due to finite model finding not being complete

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -545,9 +545,16 @@ void TermDbSygus::registerEnumerator(Node e,
       isActiveGen = false;
     }
   }
+  // When we are using smart enumeration, we often do not consider model
+  // values for arguments of any-constant constructors (in sygus_explain.cpp),
+  // hence those blocking lemmas are refutation unsound. For simplicity, we
+  // mark unsound once and for all at the beginning, meaning we do not
+  // answer "infeasible" when using smart enuemration + any-constant
+  // constructors.
   if (!isActiveGen && usingAnyConst)
   {
-    
+    Assert (d_qim!=nullptr);
+    d_qim->setRefutationUnsound(IncompleteId::QUANTIFIERS_SYGUS_SMART_BLOCK_ANY_CONSTANT); 
   }
   d_enum_active_gen[e] = isActiveGen;
   d_enum_basic[e] = isActiveGen && !isVarAgnostic;

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -553,8 +553,9 @@ void TermDbSygus::registerEnumerator(Node e,
   // constructors.
   if (!isActiveGen && usingAnyConst)
   {
-    Assert (d_qim!=nullptr);
-    d_qim->setRefutationUnsound(IncompleteId::QUANTIFIERS_SYGUS_SMART_BLOCK_ANY_CONSTANT); 
+    Assert(d_qim != nullptr);
+    d_qim->setRefutationUnsound(
+        IncompleteId::QUANTIFIERS_SYGUS_SMART_BLOCK_ANY_CONSTANT);
   }
   d_enum_active_gen[e] = isActiveGen;
   d_enum_basic[e] = isActiveGen && !isVarAgnostic;

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -410,6 +410,7 @@ void TermDbSygus::registerEnumerator(Node e,
   std::vector<TypeNode> sf_types;
   eti.getSubfieldTypes(sf_types);
   bool sharedSel = options().datatypes.dtSharedSelectors;
+  // whether this enumerator relies on any-constant constructors
   bool usingAnyConst = false;
   // for each type of subfield type of this enumerator
   for (unsigned i = 0, ntypes = sf_types.size(); i < ntypes; i++)
@@ -550,8 +551,9 @@ void TermDbSygus::registerEnumerator(Node e,
   // hence those blocking lemmas are refutation unsound. For simplicity, we
   // mark unsound once and for all at the beginning, meaning we do not
   // answer "infeasible" when using smart enuemration + any-constant
-  // constructors.
-  if (!isActiveGen && usingAnyConst)
+  // constructors. Using --sygus-repair-const on the other hand avoids this
+  // incompleteness, which is checked here.
+  if (!isActiveGen && usingAnyConst && !options().quantifiers.sygusRepairConst)
   {
     Assert(d_qim != nullptr);
     d_qim->setRefutationUnsound(

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2974,6 +2974,7 @@ set(regress_1_tests
   regress1/sygus/proj-issue181.smt2
   regress1/sygus/proj-issue183.smt2
   regress1/sygus/proj-issue185.smt2
+  regress1/sygus/proj-issue222-any-const.sy
   regress1/sygus/proj-issue264.smt2
   regress1/sygus/pLTL_5_trace.sy
   regress1/sygus/qe.sy

--- a/test/regress/cli/regress1/sygus/proj-issue222-any-const.sy
+++ b/test/regress/cli/regress1/sygus/proj-issue222-any-const.sy
@@ -1,0 +1,26 @@
+; COMMAND-LINE: --sygus-out=status --sygus-enum=smart --no-sygus-repair-const
+; EXPECT: fail
+(set-logic ALL)
+(define-fun clamp-int((x Int)) Int (ite (< 5 x) 5 (ite (< x 0) 0 x)))
+(synth-fun f 
+	((r Int)) Bool
+	((B Bool) (fv_I Int) (I Int) (IClamp Int) (IConst Int))
+	(
+		(B Bool ((Variable Bool) (> fv_I I)))
+		(fv_I Int (r IClamp))
+		(I Int (IClamp))
+		(IClamp Int ((clamp-int IConst)))
+		(IConst Int ((Constant Int)))
+	)
+)
+(synth-fun int_const
+	() Int 
+	((IConst Int))
+	(
+		(IConst Int ((Constant Int)))
+	)
+)
+(constraint (f 4))
+(constraint (not (f 1)))
+; currently does not solve, due to overpruning from smart enumeration, however it is feasible.
+(check-synth)


### PR DESCRIPTION
We currently (intentionally) overprune any-constant constructor model values, by not considering the concrete model value of their arguments when using smart enumeration in SyGuS solver.  This incompleteness was not accounted for yet, hence we could return `infeasible` incorrectly for grammars that had finitely many values modulo any-constant argument values.  https://github.com/cvc5/cvc5-projects/issues/222 was an example.

This also corrects a bug where the SyGuS conjecture itself was being included in the assertions to check with `--check-synth-sol`, making the option less trustworthy and was causing checks to fail due to the change on this PR.
