### PR TITLE
Fix printer for declarations for variables without assigned names

### DIFF
--- a/src/printer/printer.cpp
+++ b/src/printer/printer.cpp
@@ -216,8 +216,12 @@ void Printer::toStreamCmdDeclareFunction(std::ostream& out,
 
 void Printer::toStreamCmdDeclareFunction(std::ostream& out, const Node& v) const
 {
-  std::string vs = v.getName();
-  toStreamCmdDeclareFunction(out, vs, v.getType());
+  // Must print the variable on the output stream (instead of just getting the
+  // name of v), since this method may be called on variables that do not have
+  // assigned names.
+  std::stringstream ss;
+  toStream(ss, v);
+  toStreamCmdDeclareFunction(out, ss.str(), v.getType());
 }
 
 void Printer::toStreamCmdDeclarePool(std::ostream& out,


### PR DESCRIPTION
This made the print benchmark utility give bad syntax like:
```
;; post-asserts start
(set-logic ALL)
(declare-fun x () Int)
(declare-fun P (Bool) Bool)
(declare-fun || () Bool)
(assert (P BOOLEAN_TERM_VARIABLE_369))
(assert true)
(assert (= (>= x 1) BOOLEAN_TERM_VARIABLE_369))
(check-sat)
;; post-asserts end
```
where `||` is used instead of `BOOLEAN_TERM_VARIABLE_369` (as this is an internal variable without an assigned name).