### PR TITLE
Track forced logic in the symbol manager

### DIFF
--- a/src/main/interactive_shell.cpp
+++ b/src/main/interactive_shell.cpp
@@ -93,14 +93,14 @@ InteractiveShell::InteractiveShell(Solver* solver,
       d_isInteractive(isInteractive),
       d_quit(false)
 {
-  ParserBuilder parserBuilder(solver, sm, true);
-  /* Create parser with bogus input. */
-  d_parser.reset(parserBuilder.build());
   if (d_solver->getOptionInfo("force-logic").setByUser)
   {
     LogicInfo tmp(d_solver->getOption("force-logic"));
     sm->forceLogic(tmp.getLogicString());
   }
+  ParserBuilder parserBuilder(solver, sm, true);
+  /* Create parser with bogus input. */
+  d_parser.reset(parserBuilder.build());
 
 #if HAVE_LIBEDITLINE
   if (&d_in == &std::cin && isatty(fileno(stdin)))

--- a/src/main/interactive_shell.cpp
+++ b/src/main/interactive_shell.cpp
@@ -99,7 +99,7 @@ InteractiveShell::InteractiveShell(Solver* solver,
   if (d_solver->getOptionInfo("force-logic").setByUser)
   {
     LogicInfo tmp(d_solver->getOption("force-logic"));
-    d_parser->forceLogic(tmp.getLogicString());
+    sm->forceLogic(tmp.getLogicString());
   }
 
 #if HAVE_LIBEDITLINE

--- a/src/parser/api/cpp/symbol_manager.cpp
+++ b/src/parser/api/cpp/symbol_manager.cpp
@@ -456,8 +456,11 @@ void SymbolManager::forceLogic(const std::string& logic)
   d_logicIsForced = true;
   d_forcedLogic = logic;
 }
-  bool SymbolManager::isLogicForced() const { return d_logicIsForced; }
+bool SymbolManager::isLogicForced() const { return d_logicIsForced; }
 
-  const std::string& SymbolManager::getForcedLogic() const { return d_forcedLogic; }
+const std::string& SymbolManager::getForcedLogic() const
+{
+  return d_forcedLogic;
+}
 
 }  // namespace cvc5::parser

--- a/src/parser/api/cpp/symbol_manager.cpp
+++ b/src/parser/api/cpp/symbol_manager.cpp
@@ -314,7 +314,9 @@ void SymbolManager::Implementation::resetAssertions()
 SymbolManager::SymbolManager(cvc5::Solver* s)
     : d_solver(s),
       d_implementation(new SymbolManager::Implementation()),
-      d_globalDeclarations(false)
+      d_globalDeclarations(false),
+      d_logicIsForced(false),
+      d_forcedLogic()
 {
 }
 
@@ -447,5 +449,15 @@ void SymbolManager::resetAssertions()
     d_implementation->getSymbolTable().resetAssertions();
   }
 }
+
+void SymbolManager::forceLogic(const std::string& logic)
+{
+  Assert(!d_logicIsForced);
+  d_logicIsForced = true;
+  d_forcedLogic = logic;
+}
+  bool SymbolManager::isLogicForced() const { return d_logicIsForced; }
+
+  const std::string& SymbolManager::getForcedLogic() const { return d_forcedLogic; }
 
 }  // namespace cvc5::parser

--- a/src/parser/api/cpp/symbol_manager.h
+++ b/src/parser/api/cpp/symbol_manager.h
@@ -201,7 +201,7 @@ class CVC5_EXPORT SymbolManager
   /** Get the name of the last abduct or interpolant to synthesize */
   const std::string& getLastSynthName() const;
 
-  /** 
+  /**
    * Force the logic to the given string. Note that this information is
    * context-independent.
    */
@@ -210,6 +210,7 @@ class CVC5_EXPORT SymbolManager
   bool isLogicForced() const;
   /** Get the last string in an above call, valid if logic is forced */
   const std::string& getForcedLogic() const;
+
  private:
   /** The API Solver object. */
   cvc5::Solver* d_solver;

--- a/src/parser/api/cpp/symbol_manager.h
+++ b/src/parser/api/cpp/symbol_manager.h
@@ -201,6 +201,15 @@ class CVC5_EXPORT SymbolManager
   /** Get the name of the last abduct or interpolant to synthesize */
   const std::string& getLastSynthName() const;
 
+  /** 
+   * Force the logic to the given string. Note that this information is
+   * context-independent.
+   */
+  void forceLogic(const std::string& logic);
+  /** Have we called the above method? */
+  bool isLogicForced() const;
+  /** Get the last string in an above call, valid if logic is forced */
+  const std::string& getForcedLogic() const;
  private:
   /** The API Solver object. */
   cvc5::Solver* d_solver;
@@ -212,6 +221,10 @@ class CVC5_EXPORT SymbolManager
    * SMT-LIB option :global-declarations. By default, its value is false.
    */
   bool d_globalDeclarations;
+  /** Whether the logic has been forced with --force-logic. */
+  bool d_logicIsForced;
+  /** The logic, if d_logicIsForced == true. */
+  std::string d_forcedLogic;
 };
 
 }  // namespace parser

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -41,8 +41,6 @@ Parser::Parser(cvc5::Solver* solver,
                bool parseOnly)
     : d_symman(sm),
       d_symtab(sm->getSymbolTable()),
-      d_assertionLevel(0),
-      d_anonymousFunctionCount(0),
       d_done(true),
       d_checksEnabled(true),
       d_strictMode(strictMode),

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -48,8 +48,6 @@ Parser::Parser(cvc5::Solver* solver,
       d_strictMode(strictMode),
       d_parseOnly(parseOnly),
       d_canIncludeFile(true),
-      d_logicIsForced(false),
-      d_forcedLogic(),
       d_solver(solver)
 {
 }
@@ -73,14 +71,15 @@ cvc5::Term Parser::getSymbol(const std::string& name, SymbolType type)
   // Functions share var namespace
   return d_symtab->lookup(name);
 }
-
-void Parser::forceLogic(const std::string& logic)
+const std::string& Parser::getForcedLogic() const
 {
-  Assert(!d_logicIsForced);
-  d_logicIsForced = true;
-  d_forcedLogic = logic;
+  return d_symman->getForcedLogic();
 }
-
+bool Parser::logicIsForced() const
+{
+  return d_symman->isLogicForced();
+}
+  
 cvc5::Term Parser::getVariable(const std::string& name)
 {
   return getSymbol(name, SYM_VARIABLE);

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -75,11 +75,8 @@ const std::string& Parser::getForcedLogic() const
 {
   return d_symman->getForcedLogic();
 }
-bool Parser::logicIsForced() const
-{
-  return d_symman->isLogicForced();
-}
-  
+bool Parser::logicIsForced() const { return d_symman->isLogicForced(); }
+
 cvc5::Term Parser::getVariable(const std::string& name)
 {
   return getSymbol(name, SYM_VARIABLE);

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -168,18 +168,6 @@ cvc5::Sort Parser::getSort(const std::string& name,
   return t;
 }
 
-size_t Parser::getArity(const std::string& sort_name) {
-  checkDeclaration(sort_name, CHECK_DECLARED, SYM_SORT);
-  Assert(isDeclared(sort_name, SYM_SORT));
-  return d_symtab->lookupArity(sort_name);
-}
-
-/* Returns true if name is bound to a boolean variable. */
-bool Parser::isBoolean(const std::string& name) {
-  cvc5::Term expr = getVariable(name);
-  return !expr.isNull() && expr.getSort().isBoolean();
-}
-
 bool Parser::isFunctionLike(cvc5::Term fun)
 {
   if(fun.isNull()) {
@@ -188,12 +176,6 @@ bool Parser::isFunctionLike(cvc5::Term fun)
   cvc5::Sort type = fun.getSort();
   return type.isFunction() || type.isDatatypeConstructor()
          || type.isDatatypeTester() || type.isDatatypeSelector();
-}
-
-/* Returns true if name is bound to a function returning boolean. */
-bool Parser::isPredicate(const std::string& name) {
-  cvc5::Term expr = getVariable(name);
-  return !expr.isNull() && expr.getSort().isPredicate();
 }
 
 cvc5::Term Parser::bindVar(const std::string& name,
@@ -222,17 +204,6 @@ std::vector<cvc5::Term> Parser::bindBoundVars(
   for (std::pair<std::string, cvc5::Sort>& i : sortedVarNames)
   {
     vars.push_back(bindBoundVar(i.first, i.second));
-  }
-  return vars;
-}
-
-std::vector<cvc5::Term> Parser::bindVars(const std::vector<std::string> names,
-                                         const cvc5::Sort& type,
-                                         bool doOverload)
-{
-  std::vector<cvc5::Term> vars;
-  for (unsigned i = 0; i < names.size(); ++i) {
-    vars.push_back(bindVar(names[i], type, doOverload));
   }
   return vars;
 }

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -151,16 +151,6 @@ private:
   */
  bool d_canIncludeFile;
 
- /**
-  * Whether the logic has been forced with --force-logic.
-  */
- bool d_logicIsForced;
-
- /**
-  * The logic, if d_logicIsForced == true.
-  */
- std::string d_forcedLogic;
-
  /** The set of operators available in the current logic. */
  std::set<cvc5::Kind> d_logicOperators;
 
@@ -253,15 +243,14 @@ public:
   void allowIncludeFile() { d_canIncludeFile = true; }
   void disallowIncludeFile() { d_canIncludeFile = false; }
   bool canIncludeFile() const { return d_canIncludeFile; }
+  
+  const std::string& getForcedLogic() const;
+  bool logicIsForced() const;
+
 
   /** Expose the functionality from SMT/SMT2 parsers, while making
       implementation optional by returning false by default. */
   virtual bool logicIsSet() { return false; }
-
-  virtual void forceLogic(const std::string& logic);
-
-  const std::string& getForcedLogic() const { return d_forcedLogic; }
-  bool logicIsForced() const { return d_logicIsForced; }
 
   /**
    * Gets the variable currently bound to name.

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -123,16 +123,6 @@ private:
   */
  internal::parser::SymbolTable* d_symtab;
 
- /**
-  * The level of the assertions in the declaration scope.  Things declared
-  * after this level are bindings from e.g. a let, a quantifier, or a
-  * lambda.
-  */
- size_t d_assertionLevel;
-
- /** How many anonymous functions we've created. */
- size_t d_anonymousFunctionCount;
-
  /** Are we done */
  bool d_done;
 

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -330,11 +330,6 @@ public:
                      const std::vector<cvc5::Sort>& params);
 
   /**
-   * Returns arity of a (parameterized) sort, given a name and args.
-   */
-  size_t getArity(const std::string& sort_name);
-
-  /**
    * Checks if a symbol has been declared.
    * @param name the symbol name
    * @param type the symbol type
@@ -377,18 +372,6 @@ public:
   cvc5::Term bindVar(const std::string& name,
                      const cvc5::Sort& type,
                      bool doOverload = false);
-
-  /**
-   * Create a set of new cvc5 variable expressions of the given type.
-   *
-   * For each name, if a symbol with name already exists,
-   *  then if doOverload is true, we create overloaded operators.
-   *  else if doOverload is false, the existing expression is shadowed by the
-   * new expression.
-   */
-  std::vector<cvc5::Term> bindVars(const std::vector<std::string> names,
-                                   const cvc5::Sort& type,
-                                   bool doOverload = false);
 
   /**
    * Create a new cvc5 bound variable expression of the given type. This binds
@@ -605,17 +588,11 @@ public:
    */
   void preemptCommand(Command* cmd);
 
-  /** Is the symbol bound to a boolean variable? */
-  bool isBoolean(const std::string& name);
-
   /** Is fun a function (or function-like thing)?
    * Currently this means its type is either a function, constructor, tester, or
    * selector.
    */
   bool isFunctionLike(cvc5::Term fun);
-
-  /** Is the symbol bound to a predicate? */
-  bool isPredicate(const std::string& name);
 
   /** Parse and return the next command. */
   Command* nextCommand();

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -243,10 +243,9 @@ public:
   void allowIncludeFile() { d_canIncludeFile = true; }
   void disallowIncludeFile() { d_canIncludeFile = false; }
   bool canIncludeFile() const { return d_canIncludeFile; }
-  
+
   const std::string& getForcedLogic() const;
   bool logicIsForced() const;
-
 
   /** Expose the functionality from SMT/SMT2 parsers, while making
       implementation optional by returning false by default. */

--- a/src/parser/parser_builder.cpp
+++ b/src/parser/parser_builder.cpp
@@ -58,7 +58,8 @@ Parser* ParserBuilder::build()
 {
   Parser* parser = NULL;
 
-  // force the logic prior to building the parser
+  // Force the logic prior to building the parser. This makes a difference for
+  // the TPTP parser, where forced logic is processed upon construction.
   if (d_logicIsForced)
   {
     d_symman->forceLogic(d_forcedLogic);

--- a/src/parser/parser_builder.cpp
+++ b/src/parser/parser_builder.cpp
@@ -57,12 +57,13 @@ void ParserBuilder::init(cvc5::Solver* solver, SymbolManager* sm)
 Parser* ParserBuilder::build()
 {
   Parser* parser = NULL;
-  
+
   // force the logic prior to building the parser
-  if( d_logicIsForced ) {
+  if (d_logicIsForced)
+  {
     d_symman->forceLogic(d_forcedLogic);
   }
-  
+
   if (d_lang == "LANG_TPTP")
   {
     parser = new Tptp(d_solver, d_symman, d_strictMode, d_parseOnly);

--- a/src/parser/parser_builder.cpp
+++ b/src/parser/parser_builder.cpp
@@ -57,6 +57,12 @@ void ParserBuilder::init(cvc5::Solver* solver, SymbolManager* sm)
 Parser* ParserBuilder::build()
 {
   Parser* parser = NULL;
+  
+  // force the logic prior to building the parser
+  if( d_logicIsForced ) {
+    d_symman->forceLogic(d_forcedLogic);
+  }
+  
   if (d_lang == "LANG_TPTP")
   {
     parser = new Tptp(d_solver, d_symman, d_strictMode, d_parseOnly);
@@ -79,9 +85,6 @@ Parser* ParserBuilder::build()
     parser->disallowIncludeFile();
   }
 
-  if( d_logicIsForced ) {
-    d_symman->forceLogic(d_forcedLogic);
-  }
 
   return parser;
 }

--- a/src/parser/parser_builder.cpp
+++ b/src/parser/parser_builder.cpp
@@ -80,7 +80,7 @@ Parser* ParserBuilder::build()
   }
 
   if( d_logicIsForced ) {
-    parser->forceLogic(d_forcedLogic);
+    d_symman->forceLogic(d_forcedLogic);
   }
 
   return parser;

--- a/src/parser/tptp/tptp.cpp
+++ b/src/parser/tptp/tptp.cpp
@@ -66,7 +66,7 @@ Tptp::Tptp(cvc5::Solver* solver,
     }
   }
   d_hasConjecture = false;
-  // handle forced logic immediately
+  // Handle forced logic immediately.
   if (sm->isLogicForced())
   {
     preemptCommand(new SetBenchmarkLogicCommand(sm->getForcedLogic()));

--- a/src/parser/tptp/tptp.cpp
+++ b/src/parser/tptp/tptp.cpp
@@ -66,6 +66,11 @@ Tptp::Tptp(cvc5::Solver* solver,
     }
   }
   d_hasConjecture = false;
+  // handle forced logic immediately
+  if (sm->isLogicForced())
+  {
+    preemptCommand(new SetBenchmarkLogicCommand(sm->getForcedLogic()));
+  }
 }
 
 Tptp::~Tptp() {

--- a/src/parser/tptp/tptp.cpp
+++ b/src/parser/tptp/tptp.cpp
@@ -504,12 +504,6 @@ void Tptp::setHol()
   d_solver->setLogic("HO_UF");
 }
 
-void Tptp::forceLogic(const std::string& logic)
-{
-  Parser::forceLogic(logic);
-  preemptCommand(new SetBenchmarkLogicCommand(logic));
-}
-
 void Tptp::addFreeVar(cvc5::Term var)
 {
   Assert(cnf());

--- a/src/parser/tptp/tptp.h
+++ b/src/parser/tptp/tptp.h
@@ -48,8 +48,6 @@ class Tptp : public Parser {
   bool hol() const;
   void setHol();
 
-  void forceLogic(const std::string& logic) override;
-
   void addFreeVar(cvc5::Term var);
   std::vector<cvc5::Term> getFreeVar();
 


### PR DESCRIPTION
This moves the tracking of the forced logic (`--force-logic=LOGIC`) from the `Parser` to the `SymbolManager`.  It ensures that the TPTP parser handles forced logic on initialization instead of dynamically.  

Further cleanup is done to the `Parser` class to remove unecessary methods.

This is a prerequisite for the new parser API.  This ensures that `forceLogic(...)` does not need to be part of the new API for parsers.  