### PR TITLE
Reconstruct HO_CONG in LFSC proofs

### DIFF
--- a/src/proof/lfsc/lfsc_post_processor.cpp
+++ b/src/proof/lfsc/lfsc_post_processor.cpp
@@ -326,28 +326,14 @@ bool LfscProofPostprocessCallback::update(Node res,
       {
         // non n-ary kinds do not have null terminators
         Assert(nullTerm.isNull());
-        Node curL = op;
-        Node curR = op;
-        Node currEq = opEq;
-        for (size_t i = 0; i < nchildren; i++)
-        {
-          // CONG rules for each child
-          Node nextEq;
-          if (i + 1 == nchildren)
-          {
-            // if we are at the end, we prove the final equality
-            nextEq = res;
-          }
-          else
-          {
-            curL = nm->mkNode(HO_APPLY, curL, children[i][0]);
-            curR = nm->mkNode(HO_APPLY, curR, children[i][1]);
-            nextEq = curL.eqNode(curR);
-          }
-          addLfscRule(cdp, nextEq, {currEq, children[i]}, LfscRule::CONG, {});
-          currEq = nextEq;
-        }
+        updateCong(res, children, cdp, op);
       }
+    }
+    break;
+    case PfRule::HO_CONG:
+    {
+      // converted to chain of CONG, with no base operator
+      updateCong(res, children, cdp, Node::null());
     }
     break;
     case PfRule::AND_INTRO:
@@ -414,6 +400,45 @@ bool LfscProofPostprocessCallback::update(Node res,
   }
   AlwaysAssert(cdp->getProofFor(res)->getRule() != PfRule::ASSUME);
   return true;
+}
+
+void LfscProofPostprocessCallback::updateCong(Node res, const std::vector<Node>& children, CDProof* cdp, Node startOp)
+{
+  Node currEq;
+  size_t i =0;
+  size_t nchildren = children.size();
+  if (!startOp.isNull())
+  {
+    // start with reflexive equality on operator
+    currEq = startOp.eqNode(startOp);
+  }
+  else
+  {
+    // first child specifies (higher-order) operator equality
+    currEq = children[0];
+    i++;
+  }
+  Node curL = currEq[0];
+  Node curR = currEq[1];
+  NodeManager * nm = NodeManager::currentNM();
+  for (; i < nchildren; i++)
+  {
+    // CONG rules for each child
+    Node nextEq;
+    if (i + 1 == nchildren)
+    {
+      // if we are at the end, we prove the final equality
+      nextEq = res;
+    }
+    else
+    {
+      curL = nm->mkNode(HO_APPLY, curL, children[i][0]);
+      curR = nm->mkNode(HO_APPLY, curR, children[i][1]);
+      nextEq = curL.eqNode(curR);
+    }
+    addLfscRule(cdp, nextEq, {currEq, children[i]}, LfscRule::CONG, {});
+    currEq = nextEq;
+  }
 }
 
 void LfscProofPostprocessCallback::addLfscRule(

--- a/src/proof/lfsc/lfsc_post_processor.cpp
+++ b/src/proof/lfsc/lfsc_post_processor.cpp
@@ -402,10 +402,13 @@ bool LfscProofPostprocessCallback::update(Node res,
   return true;
 }
 
-void LfscProofPostprocessCallback::updateCong(Node res, const std::vector<Node>& children, CDProof* cdp, Node startOp)
+void LfscProofPostprocessCallback::updateCong(Node res,
+                                              const std::vector<Node>& children,
+                                              CDProof* cdp,
+                                              Node startOp)
 {
   Node currEq;
-  size_t i =0;
+  size_t i = 0;
   size_t nchildren = children.size();
   if (!startOp.isNull())
   {
@@ -420,7 +423,7 @@ void LfscProofPostprocessCallback::updateCong(Node res, const std::vector<Node>&
   }
   Node curL = currEq[0];
   Node curR = currEq[1];
-  NodeManager * nm = NodeManager::currentNM();
+  NodeManager* nm = NodeManager::currentNM();
   for (; i < nchildren; i++)
   {
     // CONG rules for each child

--- a/src/proof/lfsc/lfsc_post_processor.h
+++ b/src/proof/lfsc/lfsc_post_processor.h
@@ -78,8 +78,16 @@ class LfscProofPostprocessCallback : protected EnvObj,
                    const std::vector<Node>& args);
   /** Make chained form of a term */
   Node mkChain(Kind k, const std::vector<Node>& children);
-  /** */
-  void updateCong(Node res, const std::vector<Node>& children, CDProof* cdp, Node startOp);
+  /** 
+   * Reconstruct the proof for congruence proving res with the given
+   * children, populate into cdp. Used for:
+   * (1) CONG over operator startOp != null,
+   * (2) HO_CONG, where startOp = null.
+   */
+  void updateCong(Node res,
+                  const std::vector<Node>& children,
+                  CDProof* cdp,
+                  Node startOp);
   /** Make fresh dummy predicate */
   static Node mkDummyPredicate();
 };

--- a/src/proof/lfsc/lfsc_post_processor.h
+++ b/src/proof/lfsc/lfsc_post_processor.h
@@ -78,6 +78,8 @@ class LfscProofPostprocessCallback : protected EnvObj,
                    const std::vector<Node>& args);
   /** Make chained form of a term */
   Node mkChain(Kind k, const std::vector<Node>& children);
+  /** */
+  void updateCong(Node res, const std::vector<Node>& children, CDProof* cdp, Node startOp);
   /** Make fresh dummy predicate */
   static Node mkDummyPredicate();
 };


### PR DESCRIPTION
This rule appears in proofs for Kind2 for eliminating definitions.

HO_CONG is fairly trivial to reconstruct, we use the standard lfsc rule for conguence (for each premise).