### PR TITLE
Do not propagate when strings has a pending conflict

### DIFF
--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -182,6 +182,11 @@ std::string TheoryStrings::identify() const
 
 bool TheoryStrings::propagateLit(TNode literal)
 {
+  if (d_state.hasPendingConflict())
+  {
+    // pending conflict also implies we are done
+    return false;
+  }
   return d_im.propagateLit(literal);
 }
 


### PR DESCRIPTION
This adds a simple check to abort propagations from the equality engine as soon as we discover a pending conflict (usually via prefix conflicts via CAV 22).

This can sometimes lead to an order of magnitude fewer (redundant) propagations from strings on large benchmarks, leading to 15% improvement in run time.