### PR TITLE
Fix check-unsat-cores and minimal-unsat-cores

### DIFF
--- a/src/smt/assertions.cpp
+++ b/src/smt/assertions.cpp
@@ -100,6 +100,16 @@ const context::CDList<Node>& Assertions::getAssertionListDefinitions() const
   return d_assertionListDefs;
 }
 
+std::unordered_set<Node> Assertions::getCurrentAssertionListDefitions() const
+{
+  std::unordered_set<Node> defSet;
+  for (const Node& a : d_assertionListDefs)
+  {
+    defSet.insert(a);
+  }
+  return defSet;
+}
+
 void Assertions::addFormula(TNode n,
                             bool isFunDef,
                             bool maybeHasFv)

--- a/src/smt/assertions.h
+++ b/src/smt/assertions.h
@@ -98,6 +98,8 @@ class Assertions : protected EnvObj
    * that correspond to definitions (define-fun or define-fun-rec).
    */
   const context::CDList<Node>& getAssertionListDefinitions() const;
+  /** Get the set corresponding to the above */
+  std::unordered_set<Node> getCurrentAssertionListDefitions() const;
   /**
    * Get the list of assumptions, which are those registered to this class
    * on initializeCheckSat.

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1340,7 +1340,9 @@ std::vector<Node> SolverEngine::reduceUnsatCore(const std::vector<Node>& core)
     {
       if (ucAssertion != skip && removed.find(ucAssertion) == removed.end())
       {
-        coreChecker->assertFormula(ucAssertion);
+        Node assertionAfterExpansion =
+            d_smtSolver->getPreprocessor()->applySubstitutions(ucAssertion);
+        coreChecker->assertFormula(assertionAfterExpansion);
       }
     }
     Result r;
@@ -1402,7 +1404,6 @@ void SolverEngine::checkUnsatCore()
 
   d_env->verbose(1) << "SolverEngine::checkUnsatCore(): pushing core assertions"
                     << std::endl;
-  theory::TrustSubstitutionMap& tls = d_env->getTopLevelSubstitutions();
   for (UnsatCore::iterator i = core.begin(); i != core.end(); ++i)
   {
     d_env->verbose(1) << "SolverEngine::checkUnsatCore(): pushing core member "

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -524,9 +524,7 @@ void SolverEngine::defineFunction(Node func,
   defineFunction(func, def, global);
 }
 
-void SolverEngine::defineFunction(Node func,
-                    Node lambda,
-                    bool global)
+void SolverEngine::defineFunction(Node func, Node lambda, bool global)
 {
   // A define-fun is treated as a (higher-order) assertion. It is provided
   // to the assertions object. It will be added as a top-level substitution
@@ -1327,7 +1325,10 @@ UnsatCore SolverEngine::getUnsatCoreInternal()
   return UnsatCore(core);
 }
 
-void SolverEngine::assertToSubsolver(SolverEngine& subsolver, const std::vector<Node>& core, const std::unordered_set<Node>& defs, const std::unordered_set<Node>& removed)
+void SolverEngine::assertToSubsolver(SolverEngine& subsolver,
+                                     const std::vector<Node>& core,
+                                     const std::unordered_set<Node>& defs,
+                                     const std::unordered_set<Node>& removed)
 {
   for (const Node& f : core)
   {
@@ -1337,9 +1338,9 @@ void SolverEngine::assertToSubsolver(SolverEngine& subsolver, const std::vector<
       continue;
     }
     // check if it is a function definition
-    if (defs.find(f)!=defs.end())
+    if (defs.find(f) != defs.end())
     {
-      if (f.getKind()==kind::EQUAL && f[0].isVar())
+      if (f.getKind() == kind::EQUAL && f[0].isVar())
       {
         subsolver.defineFunction(f[0], f[1]);
         continue;
@@ -1348,7 +1349,7 @@ void SolverEngine::assertToSubsolver(SolverEngine& subsolver, const std::vector<
     subsolver.assertFormula(f);
   }
 }
-    
+
 std::vector<Node> SolverEngine::reduceUnsatCore(const std::vector<Node>& core)
 {
   Assert(options().smt.produceUnsatCores)
@@ -1357,7 +1358,8 @@ std::vector<Node> SolverEngine::reduceUnsatCore(const std::vector<Node>& core)
   d_env->verbose(1) << "SolverEngine::reduceUnsatCore(): reducing unsat core"
                     << std::endl;
   std::unordered_set<Node> removed;
-  std::unordered_set<Node> adefs = d_smtSolver->getAssertions().getCurrentAssertionListDefitions();
+  std::unordered_set<Node> adefs =
+      d_smtSolver->getAssertions().getCurrentAssertionListDefitions();
   for (const Node& skip : core)
   {
     std::unique_ptr<SolverEngine> coreChecker;
@@ -1386,8 +1388,8 @@ std::vector<Node> SolverEngine::reduceUnsatCore(const std::vector<Node>& core)
       {
         d_env->warning()
             << "SolverEngine::reduceUnsatCore(): could not reduce unsat core "
-              "due to "
-              "unknown result.";
+               "due to "
+               "unknown result.";
       }
     }
   }
@@ -1429,7 +1431,8 @@ void SolverEngine::checkUnsatCore()
   d_env->verbose(1) << "SolverEngine::checkUnsatCore(): pushing core assertions"
                     << std::endl;
   // set up the subsolver
-  std::unordered_set<Node> adefs = d_smtSolver->getAssertions().getCurrentAssertionListDefitions();
+  std::unordered_set<Node> adefs =
+      d_smtSolver->getAssertions().getCurrentAssertionListDefitions();
   std::unordered_set<Node> removed;
   assertToSubsolver(*coreChecker.get(), core.getCore(), adefs, removed);
   Result r;

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1340,9 +1340,7 @@ std::vector<Node> SolverEngine::reduceUnsatCore(const std::vector<Node>& core)
     {
       if (ucAssertion != skip && removed.find(ucAssertion) == removed.end())
       {
-        Node assertionAfterExpansion =
-            d_smtSolver->getPreprocessor()->applySubstitutions(ucAssertion);
-        coreChecker->assertFormula(assertionAfterExpansion);
+        coreChecker->assertFormula(ucAssertion);
       }
     }
     Result r;

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1328,31 +1328,6 @@ UnsatCore SolverEngine::getUnsatCoreInternal()
   return UnsatCore(core);
 }
 
-void SolverEngine::assertToSubsolver(SolverEngine& subsolver,
-                                     const std::vector<Node>& core,
-                                     const std::unordered_set<Node>& defs,
-                                     const std::unordered_set<Node>& removed)
-{
-  for (const Node& f : core)
-  {
-    // check if it is excluded
-    if (removed.find(f) != removed.end())
-    {
-      continue;
-    }
-    // check if it is a function definition
-    if (defs.find(f) != defs.end())
-    {
-      if (f.getKind() == kind::EQUAL && f[0].isVar())
-      {
-        subsolver.defineFunction(f[0], f[1]);
-        continue;
-      }
-    }
-    subsolver.assertFormula(f);
-  }
-}
-
 std::vector<Node> SolverEngine::reduceUnsatCore(const std::vector<Node>& core)
 {
   Assert(options().smt.produceUnsatCores)

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1405,11 +1405,9 @@ void SolverEngine::checkUnsatCore()
   theory::TrustSubstitutionMap& tls = d_env->getTopLevelSubstitutions();
   for (UnsatCore::iterator i = core.begin(); i != core.end(); ++i)
   {
-    Node assertionAfterExpansion = tls.apply(*i);
     d_env->verbose(1) << "SolverEngine::checkUnsatCore(): pushing core member "
-                      << *i << ", expanded to " << assertionAfterExpansion
-                      << std::endl;
-    coreChecker->assertFormula(assertionAfterExpansion);
+                      << *i <<  std::endl;
+    coreChecker->assertFormula(*i);
   }
   Result r;
   try

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -521,11 +521,14 @@ void SolverEngine::defineFunction(Node func,
     def = nm->mkNode(
         kind::LAMBDA, nm->mkNode(kind::BOUND_VAR_LIST, formals), def);
   }
-  defineFunction(func, def, global);
+  Node feq = func.eqNode(def);
+  d_smtSolver->getAssertions().addDefineFunDefinition(feq, global);
 }
 
 void SolverEngine::defineFunction(Node func, Node lambda, bool global)
 {
+  finishInit();
+  d_ctxManager->doPendingPops();
   // A define-fun is treated as a (higher-order) assertion. It is provided
   // to the assertions object. It will be added as a top-level substitution
   // within this class, possibly multiple times if global is true.

--- a/src/smt/solver_engine.h
+++ b/src/smt/solver_engine.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <unordered_set>
 
 #include "context/cdhashmap_forward.h"
 #include "cvc5_export.h"
@@ -269,6 +270,10 @@ class CVC5_EXPORT SolverEngine
   void defineFunction(Node func,
                       const std::vector<Node>& formals,
                       Node formula,
+                      bool global = false);
+  /** Same as above, with lambda */
+  void defineFunction(Node func,
+                      Node lambda,
                       bool global = false);
 
   /**
@@ -970,6 +975,7 @@ class CVC5_EXPORT SolverEngine
   /** Vector version of above. */
   void ensureWellFormedTerms(const std::vector<Node>& ns,
                              const std::string& src) const;
+                             void assertToSubsolver(SolverEngine& subsolver, const std::vector<Node>& core, const std::unordered_set<Node>& defs, const std::unordered_set<Node>& removed);
   /* Members -------------------------------------------------------------- */
 
   /** Solver instance that owns this SolverEngine instance. */

--- a/src/smt/solver_engine.h
+++ b/src/smt/solver_engine.h
@@ -973,10 +973,6 @@ class CVC5_EXPORT SolverEngine
   /** Vector version of above. */
   void ensureWellFormedTerms(const std::vector<Node>& ns,
                              const std::string& src) const;
-  void assertToSubsolver(SolverEngine& subsolver,
-                         const std::vector<Node>& core,
-                         const std::unordered_set<Node>& defs,
-                         const std::unordered_set<Node>& removed);
   /* Members -------------------------------------------------------------- */
 
   /** Solver instance that owns this SolverEngine instance. */

--- a/src/smt/solver_engine.h
+++ b/src/smt/solver_engine.h
@@ -21,8 +21,8 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <vector>
 #include <unordered_set>
+#include <vector>
 
 #include "context/cdhashmap_forward.h"
 #include "cvc5_export.h"
@@ -272,9 +272,7 @@ class CVC5_EXPORT SolverEngine
                       Node formula,
                       bool global = false);
   /** Same as above, with lambda */
-  void defineFunction(Node func,
-                      Node lambda,
-                      bool global = false);
+  void defineFunction(Node func, Node lambda, bool global = false);
 
   /**
    * Define functions recursive
@@ -975,7 +973,10 @@ class CVC5_EXPORT SolverEngine
   /** Vector version of above. */
   void ensureWellFormedTerms(const std::vector<Node>& ns,
                              const std::string& src) const;
-                             void assertToSubsolver(SolverEngine& subsolver, const std::vector<Node>& core, const std::unordered_set<Node>& defs, const std::unordered_set<Node>& removed);
+  void assertToSubsolver(SolverEngine& subsolver,
+                         const std::vector<Node>& core,
+                         const std::unordered_set<Node>& defs,
+                         const std::unordered_set<Node>& removed);
   /* Members -------------------------------------------------------------- */
 
   /** Solver instance that owns this SolverEngine instance. */

--- a/src/theory/quantifiers/theory_quantifiers.cpp
+++ b/src/theory/quantifiers/theory_quantifiers.cpp
@@ -119,7 +119,9 @@ Theory::PPAssertStatus TheoryQuantifiers::ppAssert(
       // must be legal
       if (isLegalElimination(eq[0], eq[1]))
       {
-        outSubstitutions.addSubstitution(eq[0], eq[1]);
+        // add substitution solved, which ensures we track that eq depends on
+        // tin, which can impact unsat cores.
+        outSubstitutions.addSubstitutionSolved(eq[0], eq[1], tin);
         return Theory::PP_ASSERT_STATUS_SOLVED;
       }
     }

--- a/src/theory/smt_engine_subsolver.cpp
+++ b/src/theory/smt_engine_subsolver.cpp
@@ -162,6 +162,32 @@ Result checkWithSubsolver(Node query,
   return r;
 }
 
+
+void assertToSubsolver(SolverEngine& subsolver,
+                                     const std::vector<Node>& core,
+                                     const std::unordered_set<Node>& defs,
+                                     const std::unordered_set<Node>& removed)
+{
+  for (const Node& f : core)
+  {
+    // check if it is excluded
+    if (removed.find(f) != removed.end())
+    {
+      continue;
+    }
+    // check if it is a function definition
+    if (defs.find(f) != defs.end())
+    {
+      if (f.getKind() == kind::EQUAL && f[0].isVar())
+      {
+        subsolver.defineFunction(f[0], f[1]);
+        continue;
+      }
+    }
+    subsolver.assertFormula(f);
+  }
+}
+
 void getModelFromSubsolver(SolverEngine& smt,
                            const std::vector<Node>& vars,
                            std::vector<Node>& vals)

--- a/src/theory/smt_engine_subsolver.cpp
+++ b/src/theory/smt_engine_subsolver.cpp
@@ -162,11 +162,10 @@ Result checkWithSubsolver(Node query,
   return r;
 }
 
-
 void assertToSubsolver(SolverEngine& subsolver,
-                                     const std::vector<Node>& core,
-                                     const std::unordered_set<Node>& defs,
-                                     const std::unordered_set<Node>& removed)
+                       const std::vector<Node>& core,
+                       const std::unordered_set<Node>& defs,
+                       const std::unordered_set<Node>& removed)
 {
   for (const Node& f : core)
   {

--- a/src/theory/smt_engine_subsolver.cpp
+++ b/src/theory/smt_engine_subsolver.cpp
@@ -174,7 +174,7 @@ void assertToSubsolver(SolverEngine& subsolver,
     {
       continue;
     }
-    // check if it is a function definition
+    // check if it is an ordinary function definition
     if (defs.find(f) != defs.end())
     {
       if (f.getKind() == kind::EQUAL && f[0].isVar())

--- a/src/theory/smt_engine_subsolver.h
+++ b/src/theory/smt_engine_subsolver.h
@@ -131,16 +131,16 @@ Result checkWithSubsolver(Node query,
 
 /**
  * Assert formulas in core to subsolver.
- * 
+ *
  * @param subsolver The subsolver to assert to
  * @param core The formulas to assert
  * @param defs The subset of core that are function definitions
  * @param removed The subset of core that should be excluded from consideration.
  */
 void assertToSubsolver(SolverEngine& subsolver,
-                        const std::vector<Node>& core,
-                        const std::unordered_set<Node>& defs,
-                        const std::unordered_set<Node>& removed);
+                       const std::vector<Node>& core,
+                       const std::unordered_set<Node>& defs,
+                       const std::unordered_set<Node>& removed);
 /**
  * Assuming smt has just been called to check-sat and returned "SAT", this
  * method adds the model for d_vars to mvs.

--- a/src/theory/smt_engine_subsolver.h
+++ b/src/theory/smt_engine_subsolver.h
@@ -130,6 +130,18 @@ Result checkWithSubsolver(Node query,
 //--------------- utilities
 
 /**
+ * Assert formulas in core to subsolver.
+ * 
+ * @param subsolver The subsolver to assert to
+ * @param core The formulas to assert
+ * @param defs The subset of core that are function definitions
+ * @param removed The subset of core that should be excluded from consideration.
+ */
+void assertToSubsolver(SolverEngine& subsolver,
+                        const std::vector<Node>& core,
+                        const std::unordered_set<Node>& defs,
+                        const std::unordered_set<Node>& removed);
+/**
  * Assuming smt has just been called to check-sat and returned "SAT", this
  * method adds the model for d_vars to mvs.
  */

--- a/src/theory/smt_engine_subsolver.h
+++ b/src/theory/smt_engine_subsolver.h
@@ -134,7 +134,9 @@ Result checkWithSubsolver(Node query,
  *
  * @param subsolver The subsolver to assert to
  * @param core The formulas to assert
- * @param defs The subset of core that are function definitions
+ * @param defs The subset of core that are (recursive or ordinary) function
+ * definitions. Ordinary function definitions are sent to the subsolver via
+ * the defineFunction interface.
  * @param removed The subset of core that should be excluded from consideration.
  */
 void assertToSubsolver(SolverEngine& subsolver,

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -506,6 +506,7 @@ set(regress_0_tests
   regress0/bv/unsound1-reduced.smt2
   regress0/chained-equality.smt2
   regress0/constant-rewrite.smtv1.smt2
+  regress0/cores/dd.uc-min-wrong.smt2 
   regress0/cores/issue3455.smt2
   regress0/cores/issue3651.smt2
   regress0/cores/issue4925.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -506,7 +506,7 @@ set(regress_0_tests
   regress0/bv/unsound1-reduced.smt2
   regress0/chained-equality.smt2
   regress0/constant-rewrite.smtv1.smt2
-  regress0/cores/dd.uc-min-wrong.smt2 
+  regress0/cores/dd.uc-min-wrong.smt2
   regress0/cores/issue3455.smt2
   regress0/cores/issue3651.smt2
   regress0/cores/issue4925.smt2

--- a/test/regress/cli/regress0/cores/dd.uc-min-wrong.smt2
+++ b/test/regress/cli/regress0/cores/dd.uc-min-wrong.smt2
@@ -1,0 +1,6 @@
+; COMMAND-LINE: --minimal-unsat-cores
+; EXPECT: unsat
+(set-logic ALL)
+(define-fun a ((b!b Int) (b!b Int)) Bool false)
+(assert (a 0 0))
+(check-sat)

--- a/test/regress/cli/regress1/nl/nl-help-unsat-quant.smt2
+++ b/test/regress/cli/regress1/nl/nl-help-unsat-quant.smt2
@@ -1,5 +1,6 @@
 ; COMMAND-LINE: --nl-ext=full
 ; EXPECT: unsat
+; DISABLE-TESTER: unsat-core
 (set-logic UFNIA)
 (set-info :status unsat)
 (set-info :source |Benchmarks from the paper: "Extending Sledgehammer with SMT Solvers" by Jasmin Blanchette, Sascha Bohme, and Lawrence C. Paulson, CADE 2011.  Translated to SMT2 by Andrew Reynolds and Morgan Deters.|)

--- a/test/regress/cli/regress1/nl/quant-nl.smt2
+++ b/test/regress/cli/regress1/nl/quant-nl.smt2
@@ -1,5 +1,6 @@
 ; COMMAND-LINE: --nl-ext=full
 ; EXPECT: unsat
+; DISABLE-TESTER: unsat-core
 (set-logic UFNIA)
 (set-info :status unsat)
 (set-info :source |Benchmarks from the paper: "Extending Sledgehammer with SMT Solvers" by Jasmin Blanchette, Sascha Bohme, and Lawrence C. Paulson, CADE 2011.  Translated to SMT2 by Andrew Reynolds and Morgan Deters.|)


### PR DESCRIPTION
This fixes bugs related to checking unsat cores and minimal unsat cores.

Both features applied top-level substitutions to assertions-to-check, which includes definitions for define-fun and substitutions learned via non-clausal simplification.  This may lead to incorrectly determining that an unsat core is unsatisfiable.

This meant that
(1) `--minimal-unsat-cores` could produce incorrect unsat cores
(2) `--check-unsat-cores` could fail to realize when an unsat core was incorrect.

The PR ensures that top-level substitutions are not applied, and assertions corresponding to definitions are treated via `defineFunction` instead of `assertFormula` on the subsolver.

This furthermore corrects an issue with unsat cores + `--macro-quant` where we were producing incorrect unsat cores but failing to realize it.  It also disables unsat cores from 2 regressions where `--check-unsat-cores` now times out.

A minimized regression for minimal-unsat-cores is added.

This may make these options slightly slower, since non-trivial substitutions must be rederived the subsolver.