### PR TITLE
Remove tracking of parse-only in parser

### DIFF
--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -37,14 +37,12 @@ namespace parser {
 
 Parser::Parser(cvc5::Solver* solver,
                SymbolManager* sm,
-               bool strictMode,
-               bool parseOnly)
+               bool strictMode)
     : d_symman(sm),
       d_symtab(sm->getSymbolTable()),
       d_done(true),
       d_checksEnabled(true),
       d_strictMode(strictMode),
-      d_parseOnly(parseOnly),
       d_canIncludeFile(true),
       d_solver(solver)
 {

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -134,9 +134,6 @@ private:
  /** Are we parsing in strict mode? */
  bool d_strictMode;
 
- /** Are we only parsing? */
- bool d_parseOnly;
-
  /**
   * Can we include files?  (Set to false for security purposes in
   * e.g. the online version.)
@@ -177,14 +174,10 @@ protected:
   * @param symm reference to the symbol manager
   * @param input the parser input
   * @param strictMode whether to incorporate strict(er) compliance checks
-  * @param parseOnly whether we are parsing only (and therefore certain checks
-  * need not be performed, like those about unimplemented features, @see
-  * unimplementedFeature())
   */
  Parser(cvc5::Solver* solver,
         SymbolManager* sm,
-        bool strictMode = false,
-        bool parseOnly = false);
+        bool strictMode = false);
 
 public:
 
@@ -606,24 +599,11 @@ public:
   }
 
   /**
-   * If we are parsing only, don't raise an exception; if we are not,
-   * raise a parse error with the given message.  There is no actual
-   * parse error, everything is as expected, but we cannot create the
-   * Expr, Type, or other requested thing yet due to internal
-   * limitations.  Even though it's not a parse error, we throw a
-   * parse error so that the input line and column information is
-   * available.
-   *
-   * Think quantifiers.  We don't have a TheoryQuantifiers yet, so we
-   * have no kind::FORALL or kind::EXISTS.  But we might want to
-   * support parsing quantifiers (just not doing anything with them).
-   * So this mechanism gives you a way to do it with --parse-only.
+   * Raise a parse error with the given message.
    */
-  inline void unimplementedFeature(const std::string& msg)
+  void unimplementedFeature(const std::string& msg)
   {
-    if(!d_parseOnly) {
-      parseError("Unimplemented feature: " + msg);
-    }
+    parseError("Unimplemented feature: " + msg);
   }
 
   /**

--- a/src/parser/parser_builder.cpp
+++ b/src/parser/parser_builder.cpp
@@ -49,7 +49,6 @@ void ParserBuilder::init(cvc5::Solver* solver, SymbolManager* sm)
   d_checksEnabled = true;
   d_strictMode = false;
   d_canIncludeFile = true;
-  d_parseOnly = false;
   d_logicIsForced = false;
   d_forcedLogic = "";
 }
@@ -67,7 +66,7 @@ std::unique_ptr<Parser> ParserBuilder::build()
 
   if (d_lang == "LANG_TPTP")
   {
-    parser.reset(new Tptp(d_solver, d_symman, d_strictMode, d_parseOnly));
+    parser.reset(new Tptp(d_solver, d_symman, d_strictMode));
   }
   else
   {
@@ -75,7 +74,6 @@ std::unique_ptr<Parser> ParserBuilder::build()
     parser.reset(new Smt2(d_solver,
                           d_symman,
                           d_strictMode,
-                          d_parseOnly,
                           d_lang == "LANG_SYGUS_V2"));
   }
 
@@ -106,18 +104,12 @@ ParserBuilder& ParserBuilder::withInputLanguage(const std::string& lang)
   return *this;
 }
 
-ParserBuilder& ParserBuilder::withParseOnly(bool flag) {
-  d_parseOnly = flag;
-  return *this;
-}
-
 ParserBuilder& ParserBuilder::withOptions()
 {
   ParserBuilder& retval = *this;
   retval = retval.withInputLanguage(d_solver->getOption("input-language"))
                .withChecks(d_solver->getOptionInfo("semantic-checks").boolValue())
                .withStrictMode(d_solver->getOptionInfo("strict-parsing").boolValue())
-               .withParseOnly(d_solver->getOptionInfo("parse-only").boolValue())
                .withIncludeFile(d_solver->getOptionInfo("filesystem-access").boolValue());
   auto info = d_solver->getOptionInfo("force-logic");
   if (info.setByUser)

--- a/src/parser/parser_builder.h
+++ b/src/parser/parser_builder.h
@@ -60,9 +60,6 @@ class CVC5_EXPORT ParserBuilder
   /** Should we allow include-file commands? */
   bool d_canIncludeFile;
 
-  /** Are we parsing only? */
-  bool d_parseOnly;
-
   /** Is the logic forced by the user? */
   bool d_logicIsForced;
 
@@ -88,19 +85,6 @@ class CVC5_EXPORT ParserBuilder
    * (Default: LANG_AUTO)
    */
   ParserBuilder& withInputLanguage(const std::string& lang);
-
-  /**
-   * Are we only parsing, or doing something with the resulting
-   * commands and expressions?  This setting affects whether the
-   * parser will raise certain errors about unimplemented features,
-   * even if there isn't a parsing error, because the result of the
-   * parse would otherwise be an incorrect parse tree and the error
-   * would go undetected.  This is specifically for circumstances
-   * where the parser is ahead of the functionality present elsewhere
-   * in cvc5 (such as quantifiers, subtypes, records, etc. in the CVC
-   * language parser).
-   */
-  ParserBuilder& withParseOnly(bool flag = true);
 
   /** Derive settings from the solver's options. */
   ParserBuilder& withOptions();

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -33,9 +33,8 @@ namespace parser {
 Smt2::Smt2(cvc5::Solver* solver,
            SymbolManager* sm,
            bool strictMode,
-           bool parseOnly,
            bool isSygus)
-    : Parser(solver, sm, strictMode, parseOnly),
+    : Parser(solver, sm, strictMode),
       d_isSygus(isSygus),
       d_logicSet(false),
       d_seenSetLogic(false)

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -71,7 +71,6 @@ class Smt2 : public Parser
   Smt2(cvc5::Solver* solver,
        SymbolManager* sm,
        bool strictMode = false,
-       bool parseOnly = false,
        bool isSygus = false);
 
  public:

--- a/src/parser/tptp/tptp.cpp
+++ b/src/parser/tptp/tptp.cpp
@@ -34,9 +34,8 @@ namespace parser {
 
 Tptp::Tptp(cvc5::Solver* solver,
            SymbolManager* sm,
-           bool strictMode,
-           bool parseOnly)
-    : Parser(solver, sm, strictMode, parseOnly),
+           bool strictMode)
+    : Parser(solver, sm, strictMode),
       d_cnf(false),
       d_fof(false),
       d_hol(false)

--- a/src/parser/tptp/tptp.h
+++ b/src/parser/tptp/tptp.h
@@ -92,8 +92,7 @@ class Tptp : public Parser {
  protected:
   Tptp(cvc5::Solver* solver,
        SymbolManager* sm,
-       bool strictMode = false,
-       bool parseOnly = false);
+       bool strictMode = false);
 
  public:
   ~Tptp();


### PR DESCRIPTION
Tracking this was intended to not raise errors when in parse-only mode.  This feature is only used by the TPTP parser. Moreover, it is used in an unintended way where malformed terms could be constructed.

This is work towards simplifying interfaces for the new parser.