### PR TITLE
Consolidate delayed resolution of indexed operators in the parser

### DIFF
--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -1414,7 +1414,8 @@ termNonVariable[cvc5::Term& expr, cvc5::Term& expr2]
  * (2) A string name.
  * (3) An expression expr.
  * (4) A type t.
- * (5) A list of indices.
+ * (5) An operator
+ * (6) A list of indices.
  *
  * A qualified identifier is the generic case of function heads.
  * With respect to the standard definition (Section 3.6 of SMT-LIB version 2.6)
@@ -1432,7 +1433,7 @@ termNonVariable[cvc5::Term& expr, cvc5::Term& expr2]
  * - For indexed functions like testers (_ is C) and bitvector extract
  * (_ extract n m), we return (3) for the appropriate operator.
  * - For floating-point conversion to_fp, tuple selectors (_ tuple_select n)
- * and updaters (_ tuple_update n), we return (5). cvc5::Kind is set to
+ * and updaters (_ tuple_update n), we return (6). cvc5::Kind is set to
  * UNDEFINED_KIND. We do this since there is no AST expression representing
  * the generic version of these operators, and we do not have
  * enough type information at this point to know the proper kind to use.

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -1414,6 +1414,7 @@ termNonVariable[cvc5::Term& expr, cvc5::Term& expr2]
  * (2) A string name.
  * (3) An expression expr.
  * (4) A type t.
+ * (5) A list of indices.
  *
  * A qualified identifier is the generic case of function heads.
  * With respect to the standard definition (Section 3.6 of SMT-LIB version 2.6)
@@ -1430,13 +1431,11 @@ termNonVariable[cvc5::Term& expr, cvc5::Term& expr2]
  * - For declared functions f, we return (2).
  * - For indexed functions like testers (_ is C) and bitvector extract
  * (_ extract n m), we return (3) for the appropriate operator.
- * - For tuple selectors (_ tuple_select n) and updaters (_ tuple_update n), we
- * return (1) and (3). cvc5::Kind is set to APPLY_SELECTOR or APPLY_UPDATER
- * respectively, and expr is set to n, which is to be interpreted by the
- * caller as the n^th generic tuple selector or updater. We do this since there
- * is no AST expression representing generic tuple select, and we do not have
- * enough type information at this point to know the type of the tuple we will
- * be selecting from.
+ * - For floating-point conversion to_fp, tuple selectors (_ tuple_select n)
+ * and updaters (_ tuple_update n), we return (5). cvc5::Kind is set to
+ * UNDEFINED_KIND. We do this since there is no AST expression representing
+ * the generic version of these operators, and we do not have
+ * enough type information at this point to know the proper kind to use.
  *
  * (Ascripted Identifiers)
  *
@@ -1460,9 +1459,6 @@ termNonVariable[cvc5::Term& expr, cvc5::Term& expr2]
  */
 qualIdentifier[cvc5::ParseOp& p]
 @init {
-  cvc5::Kind k;
-  std::string baseName;
-  cvc5::Term f;
   cvc5::Sort type;
 }
 : identifier[p]
@@ -1542,25 +1538,10 @@ identifier[cvc5::ParseOp& p]
         if (k == cvc5::UNDEFINED_KIND)
         {
           // We don't know which kind to use until we know the type of the
-          // arguments
+          // arguments. This case handles to_tp, tuple.select and tuple.update
           p.d_name = opName;
           p.d_indices = numerals;
           p.d_kind = cvc5::UNDEFINED_KIND;
-        }
-        else if (k == cvc5::APPLY_SELECTOR || k == cvc5::APPLY_UPDATER)
-        {
-          // we adopt a special syntax (_ tuple_select n) and (_ tuple_update n)
-          // for tuple selectors and updaters
-          if (numerals.size() != 1)
-          {
-            PARSER_STATE->parseError(
-                "Unexpected syntax for tuple selector or updater.");
-          }
-          // The operator is dependent upon inferring the type of the arguments,
-          // and hence the type is not available yet. Hence, we remember the
-          // index as a numeral in the parse operator.
-          p.d_kind = k;
-          p.d_expr = SOLVER->mkInteger(numerals[0]);
         }
         else
         {

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -1538,7 +1538,7 @@ identifier[cvc5::ParseOp& p]
         if (k == cvc5::UNDEFINED_KIND)
         {
           // We don't know which kind to use until we know the type of the
-          // arguments. This case handles to_tp, tuple.select and tuple.update
+          // arguments. This case handles to_fp, tuple.select and tuple.update
           p.d_name = opName;
           p.d_indices = numerals;
           p.d_kind = cvc5::UNDEFINED_KIND;

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -143,7 +143,7 @@ void Smt2::addDatatypesOperators()
     // Tuple projection is both indexed and non-indexed (when indices are empty)
     addOperator(cvc5::TUPLE_PROJECT, "tuple.project");
     addIndexedOperator(cvc5::TUPLE_PROJECT, "tuple.project");
-    // Notice that tuple operators, we use the UNDEFINED_KIND kind. 
+    // Notice that tuple operators, we use the UNDEFINED_KIND kind.
     // These are processed based on the context in which they are parsed, e.g.
     // when parsing identifiers.
     // For the tuple constructor "tuple", this is both a nullary operator
@@ -1054,14 +1054,14 @@ cvc5::Term Smt2::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
         std::stringstream ss;
         ss << "Wrong number of arguments for indexed operator to_fp, expected "
               "1 or 2, got "
-          << nchildren;
+           << nchildren;
         parseError(ss.str());
       }
       else if (!args[0].getSort().isRoundingMode())
       {
         std::stringstream ss;
         ss << "Expected a rounding mode as the first argument, got "
-          << args[0].getSort();
+           << args[0].getSort();
         parseError(ss.str());
       }
       else
@@ -1085,10 +1085,10 @@ cvc5::Term Smt2::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
         }
       }
     }
-    else if (p.d_name=="tuple.select" || p.d_name=="tuple.update")
+    else if (p.d_name == "tuple.select" || p.d_name == "tuple.update")
     {
-      bool isSelect = (p.d_name=="tuple.select");
-      if (p.d_indices.size()!=1)
+      bool isSelect = (p.d_name == "tuple.select");
+      if (p.d_indices.size() != 1)
       {
         parseError("wrong number of indices for tuple select or update");
       }
@@ -1113,20 +1113,21 @@ cvc5::Term Smt2::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
       cvc5::Term ret;
       if (isSelect)
       {
-        ret =
-            d_solver->mkTerm(cvc5::APPLY_SELECTOR, {dt[0][n].getTerm(), args[0]});
+        ret = d_solver->mkTerm(cvc5::APPLY_SELECTOR,
+                               {dt[0][n].getTerm(), args[0]});
       }
       else
       {
         ret = d_solver->mkTerm(cvc5::APPLY_UPDATER,
-                              {dt[0][n].getUpdaterTerm(), args[0], args[1]});
+                               {dt[0][n].getUpdaterTerm(), args[0], args[1]});
       }
-      Trace("parser") << "applyParseOp: return selector/updater " << ret << std::endl;
+      Trace("parser") << "applyParseOp: return selector/updater " << ret
+                      << std::endl;
       return ret;
     }
     else
     {
-      Assert (false) << "Failed to resolve indexed operator " << p.d_name;
+      Assert(false) << "Failed to resolve indexed operator " << p.d_name;
     }
   }
   else if (p.d_kind != cvc5::NULL_TERM)

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -151,8 +151,8 @@ void Smt2::addDatatypesOperators()
     // and defineVar here.
     addOperator(cvc5::APPLY_CONSTRUCTOR, "tuple");
     defineVar("tuple", d_solver->mkTuple({}, {}));
-    addIndexedOperator(cvc5::APPLY_SELECTOR, "tuple.select");
-    addIndexedOperator(cvc5::APPLY_UPDATER, "tuple.update");
+    addIndexedOperator(cvc5::UNDEFINED_KIND, "tuple.select");
+    addIndexedOperator(cvc5::UNDEFINED_KIND, "tuple.update");
   }
 }
 
@@ -1038,48 +1038,94 @@ cvc5::Term Smt2::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
   if (p.d_kind == cvc5::UNDEFINED_KIND && isIndexedOperatorEnabled(p.d_name))
   {
     // Resolve indexed symbols that cannot be resolved without knowing the type
-    // of the arguments. This is currently limited to `to_fp`.
-    Assert(p.d_name == "to_fp");
+    // of the arguments. This is currently limited to `to_fp`, `tuple.select`,
+    // and `tuple.update`.
     size_t nchildren = args.size();
-    if (nchildren == 1)
+    if (p.d_name == "to_fp")
     {
-      kind = cvc5::FLOATINGPOINT_TO_FP_FROM_IEEE_BV;
-      op = d_solver->mkOp(kind, p.d_indices);
-    }
-    else if (nchildren > 2)
-    {
-      std::stringstream ss;
-      ss << "Wrong number of arguments for indexed operator to_fp, expected "
-            "1 or 2, got "
-         << nchildren;
-      parseError(ss.str());
-    }
-    else if (!args[0].getSort().isRoundingMode())
-    {
-      std::stringstream ss;
-      ss << "Expected a rounding mode as the first argument, got "
-         << args[0].getSort();
-      parseError(ss.str());
-    }
-    else
-    {
-      cvc5::Sort t = args[1].getSort();
-
-      if (t.isFloatingPoint())
+      if (nchildren == 1)
       {
-        kind = cvc5::FLOATINGPOINT_TO_FP_FROM_FP;
+        kind = cvc5::FLOATINGPOINT_TO_FP_FROM_IEEE_BV;
         op = d_solver->mkOp(kind, p.d_indices);
       }
-      else if (t.isInteger() || t.isReal())
+      else if (nchildren > 2)
       {
-        kind = cvc5::FLOATINGPOINT_TO_FP_FROM_REAL;
-        op = d_solver->mkOp(kind, p.d_indices);
+        std::stringstream ss;
+        ss << "Wrong number of arguments for indexed operator to_fp, expected "
+              "1 or 2, got "
+          << nchildren;
+        parseError(ss.str());
+      }
+      else if (!args[0].getSort().isRoundingMode())
+      {
+        std::stringstream ss;
+        ss << "Expected a rounding mode as the first argument, got "
+          << args[0].getSort();
+        parseError(ss.str());
       }
       else
       {
-        kind = cvc5::FLOATINGPOINT_TO_FP_FROM_SBV;
-        op = d_solver->mkOp(kind, p.d_indices);
+        cvc5::Sort t = args[1].getSort();
+
+        if (t.isFloatingPoint())
+        {
+          kind = cvc5::FLOATINGPOINT_TO_FP_FROM_FP;
+          op = d_solver->mkOp(kind, p.d_indices);
+        }
+        else if (t.isInteger() || t.isReal())
+        {
+          kind = cvc5::FLOATINGPOINT_TO_FP_FROM_REAL;
+          op = d_solver->mkOp(kind, p.d_indices);
+        }
+        else
+        {
+          kind = cvc5::FLOATINGPOINT_TO_FP_FROM_SBV;
+          op = d_solver->mkOp(kind, p.d_indices);
+        }
       }
+    }
+    else if (p.d_name=="tuple.select" || p.d_name=="tuple.update")
+    {
+      bool isSelect = (p.d_name=="tuple.select");
+      if (p.d_indices.size()!=1)
+      {
+        parseError("wrong number of indices for tuple select or update");
+      }
+      uint64_t n = p.d_indices[0];
+      if (args.size() != (isSelect ? 1 : 2))
+      {
+        parseError("wrong number of arguments for tuple select or update");
+      }
+      cvc5::Sort t = args[0].getSort();
+      if (!t.isTuple())
+      {
+        parseError("tuple select or update applied to non-tuple");
+      }
+      size_t length = t.getTupleLength();
+      if (n >= length)
+      {
+        std::stringstream ss;
+        ss << "tuple is of length " << length << "; cannot access index " << n;
+        parseError(ss.str());
+      }
+      const cvc5::Datatype& dt = t.getDatatype();
+      cvc5::Term ret;
+      if (isSelect)
+      {
+        ret =
+            d_solver->mkTerm(cvc5::APPLY_SELECTOR, {dt[0][n].getTerm(), args[0]});
+      }
+      else
+      {
+        ret = d_solver->mkTerm(cvc5::APPLY_UPDATER,
+                              {dt[0][n].getUpdaterTerm(), args[0], args[1]});
+      }
+      Trace("parser") << "applyParseOp: return selector/updater " << ret << std::endl;
+      return ret;
+    }
+    else
+    {
+      Assert (false) << "Failed to resolve indexed operator " << p.d_name;
     }
   }
   else if (p.d_kind != cvc5::NULL_TERM)
@@ -1201,47 +1247,6 @@ cvc5::Term Smt2::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
     }
     cvc5::Term ret = d_solver->mkConstArray(p.d_type, constVal);
     Trace("parser") << "applyParseOp: return store all " << ret << std::endl;
-    return ret;
-  }
-  else if ((p.d_kind == cvc5::APPLY_SELECTOR || p.d_kind == cvc5::APPLY_UPDATER)
-           && !p.d_expr.isNull())
-  {
-    // tuple selector or updater case
-    if (!p.d_expr.isUInt64Value())
-    {
-      parseError(
-          "index of tuple select or update is larger than size of uint64_t");
-    }
-    uint64_t n = p.d_expr.getUInt64Value();
-    if (args.size() != (p.d_kind == cvc5::APPLY_SELECTOR ? 1 : 2))
-    {
-      parseError("wrong number of arguments for tuple select or update");
-    }
-    cvc5::Sort t = args[0].getSort();
-    if (!t.isTuple())
-    {
-      parseError("tuple select or update applied to non-tuple");
-    }
-    size_t length = t.getTupleLength();
-    if (n >= length)
-    {
-      std::stringstream ss;
-      ss << "tuple is of length " << length << "; cannot access index " << n;
-      parseError(ss.str());
-    }
-    const cvc5::Datatype& dt = t.getDatatype();
-    cvc5::Term ret;
-    if (p.d_kind == cvc5::APPLY_SELECTOR)
-    {
-      ret =
-          d_solver->mkTerm(cvc5::APPLY_SELECTOR, {dt[0][n].getTerm(), args[0]});
-    }
-    else
-    {
-      ret = d_solver->mkTerm(cvc5::APPLY_UPDATER,
-                             {dt[0][n].getUpdaterTerm(), args[0], args[1]});
-    }
-    Trace("parser") << "applyParseOp: return selector " << ret << std::endl;
     return ret;
   }
   else if (p.d_kind != cvc5::NULL_TERM)

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -143,9 +143,9 @@ void Smt2::addDatatypesOperators()
     // Tuple projection is both indexed and non-indexed (when indices are empty)
     addOperator(cvc5::TUPLE_PROJECT, "tuple.project");
     addIndexedOperator(cvc5::TUPLE_PROJECT, "tuple.project");
-    // Notice that tuple operators, we use the generic APPLY_CONSTRUCTOR,
-    // APPLY_SELECTOR and APPLY_UPDATER kinds. These are processed based on the
-    // context in which they are parsed, e.g. when parsing identifiers.
+    // Notice that tuple operators, we use the UNDEFINED_KIND kind. 
+    // These are processed based on the context in which they are parsed, e.g.
+    // when parsing identifiers.
     // For the tuple constructor "tuple", this is both a nullary operator
     // (for the 0-ary tuple), and a operator, hence we call both addOperator
     // and defineVar here.
@@ -244,6 +244,7 @@ void Smt2::addFloatingPointOperators() {
   addOperator(cvc5::FLOATINGPOINT_IS_POS, "fp.isPositive");
   addOperator(cvc5::FLOATINGPOINT_TO_REAL, "fp.to_real");
 
+  // we delay the resolution of to_fp
   addIndexedOperator(cvc5::UNDEFINED_KIND, "to_fp");
   addIndexedOperator(cvc5::FLOATINGPOINT_TO_FP_FROM_UBV, "to_fp_unsigned");
   addIndexedOperator(cvc5::FLOATINGPOINT_TO_UBV, "fp.to_ubv");


### PR DESCRIPTION
This changes the parsing for `tuple.select` and `tuple.update` to follow the pattern for parsing `to_fp` for the sake of consistency.