### PR TITLE
Move input stream exception to parser exception file

### DIFF
--- a/src/parser/input.cpp
+++ b/src/parser/input.cpp
@@ -21,17 +21,12 @@
 #include "base/output.h"
 #include "parser/parser_exception.h"
 
-
 using namespace std;
 using namespace cvc5;
 using namespace cvc5::parser;
 
 namespace cvc5 {
 namespace parser {
-
-InputStreamException::InputStreamException(const std::string& msg) :
-  Exception(msg) {
-}
 
 const std::string InputStream::getName() const {
   return d_name;

--- a/src/parser/input.h
+++ b/src/parser/input.h
@@ -33,12 +33,6 @@ namespace cvc5::parser {
 
 class Command;
 
-class InputStreamException : public internal::Exception
-{
- public:
-  InputStreamException(const std::string& msg);
-};
-
 /** Wrapper around an input stream. */
 class InputStream
 {

--- a/src/parser/parser_exception.h
+++ b/src/parser/parser_exception.h
@@ -98,6 +98,12 @@ class ParserEndOfFileException : public ParserException
 
 }; /* class ParserEndOfFileException */
 
+class InputStreamException : public internal::Exception
+{
+ public:
+  InputStreamException(const std::string& msg) : Exception(msg){}
+};
+
 }  // namespace parser
 }  // namespace cvc5
 


### PR DESCRIPTION
The parser exceptions file will be preserved in the medium term. The `input.h/cpp` files are ANTLR specific and will be deleted when we remove ANTLR.