### PR TITLE
Do not reset context when checking again with SmtDriver

### DIFF
--- a/src/smt/context_manager.cpp
+++ b/src/smt/context_manager.cpp
@@ -47,6 +47,8 @@ void ContextManager::notifyResetAssertions()
   // (see solver execution modes in the SMT-LIB standard)
   Assert(d_userLevels.size() == 0 && userContext()->getLevel() == 1);
   popto(0);
+  // push the state to maintain global context around everything
+  push();
 }
 
 void ContextManager::notifyCheckSat(bool hasAssumptions)
@@ -71,7 +73,7 @@ void ContextManager::notifyCheckSatResult(bool hasAssumptions)
 void ContextManager::setup(SmtDriver* smt)
 {
   d_smt = smt;
-  // push a context
+  // push the state to maintain global context around everything
   push();
 }
 

--- a/src/smt/smt_driver.cpp
+++ b/src/smt/smt_driver.cpp
@@ -76,12 +76,8 @@ Result SmtDriver::checkSat(const std::vector<Node>& assumptions)
         if (result.getStatus() == Result::UNKNOWN
             && result.getUnknownExplanation() == REQUIRES_CHECK_AGAIN)
         {
-          Assert(d_ctx != nullptr);
-          d_ctx->notifyResetAssertions();
           // finish init to construct new theory/prop engine
           d_smt.finishInit();
-          // setup
-          d_ctx->setup(this);
         }
         else
         {

--- a/src/smt/smt_driver_deep_restarts.cpp
+++ b/src/smt/smt_driver_deep_restarts.cpp
@@ -108,6 +108,10 @@ void SmtDriverDeepRestarts::getNextAssertions(
     }
   }
   Trace("deep-restart") << "Finished compute deep restart" << std::endl;
+  // Note that the environment may contain top-level substitutions derived
+  // on the previous check-sat. Since the context does not change, these
+  // are preserved for the next check-sat, which ensures models involving
+  // variables appearing in top-level substitutions are correct.
 }
 
 }  // namespace smt

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1870,8 +1870,6 @@ void SolverEngine::resetAssertions()
   Trace("smt") << "SMT resetAssertions()" << endl;
 
   d_ctxManager->notifyResetAssertions();
-  // push the state to maintain global context around everything
-  d_ctxManager->setup(d_smtDriver.get());
 
   // reset SmtSolver, which will construct a new prop engine
   d_smtSolver->resetAssertions();

--- a/src/theory/uf/equality_engine.cpp
+++ b/src/theory/uf/equality_engine.cpp
@@ -76,10 +76,6 @@ void EqualityEngine::init() {
   Trace("equality") << "EqualityEdge::EqualityEngine(): edge_null = " << +null_edge << std::endl;
   Trace("equality") << "EqualityEdge::EqualityEngine(): trigger_null = " << +null_trigger << std::endl;
 
-  // If we are not at level zero when we initialize this equality engine, we
-  // may remove true/false from the equality engine when we pop to level zero,
-  // which leads to issues.
-  Assert(d_context->getLevel() == 0);
 
   d_true = NodeManager::currentNM()->mkConst<bool>(true);
   d_false = NodeManager::currentNM()->mkConst<bool>(false);

--- a/src/theory/uf/equality_engine.cpp
+++ b/src/theory/uf/equality_engine.cpp
@@ -79,8 +79,6 @@ void EqualityEngine::init() {
   // Note that we previously checked whether the context level was zero here,
   // to ensure that true/false could never be removed. However, this assertion
   // restricts our ability to construct equality engines in nested contexts.
-  // Instead we track the level (for debugging).
-  d_initLevel = d_context->getLevel();
 
   d_true = NodeManager::currentNM()->mkConst<bool>(true);
   d_false = NodeManager::currentNM()->mkConst<bool>(false);
@@ -124,8 +122,7 @@ EqualityEngine::EqualityEngine(Env& env,
       d_deducedDisequalitiesSize(c, 0),
       d_deducedDisequalityReasonsSize(c, 0),
       d_propagatedDisequalities(c),
-      d_name(name),
-      d_initLevel(0)
+      d_name(name)
 {
   init();
 }
@@ -157,8 +154,7 @@ EqualityEngine::EqualityEngine(Env& env,
       d_deducedDisequalitiesSize(c, 0),
       d_deducedDisequalityReasonsSize(c, 0),
       d_propagatedDisequalities(c),
-      d_name(name),
-      d_initLevel(0)
+      d_name(name)
 {
   init();
   // since init makes notifications (e.g. new eq class for true/false), and
@@ -1845,13 +1841,6 @@ void EqualityEngine::addTriggerEqualityInternal(TNode t1, TNode t2, TNode trigge
   }
 
   Trace("equality") << d_name << "::eq::addTrigger(" << t1 << "," << t2 << ") => (" << t1NewTriggerId << ", " << t2NewTriggerId << ")" << std::endl;
-}
-
-void EqualityEngine::contextNotifyPop()
-{
-  backtrack();
-  // ensure we haven't popped beyond the level we started
-  Assert(d_initLevel <= d_context->getLevel());
 }
 
 Node EqualityEngine::evaluateTerm(TNode node) {

--- a/src/theory/uf/equality_engine.cpp
+++ b/src/theory/uf/equality_engine.cpp
@@ -1848,10 +1848,10 @@ void EqualityEngine::addTriggerEqualityInternal(TNode t1, TNode t2, TNode trigge
 }
 
 void EqualityEngine::contextNotifyPop()
-{ 
-  backtrack(); 
+{
+  backtrack();
   // ensure we haven't popped beyond the level we started
-  Assert(d_initLevel<=d_context->getLevel());
+  Assert(d_initLevel <= d_context->getLevel());
 }
 
 Node EqualityEngine::evaluateTerm(TNode node) {

--- a/src/theory/uf/equality_engine.h
+++ b/src/theory/uf/equality_engine.h
@@ -481,7 +481,7 @@ class EqualityEngine : public context::ContextNotifyObj, protected EnvObj
   /**
    * This method gets called on backtracks from the context manager.
    */
-  void contextNotifyPop() override;
+  void contextNotifyPop() override { backtrack(); }
 
   /**
    * Constructor initialization stuff.
@@ -665,9 +665,6 @@ class EqualityEngine : public context::ContextNotifyObj, protected EnvObj
 
   /** Name of the equality engine */
   std::string d_name;
-
-  /** The initial context level (for debugging) */
-  int d_initLevel;
 
   /** The internal addTerm */
   void addTermInternal(TNode t, bool isOperator = false);

--- a/src/theory/uf/equality_engine.h
+++ b/src/theory/uf/equality_engine.h
@@ -665,7 +665,7 @@ class EqualityEngine : public context::ContextNotifyObj, protected EnvObj
 
   /** Name of the equality engine */
   std::string d_name;
-  
+
   /** The initial context level (for debugging) */
   int d_initLevel;
 

--- a/src/theory/uf/equality_engine.h
+++ b/src/theory/uf/equality_engine.h
@@ -481,7 +481,7 @@ class EqualityEngine : public context::ContextNotifyObj, protected EnvObj
   /**
    * This method gets called on backtracks from the context manager.
    */
-  void contextNotifyPop() override { backtrack(); }
+  void contextNotifyPop() override;
 
   /**
    * Constructor initialization stuff.
@@ -665,6 +665,9 @@ class EqualityEngine : public context::ContextNotifyObj, protected EnvObj
 
   /** Name of the equality engine */
   std::string d_name;
+  
+  /** The initial context level (for debugging) */
+  int d_initLevel;
 
   /** The internal addTerm */
   void addTermInternal(TNode t, bool isOperator = false);


### PR DESCRIPTION
The current implementation of SmtDriver assumed that assertions should be cleared for the next check-sat, which was done by popping/pushing the contexts.  This was wrong for deep restarts since this would also clear the user assertion list and top-level substitutions in the environment.  

This meant that (1) models were incorrect when using deep restarts (when a variable was added to top-level substitutions and subsequently cleared), (2) `check-models` was ineffective when using deep restarts since the user assertion list was cleared.

This removes this behavior, meaning that `deep-restarts` generates correct models.

This required removing an assertion from the equality engine regarding when equality engines should be constructed.