### PR TITLE
bv: Remove bv2nat and int2bv kinds from BV equality engine.

### DIFF
--- a/src/theory/bv/theory_bv.cpp
+++ b/src/theory/bv/theory_bv.cpp
@@ -128,8 +128,6 @@ void TheoryBV::finishInit()
     //    ee->addFunctionKind(kind::BITVECTOR_SLE);
     //    ee->addFunctionKind(kind::BITVECTOR_SGT);
     //    ee->addFunctionKind(kind::BITVECTOR_SGE);
-    ee->addFunctionKind(kind::BITVECTOR_TO_NAT);
-    ee->addFunctionKind(kind::INT_TO_BITVECTOR);
   }
 }
 


### PR DESCRIPTION
bv2nat and int2bv are now handled by the UF theory.