### PR TITLE
bv: Remove redundant expandDefinition call in ppRewrite().

### DIFF
--- a/src/theory/bv/theory_bv.cpp
+++ b/src/theory/bv/theory_bv.cpp
@@ -266,13 +266,6 @@ Theory::PPAssertStatus TheoryBV::ppAssert(
 
 TrustNode TheoryBV::ppRewrite(TNode t, std::vector<SkolemLemma>& lems)
 {
-  // first, see if we need to expand definitions
-  TrustNode texp = d_rewriter.expandDefinition(t);
-  if (!texp.isNull())
-  {
-    return texp;
-  }
-
   Trace("theory-bv-pp-rewrite") << "ppRewrite " << t << "\n";
   Node res = t;
   if (options().bv.bitwiseEq && RewriteRule<BitwiseEq>::applies(t))


### PR DESCRIPTION
The BV rewriter does not implement expandDefinition() and therefore we shouldn't need to call it in ppRewrite().