### PR TITLE
Delay possible inference processing in strings

### DIFF
--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2639,7 +2639,7 @@ void CoreSolver::checkLengthsEqc() {
 
 void CoreSolver::processPossibleInferInfo(std::vector<CoreInferInfo>& pinfer)
 {
-  // now, determine which of the possible inferences we want to add
+  // determine which of the possible inferences we want to add
   unsigned use_index = 0;
   bool set_use_index = false;
   Trace("strings-solve") << "Possible inferences (" << pinfer.size()

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -645,6 +645,9 @@ void CoreSolver::normalizeEquivalenceClass(Node eqc,
     }
     // process the normal forms
     processNEqc(eqc, normal_forms, stype, pinfer);
+    // If we sent a lemma, or if pinfer is non-empty (a normal form could not
+    // be assigned to this equivalence class), then we return. The possible
+    // inferences (if necessary) will be processed in checkNormalFormsEq.
     if (d_im.hasProcessed() || !pinfer.empty())
     {
       return;

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -526,9 +526,17 @@ void CoreSolver::checkNormalFormsEq()
   // calculate normal forms for each equivalence class, possibly adding
   // splitting lemmas
   d_normal_form.clear();
+  // map from normal form terms (the concatenation of the terms in the normal
+  // form) to the equivalence that had that normal form
   std::map<Node, Node> nf_to_eqc;
+  // map from equivalence classes to the normal form term
   std::map<Node, Node> eqc_to_nf;
+  // the explanation for the normal form for each equivalence class
   std::map<Node, Node> eqc_to_exp;
+  // A set of possible inferences, in case we failed to compute a normal form
+  // in a call to normalizeEquivalenceClass. This set typically contains
+  // lemmas that require splitting. We delay processing these lemmas until
+  // the invocation of processPossibleInferInfo below.
   std::vector<CoreInferInfo> pinfer;
   for (const Node& eqc : d_strings_eqc)
   {
@@ -545,7 +553,8 @@ void CoreSolver::checkNormalFormsEq()
     if (!pinfer.empty())
     {
       // if we had a possible inference, we were unable to assign
-      // a normal form to this equivalence class, we break.
+      // a normal form to this equivalence class based on the call to
+      // normalizeEquivalenceClass, we break.
       break;
     }
     NormalForm& nfe = getNormalForm(eqc);

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -48,8 +48,7 @@ CoreSolver::CoreSolver(Env& env,
       d_termReg(tr),
       d_bsolver(bs),
       d_nfPairs(context()),
-      d_extDeq(userContext()),
-      d_stringsMnf(env, s, im, tr, bs)
+      d_extDeq(userContext())
 {
   d_zero = NodeManager::currentNM()->mkConstInt(Rational(0));
   d_one = NodeManager::currentNM()->mkConstInt(Rational(1));
@@ -580,11 +579,6 @@ void CoreSolver::checkNormalFormsEq()
   }
   if (!pinfer.empty())
   {
-    if (options().strings.stringModelNormalForms)
-    {
-      // if we are using model normal forms, eagerly check if there is a model
-      // here before sending the lemma in processPossibleInferInfo.
-    }
     // add one inference from our list of possible inferences
     processPossibleInferInfo(pinfer);
     return;

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -325,7 +325,7 @@ class CoreSolver : protected EnvObj
    * of string term n (for more details on normal forms, see normal_form.h
    * or see Liang et al CAV 2014). In particular, this method checks whether the
    * current normal form for each term in this equivalence class is identical.
-   * If it is not, then we add an inference via sendInference and abort the
+   * If it is not, then we add (at least one) inference to pinfer and abort the
    * call.
    *
    * stype is the string-like type of the equivalence class we are processing.

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -28,7 +28,6 @@
 #include "theory/strings/inference_manager.h"
 #include "theory/strings/normal_form.h"
 #include "theory/strings/solver_state.h"
-#include "theory/strings/strings_mnf.h"
 #include "theory/strings/term_registry.h"
 
 namespace cvc5::internal {
@@ -544,8 +543,6 @@ class CoreSolver : protected EnvObj
   std::map<Node, std::vector<int> > d_flat_form_index;
   /** Set of equalities for which we have applied extensionality. */
   NodeSet d_extDeq;
-  /** Model normal form finding module */
-  StringsMnf d_stringsMnf;
 }; /* class CoreSolver */
 
 }  // namespace strings

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -28,6 +28,7 @@
 #include "theory/strings/inference_manager.h"
 #include "theory/strings/normal_form.h"
 #include "theory/strings/solver_state.h"
+#include "theory/strings/strings_mnf.h"
 #include "theory/strings/term_registry.h"
 
 namespace cvc5::internal {
@@ -286,6 +287,10 @@ class CoreSolver : protected EnvObj
 
  private:
   /**
+   * This processes one infer info in pinfer using processInferInfo.
+   */
+  void processPossibleInferInfo(std::vector<CoreInferInfo>& pinfer);
+  /**
    * This processes the infer info ii as an inference. In more detail, it calls
    * the inference manager to process the inference, and updates the set of
    * normal form pairs. Returns true if the conclusion of ii was not true
@@ -326,7 +331,9 @@ class CoreSolver : protected EnvObj
    *
    * stype is the string-like type of the equivalence class we are processing.
    */
-  void normalizeEquivalenceClass(Node n, TypeNode stype);
+  void normalizeEquivalenceClass(Node n,
+                                 TypeNode stype,
+                                 std::vector<CoreInferInfo>& pinfer);
   /**
    * For each term in the equivalence class of eqc, this adds data regarding its
    * normal form to normal_forms. The map term_to_nf_index maps terms to the
@@ -355,7 +362,8 @@ class CoreSolver : protected EnvObj
    */
   void processNEqc(Node eqc,
                    std::vector<NormalForm>& normal_forms,
-                   TypeNode stype);
+                   TypeNode stype,
+                   std::vector<CoreInferInfo>& pinfer);
   /** process simple normal equality
    *
    * This method is called when two equal terms have normal forms nfi and nfj.
@@ -536,6 +544,8 @@ class CoreSolver : protected EnvObj
   std::map<Node, std::vector<int> > d_flat_form_index;
   /** Set of equalities for which we have applied extensionality. */
   NodeSet d_extDeq;
+  /** Model normal form finding module */
+  StringsMnf d_stringsMnf;
 }; /* class CoreSolver */
 
 }  // namespace strings

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -286,9 +286,10 @@ class CoreSolver : protected EnvObj
 
  private:
   /**
-   * This processes one infer info in pinfer using processInferInfo.
+   * This returns the index of an infer info in pinfer that we should process
+   * based on our heuristics.
    */
-  void processPossibleInferInfo(std::vector<CoreInferInfo>& pinfer);
+  size_t choosePossibleInferInfo(const std::vector<CoreInferInfo>& pinfer);
   /**
    * This processes the infer info ii as an inference. In more detail, it calls
    * the inference manager to process the inference, and updates the set of


### PR DESCRIPTION
This is work towards a model-based variant of the core strings solver.

This moves lemma processing to a more global place in the normal forms inference lemma schema in preparation for invoking the model-based module there.