### PR TITLE
Fixes for TPTP parsing

### DIFF
--- a/src/parser/tptp/Tptp.g
+++ b/src/parser/tptp/Tptp.g
@@ -583,6 +583,10 @@ definedFun[cvc5::ParseOp& p]
     {
       p.d_kind = cvc5::DIVISION;
     }
+  | '$ite'
+    {
+      p.d_kind = cvc5::ITE;
+    }
   | ( '$quotient_e' { remainder = false; }
     | '$remainder_e' { remainder = true; }
     )

--- a/src/parser/tptp/tptp.cpp
+++ b/src/parser/tptp/tptp.cpp
@@ -420,7 +420,8 @@ void Tptp::setHol()
     return;
   }
   d_hol = true;
-  d_solver->setLogic("HO_UF");
+  // since we can include arithmetic, just set the logic to include all
+  d_solver->setLogic("HO_ALL");
 }
 
 void Tptp::addFreeVar(cvc5::Term var)


### PR DESCRIPTION
Adds `$ite` as a defined operator and includes all theories (in particular, arithmetic) in THF.

This fixes all known bugs for parsing TPTP.