### PR TITLE
Refactor input parser for incremental string inputs

### DIFF
--- a/src/main/interactive_shell.cpp
+++ b/src/main/interactive_shell.cpp
@@ -98,7 +98,9 @@ InteractiveShell::InteractiveShell(Solver* solver,
   }
   /* Create parser with bogus input. */
   d_parser.reset(new cvc5::parser::InputParser(solver, sm, true));
-
+  // initialize for incremental string input
+  d_parser->setIncrementalStringInput(d_solver->getOption("input-language"),
+                                      INPUT_FILENAME);
 #if HAVE_LIBEDITLINE
   if (&d_in == &std::cin && isatty(fileno(stdin)))
   {
@@ -177,7 +179,6 @@ std::optional<InteractiveShell::CmdSeq> InteractiveShell::readCommand()
 {
   char* lineBuf = NULL;
   string line = "";
-
 restart:
 
   /* Don't do anything if the input is closed or if we've seen a
@@ -318,8 +319,7 @@ restart:
     }
   }
 
-  d_parser->setStringInput(
-      d_solver->getOption("input-language"), input, INPUT_FILENAME);
+  d_parser->appendIncrementalStringInput(input);
 
   /* There may be more than one command in the input. Build up a
      sequence. */

--- a/src/parser/input_parser.cpp
+++ b/src/parser/input_parser.cpp
@@ -19,11 +19,13 @@
 #include "parser/api/cpp/command.h"
 #include "parser/input.h"
 #include "parser/parser_builder.h"
+#include "theory/logic_info.h"
 
 namespace cvc5 {
 namespace parser {
 
 InputParser::InputParser(Solver* solver, SymbolManager* sm, bool useOptions)
+    : d_solver(solver), d_sm(sm), d_useOptions(useOptions)
 {
   // Allocate an ANTLR parser
   ParserBuilder parserBuilder(solver, sm, useOptions);
@@ -59,13 +61,20 @@ void InputParser::setStreamInput(const std::string& lang,
   d_state->setInput(Input::newStreamInput(lang, input, name));
 }
 
-void InputParser::setStringInput(const std::string& lang,
-                                 const std::string& input,
-                                 const std::string& name)
+void InputParser::setIncrementalStringInput(const std::string& lang,
+                                            const std::string& name)
 {
-  Trace("parser") << "setStringInput(" << lang << ", ..., " << name << ")"
-                  << std::endl;
-  d_state->setInput(Input::newStringInput(lang, input, name));
+  Trace("parser") << "setIncrementalStringInput(" << lang << ", ..., " << name
+                  << ")" << std::endl;
+  d_istringLang = lang;
+  d_istringName = name;
+  // if ANTLR, parser is already initialized
+}
+void InputParser::appendIncrementalStringInput(const std::string& input)
+{
+  Trace("parser") << "appendIncrementalStringInput(...)" << std::endl;
+  d_state->setInput(
+      Input::newStringInput(d_istringLang, input, d_istringName));
 }
 
 }  // namespace parser

--- a/src/parser/input_parser.cpp
+++ b/src/parser/input_parser.cpp
@@ -73,8 +73,7 @@ void InputParser::setIncrementalStringInput(const std::string& lang,
 void InputParser::appendIncrementalStringInput(const std::string& input)
 {
   Trace("parser") << "appendIncrementalStringInput(...)" << std::endl;
-  d_state->setInput(
-      Input::newStringInput(d_istringLang, input, d_istringName));
+  d_state->setInput(Input::newStringInput(d_istringLang, input, d_istringName));
 }
 
 }  // namespace parser

--- a/src/parser/input_parser.h
+++ b/src/parser/input_parser.h
@@ -66,7 +66,7 @@ class CVC5_EXPORT InputParser
                       const std::string& name);
 
   /**
-   * Set that we will be feeding strings to this parser via 
+   * Set that we will be feeding strings to this parser via
    * appendIncrementalStringInput below.
    *
    * @param lang the input language

--- a/src/parser/input_parser.h
+++ b/src/parser/input_parser.h
@@ -28,7 +28,6 @@ namespace cvc5 {
 namespace parser {
 
 class Command;
-class Input;
 class Parser;
 class SymbolManager;
 
@@ -66,15 +65,23 @@ class CVC5_EXPORT InputParser
                       std::istream& input,
                       const std::string& name);
 
-  /** Set the input for the given string
+  /**
+   * Set that we will be feeding strings to this parser via 
+   * appendIncrementalStringInput below.
    *
    * @param lang the input language
-   * @param input the input string
    * @param name the name of the stream, for use in error messages
    */
-  void setStringInput(const std::string& lang,
-                      const std::string& input,
-                      const std::string& name);
+  void setIncrementalStringInput(const std::string& lang,
+                                 const std::string& name);
+  /**
+   * Append string to the input being parsed by this parser. Should be
+   * called after calling setIncrementalStringInput and only after the
+   * previous string (if one was provided) is finished being parsed.
+   *
+   * @param input The input string
+   */
+  void appendIncrementalStringInput(const std::string& input);
 
   /**
    * Parse and return the next command.
@@ -86,6 +93,16 @@ class CVC5_EXPORT InputParser
   Term nextExpression();
 
  private:
+  /** Solver */
+  Solver* d_solver;
+  /** Symbol manager */
+  SymbolManager* d_sm;
+  /** use options */
+  bool d_useOptions;
+  /** Incremental string input language */
+  std::string d_istringLang;
+  /** Incremental string name */
+  std::string d_istringName;
   //!!!!!!!!!!!!!! TODO: this implementation is deprecated and should be
   // replaced (wishue #142).
   /**  The parser state. */


### PR DESCRIPTION
The current implementation of interactive mode assumes the lexer is reallocated for each line. The new parser will not have this limitation.

There should be no behavior change in this PR.