### PR TITLE
Make regressions robust to minor changes in parse error output

### DIFF
--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -1208,10 +1208,6 @@ termNonVariable[cvc5::Term& expr, cvc5::Term& expr2]
 }
   : LPAREN_TOK quantOp[kind]
     {
-      if (!PARSER_STATE->isTheoryEnabled(internal::theory::THEORY_QUANTIFIERS))
-      {
-        PARSER_STATE->parseError("Quantifier used in non-quantified logic.");
-      }
       PARSER_STATE->pushScope();
     }
     boundVarList[bvl]

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -940,8 +940,8 @@ void Smt2State::parseOpApplyTypeAscription(ParseOp& p, cvc5::Sort type)
 cvc5::Term Smt2State::parseOpToExpr(ParseOp& p)
 {
   Trace("parser") << "parseOpToExpr: " << p << std::endl;
-  cvc5::Term expr;
-  if (p.d_kind != cvc5::NULL_TERM || !p.d_type.isNull())
+  Term expr;
+  if (p.d_kind != NULL_TERM || !p.d_type.isNull())
   {
     parseError(
         "Bad syntax for qualified identifier operator in term position.");
@@ -950,14 +950,9 @@ cvc5::Term Smt2State::parseOpToExpr(ParseOp& p)
   {
     expr = p.d_expr;
   }
-  else if (!isDeclared(p.d_name, SYM_VARIABLE))
-  {
-    std::stringstream ss;
-    ss << "Symbol " << p.d_name << " is not declared.";
-    parseError(ss.str());
-  }
   else
   {
+    checkDeclaration(p.d_name, CHECK_DECLARED, SYM_VARIABLE);
     expr = getExpressionForName(p.d_name);
   }
   Assert(!expr.isNull());

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -961,6 +961,7 @@ set(regress_0_tests
   regress0/parser/non-strict-real-vs-int.smt2
   regress0/parser/non_well_founded_dt.smt2
   regress0/parser/non_well_founded_dts.smt2
+  regress0/parser/parser-line-error.smt2
   regress0/parser/proj-issue370-push-pop-global.smt2
   regress0/parser/quoted-define-fun.smt2
   regress0/parser/real-numerals.smt2

--- a/test/regress/cli/regress0/bv/issue-4075.smt2
+++ b/test/regress/cli/regress0/bv/issue-4075.smt2
@@ -1,10 +1,7 @@
 ; DISABLE-TESTER: dump
 ; REQUIRES: no-competition
-; EXPECT: (error "Parse Error: issue-4075.smt2:12.26: expecting number of repeats > 0
-; EXPECT:
-; EXPECT:  (simplify ((_ repeat 0) b))
-; EXPECT:                       ^
-; EXPECT:")
+; SCRUBBER: grep -o "expecting number of repeats > 0"
+; EXPECT: expecting number of repeats > 0
 ; EXIT: 1
 (set-logic QF_BV)
 (define-sort a () (_ BitVec 4))

--- a/test/regress/cli/regress0/bv/issue-4130.smt2
+++ b/test/regress/cli/regress0/bv/issue-4130.smt2
@@ -1,10 +1,7 @@
 ; DISABLE-TESTER: dump
 ; REQUIRES: no-competition
-; EXPECT: (error "Parse Error: issue-4130.smt2:11.39: expecting bit-width > 0
-; EXPECT:
-; EXPECT:   (assert (and (= a (bv2nat ((_ int2bv 0) a)))))
-; EXPECT:                                        ^
-; EXPECT: ")
+; SCRUBBER: grep -o "expecting bit-width > 0"
+; EXPECT: expecting bit-width > 0
 ; EXIT: 1
 (set-logic ALL)
 (declare-fun a () Int)

--- a/test/regress/cli/regress0/parser/issue5163.smt2
+++ b/test/regress/cli/regress0/parser/issue5163.smt2
@@ -1,5 +1,5 @@
-; SCRUBBER: grep -o "Symbol a is not declared"
-; EXPECT: Symbol a is not declared
+; SCRUBBER: grep -o "Symbol 'a' not declared as a variable"
+; EXPECT: Symbol 'a' not declared as a variable
 ; EXIT: 1
 (set-logic ALL)
 (define-fun a () Bool false)

--- a/test/regress/cli/regress0/parser/non_well_founded_dt.smt2
+++ b/test/regress/cli/regress0/parser/non_well_founded_dt.smt2
@@ -1,9 +1,6 @@
 ; REQUIRES: no-competition
-; EXPECT: (error "Parse Error: non_well_founded_dt.smt2:11.77: Datatype sort _dt5 is not well-founded
-; EXPECT: 
-; EXPECT: ... (_sel33 Bool) (_sel34 _dt5) (_sel35 _dt5))))
-; EXPECT: ^
-; EXPECT: ")
+; SCRUBBER: grep -o "Datatype sort _dt5 is not well-founded"
+; EXPECT: Datatype sort _dt5 is not well-founded
 ; EXIT: 1
 ; DISABLE-TESTER: dump
 (set-option :global-declarations true)

--- a/test/regress/cli/regress0/parser/parser-line-error.smt2
+++ b/test/regress/cli/regress0/parser/parser-line-error.smt2
@@ -1,7 +1,7 @@
 ; DISABLE-TESTER: dump
+; SCRUBBER: grep -o '(error "Parse Error: parser-line-error.smt2:8'
+; EXPECT: (error "Parse Error: parser-line-error.smt2:8
 ; EXIT: 1
-; SCRUBBER: grep -o "(error "Parse Error: parser-line-error.smt2:7"
-; EXPECT "(error "Parse Error: parser-line-error.smt2:7"
 (set-info :source |abc
 def
 ghi|)

--- a/test/regress/cli/regress0/parser/parser-line-error.smt2
+++ b/test/regress/cli/regress0/parser/parser-line-error.smt2
@@ -1,0 +1,8 @@
+; DISABLE-TESTER: dump
+; EXIT: 1
+; SCRUBBER: grep -o "(error "Parse Error: parser-line-error.smt2:7"
+; EXPECT "(error "Parse Error: parser-line-error.smt2:7"
+(set-info :source |abc
+def
+ghi|)
+misplaced text

--- a/test/regress/cli/regress0/quantifiers/issue4437-unc-quant.smt2
+++ b/test/regress/cli/regress0/quantifiers/issue4437-unc-quant.smt2
@@ -1,7 +1,7 @@
 ; DISABLE-TESTER: dump
 ; REQUIRES: no-competition
-; EXPECT: Quantifier used in non-quantified logic
-; SCRUBBER: grep -o "Quantifier used in non-quantified logic"
+; EXPECT: doesn't include THEORY_QUANTIFIERS
+; SCRUBBER: grep -o "doesn't include THEORY_QUANTIFIERS"
 ; EXIT: 1
 (set-logic QF_AUFBVLIA)
 (declare-fun a () (_ BitVec 8))

--- a/test/regress/cli/regress0/sygus/no-logic.sy
+++ b/test/regress/cli/regress0/sygus/no-logic.sy
@@ -1,9 +1,7 @@
 ; REQUIRES: no-competition
 ; COMMAND-LINE: --sygus-out=status --lang=sygus2
-; EXPECT-ERROR: no-logic.sy:8.10: No set-logic command was given before this point.
-; EXPECT-ERROR: no-logic.sy:8.10: cvc5 will make all theories available.
-; EXPECT-ERROR: no-logic.sy:8.10: Consider setting a stricter logic for (likely) better performance.
-; EXPECT-ERROR: no-logic.sy:8.10: To suppress this warning in the future use (set-logic ALL).
+; ERROR-SCRUBBER: grep -o "No set-logic command was given before this point"
+; EXPECT-ERROR: No set-logic command was given before this point
 ; EXPECT: feasible
 (synth-fun f ((x Int)) Int
   ((Start Int))

--- a/test/regress/cli/regress0/sygus/pLTL-sygus-syntax-err.sy
+++ b/test/regress/cli/regress0/sygus/pLTL-sygus-syntax-err.sy
@@ -1,11 +1,8 @@
 ; DISABLE-TESTER: dump
 ; REQUIRES: no-competition
 ; COMMAND-LINE: --sygus-out=status --sygus-rec-fun --lang=sygus2
-; EXPECT-ERROR: (error "Parse Error: pLTL-sygus-syntax-err.sy:79.19: number of arguments does not match the constructor type
-; EXPECT-ERROR:
-; EXPECT-ERROR: (Op2 <O2> <F>)
-; EXPECT-ERROR: ^
-; EXPECT-ERROR: ")
+; ERROR-SCRUBBER: grep -o "number of arguments does not match the constructor type"
+; EXPECT-ERROR: number of arguments does not match the constructor type
 ; EXIT: 1
 (set-logic HO_ALL)
 (set-option :lang sygus2)

--- a/test/regress/cli/regress0/sygus/setFeature.sy
+++ b/test/regress/cli/regress0/sygus/setFeature.sy
@@ -1,5 +1,6 @@
 ; REQUIRES: no-competition
-; EXPECT-ERROR: setFeature.sy:5.29: SyGuS feature recursion not currently supported
+; ERROR-SCRUBBER: grep -o "SyGuS feature recursion not currently supported"
+; EXPECT-ERROR: SyGuS feature recursion not currently supported
 (set-logic ALL)
 (set-feature :grammars true)
 (set-feature :recursion false)

--- a/test/regress/cli/regress1/arrayinuf_error.smt2
+++ b/test/regress/cli/regress1/arrayinuf_error.smt2
@@ -1,10 +1,7 @@
 ; DISABLE-TESTER: dump
 ; REQUIRES: no-competition
-; EXPECT: (error "Parse Error: arrayinuf_error.smt2:9.21: Symbol 'Array' not declared as a type
-; EXPECT: 
-; EXPECT:   (declare-fun a (Array Bool Bool))
-; EXPECT:                   ^
-; EXPECT: ")
+; SCRUBBER: grep -o "Symbol 'Array' not declared as a type"
+; EXPECT: Symbol 'Array' not declared as a type
 (set-logic QF_UF)
 (declare-fun a (Array Bool Bool))
 ; EXIT: 1


### PR DESCRIPTION
This also makes a few error messages more standard, including not throwing a custom exception for quantified formulas and using a standard check declaration in one place.

It also adds a logic exception to TheoryEngine::solve which was previously missing and is now triggered by a regression that was previously caught in the parser.

The new parser will throw roughly the same errors although it may use different columns (depending on whether we reference the beginning or end of strings for instance).

This also adds a regression to ensure we track line numbers for parse errors after comments and quoted symbols properly.