### PR TITLE
Clean parser state and smt2 parser state

### DIFF
--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -37,23 +37,23 @@ namespace cvc5 {
 namespace parser {
 
 ParserState::ParserState(ParserStateCallback* psc,
-                         cvc5::Solver* solver,
+                         Solver* solver,
                          SymbolManager* sm,
                          bool strictMode)
-    : d_psc(psc),
+    : d_solver(solver),
+      d_psc(psc),
       d_symman(sm),
       d_symtab(sm->getSymbolTable()),
       d_checksEnabled(true),
-      d_strictMode(strictMode),
-      d_solver(solver)
+      d_strictMode(strictMode)
 {
 }
 
 ParserState::~ParserState() {}
 
-cvc5::Solver* ParserState::getSolver() const { return d_solver; }
+Solver* ParserState::getSolver() const { return d_solver; }
 
-cvc5::Term ParserState::getSymbol(const std::string& name, SymbolType type)
+Term ParserState::getSymbol(const std::string& name, SymbolType type)
 {
   checkDeclaration(name, CHECK_DECLARED, type);
   Assert(isDeclared(name, type));
@@ -67,153 +67,155 @@ const std::string& ParserState::getForcedLogic() const
 }
 bool ParserState::logicIsForced() const { return d_symman->isLogicForced(); }
 
-cvc5::Term ParserState::getVariable(const std::string& name)
+Term ParserState::getVariable(const std::string& name)
 {
   return getSymbol(name, SYM_VARIABLE);
 }
 
-cvc5::Term ParserState::getFunction(const std::string& name)
+Term ParserState::getFunction(const std::string& name)
 {
   return getSymbol(name, SYM_VARIABLE);
 }
 
-cvc5::Term ParserState::getExpressionForName(const std::string& name)
+Term ParserState::getExpressionForName(const std::string& name)
 {
-  cvc5::Sort t;
+  Sort t;
   return getExpressionForNameAndType(name, t);
 }
 
-cvc5::Term ParserState::getExpressionForNameAndType(const std::string& name,
-                                                    cvc5::Sort t)
+Term ParserState::getExpressionForNameAndType(const std::string& name, Sort t)
 {
   Assert(isDeclared(name));
   // first check if the variable is declared and not overloaded
-  cvc5::Term expr = getVariable(name);
-  if(expr.isNull()) {
+  Term expr = getVariable(name);
+  if (expr.isNull())
+  {
     // the variable is overloaded, try with type if the type exists
-    if(!t.isNull()) {
+    if (!t.isNull())
+    {
       // if we decide later to support annotations for function types, this will
       // update to separate t into ( argument types, return type )
       expr = getOverloadedConstantForType(name, t);
-      if(expr.isNull()) {
+      if (expr.isNull())
+      {
         parseError("Cannot get overloaded constant for type ascription.");
       }
-    }else{
+    }
+    else
+    {
       parseError("Overloaded constants must be type cast.");
     }
   }
   // now, post-process the expression
   Assert(!expr.isNull());
-  cvc5::Sort te = expr.getSort();
+  Sort te = expr.getSort();
   if (te.isDatatypeConstructor() && te.getDatatypeConstructorArity() == 0)
   {
     // nullary constructors have APPLY_CONSTRUCTOR kind with no children
-    expr = d_solver->mkTerm(cvc5::APPLY_CONSTRUCTOR, {expr});
+    expr = d_solver->mkTerm(APPLY_CONSTRUCTOR, {expr});
   }
   return expr;
 }
 
-bool ParserState::getTesterName(cvc5::Term cons, std::string& name)
-{
-  return false;
-}
+bool ParserState::getTesterName(Term cons, std::string& name) { return false; }
 
-cvc5::Kind ParserState::getKindForFunction(cvc5::Term fun)
+Kind ParserState::getKindForFunction(Term fun)
 {
-  cvc5::Sort t = fun.getSort();
+  Sort t = fun.getSort();
   if (t.isFunction())
   {
-    return cvc5::APPLY_UF;
+    return APPLY_UF;
   }
   else if (t.isDatatypeConstructor())
   {
-    return cvc5::APPLY_CONSTRUCTOR;
+    return APPLY_CONSTRUCTOR;
   }
   else if (t.isDatatypeSelector())
   {
-    return cvc5::APPLY_SELECTOR;
+    return APPLY_SELECTOR;
   }
   else if (t.isDatatypeTester())
   {
-    return cvc5::APPLY_TESTER;
+    return APPLY_TESTER;
   }
   else if (t.isDatatypeUpdater())
   {
-    return cvc5::APPLY_UPDATER;
+    return APPLY_UPDATER;
   }
-  return cvc5::UNDEFINED_KIND;
+  return UNDEFINED_KIND;
 }
 
-cvc5::Sort ParserState::getSort(const std::string& name)
+Sort ParserState::getSort(const std::string& name)
 {
   checkDeclaration(name, CHECK_DECLARED, SYM_SORT);
   Assert(isDeclared(name, SYM_SORT));
-  cvc5::Sort t = d_symtab->lookupType(name);
+  Sort t = d_symtab->lookupType(name);
   return t;
 }
 
-cvc5::Sort ParserState::getParametricSort(const std::string& name,
-                                          const std::vector<cvc5::Sort>& params)
+Sort ParserState::getParametricSort(const std::string& name,
+                                    const std::vector<Sort>& params)
 {
   checkDeclaration(name, CHECK_DECLARED, SYM_SORT);
   Assert(isDeclared(name, SYM_SORT));
-  cvc5::Sort t = d_symtab->lookupType(name, params);
+  Sort t = d_symtab->lookupType(name, params);
   return t;
 }
 
-bool ParserState::isFunctionLike(cvc5::Term fun)
+bool ParserState::isFunctionLike(Term fun)
 {
-  if(fun.isNull()) {
+  if (fun.isNull())
+  {
     return false;
   }
-  cvc5::Sort type = fun.getSort();
+  Sort type = fun.getSort();
   return type.isFunction() || type.isDatatypeConstructor()
          || type.isDatatypeTester() || type.isDatatypeSelector();
 }
 
-cvc5::Term ParserState::bindVar(const std::string& name,
-                                const cvc5::Sort& type,
-                                bool doOverload)
+Term ParserState::bindVar(const std::string& name,
+                          const Sort& type,
+                          bool doOverload)
 {
   Trace("parser") << "bindVar(" << name << ", " << type << ")" << std::endl;
-  cvc5::Term expr = d_solver->mkConst(type, name);
+  Term expr = d_solver->mkConst(type, name);
   defineVar(name, expr, doOverload);
   return expr;
 }
 
-cvc5::Term ParserState::bindBoundVar(const std::string& name,
-                                     const cvc5::Sort& type)
+Term ParserState::bindBoundVar(const std::string& name, const Sort& type)
 {
   Trace("parser") << "bindBoundVar(" << name << ", " << type << ")"
                   << std::endl;
-  cvc5::Term expr = d_solver->mkVar(type, name);
+  Term expr = d_solver->mkVar(type, name);
   defineVar(name, expr);
   return expr;
 }
 
-std::vector<cvc5::Term> ParserState::bindBoundVars(
-    std::vector<std::pair<std::string, cvc5::Sort> >& sortedVarNames)
+std::vector<Term> ParserState::bindBoundVars(
+    std::vector<std::pair<std::string, Sort> >& sortedVarNames)
 {
-  std::vector<cvc5::Term> vars;
-  for (std::pair<std::string, cvc5::Sort>& i : sortedVarNames)
+  std::vector<Term> vars;
+  for (std::pair<std::string, Sort>& i : sortedVarNames)
   {
     vars.push_back(bindBoundVar(i.first, i.second));
   }
   return vars;
 }
 
-std::vector<cvc5::Term> ParserState::bindBoundVars(
-    const std::vector<std::string> names, const cvc5::Sort& type)
+std::vector<Term> ParserState::bindBoundVars(
+    const std::vector<std::string> names, const Sort& type)
 {
-  std::vector<cvc5::Term> vars;
-  for (unsigned i = 0; i < names.size(); ++i) {
+  std::vector<Term> vars;
+  for (unsigned i = 0; i < names.size(); ++i)
+  {
     vars.push_back(bindBoundVar(names[i], type));
   }
   return vars;
 }
 
 void ParserState::defineVar(const std::string& name,
-                            const cvc5::Term& val,
+                            const Term& val,
                             bool doOverload)
 {
   Trace("parser") << "defineVar( " << name << " := " << val << ")" << std::endl;
@@ -228,7 +230,7 @@ void ParserState::defineVar(const std::string& name,
 }
 
 void ParserState::defineType(const std::string& name,
-                             const cvc5::Sort& type,
+                             const Sort& type,
                              bool skipExisting)
 {
   if (skipExisting && isDeclared(name, SYM_SORT))
@@ -241,24 +243,26 @@ void ParserState::defineType(const std::string& name,
 }
 
 void ParserState::defineType(const std::string& name,
-                             const std::vector<cvc5::Sort>& params,
-                             const cvc5::Sort& type)
+                             const std::vector<Sort>& params,
+                             const Sort& type)
 {
   d_symtab->bindType(name, params, type);
   Assert(isDeclared(name, SYM_SORT));
 }
 
 void ParserState::defineParameterizedType(const std::string& name,
-                                          const std::vector<cvc5::Sort>& params,
-                                          const cvc5::Sort& type)
+                                          const std::vector<Sort>& params,
+                                          const Sort& type)
 {
-  if (TraceIsOn("parser")) {
+  if (TraceIsOn("parser"))
+  {
     Trace("parser") << "defineParameterizedType(" << name << ", "
                     << params.size() << ", [";
-    if (params.size() > 0) {
+    if (params.size() > 0)
+    {
       copy(params.begin(),
            params.end() - 1,
-           ostream_iterator<cvc5::Sort>(Trace("parser"), ", "));
+           ostream_iterator<Sort>(Trace("parser"), ", "));
       Trace("parser") << params.back();
     }
     Trace("parser") << "], " << type << ")" << std::endl;
@@ -266,51 +270,50 @@ void ParserState::defineParameterizedType(const std::string& name,
   defineType(name, params, type);
 }
 
-cvc5::Sort ParserState::mkSort(const std::string& name)
+Sort ParserState::mkSort(const std::string& name)
 {
   Trace("parser") << "newSort(" << name << ")" << std::endl;
-  cvc5::Sort type = d_solver->mkUninterpretedSort(name);
+  Sort type = d_solver->mkUninterpretedSort(name);
   defineType(name, type);
   return type;
 }
 
-cvc5::Sort ParserState::mkSortConstructor(const std::string& name, size_t arity)
+Sort ParserState::mkSortConstructor(const std::string& name, size_t arity)
 {
   Trace("parser") << "newSortConstructor(" << name << ", " << arity << ")"
                   << std::endl;
-  cvc5::Sort type = d_solver->mkUninterpretedSortConstructorSort(arity, name);
-  defineType(name, vector<cvc5::Sort>(arity), type);
+  Sort type = d_solver->mkUninterpretedSortConstructorSort(arity, name);
+  defineType(name, vector<Sort>(arity), type);
   return type;
 }
 
-cvc5::Sort ParserState::mkUnresolvedType(const std::string& name)
+Sort ParserState::mkUnresolvedType(const std::string& name)
 {
-  cvc5::Sort unresolved = d_solver->mkUnresolvedDatatypeSort(name);
+  Sort unresolved = d_solver->mkUnresolvedDatatypeSort(name);
   defineType(name, unresolved);
   return unresolved;
 }
 
-cvc5::Sort ParserState::mkUnresolvedTypeConstructor(const std::string& name,
-                                                    size_t arity)
+Sort ParserState::mkUnresolvedTypeConstructor(const std::string& name,
+                                              size_t arity)
 {
-  cvc5::Sort unresolved = d_solver->mkUnresolvedDatatypeSort(name, arity);
-  defineType(name, vector<cvc5::Sort>(arity), unresolved);
+  Sort unresolved = d_solver->mkUnresolvedDatatypeSort(name, arity);
+  defineType(name, vector<Sort>(arity), unresolved);
   return unresolved;
 }
 
-cvc5::Sort ParserState::mkUnresolvedTypeConstructor(
-    const std::string& name, const std::vector<cvc5::Sort>& params)
+Sort ParserState::mkUnresolvedTypeConstructor(const std::string& name,
+                                              const std::vector<Sort>& params)
 {
   Trace("parser") << "newSortConstructor(P)(" << name << ", " << params.size()
                   << ")" << std::endl;
-  cvc5::Sort unresolved =
-      d_solver->mkUnresolvedDatatypeSort(name, params.size());
+  Sort unresolved = d_solver->mkUnresolvedDatatypeSort(name, params.size());
   defineType(name, params, unresolved);
-  cvc5::Sort t = getParametricSort(name, params);
+  Sort t = getParametricSort(name, params);
   return unresolved;
 }
 
-cvc5::Sort ParserState::mkUnresolvedType(const std::string& name, size_t arity)
+Sort ParserState::mkUnresolvedType(const std::string& name, size_t arity)
 {
   if (arity == 0)
   {
@@ -319,52 +322,60 @@ cvc5::Sort ParserState::mkUnresolvedType(const std::string& name, size_t arity)
   return mkUnresolvedTypeConstructor(name, arity);
 }
 
-std::vector<cvc5::Sort> ParserState::bindMutualDatatypeTypes(
-    std::vector<cvc5::DatatypeDecl>& datatypes, bool doOverload)
+std::vector<Sort> ParserState::bindMutualDatatypeTypes(
+    std::vector<DatatypeDecl>& datatypes, bool doOverload)
 {
-  try {
-    std::vector<cvc5::Sort> types = d_solver->mkDatatypeSorts(datatypes);
+  try
+  {
+    std::vector<Sort> types = d_solver->mkDatatypeSorts(datatypes);
 
     Assert(datatypes.size() == types.size());
 
-    for (unsigned i = 0; i < datatypes.size(); ++i) {
-      cvc5::Sort t = types[i];
-      const cvc5::Datatype& dt = t.getDatatype();
+    for (unsigned i = 0; i < datatypes.size(); ++i)
+    {
+      Sort t = types[i];
+      const Datatype& dt = t.getDatatype();
       const std::string& name = dt.getName();
       Trace("parser-idt") << "define " << name << " as " << t << std::endl;
-      if (isDeclared(name, SYM_SORT)) {
+      if (isDeclared(name, SYM_SORT))
+      {
         throw ParserException(name + " already declared");
       }
       if (dt.isParametric())
       {
-        std::vector<cvc5::Sort> paramTypes = dt.getParameters();
+        std::vector<Sort> paramTypes = dt.getParameters();
         defineType(name, paramTypes, t);
       }
       else
       {
         defineType(name, t);
       }
-      std::unordered_set< std::string > consNames;
-      std::unordered_set< std::string > selNames;
+      std::unordered_set<std::string> consNames;
+      std::unordered_set<std::string> selNames;
       for (size_t j = 0, ncons = dt.getNumConstructors(); j < ncons; j++)
       {
-        const cvc5::DatatypeConstructor& ctor = dt[j];
-        cvc5::Term constructor = ctor.getTerm();
+        const DatatypeConstructor& ctor = dt[j];
+        Term constructor = ctor.getTerm();
         Trace("parser-idt") << "+ define " << constructor << std::endl;
         string constructorName = ctor.getName();
-        if(consNames.find(constructorName)==consNames.end()) {
-          if(!doOverload) {
+        if (consNames.find(constructorName) == consNames.end())
+        {
+          if (!doOverload)
+          {
             checkDeclaration(constructorName, CHECK_UNDECLARED);
           }
           defineVar(constructorName, constructor, doOverload);
           consNames.insert(constructorName);
-        }else{
-          throw ParserException(constructorName + " already declared in this datatype");
+        }
+        else
+        {
+          throw ParserException(constructorName
+                                + " already declared in this datatype");
         }
         std::string testerName;
         if (getTesterName(constructor, testerName))
         {
-          cvc5::Term tester = ctor.getTesterTerm();
+          Term tester = ctor.getTesterTerm();
           Trace("parser-idt") << "+ define " << testerName << std::endl;
           if (!doOverload)
           {
@@ -374,18 +385,23 @@ std::vector<cvc5::Sort> ParserState::bindMutualDatatypeTypes(
         }
         for (size_t k = 0, nargs = ctor.getNumSelectors(); k < nargs; k++)
         {
-          const cvc5::DatatypeSelector& sel = ctor[k];
-          cvc5::Term selector = sel.getTerm();
+          const DatatypeSelector& sel = ctor[k];
+          Term selector = sel.getTerm();
           Trace("parser-idt") << "+++ define " << selector << std::endl;
           string selectorName = sel.getName();
-          if(selNames.find(selectorName)==selNames.end()) {
-            if(!doOverload) {
+          if (selNames.find(selectorName) == selNames.end())
+          {
+            if (!doOverload)
+            {
               checkDeclaration(selectorName, CHECK_UNDECLARED);
             }
             defineVar(selectorName, selector, doOverload);
             selNames.insert(selectorName);
-          }else{
-            throw ParserException(selectorName + " already declared in this datatype");
+          }
+          else
+          {
+            throw ParserException(selectorName
+                                  + " already declared in this datatype");
           }
         }
       }
@@ -398,20 +414,20 @@ std::vector<cvc5::Sort> ParserState::bindMutualDatatypeTypes(
   }
 }
 
-cvc5::Sort ParserState::mkFlatFunctionType(std::vector<cvc5::Sort>& sorts,
-                                           cvc5::Sort range,
-                                           std::vector<cvc5::Term>& flattenVars)
+Sort ParserState::mkFlatFunctionType(std::vector<Sort>& sorts,
+                                     Sort range,
+                                     std::vector<Term>& flattenVars)
 {
   if (range.isFunction())
   {
-    std::vector<cvc5::Sort> domainTypes = range.getFunctionDomainSorts();
+    std::vector<Sort> domainTypes = range.getFunctionDomainSorts();
     for (unsigned i = 0, size = domainTypes.size(); i < size; i++)
     {
       sorts.push_back(domainTypes[i]);
       // the introduced variable is internal (not parsable)
       std::stringstream ss;
       ss << "__flatten_var_" << i;
-      cvc5::Term v = d_solver->mkVar(domainTypes[i], ss.str());
+      Term v = d_solver->mkVar(domainTypes[i], ss.str());
       flattenVars.push_back(v);
     }
     range = range.getFunctionCodomainSort();
@@ -423,8 +439,7 @@ cvc5::Sort ParserState::mkFlatFunctionType(std::vector<cvc5::Sort>& sorts,
   return d_solver->mkFunctionSort(sorts, range);
 }
 
-cvc5::Sort ParserState::mkFlatFunctionType(std::vector<cvc5::Sort>& sorts,
-                                           cvc5::Sort range)
+Sort ParserState::mkFlatFunctionType(std::vector<Sort>& sorts, Sort range)
 {
   if (sorts.empty())
   {
@@ -434,7 +449,7 @@ cvc5::Sort ParserState::mkFlatFunctionType(std::vector<cvc5::Sort>& sorts,
   if (TraceIsOn("parser"))
   {
     Trace("parser") << "mkFlatFunctionType: range " << range << " and domains ";
-    for (cvc5::Sort t : sorts)
+    for (Sort t : sorts)
     {
       Trace("parser") << " " << t;
     }
@@ -442,35 +457,34 @@ cvc5::Sort ParserState::mkFlatFunctionType(std::vector<cvc5::Sort>& sorts,
   }
   while (range.isFunction())
   {
-    std::vector<cvc5::Sort> domainTypes = range.getFunctionDomainSorts();
+    std::vector<Sort> domainTypes = range.getFunctionDomainSorts();
     sorts.insert(sorts.end(), domainTypes.begin(), domainTypes.end());
     range = range.getFunctionCodomainSort();
   }
   return d_solver->mkFunctionSort(sorts, range);
 }
 
-cvc5::Term ParserState::mkHoApply(cvc5::Term expr,
-                                  const std::vector<cvc5::Term>& args)
+Term ParserState::mkHoApply(Term expr, const std::vector<Term>& args)
 {
   for (unsigned i = 0; i < args.size(); i++)
   {
-    expr = d_solver->mkTerm(cvc5::HO_APPLY, {expr, args[i]});
+    expr = d_solver->mkTerm(HO_APPLY, {expr, args[i]});
   }
   return expr;
 }
 
-cvc5::Term ParserState::applyTypeAscription(cvc5::Term t, cvc5::Sort s)
+Term ParserState::applyTypeAscription(Term t, Sort s)
 {
-  cvc5::Kind k = t.getKind();
-  if (k == cvc5::SET_EMPTY)
+  Kind k = t.getKind();
+  if (k == SET_EMPTY)
   {
     t = d_solver->mkEmptySet(s);
   }
-  else if (k == cvc5::BAG_EMPTY)
+  else if (k == BAG_EMPTY)
   {
     t = d_solver->mkEmptyBag(s);
   }
-  else if (k == cvc5::CONST_SEQUENCE)
+  else if (k == CONST_SEQUENCE)
   {
     if (!s.isSequence())
     {
@@ -486,30 +500,30 @@ cvc5::Term ParserState::applyTypeAscription(cvc5::Term t, cvc5::Sort s)
     }
     t = d_solver->mkEmptySequence(s.getSequenceElementSort());
   }
-  else if (k == cvc5::SET_UNIVERSE)
+  else if (k == SET_UNIVERSE)
   {
     t = d_solver->mkUniverseSet(s);
   }
-  else if (k == cvc5::SEP_NIL)
+  else if (k == SEP_NIL)
   {
     t = d_solver->mkSepNil(s);
   }
-  else if (k == cvc5::APPLY_CONSTRUCTOR)
+  else if (k == APPLY_CONSTRUCTOR)
   {
-    std::vector<cvc5::Term> children(t.begin(), t.end());
+    std::vector<Term> children(t.begin(), t.end());
     // apply type ascription to the operator and reconstruct
     children[0] = applyTypeAscription(children[0], s);
-    t = d_solver->mkTerm(cvc5::APPLY_CONSTRUCTOR, children);
+    t = d_solver->mkTerm(APPLY_CONSTRUCTOR, children);
   }
   // !!! temporary until datatypes are refactored in the new API
-  cvc5::Sort etype = t.getSort();
+  Sort etype = t.getSort();
   if (etype.isDatatypeConstructor())
   {
     // Type ascriptions only have an effect on the node structure if this is a
     // parametric datatype.
     // get the datatype that t belongs to
-    cvc5::Sort etyped = etype.getDatatypeConstructorCodomainSort();
-    cvc5::Datatype d = etyped.getDatatype();
+    Sort etyped = etype.getDatatypeConstructorCodomainSort();
+    Datatype d = etyped.getDatatype();
     // Note that we check whether the datatype is parametric, and not whether
     // etyped is a parametric datatype, since e.g. the smt2 parser constructs
     // an arbitrary instantitated constructor term before it is resolved.
@@ -518,7 +532,7 @@ cvc5::Term ParserState::applyTypeAscription(cvc5::Term t, cvc5::Sort s)
     if (d.isParametric())
     {
       // lookup by name
-      cvc5::DatatypeConstructor dc = d.getConstructor(t.toString());
+      DatatypeConstructor dc = d.getConstructor(t.toString());
       // ask the constructor for the specialized constructor term
       t = dc.getInstantiatedTerm(s);
     }
@@ -536,7 +550,7 @@ cvc5::Term ParserState::applyTypeAscription(cvc5::Term t, cvc5::Sort s)
   // Otherwise, check that the type is correct. Type ascriptions in SMT-LIB 2.6
   // referred to the range of function sorts. Note that this is only a check
   // and does not impact the returned term.
-  cvc5::Sort checkSort = t.getSort();
+  Sort checkSort = t.getSort();
   if (checkSort.isFunction())
   {
     checkSort = checkSort.getFunctionCodomainSort();
@@ -553,12 +567,11 @@ cvc5::Term ParserState::applyTypeAscription(cvc5::Term t, cvc5::Sort s)
 
 bool ParserState::isDeclared(const std::string& name, SymbolType type)
 {
-  switch (type) {
+  switch (type)
+  {
     case SYM_VARIABLE: return d_symtab->isBound(name);
-    case SYM_SORT:
-      return d_symtab->isBoundType(name);
-    case SYM_VERBATIM:
-      Unreachable();
+    case SYM_SORT: return d_symtab->isBoundType(name);
+    case SYM_VERBATIM: Unreachable();
   }
   Assert(false);  // Unhandled(type);
   return false;
@@ -569,37 +582,41 @@ void ParserState::checkDeclaration(const std::string& varName,
                                    SymbolType type,
                                    std::string notes)
 {
-  if (!d_checksEnabled) {
+  if (!d_checksEnabled)
+  {
     return;
   }
 
-  switch (check) {
+  switch (check)
+  {
     case CHECK_DECLARED:
-      if (!isDeclared(varName, type)) {
-        parseError("Symbol '" + varName + "' not declared as a " +
-                   (type == SYM_VARIABLE ? "variable" : "type") +
-                   (notes.size() == 0 ? notes : "\n" + notes));
+      if (!isDeclared(varName, type))
+      {
+        parseError("Symbol '" + varName + "' not declared as a "
+                   + (type == SYM_VARIABLE ? "variable" : "type")
+                   + (notes.size() == 0 ? notes : "\n" + notes));
       }
       break;
 
     case CHECK_UNDECLARED:
-      if (isDeclared(varName, type)) {
-        parseError("Symbol '" + varName + "' previously declared as a " +
-                   (type == SYM_VARIABLE ? "variable" : "type") +
-                   (notes.size() == 0 ? notes : "\n" + notes));
+      if (isDeclared(varName, type))
+      {
+        parseError("Symbol '" + varName + "' previously declared as a "
+                   + (type == SYM_VARIABLE ? "variable" : "type")
+                   + (notes.size() == 0 ? notes : "\n" + notes));
       }
       break;
 
-    case CHECK_NONE:
-      break;
+    case CHECK_NONE: break;
 
     default: Assert(false);  // Unhandled(check);
   }
 }
 
-void ParserState::checkFunctionLike(cvc5::Term fun)
+void ParserState::checkFunctionLike(Term fun)
 {
-  if (d_checksEnabled && !isFunctionLike(fun)) {
+  if (d_checksEnabled && !isFunctionLike(fun))
+  {
     stringstream ss;
     ss << "Expecting function-like symbol, found '";
     ss << fun;
@@ -608,14 +625,23 @@ void ParserState::checkFunctionLike(cvc5::Term fun)
   }
 }
 
-void ParserState::addOperator(cvc5::Kind kind)
+void ParserState::addOperator(Kind kind) { d_logicOperators.insert(kind); }
+
+void ParserState::warning(const std::string& msg) { d_psc->warning(msg); }
+
+void ParserState::parseError(const std::string& msg) { d_psc->parseError(msg); }
+
+void ParserState::unexpectedEOF(const std::string& msg)
 {
-  d_logicOperators.insert(kind);
+  d_psc->unexpectedEOF(msg);
 }
+
+void ParserState::preemptCommand(Command* cmd) { d_psc->preemptCommand(cmd); }
 
 void ParserState::attributeNotSupported(const std::string& attr)
 {
-  if (d_attributesWarnedAbout.find(attr) == d_attributesWarnedAbout.end()) {
+  if (d_attributesWarnedAbout.find(attr) == d_attributesWarnedAbout.end())
+  {
     stringstream ss;
     ss << "warning: Attribute '" << attr
        << "' not supported (ignoring this and all following uses)";
@@ -623,14 +649,6 @@ void ParserState::attributeNotSupported(const std::string& attr)
     d_attributesWarnedAbout.insert(attr);
   }
 }
-
-void ParserState::warning(const std::string& msg) { d_psc->warning(msg); }
-void ParserState::parseError(const std::string& msg) { d_psc->parseError(msg); }
-void ParserState::unexpectedEOF(const std::string& msg)
-{
-  d_psc->unexpectedEOF(msg);
-}
-void ParserState::preemptCommand(Command* cmd) { d_psc->preemptCommand(cmd); }
 
 size_t ParserState::scopeLevel() const { return d_symman->scopeLevel(); }
 
@@ -645,14 +663,14 @@ void ParserState::pushGetValueScope()
   // we must bind all relevant uninterpreted constants, which coincide with
   // the set of uninterpreted constants that are printed in the definition
   // of a model.
-  std::vector<cvc5::Sort> declareSorts = d_symman->getModelDeclareSorts();
+  std::vector<Sort> declareSorts = d_symman->getModelDeclareSorts();
   Trace("parser") << "Push get value scope, with " << declareSorts.size()
                   << " declared sorts" << std::endl;
-  for (const cvc5::Sort& s : declareSorts)
+  for (const Sort& s : declareSorts)
   {
-    std::vector<cvc5::Term> elements = d_solver->getModelDomainElements(s);
+    std::vector<Term> elements = d_solver->getModelDomainElements(s);
     Trace("parser") << "elements for " << s << ":" << std::endl;
-    for (const cvc5::Term& e : elements)
+    for (const Term& e : elements)
     {
       Trace("parser") << "  " << e.getKind() << " " << e << std::endl;
       if (e.getKind() == Kind::UNINTERPRETED_SORT_VALUE)
@@ -682,14 +700,20 @@ std::wstring ParserState::processAdHocStringEsc(const std::string& s)
     std::mbtowc(nullptr, nullptr, 0);
     const char* end = s.data() + s.size();
     const char* ptr = s.data();
-    for (wchar_t c; ptr != end; ) {
+    for (wchar_t c; ptr != end;)
+    {
       int res = std::mbtowc(&c, ptr, end - ptr);
-      if (res == -1) {
+      if (res == -1)
+      {
         std::cerr << "Invalid escape sequence in " << s << std::endl;
         break;
-      } else if (res == 0) {
+      }
+      else if (res == 0)
+      {
         break;
-      } else {
+      }
+      else
+      {
         ws += c;
         ptr += res;
       }
@@ -829,7 +853,18 @@ std::wstring ParserState::processAdHocStringEsc(const std::string& s)
   return res;
 }
 
-cvc5::Term ParserState::mkCharConstant(const std::string& s)
+Term ParserState::mkStringConstant(const std::string& s)
+{
+  if (d_solver->getOption("input-language") == "LANG_SMTLIB_V2_6")
+  {
+    return d_solver->mkString(s, true);
+  }
+  // otherwise, we must process ad-hoc escape sequences
+  std::wstring str = processAdHocStringEsc(s);
+  return d_solver->mkString(str);
+}
+
+Term ParserState::mkCharConstant(const std::string& s)
 {
   Assert(s.find_first_not_of("0123456789abcdefABCDEF", 0) == std::string::npos
          && s.size() <= 5 && s.size() > 0)

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -853,17 +853,6 @@ std::wstring ParserState::processAdHocStringEsc(const std::string& s)
   return res;
 }
 
-Term ParserState::mkStringConstant(const std::string& s)
-{
-  if (d_solver->getOption("input-language") == "LANG_SMTLIB_V2_6")
-  {
-    return d_solver->mkString(s, true);
-  }
-  // otherwise, we must process ad-hoc escape sequences
-  std::wstring str = processAdHocStringEsc(s);
-  return d_solver->mkString(str);
-}
-
 Term ParserState::mkCharConstant(const std::string& s)
 {
   Assert(s.find_first_not_of("0123456789abcdefABCDEF", 0) == std::string::npos

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -20,23 +20,20 @@
 
 #include <list>
 #include <memory>
-#include <set>
 #include <string>
 
 #include "api/cpp/cvc5.h"
 #include "cvc5_export.h"
 #include "parser/api/cpp/symbol_manager.h"
-#include "parser/input.h"
 #include "parser/parse_op.h"
 #include "parser/parser_exception.h"
 #include "parser/parser_utils.h"
-#include "symbol_table.h"
+#include "parser/symbol_table.h"
 
 namespace cvc5 {
 namespace parser {
 
 class Command;
-class Input;
 
 /**
  * Callback from the parser state to the parser, for command preemption
@@ -69,455 +66,420 @@ class ParserStateCallback
  */
 class CVC5_EXPORT ParserState
 {
-private:
- /** The callback */
- ParserStateCallback* d_psc;
- /**
-  * Reference to the symbol manager, which manages the symbol table used by
-  * this parser.
-  */
- SymbolManager* d_symman;
+ public:
+  /**
+   * Create a parser state.
+   *
+   * @attention The parser takes "ownership" of the given
+   * input and will delete it on destruction.
+   *
+   * @param psc The callback for implementing parser-specific methods
+   * @param solver solver API object
+   * @param symm reference to the symbol manager
+   * @param input the parser input
+   * @param strictMode whether to incorporate strict(er) compliance checks
+   */
+  ParserState(ParserStateCallback* psc,
+              Solver* solver,
+              SymbolManager* sm,
+              bool strictMode = false);
 
- /**
-  * This current symbol table used by this parser, from symbol manager.
-  */
- internal::parser::SymbolTable* d_symtab;
+  virtual ~ParserState();
 
- /** Are semantic checks enabled during parsing? */
- bool d_checksEnabled;
+  /** Get the associated solver. */
+  Solver* getSolver() const;
 
- /** Are we parsing in strict mode? */
- bool d_strictMode;
+  /** Enable semantic checks during parsing. */
+  void enableChecks() { d_checksEnabled = true; }
 
- /** The set of operators available in the current logic. */
- std::set<cvc5::Kind> d_logicOperators;
+  /** Disable semantic checks during parsing. Disabling checks may lead to
+   * crashes on bad inputs. */
+  void disableChecks() { d_checksEnabled = false; }
 
- /** The set of attributes already warned about. */
- std::set<std::string> d_attributesWarnedAbout;
+  /** Enable strict parsing, according to the language standards. */
+  void enableStrictMode() { d_strictMode = true; }
 
- /** Lookup a symbol in the given namespace (as specified by the type).
-  * Only returns a symbol if it is not overloaded, returns null otherwise.
-  */
- cvc5::Term getSymbol(const std::string& var_name, SymbolType type);
+  /** Disable strict parsing. Allows certain syntactic infelicities to
+      pass without comment. */
+  void disableStrictMode() { d_strictMode = false; }
 
-protected:
- /** The API Solver object. */
- cvc5::Solver* d_solver;
+  bool strictModeEnabled() { return d_strictMode; }
 
-public:
- /**
-  * Create a parser state.
-  *
-  * @attention The parser takes "ownership" of the given
-  * input and will delete it on destruction.
-  *
-  * @param psc the callback to the parser
-  * @param solver solver API object
-  * @param symm reference to the symbol manager
-  * @param input the parser input
-  * @param strictMode whether to incorporate strict(er) compliance checks
-  */
- ParserState(ParserStateCallback* psc,
-             cvc5::Solver* solver,
-             SymbolManager* sm,
-             bool strictMode = false);
+  const std::string& getForcedLogic() const;
+  bool logicIsForced() const;
 
- virtual ~ParserState();
+  /** Expose the functionality from SMT/SMT2 parsers, while making
+      implementation optional by returning false by default. */
+  virtual bool logicIsSet() { return false; }
 
- /** Get the associated solver. */
- cvc5::Solver* getSolver() const;
+  /**
+   * Gets the variable currently bound to name.
+   *
+   * @param name the name of the variable
+   * @return the variable expression
+   * Only returns a variable if its name is not overloaded, returns null
+   * otherwise.
+   */
+  Term getVariable(const std::string& name);
 
- /** Enable semantic checks during parsing. */
- void enableChecks() { d_checksEnabled = true; }
+  /**
+   * Gets the function currently bound to name.
+   *
+   * @param name the name of the variable
+   * @return the variable expression
+   * Only returns a function if its name is not overloaded, returns null
+   * otherwise.
+   */
+  Term getFunction(const std::string& name);
 
- /** Disable semantic checks during parsing. Disabling checks may lead to
-  * crashes on bad inputs. */
- void disableChecks() { d_checksEnabled = false; }
+  /**
+   * Returns the expression that name should be interpreted as, based on the
+   * current binding.
+   *
+   * The symbol name should be declared.
+   * This creates the expression that the string "name" should be interpreted
+   * as. Typically this corresponds to a variable, but it may also correspond to
+   * a nullary constructor or a defined function.
+   * Only returns an expression if its name is not overloaded, returns null
+   * otherwise.
+   */
+  virtual Term getExpressionForName(const std::string& name);
 
- /** Enable strict parsing, according to the language standards. */
- void enableStrictMode() { d_strictMode = true; }
+  /**
+   * Returns the expression that name should be interpreted as, based on the
+   * current binding.
+   *
+   * This is the same as above but where the name has been type cast to t.
+   */
+  virtual Term getExpressionForNameAndType(const std::string& name, Sort t);
 
- /** Disable strict parsing. Allows certain syntactic infelicities to
-     pass without comment. */
- void disableStrictMode() { d_strictMode = false; }
+  /**
+   * If this method returns true, then name is updated with the tester name
+   * for constructor cons.
+   *
+   * In detail, notice that (user-defined) datatypes associate a unary predicate
+   * for each constructor, called its "tester". This symbol is automatically
+   * defined when a datatype is defined. The tester name for a constructor
+   * (e.g. "cons") depends on the language:
+   * - In smt versions < 2.6, the (non-standard) syntax is "is-cons",
+   * - In smt versions >= 2.6, the indexed symbol "(_ is cons)" is used. Thus,
+   * no tester symbol is necessary, since "is" is a builtin symbol. We still use
+   * the above syntax if strict mode is disabled.
+   * - In cvc, the syntax for testers is "is_cons".
+   */
+  virtual bool getTesterName(Term cons, std::string& name);
 
- bool strictModeEnabled() { return d_strictMode; }
+  /**
+   * Returns the kind that should be used for applications of expression fun.
+   * This is a generalization of ExprManager::operatorToKind that also
+   * handles variables whose types are "function-like", i.e. where
+   * checkFunctionLike(fun) returns true.
+   *
+   * For examples of the latter, this function returns
+   *   APPLY_UF if fun has function type,
+   *   APPLY_CONSTRUCTOR if fun has constructor type.
+   */
+  Kind getKindForFunction(Term fun);
 
- const std::string& getForcedLogic() const;
- bool logicIsForced() const;
-
- /** Expose the functionality from SMT/SMT2 parsers, while making
-     implementation optional by returning false by default. */
- virtual bool logicIsSet() { return false; }
-
- /**
-  * Gets the variable currently bound to name.
-  *
-  * @param name the name of the variable
-  * @return the variable expression
-  * Only returns a variable if its name is not overloaded, returns null
-  * otherwise.
-  */
- cvc5::Term getVariable(const std::string& name);
-
- /**
-  * Gets the function currently bound to name.
-  *
-  * @param name the name of the variable
-  * @return the variable expression
-  * Only returns a function if its name is not overloaded, returns null
-  * otherwise.
-  */
- cvc5::Term getFunction(const std::string& name);
-
- /**
-  * Returns the expression that name should be interpreted as, based on the
-  * current binding.
-  *
-  * The symbol name should be declared.
-  * This creates the expression that the string "name" should be interpreted as.
-  * Typically this corresponds to a variable, but it may also correspond to
-  * a nullary constructor or a defined function.
-  * Only returns an expression if its name is not overloaded, returns null
-  * otherwise.
-  */
- virtual cvc5::Term getExpressionForName(const std::string& name);
-
- /**
-  * Returns the expression that name should be interpreted as, based on the
-  * current binding.
-  *
-  * This is the same as above but where the name has been type cast to t.
-  */
- virtual cvc5::Term getExpressionForNameAndType(const std::string& name,
-                                                cvc5::Sort t);
-
- /**
-  * If this method returns true, then name is updated with the tester name
-  * for constructor cons.
-  *
-  * In detail, notice that (user-defined) datatypes associate a unary predicate
-  * for each constructor, called its "tester". This symbol is automatically
-  * defined when a datatype is defined. The tester name for a constructor
-  * (e.g. "cons") depends on the language:
-  * - In smt versions < 2.6, the (non-standard) syntax is "is-cons",
-  * - In smt versions >= 2.6, the indexed symbol "(_ is cons)" is used. Thus,
-  * no tester symbol is necessary, since "is" is a builtin symbol. We still use
-  * the above syntax if strict mode is disabled.
-  * - In cvc, the syntax for testers is "is_cons".
-  */
- virtual bool getTesterName(cvc5::Term cons, std::string& name);
- /**
-  * Returns the kind that should be used for applications of expression fun.
-  * This is a generalization of ExprManager::operatorToKind that also
-  * handles variables whose types are "function-like", i.e. where
-  * checkFunctionLike(fun) returns true.
-  *
-  * For examples of the latter, this function returns
-  *   APPLY_UF if fun has function type,
-  *   APPLY_CONSTRUCTOR if fun has constructor type.
-  */
- cvc5::Kind getKindForFunction(cvc5::Term fun);
-
- /**
-  * Returns a sort, given a name.
-  * @param sort_name the name to look up
-  */
- cvc5::Sort getSort(const std::string& sort_name);
+  /**
+   * Returns a sort, given a name.
+   * @param sort_name the name to look up
+   */
+  Sort getSort(const std::string& sort_name);
 
   /**
    * Returns a (parameterized) sort, given a name and args.
    */
-  virtual cvc5::Sort getParametricSort(const std::string& sort_name,
-                                       const std::vector<cvc5::Sort>& params);
+  virtual Sort getParametricSort(const std::string& sort_name,
+                                 const std::vector<Sort>& params);
 
- /**
-  * Checks if a symbol has been declared.
-  * @param name the symbol name
-  * @param type the symbol type
-  * @return true iff the symbol has been declared with the given type
-  */
- bool isDeclared(const std::string& name, SymbolType type = SYM_VARIABLE);
+  /**
+   * Checks if a symbol has been declared.
+   * @param name the symbol name
+   * @param type the symbol type
+   * @return true iff the symbol has been declared with the given type
+   */
+  bool isDeclared(const std::string& name, SymbolType type = SYM_VARIABLE);
 
- /**
-  * Checks if the declaration policy we want to enforce holds
-  * for the given symbol.
-  * @param name the symbol to check
-  * @param check the kind of check to perform
-  * @param type the type of the symbol
-  * @param notes notes to add to a parse error (if one is generated)
-  * @throws ParserException if checks are enabled and the check fails
-  */
- void checkDeclaration(const std::string& name,
-                       DeclarationCheck check,
-                       SymbolType type = SYM_VARIABLE,
-                       std::string notes = "");
+  /**
+   * Checks if the declaration policy we want to enforce holds
+   * for the given symbol.
+   * @param name the symbol to check
+   * @param check the kind of check to perform
+   * @param type the type of the symbol
+   * @param notes notes to add to a parse error (if one is generated)
+   * @throws ParserException if checks are enabled and the check fails
+   */
+  void checkDeclaration(const std::string& name,
+                        DeclarationCheck check,
+                        SymbolType type = SYM_VARIABLE,
+                        std::string notes = "");
 
- /**
-  * Checks whether the given expression is function-like, i.e.
-  * it expects arguments. This is checked by looking at the type
-  * of fun. Examples of function types are function, constructor,
-  * selector, tester.
-  * @param fun the expression to check
-  * @throws ParserException if checks are enabled and fun is not
-  * a function
-  */
- void checkFunctionLike(cvc5::Term fun);
+  /**
+   * Checks whether the given expression is function-like, i.e.
+   * it expects arguments. This is checked by looking at the type
+   * of fun. Examples of function types are function, constructor,
+   * selector, tester.
+   * @param fun the expression to check
+   * @throws ParserException if checks are enabled and fun is not
+   * a function
+   */
+  void checkFunctionLike(Term fun);
 
- /** Create a new cvc5 variable expression of the given type.
-  *
-  * If a symbol with name already exists,
-  *  then if doOverload is true, we create overloaded operators.
-  *  else if doOverload is false, the existing expression is shadowed by the
-  * new expression.
-  */
- cvc5::Term bindVar(const std::string& name,
-                    const cvc5::Sort& type,
-                    bool doOverload = false);
+  /** Create a new cvc5 variable expression of the given type.
+   *
+   * If a symbol with name already exists,
+   *  then if doOverload is true, we create overloaded operators.
+   *  else if doOverload is false, the existing expression is shadowed by the
+   * new expression.
+   */
+  Term bindVar(const std::string& name,
+               const Sort& type,
+               bool doOverload = false);
 
- /**
-  * Create a new cvc5 bound variable expression of the given type. This binds
-  * the symbol name to that variable in the current scope.
-  */
- cvc5::Term bindBoundVar(const std::string& name, const cvc5::Sort& type);
- /**
-  * Create a new cvc5 bound variable expressions of the given names and types.
-  * Like the method above, this binds these names to those variables in the
-  * current scope.
-  */
- std::vector<cvc5::Term> bindBoundVars(
-     std::vector<std::pair<std::string, cvc5::Sort> >& sortedVarNames);
+  /**
+   * Create a new cvc5 bound variable expression of the given type. This binds
+   * the symbol name to that variable in the current scope.
+   */
+  Term bindBoundVar(const std::string& name, const Sort& type);
+  /**
+   * Create a new cvc5 bound variable expressions of the given names and types.
+   * Like the method above, this binds these names to those variables in the
+   * current scope.
+   */
+  std::vector<Term> bindBoundVars(
+      std::vector<std::pair<std::string, Sort> >& sortedVarNames);
 
- /**
-  * Create a set of new cvc5 bound variable expressions of the given type.
-  *
-  * For each name, if a symbol with name already exists,
-  *  then if doOverload is true, we create overloaded operators.
-  *  else if doOverload is false, the existing expression is shadowed by the
-  * new expression.
-  */
- std::vector<cvc5::Term> bindBoundVars(const std::vector<std::string> names,
-                                       const cvc5::Sort& type);
+  /**
+   * Create a set of new cvc5 bound variable expressions of the given type.
+   *
+   * For each name, if a symbol with name already exists,
+   *  then if doOverload is true, we create overloaded operators.
+   *  else if doOverload is false, the existing expression is shadowed by the
+   * new expression.
+   */
+  std::vector<Term> bindBoundVars(const std::vector<std::string> names,
+                                  const Sort& type);
 
- /**
-  * Create a new variable definition (e.g., from a let binding).
-  *
-  * If a symbol with name already exists,
-  *  then if doOverload is true, we create overloaded operators.
-  *  else if doOverload is false, the existing expression is shadowed by the
-  * new expression.
-  */
- void defineVar(const std::string& name,
-                const cvc5::Term& val,
-                bool doOverload = false);
+  /** Create a new variable definition (e.g., from a let binding).
+   * If a symbol with name already exists,
+   *  then if doOverload is true, we create overloaded operators.
+   *  else if doOverload is false, the existing expression is shadowed by the
+   * new expression.
+   */
+  void defineVar(const std::string& name,
+                 const Term& val,
+                 bool doOverload = false);
 
- /**
-  * Create a new type definition.
-  *
-  * @param name The name of the type
-  * @param type The type that should be associated with the name
-  * @param skipExisting If true, the type definition is ignored if the same
-  *                     symbol has already been defined. It is assumed that
-  *                     the definition is the exact same as the existing one.
-  */
- void defineType(const std::string& name,
-                 const cvc5::Sort& type,
-                 bool skipExisting = false);
+  /**
+   * Create a new type definition.
+   *
+   * @param name The name of the type
+   * @param type The type that should be associated with the name
+   * @param skipExisting If true, the type definition is ignored if the same
+   *                     symbol has already been defined. It is assumed that
+   *                     the definition is the exact same as the existing one.
+   */
+  void defineType(const std::string& name,
+                  const Sort& type,
+                  bool skipExisting = false);
 
- /**
-  * Create a new (parameterized) type definition.
-  *
-  * @param name The name of the type
-  * @param params The type parameters
-  * @param type The type that should be associated with the name
-  */
- void defineType(const std::string& name,
-                 const std::vector<cvc5::Sort>& params,
-                 const cvc5::Sort& type);
+  /**
+   * Create a new (parameterized) type definition.
+   *
+   * @param name The name of the type
+   * @param params The type parameters
+   * @param type The type that should be associated with the name
+   */
+  void defineType(const std::string& name,
+                  const std::vector<Sort>& params,
+                  const Sort& type);
 
- /** Create a new type definition (e.g., from an SMT-LIBv2 define-sort). */
- void defineParameterizedType(const std::string& name,
-                              const std::vector<cvc5::Sort>& params,
-                              const cvc5::Sort& type);
+  /** Create a new type definition (e.g., from an SMT-LIBv2 define-sort). */
+  void defineParameterizedType(const std::string& name,
+                               const std::vector<Sort>& params,
+                               const Sort& type);
 
- /**
-  * Creates a new sort with the given name.
-  */
- cvc5::Sort mkSort(const std::string& name);
+  /**
+   * Creates a new sort with the given name.
+   */
+  Sort mkSort(const std::string& name);
 
- /**
-  * Creates a new sort constructor with the given name and arity.
-  */
- cvc5::Sort mkSortConstructor(const std::string& name, size_t arity);
+  /**
+   * Creates a new sort constructor with the given name and arity.
+   */
+  Sort mkSortConstructor(const std::string& name, size_t arity);
 
- /**
-  * Creates a new "unresolved type," used only during parsing.
-  */
- cvc5::Sort mkUnresolvedType(const std::string& name);
+  /**
+   * Creates a new "unresolved type," used only during parsing.
+   */
+  Sort mkUnresolvedType(const std::string& name);
 
- /**
-  * Creates a new unresolved (parameterized) type constructor of the given
-  * arity.
-  */
- cvc5::Sort mkUnresolvedTypeConstructor(const std::string& name, size_t arity);
- /**
-  * Creates a new unresolved (parameterized) type constructor given the type
-  * parameters.
-  */
- cvc5::Sort mkUnresolvedTypeConstructor(const std::string& name,
-                                        const std::vector<cvc5::Sort>& params);
+  /**
+   * Creates a new unresolved (parameterized) type constructor of the given
+   * arity.
+   */
+  Sort mkUnresolvedTypeConstructor(const std::string& name, size_t arity);
+  /**
+   * Creates a new unresolved (parameterized) type constructor given the type
+   * parameters.
+   */
+  Sort mkUnresolvedTypeConstructor(const std::string& name,
+                                   const std::vector<Sort>& params);
 
- /**
-  * Creates a new unresolved (parameterized) type constructor of the given
-  * arity. Calls either mkUnresolvedType or mkUnresolvedTypeConstructor
-  * depending on the arity.
-  */
- cvc5::Sort mkUnresolvedType(const std::string& name, size_t arity);
+  /**
+   * Creates a new unresolved (parameterized) type constructor of the given
+   * arity. Calls either mkUnresolvedType or mkUnresolvedTypeConstructor
+   * depending on the arity.
+   */
+  Sort mkUnresolvedType(const std::string& name, size_t arity);
 
- /**
-  * Creates and binds sorts of a list of mutually-recursive datatype
-  * declarations.
-  *
-  * For each symbol defined by the datatype, if a symbol with name already
-  * exists, then if doOverload is true, we create overloaded operators. Else, if
-  * doOverload is false, the existing expression is shadowed by the new
-  * expression.
-  */
- std::vector<cvc5::Sort> bindMutualDatatypeTypes(
-     std::vector<cvc5::DatatypeDecl>& datatypes, bool doOverload = false);
+  /**
+   * Creates and binds sorts of a list of mutually-recursive datatype
+   * declarations.
+   *
+   * For each symbol defined by the datatype, if a symbol with name already
+   * exists, then if doOverload is true, we create overloaded operators. Else,
+   * if doOverload is false, the existing expression is shadowed by the new
+   * expression.
+   */
+  std::vector<Sort> bindMutualDatatypeTypes(
+      std::vector<DatatypeDecl>& datatypes, bool doOverload = false);
 
- /**
-  * Make flat function type.
-  *
-  * Returns the "flat" function type corresponding to the function taking
-  * argument types "sorts" and range type "range".  A flat function type is
-  * one whose range is not a function. Notice that if sorts is empty and range
-  * is not a function, then this function returns range itself.
-  *
-  * If range is a function type, we add its function argument sorts to sorts
-  * and consider its function range as the new range. For each sort S added
-  * to sorts in this process, we add a new bound variable of sort S to
-  * flattenVars.
-  *
-  * For example:
-  * mkFlattenFunctionType( { Int, (-> Real Real) }, (-> Int Bool), {} ):
-  * - returns the the function type (-> Int (-> Real Real) Int Bool)
-  * - updates sorts to { Int, (-> Real Real), Int },
-  * - updates flattenVars to { x }, where x is bound variable of type Int.
-  *
-  * Notice that this method performs only one level of flattening, for example,
-  * mkFlattenFunctionType({ Int, (-> Real Real) }, (-> Int (-> Int Bool)), {}):
-  * - returns the the function type (-> Int (-> Real Real) Int (-> Int Bool))
-  * - updates sorts to { Int, (-> Real Real), Int },
-  * - updates flattenVars to { x }, where x is bound variable of type Int.
-  *
-  * This method is required so that we do not return functions
-  * that have function return type (these give an unhandled exception
-  * in the ExprManager). For examples of the equivalence between function
-  * definitions in the proposed higher-order extension of the smt2 language,
-  * see page 3 of http://matryoshka.gforge.inria.fr/pubs/PxTP2017.pdf.
-  *
-  * The argument flattenVars is needed in the case of defined functions
-  * with function return type. These have implicit arguments, for instance:
-  *    (define-fun Q ((x Int)) (-> Int Int) (lambda y (P x)))
-  * is equivalent to the command:
-  *    (define-fun Q ((x Int) (z Int)) Int (@ (lambda y (P x)) z))
-  * where @ is (higher-order) application. In this example, z is added to
-  * flattenVars.
-  */
- cvc5::Sort mkFlatFunctionType(std::vector<cvc5::Sort>& sorts,
-                               cvc5::Sort range,
-                               std::vector<cvc5::Term>& flattenVars);
+  /** make flat function type
+   *
+   * Returns the "flat" function type corresponding to the function taking
+   * argument types "sorts" and range type "range".  A flat function type is
+   * one whose range is not a function. Notice that if sorts is empty and range
+   * is not a function, then this function returns range itself.
+   *
+   * If range is a function type, we add its function argument sorts to sorts
+   * and consider its function range as the new range. For each sort S added
+   * to sorts in this process, we add a new bound variable of sort S to
+   * flattenVars.
+   *
+   * For example:
+   * mkFlattenFunctionType( { Int, (-> Real Real) }, (-> Int Bool), {} ):
+   * - returns the the function type (-> Int (-> Real Real) Int Bool)
+   * - updates sorts to { Int, (-> Real Real), Int },
+   * - updates flattenVars to { x }, where x is bound variable of type Int.
+   *
+   * Notice that this method performs only one level of flattening, for example,
+   * mkFlattenFunctionType({ Int, (-> Real Real) }, (-> Int (-> Int Bool)), {}):
+   * - returns the the function type (-> Int (-> Real Real) Int (-> Int Bool))
+   * - updates sorts to { Int, (-> Real Real), Int },
+   * - updates flattenVars to { x }, where x is bound variable of type Int.
+   *
+   * This method is required so that we do not return functions
+   * that have function return type (these give an unhandled exception
+   * in the ExprManager). For examples of the equivalence between function
+   * definitions in the proposed higher-order extension of the smt2 language,
+   * see page 3 of http://matryoshka.gforge.inria.fr/pubs/PxTP2017.pdf.
+   *
+   * The argument flattenVars is needed in the case of defined functions
+   * with function return type. These have implicit arguments, for instance:
+   *    (define-fun Q ((x Int)) (-> Int Int) (lambda y (P x)))
+   * is equivalent to the command:
+   *    (define-fun Q ((x Int) (z Int)) Int (@ (lambda y (P x)) z))
+   * where @ is (higher-order) application. In this example, z is added to
+   * flattenVars.
+   */
+  Sort mkFlatFunctionType(std::vector<Sort>& sorts,
+                          Sort range,
+                          std::vector<Term>& flattenVars);
 
- /**
-  * Make flat function type.
-  *
-  * Same as above, but does not take argument flattenVars.
-  * This is used when the arguments of the function are not important (for
-  * instance, if we are only using this type in a declare-fun).
-  */
- cvc5::Sort mkFlatFunctionType(std::vector<cvc5::Sort>& sorts,
-                               cvc5::Sort range);
+  /** make flat function type
+   *
+   * Same as above, but does not take argument flattenVars.
+   * This is used when the arguments of the function are not important (for
+   * instance, if we are only using this type in a declare-fun).
+   */
+  Sort mkFlatFunctionType(std::vector<Sort>& sorts, Sort range);
 
- /**
-  * Make higher-order apply.
-  *
-  * This returns the left-associative curried application of (function) expr to
-  * the arguments in args.
-  *
-  * For example, mkHoApply( f, { a, b }, 0 ) returns
-  *  (HO_APPLY (HO_APPLY f a) b)
-  *
-  * If args is non-empty, the expected type of expr is (-> T0 ... Tn T), where
-  *    args[i].getType() = Ti
-  * for each i where 0 <= i < args.size(). If expr is not of this
-  * type, the expression returned by this method will not be well typed.
-  */
- cvc5::Term mkHoApply(cvc5::Term expr, const std::vector<cvc5::Term>& args);
+  /** make higher-order apply
+   *
+   * This returns the left-associative curried application of (function) expr to
+   * the arguments in args.
+   *
+   * For example, mkHoApply( f, { a, b }, 0 ) returns
+   *  (HO_APPLY (HO_APPLY f a) b)
+   *
+   * If args is non-empty, the expected type of expr is (-> T0 ... Tn T), where
+   *    args[i].getType() = Ti
+   * for each i where 0 <= i < args.size(). If expr is not of this
+   * type, the expression returned by this method will not be well typed.
+   */
+  Term mkHoApply(Term expr, const std::vector<Term>& args);
 
- /**
-  * Apply type ascription.
-  *
-  * Return term t with a type ascription applied to it. This is used for
-  * syntax like (as t T) in smt2 and t::T in the CVC language. This includes:
-  * - (as set.empty (Set T))
-  * - (as emptybag (Bag T))
-  * - (as univset (Set T))
-  * - (as sep.nil T)
-  * - (cons T)
-  * - ((as cons T) t1 ... tn) where cons is a parametric datatype constructor.
-  *
-  * The term to ascribe t is a term whose kind and children (but not type)
-  * are equivalent to that of the term returned by this method.
-  *
-  * Notice that method is not necessarily a cast. In actuality, the above terms
-  * should be understood as symbols indexed by types. However, SMT-LIB does not
-  * permit types as indices, so we must use, e.g. (as set.empty (Set T))
-  * instead of (_ set.empty (Set T)).
-  *
-  * @param t The term to ascribe a type
-  * @param s The sort to ascribe
-  * @return Term t with sort s ascribed.
-  */
- cvc5::Term applyTypeAscription(cvc5::Term t, cvc5::Sort s);
+  /** Apply type ascription
+   *
+   * Return term t with a type ascription applied to it. This is used for
+   * syntax like (as t T) in smt2 and t::T in the CVC language. This includes:
+   * - (as set.empty (Set T))
+   * - (as emptybag (Bag T))
+   * - (as univset (Set T))
+   * - (as sep.nil T)
+   * - (cons T)
+   * - ((as cons T) t1 ... tn) where cons is a parametric datatype constructor.
+   *
+   * The term to ascribe t is a term whose kind and children (but not type)
+   * are equivalent to that of the term returned by this method.
+   *
+   * Notice that method is not necessarily a cast. In actuality, the above terms
+   * should be understood as symbols indexed by types. However, SMT-LIB does not
+   * permit types as indices, so we must use, e.g. (as set.empty (Set T))
+   * instead of (_ set.empty (Set T)).
+   *
+   * @param t The term to ascribe a type
+   * @param s The sort to ascribe
+   * @return Term t with sort s ascribed.
+   */
+  Term applyTypeAscription(Term t, Sort s);
 
- /**
-  * Add an operator to the current legal set.
-  *
-  * @param kind the built-in operator to add
-  */
- void addOperator(cvc5::Kind kind);
+  /**
+   * Add an operator to the current legal set.
+   *
+   * @param kind the built-in operator to add
+   */
+  void addOperator(Kind kind);
 
- /** Is fun a function (or function-like thing)?
-  * Currently this means its type is either a function, constructor, tester, or
-  * selector.
-  */
- bool isFunctionLike(cvc5::Term fun);
+  /** Is fun a function (or function-like thing)?
+   * Currently this means its type is either a function, constructor, tester, or
+   * selector.
+   */
+  bool isFunctionLike(Term fun);
 
- /** Issue a warning to the user, but only once per attribute. */
- void attributeNotSupported(const std::string& attr);
+  //-------------------- callbacks to parser
+  /** Issue a warning to the user. */
+  void warning(const std::string& msg);
+  /** Raise a parse error with the given message. */
+  void parseError(const std::string& msg);
+  /** Unexpectedly encountered an EOF */
+  void unexpectedEOF(const std::string& msg);
+  /** Preempt command */
+  void preemptCommand(Command* cmd);
+  //-------------------- end callbacks to parser
+  /** Issue a warning to the user, but only once per attribute. */
+  void attributeNotSupported(const std::string& attr);
 
- /** Issue a warning to the user. */
- void warning(const std::string& msg);
- /** Raise a parse error with the given message. */
- void parseError(const std::string& msg);
- /** Unexpectedly encountered an EOF */
- void unexpectedEOF(const std::string& msg);
- /**
-  * Preempt the next returned command with other ones; used to
-  * support the :named attribute in SMT-LIBv2, which implicitly
-  * inserts a new command before the current one. Also used in TPTP
-  * because function and predicate symbols are implicitly declared.
-  */
- void preemptCommand(Command* cmd);
-
- /**
-  * Raise a parse error with the given message.
-  */
- void unimplementedFeature(const std::string& msg)
- {
-   parseError("Unimplemented feature: " + msg);
- }
+  /**
+   * If we are parsing only, don't raise an exception; if we are not,
+   * raise a parse error with the given message.  There is no actual
+   * parse error, everything is as expected, but we cannot create the
+   * Expr, Type, or other requested thing yet due to internal
+   * limitations.  Even though it's not a parse error, we throw a
+   * parse error so that the input line and column information is
+   * available.
+   *
+   * Think quantifiers.  We don't have a TheoryQuantifiers yet, so we
+   * have no kind::FORALL or kind::EXISTS.  But we might want to
+   * support parsing quantifiers (just not doing anything with them).
+   * So this mechanism gives you a way to do it with --parse-only.
+   */
+  void unimplementedFeature(const std::string& msg)
+  {
+    parseError("Unimplemented feature: " + msg);
+  }
 
   /**
    * Gets the current declaration level.
@@ -553,7 +515,7 @@ public:
 
   //------------------------ operator overloading
   /** is this function overloaded? */
-  bool isOverloadedFunction(cvc5::Term fun)
+  bool isOverloadedFunction(Term fun)
   {
     return d_symtab->isOverloadedFunction(fun);
   }
@@ -561,8 +523,8 @@ public:
   /** Get overloaded constant for type.
    * If possible, it returns a defined symbol with name
    * that has type t. Otherwise returns null expression.
-  */
-  cvc5::Term getOverloadedConstantForType(const std::string& name, cvc5::Sort t)
+   */
+  Term getOverloadedConstantForType(const std::string& name, Sort t)
   {
     return d_symtab->getOverloadedConstantForType(name, t);
   }
@@ -572,12 +534,21 @@ public:
    * and a vector of expected argument types. Otherwise returns
    * null expression.
    */
-  cvc5::Term getOverloadedFunctionForTypes(const std::string& name,
-                                           std::vector<cvc5::Sort>& argTypes)
+  Term getOverloadedFunctionForTypes(const std::string& name,
+                                     std::vector<Sort>& argTypes)
   {
     return d_symtab->getOverloadedFunctionForTypes(name, argTypes);
   }
   //------------------------ end operator overloading
+  /**
+   * Make string constant
+   *
+   * This makes the string constant based on the string s. This may involve
+   * processing ad-hoc escape sequences (if the language is not
+   * SMT-LIB 2.6 or higher), or otherwise calling the solver to construct
+   * the string.
+   */
+  Term mkStringConstant(const std::string& s);
 
   /**
    * Make string constant from a single character in hex representation
@@ -585,7 +556,7 @@ public:
    * This makes the string constant based on the character from the strings,
    * represented as a hexadecimal code point.
    */
-  cvc5::Term mkCharConstant(const std::string& s);
+  Term mkCharConstant(const std::string& s);
 
   /** ad-hoc string escaping
    *
@@ -599,15 +570,49 @@ public:
    */
   std::wstring processAdHocStringEsc(const std::string& s);
 
-  /**
-   * Include smt2 file
-   */
-  void includeSmt2File(const std::string& filename);
-  /**
-   * Include tptp file
-   */
-  void includeTptpFile(const std::string& filename, const std::string& tptpDir);
+ protected:
+  /** The API Solver object. */
+  Solver* d_solver;
 
+ private:
+  /** The callback */
+  ParserStateCallback* d_psc;
+  /**
+   * Reference to the symbol manager, which manages the symbol table used by
+   * this parser.
+   */
+  SymbolManager* d_symman;
+
+  /**
+   * This current symbol table used by this parser, from symbol manager.
+   */
+  internal::parser::SymbolTable* d_symtab;
+
+  /** Are semantic checks enabled during parsing? */
+  bool d_checksEnabled;
+
+  /** Are we parsing in strict mode? */
+  bool d_strictMode;
+
+  /** The set of operators available in the current logic. */
+  std::set<Kind> d_logicOperators;
+
+  /** The set of attributes already warned about. */
+  std::set<std::string> d_attributesWarnedAbout;
+
+  /**
+   * "Preemption commands": extra commands implied by subterms that
+   * should be issued before the currently-being-parsed command is
+   * issued.  Used to support SMT-LIBv2 ":named" attribute on terms.
+   *
+   * Owns the memory of the Commands in the queue.
+   */
+  std::list<Command*> d_commandQueue;
+
+  /** Lookup a symbol in the given namespace (as specified by the type).
+   * Only returns a symbol if it is not overloaded, returns null otherwise.
+   */
+  Term getSymbol(const std::string& var_name, SymbolType type);
 }; /* class Parser */
 
 }  // namespace parser

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -540,15 +540,6 @@ class CVC5_EXPORT ParserState
     return d_symtab->getOverloadedFunctionForTypes(name, argTypes);
   }
   //------------------------ end operator overloading
-  /**
-   * Make string constant
-   *
-   * This makes the string constant based on the string s. This may involve
-   * processing ad-hoc escape sequences (if the language is not
-   * SMT-LIB 2.6 or higher), or otherwise calling the solver to construct
-   * the string.
-   */
-  Term mkStringConstant(const std::string& s);
 
   /**
    * Make string constant from a single character in hex representation

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -40,219 +40,218 @@ Smt2State::~Smt2State() {}
 
 void Smt2State::addArithmeticOperators()
 {
-  addOperator(cvc5::ADD, "+");
-  addOperator(cvc5::SUB, "-");
-  // cvc5::SUB is converted to cvc5::NEG if there is only a single operand
-  ParserState::addOperator(cvc5::NEG);
-  addOperator(cvc5::MULT, "*");
-  addOperator(cvc5::LT, "<");
-  addOperator(cvc5::LEQ, "<=");
-  addOperator(cvc5::GT, ">");
-  addOperator(cvc5::GEQ, ">=");
+  addOperator(ADD, "+");
+  addOperator(SUB, "-");
+  // SUB is converted to NEG if there is only a single operand
+  ParserState::addOperator(NEG);
+  addOperator(MULT, "*");
+  addOperator(LT, "<");
+  addOperator(LEQ, "<=");
+  addOperator(GT, ">");
+  addOperator(GEQ, ">=");
 
   if (!strictModeEnabled())
   {
     // NOTE: this operator is non-standard
-    addOperator(cvc5::POW, "^");
+    addOperator(POW, "^");
   }
 }
 
 void Smt2State::addTranscendentalOperators()
 {
-  addOperator(cvc5::EXPONENTIAL, "exp");
-  addOperator(cvc5::SINE, "sin");
-  addOperator(cvc5::COSINE, "cos");
-  addOperator(cvc5::TANGENT, "tan");
-  addOperator(cvc5::COSECANT, "csc");
-  addOperator(cvc5::SECANT, "sec");
-  addOperator(cvc5::COTANGENT, "cot");
-  addOperator(cvc5::ARCSINE, "arcsin");
-  addOperator(cvc5::ARCCOSINE, "arccos");
-  addOperator(cvc5::ARCTANGENT, "arctan");
-  addOperator(cvc5::ARCCOSECANT, "arccsc");
-  addOperator(cvc5::ARCSECANT, "arcsec");
-  addOperator(cvc5::ARCCOTANGENT, "arccot");
-  addOperator(cvc5::SQRT, "sqrt");
+  addOperator(EXPONENTIAL, "exp");
+  addOperator(SINE, "sin");
+  addOperator(COSINE, "cos");
+  addOperator(TANGENT, "tan");
+  addOperator(COSECANT, "csc");
+  addOperator(SECANT, "sec");
+  addOperator(COTANGENT, "cot");
+  addOperator(ARCSINE, "arcsin");
+  addOperator(ARCCOSINE, "arccos");
+  addOperator(ARCTANGENT, "arctan");
+  addOperator(ARCCOSECANT, "arccsc");
+  addOperator(ARCSECANT, "arcsec");
+  addOperator(ARCCOTANGENT, "arccot");
+  addOperator(SQRT, "sqrt");
 }
 
 void Smt2State::addQuantifiersOperators() {}
 
 void Smt2State::addBitvectorOperators()
 {
-  addOperator(cvc5::BITVECTOR_CONCAT, "concat");
-  addOperator(cvc5::BITVECTOR_NOT, "bvnot");
-  addOperator(cvc5::BITVECTOR_AND, "bvand");
-  addOperator(cvc5::BITVECTOR_OR, "bvor");
-  addOperator(cvc5::BITVECTOR_NEG, "bvneg");
-  addOperator(cvc5::BITVECTOR_ADD, "bvadd");
-  addOperator(cvc5::BITVECTOR_MULT, "bvmul");
-  addOperator(cvc5::BITVECTOR_UDIV, "bvudiv");
-  addOperator(cvc5::BITVECTOR_UREM, "bvurem");
-  addOperator(cvc5::BITVECTOR_SHL, "bvshl");
-  addOperator(cvc5::BITVECTOR_LSHR, "bvlshr");
-  addOperator(cvc5::BITVECTOR_ULT, "bvult");
-  addOperator(cvc5::BITVECTOR_NAND, "bvnand");
-  addOperator(cvc5::BITVECTOR_NOR, "bvnor");
-  addOperator(cvc5::BITVECTOR_XOR, "bvxor");
-  addOperator(cvc5::BITVECTOR_XNOR, "bvxnor");
-  addOperator(cvc5::BITVECTOR_COMP, "bvcomp");
-  addOperator(cvc5::BITVECTOR_SUB, "bvsub");
-  addOperator(cvc5::BITVECTOR_SDIV, "bvsdiv");
-  addOperator(cvc5::BITVECTOR_SREM, "bvsrem");
-  addOperator(cvc5::BITVECTOR_SMOD, "bvsmod");
-  addOperator(cvc5::BITVECTOR_ASHR, "bvashr");
-  addOperator(cvc5::BITVECTOR_ULE, "bvule");
-  addOperator(cvc5::BITVECTOR_UGT, "bvugt");
-  addOperator(cvc5::BITVECTOR_UGE, "bvuge");
-  addOperator(cvc5::BITVECTOR_SLT, "bvslt");
-  addOperator(cvc5::BITVECTOR_SLE, "bvsle");
-  addOperator(cvc5::BITVECTOR_SGT, "bvsgt");
-  addOperator(cvc5::BITVECTOR_SGE, "bvsge");
-  addOperator(cvc5::BITVECTOR_REDOR, "bvredor");
-  addOperator(cvc5::BITVECTOR_REDAND, "bvredand");
-  addOperator(cvc5::BITVECTOR_UADDO, "bvuaddo");
-  addOperator(cvc5::BITVECTOR_SADDO, "bvsaddo");
-  addOperator(cvc5::BITVECTOR_UMULO, "bvumulo");
-  addOperator(cvc5::BITVECTOR_SMULO, "bvsmulo");
-  addOperator(cvc5::BITVECTOR_USUBO, "bvusubo");
-  addOperator(cvc5::BITVECTOR_SSUBO, "bvssubo");
-  addOperator(cvc5::BITVECTOR_SDIVO, "bvsdivo");
+  addOperator(BITVECTOR_CONCAT, "concat");
+  addOperator(BITVECTOR_NOT, "bvnot");
+  addOperator(BITVECTOR_AND, "bvand");
+  addOperator(BITVECTOR_OR, "bvor");
+  addOperator(BITVECTOR_NEG, "bvneg");
+  addOperator(BITVECTOR_ADD, "bvadd");
+  addOperator(BITVECTOR_MULT, "bvmul");
+  addOperator(BITVECTOR_UDIV, "bvudiv");
+  addOperator(BITVECTOR_UREM, "bvurem");
+  addOperator(BITVECTOR_SHL, "bvshl");
+  addOperator(BITVECTOR_LSHR, "bvlshr");
+  addOperator(BITVECTOR_ULT, "bvult");
+  addOperator(BITVECTOR_NAND, "bvnand");
+  addOperator(BITVECTOR_NOR, "bvnor");
+  addOperator(BITVECTOR_XOR, "bvxor");
+  addOperator(BITVECTOR_XNOR, "bvxnor");
+  addOperator(BITVECTOR_COMP, "bvcomp");
+  addOperator(BITVECTOR_SUB, "bvsub");
+  addOperator(BITVECTOR_SDIV, "bvsdiv");
+  addOperator(BITVECTOR_SREM, "bvsrem");
+  addOperator(BITVECTOR_SMOD, "bvsmod");
+  addOperator(BITVECTOR_ASHR, "bvashr");
+  addOperator(BITVECTOR_ULE, "bvule");
+  addOperator(BITVECTOR_UGT, "bvugt");
+  addOperator(BITVECTOR_UGE, "bvuge");
+  addOperator(BITVECTOR_SLT, "bvslt");
+  addOperator(BITVECTOR_SLE, "bvsle");
+  addOperator(BITVECTOR_SGT, "bvsgt");
+  addOperator(BITVECTOR_SGE, "bvsge");
+  addOperator(BITVECTOR_REDOR, "bvredor");
+  addOperator(BITVECTOR_REDAND, "bvredand");
+  addOperator(BITVECTOR_UADDO, "bvuaddo");
+  addOperator(BITVECTOR_SADDO, "bvsaddo");
+  addOperator(BITVECTOR_UMULO, "bvumulo");
+  addOperator(BITVECTOR_SMULO, "bvsmulo");
+  addOperator(BITVECTOR_USUBO, "bvusubo");
+  addOperator(BITVECTOR_SSUBO, "bvssubo");
+  addOperator(BITVECTOR_SDIVO, "bvsdivo");
 
-  addIndexedOperator(cvc5::BITVECTOR_EXTRACT, "extract");
-  addIndexedOperator(cvc5::BITVECTOR_REPEAT, "repeat");
-  addIndexedOperator(cvc5::BITVECTOR_ZERO_EXTEND, "zero_extend");
-  addIndexedOperator(cvc5::BITVECTOR_SIGN_EXTEND, "sign_extend");
-  addIndexedOperator(cvc5::BITVECTOR_ROTATE_LEFT, "rotate_left");
-  addIndexedOperator(cvc5::BITVECTOR_ROTATE_RIGHT, "rotate_right");
+  addIndexedOperator(BITVECTOR_EXTRACT, "extract");
+  addIndexedOperator(BITVECTOR_REPEAT, "repeat");
+  addIndexedOperator(BITVECTOR_ZERO_EXTEND, "zero_extend");
+  addIndexedOperator(BITVECTOR_SIGN_EXTEND, "sign_extend");
+  addIndexedOperator(BITVECTOR_ROTATE_LEFT, "rotate_left");
+  addIndexedOperator(BITVECTOR_ROTATE_RIGHT, "rotate_right");
 }
 
 void Smt2State::addDatatypesOperators()
 {
-  ParserState::addOperator(cvc5::APPLY_CONSTRUCTOR);
-  ParserState::addOperator(cvc5::APPLY_TESTER);
-  ParserState::addOperator(cvc5::APPLY_SELECTOR);
+  ParserState::addOperator(APPLY_CONSTRUCTOR);
+  ParserState::addOperator(APPLY_TESTER);
+  ParserState::addOperator(APPLY_SELECTOR);
 
   if (!strictModeEnabled())
   {
-    ParserState::addOperator(cvc5::APPLY_UPDATER);
+    ParserState::addOperator(APPLY_UPDATER);
     // Tuple projection is both indexed and non-indexed (when indices are empty)
-    addOperator(cvc5::TUPLE_PROJECT, "tuple.project");
-    addIndexedOperator(cvc5::TUPLE_PROJECT, "tuple.project");
+    addOperator(TUPLE_PROJECT, "tuple.project");
+    addIndexedOperator(TUPLE_PROJECT, "tuple.project");
     // Notice that tuple operators, we use the UNDEFINED_KIND kind.
     // These are processed based on the context in which they are parsed, e.g.
     // when parsing identifiers.
     // For the tuple constructor "tuple", this is both a nullary operator
     // (for the 0-ary tuple), and a operator, hence we call both addOperator
     // and defineVar here.
-    addOperator(cvc5::APPLY_CONSTRUCTOR, "tuple");
+    addOperator(APPLY_CONSTRUCTOR, "tuple");
     defineVar("tuple", d_solver->mkTuple({}, {}));
-    addIndexedOperator(cvc5::UNDEFINED_KIND, "tuple.select");
-    addIndexedOperator(cvc5::UNDEFINED_KIND, "tuple.update");
+    addIndexedOperator(UNDEFINED_KIND, "tuple.select");
+    addIndexedOperator(UNDEFINED_KIND, "tuple.update");
   }
 }
 
 void Smt2State::addStringOperators()
 {
-  defineVar("re.all", getSolver()->mkRegexpAll());
-  addOperator(cvc5::STRING_CONCAT, "str.++");
-  addOperator(cvc5::STRING_LENGTH, "str.len");
-  addOperator(cvc5::STRING_SUBSTR, "str.substr");
-  addOperator(cvc5::STRING_CONTAINS, "str.contains");
-  addOperator(cvc5::STRING_CHARAT, "str.at");
-  addOperator(cvc5::STRING_INDEXOF, "str.indexof");
-  addOperator(cvc5::STRING_REPLACE, "str.replace");
-  addOperator(cvc5::STRING_PREFIX, "str.prefixof");
-  addOperator(cvc5::STRING_SUFFIX, "str.suffixof");
-  addOperator(cvc5::STRING_FROM_CODE, "str.from_code");
-  addOperator(cvc5::STRING_IS_DIGIT, "str.is_digit");
-  addOperator(cvc5::STRING_REPLACE_RE, "str.replace_re");
-  addOperator(cvc5::STRING_REPLACE_RE_ALL, "str.replace_re_all");
+  defineVar("re.all", d_solver->mkRegexpAll());
+  addOperator(STRING_CONCAT, "str.++");
+  addOperator(STRING_LENGTH, "str.len");
+  addOperator(STRING_SUBSTR, "str.substr");
+  addOperator(STRING_CONTAINS, "str.contains");
+  addOperator(STRING_CHARAT, "str.at");
+  addOperator(STRING_INDEXOF, "str.indexof");
+  addOperator(STRING_REPLACE, "str.replace");
+  addOperator(STRING_PREFIX, "str.prefixof");
+  addOperator(STRING_SUFFIX, "str.suffixof");
+  addOperator(STRING_FROM_CODE, "str.from_code");
+  addOperator(STRING_IS_DIGIT, "str.is_digit");
+  addOperator(STRING_REPLACE_RE, "str.replace_re");
+  addOperator(STRING_REPLACE_RE_ALL, "str.replace_re_all");
   if (!strictModeEnabled())
   {
-    addOperator(cvc5::STRING_INDEXOF_RE, "str.indexof_re");
-    addOperator(cvc5::STRING_UPDATE, "str.update");
-    addOperator(cvc5::STRING_TO_LOWER, "str.to_lower");
-    addOperator(cvc5::STRING_TO_UPPER, "str.to_upper");
-    addOperator(cvc5::STRING_REV, "str.rev");
+    addOperator(STRING_INDEXOF_RE, "str.indexof_re");
+    addOperator(STRING_UPDATE, "str.update");
+    addOperator(STRING_TO_LOWER, "str.to_lower");
+    addOperator(STRING_TO_UPPER, "str.to_upper");
+    addOperator(STRING_REV, "str.rev");
     // sequence versions
-    addOperator(cvc5::SEQ_CONCAT, "seq.++");
-    addOperator(cvc5::SEQ_LENGTH, "seq.len");
-    addOperator(cvc5::SEQ_EXTRACT, "seq.extract");
-    addOperator(cvc5::SEQ_UPDATE, "seq.update");
-    addOperator(cvc5::SEQ_AT, "seq.at");
-    addOperator(cvc5::SEQ_CONTAINS, "seq.contains");
-    addOperator(cvc5::SEQ_INDEXOF, "seq.indexof");
-    addOperator(cvc5::SEQ_REPLACE, "seq.replace");
-    addOperator(cvc5::SEQ_PREFIX, "seq.prefixof");
-    addOperator(cvc5::SEQ_SUFFIX, "seq.suffixof");
-    addOperator(cvc5::SEQ_REV, "seq.rev");
-    addOperator(cvc5::SEQ_REPLACE_ALL, "seq.replace_all");
-    addOperator(cvc5::SEQ_UNIT, "seq.unit");
-    addOperator(cvc5::SEQ_NTH, "seq.nth");
+    addOperator(SEQ_CONCAT, "seq.++");
+    addOperator(SEQ_LENGTH, "seq.len");
+    addOperator(SEQ_EXTRACT, "seq.extract");
+    addOperator(SEQ_UPDATE, "seq.update");
+    addOperator(SEQ_AT, "seq.at");
+    addOperator(SEQ_CONTAINS, "seq.contains");
+    addOperator(SEQ_INDEXOF, "seq.indexof");
+    addOperator(SEQ_REPLACE, "seq.replace");
+    addOperator(SEQ_PREFIX, "seq.prefixof");
+    addOperator(SEQ_SUFFIX, "seq.suffixof");
+    addOperator(SEQ_REV, "seq.rev");
+    addOperator(SEQ_REPLACE_ALL, "seq.replace_all");
+    addOperator(SEQ_UNIT, "seq.unit");
+    addOperator(SEQ_NTH, "seq.nth");
   }
-  addOperator(cvc5::STRING_FROM_INT, "str.from_int");
-  addOperator(cvc5::STRING_TO_INT, "str.to_int");
-  addOperator(cvc5::STRING_IN_REGEXP, "str.in_re");
-  addOperator(cvc5::STRING_TO_REGEXP, "str.to_re");
-  addOperator(cvc5::STRING_TO_CODE, "str.to_code");
-  addOperator(cvc5::STRING_REPLACE_ALL, "str.replace_all");
+  addOperator(STRING_FROM_INT, "str.from_int");
+  addOperator(STRING_TO_INT, "str.to_int");
+  addOperator(STRING_IN_REGEXP, "str.in_re");
+  addOperator(STRING_TO_REGEXP, "str.to_re");
+  addOperator(STRING_TO_CODE, "str.to_code");
+  addOperator(STRING_REPLACE_ALL, "str.replace_all");
 
-  addOperator(cvc5::REGEXP_CONCAT, "re.++");
-  addOperator(cvc5::REGEXP_UNION, "re.union");
-  addOperator(cvc5::REGEXP_INTER, "re.inter");
-  addOperator(cvc5::REGEXP_STAR, "re.*");
-  addOperator(cvc5::REGEXP_PLUS, "re.+");
-  addOperator(cvc5::REGEXP_OPT, "re.opt");
-  addIndexedOperator(cvc5::REGEXP_REPEAT, "re.^");
-  addIndexedOperator(cvc5::REGEXP_LOOP, "re.loop");
-  addOperator(cvc5::REGEXP_RANGE, "re.range");
-  addOperator(cvc5::REGEXP_COMPLEMENT, "re.comp");
-  addOperator(cvc5::REGEXP_DIFF, "re.diff");
-  addOperator(cvc5::STRING_LT, "str.<");
-  addOperator(cvc5::STRING_LEQ, "str.<=");
+  addOperator(REGEXP_CONCAT, "re.++");
+  addOperator(REGEXP_UNION, "re.union");
+  addOperator(REGEXP_INTER, "re.inter");
+  addOperator(REGEXP_STAR, "re.*");
+  addOperator(REGEXP_PLUS, "re.+");
+  addOperator(REGEXP_OPT, "re.opt");
+  addIndexedOperator(REGEXP_REPEAT, "re.^");
+  addIndexedOperator(REGEXP_LOOP, "re.loop");
+  addOperator(REGEXP_RANGE, "re.range");
+  addOperator(REGEXP_COMPLEMENT, "re.comp");
+  addOperator(REGEXP_DIFF, "re.diff");
+  addOperator(STRING_LT, "str.<");
+  addOperator(STRING_LEQ, "str.<=");
 }
 
 void Smt2State::addFloatingPointOperators()
 {
-  addOperator(cvc5::FLOATINGPOINT_FP, "fp");
-  addOperator(cvc5::FLOATINGPOINT_EQ, "fp.eq");
-  addOperator(cvc5::FLOATINGPOINT_ABS, "fp.abs");
-  addOperator(cvc5::FLOATINGPOINT_NEG, "fp.neg");
-  addOperator(cvc5::FLOATINGPOINT_ADD, "fp.add");
-  addOperator(cvc5::FLOATINGPOINT_SUB, "fp.sub");
-  addOperator(cvc5::FLOATINGPOINT_MULT, "fp.mul");
-  addOperator(cvc5::FLOATINGPOINT_DIV, "fp.div");
-  addOperator(cvc5::FLOATINGPOINT_FMA, "fp.fma");
-  addOperator(cvc5::FLOATINGPOINT_SQRT, "fp.sqrt");
-  addOperator(cvc5::FLOATINGPOINT_REM, "fp.rem");
-  addOperator(cvc5::FLOATINGPOINT_RTI, "fp.roundToIntegral");
-  addOperator(cvc5::FLOATINGPOINT_MIN, "fp.min");
-  addOperator(cvc5::FLOATINGPOINT_MAX, "fp.max");
-  addOperator(cvc5::FLOATINGPOINT_LEQ, "fp.leq");
-  addOperator(cvc5::FLOATINGPOINT_LT, "fp.lt");
-  addOperator(cvc5::FLOATINGPOINT_GEQ, "fp.geq");
-  addOperator(cvc5::FLOATINGPOINT_GT, "fp.gt");
-  addOperator(cvc5::FLOATINGPOINT_IS_NORMAL, "fp.isNormal");
-  addOperator(cvc5::FLOATINGPOINT_IS_SUBNORMAL, "fp.isSubnormal");
-  addOperator(cvc5::FLOATINGPOINT_IS_ZERO, "fp.isZero");
-  addOperator(cvc5::FLOATINGPOINT_IS_INF, "fp.isInfinite");
-  addOperator(cvc5::FLOATINGPOINT_IS_NAN, "fp.isNaN");
-  addOperator(cvc5::FLOATINGPOINT_IS_NEG, "fp.isNegative");
-  addOperator(cvc5::FLOATINGPOINT_IS_POS, "fp.isPositive");
-  addOperator(cvc5::FLOATINGPOINT_TO_REAL, "fp.to_real");
+  addOperator(FLOATINGPOINT_FP, "fp");
+  addOperator(FLOATINGPOINT_EQ, "fp.eq");
+  addOperator(FLOATINGPOINT_ABS, "fp.abs");
+  addOperator(FLOATINGPOINT_NEG, "fp.neg");
+  addOperator(FLOATINGPOINT_ADD, "fp.add");
+  addOperator(FLOATINGPOINT_SUB, "fp.sub");
+  addOperator(FLOATINGPOINT_MULT, "fp.mul");
+  addOperator(FLOATINGPOINT_DIV, "fp.div");
+  addOperator(FLOATINGPOINT_FMA, "fp.fma");
+  addOperator(FLOATINGPOINT_SQRT, "fp.sqrt");
+  addOperator(FLOATINGPOINT_REM, "fp.rem");
+  addOperator(FLOATINGPOINT_RTI, "fp.roundToIntegral");
+  addOperator(FLOATINGPOINT_MIN, "fp.min");
+  addOperator(FLOATINGPOINT_MAX, "fp.max");
+  addOperator(FLOATINGPOINT_LEQ, "fp.leq");
+  addOperator(FLOATINGPOINT_LT, "fp.lt");
+  addOperator(FLOATINGPOINT_GEQ, "fp.geq");
+  addOperator(FLOATINGPOINT_GT, "fp.gt");
+  addOperator(FLOATINGPOINT_IS_NORMAL, "fp.isNormal");
+  addOperator(FLOATINGPOINT_IS_SUBNORMAL, "fp.isSubnormal");
+  addOperator(FLOATINGPOINT_IS_ZERO, "fp.isZero");
+  addOperator(FLOATINGPOINT_IS_INF, "fp.isInfinite");
+  addOperator(FLOATINGPOINT_IS_NAN, "fp.isNaN");
+  addOperator(FLOATINGPOINT_IS_NEG, "fp.isNegative");
+  addOperator(FLOATINGPOINT_IS_POS, "fp.isPositive");
+  addOperator(FLOATINGPOINT_TO_REAL, "fp.to_real");
 
-  // we delay the resolution of to_fp
-  addIndexedOperator(cvc5::UNDEFINED_KIND, "to_fp");
-  addIndexedOperator(cvc5::FLOATINGPOINT_TO_FP_FROM_UBV, "to_fp_unsigned");
-  addIndexedOperator(cvc5::FLOATINGPOINT_TO_UBV, "fp.to_ubv");
-  addIndexedOperator(cvc5::FLOATINGPOINT_TO_SBV, "fp.to_sbv");
+  addIndexedOperator(UNDEFINED_KIND, "to_fp");
+  addIndexedOperator(FLOATINGPOINT_TO_FP_FROM_UBV, "to_fp_unsigned");
+  addIndexedOperator(FLOATINGPOINT_TO_UBV, "fp.to_ubv");
+  addIndexedOperator(FLOATINGPOINT_TO_SBV, "fp.to_sbv");
 
   if (!strictModeEnabled())
   {
-    addIndexedOperator(cvc5::FLOATINGPOINT_TO_FP_FROM_IEEE_BV, "to_fp_bv");
-    addIndexedOperator(cvc5::FLOATINGPOINT_TO_FP_FROM_FP, "to_fp_fp");
-    addIndexedOperator(cvc5::FLOATINGPOINT_TO_FP_FROM_REAL, "to_fp_real");
-    addIndexedOperator(cvc5::FLOATINGPOINT_TO_FP_FROM_SBV, "to_fp_signed");
+    addIndexedOperator(FLOATINGPOINT_TO_FP_FROM_IEEE_BV, "to_fp_bv");
+    addIndexedOperator(FLOATINGPOINT_TO_FP_FROM_FP, "to_fp_fp");
+    addIndexedOperator(FLOATINGPOINT_TO_FP_FROM_REAL, "to_fp_real");
+    addIndexedOperator(FLOATINGPOINT_TO_FP_FROM_SBV, "to_fp_signed");
   }
 }
 
@@ -262,12 +261,12 @@ void Smt2State::addSepOperators()
   // the Boolean sort is a placeholder here since we don't have type info
   // without type annotation
   defineVar("sep.nil", d_solver->mkSepNil(d_solver->getBooleanSort()));
-  addOperator(cvc5::SEP_STAR, "sep");
-  addOperator(cvc5::SEP_PTO, "pto");
-  addOperator(cvc5::SEP_WAND, "wand");
-  ParserState::addOperator(cvc5::SEP_STAR);
-  ParserState::addOperator(cvc5::SEP_PTO);
-  ParserState::addOperator(cvc5::SEP_WAND);
+  addOperator(SEP_STAR, "sep");
+  addOperator(SEP_PTO, "pto");
+  addOperator(SEP_WAND, "wand");
+  ParserState::addOperator(SEP_STAR);
+  ParserState::addOperator(SEP_PTO);
+  ParserState::addOperator(SEP_WAND);
 }
 
 void Smt2State::addCoreSymbols()
@@ -278,17 +277,17 @@ void Smt2State::addCoreSymbols()
   defineType("Table", d_solver->mkBagSort(tupleSort), true);
   defineVar("true", d_solver->mkTrue(), true);
   defineVar("false", d_solver->mkFalse(), true);
-  addOperator(cvc5::AND, "and");
-  addOperator(cvc5::DISTINCT, "distinct");
-  addOperator(cvc5::EQUAL, "=");
-  addOperator(cvc5::IMPLIES, "=>");
-  addOperator(cvc5::ITE, "ite");
-  addOperator(cvc5::NOT, "not");
-  addOperator(cvc5::OR, "or");
-  addOperator(cvc5::XOR, "xor");
+  addOperator(AND, "and");
+  addOperator(DISTINCT, "distinct");
+  addOperator(EQUAL, "=");
+  addOperator(IMPLIES, "=>");
+  addOperator(ITE, "ite");
+  addOperator(NOT, "not");
+  addOperator(OR, "or");
+  addOperator(XOR, "xor");
 }
 
-void Smt2State::addOperator(cvc5::Kind kind, const std::string& name)
+void Smt2State::addOperator(Kind kind, const std::string& name)
 {
   Trace("parser") << "Smt2State::addOperator( " << kind << ", " << name << " )"
                   << std::endl;
@@ -296,7 +295,7 @@ void Smt2State::addOperator(cvc5::Kind kind, const std::string& name)
   d_operatorKindMap[name] = kind;
 }
 
-void Smt2State::addIndexedOperator(cvc5::Kind tKind, const std::string& name)
+void Smt2State::addIndexedOperator(Kind tKind, const std::string& name)
 {
   ParserState::addOperator(tKind);
   d_indexedOpKindMap[name] = tKind;
@@ -307,7 +306,7 @@ bool Smt2State::isIndexedOperatorEnabled(const std::string& name) const
   return d_indexedOpKindMap.find(name) != d_indexedOpKindMap.end();
 }
 
-cvc5::Kind Smt2State::getOperatorKind(const std::string& name) const
+Kind Smt2State::getOperatorKind(const std::string& name) const
 {
   // precondition: isOperatorEnabled(name)
   return d_operatorKindMap.find(name)->second;
@@ -402,7 +401,7 @@ bool Smt2State::hasCardinalityConstraints() const
 
 bool Smt2State::logicIsSet() { return d_logicSet; }
 
-bool Smt2State::getTesterName(cvc5::Term cons, std::string& name)
+bool Smt2State::getTesterName(Term cons, std::string& name)
 {
   if (strictModeEnabled())
   {
@@ -416,8 +415,8 @@ bool Smt2State::getTesterName(cvc5::Term cons, std::string& name)
   return true;
 }
 
-cvc5::Term Smt2State::mkIndexedConstant(const std::string& name,
-                                        const std::vector<uint32_t>& numerals)
+Term Smt2State::mkIndexedConstant(const std::string& name,
+                                  const std::vector<uint32_t>& numerals)
 {
   if (d_logic.isTheoryEnabled(internal::theory::THEORY_FP))
   {
@@ -453,10 +452,10 @@ cvc5::Term Smt2State::mkIndexedConstant(const std::string& name,
   // NOTE: Theory parametric constants go here
 
   parseError(std::string("Unknown indexed literal `") + name + "'");
-  return cvc5::Term();
+  return Term();
 }
 
-cvc5::Kind Smt2State::getIndexedOpKind(const std::string& name)
+Kind Smt2State::getIndexedOpKind(const std::string& name)
 {
   const auto& kIt = d_indexedOpKindMap.find(name);
   if (kIt != d_indexedOpKindMap.end())
@@ -464,42 +463,42 @@ cvc5::Kind Smt2State::getIndexedOpKind(const std::string& name)
     return (*kIt).second;
   }
   parseError(std::string("Unknown indexed function `") + name + "'");
-  return cvc5::UNDEFINED_KIND;
+  return UNDEFINED_KIND;
 }
 
-cvc5::Term Smt2State::bindDefineFunRec(
+Term Smt2State::bindDefineFunRec(
     const std::string& fname,
-    const std::vector<std::pair<std::string, cvc5::Sort>>& sortedVarNames,
-    cvc5::Sort t,
-    std::vector<cvc5::Term>& flattenVars)
+    const std::vector<std::pair<std::string, Sort>>& sortedVarNames,
+    Sort t,
+    std::vector<Term>& flattenVars)
 {
-  std::vector<cvc5::Sort> sorts;
-  for (const std::pair<std::string, cvc5::Sort>& svn : sortedVarNames)
+  std::vector<Sort> sorts;
+  for (const std::pair<std::string, Sort>& svn : sortedVarNames)
   {
     sorts.push_back(svn.second);
   }
 
   // make the flattened function type, add bound variables
   // to flattenVars if the defined function was given a function return type.
-  cvc5::Sort ft = mkFlatFunctionType(sorts, t, flattenVars);
+  Sort ft = mkFlatFunctionType(sorts, t, flattenVars);
 
   // allow overloading
   return bindVar(fname, ft, true);
 }
 
 void Smt2State::pushDefineFunRecScope(
-    const std::vector<std::pair<std::string, cvc5::Sort>>& sortedVarNames,
-    cvc5::Term func,
-    const std::vector<cvc5::Term>& flattenVars,
-    std::vector<cvc5::Term>& bvs)
+    const std::vector<std::pair<std::string, Sort>>& sortedVarNames,
+    Term func,
+    const std::vector<Term>& flattenVars,
+    std::vector<Term>& bvs)
 {
   pushScope();
 
   // bound variables are those that are explicitly named in the preamble
   // of the define-fun(s)-rec command, we define them here
-  for (const std::pair<std::string, cvc5::Sort>& svn : sortedVarNames)
+  for (const std::pair<std::string, Sort>& svn : sortedVarNames)
   {
-    cvc5::Term v = bindBoundVar(svn.first, svn.second);
+    Term v = bindBoundVar(svn.first, svn.second);
     bvs.push_back(v);
   }
 
@@ -512,7 +511,7 @@ void Smt2State::reset()
   d_seenSetLogic = false;
   d_logic = internal::LogicInfo();
   d_operatorKindMap.clear();
-  d_lastNamedTerm = std::pair<cvc5::Term, std::string>();
+  d_lastNamedTerm = std::pair<Term, std::string>();
 }
 
 std::unique_ptr<Command> Smt2State::invConstraint(
@@ -529,7 +528,7 @@ std::unique_ptr<Command> Smt2State::invConstraint(
         "arguments.");
   }
 
-  std::vector<cvc5::Term> terms;
+  std::vector<Term> terms;
   for (const std::string& name : names)
   {
     if (!isDeclared(name))
@@ -566,7 +565,8 @@ Command* Smt2State::setLogic(std::string name, bool fromCommand)
   d_logic = name;
 
   // if sygus is enabled, we must enable UF, datatypes, and integer arithmetic
-  if(sygus()) {
+  if (sygus())
+  {
     if (!d_logic.isQuantified())
     {
       warning("Logics in sygus are assumed to contain quantifiers.");
@@ -579,44 +579,45 @@ Command* Smt2State::setLogic(std::string name, bool fromCommand)
 
   if (d_logic.isTheoryEnabled(internal::theory::THEORY_UF))
   {
-    ParserState::addOperator(cvc5::APPLY_UF);
+    ParserState::addOperator(APPLY_UF);
   }
 
   if (d_logic.isHigherOrder())
   {
-    addOperator(cvc5::HO_APPLY, "@");
+    addOperator(HO_APPLY, "@");
   }
 
   if (d_logic.isTheoryEnabled(internal::theory::THEORY_ARITH))
   {
-    if(d_logic.areIntegersUsed()) {
+    if (d_logic.areIntegersUsed())
+    {
       defineType("Int", d_solver->getIntegerSort(), true);
       addArithmeticOperators();
       if (!strictModeEnabled() || !d_logic.isLinear())
       {
-        addOperator(cvc5::INTS_DIVISION, "div");
-        addOperator(cvc5::INTS_MODULUS, "mod");
-        addOperator(cvc5::ABS, "abs");
+        addOperator(INTS_DIVISION, "div");
+        addOperator(INTS_MODULUS, "mod");
+        addOperator(ABS, "abs");
       }
-      addIndexedOperator(cvc5::DIVISIBLE, "divisible");
+      addIndexedOperator(DIVISIBLE, "divisible");
     }
 
     if (d_logic.areRealsUsed())
     {
       defineType("Real", d_solver->getRealSort(), true);
       addArithmeticOperators();
-      addOperator(cvc5::DIVISION, "/");
+      addOperator(DIVISION, "/");
       if (!strictModeEnabled())
       {
-        addOperator(cvc5::ABS, "abs");
+        addOperator(ABS, "abs");
       }
     }
 
     if (d_logic.areIntegersUsed() && d_logic.areRealsUsed())
     {
-      addOperator(cvc5::TO_INTEGER, "to_int");
-      addOperator(cvc5::IS_INTEGER, "is_int");
-      addOperator(cvc5::TO_REAL, "to_real");
+      addOperator(TO_INTEGER, "to_int");
+      addOperator(IS_INTEGER, "is_int");
+      addOperator(TO_REAL, "to_real");
     }
 
     if (d_logic.areTranscendentalsUsed())
@@ -627,17 +628,17 @@ Command* Smt2State::setLogic(std::string name, bool fromCommand)
     if (!strictModeEnabled())
     {
       // integer version of AND
-      addIndexedOperator(cvc5::IAND, "iand");
+      addIndexedOperator(IAND, "iand");
       // pow2
-      addOperator(cvc5::POW2, "int.pow2");
+      addOperator(POW2, "int.pow2");
     }
   }
 
   if (d_logic.isTheoryEnabled(internal::theory::THEORY_ARRAYS))
   {
-    addOperator(cvc5::SELECT, "select");
-    addOperator(cvc5::STORE, "store");
-    addOperator(cvc5::EQ_RANGE, "eqrange");
+    addOperator(SELECT, "select");
+    addOperator(STORE, "store");
+    addOperator(EQ_RANGE, "eqrange");
   }
 
   if (d_logic.isTheoryEnabled(internal::theory::THEORY_BV))
@@ -649,14 +650,14 @@ Command* Smt2State::setLogic(std::string name, bool fromCommand)
         && d_logic.areIntegersUsed())
     {
       // Conversions between bit-vectors and integers
-      addOperator(cvc5::BITVECTOR_TO_NAT, "bv2nat");
-      addIndexedOperator(cvc5::INT_TO_BITVECTOR, "int2bv");
+      addOperator(BITVECTOR_TO_NAT, "bv2nat");
+      addIndexedOperator(INT_TO_BITVECTOR, "int2bv");
     }
   }
 
   if (d_logic.isTheoryEnabled(internal::theory::THEORY_DATATYPES))
   {
-    const std::vector<cvc5::Sort> types;
+    const std::vector<Sort> types;
     defineType("Tuple", d_solver->mkTupleSort(types), true);
     addDatatypesOperators();
   }
@@ -669,68 +670,68 @@ Command* Smt2State::setLogic(std::string name, bool fromCommand)
     defineVar("set.universe",
               d_solver->mkUniverseSet(d_solver->getBooleanSort()));
 
-    addOperator(cvc5::SET_UNION, "set.union");
-    addOperator(cvc5::SET_INTER, "set.inter");
-    addOperator(cvc5::SET_MINUS, "set.minus");
-    addOperator(cvc5::SET_SUBSET, "set.subset");
-    addOperator(cvc5::SET_MEMBER, "set.member");
-    addOperator(cvc5::SET_SINGLETON, "set.singleton");
-    addOperator(cvc5::SET_INSERT, "set.insert");
-    addOperator(cvc5::SET_CARD, "set.card");
-    addOperator(cvc5::SET_COMPLEMENT, "set.complement");
-    addOperator(cvc5::SET_CHOOSE, "set.choose");
-    addOperator(cvc5::SET_IS_SINGLETON, "set.is_singleton");
-    addOperator(cvc5::SET_MAP, "set.map");
-    addOperator(cvc5::SET_FILTER, "set.filter");
-    addOperator(cvc5::SET_FOLD, "set.fold");
-    addOperator(cvc5::RELATION_JOIN, "rel.join");
-    addOperator(cvc5::RELATION_PRODUCT, "rel.product");
-    addOperator(cvc5::RELATION_TRANSPOSE, "rel.transpose");
-    addOperator(cvc5::RELATION_TCLOSURE, "rel.tclosure");
-    addOperator(cvc5::RELATION_JOIN_IMAGE, "rel.join_image");
-    addOperator(cvc5::RELATION_IDEN, "rel.iden");
+    addOperator(SET_UNION, "set.union");
+    addOperator(SET_INTER, "set.inter");
+    addOperator(SET_MINUS, "set.minus");
+    addOperator(SET_SUBSET, "set.subset");
+    addOperator(SET_MEMBER, "set.member");
+    addOperator(SET_SINGLETON, "set.singleton");
+    addOperator(SET_INSERT, "set.insert");
+    addOperator(SET_CARD, "set.card");
+    addOperator(SET_COMPLEMENT, "set.complement");
+    addOperator(SET_CHOOSE, "set.choose");
+    addOperator(SET_IS_SINGLETON, "set.is_singleton");
+    addOperator(SET_MAP, "set.map");
+    addOperator(SET_FILTER, "set.filter");
+    addOperator(SET_FOLD, "set.fold");
+    addOperator(RELATION_JOIN, "rel.join");
+    addOperator(RELATION_PRODUCT, "rel.product");
+    addOperator(RELATION_TRANSPOSE, "rel.transpose");
+    addOperator(RELATION_TCLOSURE, "rel.tclosure");
+    addOperator(RELATION_JOIN_IMAGE, "rel.join_image");
+    addOperator(RELATION_IDEN, "rel.iden");
     // these operators can be with/without indices
-    addOperator(cvc5::RELATION_GROUP, "rel.group");
-    addOperator(cvc5::RELATION_AGGREGATE, "rel.aggr");
-    addOperator(cvc5::RELATION_PROJECT, "rel.project");
-    addIndexedOperator(cvc5::RELATION_GROUP, "rel.group");
-    addIndexedOperator(cvc5::RELATION_AGGREGATE, "rel.aggr");
-    addIndexedOperator(cvc5::RELATION_PROJECT, "rel.project");
+    addOperator(RELATION_GROUP, "rel.group");
+    addOperator(RELATION_AGGREGATE, "rel.aggr");
+    addOperator(RELATION_PROJECT, "rel.project");
+    addIndexedOperator(RELATION_GROUP, "rel.group");
+    addIndexedOperator(RELATION_AGGREGATE, "rel.aggr");
+    addIndexedOperator(RELATION_PROJECT, "rel.project");
   }
 
   if (d_logic.isTheoryEnabled(internal::theory::THEORY_BAGS))
   {
     defineVar("bag.empty", d_solver->mkEmptyBag(Sort()));
-    addOperator(cvc5::BAG_UNION_MAX, "bag.union_max");
-    addOperator(cvc5::BAG_UNION_DISJOINT, "bag.union_disjoint");
-    addOperator(cvc5::BAG_INTER_MIN, "bag.inter_min");
-    addOperator(cvc5::BAG_DIFFERENCE_SUBTRACT, "bag.difference_subtract");
-    addOperator(cvc5::BAG_DIFFERENCE_REMOVE, "bag.difference_remove");
-    addOperator(cvc5::BAG_SUBBAG, "bag.subbag");
-    addOperator(cvc5::BAG_COUNT, "bag.count");
-    addOperator(cvc5::BAG_MEMBER, "bag.member");
-    addOperator(cvc5::BAG_DUPLICATE_REMOVAL, "bag.duplicate_removal");
-    addOperator(cvc5::BAG_MAKE, "bag");
-    addOperator(cvc5::BAG_CARD, "bag.card");
-    addOperator(cvc5::BAG_CHOOSE, "bag.choose");
-    addOperator(cvc5::BAG_IS_SINGLETON, "bag.is_singleton");
-    addOperator(cvc5::BAG_FROM_SET, "bag.from_set");
-    addOperator(cvc5::BAG_TO_SET, "bag.to_set");
-    addOperator(cvc5::BAG_MAP, "bag.map");
-    addOperator(cvc5::BAG_FILTER, "bag.filter");
-    addOperator(cvc5::BAG_FOLD, "bag.fold");
-    addOperator(cvc5::BAG_PARTITION, "bag.partition");
-    addOperator(cvc5::TABLE_PRODUCT, "table.product");
-    addOperator(cvc5::BAG_PARTITION, "table.group");
+    addOperator(BAG_UNION_MAX, "bag.union_max");
+    addOperator(BAG_UNION_DISJOINT, "bag.union_disjoint");
+    addOperator(BAG_INTER_MIN, "bag.inter_min");
+    addOperator(BAG_DIFFERENCE_SUBTRACT, "bag.difference_subtract");
+    addOperator(BAG_DIFFERENCE_REMOVE, "bag.difference_remove");
+    addOperator(BAG_SUBBAG, "bag.subbag");
+    addOperator(BAG_COUNT, "bag.count");
+    addOperator(BAG_MEMBER, "bag.member");
+    addOperator(BAG_DUPLICATE_REMOVAL, "bag.duplicate_removal");
+    addOperator(BAG_MAKE, "bag");
+    addOperator(BAG_CARD, "bag.card");
+    addOperator(BAG_CHOOSE, "bag.choose");
+    addOperator(BAG_IS_SINGLETON, "bag.is_singleton");
+    addOperator(BAG_FROM_SET, "bag.from_set");
+    addOperator(BAG_TO_SET, "bag.to_set");
+    addOperator(BAG_MAP, "bag.map");
+    addOperator(BAG_FILTER, "bag.filter");
+    addOperator(BAG_FOLD, "bag.fold");
+    addOperator(BAG_PARTITION, "bag.partition");
+    addOperator(TABLE_PRODUCT, "table.product");
+    addOperator(BAG_PARTITION, "table.group");
     // these operators can be with/without indices
-    addOperator(cvc5::TABLE_PROJECT, "table.project");
-    addOperator(cvc5::TABLE_AGGREGATE, "table.aggr");
-    addOperator(cvc5::TABLE_JOIN, "table.join");
-    addOperator(cvc5::TABLE_GROUP, "table.group");
-    addIndexedOperator(cvc5::TABLE_PROJECT, "table.project");
-    addIndexedOperator(cvc5::TABLE_AGGREGATE, "table.aggr");
-    addIndexedOperator(cvc5::TABLE_JOIN, "table.join");
-    addIndexedOperator(cvc5::TABLE_GROUP, "table.group");
+    addOperator(TABLE_PROJECT, "table.project");
+    addOperator(TABLE_AGGREGATE, "table.aggr");
+    addOperator(TABLE_JOIN, "table.join");
+    addOperator(TABLE_GROUP, "table.group");
+    addIndexedOperator(TABLE_PROJECT, "table.project");
+    addIndexedOperator(TABLE_AGGREGATE, "table.aggr");
+    addIndexedOperator(TABLE_JOIN, "table.join");
+    addIndexedOperator(TABLE_GROUP, "table.group");
   }
   if (d_logic.isTheoryEnabled(internal::theory::THEORY_STRINGS))
   {
@@ -748,7 +749,8 @@ Command* Smt2State::setLogic(std::string name, bool fromCommand)
     addStringOperators();
   }
 
-  if(d_logic.isQuantified()) {
+  if (d_logic.isQuantified())
+  {
     addQuantifiersOperators();
   }
 
@@ -760,23 +762,20 @@ Command* Smt2State::setLogic(std::string name, bool fromCommand)
     defineType("Float64", d_solver->mkFloatingPointSort(11, 53), true);
     defineType("Float128", d_solver->mkFloatingPointSort(15, 113), true);
 
-    defineVar("RNE",
-              d_solver->mkRoundingMode(cvc5::ROUND_NEAREST_TIES_TO_EVEN));
+    defineVar("RNE", d_solver->mkRoundingMode(ROUND_NEAREST_TIES_TO_EVEN));
     defineVar("roundNearestTiesToEven",
-              d_solver->mkRoundingMode(cvc5::ROUND_NEAREST_TIES_TO_EVEN));
-    defineVar("RNA",
-              d_solver->mkRoundingMode(cvc5::ROUND_NEAREST_TIES_TO_AWAY));
+              d_solver->mkRoundingMode(ROUND_NEAREST_TIES_TO_EVEN));
+    defineVar("RNA", d_solver->mkRoundingMode(ROUND_NEAREST_TIES_TO_AWAY));
     defineVar("roundNearestTiesToAway",
-              d_solver->mkRoundingMode(cvc5::ROUND_NEAREST_TIES_TO_AWAY));
-    defineVar("RTP", d_solver->mkRoundingMode(cvc5::ROUND_TOWARD_POSITIVE));
+              d_solver->mkRoundingMode(ROUND_NEAREST_TIES_TO_AWAY));
+    defineVar("RTP", d_solver->mkRoundingMode(ROUND_TOWARD_POSITIVE));
     defineVar("roundTowardPositive",
-              d_solver->mkRoundingMode(cvc5::ROUND_TOWARD_POSITIVE));
-    defineVar("RTN", d_solver->mkRoundingMode(cvc5::ROUND_TOWARD_NEGATIVE));
+              d_solver->mkRoundingMode(ROUND_TOWARD_POSITIVE));
+    defineVar("RTN", d_solver->mkRoundingMode(ROUND_TOWARD_NEGATIVE));
     defineVar("roundTowardNegative",
-              d_solver->mkRoundingMode(cvc5::ROUND_TOWARD_NEGATIVE));
-    defineVar("RTZ", d_solver->mkRoundingMode(cvc5::ROUND_TOWARD_ZERO));
-    defineVar("roundTowardZero",
-              d_solver->mkRoundingMode(cvc5::ROUND_TOWARD_ZERO));
+              d_solver->mkRoundingMode(ROUND_TOWARD_NEGATIVE));
+    defineVar("RTZ", d_solver->mkRoundingMode(ROUND_TOWARD_ZERO));
+    defineVar("roundTowardZero", d_solver->mkRoundingMode(ROUND_TOWARD_ZERO));
 
     addFloatingPointOperators();
   }
@@ -804,11 +803,11 @@ Command* Smt2State::setLogic(std::string name, bool fromCommand)
   return cmd;
 } /* Smt2State::setLogic() */
 
-cvc5::Grammar* Smt2State::mkGrammar(const std::vector<cvc5::Term>& boundVars,
-                                    const std::vector<cvc5::Term>& ntSymbols)
+Grammar* Smt2State::mkGrammar(const std::vector<Term>& boundVars,
+                              const std::vector<Term>& ntSymbols)
 {
   d_allocGrammars.emplace_back(
-      new cvc5::Grammar(d_solver->mkGrammar(boundVars, ntSymbols)));
+      new Grammar(d_solver->mkGrammar(boundVars, ntSymbols)));
   return d_allocGrammars.back().get();
 }
 
@@ -880,7 +879,7 @@ bool Smt2State::isAbstractValue(const std::string& name)
          && name.find_first_not_of("0123456789", 1) == std::string::npos;
 }
 
-cvc5::Term Smt2State::mkRealOrIntFromNumeral(const std::string& str)
+Term Smt2State::mkRealOrIntFromNumeral(const std::string& str)
 {
   // if arithmetic is enabled, and integers are disabled
   if (d_logic.isTheoryEnabled(internal::theory::THEORY_ARITH)
@@ -891,7 +890,7 @@ cvc5::Term Smt2State::mkRealOrIntFromNumeral(const std::string& str)
   return d_solver->mkInteger(str);
 }
 
-void Smt2State::parseOpApplyTypeAscription(ParseOp& p, cvc5::Sort type)
+void Smt2State::parseOpApplyTypeAscription(ParseOp& p, Sort type)
 {
   Trace("parser") << "parseOpApplyTypeAscription : " << p << " " << type
                   << std::endl;
@@ -937,11 +936,11 @@ void Smt2State::parseOpApplyTypeAscription(ParseOp& p, cvc5::Sort type)
   p.d_expr = applyTypeAscription(p.d_expr, type);
 }
 
-cvc5::Term Smt2State::parseOpToExpr(ParseOp& p)
+Term Smt2State::parseOpToExpr(ParseOp& p)
 {
   Trace("parser") << "parseOpToExpr: " << p << std::endl;
-  cvc5::Term expr;
-  if (p.d_kind != cvc5::NULL_TERM || !p.d_type.isNull())
+  Term expr;
+  if (p.d_kind != NULL_TERM || !p.d_type.isNull())
   {
     parseError(
         "Bad syntax for qualified identifier operator in term position.");
@@ -950,37 +949,31 @@ cvc5::Term Smt2State::parseOpToExpr(ParseOp& p)
   {
     expr = p.d_expr;
   }
-  else if (!isDeclared(p.d_name, SYM_VARIABLE))
-  {
-    std::stringstream ss;
-    ss << "Symbol " << p.d_name << " is not declared.";
-    parseError(ss.str());
-  }
   else
   {
+    checkDeclaration(p.d_name, CHECK_DECLARED, SYM_VARIABLE);
     expr = getExpressionForName(p.d_name);
   }
   Assert(!expr.isNull());
   return expr;
 }
 
-cvc5::Term Smt2State::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
+Term Smt2State::applyParseOp(const ParseOp& p, std::vector<Term>& args)
 {
   bool isBuiltinOperator = false;
   // the builtin kind of the overall return expression
-  cvc5::Kind kind = cvc5::NULL_TERM;
+  Kind kind = NULL_TERM;
   // First phase: process the operator
   if (TraceIsOn("parser"))
   {
     Trace("parser") << "applyParseOp: " << p << " to:" << std::endl;
-    for (std::vector<cvc5::Term>::iterator i = args.begin(); i != args.end();
-         ++i)
+    for (std::vector<Term>::iterator i = args.begin(); i != args.end(); ++i)
     {
       Trace("parser") << "++ " << *i << std::endl;
     }
   }
-  cvc5::Op op;
-  if (p.d_kind == cvc5::UNDEFINED_KIND && isIndexedOperatorEnabled(p.d_name))
+  Op op;
+  if (p.d_kind == UNDEFINED_KIND && isIndexedOperatorEnabled(p.d_name))
   {
     // Resolve indexed symbols that cannot be resolved without knowing the type
     // of the arguments. This is currently limited to `to_fp`, `tuple.select`,
@@ -990,7 +983,7 @@ cvc5::Term Smt2State::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
     {
       if (nchildren == 1)
       {
-        kind = cvc5::FLOATINGPOINT_TO_FP_FROM_IEEE_BV;
+        kind = FLOATINGPOINT_TO_FP_FROM_IEEE_BV;
         op = d_solver->mkOp(kind, p.d_indices);
       }
       else if (nchildren > 2)
@@ -1010,21 +1003,21 @@ cvc5::Term Smt2State::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
       }
       else
       {
-        cvc5::Sort t = args[1].getSort();
+        Sort t = args[1].getSort();
 
         if (t.isFloatingPoint())
         {
-          kind = cvc5::FLOATINGPOINT_TO_FP_FROM_FP;
+          kind = FLOATINGPOINT_TO_FP_FROM_FP;
           op = d_solver->mkOp(kind, p.d_indices);
         }
         else if (t.isInteger() || t.isReal())
         {
-          kind = cvc5::FLOATINGPOINT_TO_FP_FROM_REAL;
+          kind = FLOATINGPOINT_TO_FP_FROM_REAL;
           op = d_solver->mkOp(kind, p.d_indices);
         }
         else
         {
-          kind = cvc5::FLOATINGPOINT_TO_FP_FROM_SBV;
+          kind = FLOATINGPOINT_TO_FP_FROM_SBV;
           op = d_solver->mkOp(kind, p.d_indices);
         }
       }
@@ -1041,7 +1034,7 @@ cvc5::Term Smt2State::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
       {
         parseError("wrong number of arguments for tuple select or update");
       }
-      cvc5::Sort t = args[0].getSort();
+      Sort t = args[0].getSort();
       if (!t.isTuple())
       {
         parseError("tuple select or update applied to non-tuple");
@@ -1053,16 +1046,15 @@ cvc5::Term Smt2State::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
         ss << "tuple is of length " << length << "; cannot access index " << n;
         parseError(ss.str());
       }
-      const cvc5::Datatype& dt = t.getDatatype();
-      cvc5::Term ret;
+      const Datatype& dt = t.getDatatype();
+      Term ret;
       if (isSelect)
       {
-        ret = d_solver->mkTerm(cvc5::APPLY_SELECTOR,
-                               {dt[0][n].getTerm(), args[0]});
+        ret = d_solver->mkTerm(APPLY_SELECTOR, {dt[0][n].getTerm(), args[0]});
       }
       else
       {
-        ret = d_solver->mkTerm(cvc5::APPLY_UPDATER,
+        ret = d_solver->mkTerm(APPLY_UPDATER,
                                {dt[0][n].getUpdaterTerm(), args[0], args[1]});
       }
       Trace("parser") << "applyParseOp: return selector/updater " << ret
@@ -1074,7 +1066,7 @@ cvc5::Term Smt2State::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
       Assert(false) << "Failed to resolve indexed operator " << p.d_name;
     }
   }
-  else if (p.d_kind != cvc5::NULL_TERM)
+  else if (p.d_kind != NULL_TERM)
   {
     // It is a special case, e.g. tuple.select or array constant specification.
     // We have to wait until the arguments are parsed to resolve it.
@@ -1082,8 +1074,8 @@ cvc5::Term Smt2State::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
   else if (!p.d_expr.isNull())
   {
     // An explicit operator, e.g. an apply function
-    cvc5::Kind fkind = getKindForFunction(p.d_expr);
-    if (fkind != cvc5::UNDEFINED_KIND)
+    Kind fkind = getKindForFunction(p.d_expr);
+    if (fkind != UNDEFINED_KIND)
     {
       // Some operators may require a specific kind.
       // Testers are handled differently than other indexed operators,
@@ -1117,12 +1109,12 @@ cvc5::Term Smt2State::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
         kind = NULL_TERM;
         isBuiltinOperator = false;
       }
-      else if (kind == cvc5::APPLY_CONSTRUCTOR)
+      else if (kind == APPLY_CONSTRUCTOR)
       {
         // tuple application
-        std::vector<cvc5::Sort> sorts;
-        std::vector<cvc5::Term> terms;
-        for (const cvc5::Term& arg : args)
+        std::vector<Sort> sorts;
+        std::vector<Term> terms;
+        for (const Term& arg : args)
         {
           sorts.emplace_back(arg.getSort());
           terms.emplace_back(arg);
@@ -1136,7 +1128,7 @@ cvc5::Term Smt2State::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
     {
       // A non-built-in function application, get the expression
       checkDeclaration(p.d_name, CHECK_DECLARED, SYM_VARIABLE);
-      cvc5::Term v = getVariable(p.d_name);
+      Term v = getVariable(p.d_name);
       if (!v.isNull())
       {
         checkFunctionLike(v);
@@ -1149,14 +1141,12 @@ cvc5::Term Smt2State::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
         // Could not find the expression. It may be an overloaded symbol,
         // in which case we may find it after knowing the types of its
         // arguments.
-        std::vector<cvc5::Sort> argTypes;
-        for (std::vector<cvc5::Term>::iterator i = args.begin();
-             i != args.end();
-             ++i)
+        std::vector<Sort> argTypes;
+        for (std::vector<Term>::iterator i = args.begin(); i != args.end(); ++i)
         {
           argTypes.push_back((*i).getSort());
         }
-        cvc5::Term fop = getOverloadedFunctionForTypes(p.d_name, argTypes);
+        Term fop = getOverloadedFunctionForTypes(p.d_name, argTypes);
         if (!fop.isNull())
         {
           checkFunctionLike(fop);
@@ -1173,13 +1163,13 @@ cvc5::Term Smt2State::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
     }
   }
   // handle special cases
-  if (p.d_kind == cvc5::CONST_ARRAY && !p.d_type.isNull())
+  if (p.d_kind == CONST_ARRAY && !p.d_type.isNull())
   {
     if (args.size() != 1)
     {
       parseError("Too many arguments to array constant.");
     }
-    cvc5::Term constVal = args[0];
+    Term constVal = args[0];
 
     if (p.d_type.getArrayElementSort() != constVal.getSort())
     {
@@ -1191,11 +1181,11 @@ cvc5::Term Smt2State::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
          << "computed const type: " << constVal.getSort();
       parseError(ss.str());
     }
-    cvc5::Term ret = d_solver->mkConstArray(p.d_type, constVal);
+    Term ret = d_solver->mkConstArray(p.d_type, constVal);
     Trace("parser") << "applyParseOp: return store all " << ret << std::endl;
     return ret;
   }
-  else if (p.d_kind != cvc5::NULL_TERM)
+  else if (p.d_kind != NULL_TERM)
   {
     // it should not have an expression or type specified at this point
     if (!p.d_expr.isNull() || !p.d_type.isNull())
@@ -1209,7 +1199,7 @@ cvc5::Term Smt2State::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
   }
   else if (isBuiltinOperator)
   {
-    if (kind == cvc5::EQUAL || kind == cvc5::DISTINCT)
+    if (kind == EQUAL || kind == DISTINCT)
     {
       bool isReal = false;
       // need hol if these operators are applied over function args
@@ -1240,46 +1230,45 @@ cvc5::Term Smt2State::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
           Sort s = i.getSort();
           if (s.isInteger())
           {
-            i = d_solver->mkTerm(cvc5::TO_REAL, {i});
+            i = d_solver->mkTerm(TO_REAL, {i});
           }
         }
       }
     }
-    if (!strictModeEnabled() && (kind == cvc5::AND || kind == cvc5::OR)
-        && args.size() == 1)
+    if (!strictModeEnabled() && (kind == AND || kind == OR) && args.size() == 1)
     {
       // Unary AND/OR can be replaced with the argument.
       Trace("parser") << "applyParseOp: return unary " << args[0] << std::endl;
       return args[0];
     }
-    else if (kind == cvc5::SUB && args.size() == 1)
+    else if (kind == SUB && args.size() == 1)
     {
       if (isConstInt(args[0]) && args[0].getRealOrIntegerValueSign() > 0)
       {
         // (- n) denotes a negative value
         std::stringstream suminus;
         suminus << "-" << args[0].getIntegerValue();
-        cvc5::Term ret = d_solver->mkInteger(suminus.str());
+        Term ret = d_solver->mkInteger(suminus.str());
         Trace("parser") << "applyParseOp: return negative constant " << ret
                         << std::endl;
         return ret;
       }
-      cvc5::Term ret = d_solver->mkTerm(cvc5::NEG, {args[0]});
+      Term ret = d_solver->mkTerm(NEG, {args[0]});
       Trace("parser") << "applyParseOp: return uminus " << ret << std::endl;
       return ret;
     }
-    else if (kind == cvc5::DIVISION && args.size() == 2 && isConstInt(args[0])
+    else if (kind == DIVISION && args.size() == 2 && isConstInt(args[0])
              && isConstInt(args[1]) && args[1].getRealOrIntegerValueSign() > 0)
     {
       // (/ m n) or (/ (- m) n) denote values in reals
       std::stringstream sdiv;
       sdiv << args[0].getIntegerValue() << "/" << args[1].getIntegerValue();
-      cvc5::Term ret = d_solver->mkReal(sdiv.str());
+      Term ret = d_solver->mkReal(sdiv.str());
       Trace("parser") << "applyParseOp: return rational constant " << ret
                       << std::endl;
       return ret;
     }
-    cvc5::Term ret = d_solver->mkTerm(kind, args);
+    Term ret = d_solver->mkTerm(kind, args);
     Trace("parser") << "applyParseOp: return default builtin " << ret
                     << std::endl;
     return ret;
@@ -1288,7 +1277,7 @@ cvc5::Term Smt2State::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
   if (args.size() >= 2)
   {
     // may be partially applied function, in this case we use HO_APPLY
-    cvc5::Sort argt = args[0].getSort();
+    Sort argt = args[0].getSort();
     if (argt.isFunction())
     {
       unsigned arity = argt.getFunctionArity();
@@ -1303,7 +1292,7 @@ cvc5::Term Smt2State::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
         Trace("parser") << "Partial application of " << args[0];
         Trace("parser") << " : #argTypes = " << arity;
         Trace("parser") << ", #args = " << args.size() - 1 << std::endl;
-        cvc5::Term ret = d_solver->mkTerm(cvc5::HO_APPLY, args);
+        Term ret = d_solver->mkTerm(HO_APPLY, args);
         Trace("parser") << "applyParseOp: return curry higher order " << ret
                         << std::endl;
         // must curry the partial application
@@ -1313,25 +1302,24 @@ cvc5::Term Smt2State::applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args)
   }
   if (!op.isNull())
   {
-    cvc5::Term ret = d_solver->mkTerm(op, args);
+    Term ret = d_solver->mkTerm(op, args);
     Trace("parser") << "applyParseOp: return op : " << ret << std::endl;
     return ret;
   }
-  if (kind == cvc5::NULL_TERM)
+  if (kind == NULL_TERM)
   {
     // should never happen in the new API
     parseError("do not know how to process parse op");
   }
   Trace("parser") << "Try default term construction for kind " << kind
                   << " #args = " << args.size() << "..." << std::endl;
-  cvc5::Term ret = d_solver->mkTerm(kind, args);
+  Term ret = d_solver->mkTerm(kind, args);
   Trace("parser") << "applyParseOp: return : " << ret << std::endl;
   return ret;
 }
 
-
 Sort Smt2State::getParametricSort(const std::string& name,
-                             const std::vector<Sort>& args)
+                                  const std::vector<Sort>& args)
 {
   if (args.empty())
   {
@@ -1407,7 +1395,7 @@ Sort Smt2State::getParametricSort(const std::string& name,
 }
 
 Sort Smt2State::getIndexedSort(const std::string& name,
-                          const std::vector<uint32_t>& numerals)
+                               const std::vector<uint32_t>& numerals)
 {
   Sort ret;
   if (name == "BitVec")
@@ -1491,7 +1479,7 @@ std::unique_ptr<Command> Smt2State::handlePop(std::optional<uint32_t> nscopes)
   return std::make_unique<PopCommand>(*nscopes);
 }
 
-void Smt2State::notifyNamedExpression(cvc5::Term& expr, std::string name)
+void Smt2State::notifyNamedExpression(Term& expr, std::string name)
 {
   checkUserSymbol(name);
   // remember the expression name in the symbol manager
@@ -1519,7 +1507,7 @@ void Smt2State::notifyNamedExpression(cvc5::Term& expr, std::string name)
   setLastNamedTerm(expr, name);
 }
 
-cvc5::Term Smt2State::mkAnd(const std::vector<cvc5::Term>& es) const
+Term Smt2State::mkAnd(const std::vector<Term>& es) const
 {
   if (es.size() == 0)
   {
@@ -1529,12 +1517,12 @@ cvc5::Term Smt2State::mkAnd(const std::vector<cvc5::Term>& es) const
   {
     return es[0];
   }
-  return d_solver->mkTerm(cvc5::AND, es);
+  return d_solver->mkTerm(AND, es);
 }
 
-bool Smt2State::isConstInt(const cvc5::Term& t)
+bool Smt2State::isConstInt(const Term& t)
 {
-  return t.getKind() == cvc5::CONST_INTEGER;
+  return t.getKind() == CONST_INTEGER;
 }
 
 }  // namespace parser

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -949,9 +949,14 @@ Term Smt2State::parseOpToExpr(ParseOp& p)
   {
     expr = p.d_expr;
   }
+  else if (!isDeclared(p.d_name, SYM_VARIABLE))
+  {
+    std::stringstream ss;
+    ss << "Symbol " << p.d_name << " is not declared.";
+    parseError(ss.str());
+  }
   else
   {
-    checkDeclaration(p.d_name, CHECK_DECLARED, SYM_VARIABLE);
     expr = getExpressionForName(p.d_name);
   }
   Assert(!expr.isNull());

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -15,8 +15,8 @@
 
 #include "cvc5parser_private.h"
 
-#ifndef CVC5__PARSER__SMT2_H
-#define CVC5__PARSER__SMT2_H
+#ifndef CVC5__PARSER__SMT2__SMT2_H
+#define CVC5__PARSER__SMT2__SMT2_H
 
 #include <optional>
 #include <sstream>
@@ -38,28 +38,6 @@ namespace parser {
  */
 class Smt2State : public ParserState
 {
- private:
-  /** Are we parsing a sygus file? */
-  bool d_isSygus;
-  /** Has the logic been set (either by forcing it or a set-logic command)? */
-  bool d_logicSet;
-  /** Have we seen a set-logic command yet? */
-  bool d_seenSetLogic;
-
-  internal::LogicInfo d_logic;
-  std::unordered_map<std::string, cvc5::Kind> d_operatorKindMap;
-  /**
-   * Maps indexed symbols to the kind of the operator (e.g. "extract" to
-   * BITVECTOR_EXTRACT).
-   */
-  std::unordered_map<std::string, cvc5::Kind> d_indexedOpKindMap;
-  std::pair<cvc5::Term, std::string> d_lastNamedTerm;
-  /**
-   * A list of sygus grammar objects. We keep track of them here to ensure that
-   * they don't get deleted before the commands using them get invoked.
-   */
-  std::vector<std::unique_ptr<cvc5::Grammar>> d_allocGrammars;
-
  public:
   Smt2State(ParserStateCallback* psc,
             Solver* solver,
@@ -74,7 +52,7 @@ class Smt2State : public ParserState
    */
   void addCoreSymbols();
 
-  void addOperator(cvc5::Kind k, const std::string& name);
+  void addOperator(Kind k, const std::string& name);
 
   /**
    * Registers an indexed function symbol.
@@ -85,7 +63,7 @@ class Smt2State : public ParserState
    *              be`UNDEFINED_KIND`.
    * @param name The name of the symbol (e.g. "extract")
    */
-  void addIndexedOperator(cvc5::Kind tKind, const std::string& name);
+  void addIndexedOperator(Kind tKind, const std::string& name);
   /**
    * Checks whether an indexed operator is enabled. All indexed operators in
    * the current logic are considered to be enabled. This includes operators
@@ -96,7 +74,7 @@ class Smt2State : public ParserState
    */
   bool isIndexedOperatorEnabled(const std::string& name) const;
 
-  cvc5::Kind getOperatorKind(const std::string& name) const;
+  Kind getOperatorKind(const std::string& name) const;
 
   bool isOperatorEnabled(const std::string& name) const;
 
@@ -131,8 +109,8 @@ class Smt2State : public ParserState
    * @return The term corresponding to the constant or a parse error if name is
    *         not valid.
    */
-  cvc5::Term mkIndexedConstant(const std::string& name,
-                               const std::vector<uint32_t>& numerals);
+  Term mkIndexedConstant(const std::string& name,
+                         const std::vector<uint32_t>& numerals);
 
   /**
    * Creates an indexed operator kind, e.g. BITVECTOR_EXTRACT for "extract".
@@ -141,13 +119,13 @@ class Smt2State : public ParserState
    * @return The kind corresponding to the indexed operator or a parse
    *         error if the name is not valid.
    */
-  cvc5::Kind getIndexedOpKind(const std::string& name);
+  Kind getIndexedOpKind(const std::string& name);
 
   /**
    * If we are in a version < 2.6, this updates name to the tester name of cons,
    * e.g. "is-cons".
    */
-  bool getTesterName(cvc5::Term cons, std::string& name) override;
+  bool getTesterName(Term cons, std::string& name) override;
 
   /** Make function defined by a define-fun(s)-rec command.
    *
@@ -163,11 +141,11 @@ class Smt2State : public ParserState
    * added to flattenVars in this function if the function is given a function
    * range type.
    */
-  cvc5::Term bindDefineFunRec(
+  Term bindDefineFunRec(
       const std::string& fname,
-      const std::vector<std::pair<std::string, cvc5::Sort>>& sortedVarNames,
-      cvc5::Sort t,
-      std::vector<cvc5::Term>& flattenVars);
+      const std::vector<std::pair<std::string, Sort>>& sortedVarNames,
+      Sort t,
+      std::vector<Term>& flattenVars);
 
   /** Push scope for define-fun-rec
    *
@@ -187,10 +165,10 @@ class Smt2State : public ParserState
    *     that defined this definition and stores it in bvs.
    */
   void pushDefineFunRecScope(
-      const std::vector<std::pair<std::string, cvc5::Sort>>& sortedVarNames,
-      cvc5::Term func,
-      const std::vector<cvc5::Term>& flattenVars,
-      std::vector<cvc5::Term>& bvs);
+      const std::vector<std::pair<std::string, Sort>>& sortedVarNames,
+      Term func,
+      const std::vector<Term>& flattenVars,
+      std::vector<Term>& bvs);
 
   void reset() override;
 
@@ -227,8 +205,8 @@ class Smt2State : public ParserState
    * @param ntSymbols the pre-declaration of the non-terminal symbols
    * @return a pointer to the grammar
    */
-  cvc5::Grammar* mkGrammar(const std::vector<cvc5::Term>& boundVars,
-                           const std::vector<cvc5::Term>& ntSymbols);
+  Grammar* mkGrammar(const std::vector<Term>& boundVars,
+                     const std::vector<Term>& ntSymbols);
 
   /** Are we using a sygus language? */
   bool sygus() const;
@@ -271,18 +249,14 @@ class Smt2State : public ParserState
       parseError(ss.str());
     }
   }
-
-  void setLastNamedTerm(cvc5::Term e, std::string name)
+  void setLastNamedTerm(Term e, std::string name)
   {
     d_lastNamedTerm = std::make_pair(e, name);
   }
 
-  void clearLastNamedTerm()
-  {
-    d_lastNamedTerm = std::make_pair(cvc5::Term(), "");
-  }
+  void clearLastNamedTerm() { d_lastNamedTerm = std::make_pair(Term(), ""); }
 
-  std::pair<cvc5::Term, std::string> lastNamedTerm() { return d_lastNamedTerm; }
+  std::pair<Term, std::string> lastNamedTerm() { return d_lastNamedTerm; }
 
   /** Does name denote an abstract value? (of the form '@n' for numeral n). */
   bool isAbstractValue(const std::string& name);
@@ -293,7 +267,7 @@ class Smt2State : public ParserState
    * In particular, if arithmetic is enabled, but integers are disabled, then
    * we construct a real. Otherwise, we construct an integer.
    */
-  cvc5::Term mkRealOrIntFromNumeral(const std::string& str);
+  Term mkRealOrIntFromNumeral(const std::string& str);
 
   /**
    * Smt2 parser provides its own checkDeclaration, which does the
@@ -321,7 +295,7 @@ class Smt2State : public ParserState
    * Notify that expression expr was given name std::string via a :named
    * attribute.
    */
-  void notifyNamedExpression(cvc5::Term& expr, std::string name);
+  void notifyNamedExpression(Term& expr, std::string name);
 
   // Throw a ParserException with msg appended with the current logic.
   inline void parseErrorLogic(const std::string& msg)
@@ -347,7 +321,7 @@ class Smt2State : public ParserState
    * - If p's expression field is set, then we leave p unchanged, check if
    * that expression has the given type and throw a parse error otherwise.
    */
-  void parseOpApplyTypeAscription(ParseOp& p, cvc5::Sort type);
+  void parseOpApplyTypeAscription(ParseOp& p, Sort type);
   /**
    * This converts a ParseOp to expression, assuming it is a standalone term.
    *
@@ -357,7 +331,7 @@ class Smt2State : public ParserState
    * of this class.
    * In other cases, a parse error is thrown.
    */
-  cvc5::Term parseOpToExpr(ParseOp& p);
+  Term parseOpToExpr(ParseOp& p);
   /**
    * Apply parse operator to list of arguments, and return the resulting
    * expression.
@@ -390,7 +364,7 @@ class Smt2State : public ParserState
    * - If the overall expression is a partial application, then we process this
    * as a chain of HO_APPLY terms.
    */
-  cvc5::Term applyParseOp(ParseOp& p, std::vector<cvc5::Term>& args);
+  Term applyParseOp(const ParseOp& p, std::vector<Term>& args);
   /**
    * Returns a (parameterized) sort, given a name and args.
    */
@@ -417,7 +391,6 @@ class Smt2State : public ParserState
   std::unique_ptr<Command> handlePop(std::optional<uint32_t> nscopes);
 
  private:
-
   void addArithmeticOperators();
 
   void addTranscendentalOperators();
@@ -441,14 +414,37 @@ class Smt2State : public ParserState
    * @return True if `es` is empty, `e` if `es` consists of a single element
    *         `e`, the conjunction of expressions otherwise.
    */
-  cvc5::Term mkAnd(const std::vector<cvc5::Term>& es) const;
+  Term mkAnd(const std::vector<Term>& es) const;
   /**
    * Is term t a constant integer?
    */
-  static bool isConstInt(const cvc5::Term& t);
-}; /* class Smt2 */
+  static bool isConstInt(const Term& t);
+
+  /** Are we parsing a sygus file? */
+  bool d_isSygus;
+  /** Has the logic been set (either by forcing it or a set-logic command)? */
+  bool d_logicSet;
+  /** Have we seen a set-logic command yet? */
+  bool d_seenSetLogic;
+  /** The current logic */
+  internal::LogicInfo d_logic;
+  /** Maps strings to the operator it is bound to */
+  std::unordered_map<std::string, Kind> d_operatorKindMap;
+  /**
+   * Maps indexed symbols to the kind of the operator (e.g. "extract" to
+   * BITVECTOR_EXTRACT).
+   */
+  std::unordered_map<std::string, Kind> d_indexedOpKindMap;
+  /** The last named term and its name */
+  std::pair<Term, std::string> d_lastNamedTerm;
+  /**
+   * A list of sygus grammar objects. We keep track of them here to ensure that
+   * they don't get deleted before the commands using them get invoked.
+   */
+  std::vector<std::unique_ptr<Grammar>> d_allocGrammars;
+};
 
 }  // namespace parser
 }  // namespace cvc5
 
-#endif /* CVC5__PARSER__SMT2_H */
+#endif

--- a/test/regress/cli/regress0/parser/issue5163.smt2
+++ b/test/regress/cli/regress0/parser/issue5163.smt2
@@ -1,5 +1,5 @@
-; SCRUBBER: grep -o "Symbol a is not declared"
-; EXPECT: Symbol a is not declared
+; SCRUBBER: grep -o "Symbol 'a' not declared as a variable"
+; EXPECT: Symbol 'a' not declared as a variable
 ; EXIT: 1
 (set-logic ALL)
 (define-fun a () Bool false)

--- a/test/regress/cli/regress0/parser/issue5163.smt2
+++ b/test/regress/cli/regress0/parser/issue5163.smt2
@@ -1,5 +1,5 @@
-; SCRUBBER: grep -o "Symbol 'a' not declared as a variable"
-; EXPECT: Symbol 'a' not declared as a variable
+; SCRUBBER: grep -o "Symbol a is not declared"
+; EXPECT: Symbol a is not declared
 ; EXIT: 1
 (set-logic ALL)
 (define-fun a () Bool false)


### PR DESCRIPTION
Removes spurious `cvc5::`, orders class members based on standard, fixes identation issues, removes now obsolete references to ANTLR specific files, removes deprecated methods.