### PR TITLE
Move string code point solver to own file

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1092,6 +1092,8 @@ libcvc5_add_sources(
   theory/strings/arith_entail.h
   theory/strings/base_solver.cpp
   theory/strings/base_solver.h
+  theory/strings/code_point_solver.cpp
+  theory/strings/code_point_solver.h
   theory/strings/core_solver.cpp
   theory/strings/core_solver.h
   theory/strings/eager_solver.cpp

--- a/src/theory/strings/code_point_solver.cpp
+++ b/src/theory/strings/code_point_solver.cpp
@@ -17,7 +17,12 @@
 
 #include "theory/strings/inference_manager.h"
 #include "theory/strings/solver_state.h"
+#include "theory/strings/term_registry.h"
 #include "theory/strings/base_solver.h"
+#include "theory/strings/word.h"
+#include "util/rational.h"
+
+using namespace cvc5::internal::kind;
 
 namespace cvc5::internal {
 namespace theory {
@@ -34,9 +39,10 @@ CodePointSolver::CodePointSolver(Env& env,
       d_termReg(tr),
       d_bsolver(bs)
 {
+  d_negOne = NodeManager::currentNM()->mkConstInt(Rational(-1));
 }
 
-void TheoryStrings::checkCodes()
+void CodePointSolver::checkCodes()
 {
   // ensure that lemmas regarding str.code been added for each constant string
   // of length one
@@ -88,7 +94,7 @@ void TheoryStrings::checkCodes()
       {
         Node vc = nm->mkNode(kind::STRING_TO_CODE, ei->d_codeTerm.get());
         // only relevant for injectivity if not already equal to negative one
-        if (!d_state.areEqual(vc, d_neg_one))
+        if (!d_state.areEqual(vc, d_negOne))
         {
           nconst_codes.push_back(vc);
         }
@@ -113,7 +119,7 @@ void TheoryStrings::checkCodes()
           << "Compare codes : " << c1 << " " << c2 << std::endl;
       if (!d_state.areDisequal(c1, c2))
       {
-        Node eq_no = c1.eqNode(d_neg_one);
+        Node eq_no = c1.eqNode(d_negOne);
         Node deq = c1.eqNode(c2).negate();
         Node eqn = c1[0].eqNode(c2[0]);
         // str.code(x)==-1 V str.code(x)!=str.code(y) V x==y

--- a/src/theory/strings/code_point_solver.cpp
+++ b/src/theory/strings/code_point_solver.cpp
@@ -1,0 +1,132 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds, Andres Noetzli, Tianyi Liang
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2022 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Subsolver for handling code points
+ */
+
+#include "theory/strings/code_point_solver.h"
+
+#include "theory/strings/inference_manager.h"
+#include "theory/strings/solver_state.h"
+#include "theory/strings/base_solver.h"
+
+namespace cvc5::internal {
+namespace theory {
+namespace strings {
+  
+CodePointSolver::CodePointSolver(Env& env,
+                       SolverState& s,
+                       InferenceManager& im,
+                       TermRegistry& tr,
+                       BaseSolver& bs)
+    : EnvObj(env),
+      d_state(s),
+      d_im(im),
+      d_termReg(tr),
+      d_bsolver(bs)
+{
+}
+
+void TheoryStrings::checkCodes()
+{
+  // ensure that lemmas regarding str.code been added for each constant string
+  // of length one
+  if (!d_termReg.hasStringCode())
+  {
+    return;
+  }
+  NodeManager* nm = NodeManager::currentNM();
+  // str.code applied to the code term for each equivalence class that has a
+  // code term but is not a constant
+  std::vector<Node> nconst_codes;
+  // str.code applied to the proxy variables for each equivalence classes that
+  // are constants of size one
+  std::vector<Node> const_codes;
+  const std::vector<Node>& seqc = d_bsolver.getStringLikeEqc();
+  for (const Node& eqc : seqc)
+  {
+    if (!eqc.getType().isString())
+    {
+      continue;
+    }
+    if (eqc.isConst())
+    {
+      Node c = eqc;
+      Trace("strings-code-debug") << "Get proxy variable for " << c
+                                  << std::endl;
+      Node cc = nm->mkNode(kind::STRING_TO_CODE, c);
+      cc = rewrite(cc);
+      Assert(cc.isConst());
+      Node cp = d_termReg.ensureProxyVariableFor(c);
+      Node vc = nm->mkNode(STRING_TO_CODE, cp);
+      if (!d_state.areEqual(cc, vc))
+      {
+        std::vector<Node> emptyVec;
+        d_im.sendInference(
+            emptyVec, cc.eqNode(vc), InferenceId::STRINGS_CODE_PROXY);
+      }
+      // only relevant for injectivity if length is 1 (e.g. it has a valid
+      // code point)
+      if (Word::getLength(c) == 1)
+      {
+        const_codes.push_back(vc);
+      }
+    }
+    else
+    {
+      EqcInfo* ei = d_state.getOrMakeEqcInfo(eqc, false);
+      if (ei && !ei->d_codeTerm.get().isNull())
+      {
+        Node vc = nm->mkNode(kind::STRING_TO_CODE, ei->d_codeTerm.get());
+        // only relevant for injectivity if not already equal to negative one
+        if (!d_state.areEqual(vc, d_neg_one))
+        {
+          nconst_codes.push_back(vc);
+        }
+      }
+    }
+  }
+  if (d_im.hasProcessed())
+  {
+    return;
+  }
+  // now, ensure that str.code is injective
+  std::vector<Node> cmps;
+  cmps.insert(cmps.end(), const_codes.rbegin(), const_codes.rend());
+  cmps.insert(cmps.end(), nconst_codes.rbegin(), nconst_codes.rend());
+  for (unsigned i = 0, num_ncc = nconst_codes.size(); i < num_ncc; i++)
+  {
+    Node c1 = nconst_codes[i];
+    cmps.pop_back();
+    for (const Node& c2 : cmps)
+    {
+      Trace("strings-code-debug")
+          << "Compare codes : " << c1 << " " << c2 << std::endl;
+      if (!d_state.areDisequal(c1, c2))
+      {
+        Node eq_no = c1.eqNode(d_neg_one);
+        Node deq = c1.eqNode(c2).negate();
+        Node eqn = c1[0].eqNode(c2[0]);
+        // str.code(x)==-1 V str.code(x)!=str.code(y) V x==y
+        Node inj_lem = nm->mkNode(kind::OR, eq_no, deq, eqn);
+        deq = rewrite(deq);
+        d_im.addPendingPhaseRequirement(deq, false);
+        std::vector<Node> emptyVec;
+        d_im.sendInference(emptyVec, inj_lem, InferenceId::STRINGS_CODE_INJ);
+      }
+    }
+  }
+}
+
+}  // namespace strings
+}  // namespace theory
+}  // namespace cvc5::internal

--- a/src/theory/strings/code_point_solver.cpp
+++ b/src/theory/strings/code_point_solver.cpp
@@ -15,10 +15,10 @@
 
 #include "theory/strings/code_point_solver.h"
 
+#include "theory/strings/base_solver.h"
 #include "theory/strings/inference_manager.h"
 #include "theory/strings/solver_state.h"
 #include "theory/strings/term_registry.h"
-#include "theory/strings/base_solver.h"
 #include "theory/strings/word.h"
 #include "util/rational.h"
 
@@ -27,17 +27,13 @@ using namespace cvc5::internal::kind;
 namespace cvc5::internal {
 namespace theory {
 namespace strings {
-  
+
 CodePointSolver::CodePointSolver(Env& env,
-                       SolverState& s,
-                       InferenceManager& im,
-                       TermRegistry& tr,
-                       BaseSolver& bs)
-    : EnvObj(env),
-      d_state(s),
-      d_im(im),
-      d_termReg(tr),
-      d_bsolver(bs)
+                                 SolverState& s,
+                                 InferenceManager& im,
+                                 TermRegistry& tr,
+                                 BaseSolver& bs)
+    : EnvObj(env), d_state(s), d_im(im), d_termReg(tr), d_bsolver(bs)
 {
   d_negOne = NodeManager::currentNM()->mkConstInt(Rational(-1));
 }
@@ -67,8 +63,8 @@ void CodePointSolver::checkCodes()
     if (eqc.isConst())
     {
       Node c = eqc;
-      Trace("strings-code-debug") << "Get proxy variable for " << c
-                                  << std::endl;
+      Trace("strings-code-debug")
+          << "Get proxy variable for " << c << std::endl;
       Node cc = nm->mkNode(kind::STRING_TO_CODE, c);
       cc = rewrite(cc);
       Assert(cc.isConst());

--- a/src/theory/strings/code_point_solver.h
+++ b/src/theory/strings/code_point_solver.h
@@ -1,0 +1,60 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds, Tianyi Liang, Andres Noetzli
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2022 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Subsolver for handling code points
+ */
+
+#include "cvc5_private.h"
+
+#ifndef CVC5__THEORY__STRINGS__CODE_POINT_SOLVER_H
+#define CVC5__THEORY__STRINGS__CODE_POINT_SOLVER_H
+
+#include "smt/env_obj.h"
+
+namespace cvc5::internal {
+namespace theory {
+namespace strings {
+
+class BaseSolver;
+class InferenceManager;
+class TermRegistry;
+class SolverState;
+
+/**
+ * Subsolver for handling code points, see "A Decision Procedure for String to
+ * Code Point Conversion", Reynolds et al IJCAR 2020.
+ */
+class CodePointSolver {
+ public:
+CodePointSolver(Env& env,
+                       SolverState& s,
+                       InferenceManager& im,
+                       TermRegistry& tr,
+                       BaseSolver& bs);
+  ~CodePointSolver();
+  /** check codes
+   *
+   * This inference schema ensures that constraints between str.code terms
+   * are satisfied by models that correspond to extensions of the current
+   * assignment. In particular, this method ensures that str.code can be
+   * given an interpretation that is injective for string arguments with length
+   * one. It may add lemmas of the form:
+   *   str.code(x) == -1 V str.code(x) != str.code(y) V x == y
+   */
+  void checkCodes();
+};
+
+}  // namespace strings
+}  // namespace theory
+}  // namespace cvc5::internal
+
+#endif /* CVC5__THEORY__STRINGS__CODE_POINT_SOLVER_H */

--- a/src/theory/strings/code_point_solver.h
+++ b/src/theory/strings/code_point_solver.h
@@ -33,13 +33,14 @@ class SolverState;
  * Subsolver for handling code points, see "A Decision Procedure for String to
  * Code Point Conversion", Reynolds et al IJCAR 2020.
  */
-class CodePointSolver : protected EnvObj {
+class CodePointSolver : protected EnvObj
+{
  public:
-CodePointSolver(Env& env,
-                       SolverState& s,
-                       InferenceManager& im,
-                       TermRegistry& tr,
-                       BaseSolver& bs);
+  CodePointSolver(Env& env,
+                  SolverState& s,
+                  InferenceManager& im,
+                  TermRegistry& tr,
+                  BaseSolver& bs);
   ~CodePointSolver() {}
   /** check codes
    *
@@ -51,7 +52,8 @@ CodePointSolver(Env& env,
    *   str.code(x) == -1 V str.code(x) != str.code(y) V x == y
    */
   void checkCodes();
-protected:
+
+ protected:
   /** The solver state object */
   SolverState& d_state;
   /** The (custom) output channel of the theory of strings */

--- a/src/theory/strings/code_point_solver.h
+++ b/src/theory/strings/code_point_solver.h
@@ -33,14 +33,14 @@ class SolverState;
  * Subsolver for handling code points, see "A Decision Procedure for String to
  * Code Point Conversion", Reynolds et al IJCAR 2020.
  */
-class CodePointSolver {
+class CodePointSolver : protected EnvObj {
  public:
 CodePointSolver(Env& env,
                        SolverState& s,
                        InferenceManager& im,
                        TermRegistry& tr,
                        BaseSolver& bs);
-  ~CodePointSolver();
+  ~CodePointSolver() {}
   /** check codes
    *
    * This inference schema ensures that constraints between str.code terms
@@ -51,6 +51,17 @@ CodePointSolver(Env& env,
    *   str.code(x) == -1 V str.code(x) != str.code(y) V x == y
    */
   void checkCodes();
+protected:
+  /** The solver state object */
+  SolverState& d_state;
+  /** The (custom) output channel of the theory of strings */
+  InferenceManager& d_im;
+  /** Reference to the term registry of theory of strings */
+  TermRegistry& d_termReg;
+  /** reference to the base solver, used for certain queries */
+  BaseSolver& d_bsolver;
+  /** Commonly used constants */
+  Node d_negOne;
 };
 
 }  // namespace strings

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2655,6 +2655,24 @@ void CoreSolver::checkLengthsEqc() {
   }
 }
 
+void CoreSolver::checkRegisterTermsNormalForms()
+{
+  const std::vector<Node>& seqc = d_bsolver.getStringLikeEqc();
+  for (const Node& eqc : seqc)
+  {
+    NormalForm& nfi = getNormalForm(eqc);
+    // check if there is a length term for this equivalence class
+    EqcInfo* ei = d_state.getOrMakeEqcInfo(eqc, false);
+    Node lt = ei ? ei->d_lengthTerm : Node::null();
+    if (lt.isNull())
+    {
+      Node c = d_termReg.mkNConcat(nfi.d_nf, eqc.getType());
+      d_termReg.registerTerm(c);
+    }
+  }
+}
+
+
 size_t CoreSolver::choosePossibleInferInfo(const std::vector<CoreInferInfo>& pinfer)
 {
   // now, determine which of the possible inferences we want to add

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2672,7 +2672,6 @@ void CoreSolver::checkRegisterTermsNormalForms()
   }
 }
 
-
 size_t CoreSolver::choosePossibleInferInfo(const std::vector<CoreInferInfo>& pinfer)
 {
   // now, determine which of the possible inferences we want to add

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -201,6 +201,13 @@ class CoreSolver : protected EnvObj
    * shown to be helpful.
    */
   void checkLengthsEqc();
+  /** check register terms for normal forms
+   *
+   * This calls registerTerm(str.++(t1, ..., tn ), 3) on the normal forms
+   * (t1, ..., tn) of all string equivalence classes { s1, ..., sm } such that
+   * there does not exist a term of the form str.len(si) in the current context.
+   */
+  void checkRegisterTermsNormalForms();
   //-----------------------end inference steps
 
   //--------------------------- query functions

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -78,6 +78,7 @@ TheoryStrings::TheoryStrings(Env& env, OutputChannel& out, Valuation valuation)
                 d_csolver,
                 d_extTheory,
                 d_statistics),
+      d_psolver(env, d_state, d_im, d_termReg, d_bsolver),
       d_asolver(env,
                 d_state,
                 d_im,
@@ -1106,113 +1107,6 @@ void TheoryStrings::notifySharedTerm(TNode n)
   }
 }
 
-void TheoryStrings::checkCodes()
-{
-  // ensure that lemmas regarding str.code been added for each constant string
-  // of length one
-  if (d_termReg.hasStringCode())
-  {
-    NodeManager* nm = NodeManager::currentNM();
-    // str.code applied to the code term for each equivalence class that has a
-    // code term but is not a constant
-    std::vector<Node> nconst_codes;
-    // str.code applied to the proxy variables for each equivalence classes that
-    // are constants of size one
-    std::vector<Node> const_codes;
-    const std::vector<Node>& seqc = d_bsolver.getStringLikeEqc();
-    for (const Node& eqc : seqc)
-    {
-      if (!eqc.getType().isString())
-      {
-        continue;
-      }
-      if (eqc.isConst())
-      {
-        Node c = eqc;
-        Trace("strings-code-debug") << "Get proxy variable for " << c
-                                    << std::endl;
-        Node cc = nm->mkNode(kind::STRING_TO_CODE, c);
-        cc = rewrite(cc);
-        Assert(cc.isConst());
-        Node cp = d_termReg.ensureProxyVariableFor(c);
-        Node vc = nm->mkNode(STRING_TO_CODE, cp);
-        if (!d_state.areEqual(cc, vc))
-        {
-          std::vector<Node> emptyVec;
-          d_im.sendInference(
-              emptyVec, cc.eqNode(vc), InferenceId::STRINGS_CODE_PROXY);
-        }
-        // only relevant for injectivity if length is 1 (e.g. it has a valid
-        // code point)
-        if (Word::getLength(c) == 1)
-        {
-          const_codes.push_back(vc);
-        }
-      }
-      else
-      {
-        EqcInfo* ei = d_state.getOrMakeEqcInfo(eqc, false);
-        if (ei && !ei->d_codeTerm.get().isNull())
-        {
-          Node vc = nm->mkNode(kind::STRING_TO_CODE, ei->d_codeTerm.get());
-          // only relevant for injectivity if not already equal to negative one
-          if (!d_state.areEqual(vc, d_neg_one))
-          {
-            nconst_codes.push_back(vc);
-          }
-        }
-      }
-    }
-    if (d_im.hasProcessed())
-    {
-      return;
-    }
-    // now, ensure that str.code is injective
-    std::vector<Node> cmps;
-    cmps.insert(cmps.end(), const_codes.rbegin(), const_codes.rend());
-    cmps.insert(cmps.end(), nconst_codes.rbegin(), nconst_codes.rend());
-    for (unsigned i = 0, num_ncc = nconst_codes.size(); i < num_ncc; i++)
-    {
-      Node c1 = nconst_codes[i];
-      cmps.pop_back();
-      for (const Node& c2 : cmps)
-      {
-        Trace("strings-code-debug")
-            << "Compare codes : " << c1 << " " << c2 << std::endl;
-        if (!d_state.areDisequal(c1, c2))
-        {
-          Node eq_no = c1.eqNode(d_neg_one);
-          Node deq = c1.eqNode(c2).negate();
-          Node eqn = c1[0].eqNode(c2[0]);
-          // str.code(x)==-1 V str.code(x)!=str.code(y) V x==y
-          Node inj_lem = nm->mkNode(kind::OR, eq_no, deq, eqn);
-          deq = rewrite(deq);
-          d_im.addPendingPhaseRequirement(deq, false);
-          std::vector<Node> emptyVec;
-          d_im.sendInference(emptyVec, inj_lem, InferenceId::STRINGS_CODE_INJ);
-        }
-      }
-    }
-  }
-}
-
-void TheoryStrings::checkRegisterTermsNormalForms()
-{
-  const std::vector<Node>& seqc = d_bsolver.getStringLikeEqc();
-  for (const Node& eqc : seqc)
-  {
-    NormalForm& nfi = d_csolver.getNormalForm(eqc);
-    // check if there is a length term for this equivalence class
-    EqcInfo* ei = d_state.getOrMakeEqcInfo(eqc, false);
-    Node lt = ei ? ei->d_lengthTerm : Node::null();
-    if (lt.isNull())
-    {
-      Node c = d_termReg.mkNConcat(nfi.d_nf, eqc.getType());
-      d_termReg.registerTerm(c);
-    }
-  }
-}
-
 TrustNode TheoryStrings::ppRewrite(TNode atom, std::vector<SkolemLemma>& lems)
 {
   Trace("strings-ppr") << "TheoryStrings::ppRewrite " << atom << std::endl;
@@ -1306,12 +1200,12 @@ void TheoryStrings::runInferStep(InferStep s, Theory::Effort e, int effort)
     case CHECK_FLAT_FORMS: d_csolver.checkFlatForms(); break;
     case CHECK_NORMAL_FORMS_EQ: d_csolver.checkNormalFormsEq(); break;
     case CHECK_NORMAL_FORMS_DEQ: d_csolver.checkNormalFormsDeq(); break;
-    case CHECK_CODES: checkCodes(); break;
+    case CHECK_CODES: d_psolver.checkCodes(); break;
     case CHECK_LENGTH_EQC: d_csolver.checkLengthsEqc(); break;
     case CHECK_SEQUENCES_ARRAY_CONCAT: d_asolver.checkArrayConcat(); break;
     case CHECK_SEQUENCES_ARRAY: d_asolver.checkArray(); break;
     case CHECK_SEQUENCES_ARRAY_EAGER: d_asolver.checkArrayEager(); break;
-    case CHECK_REGISTER_TERMS_NF: checkRegisterTermsNormalForms(); break;
+    case CHECK_REGISTER_TERMS_NF: d_csolver.checkRegisterTermsNormalForms(); break;
     case CHECK_EXTF_REDUCTION: d_esolver.checkExtfReductions(effort); break;
     case CHECK_MEMBERSHIP: d_rsolver.checkMemberships(effort); break;
     case CHECK_CARDINALITY: d_bsolver.checkCardinality(); break;

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -1205,7 +1205,9 @@ void TheoryStrings::runInferStep(InferStep s, Theory::Effort e, int effort)
     case CHECK_SEQUENCES_ARRAY_CONCAT: d_asolver.checkArrayConcat(); break;
     case CHECK_SEQUENCES_ARRAY: d_asolver.checkArray(); break;
     case CHECK_SEQUENCES_ARRAY_EAGER: d_asolver.checkArrayEager(); break;
-    case CHECK_REGISTER_TERMS_NF: d_csolver.checkRegisterTermsNormalForms(); break;
+    case CHECK_REGISTER_TERMS_NF:
+      d_csolver.checkRegisterTermsNormalForms();
+      break;
     case CHECK_EXTF_REDUCTION: d_esolver.checkExtfReductions(effort); break;
     case CHECK_MEMBERSHIP: d_rsolver.checkMemberships(effort); break;
     case CHECK_CARDINALITY: d_bsolver.checkCardinality(); break;

--- a/src/theory/strings/theory_strings.h
+++ b/src/theory/strings/theory_strings.h
@@ -28,6 +28,7 @@
 #include "theory/ext_theory.h"
 #include "theory/strings/array_solver.h"
 #include "theory/strings/base_solver.h"
+#include "theory/strings/code_point_solver.h"
 #include "theory/strings/core_solver.h"
 #include "theory/strings/eager_solver.h"
 #include "theory/strings/extf_solver.h"
@@ -197,30 +198,6 @@ class TheoryStrings : public Theory {
    * of atom, including calls to registerTerm.
    */
   void assertPendingFact(Node atom, bool polarity, Node exp);
-  //-----------------------inference steps
-  /** check register terms pre-normal forms
-   *
-   * This calls registerTerm(n,2) on all non-congruent strings in the
-   * equality engine of this class.
-   */
-  void checkRegisterTermsPreNormalForm();
-  /** check codes
-   *
-   * This inference schema ensures that constraints between str.code terms
-   * are satisfied by models that correspond to extensions of the current
-   * assignment. In particular, this method ensures that str.code can be
-   * given an interpretation that is injective for string arguments with length
-   * one. It may add lemmas of the form:
-   *   str.code(x) == -1 V str.code(x) != str.code(y) V x == y
-   */
-  void checkCodes();
-  /** check register terms for normal forms
-   *
-   * This calls registerTerm(str.++(t1, ..., tn ), 3) on the normal forms
-   * (t1, ..., tn) of all string equivalence classes { s1, ..., sm } such that
-   * there does not exist a term of the form str.len(si) in the current context.
-   */
-  void checkRegisterTermsNormalForms();
   /**
    * Turn a sequence constant into a skeleton specifying how to construct
    * its value.
@@ -298,6 +275,8 @@ class TheoryStrings : public Theory {
    * involving extended string functions.
    */
   ExtfSolver d_esolver;
+  /** Code point solver */
+  CodePointSolver d_psolver;
   /**
    * The array solver, which implements specialized approaches for
    * seq.nth/seq.update.


### PR DESCRIPTION
Code move only.

Also moves the last remaining inference scheme in TheoryStrings into the core solver.