### PR TITLE
Separate propagation and lemma phases in core strings solver

### DIFF
--- a/src/theory/incomplete_id.cpp
+++ b/src/theory/incomplete_id.cpp
@@ -52,6 +52,7 @@ const char* toString(IncompleteId i)
     case IncompleteId::UF_CARD_MODE: return "UF_CARD_MODE";
     case IncompleteId::STOP_SEARCH: return "STOP_SEARCH";
     case IncompleteId::UNKNOWN: return "UNKNOWN";
+    case IncompleteId::NONE: return "NONE";
     default: return "?IncompleteId?";
   }
 }

--- a/src/theory/incomplete_id.h
+++ b/src/theory/incomplete_id.h
@@ -82,7 +82,8 @@ enum class IncompleteId
   // the prop layer stopped search
   STOP_SEARCH,
   //------------------- unknown
-  UNKNOWN
+  UNKNOWN,
+  NONE
 };
 
 /**

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2641,7 +2641,7 @@ void CoreSolver::checkRegisterTermsNormalForms()
   }
 }
 
-size_t CoreSolver::choosePossibleInferInfo(const std::vector<CoreInferInfo>& pinfer)
+size_t CoreSolver::pickInferInfo(const std::vector<CoreInferInfo>& pinfer)
 {
   // now, determine which of the possible inferences we want to add
   unsigned use_index = 0;
@@ -2675,7 +2675,7 @@ void CoreSolver::checkNormalFormsEq()
   if (!d_pinfers.empty())
   {
     // add one inference from our list of possible inferences
-    size_t use_index = choosePossibleInferInfo(d_pinfers);
+    size_t use_index = pickInferInfo(d_pinfers);
     InferInfo& ii = d_pinfers[use_index].d_infer;
     // process the state change to this solver
     if (!ii.d_nfPair[0].isNull())

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -650,16 +650,13 @@ NormalForm& CoreSolver::getNormalForm(Node n)
   std::map<Node, NormalForm>::iterator itn = d_normal_form.find(n);
   if (itn == d_normal_form.end())
   {
-    Trace("strings-warn") << "WARNING: returning self normal form for " << n
+    Trace("strings-warn") << "WARNING: returning empty normal form for " << n
                           << std::endl;
     // Shouln't ask for normal forms of strings that weren't computed. This
     // likely means that n is not a representative or not a term in the current
-    // context. We simply return a normal form here with n as a component in
-    // this case.
+    // context. We simply return a default normal form here in this case.
     Assert(false);
-    NormalForm& nf = d_normal_form[n];
-    nf.init(n);
-    return nf;
+    return d_normal_form[n];
   }
   return itn->second;
 }

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2704,7 +2704,6 @@ void CoreSolver::checkNormalFormsEq()
     d_im.sendInference(ii, true);
     return;
   }
-  // d_pinfers.clear();
   //  process incompleteness
   if (d_modelUnsoundId != IncompleteId::NONE)
   {

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -534,11 +534,6 @@ void CoreSolver::checkNormalFormsEqProp()
   // map from normal form terms (the concatenation of the terms in the normal
   // form) to the equivalence that had that normal form
   std::map<Node, Node> nf_to_eqc;
-  // A set of possible inferences, in case we failed to compute a normal form
-  // in a call to normalizeEquivalenceClass. This set typically contains
-  // lemmas that require splitting. We delay processing these lemmas until
-  // the invocation of processInferInfo below.
-  std::vector<CoreInferInfo> pinfer;
   for (const Node& eqc : d_strings_eqc)
   {
     Assert(d_pinfers.empty());

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -657,11 +657,6 @@ void CoreSolver::normalizeEquivalenceClass(Node eqc,
   }
 }
 
-const std::vector<Node>& CoreSolver::getStringsEqc() const
-{
-  return d_strings_eqc;
-}
-
 NormalForm& CoreSolver::getNormalForm(Node n)
 {
   std::map<Node, NormalForm>::iterator itn = d_normal_form.find(n);

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -524,6 +524,8 @@ Node CoreSolver::checkCycles( Node eqc, std::vector< Node >& curr, std::vector< 
 
 void CoreSolver::checkNormalFormsEqProp()
 {
+  // Reset the possible inferences and model unsoundness id. These are
+  // set in this method and processed in checkNormalFormsEq.
   d_pinfers.clear();
   d_modelUnsoundId = IncompleteId::NONE;
   // calculate normal forms for each equivalence class, possibly adding

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -534,10 +534,6 @@ void CoreSolver::checkNormalFormsEqProp()
   // map from normal form terms (the concatenation of the terms in the normal
   // form) to the equivalence that had that normal form
   std::map<Node, Node> nf_to_eqc;
-  // map from equivalence classes to the normal form term
-  std::map<Node, Node> eqc_to_nf;
-  // the explanation for the normal form for each equivalence class
-  std::map<Node, Node> eqc_to_exp;
   // A set of possible inferences, in case we failed to compute a normal form
   // in a call to normalizeEquivalenceClass. This set typically contains
   // lemmas that require splitting. We delay processing these lemmas until
@@ -571,10 +567,9 @@ void CoreSolver::checkNormalFormsEqProp()
       NormalForm& nfe_eq = getNormalForm(itn->second);
       // two equivalence classes have same normal form, merge
       std::vector<Node> nf_exp(nfe.d_exp.begin(), nfe.d_exp.end());
-      Node eexp = eqc_to_exp[itn->second];
-      if (eexp != d_true)
+      if (!nfe_eq.d_exp.empty())
       {
-        nf_exp.push_back(eexp);
+        nf_exp.push_back(utils::mkAnd(nfe_eq.d_exp));
       }
       Node eq = nfe.d_base.eqNode(nfe_eq.d_base);
       d_im.sendInference(nf_exp, eq, InferenceId::STRINGS_NORMAL_FORM);
@@ -586,8 +581,6 @@ void CoreSolver::checkNormalFormsEqProp()
     else
     {
       nf_to_eqc[nf_term] = eqc;
-      eqc_to_nf[eqc] = nf_term;
-      eqc_to_exp[eqc] = utils::mkAnd(nfe.d_exp);
     }
     Trace("strings-process-debug")
         << "Done verifying normal forms are the same for " << eqc << std::endl;

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -48,7 +48,8 @@ CoreSolver::CoreSolver(Env& env,
       d_termReg(tr),
       d_bsolver(bs),
       d_nfPairs(context()),
-      d_extDeq(userContext())
+      d_extDeq(userContext()),
+      d_modelUnsoundId(IncompleteId::NONE)
 {
   d_zero = NodeManager::currentNM()->mkConstInt(Rational(0));
   d_one = NodeManager::currentNM()->mkConstInt(Rational(1));
@@ -521,8 +522,10 @@ Node CoreSolver::checkCycles( Node eqc, std::vector< Node >& curr, std::vector< 
   return Node::null();
 }
 
-void CoreSolver::checkNormalFormsEq()
+void CoreSolver::checkNormalFormsEqProp()
 {
+  d_pinfers.clear();
+  d_modelUnsoundId = IncompleteId::NONE;
   // calculate normal forms for each equivalence class, possibly adding
   // splitting lemmas
   d_normal_form.clear();
@@ -540,22 +543,23 @@ void CoreSolver::checkNormalFormsEq()
   std::vector<CoreInferInfo> pinfer;
   for (const Node& eqc : d_strings_eqc)
   {
-    Assert(pinfer.empty());
+    Assert(d_pinfers.empty());
     TypeNode stype = eqc.getType();
     Trace("strings-process-debug") << "- Verify normal forms are the same for "
                                    << eqc << std::endl;
-    normalizeEquivalenceClass(eqc, stype, pinfer);
+    normalizeEquivalenceClass(eqc, stype, d_pinfers);
     Trace("strings-debug") << "Finished normalizing eqc..." << std::endl;
     if (d_im.hasProcessed())
     {
       return;
     }
-    if (!pinfer.empty())
+    if (!d_pinfers.empty())
     {
       // if we had a possible inference, we were unable to assign
       // a normal form to this equivalence class based on the call to
-      // normalizeEquivalenceClass, we break.
-      break;
+      // normalizeEquivalenceClass, we return. We process the possible
+      // inferences later in checkNormalFormsEq if necessary.
+      return;
     }
     NormalForm& nfe = getNormalForm(eqc);
     Node nf_term = d_termReg.mkNConcat(nfe.d_nf, stype);
@@ -585,32 +589,6 @@ void CoreSolver::checkNormalFormsEq()
     }
     Trace("strings-process-debug")
         << "Done verifying normal forms are the same for " << eqc << std::endl;
-  }
-  if (!pinfer.empty())
-  {
-    // add one inference from our list of possible inferences
-    size_t use_index = choosePossibleInferInfo(pinfer);
-    Trace("strings-solve") << "...choose #" << use_index << std::endl;
-    if (!processInferInfo(pinfer[use_index]))
-    {
-      Unhandled() << "Failed to process infer info " << pinfer[use_index].d_infer
-                  << std::endl;
-    }
-    return;
-  }
-  if (TraceIsOn("strings-nf"))
-  {
-    Trace("strings-nf") << "**** Normal forms are : " << std::endl;
-    for (std::map<Node, Node>::iterator it = eqc_to_exp.begin();
-         it != eqc_to_exp.end();
-         ++it)
-    {
-      NormalForm& nf = getNormalForm(it->first);
-      Trace("strings-nf") << "  N[" << it->first << "] (base " << nf.d_base
-                          << ") = " << eqc_to_nf[it->first] << std::endl;
-      Trace("strings-nf") << "     exp: " << it->second << std::endl;
-    }
-    Trace("strings-nf") << std::endl;
   }
 }
 
@@ -677,18 +655,26 @@ void CoreSolver::normalizeEquivalenceClass(Node eqc,
   }
 }
 
+const std::vector<Node>& CoreSolver::getStringsEqc() const
+{
+  return d_strings_eqc;
+}
+
 NormalForm& CoreSolver::getNormalForm(Node n)
 {
   std::map<Node, NormalForm>::iterator itn = d_normal_form.find(n);
   if (itn == d_normal_form.end())
   {
-    Trace("strings-warn") << "WARNING: returning empty normal form for " << n
+    Trace("strings-warn") << "WARNING: returning self normal form for " << n
                           << std::endl;
     // Shouln't ask for normal forms of strings that weren't computed. This
     // likely means that n is not a representative or not a term in the current
-    // context. We simply return a default normal form here in this case.
+    // context. We simply return a normal form here with n as a component in
+    // this case.
     Assert(false);
-    return d_normal_form[n];
+    NormalForm& nf = d_normal_form[n];
+    nf.init(n);
+    return nf;
   }
   return itn->second;
 }
@@ -1425,7 +1411,7 @@ void CoreSolver::processSimpleNEq(NormalForm& nfi,
       lenEq = rewrite(lenEq);
       iinfo.d_conc = nm->mkNode(OR, lenEq, lenEq.negate());
       iinfo.setId(InferenceId::STRINGS_LEN_SPLIT);
-      info.d_pendingPhase[lenEq] = true;
+      info.d_infer.d_pendingPhase[lenEq] = true;
       pinfer.push_back(info);
       break;
     }
@@ -1753,7 +1739,7 @@ CoreSolver::ProcessLoopResult CoreSolver::processLoop(NormalForm& nfi,
     // note we cannot convert looping word equations into regular expressions if
     // we are handling sequences, since there is no analog for regular
     // expressions over sequences currently
-    d_im.setModelUnsound(IncompleteId::STRINGS_LOOP_SKIP);
+    d_modelUnsoundId = IncompleteId::STRINGS_LOOP_SKIP;
     return ProcessLoopResult::SKIPPED;
   }
 
@@ -1899,7 +1885,7 @@ CoreSolver::ProcessLoopResult CoreSolver::processLoop(NormalForm& nfi,
     else if (options().strings.stringProcessLoopMode
              == options::ProcessLoopMode::SIMPLE)
     {
-      d_im.setModelUnsound(IncompleteId::STRINGS_LOOP_SKIP);
+      d_modelUnsoundId = IncompleteId::STRINGS_LOOP_SKIP;
       return ProcessLoopResult::SKIPPED;
     }
 
@@ -1936,8 +1922,8 @@ CoreSolver::ProcessLoopResult CoreSolver::processLoop(NormalForm& nfi,
   // we will be done
   iinfo.d_conc = conc;
   iinfo.setId(InferenceId::STRINGS_FLOOP);
-  info.d_nfPair[0] = nfi.d_base;
-  info.d_nfPair[1] = nfj.d_base;
+  info.d_infer.d_nfPair[0] = nfi.d_base;
+  info.d_infer.d_nfPair[1] = nfj.d_base;
   return ProcessLoopResult::INFERENCE;
 }
 
@@ -2605,7 +2591,8 @@ void CoreSolver::checkNormalFormsDeq()
   }
 }
 
-void CoreSolver::checkLengthsEqc() {
+void CoreSolver::checkLengthsEqc()
+{
   for (unsigned i = 0; i < d_strings_eqc.size(); i++)
   {
     TypeNode stype = d_strings_eqc[i].getType();
@@ -2700,34 +2687,48 @@ size_t CoreSolver::choosePossibleInferInfo(const std::vector<CoreInferInfo>& pin
   return use_index;
 }
 
-bool CoreSolver::processInferInfo(CoreInferInfo& cii)
+void CoreSolver::checkNormalFormsEq()
 {
-  InferInfo& ii = cii.d_infer;
-  // rewrite the conclusion, ensure non-trivial
-  Node concr = rewrite(ii.d_conc);
-
-  if (concr == d_true)
+  // we've computed the possible inferences above
+  if (!d_pinfers.empty())
   {
-    // conclusion rewrote to true
-    return false;
+    // if we have a candidate model, then we are done.
+    if (d_state.hasCandidateModel())
+    {
+      d_im.markFinished();
+      return;
+    }
+    // add one inference from our list of possible inferences
+    size_t use_index = choosePossibleInferInfo(d_pinfers);
+    InferInfo& ii = d_pinfers[use_index];
+    // process the state change to this solver
+    if (!ii.d_nfPair[0].isNull())
+    {
+      Assert(!ii.d_nfPair[1].isNull());
+      addNormalFormPair(ii.d_nfPair[0], ii.d_nfPair[1]);
+    }
+    d_im.sendInference(ii, true);
+    return;
   }
-  // process the state change to this solver
-  if (!cii.d_nfPair[0].isNull())
+  // d_pinfers.clear();
+  //  process incompleteness
+  if (d_modelUnsoundId != IncompleteId::NONE)
   {
-    Assert(!cii.d_nfPair[1].isNull());
-    addNormalFormPair(cii.d_nfPair[0], cii.d_nfPair[1]);
+    d_im.setModelUnsound(d_modelUnsoundId);
+    d_modelUnsoundId = IncompleteId::NONE;
   }
-  // send phase requirements
-  for (const std::pair<const Node, bool>& pp : cii.d_pendingPhase)
+  if (TraceIsOn("strings-nf"))
   {
-    Node ppr = rewrite(pp.first);
-    d_im.addPendingPhaseRequirement(ppr, pp.second);
+    Trace("strings-nf") << "**** Normal forms are : " << std::endl;
+    for (const Node& eqc : d_strings_eqc)
+    {
+      NormalForm& nf = getNormalForm(eqc);
+      Trace("strings-nf") << "  N[" << eqc << "] (base " << nf.d_base
+                          << ") = " << nf.d_nf << std::endl;
+      Trace("strings-nf") << "     exp: " << nf.d_exp << std::endl;
+    }
+    Trace("strings-nf") << std::endl;
   }
-
-  // send the inference, which is a lemma
-  d_im.sendInference(ii, true);
-
-  return true;
 }
 
 }  // namespace strings

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2692,15 +2692,9 @@ void CoreSolver::checkNormalFormsEq()
   // we've computed the possible inferences above
   if (!d_pinfers.empty())
   {
-    // if we have a candidate model, then we are done.
-    if (d_state.hasCandidateModel())
-    {
-      d_im.markFinished();
-      return;
-    }
     // add one inference from our list of possible inferences
     size_t use_index = choosePossibleInferInfo(d_pinfers);
-    InferInfo& ii = d_pinfers[use_index];
+    InferInfo& ii = d_pinfers[use_index].d_infer;
     // process the state change to this solver
     if (!ii.d_nfPair[0].isNull())
     {

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -553,9 +553,16 @@ class CoreSolver : protected EnvObj
   std::map<Node, std::vector<int> > d_flat_form_index;
   /** Set of equalities for which we have applied extensionality. */
   NodeSet d_extDeq;
-  /** Whether we set model unsound */
+  /**
+   * If not IncompleteId::NONE, this is reason why the normal form computation
+   * was model unsound. We set model incomplete in the lemma phase of
+   * normal form equality computation if necessary.
+   */
   IncompleteId d_modelUnsoundId;
-  /** Possible infers */
+  /**
+   * Possible inferences, computed during the propagation phase of
+   * normal form equality computation, and sent during the lemma phase.
+   */
   std::vector<CoreInferInfo> d_pinfers;
 }; /* class CoreSolver */
 

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -177,7 +177,7 @@ class CoreSolver : protected EnvObj
    * setModelUnsound on the output channel during checkNormalFormsEq below.
    */
   void checkNormalFormsEqProp();
-  /** 
+  /**
    * Sends a lemma computed in the above check, if one exists, and processes
    * model unsoundness if necessary.
    */

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -172,9 +172,15 @@ class CoreSolver : protected EnvObj
    * are assigned for all equivalence classes.
    * In the case of (B), the possible lemmas are buffered in this class, and
    * are sent to the inference manager only when checkNormalFormsEq is called.
+   * In the case of (C), it is possible that model unsoundness was introduced,
+   * for example, by ignoring cyclic word equations. In this case, we
+   * setModelUnsound on the output channel during checkNormalFormsEq below.
    */
   void checkNormalFormsEqProp();
-  /** Sends a lemma computed in the above check, if one exists. */
+  /** 
+   * Sends a lemma computed in the above check, if one exists, and processes
+   * model unsoundness if necessary.
+   */
   void checkNormalFormsEq();
   /** check normal forms disequalities
    *
@@ -295,12 +301,12 @@ class CoreSolver : protected EnvObj
                                      std::vector<Node>& newSkolems);
  private:
   /**
-   * This processes the infer info ii as an inference. In more detail, it calls
-   * the inference manager to process the inference, and updates the set of
-   * normal form pairs. Returns true if the conclusion of ii was not true
-   * after rewriting. If the conclusion is true, this method does nothing.
+   * This returns the index of the inference in pinfer that should be processed
+   * based on our heuristics. In particular, we favor certain identifiers
+   * before others, as well as considering the position in a concatentation
+   * term they reference.
    */
-  size_t choosePossibleInferInfo(const std::vector<CoreInferInfo>& pinfer);
+  size_t pickInferInfo(const std::vector<CoreInferInfo>& pinfer);
   /** Add that (n1,n2) is a normal form pair in the current context. */
   void addNormalFormPair(Node n1, Node n2);
   /** Is (n1,n2) a normal form pair in the current context? */

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -215,11 +215,6 @@ class CoreSolver : protected EnvObj
 
   //--------------------------- query functions
   /**
-   * Get the list of string equivalence classes, which respects the
-   * containment ordering as described in checkCycles.
-   */
-  const std::vector<Node>& getStringsEqc() const;
-  /**
    * Get normal form for string term n. For details on this data structure,
    * see theory/strings/normal_form.h.
    *

--- a/src/theory/strings/infer_info.h
+++ b/src/theory/strings/infer_info.h
@@ -104,6 +104,14 @@ class InferInfo : public TheoryInference
    * can be assumed for them.
    */
   std::map<LengthStatus, std::vector<Node> > d_skolems;
+  /**
+   * The pending phase requirements, see InferenceManager::sendPhaseRequirement.
+   */
+  std::map<Node, bool> d_pendingPhase;
+  /**
+   * The normal form pair that is cached as a result of this inference.
+   */
+  Node d_nfPair[2];
   /**  Is this infer info trivial? True if d_conc is true. */
   bool isTrivial() const;
   /**

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -360,6 +360,12 @@ TrustNode InferenceManager::processLemma(InferInfo& ii, LemmaProperty& p)
   {
     p |= LemmaProperty::NEEDS_JUSTIFY;
   }
+  // send phase requirements
+  for (const std::pair<const Node, bool>& pp : ii.d_pendingPhase)
+  {
+    Node ppr = rewrite(pp.first);
+    addPendingPhaseRequirement(ppr, pp.second);
+  }
   Trace("strings-assert") << "(assert " << tlem.getNode() << ") ; lemma "
                           << ii.getId() << std::endl;
   Trace("strings-lemma") << "Strings::Lemma: " << tlem.getNode() << " by "

--- a/src/theory/strings/strategy.cpp
+++ b/src/theory/strings/strategy.cpp
@@ -31,6 +31,7 @@ std::ostream& operator<<(std::ostream& out, InferStep s)
     case CHECK_EXTF_EVAL: out << "check_extf_eval"; break;
     case CHECK_CYCLES: out << "check_cycles"; break;
     case CHECK_FLAT_FORMS: out << "check_flat_forms"; break;
+    case CHECK_NORMAL_FORMS_EQ_PROP: out << "check_normal_forms_eq_prop"; break;
     case CHECK_NORMAL_FORMS_EQ: out << "check_normal_forms_eq"; break;
     case CHECK_NORMAL_FORMS_DEQ: out << "check_normal_forms_deq"; break;
     case CHECK_CODES: out << "check_codes"; break;
@@ -115,6 +116,7 @@ void Strategy::initializeStrategy()
       addStrategyStep(CHECK_FLAT_FORMS);
     }
     addStrategyStep(CHECK_EXTF_REDUCTION, 1);
+    addStrategyStep(CHECK_NORMAL_FORMS_EQ_PROP);
     addStrategyStep(CHECK_NORMAL_FORMS_EQ);
     addStrategyStep(CHECK_EXTF_EVAL, 1);
     addStrategyStep(CHECK_NORMAL_FORMS_DEQ);

--- a/src/theory/strings/strategy.h
+++ b/src/theory/strings/strategy.h
@@ -47,6 +47,8 @@ enum InferStep
   CHECK_CYCLES,
   // check flat forms
   CHECK_FLAT_FORMS,
+  // check normal forms equalities, propagate only
+  CHECK_NORMAL_FORMS_EQ_PROP,
   // check normal forms equalities
   CHECK_NORMAL_FORMS_EQ,
   // check normal forms disequalities

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -1198,6 +1198,7 @@ void TheoryStrings::runInferStep(InferStep s, Theory::Effort e, int effort)
     case CHECK_EXTF_EVAL: d_esolver.checkExtfEval(effort); break;
     case CHECK_CYCLES: d_csolver.checkCycles(); break;
     case CHECK_FLAT_FORMS: d_csolver.checkFlatForms(); break;
+    case CHECK_NORMAL_FORMS_EQ_PROP: d_csolver.checkNormalFormsEqProp(); break;
     case CHECK_NORMAL_FORMS_EQ: d_csolver.checkNormalFormsEq(); break;
     case CHECK_NORMAL_FORMS_DEQ: d_csolver.checkNormalFormsDeq(); break;
     case CHECK_CODES: d_psolver.checkCodes(); break;


### PR DESCRIPTION
This will allow further extensions to the strategy for steps that should go between these two phases.  These two phases are run back-to-back, hence there should be no behavior changes in this PR.

Also makes some minor changes to InferInfo in preparation for making side effect processing more consistent.
