### PR TITLE
Refactor extended function solver

### DIFF
--- a/src/theory/strings/extf_solver.cpp
+++ b/src/theory/strings/extf_solver.cpp
@@ -90,7 +90,9 @@ bool ExtfSolver::shouldDoReduction(int effort, Node n, int pol)
     Trace("strings-extf-debug") << "...skip due to model active" << std::endl;
     return false;
   }
-  if (d_reduced.find(n)!=d_reduced.end())
+  // check with negation
+  Node nn = pol == -1 ? n.notNode() : n;
+  if (d_reduced.find(nn) != d_reduced.end())
   {
     // already sent a reduction lemma
     Trace("strings-extf-debug") << "...skip due to reduced" << std::endl;
@@ -101,77 +103,39 @@ bool ExtfSolver::shouldDoReduction(int effort, Node n, int pol)
   if (k == STRING_SUBSTR || (k == STRING_CONTAINS && pol == 1))
   {
     // we reduce these semi-eagerly, at effort 1
-    if (effort != 1)
-    {
-      return false;
-    }
+    return (effort == 1);
   }
   else if (k == STRING_CONTAINS && pol == -1)
   {
     // negative contains reduces at level 2, or 3 if guessing model
     int reffort = options().strings.stringModelBasedReduction ? 3 : 2;
-    if (effort == reffort)
-    {
-      Node x = n[0];
-      Node s = n[1];
-      std::vector<Node> lexp;
-      Node lenx = d_state.getLength(x, lexp);
-      Node lens = d_state.getLength(s, lexp);
-      if (d_state.areEqual(lenx, lens))
-      {
-        // We can reduce negative contains to a disequality when lengths are
-        // equal. In other words, len( x ) = len( s ) implies
-        //   ~contains( x, s ) reduces to x != s.
-        if (d_state.areDisequal(x, s))
-        {
-          Trace("strings-extf-debug")
-              << "  resolve extf : " << n
-              << " based on equal lengths disequality." << std::endl;
-          // this depends on the current assertions, so this
-          // inference is context-dependent
-          d_extt.markInactive(n, ExtReducedId::STRINGS_NEG_CTN_DEQ, true);
-          return true;
-        }
-        return true;
-      }
-    }
-    else
-    {
-      return false;
-    }
+    return (effort == reffort);
   }
   else if (k == SEQ_UNIT || k == STRING_UNIT || k == STRING_IN_REGEXP
-           || k == STRING_TO_CODE || (k == STRING_CONTAINS && pol == 0))
+           || k == STRING_TO_CODE || (n.getType().isBoolean() && pol == 0))
   {
     // never necessary to reduce seq.unit. str.to_code or str.in_re here.
     // also, we do not reduce str.contains that are preregistered but not
     // asserted (pol=0).
     return false;
   }
-  else
+  else if (options().strings.seqArray != options::SeqArrayMode::NONE)
   {
-    if (options().strings.seqArray != options::SeqArrayMode::NONE)
+    if (k == SEQ_NTH)
     {
-      if (k == SEQ_NTH)
-      {
-        // don't need to reduce seq.nth when sequence update solver is used
-        return false;
-      }
-      else if ((k == STRING_UPDATE || k == STRING_SUBSTR)
-               && d_termReg.isHandledUpdateOrSubstr(n))
-      {
-        // don't need to reduce certain seq.update
-        // don't need to reduce certain seq.extract with length 1
-        return false;
-      }
+      // don't need to reduce seq.nth when sequence update solver is used
+      return false;
     }
-    if (effort != 2)
+    else if ((k == STRING_UPDATE || k == STRING_SUBSTR)
+             && d_termReg.isHandledUpdateOrSubstr(n))
     {
-      // all other operators reduce at level 2
+      // don't need to reduce certain seq.update
+      // don't need to reduce certain seq.extract with length 1
       return false;
     }
   }
-  return true;
+  // all other operators reduce at level 2
+  return (effort == 2);
 }
 
 void ExtfSolver::doReduction(Node n, int pol)
@@ -209,7 +173,7 @@ void ExtfSolver::doReduction(Node n, int pol)
       return;
     }
   }
-  Node c_n = pol == -1 ? n.negate() : n;
+  Node nn = pol == -1 ? n.notNode() : n;
   Trace("strings-process-debug")
       << "Process reduction for " << n << ", pol = " << pol << std::endl;
   if (k == STRING_CONTAINS && pol == 1)
@@ -230,8 +194,8 @@ void ExtfSolver::doReduction(Node n, int pol)
         << std::endl;
     Trace("strings-red-lemma") << "Reduction (positive contains) lemma : " << n
                                << " => " << eq << std::endl;
-    // context-dependent because it depends on the polarity of n itself
-    d_extt.markInactive(n, ExtReducedId::STRINGS_POS_CTN, true);
+    // reduced positively
+    d_reduced.insert(nn);
   }
   else
   {
@@ -255,6 +219,7 @@ void ExtfSolver::doReduction(Node n, int pol)
       Trace("strings-extf-debug")
           << "  resolve extf : " << n << " based on (trivial) reduction."
           << std::endl;
+      d_reduced.insert(nn);
     }
     else
     {
@@ -263,12 +228,25 @@ void ExtfSolver::doReduction(Node n, int pol)
       d_im.sendInference(ii, true);
       Trace("strings-extf-debug")
           << "  resolve extf : " << n << " based on reduction." << std::endl;
+      d_reduced.insert(nn);
     }
-    d_reduced.insert(n);
   }
 }
 
-void ExtfSolver::checkExtfReductions(int effort)
+void ExtfSolver::checkExtfReductionsEager()
+{
+  // return value is ignored
+  checkExtfReductionsInternal(1, true);
+}
+
+void ExtfSolver::checkExtfReductions(Theory::Effort e)
+{
+  int effort = e == Theory::EFFORT_LAST_CALL ? 3 : 2;
+  // return value is ignored
+  checkExtfReductionsInternal(effort, true);
+}
+
+bool ExtfSolver::checkExtfReductionsInternal(int effort, bool doSend)
 {
   // Notice we don't make a standard call to ExtTheory::doReductions here,
   // since certain optimizations like context-dependent reductions and
@@ -297,13 +275,14 @@ void ExtfSolver::checkExtfReductions(int effort)
     if (shouldDoReduction(effort, n, pol))
     {
       doReduction(n, pol);
-      // we do not mark as reduced, since we may want to evaluate
+      // we do not mark as inactive, since we may want to evaluate
       if (d_im.hasProcessed())
       {
-        return;
+        return true;
       }
     }
   }
+  return false;
 }
 
 void ExtfSolver::checkExtfEval(int effort)
@@ -855,6 +834,13 @@ std::string ExtfSolver::debugPrintModel()
   }
   return ss.str();
 }
+
+bool ExtfSolver::isReduced(const Node& n) const
+{
+  return d_reduced.find(n) != d_reduced.end();
+}
+
+void ExtfSolver::markReduced(const Node& n) { d_reduced.insert(n); }
 
 }  // namespace strings
 }  // namespace theory

--- a/src/theory/strings/extf_solver.cpp
+++ b/src/theory/strings/extf_solver.cpp
@@ -90,7 +90,8 @@ bool ExtfSolver::shouldDoReduction(int effort, Node n, int pol)
     Trace("strings-extf-debug") << "...skip due to model active" << std::endl;
     return false;
   }
-  // check with negation
+  // check with negation if requested (only applied to Boolean terms)
+  Assert(n.getType().isBoolean() || pol != -1);
   Node nn = pol == -1 ? n.notNode() : n;
   if (d_reduced.find(nn) != d_reduced.end())
   {
@@ -195,6 +196,7 @@ void ExtfSolver::doReduction(Node n, int pol)
     Trace("strings-red-lemma") << "Reduction (positive contains) lemma : " << n
                                << " => " << eq << std::endl;
     // reduced positively
+    Assert(nn == n);
     d_reduced.insert(nn);
   }
   else

--- a/src/theory/strings/extf_solver.h
+++ b/src/theory/strings/extf_solver.h
@@ -119,11 +119,18 @@ class ExtfSolver : protected EnvObj
    * and F is a formula that constrains k based on the definition of f.
    *
    * For more details, this is step 7 from Strategy 1 in Reynolds et al,
-   * CAV 2017. We stratify this in practice, where calling this with effort=1
-   * reduces some of the "easier" extended functions, and effort=2 reduces
-   * the rest.
+   * CAV 2017. We stratify this in practice based on the effort level,
+   * where for instance, we reduce negatively asserted str.contains only
+   * at LAST_CALL effort. For more information see discussion of "model-based
+   * reductions" in Reynolds et al CAV 2022.
    */
-  void checkExtfReductions(int effort);
+  void checkExtfReductions(Theory::Effort e);
+  /**
+   * Check for extended functions that should be applied eagerly. This is
+   * called earlier in the search strategy of strings, in particular before
+   * the core equality reasoning is done.
+   */
+  void checkExtfReductionsEager();
   /** get preprocess module */
   StringsPreprocess* getPreprocess() { return &d_preproc; }
 
@@ -176,6 +183,21 @@ class ExtfSolver : protected EnvObj
    * string.
    */
   std::string debugPrintModel();
+
+  /**
+   * Is extended function (or regular expression membership) reduced? Note that
+   * if n has Boolean type, our reductions are dependent upon the polarity of n,
+   * in which case n may be the negation of an extended function. For
+   * example, (not (str.in_re x R)) indicates that we have reduced
+   * (str.in_re x R) based on its negative unfolding.
+   */
+  bool isReduced(const Node& n) const;
+  /**
+   * Mark that extended function (or regular expression membership)  n has been
+   * reduced. Like above, n could be a negation of an extended function of
+   * Boolean type.
+   */
+  void markReduced(const Node& n);
 
  private:
   /**

--- a/src/theory/strings/extf_solver.h
+++ b/src/theory/strings/extf_solver.h
@@ -193,7 +193,7 @@ class ExtfSolver : protected EnvObj
    */
   bool isReduced(const Node& n) const;
   /**
-   * Mark that extended function (or regular expression membership)  n has been
+   * Mark that extended function (or regular expression membership) n has been
    * reduced. Like above, n could be a negation of an extended function of
    * Boolean type.
    */

--- a/src/theory/strings/strategy.cpp
+++ b/src/theory/strings/strategy.cpp
@@ -35,6 +35,7 @@ std::ostream& operator<<(std::ostream& out, InferStep s)
     case CHECK_NORMAL_FORMS_DEQ: out << "check_normal_forms_deq"; break;
     case CHECK_CODES: out << "check_codes"; break;
     case CHECK_LENGTH_EQC: out << "check_length_eqc"; break;
+    case CHECK_EXTF_REDUCTION_EAGER: out << "check_extf_reduction_eager"; break;
     case CHECK_EXTF_REDUCTION: out << "check_extf_reduction"; break;
     case CHECK_MEMBERSHIP: out << "check_membership"; break;
     case CHECK_CARDINALITY: out << "check_cardinality"; break;
@@ -114,7 +115,7 @@ void Strategy::initializeStrategy()
     {
       addStrategyStep(CHECK_FLAT_FORMS);
     }
-    addStrategyStep(CHECK_EXTF_REDUCTION, 1);
+    addStrategyStep(CHECK_EXTF_REDUCTION_EAGER);
     addStrategyStep(CHECK_NORMAL_FORMS_EQ);
     addStrategyStep(CHECK_EXTF_EVAL, 1);
     addStrategyStep(CHECK_NORMAL_FORMS_DEQ);
@@ -130,7 +131,7 @@ void Strategy::initializeStrategy()
     }
     if (options().strings.stringExp)
     {
-      addStrategyStep(CHECK_EXTF_REDUCTION, 2);
+      addStrategyStep(CHECK_EXTF_REDUCTION);
     }
     addStrategyStep(CHECK_MEMBERSHIP);
     addStrategyStep(CHECK_CARDINALITY);
@@ -141,7 +142,7 @@ void Strategy::initializeStrategy()
       addStrategyStep(CHECK_EXTF_EVAL, 3);
       if (options().strings.stringExp)
       {
-        addStrategyStep(CHECK_EXTF_REDUCTION, 3);
+        addStrategyStep(CHECK_EXTF_REDUCTION);
       }
       addStrategyStep(CHECK_MEMBERSHIP, 3);
       step_end[Theory::EFFORT_LAST_CALL] = d_infer_steps.size() - 1;

--- a/src/theory/strings/strategy.h
+++ b/src/theory/strings/strategy.h
@@ -57,6 +57,8 @@ enum InferStep
   CHECK_LENGTH_EQC,
   // check register terms for normal forms
   CHECK_REGISTER_TERMS_NF,
+  // check for eager extended function reductions
+  CHECK_EXTF_REDUCTION_EAGER,
   // check extended function reductions
   CHECK_EXTF_REDUCTION,
   // check regular expression memberships

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -1208,7 +1208,10 @@ void TheoryStrings::runInferStep(InferStep s, Theory::Effort e, int effort)
     case CHECK_REGISTER_TERMS_NF:
       d_csolver.checkRegisterTermsNormalForms();
       break;
-    case CHECK_EXTF_REDUCTION: d_esolver.checkExtfReductions(effort); break;
+    case CHECK_EXTF_REDUCTION_EAGER:
+      d_esolver.checkExtfReductionsEager();
+      break;
+    case CHECK_EXTF_REDUCTION: d_esolver.checkExtfReductions(e); break;
     case CHECK_MEMBERSHIP: d_rsolver.checkMemberships(effort); break;
     case CHECK_CARDINALITY: d_bsolver.checkCardinality(); break;
     default: Unreachable(); break;


### PR DESCRIPTION
This makes several refactorings to the extended function solver. The main goal is to allow more flexibility for modifying our strategy for handling regular expressions.

In particular, this PR:

- It makes the "reduced" set aware of the polarity of extended function predicates (e.g. contains and memberships). It improves our reductions for contains so that it is reduced context-independent + aware of polarity instead of marked inactive. This potentially avoids spurious computation of reductions.
- Makes minor simplifications and corrections to shouldDoReduction.

This is in preparation for https://github.com/cvc5/cvc5/pull/9373.
