### PR TITLE
ci: Temporarily disable macos builds.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,24 +18,24 @@ jobs:
             exclude_regress: 3-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
-          - name: macos:production
-            os: macos-11
-            config: production --auto-download --python-bindings --editline
-            cache-key: production
-            strip-bin: strip
-            python-bindings: true
-            check-examples: true
-            binary-name: cvc5-macOS
-            exclude_regress: 3-4
-            run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
+              #- name: macos:production
+              #  os: macos-11
+              #  config: production --auto-download --python-bindings --editline
+              #  cache-key: production
+              #  strip-bin: strip
+              #  python-bindings: true
+              #  check-examples: true
+              #  binary-name: cvc5-macOS
+              #  exclude_regress: 3-4
+              #  run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
-          - name: macos:production-arm64
-            os: macos-12
-            config: production --auto-download --python-bindings --editline --arm64
-            cache-key: production-arm64
-            strip-bin: strip
-            python-bindings: true
-            binary-name: cvc5-macOS-arm64
+              #- name: macos:production-arm64
+              #  os: macos-12
+              #  config: production --auto-download --python-bindings --editline --arm64
+              #  cache-key: production-arm64
+              #  strip-bin: strip
+              #  python-bindings: true
+              #  binary-name: cvc5-macOS-arm64
 
           - name: win64:production
             os: ubuntu-latest


### PR DESCRIPTION
macos builds are currently failing on CI due to Python version issues. We'll disable the builds for now until we can fix this issue.