### PR TITLE
Lazily resolve symbol table lookups for testers and updaters

### DIFF
--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -1483,40 +1483,17 @@ identifier[cvc5::ParseOp& p]
   // indexed functions
 
   | LPAREN_TOK INDEX_TOK
-    ( TESTER_TOK term[f, f2]
+    ( TESTER_TOK symbol[opName,CHECK_NONE,SYM_VARIABLE]
       {
-        if (f.getKind() == cvc5::APPLY_CONSTRUCTOR && f.getNumChildren() == 1)
-        {
-          // for nullary constructors, must get the operator
-          f = f[0];
-        }
-        if (!f.getSort().isDatatypeConstructor())
-        {
-          PARSER_STATE->parseError(
-              "Bad syntax for (_ is X), X must be a constructor.");
-        }
-        // get the datatype that f belongs to
-        cvc5::Sort sf = f.getSort().getDatatypeConstructorCodomainSort();
-        cvc5::Datatype d = sf.getDatatype();
-        // lookup by name
-        cvc5::DatatypeConstructor dc = d.getConstructor(f.toString());
-        p.d_expr = dc.getTesterTerm();
+        // operator is resolved after parsing to handle overloading
+        p.d_kind = APPLY_TESTER;
+        p.d_name = opName;
       }
-    | UPDATE_TOK term[f, f2]
+    | UPDATE_TOK symbol[opName,CHECK_NONE,SYM_VARIABLE]
       {
-        if (!f.getSort().isDatatypeSelector())
-        {
-          PARSER_STATE->parseError(
-              "Bad syntax for (_ update X), X must be a selector.");
-        }
-        std::string sname = f.toString();
-        // get the datatype that f belongs to
-        cvc5::Sort sf = f.getSort().getDatatypeSelectorDomainSort();
-        cvc5::Datatype d = sf.getDatatype();
-        // find the selector
-        cvc5::DatatypeSelector ds = d.getSelector(f.toString());
-        // get the updater term
-        p.d_expr = ds.getUpdaterTerm();
+        // operator is resolved after parsing to handle overloading
+        p.d_kind = APPLY_UPDATER;
+        p.d_name = opName;
       }
     | functionName[opName, CHECK_NONE] nonemptyNumeralList[numerals]
       {

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -122,9 +122,15 @@ class Smt2State : public ParserState
   /** Same as above, for constants indexed by symbols. */
   Term mkIndexedConstant(const std::string& name,
                          const std::vector<std::string>& symbols);
-  /** Same as above, for constants indexed by symbols. */
-  Term mkIndexedOp(const std::string& name,
-                   const std::vector<std::string>& symbols);
+  /**
+   * Make the operator for kind k that is indexed by the given symbols.
+   * The arguments are passed for the purposes of resolving overloading.
+   * For example, this method is used to construct the proper tester. This
+   * requires knowing the type of the (first) argument in args.
+   */
+  Term mkIndexedOp(Kind k,
+                   const std::vector<std::string>& symbols,
+                   const std::vector<Term>& args);
 
   /**
    * Creates an indexed operator kind, e.g. BITVECTOR_EXTRACT for "extract".

--- a/test/regress/cli/regress0/issue1063-overloading-dt-cons.smt2
+++ b/test/regress/cli/regress0/issue1063-overloading-dt-cons.smt2
@@ -10,5 +10,5 @@
 (assert (= (var_1 1) (as None Enum1)))
 (assert (not ((_ is In_Air) (var_0 0))))
 (declare-fun var_2 () Enum1)
-(assert ((_ is (as None Enum1)) var_2))
+(assert ((_ is None) var_2))
 (check-sat)


### PR DESCRIPTION
This is in preparation for the flex parser.

This corrects the ANTLR grammar and SMT state for parsing testers and updaters for overloaded selectors or constructors so that indices of these are *symbols* not *constructor terms*. To handle overloading, symbol table lookups must be done lazily.