### PR TITLE
Ensure facts from sequences array solver are rewritten

### DIFF
--- a/src/theory/strings/array_solver.cpp
+++ b/src/theory/strings/array_solver.cpp
@@ -392,6 +392,9 @@ void ArraySolver::checkTerm(Node t, bool checkInv)
     {
       eq = t.eqNode(finalc);
     }
+    // Must rewrite the equality to ensure terms are in rewritten form. This
+    // is important since this inference may be processed as a fact.
+    eq = rewrite(eq);
     iid = checkInv ? InferenceId::STRINGS_ARRAY_UPDATE_CONCAT_INVERSE
                    : InferenceId::STRINGS_ARRAY_UPDATE_CONCAT;
   }

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -371,6 +371,22 @@ void InferenceManager::processFact(InferInfo& ii, ProofGenerator*& pg)
     d_ipc->notifyFact(ii);
     pg = d_ipc.get();
   }
+  // ensure facts are for rewritten terms
+  if (Configuration::isAssertionBuild())
+  {
+    Node atom = ii.d_conc.getKind()==NOT ? ii.d_conc[0] : ii.d_conc;
+    if (atom.getKind()==EQUAL)
+    {
+      for (const Node& n : atom)
+      {
+        Assert(rewrite(n)==n);
+      }
+    }
+    else
+    {
+      Assert(rewrite(atom)==atom);
+    }
+  }
 }
 
 TrustNode InferenceManager::processLemma(InferInfo& ii, LemmaProperty& p)

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -377,10 +377,8 @@ void InferenceManager::processFact(InferInfo& ii, ProofGenerator*& pg)
     Node atom = ii.d_conc.getKind()==NOT ? ii.d_conc[0] : ii.d_conc;
     if (atom.getKind()==EQUAL)
     {
-      for (const Node& n : atom)
-      {
-        Assert(rewrite(n)==n);
-      }
+      Assert(rewrite(atom[0])==atom[0]);
+      Assert(rewrite(atom[1])==atom[1]);
     }
     else
     {


### PR DESCRIPTION
Alternative fix for https://github.com/cvc5/cvc5/pull/9076.

This adds assertions that catch non-rewritten terms being added to strings equality engine, which fail for 3 current regressions.  It corrects the issue by calling the rewriter for an inferences from the sequences array solver.