### PR TITLE
Add Flex parser for SMT2 sorts

### DIFF
--- a/src/parser/smt2/smt2_term_parser.cpp
+++ b/src/parser/smt2/smt2_term_parser.cpp
@@ -28,6 +28,126 @@ Smt2TermParser::Smt2TermParser(Smt2Lexer& lex, Smt2State& state)
 {
 }
 
+
+Sort Smt2TermParser::parseSort()
+{
+  Sort ret;
+  Token tok;
+  std::vector<std::pair<std::string, std::vector<Sort>>> sstack;
+  do
+  {
+    tok = d_lex.nextToken();
+    switch (tok)
+    {
+      // ------------------- open paren
+      case Token::LPAREN_TOK:
+      {
+        tok = d_lex.nextToken();
+        switch (tok)
+        {
+          case Token::INDEX_TOK:
+          {
+            // a standalone indexed symbol
+            std::string name = parseSymbol(CHECK_NONE, SYM_SORT);
+            std::vector<std::string> numerals = parseNumeralList();
+            d_lex.eatToken(Token::RPAREN_TOK);
+            ret = d_state.getIndexedSort(name, numerals);
+          }
+          break;
+          case Token::SYMBOL:
+          case Token::QUOTED_SYMBOL:
+          {
+            // sort constructor identifier
+            std::string name = tokenStrToSymbol(tok);
+            // open a new stack frame
+            std::vector<Sort> emptyArgs;
+            sstack.emplace_back(name, emptyArgs);
+          }
+          break;
+          default:
+            // NOTE: it is possible to have sorts e.g.
+            // ((_ FixedSizeList 4) Real) where tok would be LPAREN_TOK here.
+            // However, we have no such examples in cvc5 currently.
+            d_lex.unexpectedTokenError(tok,
+                                       "Expected SMT-LIBv2 sort constructor");
+            break;
+        }
+      }
+      break;
+      // ------------------- close paren
+      case Token::RPAREN_TOK:
+      {
+        if (sstack.empty())
+        {
+          d_lex.unexpectedTokenError(
+              tok, "Mismatched parentheses in SMT-LIBv2 sort");
+        }
+        // Construct the (parametric) sort specified by sstack.back()
+        ret = d_state.getParametricSort(sstack.back().first,
+                                        sstack.back().second);
+        // pop the stack
+        sstack.pop_back();
+      }
+      break;
+      // ------------------- a simple (defined or builtin) sort
+      case Token::SYMBOL:
+      case Token::QUOTED_SYMBOL:
+      {
+        std::string name = tokenStrToSymbol(tok);
+        ret = d_state.getSort(name);
+      }
+      break;
+      default:
+        d_lex.unexpectedTokenError(tok, "Expected SMT-LIBv2 sort");
+        break;
+    }
+    if (!ret.isNull())
+    {
+      // add it to the list and reset ret
+      if (!sstack.empty())
+      {
+        sstack.back().second.push_back(ret);
+        ret = Sort();
+      }
+      // otherwise it will be returned
+    }
+  } while (!sstack.empty());
+  Assert(!ret.isNull());
+  return ret;
+}
+
+std::vector<Sort> Smt2TermParser::parseSortList()
+{
+  d_lex.eatToken(Token::LPAREN_TOK);
+  std::vector<Sort> sorts;
+  Token tok = d_lex.nextToken();
+  while (tok != Token::RPAREN_TOK)
+  {
+    d_lex.reinsertToken(tok);
+    Sort s = parseSort();
+    sorts.push_back(s);
+    tok = d_lex.nextToken();
+  }
+  return sorts;
+}
+
+std::vector<std::pair<std::string, Sort>> Smt2TermParser::parseSortedVarList()
+{
+  std::vector<std::pair<std::string, Sort>> varList;
+  d_lex.eatToken(Token::LPAREN_TOK);
+  std::string name;
+  Sort t;
+  // while the next token is LPAREN, exit if RPAREN
+  while (d_lex.eatTokenChoice(Token::LPAREN_TOK, Token::RPAREN_TOK))
+  {
+    name = parseSymbol(CHECK_NONE, SYM_VARIABLE);
+    t = parseSort();
+    varList.emplace_back(name, t);
+    d_lex.eatToken(Token::RPAREN_TOK);
+  }
+  return varList;
+}
+
 std::string Smt2TermParser::parseSymbol(DeclarationCheck check, SymbolType type)
 {
   Token tok = d_lex.nextToken();

--- a/src/parser/smt2/smt2_term_parser.h
+++ b/src/parser/smt2/smt2_term_parser.h
@@ -36,6 +36,15 @@ class Smt2TermParser
   Smt2TermParser(Smt2Lexer& lex, Smt2State& state);
   virtual ~Smt2TermParser() {}
 
+  /** Parse an SMT-LIB sort <sort> */
+  Sort parseSort();
+  /** Parses parentheses-enclosed sort list (<sort>)*) */
+  std::vector<Sort> parseSortList();
+  /**
+   * Parse parentheses-enclosed sorted variable list of the form:
+   * ((<symbol> <sort>)*)
+   */
+  std::vector<std::pair<std::string, Sort>> parseSortedVarList();
   /**
    * Parse symbol, which returns the string of the parsed symbol if the next
    * token is a valid smt2 symbol.

--- a/src/parser/smt2/smt2_term_parser.h
+++ b/src/parser/smt2/smt2_term_parser.h
@@ -38,7 +38,7 @@ class Smt2TermParser
 
   /** Parse an SMT-LIB sort <sort> */
   Sort parseSort();
-  /** Parses parentheses-enclosed sort list (<sort>)*) */
+  /** Parses parentheses-enclosed sort list (<sort>*) */
   std::vector<Sort> parseSortList();
   /**
    * Parse parentheses-enclosed sorted variable list of the form:


### PR DESCRIPTION
Maintains a stack to avoid recursion, similar to https://github.com/cvc5/cvc5/pull/9418.