### PR TITLE
improve Smt2TermParser::unescapedString

### DIFF
--- a/src/parser/smt2/smt2_term_parser.cpp
+++ b/src/parser/smt2/smt2_term_parser.cpp
@@ -149,17 +149,16 @@ void Smt2TermParser::unescapeString(std::string& s)
           "as escape sequences");
     }
   }
-  size_t i=0;
-  while (i<s.size())
+  size_t dst = 0;
+  for (size_t src = 0; src<s.size(); ++src, ++dst)
   {
-    if (s[i]=='"')
+    s[dst] = s[src];
+    if (s[src]=='"')
     {
-      // "" becomes "
-      Assert (i+1<s.size() && s[i+1]=='"');
-      s.erase(i,1);
+      ++src;
     }
-    i++;
   }
+  s.erase(dst);
 }
 
 }  // namespace parser


### PR DESCRIPTION
Before, we erased escape characters, char-by-char, which is likely slow.

Now, we copy the unescaped characters forward in the string, and then truncate.