### PR TITLE
Fixed CI actions on macOS.

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -67,21 +67,11 @@ runs:
         echo "::group::Install macOS software"
         brew update --quiet
 
-        # Hardcode python version to be 3.10 on macOS.
+        # Temporary workaround while versions of python greater than 3.10 are not supported:
+        # Hardcoding python version to 3.10 on macOS CI.
         brew install python@3.10
         ln -s -f /usr/local/bin/python3.10 /usr/local/bin/python3
 
-        # Temporary workaround for https://github.com/actions/setup-python/issues/577
-        # rm -f /usr/local/bin/2to3
-        # rm -f /usr/local/bin/idle3
-        # rm -f /usr/local/bin/pydoc3
-        # rm -f /usr/local/bin/python3
-        # rm -f /usr/local/bin/python3-config
-        # rm -f /usr/local/bin/2to3-3.11
-        # rm -f /usr/local/bin/idle3.11
-        # rm -f /usr/local/bin/pydoc3.11
-        # rm -f /usr/local/bin/python3.11
-        # rm -f /usr/local/bin/python3.11-config
         brew install \
           ccache \
           cln \
@@ -89,7 +79,6 @@ runs:
           pkgconfig \
           flex \
           gnu-sed
-
         python3 -m pip install --user pexpect setuptools toml
         # Make ImageVersion accessible as env.image_version. Environment
         # variables of the runner are not automatically imported:

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -89,7 +89,7 @@ runs:
         brew install pyenv
         pyenv install 3.10
         pyenv versions
-        pyenv local 3.10
+        pyenv global 3.10
         PATH="~/.pyenv/shims:${PATH}"
 
         python3 -m pip install --user pexpect setuptools toml

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -85,14 +85,9 @@ runs:
           flex \
           gnu-sed
 
-        echo "nocheckin python3 --version"
-        python3 --version
-
-        brew install python@3.10
+        brew uninstall python3
+        brew install python3@3.10
         brew link python@3.10
-
-        echo "nocheckin python3 --version"
-        python3 --version
 
         python3 -m pip install --user pexpect setuptools toml
         # Make ImageVersion accessible as env.image_version. Environment

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -85,9 +85,14 @@ runs:
           flex \
           gnu-sed
 
+        echo "brew list python python3"
+        brew list python python3
+
         brew unlink python@3.11
         brew link --force python@3.10
-        /usr/local/Frameworks/Python.framework/Versions/3.10/bin/python3.10 -m pip install toml pexpect setuptools 
+        
+        echo "brew list python python3"
+        brew list python python3
 
         python3 -m pip install --user pexpect setuptools toml
         # Make ImageVersion accessible as env.image_version. Environment

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -87,6 +87,7 @@ runs:
 
         brew unlink python@3.11
         brew link --force python@3.10
+        /usr/local/Frameworks/Python.framework/Versions/3.10/bin/python3.10 -m pip install toml pexpect setuptools 
 
         python3 -m pip install --user pexpect setuptools toml
         # Make ImageVersion accessible as env.image_version. Environment

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -86,12 +86,8 @@ runs:
           gnu-sed
 
         # Install python 3.10.
-        brew install pyenv
-        pyenv install 3.10
-        pyenv versions
-        pyenv global 3.10
-        PATH="~/.pyenv/shims:${PATH}"
-
+        brew install python@3.10
+        
         python3 -m pip install --user pexpect setuptools toml
         # Make ImageVersion accessible as env.image_version. Environment
         # variables of the runner are not automatically imported:

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -84,6 +84,14 @@ runs:
           pkgconfig \
           flex \
           gnu-sed
+
+        # Install python 3.10.
+        brew install pyenv
+        pyenv install 3.10
+        pyenv versions
+        pyenv local 3.10
+        PATH="~/.pyenv/shims:${PATH}"
+
         python3 -m pip install --user pexpect setuptools toml
         # Make ImageVersion accessible as env.image_version. Environment
         # variables of the runner are not automatically imported:

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -66,17 +66,24 @@ runs:
       run: |
         echo "::group::Install macOS software"
         brew update --quiet
+
+        brew unlink python@3.11
+        brew link --force python@3.10
+        echo "where python3"
+        where python3
+        python3 --version
+
         # Temporary workaround for https://github.com/actions/setup-python/issues/577
-        rm -f /usr/local/bin/2to3
-        rm -f /usr/local/bin/idle3
-        rm -f /usr/local/bin/pydoc3
-        rm -f /usr/local/bin/python3
-        rm -f /usr/local/bin/python3-config
-        rm -f /usr/local/bin/2to3-3.11
-        rm -f /usr/local/bin/idle3.11
-        rm -f /usr/local/bin/pydoc3.11
-        rm -f /usr/local/bin/python3.11
-        rm -f /usr/local/bin/python3.11-config
+        # rm -f /usr/local/bin/2to3
+        # rm -f /usr/local/bin/idle3
+        # rm -f /usr/local/bin/pydoc3
+        # rm -f /usr/local/bin/python3
+        # rm -f /usr/local/bin/python3-config
+        # rm -f /usr/local/bin/2to3-3.11
+        # rm -f /usr/local/bin/idle3.11
+        # rm -f /usr/local/bin/pydoc3.11
+        # rm -f /usr/local/bin/python3.11
+        # rm -f /usr/local/bin/python3.11-config
         brew install \
           ccache \
           cln \
@@ -84,15 +91,6 @@ runs:
           pkgconfig \
           flex \
           gnu-sed
-
-        echo "brew list python python3"
-        brew list python python3
-
-        brew unlink python@3.11
-        brew link --force python@3.10
-        
-        echo "brew list python python3"
-        brew list python python3
 
         python3 -m pip install --user pexpect setuptools toml
         # Make ImageVersion accessible as env.image_version. Environment

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -67,12 +67,9 @@ runs:
         echo "::group::Install macOS software"
         brew update --quiet
 
-        brew unlink python@3.11
-        brew link --force python@3.10
-        echo "ls -l /usr/local/bin/python*"
-        ls -l /usr/local/bin/python*
-        echo "python --version"
-        python --version
+        # Hardcode python version to be 3.10 on macOS.
+        brew install python@3.10
+        ln -s -f /usr/local/bin/python3.10 /usr/local/bin/python3
 
         # Temporary workaround for https://github.com/actions/setup-python/issues/577
         # rm -f /usr/local/bin/2to3

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -85,11 +85,14 @@ runs:
           flex \
           gnu-sed
 
-        # Install python 3.10.
+        echo "nocheckin python3 --version"
+        python3 --version
+
         brew install python@3.10
-        sudo mkdir -p /usr/local/Frameworks
-        sudo chown -R $(whoami) /usr/local/*
-        brew link python3
+        brew link python@3.10
+
+        echo "nocheckin python3 --version"
+        python3 --version
 
         python3 -m pip install --user pexpect setuptools toml
         # Make ImageVersion accessible as env.image_version. Environment

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -69,9 +69,10 @@ runs:
 
         brew unlink python@3.11
         brew link --force python@3.10
-        echo "where python3"
-        where python3
-        python3 --version
+        echo "ls -l /usr/local/bin/python*"
+        ls -l /usr/local/bin/python*
+        echo "python --version"
+        python --version
 
         # Temporary workaround for https://github.com/actions/setup-python/issues/577
         # rm -f /usr/local/bin/2to3

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -87,7 +87,10 @@ runs:
 
         # Install python 3.10.
         brew install python@3.10
-        
+        sudo mkdir -p /usr/local/Frameworks
+        sudo chown -R $(whoami) /usr/local/*
+        brew link python3
+
         python3 -m pip install --user pexpect setuptools toml
         # Make ImageVersion accessible as env.image_version. Environment
         # variables of the runner are not automatically imported:

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -85,9 +85,8 @@ runs:
           flex \
           gnu-sed
 
-        brew uninstall python3
-        brew install python3@3.10
-        brew link python@3.10
+        brew unlink python@3.11
+        brew link --force python@3.10
 
         python3 -m pip install --user pexpect setuptools toml
         # Make ImageVersion accessible as env.image_version. Environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,70 +6,71 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: ubuntu:production
-            os: ubuntu-latest
-            config: production --auto-download --all-bindings --editline --docs
-            cache-key: production
-            strip-bin: strip
-            python-bindings: true
-            build-documentation: true
-            check-examples: true
-            binary-name: cvc5-Linux
-            exclude_regress: 3-4
-            run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
+          # - name: ubuntu:production
+          #   os: ubuntu-latest
+          #   config: production --auto-download --all-bindings --editline --docs
+          #   cache-key: production
+          #   strip-bin: strip
+          #   python-bindings: true
+          #   build-documentation: true
+          #   check-examples: true
+          #   binary-name: cvc5-Linux
+          #   exclude_regress: 3-4
+          #   run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
-              #          - name: macos:production
-              #            os: macos-11
-              #            config: production --auto-download --python-bindings --editline
-              #            cache-key: production
-              #            strip-bin: strip
-              #            python-bindings: true
-              #            check-examples: true
-              #            binary-name: cvc5-macOS
-              #            exclude_regress: 3-4
-              #            run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
-              #
-              #          - name: macos:production-arm64
-              #            os: macos-12
-              #            config: production --auto-download --python-bindings --editline --arm64
-              #            cache-key: production-arm64
-              #            strip-bin: strip
-              #            python-bindings: true
-              #            binary-name: cvc5-macOS-arm64
+          # #temporary
+           - name: macos:production
+             os: macos-11
+             config: production --auto-download --python-bindings --editline
+             cache-key: production
+             strip-bin: strip
+             python-bindings: true
+             check-examples: true
+             binary-name: cvc5-macOS
+             exclude_regress: 3-4
+             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
+ 
+           - name: macos:production-arm64
+             os: macos-12
+             config: production --auto-download --python-bindings --editline --arm64
+             cache-key: production-arm64
+             strip-bin: strip
+             python-bindings: true
+             binary-name: cvc5-macOS-arm64
 
-          - name: win64:production
-            os: ubuntu-latest
-            config: production --auto-download --win64
-            cache-key: productionwin64
-            strip-bin: x86_64-w64-mingw32-strip
-            windows-build: true
-            binary-name: cvc5-Win64.exe
-            binary-ext: .exe
-
-          - name: ubuntu:production-clang
-            os: ubuntu-18.04
-            env: CC=clang CXX=clang++
-            config: production --auto-download --no-poly
-            cache-key: productionclang
-            check-examples: true
-            exclude_regress: 3-4
-            run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
-
-          - name: ubuntu:production-dbg
-            os: ubuntu-18.04
-            config: production --auto-download --assertions --tracing --unit-testing --all-bindings --editline --cocoa
-            cache-key: dbg
-            exclude_regress: 3-4
-            run_regression_args: --tester base --tester model --tester synth --tester abduct --tester proof --tester dump
-            python-bindings: true
-
-          - name: ubuntu:production-dbg-clang
-            os: ubuntu-latest
-            env: CC=clang CXX=clang++
-            config: production --auto-download --assertions --tracing --cln --gpl
-            cache-key: dbgclang
-            exclude_regress: 3-4
-            run_regression_args: --tester base --tester model --tester synth --tester abduct --tester unsat-core --tester dump
+          # - name: win64:production
+          #   os: ubuntu-latest
+          #   config: production --auto-download --win64
+          #   cache-key: productionwin64
+          #   strip-bin: x86_64-w64-mingw32-strip
+          #   windows-build: true
+          #   binary-name: cvc5-Win64.exe
+          #   binary-ext: .exe
+          # 
+          # - name: ubuntu:production-clang
+          #   os: ubuntu-18.04
+          #   env: CC=clang CXX=clang++
+          #   config: production --auto-download --no-poly
+          #   cache-key: productionclang
+          #   check-examples: true
+          #   exclude_regress: 3-4
+          #   run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
+          # 
+          # - name: ubuntu:production-dbg
+          #   os: ubuntu-18.04
+          #   config: production --auto-download --assertions --tracing --unit-testing --all-bindings --editline --cocoa
+          #   cache-key: dbg
+          #   exclude_regress: 3-4
+          #   run_regression_args: --tester base --tester model --tester synth --tester abduct --tester proof --tester dump
+          #   python-bindings: true
+          # 
+          # - name: ubuntu:production-dbg-clang
+          #   os: ubuntu-latest
+          #   env: CC=clang CXX=clang++
+          #   config: production --auto-download --assertions --tracing --cln --gpl
+          #   cache-key: dbgclang
+          #   exclude_regress: 3-4
+          #   run_regression_args: --tester base --tester model --tester synth --tester abduct --tester unsat-core --tester dump
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,18 @@ jobs:
     strategy:
       matrix:
         include:
-          # - name: ubuntu:production
-          #   os: ubuntu-latest
-          #   config: production --auto-download --all-bindings --editline --docs
-          #   cache-key: production
-          #   strip-bin: strip
-          #   python-bindings: true
-          #   build-documentation: true
-          #   check-examples: true
-          #   binary-name: cvc5-Linux
-          #   exclude_regress: 3-4
-          #   run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
+           - name: ubuntu:production
+             os: ubuntu-latest
+             config: production --auto-download --all-bindings --editline --docs
+             cache-key: production
+             strip-bin: strip
+             python-bindings: true
+             build-documentation: true
+             check-examples: true
+             binary-name: cvc5-Linux
+             exclude_regress: 3-4
+             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
-          # #temporary
            - name: macos:production
              os: macos-11
              config: production --auto-download --python-bindings --editline
@@ -38,39 +37,39 @@ jobs:
              python-bindings: true
              binary-name: cvc5-macOS-arm64
 
-          # - name: win64:production
-          #   os: ubuntu-latest
-          #   config: production --auto-download --win64
-          #   cache-key: productionwin64
-          #   strip-bin: x86_64-w64-mingw32-strip
-          #   windows-build: true
-          #   binary-name: cvc5-Win64.exe
-          #   binary-ext: .exe
-          # 
-          # - name: ubuntu:production-clang
-          #   os: ubuntu-18.04
-          #   env: CC=clang CXX=clang++
-          #   config: production --auto-download --no-poly
-          #   cache-key: productionclang
-          #   check-examples: true
-          #   exclude_regress: 3-4
-          #   run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
-          # 
-          # - name: ubuntu:production-dbg
-          #   os: ubuntu-18.04
-          #   config: production --auto-download --assertions --tracing --unit-testing --all-bindings --editline --cocoa
-          #   cache-key: dbg
-          #   exclude_regress: 3-4
-          #   run_regression_args: --tester base --tester model --tester synth --tester abduct --tester proof --tester dump
-          #   python-bindings: true
-          # 
-          # - name: ubuntu:production-dbg-clang
-          #   os: ubuntu-latest
-          #   env: CC=clang CXX=clang++
-          #   config: production --auto-download --assertions --tracing --cln --gpl
-          #   cache-key: dbgclang
-          #   exclude_regress: 3-4
-          #   run_regression_args: --tester base --tester model --tester synth --tester abduct --tester unsat-core --tester dump
+           - name: win64:production
+             os: ubuntu-latest
+             config: production --auto-download --win64
+             cache-key: productionwin64
+             strip-bin: x86_64-w64-mingw32-strip
+             windows-build: true
+             binary-name: cvc5-Win64.exe
+             binary-ext: .exe
+           
+           - name: ubuntu:production-clang
+             os: ubuntu-18.04
+             env: CC=clang CXX=clang++
+             config: production --auto-download --no-poly
+             cache-key: productionclang
+             check-examples: true
+             exclude_regress: 3-4
+             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
+           
+           - name: ubuntu:production-dbg
+             os: ubuntu-18.04
+             config: production --auto-download --assertions --tracing --unit-testing --all-bindings --editline --cocoa
+             cache-key: dbg
+             exclude_regress: 3-4
+             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester proof --tester dump
+             python-bindings: true
+           
+           - name: ubuntu:production-dbg-clang
+             os: ubuntu-latest
+             env: CC=clang CXX=clang++
+             config: production --auto-download --assertions --tracing --cln --gpl
+             cache-key: dbgclang
+             exclude_regress: 3-4
+             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester unsat-core --tester dump
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,70 +6,70 @@ jobs:
     strategy:
       matrix:
         include:
-           - name: ubuntu:production
-             os: ubuntu-latest
-             config: production --auto-download --all-bindings --editline --docs
-             cache-key: production
-             strip-bin: strip
-             python-bindings: true
-             build-documentation: true
-             check-examples: true
-             binary-name: cvc5-Linux
-             exclude_regress: 3-4
-             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
+          - name: ubuntu:production
+            os: ubuntu-latest
+            config: production --auto-download --all-bindings --editline --docs
+            cache-key: production
+            strip-bin: strip
+            python-bindings: true
+            build-documentation: true
+            check-examples: true
+            binary-name: cvc5-Linux
+            exclude_regress: 3-4
+            run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
-           - name: macos:production
-             os: macos-11
-             config: production --auto-download --python-bindings --editline
-             cache-key: production
-             strip-bin: strip
-             python-bindings: true
-             check-examples: true
-             binary-name: cvc5-macOS
-             exclude_regress: 3-4
-             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
+          - name: macos:production
+            os: macos-11
+            config: production --auto-download --python-bindings --editline
+            cache-key: production
+            strip-bin: strip
+            python-bindings: true
+            check-examples: true
+            binary-name: cvc5-macOS
+            exclude_regress: 3-4
+            run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
  
-           - name: macos:production-arm64
-             os: macos-12
-             config: production --auto-download --python-bindings --editline --arm64
-             cache-key: production-arm64
-             strip-bin: strip
-             python-bindings: true
-             binary-name: cvc5-macOS-arm64
+          - name: macos:production-arm64
+            os: macos-12
+            config: production --auto-download --python-bindings --editline --arm64
+            cache-key: production-arm64
+            strip-bin: strip
+            python-bindings: true
+            binary-name: cvc5-macOS-arm64
 
-           - name: win64:production
-             os: ubuntu-latest
-             config: production --auto-download --win64
-             cache-key: productionwin64
-             strip-bin: x86_64-w64-mingw32-strip
-             windows-build: true
-             binary-name: cvc5-Win64.exe
-             binary-ext: .exe
-           
-           - name: ubuntu:production-clang
-             os: ubuntu-18.04
-             env: CC=clang CXX=clang++
-             config: production --auto-download --no-poly
-             cache-key: productionclang
-             check-examples: true
-             exclude_regress: 3-4
-             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
-           
-           - name: ubuntu:production-dbg
-             os: ubuntu-18.04
-             config: production --auto-download --assertions --tracing --unit-testing --all-bindings --editline --cocoa
-             cache-key: dbg
-             exclude_regress: 3-4
-             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester proof --tester dump
-             python-bindings: true
-           
-           - name: ubuntu:production-dbg-clang
-             os: ubuntu-latest
-             env: CC=clang CXX=clang++
-             config: production --auto-download --assertions --tracing --cln --gpl
-             cache-key: dbgclang
-             exclude_regress: 3-4
-             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester unsat-core --tester dump
+          - name: win64:production
+            os: ubuntu-latest
+            config: production --auto-download --win64
+            cache-key: productionwin64
+            strip-bin: x86_64-w64-mingw32-strip
+            windows-build: true
+            binary-name: cvc5-Win64.exe
+            binary-ext: .exe
+          
+          - name: ubuntu:production-clang
+            os: ubuntu-18.04
+            env: CC=clang CXX=clang++
+            config: production --auto-download --no-poly
+            cache-key: productionclang
+            check-examples: true
+            exclude_regress: 3-4
+            run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
+          
+          - name: ubuntu:production-dbg
+            os: ubuntu-18.04
+            config: production --auto-download --assertions --tracing --unit-testing --all-bindings --editline --cocoa
+            cache-key: dbg
+            exclude_regress: 3-4
+            run_regression_args: --tester base --tester model --tester synth --tester abduct --tester proof --tester dump
+            python-bindings: true
+          
+          - name: ubuntu:production-dbg-clang
+            os: ubuntu-latest
+            env: CC=clang CXX=clang++
+            config: production --auto-download --assertions --tracing --cln --gpl
+            cache-key: dbgclang
+            exclude_regress: 3-4
+            run_regression_args: --tester base --tester model --tester synth --tester abduct --tester unsat-core --tester dump
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 # The build system configuration.
 ##
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.12)
 
 #-----------------------------------------------------------------------------#
 # Project configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,7 +321,7 @@ else()
   endif()
 endif()
 
-find_package(PythonInterp 3 REQUIRED)
+find_package(Python 3.6...<3.11 COMPONENTS Interpreter REQUIRED)
 find_package(GMP 6.1 REQUIRED)
 
 if(ENABLE_ASAN)
@@ -494,7 +494,7 @@ if(BUILD_BINDINGS_PYTHON AND NOT BUILD_SHARED_LIBS)
   set(BUILD_BINDINGS_PYTHON OFF)
 endif()
 if(BUILD_BINDINGS_PYTHON)
-  set(BUILD_BINDINGS_PYTHON_VERSION ${PYTHON_VERSION_MAJOR})
+  set(BUILD_BINDINGS_PYTHON_VERSION 3.6...<3.11)
   add_subdirectory(src/api/python)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,7 +322,9 @@ else()
 endif()
 
 find_package(Python 3.6...<3.11 COMPONENTS Interpreter REQUIRED)
-# Cmake package PythonExtensions is not compatible with FindPython.
+
+# 'PythonExtensions' is not yet compatible with cmake's new 'FindPython'.
+#     https://github.com/scikit-build/scikit-build/issues/506
 # We define the following symbols below to be backward compatible.
 set(PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
 set(PYTHON_INCLUDE_DIR "${Python_INCLUDE_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,8 +323,10 @@ endif()
 
 find_package(Python 3.6...<3.11 COMPONENTS Interpreter REQUIRED)
 # Cmake package PythonExtensions is not compatible with FindPython.
-# We define PYTHON_EXECUTABLE here to be backward compatible.
+# We define the following symbols below to be backward compatible.
 set(PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
+set(PYTHON_INCLUDE_DIR "${Python_INCLUDE_DIR}")
+set(PYTHON_LIBRARY "${Python_LIBRARY}")
 
 find_package(GMP 6.1 REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,6 +322,10 @@ else()
 endif()
 
 find_package(Python 3.6...<3.11 COMPONENTS Interpreter REQUIRED)
+# Cmake package PythonExtensions is not compatible with FindPython.
+# We define PYTHON_EXECUTABLE here to be backward compatible.
+set(PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
+
 find_package(GMP 6.1 REQUIRED)
 
 if(ENABLE_ASAN)

--- a/cmake/Helpers.cmake
+++ b/cmake/Helpers.cmake
@@ -236,7 +236,7 @@ endmacro()
 function(check_python_module module)
   execute_process(
     COMMAND
-    ${PYTHON_EXECUTABLE} -c "import ${module}"
+    ${Python_EXECUTABLE} -c "import ${module}"
     RESULT_VARIABLE
       RET_MODULE_TEST
     ERROR_QUIET
@@ -249,9 +249,9 @@ function(check_python_module module)
   if(RET_MODULE_TEST)
     message(FATAL_ERROR
         "Could not find module ${module_name} for Python "
-        "version ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}. "
+        "version ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}. "
         "Make sure to install ${module_name} for this Python version "
-        "via \n`${PYTHON_EXECUTABLE} -m pip install ${module_name}'.\n"
+        "via \n`${Python_EXECUTABLE} -m pip install ${module_name}'.\n"
         "Note: You need to have pip installed for this Python version.")
   endif()
 endfunction()

--- a/examples/api/python/CMakeLists.txt
+++ b/examples/api/python/CMakeLists.txt
@@ -36,12 +36,12 @@ set(EXAMPLES_API_PYTHON
   transcendentals
 )
 
-find_package(PythonInterp ${CVC5_BINDINGS_PYTHON_VERSION} REQUIRED)
+find_package(Python ${CVC5_BINDINGS_PYTHON_VERSION} REQUIRED)
 
 # Find Python bindings in the corresponding python-*/site-packages directory.
 # Lookup Python module directory and store path in PYTHON_MODULE_PATH.
 execute_process(COMMAND
-                  ${PYTHON_EXECUTABLE} -c
+                  ${Python_EXECUTABLE} -c
                     "from distutils.sysconfig import get_python_lib;\
                      print(get_python_lib(plat_specific=True,\
                              prefix='${CMAKE_PREFIX_PATH}/../..'))"
@@ -53,7 +53,7 @@ function(create_python_example example)
   add_test(
     NAME ${example_test}
     COMMAND
-      "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/api/python/${example}.py"
+      "${Python_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/api/python/${example}.py"
   )
   set_tests_properties(${example_test} PROPERTIES
     LABELS "example"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1309,7 +1309,7 @@ add_custom_command(
   COMMAND
     ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/options
   COMMAND
-    ${PYTHON_EXECUTABLE}
+    ${Python_EXECUTABLE}
     ${CMAKE_CURRENT_LIST_DIR}/options/mkoptions.py
     ${CMAKE_CURRENT_LIST_DIR}
     ${CMAKE_BINARY_DIR}

--- a/src/api/java/CMakeLists.txt
+++ b/src/api/java/CMakeLists.txt
@@ -28,7 +28,7 @@ add_custom_command(
   OUTPUT
     ${JAVA_KIND_FILE}
   COMMAND
-    "${PYTHON_EXECUTABLE}"
+    "${Python_EXECUTABLE}"
     "${CMAKE_CURRENT_BINARY_DIR}/genenums.py"
     --enums-header "${PROJECT_SOURCE_DIR}/src/api/cpp/cvc5_kind.h"
     --java-api-path "${CMAKE_CURRENT_BINARY_DIR}/io/github/"
@@ -47,7 +47,7 @@ add_custom_command(
   OUTPUT
     ${JAVA_SORT_KIND_FILE}
   COMMAND
-    "${PYTHON_EXECUTABLE}"
+    "${Python_EXECUTABLE}"
     "${CMAKE_CURRENT_BINARY_DIR}/genenums.py"
     --enums-header "${PROJECT_SOURCE_DIR}/src/api/cpp/cvc5_sort_kind.h"
     --java-api-path "${CMAKE_CURRENT_BINARY_DIR}/io/github/"
@@ -68,7 +68,7 @@ add_custom_command(
   OUTPUT
   ${JAVA_TYPES_FILES}
   COMMAND
-    "${PYTHON_EXECUTABLE}"
+    "${Python_EXECUTABLE}"
     "${CMAKE_CURRENT_BINARY_DIR}/genenums.py"
     --enums-header "${PROJECT_SOURCE_DIR}/src/api/cpp/cvc5_types.h"
     --java-api-path "${CMAKE_CURRENT_BINARY_DIR}/io/github/"

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -43,8 +43,7 @@ endif()
 # Required for Cython target below
 list(APPEND CMAKE_MODULE_PATH ${SKBUILD_CMAKE_MODULE_PATH})
 
-# nocheckin
-# find_package(PythonExtensions REQUIRED)
+find_package(PythonExtensions REQUIRED)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   # As a temporary workaround, we do not support python 3.11 due to the problem described above.

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -43,7 +43,8 @@ endif()
 # Required for Cython target below
 list(APPEND CMAKE_MODULE_PATH ${SKBUILD_CMAKE_MODULE_PATH})
 
-find_package(PythonExtensions REQUIRED)
+# nocheckin
+# find_package(PythonExtensions REQUIRED)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   # As a temporary workaround, we do not support python 3.11 due to the problem described above.

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -46,9 +46,10 @@ list(APPEND CMAKE_MODULE_PATH ${SKBUILD_CMAKE_MODULE_PATH})
 find_package(PythonExtensions REQUIRED)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  # As a temporary workaround, we do not support python 3.11 due to the problem described above.
-  # Once this issue (https://github.com/actions/setup-python/issues/577) is
-  # solved, we will be able to add support to version 3.11.
+  # Python 3.11 is not supported because of this issue in Github's CI automation system:
+  #    https://github.com/actions/setup-python/issues/577
+  # It is possible to work around this issue by hardcoding 
+  # the greatest supported python version:
   find_package(Python 3.6...<3.11 COMPONENTS Development)
   set(PYTHON_INCLUDE_DIRS "${Python_INCLUDE_DIRS}")
   set(PYTHON_LIBRARY "${Python_LIBRARIES}")

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -24,7 +24,7 @@ check_python_module("setuptools")
 # They are distributed under <scikit-build directory>/resources/cmake
 execute_process(
   COMMAND
-    ${PYTHON_EXECUTABLE} -c "from __future__ import print_function; \
+    ${Python_EXECUTABLE} -c "from __future__ import print_function; \
       import os; import skbuild; \
       cmake_module_path=os.path.join(os.path.dirname(skbuild.__file__), \
         'resources', 'cmake'); print(cmake_module_path, end='')"
@@ -45,15 +45,7 @@ list(APPEND CMAKE_MODULE_PATH ${SKBUILD_CMAKE_MODULE_PATH})
 
 find_package(PythonExtensions REQUIRED)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND
-   CMAKE_VERSION VERSION_GREATER_EQUAL "3.12")
-  # On macOS, find_package(PythonLibs ...) does not find the Python include
-  # directory or library when they were installed via homebrew.
-  # find_package(Python ...) is more robust, but only available on newer
-  # versions of CMake. If we are compiling cvc5 on macOS and we have a newer
-  # version of CMake available, we try to use find_package(Python ...) to find
-  # the paths.
-
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   # As a temporary workaround, we do not support python 3.11 due to the problem described above.
   # Once this issue (https://github.com/actions/setup-python/issues/577) is
   # solved, we will be able to add support to version 3.11.
@@ -77,7 +69,7 @@ add_custom_command(
   OUTPUT
     ${GENERATED_KINDS_FILES}
   COMMAND
-    "${PYTHON_EXECUTABLE}"
+    "${Python_EXECUTABLE}"
     "${CMAKE_CURRENT_BINARY_DIR}/genenums.py"
     --enums-header "${PROJECT_SOURCE_DIR}/src/api/cpp/cvc5_kind.h"
     --enums-file-prefix "${CMAKE_CURRENT_BINARY_DIR}/cvc5kinds"
@@ -97,7 +89,7 @@ add_custom_command(
   OUTPUT
     ${GENERATED_SORT_KINDS_FILES}
   COMMAND
-    "${PYTHON_EXECUTABLE}"
+    "${Python_EXECUTABLE}"
     "${CMAKE_CURRENT_BINARY_DIR}/genenums.py"
     --enums-header "${PROJECT_SOURCE_DIR}/src/api/cpp/cvc5_sort_kind.h"
     --enums-file-prefix "${CMAKE_CURRENT_BINARY_DIR}/cvc5sortkinds"
@@ -116,7 +108,7 @@ add_custom_command(
   OUTPUT
     ${GENERATED_TYPES_FILES}
   COMMAND
-    "${PYTHON_EXECUTABLE}"
+    "${Python_EXECUTABLE}"
     "${CMAKE_CURRENT_BINARY_DIR}/genenums.py"
     --enums-header "${PROJECT_SOURCE_DIR}/src/api/cpp/cvc5_types.h"
     --enums-file-prefix "${CMAKE_CURRENT_BINARY_DIR}/cvc5types"
@@ -202,13 +194,13 @@ configure_file(__init__.py.in cvc5/__init__.py)
 # figure out if we're in a virtualenv
 execute_process(OUTPUT_VARIABLE IN_VIRTUALENV
   COMMAND
-  "${PYTHON_EXECUTABLE}"
+  "${Python_EXECUTABLE}"
   -c
   "from __future__ import print_function; import os;
 print('YES' if 'VIRTUAL_ENV' in os.environ else 'NO', end='')")
 
 set(INSTALL_CMD
-    "${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py install")
+    "${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py install")
 # if we're in a virtualenv, we install it in the virtualenv lib location
 # otherwise install in site-packages
 # option --single-version-externally-managed prevents it from being

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -45,15 +45,12 @@ list(APPEND CMAKE_MODULE_PATH ${SKBUILD_CMAKE_MODULE_PATH})
 
 find_package(PythonExtensions REQUIRED)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  # Python 3.11 is not supported because of this issue in Github's CI automation system:
-  #    https://github.com/actions/setup-python/issues/577
-  # It is possible to work around this issue by hardcoding 
-  # the greatest supported python version:
-  find_package(Python 3.6...<3.11 COMPONENTS Development)
-  set(PYTHON_INCLUDE_DIRS "${Python_INCLUDE_DIRS}")
-  set(PYTHON_LIBRARY "${Python_LIBRARIES}")
-endif()
+# 'PythonExtensions' is not yet compatible with cmake's new 'FindPython'.
+#     https://github.com/scikit-build/scikit-build/issues/506
+# We define the following symbols below to be backward compatible.
+find_package(Python 3.6...<3.11 COMPONENTS Development)
+set(PYTHON_INCLUDE_DIRS "${Python_INCLUDE_DIRS}")
+set(PYTHON_LIBRARY "${Python_LIBRARIES}")
 
 find_package(Cython 0.29 REQUIRED)
 

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -51,7 +51,7 @@ file(GLOB_RECURSE source_files
 
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/Trace_tags.h
-  COMMAND ${PYTHON_EXECUTABLE} ${collect_tags_script} ${CMAKE_CURRENT_BINARY_DIR}/ ${PROJECT_SOURCE_DIR}/src
+  COMMAND ${Python_EXECUTABLE} ${collect_tags_script} ${CMAKE_CURRENT_BINARY_DIR}/ ${PROJECT_SOURCE_DIR}/src
   DEPENDS ${collect_tags_script} ${source_files}
 )
 

--- a/test/api/python/CMakeLists.txt
+++ b/test/api/python/CMakeLists.txt
@@ -13,8 +13,6 @@
 # The build system configuration.
 ##
 
-find_package(Python3 3.6...<3.11 COMPONENTS Interpreter Development)
-
 # Add Python bindings API tests.
 macro(cvc5_add_python_api_test name filename)
 # We create test target 'api/python/myapitest' and run it with

--- a/test/api/python/CMakeLists.txt
+++ b/test/api/python/CMakeLists.txt
@@ -13,13 +13,15 @@
 # The build system configuration.
 ##
 
+find_package(Python3 3.6...<3.11 COMPONENTS Interpreter Development)
+
 # Add Python bindings API tests.
 macro(cvc5_add_python_api_test name filename)
 # We create test target 'api/python/myapitest' and run it with
 # 'ctest -R "api/python/myapitest"'.
   set(test_name api/python/${name})
   add_test (NAME ${test_name}
-    COMMAND ${PYTHON_EXECUTABLE}
+    COMMAND ${Python_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/${filename}
     # directory for importing the python bindings
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src/api/python)

--- a/test/binary/CMakeLists.txt
+++ b/test/binary/CMakeLists.txt
@@ -22,7 +22,7 @@ if (USE_EDITLINE)
 
   # Check for pexpect -- zero return code is success
   execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import pexpect"
+    COMMAND ${Python_EXECUTABLE} -c "import pexpect"
     RESULT_VARIABLE PEXPECT_RC
     ERROR_QUIET
   )
@@ -34,7 +34,7 @@ if (USE_EDITLINE)
     add_test(
       NAME interactive_shell
       COMMAND
-      "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/test/binary/interactive_shell.py"
+      "${Python_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/test/binary/interactive_shell.py"
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
     )
     set_tests_properties(interactive_shell PROPERTIES LABELS "binary")

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -3485,7 +3485,7 @@ macro(cvc5_add_regression_test level file)
   endif()
 
   add_test(${file}
-    ${PYTHON_EXECUTABLE}
+    ${Python_EXECUTABLE}
     ${run_regress_script}
     ${RUN_REGRESSION_ARGS}
     --lfsc-binary ${CMAKE_SOURCE_DIR}/deps/bin/lfscc

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -3494,22 +3494,10 @@ macro(cvc5_add_regression_test level file)
     ${path_to_cvc5}/cvc5${CMAKE_EXECUTABLE_SUFFIX}
     ${CMAKE_CURRENT_LIST_DIR}/${file})
   set_tests_properties(${file} PROPERTIES LABELS "regress${level}")
-
-  # For CMake 3.9.0 and newer, skipped tests do not count as a failure anymore:
-  # https://cmake.org/cmake/help/latest/release/3.9.html#other-changes
-  # This means that for newer versions, we can use the SKIP_RETURN_CODE to mark
-  # skipped tests as such.
-  if(NOT ${CMAKE_VERSION} VERSION_LESS "3.9.0")
-    set_tests_properties(${file} PROPERTIES SKIP_RETURN_CODE 77)
-  endif()
+  set_tests_properties(${file} PROPERTIES SKIP_RETURN_CODE 77)
 endmacro()
 
-if(NOT ${CMAKE_VERSION} VERSION_LESS "3.9.0")
-  # For CMake 3.9.0 and newer, we want the regression script to return 77 for
-  # skipped tests, such that we can mark them as skipped. See the
-  # `cvc5_add_regression_test` macro for more details.
-  set(RUN_REGRESSION_ARGS ${RUN_REGRESSION_ARGS} --use-skip-return-code)
-endif()
+set(RUN_REGRESSION_ARGS ${RUN_REGRESSION_ARGS} --use-skip-return-code)
 
 foreach(file ${regress_0_tests})
   cvc5_add_regression_test(0 ${file})

--- a/test/unit/api/python/CMakeLists.txt
+++ b/test/unit/api/python/CMakeLists.txt
@@ -22,7 +22,7 @@ macro(cvc5_add_python_api_unit_test name filename)
 # 'ctest -R "unit/api/python/myapitest"'.
   set(test_name unit/api/python/${name})
   add_test (NAME ${test_name}
-    COMMAND ${PYTHON_EXECUTABLE}
+    COMMAND ${Python_EXECUTABLE}
             -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/${filename}
     # directory for importing the python bindings
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src/api/python)


### PR DESCRIPTION
I increased cmake's minimum version in order to use the FindPython module, which allows the build system to specify python versions that are supported. Currently the support is extended to 3.6 through 3.10. I also removed some backward compatible conditions that do not apply anymore provided that cmake's minimum version is guaranteed to be 3.12. 