### PR TITLE
Add the smt2 Flex parser

### DIFF
--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -77,6 +77,8 @@ set(libcvc5parser_src_files
   smt2/smt2_lexer.h
   smt2/smt2_input.cpp
   smt2/smt2_input.h
+  smt2/smt2_parser.cpp
+  smt2/smt2_parser.h
   smt2/smt2_term_parser.cpp
   smt2/smt2_term_parser.h
   smt2/sygus_input.cpp

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -75,6 +75,8 @@ set(libcvc5parser_src_files
   smt2/smt2_cmd_parser.h
   smt2/smt2_lexer.cpp
   smt2/smt2_lexer.h
+  smt2/smt2_cmd_parser.cpp
+  smt2/smt2_cmd_parser.h
   smt2/smt2_input.cpp
   smt2/smt2_input.h
   smt2/smt2_parser.cpp

--- a/src/parser/smt2/smt2_parser.cpp
+++ b/src/parser/smt2/smt2_parser.cpp
@@ -1,0 +1,57 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2022 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The flex smt2 parser.
+ */
+
+#include "parser/smt2/smt2_parser.h"
+
+#include "base/output.h"
+#include "parser/api/cpp/command.h"
+
+namespace cvc5 {
+namespace parser {
+
+Smt2Parser::Smt2Parser(Solver* solver,
+                       SymbolManager* sm,
+                       bool strictMode,
+                       bool isSygus)
+    : FlexParser(solver, sm),
+      d_slex(isSygus, strictMode),
+      d_state(this, solver, sm, strictMode, isSygus),
+      d_termParser(d_slex, d_state),
+      d_cmdParser(d_slex, d_state, d_termParser)
+{
+  d_lex = &d_slex;
+}
+
+Command* Smt2Parser::parseNextCommand()
+{
+  // !!! note that the memory management of commands will change after we
+  // remove the ANTLR parser.
+  std::unique_ptr<Command> cmd = d_cmdParser.parseNextCommand();
+  return cmd.release();
+}
+
+Term Smt2Parser::parseNextExpression()
+{
+  // check for EOF here and return null if so
+  Token tok = d_slex.peekToken();
+  if (tok == Token::EOF_TOK)
+  {
+    return Term();
+  }
+  return d_termParser.parseTerm();
+}
+
+}  // namespace parser
+}  // namespace cvc5

--- a/src/parser/smt2/smt2_parser.h
+++ b/src/parser/smt2/smt2_parser.h
@@ -1,0 +1,66 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2022 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The flex smt2 parser.
+ */
+
+#include "cvc5parser_public.h"
+
+#ifndef CVC5__PARSER__SMT2__SMT2_PARSER_H
+#define CVC5__PARSER__SMT2__SMT2_PARSER_H
+
+#include "api/cpp/cvc5.h"
+#include "parser/flex_parser.h"
+#include "parser/smt2/smt2.h"
+#include "parser/smt2/smt2_cmd_parser.h"
+#include "parser/smt2/smt2_lexer.h"
+#include "parser/smt2/smt2_term_parser.h"
+
+namespace cvc5 {
+namespace parser {
+
+/**
+ * Flex-based smt2 parser. It maintains a lexer, a state, a term parser and a
+ * command parser. The latter two are used for parsing terms and commands. The
+ * command parser depends on the term parser.
+ */
+class Smt2Parser : public FlexParser
+{
+ public:
+  Smt2Parser(Solver* solver,
+             SymbolManager* sm,
+             bool strictMode = false,
+             bool isSygus = false);
+  virtual ~Smt2Parser() {}
+
+ protected:
+  /**
+   * Parse and return the next command.
+   */
+  Command* parseNextCommand() override;
+
+  /** Parse and return the next expression. */
+  Term parseNextExpression() override;
+  /** The lexer */
+  Smt2Lexer d_slex;
+  /** The state */
+  Smt2State d_state;
+  /** Term parser */
+  Smt2TermParser d_termParser;
+  /** Command parser */
+  Smt2CmdParser d_cmdParser;
+};
+
+}  // namespace parser
+}  // namespace cvc5
+
+#endif /* CVC5__PARSER__SMT2_H */


### PR DESCRIPTION
This implements the two necessary methods for the parser interface: parsing commands and terms, using the previously introduced classes.