### PR TITLE
cmake: Fix flex detection for Apple Silicon homebrew.

### DIFF
--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -20,7 +20,8 @@ find_package(Java COMPONENTS Runtime REQUIRED)
 
 # Search for flex installed via homebrew.
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/flex")
+  list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/flex") # macOS Intel
+  list(APPEND CMAKE_PREFIX_PATH "/opt/homebrew/opt/flex") # macOS Apple Silicon
 endif()
 find_package(FLEX REQUIRED)
 


### PR DESCRIPTION
Adds Apple Silicon homebrew path for flex to CMAKE_PREFIX_PATH.

Fixes #9459