### PR TITLE
Pass optional output stream to computeType methods

### DIFF
--- a/src/expr/mkexpr
+++ b/src/expr/mkexpr
@@ -157,7 +157,7 @@ function typerule {
   check_theory_seen
   typerules="${typerules}
   case kind::$1:
-    typeNode = $2::computeType(nodeManager, n, check);
+    typeNode = $2::computeType(nodeManager, n, check, errOut);
     break;
 "
 }

--- a/src/expr/node_manager_template.cpp
+++ b/src/expr/node_manager_template.cpp
@@ -483,7 +483,7 @@ std::vector<NodeValue*> NodeManager::TopologicalSort(
   return order;
 } /* NodeManager::TopologicalSort() */
 
-TypeNode NodeManager::getType(TNode n, bool check)
+TypeNode NodeManager::getType(TNode n, bool check, std::ostream* errOut)
 {
   TypeNode typeNode;
   bool hasType = getAttribute(n, TypeAttr(), typeNode);
@@ -527,7 +527,7 @@ TypeNode NodeManager::getType(TNode n, bool check)
       {
         Assert(check || m.getMetaKind() != kind::metakind::NULLARY_OPERATOR);
         /* All the children have types, time to compute */
-        typeNode = TypeChecker::computeType(this, m, check);
+        typeNode = TypeChecker::computeType(this, m, check, errOut);
         worklist.pop();
       }
     }  // end while

--- a/src/expr/node_manager_template.h
+++ b/src/expr/node_manager_template.h
@@ -335,8 +335,9 @@ class NodeManager
    * @param n the Node for which we want a type
    * @param check whether we should check the type as we compute it
    * (default: false)
+   * @param errOut An (optional) output stream to print type checking errors
    */
-  TypeNode getType(TNode n, bool check = false);
+  TypeNode getType(TNode n, bool check = false, std::ostream* errOut = nullptr);
 
   /** Get the (singleton) type for Booleans. */
   TypeNode booleanType();

--- a/src/expr/type_checker.h
+++ b/src/expr/type_checker.h
@@ -26,7 +26,6 @@ namespace expr {
 
 class TypeChecker {
 public:
- static TypeNode preComputeType(NodeManager* nodeManager, TNode n);
  static TypeNode computeType(NodeManager* nodeManager,
                              TNode n,
                              bool check = false,

--- a/src/expr/type_checker.h
+++ b/src/expr/type_checker.h
@@ -26,9 +26,11 @@ namespace expr {
 
 class TypeChecker {
 public:
+ static TypeNode preComputeType(NodeManager* nodeManager, TNode n);
  static TypeNode computeType(NodeManager* nodeManager,
                              TNode n,
-                             bool check = false);
+                             bool check = false,
+                             std::ostream* errOut = nullptr);
 
  static bool computeIsConst(NodeManager* nodeManager, TNode n);
 

--- a/src/expr/type_checker_template.cpp
+++ b/src/expr/type_checker_template.cpp
@@ -27,17 +27,22 @@ ${typechecker_includes}
 namespace cvc5::internal {
 namespace expr {
 
-TypeNode TypeChecker::computeType(NodeManager* nodeManager,
-                                  TNode n,
-                                  bool check,
-                                  std::ostream* errOut)
+TypeNode TypeChecker::computeType(NodeManager* nodeManager, TNode n, bool check)
 {
   TypeNode typeNode;
 
   // Infer the type
   switch (n.getKind())
   {
-    // clang-format off
+    case kind::VARIABLE:
+    case kind::SKOLEM:
+      typeNode = nodeManager->getAttribute(n, TypeAttr());
+      break;
+    case kind::BUILTIN:
+      typeNode = nodeManager->builtinOperatorType();
+      break;
+
+      // clang-format off
 ${typerules}
       // clang-format on
 
@@ -45,9 +50,14 @@ ${typerules}
       Trace("getType") << "FAILURE" << std::endl;
       Unhandled() << " " << n.getKind();
   }
+
+  nodeManager->setAttribute(n, TypeAttr(), typeNode);
+  nodeManager->setAttribute(n, TypeCheckedAttr(),
+                            check || nodeManager->getAttribute(n, TypeCheckedAttr()));
+
   return typeNode;
 
-} /* TypeChecker::computeType */
+}/* TypeChecker::computeType */
 
 bool TypeChecker::computeIsConst(NodeManager* nodeManager, TNode n)
 {

--- a/src/expr/type_checker_template.cpp
+++ b/src/expr/type_checker_template.cpp
@@ -27,22 +27,17 @@ ${typechecker_includes}
 namespace cvc5::internal {
 namespace expr {
 
-TypeNode TypeChecker::computeType(NodeManager* nodeManager, TNode n, bool check)
+TypeNode TypeChecker::computeType(NodeManager* nodeManager,
+                                  TNode n,
+                                  bool check,
+                                  std::ostream* errOut)
 {
   TypeNode typeNode;
 
   // Infer the type
   switch (n.getKind())
   {
-    case kind::VARIABLE:
-    case kind::SKOLEM:
-      typeNode = nodeManager->getAttribute(n, TypeAttr());
-      break;
-    case kind::BUILTIN:
-      typeNode = nodeManager->builtinOperatorType();
-      break;
-
-      // clang-format off
+    // clang-format off
 ${typerules}
       // clang-format on
 
@@ -50,14 +45,9 @@ ${typerules}
       Trace("getType") << "FAILURE" << std::endl;
       Unhandled() << " " << n.getKind();
   }
-
-  nodeManager->setAttribute(n, TypeAttr(), typeNode);
-  nodeManager->setAttribute(n, TypeCheckedAttr(),
-                            check || nodeManager->getAttribute(n, TypeCheckedAttr()));
-
   return typeNode;
 
-}/* TypeChecker::computeType */
+} /* TypeChecker::computeType */
 
 bool TypeChecker::computeIsConst(NodeManager* nodeManager, TNode n)
 {

--- a/src/expr/type_checker_template.cpp
+++ b/src/expr/type_checker_template.cpp
@@ -27,7 +27,9 @@ ${typechecker_includes}
 namespace cvc5::internal {
 namespace expr {
 
-TypeNode TypeChecker::computeType(NodeManager* nodeManager, TNode n, bool check,
+TypeNode TypeChecker::computeType(NodeManager* nodeManager,
+                                  TNode n,
+                                  bool check,
                                   std::ostream* errOut)
 {
   TypeNode typeNode;

--- a/src/expr/type_checker_template.cpp
+++ b/src/expr/type_checker_template.cpp
@@ -27,7 +27,8 @@ ${typechecker_includes}
 namespace cvc5::internal {
 namespace expr {
 
-TypeNode TypeChecker::computeType(NodeManager* nodeManager, TNode n, bool check)
+TypeNode TypeChecker::computeType(NodeManager* nodeManager, TNode n, bool check,
+                                  std::ostream* errOut)
 {
   TypeNode typeNode;
 

--- a/src/expr/type_checker_util.h
+++ b/src/expr/type_checker_util.h
@@ -185,10 +185,6 @@ class SimpleTypeRule
     }
     return R::mkType(nm);
   }
-  static TypeNode preComputeType(NodeManager* nm, TNode n)
-  {
-    return R::mkType(nm);
-  }
 };
 
 /** 
@@ -218,10 +214,6 @@ class SimpleTypeRuleVar
         }
       }
     }
-    return R::mkType(nm);
-  }
-  static TypeNode preComputeType(NodeManager* nm, TNode n)
-  {
     return R::mkType(nm);
   }
 };

--- a/src/expr/type_checker_util.h
+++ b/src/expr/type_checker_util.h
@@ -154,7 +154,10 @@ template <class R, class A0 = ANone, class A1 = ANone, class A2 = ANone>
 class SimpleTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nm, TNode n, bool check)
+  static TypeNode computeType(NodeManager* nm,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut)
   {
     if (check)
     {
@@ -182,6 +185,10 @@ class SimpleTypeRule
     }
     return R::mkType(nm);
   }
+  static TypeNode preComputeType(NodeManager* nm, TNode n)
+  {
+    return R::mkType(nm);
+  }
 };
 
 /** 
@@ -193,7 +200,10 @@ template <class R, class A>
 class SimpleTypeRuleVar
 {
  public:
-  static TypeNode computeType(NodeManager* nm, TNode n, bool check)
+  static TypeNode computeType(NodeManager* nm,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut)
   {
     if (check)
     {
@@ -208,6 +218,10 @@ class SimpleTypeRuleVar
         }
       }
     }
+    return R::mkType(nm);
+  }
+  static TypeNode preComputeType(NodeManager* nm, TNode n)
+  {
     return R::mkType(nm);
   }
 };

--- a/src/theory/arith/theory_arith_type_rules.cpp
+++ b/src/theory/arith/theory_arith_type_rules.cpp
@@ -23,7 +23,8 @@ namespace arith {
 
 TypeNode ArithConstantTypeRule::computeType(NodeManager* nodeManager,
                                             TNode n,
-                                            bool check)
+                                            bool check,
+                                            std::ostream* errOut)
 {
   // we use different kinds for constant integers and reals
   if (n.getKind() == kind::CONST_RATIONAL)
@@ -45,20 +46,22 @@ TypeNode ArithConstantTypeRule::computeType(NodeManager* nodeManager,
 }
 
 TypeNode ArithRealAlgebraicNumberOpTypeRule::computeType(
-    NodeManager* nodeManager, TNode n, bool check)
+    NodeManager* nodeManager, TNode n, bool check, std::ostream* errOut)
 {
   return nodeManager->realType();
 }
 TypeNode ArithRealAlgebraicNumberTypeRule::computeType(NodeManager* nodeManager,
                                                        TNode n,
-                                                       bool check)
+                                                       bool check,
+                                                       std::ostream* errOut)
 {
   return nodeManager->realType();
 }
 
 TypeNode ArithOperatorTypeRule::computeType(NodeManager* nodeManager,
                                             TNode n,
-                                            bool check)
+                                            bool check,
+                                            std::ostream* errOut)
 {
   TypeNode integerType = nodeManager->integerType();
   TypeNode realType = nodeManager->realType();
@@ -104,7 +107,8 @@ TypeNode ArithOperatorTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode ArithRelationTypeRule::computeType(NodeManager* nodeManager,
                                             TNode n,
-                                            bool check)
+                                            bool check,
+                                            std::ostream* errOut)
 {
   if (check)
   {
@@ -121,7 +125,8 @@ TypeNode ArithRelationTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode RealNullaryOperatorTypeRule::computeType(NodeManager* nodeManager,
                                                   TNode n,
-                                                  bool check)
+                                                  bool check,
+                                                  std::ostream* errOut)
 {
   // for nullary operators, we only computeType for check=true, since they are
   // given TypeAttr() on creation
@@ -136,7 +141,8 @@ TypeNode RealNullaryOperatorTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode IAndOpTypeRule::computeType(NodeManager* nodeManager,
                                      TNode n,
-                                     bool check)
+                                     bool check,
+                                     std::ostream* errOut)
 {
   if (n.getKind() != kind::IAND_OP)
   {
@@ -151,7 +157,8 @@ TypeNode IAndOpTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode IAndTypeRule::computeType(NodeManager* nodeManager,
                                    TNode n,
-                                   bool check)
+                                   bool check,
+                                   std::ostream* errOut)
 {
   if (n.getKind() != kind::IAND)
   {
@@ -171,7 +178,8 @@ TypeNode IAndTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode Pow2TypeRule::computeType(NodeManager* nodeManager,
                                    TNode n,
-                                   bool check)
+                                   bool check,
+                                   std::ostream* errOut)
 {
   if (n.getKind() != kind::POW2)
   {
@@ -190,7 +198,8 @@ TypeNode Pow2TypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode IndexedRootPredicateTypeRule::computeType(NodeManager* nodeManager,
                                                    TNode n,
-                                                   bool check)
+                                                   bool check,
+                                                   std::ostream* errOut)
 {
   if (check)
   {

--- a/src/theory/arith/theory_arith_type_rules.h
+++ b/src/theory/arith/theory_arith_type_rules.h
@@ -32,7 +32,10 @@ namespace arith {
 class ArithConstantTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -42,7 +45,10 @@ class ArithConstantTypeRule
 class ArithRealAlgebraicNumberOpTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -52,7 +58,10 @@ class ArithRealAlgebraicNumberOpTypeRule
 class ArithRealAlgebraicNumberTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -62,7 +71,10 @@ class ArithRealAlgebraicNumberTypeRule
 class ArithRelationTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -72,14 +84,20 @@ class ArithRelationTypeRule
 class ArithOperatorTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /** Type rule for nullary real operators. */
 class RealNullaryOperatorTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -89,7 +107,10 @@ class RealNullaryOperatorTypeRule
 class IAndOpTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -99,7 +120,10 @@ class IAndOpTypeRule
 class IAndTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -109,7 +133,10 @@ class IAndTypeRule
 class Pow2TypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -120,7 +147,10 @@ class Pow2TypeRule
 class IndexedRootPredicateTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 }  // namespace arith

--- a/src/theory/arrays/theory_arrays_type_rules.cpp
+++ b/src/theory/arrays/theory_arrays_type_rules.cpp
@@ -28,7 +28,8 @@ namespace arrays {
 
 TypeNode ArraySelectTypeRule::computeType(NodeManager* nodeManager,
                                           TNode n,
-                                          bool check)
+                                          bool check,
+                                          std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SELECT);
   TypeNode arrayType = n[0].getType(check);
@@ -51,7 +52,8 @@ TypeNode ArraySelectTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode ArrayStoreTypeRule::computeType(NodeManager* nodeManager,
                                          TNode n,
-                                         bool check)
+                                         bool check,
+                                         std::ostream* errOut)
 {
   if (n.getKind() == kind::STORE)
   {
@@ -179,7 +181,8 @@ bool ArrayStoreTypeRule::computeIsConst(NodeManager* nodeManager, TNode n)
 
 TypeNode ArrayTableFunTypeRule::computeType(NodeManager* nodeManager,
                                             TNode n,
-                                            bool check)
+                                            bool check,
+                                            std::ostream* errOut)
 {
   Assert(n.getKind() == kind::ARR_TABLE_FUN);
   TypeNode arrayType = n[0].getType(check);
@@ -214,7 +217,8 @@ TypeNode ArrayTableFunTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode ArrayLambdaTypeRule::computeType(NodeManager* nodeManager,
                                           TNode n,
-                                          bool check)
+                                          bool check,
+                                          std::ostream* errOut)
 {
   Assert(n.getKind() == kind::ARRAY_LAMBDA);
   TypeNode lamType = n[0].getType(check);
@@ -273,7 +277,8 @@ Node ArraysProperties::mkGroundTerm(TypeNode type)
 
 TypeNode ArrayPartialSelectTypeRule::computeType(NodeManager* nodeManager,
                                                  TNode n,
-                                                 bool check)
+                                                 bool check,
+                                                 std::ostream* errOut)
 {
   Assert(n.getKind() == kind::PARTIAL_SELECT_0
          || n.getKind() == kind::PARTIAL_SELECT_1);
@@ -282,7 +287,8 @@ TypeNode ArrayPartialSelectTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode ArrayEqRangeTypeRule::computeType(NodeManager* nodeManager,
                                            TNode n,
-                                           bool check)
+                                           bool check,
+                                           std::ostream* errOut)
 {
   Assert(n.getKind() == kind::EQ_RANGE);
   if (check)

--- a/src/theory/arrays/theory_arrays_type_rules.h
+++ b/src/theory/arrays/theory_arrays_type_rules.h
@@ -27,24 +27,36 @@ namespace arrays {
 
 struct ArraySelectTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 struct ArrayStoreTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 
   static bool computeIsConst(NodeManager* nodeManager, TNode n);
 };
 
 struct ArrayTableFunTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 struct ArrayLambdaTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 struct ArraysProperties
@@ -58,12 +70,18 @@ struct ArraysProperties
 
 struct ArrayPartialSelectTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 struct ArrayEqRangeTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 }  // namespace arrays

--- a/src/theory/bags/theory_bags_type_rules.cpp
+++ b/src/theory/bags/theory_bags_type_rules.cpp
@@ -35,7 +35,8 @@ using namespace datatypes;
 
 TypeNode BinaryOperatorTypeRule::computeType(NodeManager* nodeManager,
                                              TNode n,
-                                             bool check)
+                                             bool check,
+                                             std::ostream* errOut)
 {
   Assert(n.getKind() == kind::BAG_UNION_MAX
          || n.getKind() == kind::BAG_UNION_DISJOINT
@@ -73,7 +74,8 @@ bool BinaryOperatorTypeRule::computeIsConst(NodeManager* nodeManager, TNode n)
 
 TypeNode SubBagTypeRule::computeType(NodeManager* nodeManager,
                                      TNode n,
-                                     bool check)
+                                     bool check,
+                                     std::ostream* errOut)
 {
   Assert(n.getKind() == kind::BAG_SUBBAG);
   TypeNode bagType = n[0].getType(check);
@@ -95,7 +97,8 @@ TypeNode SubBagTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode CountTypeRule::computeType(NodeManager* nodeManager,
                                     TNode n,
-                                    bool check)
+                                    bool check,
+                                    std::ostream* errOut)
 {
   Assert(n.getKind() == kind::BAG_COUNT);
   TypeNode bagType = n[1].getType(check);
@@ -124,7 +127,8 @@ TypeNode CountTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode MemberTypeRule::computeType(NodeManager* nodeManager,
                                      TNode n,
-                                     bool check)
+                                     bool check,
+                                     std::ostream* errOut)
 {
   Assert(n.getKind() == kind::BAG_MEMBER);
   TypeNode bagType = n[1].getType(check);
@@ -153,7 +157,8 @@ TypeNode MemberTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode DuplicateRemovalTypeRule::computeType(NodeManager* nodeManager,
                                                TNode n,
-                                               bool check)
+                                               bool check,
+                                               std::ostream* errOut)
 {
   Assert(n.getKind() == kind::BAG_DUPLICATE_REMOVAL);
   TypeNode bagType = n[0].getType(check);
@@ -170,7 +175,10 @@ TypeNode DuplicateRemovalTypeRule::computeType(NodeManager* nodeManager,
   return bagType;
 }
 
-TypeNode BagMakeTypeRule::computeType(NodeManager* nm, TNode n, bool check)
+TypeNode BagMakeTypeRule::computeType(NodeManager* nm,
+                                      TNode n,
+                                      bool check,
+                                      std::ostream* errOut)
 {
   Assert(n.getKind() == kind::BAG_MAKE);
   TypeNode actualElementType = n[0].getType(check);
@@ -206,7 +214,8 @@ bool BagMakeTypeRule::computeIsConst(NodeManager* nodeManager, TNode n)
 
 TypeNode IsSingletonTypeRule::computeType(NodeManager* nodeManager,
                                           TNode n,
-                                          bool check)
+                                          bool check,
+                                          std::ostream* errOut)
 {
   Assert(n.getKind() == kind::BAG_IS_SINGLETON);
   TypeNode bagType = n[0].getType(check);
@@ -223,7 +232,8 @@ TypeNode IsSingletonTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode EmptyBagTypeRule::computeType(NodeManager* nodeManager,
                                        TNode n,
-                                       bool check)
+                                       bool check,
+                                       std::ostream* errOut)
 {
   Assert(n.getKind() == kind::BAG_EMPTY);
   EmptyBag emptyBag = n.getConst<EmptyBag>();
@@ -232,7 +242,8 @@ TypeNode EmptyBagTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode CardTypeRule::computeType(NodeManager* nodeManager,
                                    TNode n,
-                                   bool check)
+                                   bool check,
+                                   std::ostream* errOut)
 {
   Assert(n.getKind() == kind::BAG_CARD);
   TypeNode bagType = n[0].getType(check);
@@ -249,7 +260,8 @@ TypeNode CardTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode ChooseTypeRule::computeType(NodeManager* nodeManager,
                                      TNode n,
-                                     bool check)
+                                     bool check,
+                                     std::ostream* errOut)
 {
   Assert(n.getKind() == kind::BAG_CHOOSE);
   TypeNode bagType = n[0].getType(check);
@@ -266,7 +278,8 @@ TypeNode ChooseTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode FromSetTypeRule::computeType(NodeManager* nodeManager,
                                       TNode n,
-                                      bool check)
+                                      bool check,
+                                      std::ostream* errOut)
 {
   Assert(n.getKind() == kind::BAG_FROM_SET);
   TypeNode setType = n[0].getType(check);
@@ -285,7 +298,8 @@ TypeNode FromSetTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode ToSetTypeRule::computeType(NodeManager* nodeManager,
                                     TNode n,
-                                    bool check)
+                                    bool check,
+                                    std::ostream* errOut)
 {
   Assert(n.getKind() == kind::BAG_TO_SET);
   TypeNode bagType = n[0].getType(check);
@@ -304,7 +318,8 @@ TypeNode ToSetTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode BagMapTypeRule::computeType(NodeManager* nodeManager,
                                      TNode n,
-                                     bool check)
+                                     bool check,
+                                     std::ostream* errOut)
 {
   Assert(n.getKind() == kind::BAG_MAP);
   TypeNode functionType = n[0].getType(check);
@@ -346,7 +361,8 @@ TypeNode BagMapTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode BagFilterTypeRule::computeType(NodeManager* nodeManager,
                                         TNode n,
-                                        bool check)
+                                        bool check,
+                                        std::ostream* errOut)
 {
   Assert(n.getKind() == kind::BAG_FILTER);
   TypeNode functionType = n[0].getType(check);
@@ -388,7 +404,8 @@ TypeNode BagFilterTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode BagFoldTypeRule::computeType(NodeManager* nodeManager,
                                       TNode n,
-                                      bool check)
+                                      bool check,
+                                      std::ostream* errOut)
 {
   Assert(n.getKind() == kind::BAG_FOLD);
   TypeNode functionType = n[0].getType(check);
@@ -439,7 +456,8 @@ TypeNode BagFoldTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode BagPartitionTypeRule::computeType(NodeManager* nodeManager,
                                            TNode n,
-                                           bool check)
+                                           bool check,
+                                           std::ostream* errOut)
 {
   Assert(n.getKind() == kind::BAG_PARTITION);
   TypeNode functionType = n[0].getType(check);
@@ -483,7 +501,8 @@ TypeNode BagPartitionTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode TableProductTypeRule::computeType(NodeManager* nodeManager,
                                            TNode n,
-                                           bool check)
+                                           bool check,
+                                           std::ostream* errOut)
 {
   Assert(n.getKind() == kind::TABLE_PRODUCT);
   Node A = n[0];
@@ -518,7 +537,10 @@ TypeNode TableProductTypeRule::computeType(NodeManager* nodeManager,
   return retType;
 }
 
-TypeNode TableProjectTypeRule::computeType(NodeManager* nm, TNode n, bool check)
+TypeNode TableProjectTypeRule::computeType(NodeManager* nm,
+                                           TNode n,
+                                           bool check,
+                                           std::ostream* errOut)
 {
   Assert(n.getKind() == kind::TABLE_PROJECT && n.hasOperator()
          && n.getOperator().getKind() == kind::TABLE_PROJECT_OP);
@@ -575,7 +597,8 @@ TypeNode TableProjectTypeRule::computeType(NodeManager* nm, TNode n, bool check)
 
 TypeNode TableAggregateTypeRule::computeType(NodeManager* nm,
                                              TNode n,
-                                             bool check)
+                                             bool check,
+                                             std::ostream* errOut)
 {
   Assert(n.getKind() == kind::TABLE_AGGREGATE && n.hasOperator()
          && n.getOperator().getKind() == kind::TABLE_AGGREGATE_OP);
@@ -639,7 +662,10 @@ TypeNode TableAggregateTypeRule::computeType(NodeManager* nm,
   return nm->mkBagType(functionType.getRangeType());
 }
 
-TypeNode TableJoinTypeRule::computeType(NodeManager* nm, TNode n, bool check)
+TypeNode TableJoinTypeRule::computeType(NodeManager* nm,
+                                        TNode n,
+                                        bool check,
+                                        std::ostream* errOut)
 {
   Assert(n.getKind() == kind::TABLE_JOIN && n.hasOperator()
          && n.getOperator().getKind() == kind::TABLE_JOIN_OP);
@@ -706,7 +732,10 @@ TypeNode TableJoinTypeRule::computeType(NodeManager* nm, TNode n, bool check)
   return nm->mkBagType(retTupleType);
 }
 
-TypeNode TableGroupTypeRule::computeType(NodeManager* nm, TNode n, bool check)
+TypeNode TableGroupTypeRule::computeType(NodeManager* nm,
+                                         TNode n,
+                                         bool check,
+                                         std::ostream* errOut)
 {
   Assert(n.getKind() == kind::TABLE_GROUP && n.hasOperator()
          && n.getOperator().getKind() == kind::TABLE_GROUP_OP);

--- a/src/theory/bags/theory_bags_type_rules.h
+++ b/src/theory/bags/theory_bags_type_rules.h
@@ -35,7 +35,10 @@ namespace bags {
  */
 struct BinaryOperatorTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
   static bool computeIsConst(NodeManager* nodeManager, TNode n);
 }; /* struct BinaryOperatorTypeRule */
 
@@ -45,7 +48,10 @@ struct BinaryOperatorTypeRule
  */
 struct SubBagTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct SubBagTypeRule */
 
 /**
@@ -54,7 +60,10 @@ struct SubBagTypeRule
  */
 struct CountTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct CountTypeRule */
 
 /**
@@ -63,7 +72,10 @@ struct CountTypeRule
  */
 struct MemberTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -71,7 +83,10 @@ struct MemberTypeRule
  */
 struct DuplicateRemovalTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct DuplicateRemovalTypeRule */
 
 /**
@@ -80,7 +95,10 @@ struct DuplicateRemovalTypeRule
  */
 struct BagMakeTypeRule
 {
-  static TypeNode computeType(NodeManager* nm, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nm,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
   static bool computeIsConst(NodeManager* nodeManager, TNode n);
 }; /* struct BagMakeTypeRule */
 
@@ -89,7 +107,10 @@ struct BagMakeTypeRule
  */
 struct IsSingletonTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct IsSingletonTypeRule */
 
 /**
@@ -97,7 +118,10 @@ struct IsSingletonTypeRule
  */
 struct EmptyBagTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct EmptyBagTypeRule */
 
 /**
@@ -105,7 +129,10 @@ struct EmptyBagTypeRule
  */
 struct CardTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct CardTypeRule */
 
 /**
@@ -113,7 +140,10 @@ struct CardTypeRule
  */
 struct ChooseTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct ChooseTypeRule */
 
 /**
@@ -121,7 +151,10 @@ struct ChooseTypeRule
  */
 struct FromSetTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct FromSetTypeRule */
 
 /**
@@ -129,7 +162,10 @@ struct FromSetTypeRule
  */
 struct ToSetTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct ToSetTypeRule */
 
 /**
@@ -138,7 +174,10 @@ struct ToSetTypeRule
  */
 struct BagMapTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct BagMapTypeRule */
 
 /**
@@ -147,7 +186,10 @@ struct BagMapTypeRule
  */
 struct BagFilterTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct BagFilterTypeRule */
 
 /**
@@ -156,7 +198,10 @@ struct BagFilterTypeRule
  */
 struct BagFoldTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct BagFoldTypeRule */
 
 /**
@@ -166,7 +211,10 @@ struct BagFoldTypeRule
  */
 struct BagPartitionTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct BagFoldTypeRule */
 
 /**
@@ -175,7 +223,10 @@ struct BagPartitionTypeRule
  */
 struct TableProductTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct BagFoldTypeRule */
 
 /**
@@ -186,7 +237,10 @@ struct TableProductTypeRule
  */
 struct TableProjectTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct TableProjectTypeRule */
 
 /**
@@ -199,7 +253,10 @@ struct TableProjectTypeRule
  */
 struct TableAggregateTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct TableAggregateTypeRule */
 
 /**
@@ -213,7 +270,10 @@ struct TableAggregateTypeRule
  */
 struct TableJoinTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct TableJoinTypeRule */
 
 /**
@@ -224,7 +284,10 @@ struct TableJoinTypeRule
  */
 struct TableGroupTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct TableGroupTypeRule */
 
 struct BagsProperties

--- a/src/theory/booleans/theory_bool_type_rules.cpp
+++ b/src/theory/booleans/theory_bool_type_rules.cpp
@@ -23,7 +23,8 @@ namespace boolean {
 
 TypeNode BooleanTypeRule::computeType(NodeManager* nodeManager,
                                       TNode n,
-                                      bool check)
+                                      bool check,
+                              std::ostream* errOut)
 {
   TypeNode booleanType = nodeManager->booleanType();
   if (check)
@@ -44,7 +45,8 @@ TypeNode BooleanTypeRule::computeType(NodeManager* nodeManager,
   return booleanType;
 }
 
-TypeNode IteTypeRule::computeType(NodeManager* nodeManager, TNode n, bool check)
+TypeNode IteTypeRule::computeType(NodeManager* nodeManager, TNode n, bool check,
+                              std::ostream* errOut)
 {
   TypeNode thenType = n[1].getType(check);
   if (check)

--- a/src/theory/booleans/theory_bool_type_rules.cpp
+++ b/src/theory/booleans/theory_bool_type_rules.cpp
@@ -24,7 +24,7 @@ namespace boolean {
 TypeNode BooleanTypeRule::computeType(NodeManager* nodeManager,
                                       TNode n,
                                       bool check,
-                              std::ostream* errOut)
+                                      std::ostream* errOut)
 {
   TypeNode booleanType = nodeManager->booleanType();
   if (check)
@@ -45,8 +45,10 @@ TypeNode BooleanTypeRule::computeType(NodeManager* nodeManager,
   return booleanType;
 }
 
-TypeNode IteTypeRule::computeType(NodeManager* nodeManager, TNode n, bool check,
-                              std::ostream* errOut)
+TypeNode IteTypeRule::computeType(NodeManager* nodeManager,
+                                  TNode n,
+                                  bool check,
+                                  std::ostream* errOut)
 {
   TypeNode thenType = n[1].getType(check);
   if (check)

--- a/src/theory/booleans/theory_bool_type_rules.h
+++ b/src/theory/booleans/theory_bool_type_rules.h
@@ -28,13 +28,21 @@ namespace boolean {
 class BooleanTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode preComputeType(NodeManager* nm, TNode n);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class IteTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode preComputeType(NodeManager* nm, TNode n);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 }  // namespace boolean

--- a/src/theory/builtin/theory_builtin_type_rules.cpp
+++ b/src/theory/builtin/theory_builtin_type_rules.cpp
@@ -25,7 +25,8 @@ namespace builtin {
 
 TypeNode EqualityTypeRule::computeType(NodeManager* nodeManager,
                                        TNode n,
-                                       bool check)
+                                       bool check,
+                                       std::ostream* errOut)
 {
   TypeNode booleanType = nodeManager->booleanType();
 
@@ -50,7 +51,8 @@ TypeNode EqualityTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode DistinctTypeRule::computeType(NodeManager* nodeManager,
                                        TNode n,
-                                       bool check)
+                                       bool check,
+                                       std::ostream* errOut)
 {
   if (check)
   {
@@ -72,7 +74,8 @@ TypeNode DistinctTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode SExprTypeRule::computeType(NodeManager* nodeManager,
                                     TNode n,
-                                    bool check)
+                                    bool check,
+                                    std::ostream* errOut)
 {
   if (check)
   {
@@ -86,14 +89,16 @@ TypeNode SExprTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode UninterpretedSortValueTypeRule::computeType(NodeManager* nodeManager,
                                                      TNode n,
-                                                     bool check)
+                                                     bool check,
+                                                     std::ostream* errOut)
 {
   return n.getConst<UninterpretedSortValue>().getType();
 }
 
 TypeNode WitnessTypeRule::computeType(NodeManager* nodeManager,
                                       TNode n,
-                                      bool check)
+                                      bool check,
+                                      std::ostream* errOut)
 {
   if (n[0].getType(check) != nodeManager->boundVarListType())
   {

--- a/src/theory/builtin/theory_builtin_type_rules.h
+++ b/src/theory/builtin/theory_builtin_type_rules.h
@@ -30,31 +30,46 @@ namespace builtin {
 class EqualityTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class DistinctTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class SExprTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class UninterpretedSortValueTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class WitnessTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class SortProperties

--- a/src/theory/bv/theory_bv_type_rules.cpp
+++ b/src/theory/bv/theory_bv_type_rules.cpp
@@ -40,7 +40,8 @@ Cardinality CardinalityComputer::computeCardinality(TypeNode type)
 
 TypeNode BitVectorConstantTypeRule::computeType(NodeManager* nodeManager,
                                                 TNode n,
-                                                bool check)
+                                                bool check,
+                                                std::ostream* errOut)
 {
   if (check)
   {
@@ -54,7 +55,8 @@ TypeNode BitVectorConstantTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode BitVectorFixedWidthTypeRule::computeType(NodeManager* nodeManager,
                                                   TNode n,
-                                                  bool check)
+                                                  bool check,
+                                                  std::ostream* errOut)
 {
   TNode::iterator it = n.begin();
   TypeNode t = (*it).getType(check);
@@ -79,7 +81,8 @@ TypeNode BitVectorFixedWidthTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode BitVectorPredicateTypeRule::computeType(NodeManager* nodeManager,
                                                  TNode n,
-                                                 bool check)
+                                                 bool check,
+                                                 std::ostream* errOut)
 {
   if (check)
   {
@@ -100,7 +103,8 @@ TypeNode BitVectorPredicateTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode BitVectorRedTypeRule::computeType(NodeManager* nodeManager,
                                            TNode n,
-                                           bool check)
+                                           bool check,
+                                           std::ostream* errOut)
 {
   if (check)
   {
@@ -115,7 +119,8 @@ TypeNode BitVectorRedTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode BitVectorBVPredTypeRule::computeType(NodeManager* nodeManager,
                                               TNode n,
-                                              bool check)
+                                              bool check,
+                                              std::ostream* errOut)
 {
   if (check)
   {
@@ -132,7 +137,8 @@ TypeNode BitVectorBVPredTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode BitVectorConcatTypeRule::computeType(NodeManager* nodeManager,
                                               TNode n,
-                                              bool check)
+                                              bool check,
+                                              std::ostream* errOut)
 {
   uint32_t size = 0;
   for (const auto& child : n)
@@ -152,7 +158,8 @@ TypeNode BitVectorConcatTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode BitVectorITETypeRule::computeType(NodeManager* nodeManager,
                                            TNode n,
-                                           bool check)
+                                           bool check,
+                                           std::ostream* errOut)
 {
   Assert(n.getNumChildren() == 3);
   TypeNode thenpart = n[1].getType(check);
@@ -176,7 +183,8 @@ TypeNode BitVectorITETypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode BitVectorBitOfTypeRule::computeType(NodeManager* nodeManager,
                                              TNode n,
-                                             bool check)
+                                             bool check,
+                                             std::ostream* errOut)
 {
   if (check)
   {
@@ -198,7 +206,8 @@ TypeNode BitVectorBitOfTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode BitVectorExtractTypeRule::computeType(NodeManager* nodeManager,
                                                TNode n,
-                                               bool check)
+                                               bool check,
+                                               std::ostream* errOut)
 {
   BitVectorExtract extractInfo = n.getOperator().getConst<BitVectorExtract>();
 
@@ -230,7 +239,8 @@ TypeNode BitVectorExtractTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode BitVectorRepeatTypeRule::computeType(NodeManager* nodeManager,
                                               TNode n,
-                                              bool check)
+                                              bool check,
+                                              std::ostream* errOut)
 {
   TypeNode t = n[0].getType(check);
   // NOTE: We're throwing a type-checking exception here even
@@ -250,7 +260,8 @@ TypeNode BitVectorRepeatTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode BitVectorExtendTypeRule::computeType(NodeManager* nodeManager,
                                               TNode n,
-                                              bool check)
+                                              bool check,
+                                              std::ostream* errOut)
 {
   TypeNode t = n[0].getType(check);
   // NOTE: We're throwing a type-checking exception here even
@@ -268,7 +279,8 @@ TypeNode BitVectorExtendTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode BitVectorEagerAtomTypeRule::computeType(NodeManager* nodeManager,
                                                  TNode n,
-                                                 bool check)
+                                                 bool check,
+                                                 std::ostream* errOut)
 {
   if (check)
   {
@@ -282,7 +294,7 @@ TypeNode BitVectorEagerAtomTypeRule::computeType(NodeManager* nodeManager,
 }
 
 TypeNode BitVectorAckermanizationUdivTypeRule::computeType(
-    NodeManager* nodeManager, TNode n, bool check)
+    NodeManager* nodeManager, TNode n, bool check, std::ostream* errOut)
 {
   TypeNode lhsType = n[0].getType(check);
   if (check)
@@ -296,7 +308,7 @@ TypeNode BitVectorAckermanizationUdivTypeRule::computeType(
 }
 
 TypeNode BitVectorAckermanizationUremTypeRule::computeType(
-    NodeManager* nodeManager, TNode n, bool check)
+    NodeManager* nodeManager, TNode n, bool check, std::ostream* errOut)
 {
   TypeNode lhsType = n[0].getType(check);
   if (check)

--- a/src/theory/bv/theory_bv_type_rules.h
+++ b/src/theory/bv/theory_bv_type_rules.h
@@ -40,7 +40,10 @@ class CardinalityComputer
 class BitVectorConstantTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /* -------------------------------------------------------------------------- */
@@ -48,7 +51,10 @@ class BitVectorConstantTypeRule
 class BitVectorFixedWidthTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /* -------------------------------------------------------------------------- */
@@ -56,19 +62,28 @@ class BitVectorFixedWidthTypeRule
 class BitVectorPredicateTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class BitVectorRedTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class BitVectorBVPredTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /* -------------------------------------------------------------------------- */
@@ -78,7 +93,10 @@ class BitVectorBVPredTypeRule
 class BitVectorConcatTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class BitVectorToBVTypeRule
@@ -86,7 +104,8 @@ class BitVectorToBVTypeRule
  public:
   inline static TypeNode computeType(NodeManager* nodeManager,
                                      TNode n,
-                                     bool check)
+                                     bool check,
+                                     std::ostream* errOut)
   {
     for (const auto& child : n)
     {
@@ -103,7 +122,10 @@ class BitVectorToBVTypeRule
 class BitVectorITETypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /* -------------------------------------------------------------------------- */
@@ -113,25 +135,37 @@ class BitVectorITETypeRule
 class BitVectorBitOfTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class BitVectorExtractTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class BitVectorRepeatTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class BitVectorExtendTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /* -------------------------------------------------------------------------- */
@@ -141,19 +175,28 @@ class BitVectorExtendTypeRule
 class BitVectorEagerAtomTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class BitVectorAckermanizationUdivTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class BitVectorAckermanizationUremTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 }  // namespace bv

--- a/src/theory/datatypes/theory_datatypes_type_rules.cpp
+++ b/src/theory/datatypes/theory_datatypes_type_rules.cpp
@@ -33,7 +33,8 @@ namespace datatypes {
 
 TypeNode DatatypeConstructorTypeRule::computeType(NodeManager* nodeManager,
                                                   TNode n,
-                                                  bool check)
+                                                  bool check,
+                                                  std::ostream* errOut)
 {
   Assert(n.getKind() == kind::APPLY_CONSTRUCTOR);
   TypeNode consType = n.getOperator().getType(check);
@@ -118,7 +119,8 @@ bool DatatypeConstructorTypeRule::computeIsConst(NodeManager* nodeManager,
 
 TypeNode DatatypeSelectorTypeRule::computeType(NodeManager* nodeManager,
                                                TNode n,
-                                               bool check)
+                                               bool check,
+                                               std::ostream* errOut)
 {
   Assert(n.getKind() == kind::APPLY_SELECTOR);
   TypeNode selType = n.getOperator().getType(check);
@@ -174,7 +176,8 @@ TypeNode DatatypeSelectorTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode DatatypeTesterTypeRule::computeType(NodeManager* nodeManager,
                                              TNode n,
-                                             bool check)
+                                             bool check,
+                                             std::ostream* errOut)
 {
   Assert(n.getKind() == kind::APPLY_TESTER);
   if (check)
@@ -214,7 +217,8 @@ TypeNode DatatypeTesterTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode DatatypeUpdateTypeRule::computeType(NodeManager* nodeManager,
                                              TNode n,
-                                             bool check)
+                                             bool check,
+                                             std::ostream* errOut)
 {
   Assert(n.getKind() == kind::APPLY_UPDATER);
   TypeNode updType = n.getOperator().getType(check);
@@ -250,7 +254,8 @@ TypeNode DatatypeUpdateTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode DatatypeAscriptionTypeRule::computeType(NodeManager* nodeManager,
                                                  TNode n,
-                                                 bool check)
+                                                 bool check,
+                                                 std::ostream* errOut)
 {
   Trace("typecheck-idt") << "typechecking ascription: " << n << std::endl;
   Assert(n.getKind() == kind::APPLY_TYPE_ASCRIPTION);
@@ -295,7 +300,8 @@ Cardinality ConstructorProperties::computeCardinality(TypeNode type)
 
 TypeNode DtSizeTypeRule::computeType(NodeManager* nodeManager,
                                      TNode n,
-                                     bool check)
+                                     bool check,
+                                     std::ostream* errOut)
 {
   if (check)
   {
@@ -311,7 +317,8 @@ TypeNode DtSizeTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode DtBoundTypeRule::computeType(NodeManager* nodeManager,
                                       TNode n,
-                                      bool check)
+                                      bool check,
+                                      std::ostream* errOut)
 {
   if (check)
   {
@@ -337,7 +344,8 @@ TypeNode DtBoundTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode DtSygusEvalTypeRule::computeType(NodeManager* nodeManager,
                                           TNode n,
-                                          bool check)
+                                          bool check,
+                                          std::ostream* errOut)
 {
   TypeNode headType = n[0].getType(check);
   if (!headType.isDatatype())
@@ -378,7 +386,8 @@ TypeNode DtSygusEvalTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode MatchTypeRule::computeType(NodeManager* nodeManager,
                                     TNode n,
-                                    bool check)
+                                    bool check,
+                                    std::ostream* errOut)
 {
   Assert(n.getKind() == kind::MATCH);
 
@@ -478,7 +487,8 @@ TypeNode MatchTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode MatchCaseTypeRule::computeType(NodeManager* nodeManager,
                                         TNode n,
-                                        bool check)
+                                        bool check,
+                                        std::ostream* errOut)
 {
   Assert(n.getKind() == kind::MATCH_CASE);
   if (check)
@@ -495,7 +505,8 @@ TypeNode MatchCaseTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode MatchBindCaseTypeRule::computeType(NodeManager* nodeManager,
                                             TNode n,
-                                            bool check)
+                                            bool check,
+                                            std::ostream* errOut)
 {
   Assert(n.getKind() == kind::MATCH_BIND_CASE);
   if (check)
@@ -515,7 +526,10 @@ TypeNode MatchBindCaseTypeRule::computeType(NodeManager* nodeManager,
   return n[2].getType(check);
 }
 
-TypeNode TupleProjectTypeRule::computeType(NodeManager* nm, TNode n, bool check)
+TypeNode TupleProjectTypeRule::computeType(NodeManager* nm,
+                                           TNode n,
+                                           bool check,
+                                           std::ostream* errOut)
 {
   Assert(n.getKind() == kind::TUPLE_PROJECT && n.hasOperator()
          && n.getOperator().getKind() == kind::TUPLE_PROJECT_OP);
@@ -561,7 +575,8 @@ TypeNode TupleProjectTypeRule::computeType(NodeManager* nm, TNode n, bool check)
 
 TypeNode CodatatypeBoundVariableTypeRule::computeType(NodeManager* nodeManager,
                                                       TNode n,
-                                                      bool check)
+                                                      bool check,
+                                                      std::ostream* errOut)
 {
   return n.getConst<CodatatypeBoundVariable>().getType();
 }

--- a/src/theory/datatypes/theory_datatypes_type_rules.h
+++ b/src/theory/datatypes/theory_datatypes_type_rules.h
@@ -33,7 +33,10 @@ namespace datatypes {
  * for type substitution sigma, and returns T * sigma.
  */
 struct DatatypeConstructorTypeRule {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 
   /**
    * A constructor term is constant if it is an AST built from constructor
@@ -48,7 +51,10 @@ struct DatatypeConstructorTypeRule {
  * This rule is generalized for parametric datatypes.
  */
 struct DatatypeSelectorTypeRule {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -57,7 +63,10 @@ struct DatatypeSelectorTypeRule {
  * This rule is generalized for parametric datatypes.
  */
 struct DatatypeTesterTypeRule {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -67,7 +76,10 @@ struct DatatypeTesterTypeRule {
  */
 struct DatatypeUpdateTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -77,7 +89,10 @@ struct DatatypeUpdateTypeRule
  */
 struct DatatypeAscriptionTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 struct ConstructorProperties
@@ -90,7 +105,10 @@ struct ConstructorProperties
  */
 class DtSizeTypeRule {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -99,7 +117,10 @@ class DtSizeTypeRule {
  */
 class DtBoundTypeRule {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -111,7 +132,10 @@ class DtBoundTypeRule {
 class DtSygusEvalTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -134,7 +158,10 @@ class DtSygusEvalTypeRule
 class MatchTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -144,7 +171,10 @@ class MatchTypeRule
 class MatchCaseTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -155,7 +185,10 @@ class MatchCaseTypeRule
 class MatchBindCaseTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -167,7 +200,10 @@ class MatchBindCaseTypeRule
 class TupleProjectTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nm, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nm,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -177,7 +213,10 @@ class TupleProjectTypeRule
 class CodatatypeBoundVariableTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 }  // namespace datatypes

--- a/src/theory/ff/theory_ff_type_rules.cpp
+++ b/src/theory/ff/theory_ff_type_rules.cpp
@@ -33,7 +33,8 @@ Cardinality FiniteFieldProperties::computeCardinality(TypeNode type)
 
 TypeNode FiniteFieldConstantTypeRule::computeType(NodeManager* nodeManager,
                                                   TNode n,
-                                                  bool _check)
+                                                  bool check,
+                                                  std::ostream* errOut)
 {
   return nodeManager->mkFiniteFieldType(
       n.getConst<FiniteFieldValue>().getFieldSize());
@@ -41,7 +42,8 @@ TypeNode FiniteFieldConstantTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode FiniteFieldFixedFieldTypeRule::computeType(NodeManager* nodeManager,
                                                     TNode n,
-                                                    bool check)
+                                                    bool check,
+                                                    std::ostream* errOut)
 {
   TNode::iterator it = n.begin();
   TypeNode t = (*it).getType(check);

--- a/src/theory/ff/theory_ff_type_rules.h
+++ b/src/theory/ff/theory_ff_type_rules.h
@@ -37,7 +37,10 @@ struct FiniteFieldProperties
 class FiniteFieldConstantTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /* -------------------------------------------------------------------------- */
@@ -45,7 +48,10 @@ class FiniteFieldConstantTypeRule
 class FiniteFieldFixedFieldTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 }  // namespace ff

--- a/src/theory/fp/theory_fp_type_rules.cpp
+++ b/src/theory/fp/theory_fp_type_rules.cpp
@@ -32,7 +32,8 @@ namespace fp {
 
 TypeNode FloatingPointConstantTypeRule::computeType(NodeManager* nodeManager,
                                                     TNode n,
-                                                    bool check)
+                                                    bool check,
+                                                    std::ostream* errOut)
 {
   TRACE("FloatingPointConstantTypeRule");
 
@@ -56,7 +57,8 @@ TypeNode FloatingPointConstantTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode RoundingModeConstantTypeRule::computeType(NodeManager* nodeManager,
                                                    TNode n,
-                                                   bool check)
+                                                   bool check,
+                                                   std::ostream* errOut)
 {
   TRACE("RoundingModeConstantTypeRule");
 
@@ -66,7 +68,8 @@ TypeNode RoundingModeConstantTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode FloatingPointFPTypeRule::computeType(NodeManager* nodeManager,
                                               TNode n,
-                                              bool check)
+                                              bool check,
+                                              std::ostream* errOut)
 {
   TRACE("FloatingPointFPTypeRule");
 
@@ -110,7 +113,8 @@ TypeNode FloatingPointFPTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode FloatingPointTestTypeRule::computeType(NodeManager* nodeManager,
                                                 TNode n,
-                                                bool check)
+                                                bool check,
+                                                std::ostream* errOut)
 {
   TRACE("FloatingPointTestTypeRule");
 
@@ -140,7 +144,8 @@ TypeNode FloatingPointTestTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode FloatingPointOperationTypeRule::computeType(NodeManager* nodeManager,
                                                      TNode n,
-                                                     bool check)
+                                                     bool check,
+                                                     std::ostream* errOut)
 {
   TRACE("FloatingPointOperationTypeRule");
 
@@ -169,7 +174,7 @@ TypeNode FloatingPointOperationTypeRule::computeType(NodeManager* nodeManager,
 }
 
 TypeNode FloatingPointRoundingOperationTypeRule::computeType(
-    NodeManager* nodeManager, TNode n, bool check)
+    NodeManager* nodeManager, TNode n, bool check, std::ostream* errOut)
 {
   TRACE("FloatingPointRoundingOperationTypeRule");
 
@@ -209,7 +214,7 @@ TypeNode FloatingPointRoundingOperationTypeRule::computeType(
 }
 
 TypeNode FloatingPointPartialOperationTypeRule::computeType(
-    NodeManager* nodeManager, TNode n, bool check)
+    NodeManager* nodeManager, TNode n, bool check, std::ostream* errOut)
 {
   TRACE("FloatingPointOperationTypeRule");
   AlwaysAssert(n.getNumChildren() > 0);
@@ -249,7 +254,7 @@ TypeNode FloatingPointPartialOperationTypeRule::computeType(
 }
 
 TypeNode FloatingPointParametricOpTypeRule::computeType(
-    NodeManager* nodeManager, TNode n, bool check)
+    NodeManager* nodeManager, TNode n, bool check, std::ostream* errOut)
 {
   TRACE("FloatingPointParametricOpTypeRule");
 
@@ -257,7 +262,7 @@ TypeNode FloatingPointParametricOpTypeRule::computeType(
 }
 
 TypeNode FloatingPointToFPIEEEBitVectorTypeRule::computeType(
-    NodeManager* nodeManager, TNode n, bool check)
+    NodeManager* nodeManager, TNode n, bool check, std::ostream* errOut)
 {
   TRACE("FloatingPointToFPIEEEBitVectorTypeRule");
   AlwaysAssert(n.getNumChildren() == 1);
@@ -291,7 +296,7 @@ TypeNode FloatingPointToFPIEEEBitVectorTypeRule::computeType(
 }
 
 TypeNode FloatingPointToFPFloatingPointTypeRule::computeType(
-    NodeManager* nodeManager, TNode n, bool check)
+    NodeManager* nodeManager, TNode n, bool check, std::ostream* errOut)
 {
   TRACE("FloatingPointToFPFloatingPointTypeRule");
   AlwaysAssert(n.getNumChildren() == 2);
@@ -325,7 +330,8 @@ TypeNode FloatingPointToFPFloatingPointTypeRule::computeType(
 
 TypeNode FloatingPointToFPRealTypeRule::computeType(NodeManager* nodeManager,
                                                     TNode n,
-                                                    bool check)
+                                                    bool check,
+                                                    std::ostream* errOut)
 {
   TRACE("FloatingPointToFPRealTypeRule");
   AlwaysAssert(n.getNumChildren() == 2);
@@ -358,7 +364,7 @@ TypeNode FloatingPointToFPRealTypeRule::computeType(NodeManager* nodeManager,
 }
 
 TypeNode FloatingPointToFPSignedBitVectorTypeRule::computeType(
-    NodeManager* nodeManager, TNode n, bool check)
+    NodeManager* nodeManager, TNode n, bool check, std::ostream* errOut)
 {
   TRACE("FloatingPointToFPSignedBitVectorTypeRule");
   AlwaysAssert(n.getNumChildren() == 2);
@@ -391,7 +397,7 @@ TypeNode FloatingPointToFPSignedBitVectorTypeRule::computeType(
 }
 
 TypeNode FloatingPointToFPUnsignedBitVectorTypeRule::computeType(
-    NodeManager* nodeManager, TNode n, bool check)
+    NodeManager* nodeManager, TNode n, bool check, std::ostream* errOut)
 {
   TRACE("FloatingPointToFPUnsignedBitVectorTypeRule");
   AlwaysAssert(n.getNumChildren() == 2);
@@ -425,7 +431,8 @@ TypeNode FloatingPointToFPUnsignedBitVectorTypeRule::computeType(
 
 TypeNode FloatingPointToUBVTypeRule::computeType(NodeManager* nodeManager,
                                                  TNode n,
-                                                 bool check)
+                                                 bool check,
+                                                 std::ostream* errOut)
 {
   TRACE("FloatingPointToUBVTypeRule");
   AlwaysAssert(n.getNumChildren() == 2);
@@ -458,7 +465,8 @@ TypeNode FloatingPointToUBVTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode FloatingPointToSBVTypeRule::computeType(NodeManager* nodeManager,
                                                  TNode n,
-                                                 bool check)
+                                                 bool check,
+                                                 std::ostream* errOut)
 {
   TRACE("FloatingPointToSBVTypeRule");
   AlwaysAssert(n.getNumChildren() == 2);
@@ -491,7 +499,8 @@ TypeNode FloatingPointToSBVTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode FloatingPointToUBVTotalTypeRule::computeType(NodeManager* nodeManager,
                                                       TNode n,
-                                                      bool check)
+                                                      bool check,
+                                                      std::ostream* errOut)
 {
   TRACE("FloatingPointToUBVTotalTypeRule");
   AlwaysAssert(n.getNumChildren() == 3);
@@ -538,7 +547,8 @@ TypeNode FloatingPointToUBVTotalTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode FloatingPointToSBVTotalTypeRule::computeType(NodeManager* nodeManager,
                                                       TNode n,
-                                                      bool check)
+                                                      bool check,
+                                                      std::ostream* errOut)
 {
   TRACE("FloatingPointToSBVTotalTypeRule");
   AlwaysAssert(n.getNumChildren() == 3);
@@ -583,7 +593,8 @@ TypeNode FloatingPointToSBVTotalTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode FloatingPointToRealTypeRule::computeType(NodeManager* nodeManager,
                                                   TNode n,
-                                                  bool check)
+                                                  bool check,
+                                                  std::ostream* errOut)
 {
   TRACE("FloatingPointToRealTypeRule");
   AlwaysAssert(n.getNumChildren() == 1);
@@ -604,7 +615,8 @@ TypeNode FloatingPointToRealTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode FloatingPointToRealTotalTypeRule::computeType(NodeManager* nodeManager,
                                                        TNode n,
-                                                       bool check)
+                                                       bool check,
+                                                       std::ostream* errOut)
 {
   TRACE("FloatingPointToRealTotalTypeRule");
   AlwaysAssert(n.getNumChildren() == 2);
@@ -634,7 +646,8 @@ TypeNode FloatingPointToRealTotalTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode FloatingPointComponentBit::computeType(NodeManager* nodeManager,
                                                 TNode n,
-                                                bool check)
+                                                bool check,
+                                                std::ostream* errOut)
 {
   TRACE("FloatingPointComponentBit");
 
@@ -664,7 +677,8 @@ TypeNode FloatingPointComponentBit::computeType(NodeManager* nodeManager,
 
 TypeNode FloatingPointComponentExponent::computeType(NodeManager* nodeManager,
                                                      TNode n,
-                                                     bool check)
+                                                     bool check,
+                                                     std::ostream* errOut)
 {
   TRACE("FloatingPointComponentExponent");
 
@@ -700,7 +714,7 @@ TypeNode FloatingPointComponentExponent::computeType(NodeManager* nodeManager,
 }
 
 TypeNode FloatingPointComponentSignificand::computeType(
-    NodeManager* nodeManager, TNode n, bool check)
+    NodeManager* nodeManager, TNode n, bool check, std::ostream* errOut)
 {
   TRACE("FloatingPointComponentSignificand");
 
@@ -733,7 +747,8 @@ TypeNode FloatingPointComponentSignificand::computeType(
 
 TypeNode RoundingModeBitBlast::computeType(NodeManager* nodeManager,
                                            TNode n,
-                                           bool check)
+                                           bool check,
+                                           std::ostream* errOut)
 {
   TRACE("RoundingModeBitBlast");
 

--- a/src/theory/fp/theory_fp_type_rules.h
+++ b/src/theory/fp/theory_fp_type_rules.h
@@ -32,21 +32,30 @@ namespace fp {
 class FloatingPointConstantTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /** Type rule for roundingmode values. */
 class RoundingModeConstantTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /** Type rule for (fp ...) operator. */
 class FloatingPointFPTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -56,7 +65,10 @@ class FloatingPointFPTypeRule
 class FloatingPointTestTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -67,7 +79,10 @@ class FloatingPointTestTypeRule
 class FloatingPointOperationTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -78,7 +93,10 @@ class FloatingPointOperationTypeRule
 class FloatingPointRoundingOperationTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -89,7 +107,10 @@ class FloatingPointRoundingOperationTypeRule
 class FloatingPointPartialOperationTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -100,56 +121,80 @@ class FloatingPointPartialOperationTypeRule
 class FloatingPointParametricOpTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /** Type rule for floating-point to_fp conversion from IEEE bit-vector. */
 class FloatingPointToFPIEEEBitVectorTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /** Type rule for floating-point to_fp conversion from floating-point. */
 class FloatingPointToFPFloatingPointTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /** Type rule for floating-point to_fp conversion from real. */
 class FloatingPointToFPRealTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /** Type rule for floating-point to_fp conversion from signed bit-vector. */
 class FloatingPointToFPSignedBitVectorTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /** Type rule for floating-point to_fp conversion from unsigned bit-vector. */
 class FloatingPointToFPUnsignedBitVectorTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /** Type rule for conversion from floating-point to unsigned bit-vector. */
 class FloatingPointToUBVTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /** Type rule for conversion from floating-point to signed bit-vector. */
 class FloatingPointToSBVTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -159,7 +204,10 @@ class FloatingPointToSBVTypeRule
 class FloatingPointToUBVTotalTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -169,49 +217,70 @@ class FloatingPointToUBVTotalTypeRule
 class FloatingPointToSBVTotalTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /** Type rule for conversion from floating-point to real. */
 class FloatingPointToRealTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /** Type rule for conversion from floating-point to real (total version). */
 class FloatingPointToRealTotalTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /** Type rule for floating-point components of bit-width 1. */
 class FloatingPointComponentBit
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /** Type rule for floating-point exponent component. */
 class FloatingPointComponentExponent
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /** Type rule for floating-point significand component. */
 class FloatingPointComponentSignificand
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /** Type rule for the ROUNDINGMODE_BITBLAST operator. */
 class RoundingModeBitBlast
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /** Cardinality computation for floating-point sorts. */

--- a/src/theory/quantifiers/theory_quantifiers_type_rules.cpp
+++ b/src/theory/quantifiers/theory_quantifiers_type_rules.cpp
@@ -21,7 +21,8 @@ namespace quantifiers {
 
 TypeNode QuantifierTypeRule::computeType(NodeManager* nodeManager,
                                          TNode n,
-                                         bool check)
+                                         bool check,
+                                         std::ostream* errOut)
 {
   Trace("typecheck-q") << "type check for fa " << n << std::endl;
   Assert((n.getKind() == kind::FORALL || n.getKind() == kind::EXISTS)
@@ -65,7 +66,8 @@ TypeNode QuantifierTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode QuantifierBoundVarListTypeRule::computeType(NodeManager* nodeManager,
                                                      TNode n,
-                                                     bool check)
+                                                     bool check,
+                                                     std::ostream* errOut)
 {
   Assert(n.getKind() == kind::BOUND_VAR_LIST);
   if (check)
@@ -84,7 +86,8 @@ TypeNode QuantifierBoundVarListTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode QuantifierInstPatternTypeRule::computeType(NodeManager* nodeManager,
                                                     TNode n,
-                                                    bool check)
+                                                    bool check,
+                                                    std::ostream* errOut)
 {
   Assert(n.getKind() == kind::INST_PATTERN);
   if (check)
@@ -104,7 +107,8 @@ TypeNode QuantifierInstPatternTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode QuantifierAnnotationTypeRule::computeType(NodeManager* nodeManager,
                                                    TNode n,
-                                                   bool check)
+                                                   bool check,
+                                                   std::ostream* errOut)
 {
   if (n.getKind() == kind::INST_ATTRIBUTE)
   {
@@ -122,7 +126,7 @@ TypeNode QuantifierAnnotationTypeRule::computeType(NodeManager* nodeManager,
 }
 
 TypeNode QuantifierInstPatternListTypeRule::computeType(
-    NodeManager* nodeManager, TNode n, bool check)
+    NodeManager* nodeManager, TNode n, bool check, std::ostream* errOut)
 {
   Assert(n.getKind() == kind::INST_PATTERN_LIST);
   if (check)
@@ -144,7 +148,7 @@ TypeNode QuantifierInstPatternListTypeRule::computeType(
   return nodeManager->instPatternListType();
 }
 TypeNode QuantifierOracleFormulaGenTypeRule::computeType(
-    NodeManager* nodeManager, TNode n, bool check)
+    NodeManager* nodeManager, TNode n, bool check, std::ostream* errOut)
 {
   Assert(n.getKind() == kind::ORACLE_FORMULA_GEN);
   if (check)

--- a/src/theory/quantifiers/theory_quantifiers_type_rules.h
+++ b/src/theory/quantifiers/theory_quantifiers_type_rules.h
@@ -38,7 +38,10 @@ namespace quantifiers {
  */
 struct QuantifierTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -47,7 +50,10 @@ struct QuantifierTypeRule
  */
 struct QuantifierBoundVarListTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -57,7 +63,10 @@ struct QuantifierBoundVarListTypeRule
  */
 struct QuantifierInstPatternTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -69,7 +78,10 @@ struct QuantifierInstPatternTypeRule
  */
 struct QuantifierAnnotationTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -79,7 +91,10 @@ struct QuantifierAnnotationTypeRule
  */
 struct QuantifierInstPatternListTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -89,7 +104,10 @@ struct QuantifierInstPatternListTypeRule
  */
 struct QuantifierOracleFormulaGenTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 }  // namespace quantifiers

--- a/src/theory/sep/theory_sep_type_rules.cpp
+++ b/src/theory/sep/theory_sep_type_rules.cpp
@@ -21,7 +21,8 @@ namespace sep {
 
 TypeNode SepEmpTypeRule::computeType(NodeManager* nodeManager,
                                      TNode n,
-                                     bool check)
+                                     bool check,
+                                     std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SEP_EMP);
   return nodeManager->booleanType();
@@ -29,7 +30,8 @@ TypeNode SepEmpTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode SepPtoTypeRule::computeType(NodeManager* nodeManager,
                                      TNode n,
-                                     bool check)
+                                     bool check,
+                                     std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SEP_PTO);
   if (check)
@@ -42,7 +44,8 @@ TypeNode SepPtoTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode SepStarTypeRule::computeType(NodeManager* nodeManager,
                                       TNode n,
-                                      bool check)
+                                      bool check,
+                                      std::ostream* errOut)
 {
   TypeNode btype = nodeManager->booleanType();
   Assert(n.getKind() == kind::SEP_STAR);
@@ -63,7 +66,8 @@ TypeNode SepStarTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode SepWandTypeRule::computeType(NodeManager* nodeManager,
                                       TNode n,
-                                      bool check)
+                                      bool check,
+                                      std::ostream* errOut)
 {
   TypeNode btype = nodeManager->booleanType();
   Assert(n.getKind() == kind::SEP_WAND);
@@ -84,7 +88,8 @@ TypeNode SepWandTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode SepLabelTypeRule::computeType(NodeManager* nodeManager,
                                        TNode n,
-                                       bool check)
+                                       bool check,
+                                       std::ostream* errOut)
 {
   TypeNode btype = nodeManager->booleanType();
   Assert(n.getKind() == kind::SEP_LABEL);
@@ -107,7 +112,8 @@ TypeNode SepLabelTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode SepNilTypeRule::computeType(NodeManager* nodeManager,
                                      TNode n,
-                                     bool check)
+                                     bool check,
+                                     std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SEP_NIL);
   Assert(check);

--- a/src/theory/sep/theory_sep_type_rules.h
+++ b/src/theory/sep/theory_sep_type_rules.h
@@ -32,7 +32,10 @@ namespace sep {
 class SepEmpTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -42,7 +45,10 @@ class SepEmpTypeRule
  */
 struct SepPtoTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -51,7 +57,10 @@ struct SepPtoTypeRule
  */
 struct SepStarTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -60,7 +69,10 @@ struct SepStarTypeRule
  */
 struct SepWandTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -70,7 +82,10 @@ struct SepWandTypeRule
  */
 struct SepLabelTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -79,7 +94,10 @@ struct SepLabelTypeRule
  */
 struct SepNilTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 }  // namespace sep

--- a/src/theory/sets/theory_sets_type_rules.cpp
+++ b/src/theory/sets/theory_sets_type_rules.cpp
@@ -32,7 +32,8 @@ using namespace cvc5::internal::theory::datatypes;
 
 TypeNode SetsBinaryOperatorTypeRule::computeType(NodeManager* nodeManager,
                                                  TNode n,
-                                                 bool check)
+                                                 bool check,
+                                                 std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SET_UNION || n.getKind() == kind::SET_INTER
          || n.getKind() == kind::SET_MINUS);
@@ -69,7 +70,8 @@ bool SetsBinaryOperatorTypeRule::computeIsConst(NodeManager* nodeManager,
 
 TypeNode SubsetTypeRule::computeType(NodeManager* nodeManager,
                                      TNode n,
-                                     bool check)
+                                     bool check,
+                                     std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SET_SUBSET);
   TypeNode setType = n[0].getType(check);
@@ -91,7 +93,8 @@ TypeNode SubsetTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode MemberTypeRule::computeType(NodeManager* nodeManager,
                                      TNode n,
-                                     bool check)
+                                     bool check,
+                                     std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SET_MEMBER);
   TypeNode setType = n[1].getType(check);
@@ -120,7 +123,8 @@ TypeNode MemberTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode SingletonTypeRule::computeType(NodeManager* nodeManager,
                                         TNode n,
-                                        bool check)
+                                        bool check,
+                                        std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SET_SINGLETON);
   TypeNode type1 = n[0].getType(check);
@@ -135,7 +139,8 @@ bool SingletonTypeRule::computeIsConst(NodeManager* nodeManager, TNode n)
 
 TypeNode EmptySetTypeRule::computeType(NodeManager* nodeManager,
                                        TNode n,
-                                       bool check)
+                                       bool check,
+                                       std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SET_EMPTY);
   EmptySet emptySet = n.getConst<EmptySet>();
@@ -144,7 +149,8 @@ TypeNode EmptySetTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode CardTypeRule::computeType(NodeManager* nodeManager,
                                    TNode n,
-                                   bool check)
+                                   bool check,
+                                   std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SET_CARD);
   TypeNode setType = n[0].getType(check);
@@ -161,7 +167,8 @@ TypeNode CardTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode ComplementTypeRule::computeType(NodeManager* nodeManager,
                                          TNode n,
-                                         bool check)
+                                         bool check,
+                                         std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SET_COMPLEMENT);
   TypeNode setType = n[0].getType(check);
@@ -178,7 +185,8 @@ TypeNode ComplementTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode UniverseSetTypeRule::computeType(NodeManager* nodeManager,
                                           TNode n,
-                                          bool check)
+                                          bool check,
+                                          std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SET_UNIVERSE);
   // for nullary operators, we only computeType for check=true, since they are
@@ -195,7 +203,8 @@ TypeNode UniverseSetTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode ComprehensionTypeRule::computeType(NodeManager* nodeManager,
                                             TNode n,
-                                            bool check)
+                                            bool check,
+                                            std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SET_COMPREHENSION);
   if (check)
@@ -216,7 +225,8 @@ TypeNode ComprehensionTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode ChooseTypeRule::computeType(NodeManager* nodeManager,
                                      TNode n,
-                                     bool check)
+                                     bool check,
+                                     std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SET_CHOOSE);
   TypeNode setType = n[0].getType(check);
@@ -233,7 +243,8 @@ TypeNode ChooseTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode IsSingletonTypeRule::computeType(NodeManager* nodeManager,
                                           TNode n,
-                                          bool check)
+                                          bool check,
+                                          std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SET_IS_SINGLETON);
   TypeNode setType = n[0].getType(check);
@@ -250,7 +261,8 @@ TypeNode IsSingletonTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode InsertTypeRule::computeType(NodeManager* nodeManager,
                                      TNode n,
-                                     bool check)
+                                     bool check,
+                                     std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SET_INSERT);
   size_t numChildren = n.getNumChildren();
@@ -279,7 +291,8 @@ TypeNode InsertTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode SetMapTypeRule::computeType(NodeManager* nodeManager,
                                      TNode n,
-                                     bool check)
+                                     bool check,
+                                     std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SET_MAP);
   TypeNode functionType = n[0].getType(check);
@@ -321,7 +334,8 @@ TypeNode SetMapTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode SetFilterTypeRule::computeType(NodeManager* nodeManager,
                                         TNode n,
-                                        bool check)
+                                        bool check,
+                                        std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SET_FILTER);
   TypeNode functionType = n[0].getType(check);
@@ -363,7 +377,8 @@ TypeNode SetFilterTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode SetFoldTypeRule::computeType(NodeManager* nodeManager,
                                       TNode n,
-                                      bool check)
+                                      bool check,
+                                      std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SET_FOLD);
   TypeNode functionType = n[0].getType(check);
@@ -414,7 +429,8 @@ TypeNode SetFoldTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode RelBinaryOperatorTypeRule::computeType(NodeManager* nodeManager,
                                                 TNode n,
-                                                bool check)
+                                                bool check,
+                                                std::ostream* errOut)
 {
   Assert(n.getKind() == kind::RELATION_PRODUCT
          || n.getKind() == kind::RELATION_JOIN);
@@ -472,7 +488,8 @@ TypeNode RelBinaryOperatorTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode RelTransposeTypeRule::computeType(NodeManager* nodeManager,
                                            TNode n,
-                                           bool check)
+                                           bool check,
+                                           std::ostream* errOut)
 {
   Assert(n.getKind() == kind::RELATION_TRANSPOSE);
   TypeNode setType = n[0].getType(check);
@@ -488,7 +505,8 @@ TypeNode RelTransposeTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode RelTransClosureTypeRule::computeType(NodeManager* nodeManager,
                                               TNode n,
-                                              bool check)
+                                              bool check,
+                                              std::ostream* errOut)
 {
   Assert(n.getKind() == kind::RELATION_TCLOSURE);
   TypeNode setType = n[0].getType(check);
@@ -517,7 +535,8 @@ TypeNode RelTransClosureTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode JoinImageTypeRule::computeType(NodeManager* nodeManager,
                                         TNode n,
-                                        bool check)
+                                        bool check,
+                                        std::ostream* errOut)
 {
   Assert(n.getKind() == kind::RELATION_JOIN_IMAGE);
 
@@ -560,7 +579,8 @@ TypeNode JoinImageTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode RelIdenTypeRule::computeType(NodeManager* nodeManager,
                                       TNode n,
-                                      bool check)
+                                      bool check,
+                                      std::ostream* errOut)
 {
   Assert(n.getKind() == kind::RELATION_IDEN);
   TypeNode setType = n[0].getType(check);
@@ -582,7 +602,10 @@ TypeNode RelIdenTypeRule::computeType(NodeManager* nodeManager,
   return nodeManager->mkSetType(nodeManager->mkTupleType(tupleTypes));
 }
 
-TypeNode RelationGroupTypeRule::computeType(NodeManager* nm, TNode n, bool check)
+TypeNode RelationGroupTypeRule::computeType(NodeManager* nm,
+                                            TNode n,
+                                            bool check,
+                                            std::ostream* errOut)
 {
   Assert(n.getKind() == kind::RELATION_GROUP && n.hasOperator()
          && n.getOperator().getKind() == kind::RELATION_GROUP_OP);
@@ -617,7 +640,8 @@ TypeNode RelationGroupTypeRule::computeType(NodeManager* nm, TNode n, bool check
 
 TypeNode RelationAggregateTypeRule::computeType(NodeManager* nm,
                                                 TNode n,
-                                                bool check)
+                                                bool check,
+                                                std::ostream* errOut)
 {
   Assert(n.getKind() == kind::RELATION_AGGREGATE && n.hasOperator()
          && n.getOperator().getKind() == kind::RELATION_AGGREGATE_OP);
@@ -683,7 +707,8 @@ TypeNode RelationAggregateTypeRule::computeType(NodeManager* nm,
 
 TypeNode RelationProjectTypeRule::computeType(NodeManager* nm,
                                               TNode n,
-                                              bool check)
+                                              bool check,
+                                              std::ostream* errOut)
 {
   Assert(n.getKind() == kind::RELATION_PROJECT && n.hasOperator()
          && n.getOperator().getKind() == kind::RELATION_PROJECT_OP);

--- a/src/theory/sets/theory_sets_type_rules.h
+++ b/src/theory/sets/theory_sets_type_rules.h
@@ -31,7 +31,10 @@ namespace sets {
  */
 struct SetsBinaryOperatorTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
   static bool computeIsConst(NodeManager* nodeManager, TNode n);
 };
 
@@ -41,7 +44,10 @@ struct SetsBinaryOperatorTypeRule
  */
 struct SubsetTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -50,7 +56,10 @@ struct SubsetTypeRule
  */
 struct MemberTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -59,7 +68,10 @@ struct MemberTypeRule
  */
 struct SingletonTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 
   static bool computeIsConst(NodeManager* nodeManager, TNode n);
 };
@@ -69,7 +81,10 @@ struct SingletonTypeRule
  */
 struct EmptySetTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -77,7 +92,10 @@ struct EmptySetTypeRule
  */
 struct CardTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -85,7 +103,10 @@ struct CardTypeRule
  */
 struct ComplementTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -93,7 +114,10 @@ struct ComplementTypeRule
  */
 struct UniverseSetTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -103,7 +127,10 @@ struct UniverseSetTypeRule
  */
 struct ComprehensionTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -111,7 +138,10 @@ struct ComprehensionTypeRule
  */
 struct ChooseTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -119,7 +149,10 @@ struct ChooseTypeRule
  */
 struct IsSingletonTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -128,7 +161,10 @@ struct IsSingletonTypeRule
  */
 struct InsertTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -137,7 +173,10 @@ struct InsertTypeRule
  */
 struct SetMapTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct SetMapTypeRule */
 
 /**
@@ -146,7 +185,10 @@ struct SetMapTypeRule
  */
 struct SetFilterTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct SetFilterTypeRule */
 
 /**
@@ -155,7 +197,10 @@ struct SetFilterTypeRule
  */
 struct SetFoldTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct SetFoldTypeRule */
 
 /**
@@ -169,7 +214,10 @@ struct SetFoldTypeRule
  */
 struct RelBinaryOperatorTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -179,7 +227,10 @@ struct RelBinaryOperatorTypeRule
  */
 struct RelTransposeTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -188,7 +239,10 @@ struct RelTransposeTypeRule
  */
 struct RelTransClosureTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -199,7 +253,10 @@ struct RelTransClosureTypeRule
  */
 struct JoinImageTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -209,7 +266,10 @@ struct JoinImageTypeRule
  */
 struct RelIdenTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -220,7 +280,10 @@ struct RelIdenTypeRule
  */
 struct RelationGroupTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct RelationGroupTypeRule */
 
 /**
@@ -231,7 +294,10 @@ struct RelationGroupTypeRule
  */
 struct RelationProjectTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct RelationProjectTypeRule */
 
 /**
@@ -244,7 +310,10 @@ struct RelationProjectTypeRule
  */
 struct RelationAggregateTypeRule
 {
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* struct RelationAggregateTypeRule */
 
 struct SetsProperties

--- a/src/theory/strings/theory_strings_type_rules.cpp
+++ b/src/theory/strings/theory_strings_type_rules.cpp
@@ -27,7 +27,8 @@ namespace strings {
 
 TypeNode StringConcatTypeRule::computeType(NodeManager* nodeManager,
                                            TNode n,
-                                           bool check)
+                                           bool check,
+                                           std::ostream* errOut)
 {
   TypeNode tret;
   for (const Node& nc : n)
@@ -60,7 +61,8 @@ TypeNode StringConcatTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode StringSubstrTypeRule::computeType(NodeManager* nodeManager,
                                            TNode n,
-                                           bool check)
+                                           bool check,
+                                           std::ostream* errOut)
 {
   TypeNode t = n[0].getType(check);
   if (check)
@@ -88,7 +90,8 @@ TypeNode StringSubstrTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode StringUpdateTypeRule::computeType(NodeManager* nodeManager,
                                            TNode n,
-                                           bool check)
+                                           bool check,
+                                           std::ostream* errOut)
 {
   TypeNode t = n[0].getType(check);
   if (check)
@@ -116,7 +119,8 @@ TypeNode StringUpdateTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode StringAtTypeRule::computeType(NodeManager* nodeManager,
                                        TNode n,
-                                       bool check)
+                                       bool check,
+                                       std::ostream* errOut)
 {
   TypeNode t = n[0].getType(check);
   if (check)
@@ -138,7 +142,8 @@ TypeNode StringAtTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode StringIndexOfTypeRule::computeType(NodeManager* nodeManager,
                                             TNode n,
-                                            bool check)
+                                            bool check,
+                                            std::ostream* errOut)
 {
   if (check)
   {
@@ -168,7 +173,8 @@ TypeNode StringIndexOfTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode StringReplaceTypeRule::computeType(NodeManager* nodeManager,
                                             TNode n,
-                                            bool check)
+                                            bool check,
+                                            std::ostream* errOut)
 {
   TypeNode t = n[0].getType(check);
   if (check)
@@ -200,7 +206,8 @@ TypeNode StringReplaceTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode StringStrToBoolTypeRule::computeType(NodeManager* nodeManager,
                                               TNode n,
-                                              bool check)
+                                              bool check,
+                                              std::ostream* errOut)
 {
   if (check)
   {
@@ -217,7 +224,8 @@ TypeNode StringStrToBoolTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode StringStrToIntTypeRule::computeType(NodeManager* nodeManager,
                                              TNode n,
-                                             bool check)
+                                             bool check,
+                                             std::ostream* errOut)
 {
   if (check)
   {
@@ -234,7 +242,8 @@ TypeNode StringStrToIntTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode StringStrToStrTypeRule::computeType(NodeManager* nodeManager,
                                              TNode n,
-                                             bool check)
+                                             bool check,
+                                             std::ostream* errOut)
 {
   TypeNode t = n[0].getType(check);
   if (check)
@@ -251,7 +260,8 @@ TypeNode StringStrToStrTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode StringRelationTypeRule::computeType(NodeManager* nodeManager,
                                              TNode n,
-                                             bool check)
+                                             bool check,
+                                             std::ostream* errOut)
 {
   if (check)
   {
@@ -273,7 +283,8 @@ TypeNode StringRelationTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode RegExpRangeTypeRule::computeType(NodeManager* nodeManager,
                                           TNode n,
-                                          bool check)
+                                          bool check,
+                                          std::ostream* errOut)
 {
   if (check)
   {
@@ -294,7 +305,8 @@ TypeNode RegExpRangeTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode StringToRegExpTypeRule::computeType(NodeManager* nodeManager,
                                              TNode n,
-                                             bool check)
+                                             bool check,
+                                             std::ostream* errOut)
 {
   if (check)
   {
@@ -315,7 +327,8 @@ bool StringToRegExpTypeRule::computeIsConst(NodeManager* nodeManager, TNode n)
 
 TypeNode ConstSequenceTypeRule::computeType(NodeManager* nodeManager,
                                             TNode n,
-                                            bool check)
+                                            bool check,
+                                            std::ostream* errOut)
 {
   Assert(n.getKind() == kind::CONST_SEQUENCE);
   return nodeManager->mkSequenceType(n.getConst<Sequence>().getType());
@@ -323,7 +336,8 @@ TypeNode ConstSequenceTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode SeqUnitTypeRule::computeType(NodeManager* nodeManager,
                                       TNode n,
-                                      bool check)
+                                      bool check,
+                                      std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SEQ_UNIT);
   TypeNode argType = n[0].getType(check);
@@ -332,7 +346,8 @@ TypeNode SeqUnitTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode SeqNthTypeRule::computeType(NodeManager* nodeManager,
                                      TNode n,
-                                     bool check)
+                                     bool check,
+                                     std::ostream* errOut)
 {
   Assert(n.getKind() == kind::SEQ_NTH);
   TypeNode t = n[0].getType(check);

--- a/src/theory/strings/theory_strings_type_rules.h
+++ b/src/theory/strings/theory_strings_type_rules.h
@@ -31,72 +31,108 @@ namespace strings {
 class StringConcatTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class StringSubstrTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class StringUpdateTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class StringAtTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class StringIndexOfTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class StringReplaceTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class StringStrToBoolTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class StringStrToIntTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class StringStrToStrTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class StringRelationTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class RegExpRangeTypeRule {
 public:
- static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+ static TypeNode computeType(NodeManager* nodeManager,
+                             TNode n,
+                             bool check,
+                             std::ostream* errOut);
 };
 
 class StringToRegExpTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 
   /**
    * Returns true if the argument to STRING_TO_REGEXP is a constant.
@@ -115,19 +151,28 @@ class StringToRegExpTypeRule
 class ConstSequenceTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class SeqUnitTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class SeqNthTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /** Properties of the sequence type */

--- a/src/theory/uf/theory_uf_type_rules.cpp
+++ b/src/theory/uf/theory_uf_type_rules.cpp
@@ -29,7 +29,10 @@ namespace cvc5::internal {
 namespace theory {
 namespace uf {
 
-TypeNode UfTypeRule::computeType(NodeManager* nodeManager, TNode n, bool check)
+TypeNode UfTypeRule::computeType(NodeManager* nodeManager,
+                                 TNode n,
+                                 bool check,
+                                 std::ostream* errOut)
 {
   TNode f = n.getOperator();
   TypeNode fType = f.getType(check);
@@ -70,7 +73,8 @@ TypeNode UfTypeRule::computeType(NodeManager* nodeManager, TNode n, bool check)
 
 TypeNode CardinalityConstraintOpTypeRule::computeType(NodeManager* nodeManager,
                                                       TNode n,
-                                                      bool check)
+                                                      bool check,
+                                                      std::ostream* errOut)
 {
   if (check)
   {
@@ -91,13 +95,14 @@ TypeNode CardinalityConstraintOpTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode CardinalityConstraintTypeRule::computeType(NodeManager* nodeManager,
                                                     TNode n,
-                                                    bool check)
+                                                    bool check,
+                                                    std::ostream* errOut)
 {
   return nodeManager->booleanType();
 }
 
 TypeNode CombinedCardinalityConstraintOpTypeRule::computeType(
-    NodeManager* nodeManager, TNode n, bool check)
+    NodeManager* nodeManager, TNode n, bool check, std::ostream* errOut)
 {
   if (check)
   {
@@ -113,14 +118,15 @@ TypeNode CombinedCardinalityConstraintOpTypeRule::computeType(
 }
 
 TypeNode CombinedCardinalityConstraintTypeRule::computeType(
-    NodeManager* nodeManager, TNode n, bool check)
+    NodeManager* nodeManager, TNode n, bool check, std::ostream* errOut)
 {
   return nodeManager->booleanType();
 }
 
 TypeNode HoApplyTypeRule::computeType(NodeManager* nodeManager,
                                       TNode n,
-                                      bool check)
+                                      bool check,
+                                      std::ostream* errOut)
 {
   Assert(n.getKind() == kind::HO_APPLY);
   TypeNode fType = n[0].getType(check);
@@ -159,7 +165,8 @@ TypeNode HoApplyTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode LambdaTypeRule::computeType(NodeManager* nodeManager,
                                      TNode n,
-                                     bool check)
+                                     bool check,
+                                     std::ostream* errOut)
 {
   if (n[0].getType(check) != nodeManager->boundVarListType())
   {
@@ -179,7 +186,8 @@ TypeNode LambdaTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode FunctionArrayConstTypeRule::computeType(NodeManager* nodeManager,
                                                  TNode n,
-                                                 bool check)
+                                                 bool check,
+                                                 std::ostream* errOut)
 {
   Assert(n.getKind() == kind::FUNCTION_ARRAY_CONST);
   const FunctionArrayConst& fc = n.getConst<FunctionArrayConst>();
@@ -227,7 +235,8 @@ Node FunctionProperties::mkGroundTerm(TypeNode type)
 
 TypeNode IntToBitVectorOpTypeRule::computeType(NodeManager* nodeManager,
                                                TNode n,
-                                               bool check)
+                                               bool check,
+                                               std::ostream* errOut)
 {
   Assert(n.getKind() == kind::INT_TO_BITVECTOR_OP);
   size_t bvSize = n.getConst<IntToBitVector>();
@@ -241,7 +250,8 @@ TypeNode IntToBitVectorOpTypeRule::computeType(NodeManager* nodeManager,
 
 TypeNode BitVectorConversionTypeRule::computeType(NodeManager* nodeManager,
                                                   TNode n,
-                                                  bool check)
+                                                  bool check,
+                                                  std::ostream* errOut)
 {
   if (n.getKind() == kind::BITVECTOR_TO_NAT)
   {

--- a/src/theory/uf/theory_uf_type_rules.h
+++ b/src/theory/uf/theory_uf_type_rules.h
@@ -33,7 +33,10 @@ namespace uf {
 class UfTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -42,7 +45,10 @@ class UfTypeRule
 class CardinalityConstraintTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -53,7 +59,10 @@ class CardinalityConstraintTypeRule
 class CardinalityConstraintOpTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -63,7 +72,10 @@ class CardinalityConstraintOpTypeRule
 class CombinedCardinalityConstraintTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -74,7 +86,10 @@ class CombinedCardinalityConstraintTypeRule
 class CombinedCardinalityConstraintOpTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -86,7 +101,10 @@ class HoApplyTypeRule
 {
  public:
   // the typing rule for HO_APPLY terms
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -97,7 +115,10 @@ class HoApplyTypeRule
 class LambdaTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 }; /* class LambdaTypeRule */
 
 /**
@@ -107,7 +128,10 @@ class LambdaTypeRule
 class FunctionArrayConstTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 class FunctionProperties
@@ -129,7 +153,10 @@ class FunctionProperties
 class IntToBitVectorOpTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 /**
@@ -141,7 +168,10 @@ class IntToBitVectorOpTypeRule
 class BitVectorConversionTypeRule
 {
  public:
-  static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
 };
 
 }  // namespace uf


### PR DESCRIPTION
This is work towards eliminating exceptions from the type checker.

We now pass an (optional) output stream to getType, which will be used to output debugging information when type checking fails.

Follow-up PRs will make it so that type checking errors will: (1) return the null TypeNode, (2) write the error message to `errOut` if it exists.