### PR TITLE
cmake: Force Python version for FindPythonInterp and FindPythonLibs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,14 +322,6 @@ else()
 endif()
 
 find_package(Python 3.6...3.10.999 COMPONENTS Interpreter REQUIRED)
-
-# 'PythonExtensions' is not yet compatible with cmake's new 'FindPython'.
-#     https://github.com/scikit-build/scikit-build/issues/506
-# We define the following symbols below to be backward compatible.
-set(PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
-set(PYTHON_INCLUDE_DIR "${Python_INCLUDE_DIR}")
-set(PYTHON_LIBRARY "${Python_LIBRARY}")
-
 find_package(GMP 6.1 REQUIRED)
 
 if(ENABLE_ASAN)

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -43,14 +43,17 @@ endif()
 # Required for Cython target below
 list(APPEND CMAKE_MODULE_PATH ${SKBUILD_CMAKE_MODULE_PATH})
 
-find_package(PythonExtensions REQUIRED)
-
 # 'PythonExtensions' is not yet compatible with cmake's new 'FindPython'.
 #     https://github.com/scikit-build/scikit-build/issues/506
 # We define the following symbols below to be backward compatible.
 find_package(Python 3.6...3.10.999 COMPONENTS Development)
-set(PYTHON_INCLUDE_DIRS "${Python_INCLUDE_DIRS}")
-set(PYTHON_LIBRARY "${Python_LIBRARIES}")
+
+# Since PythonExtensions still uses PythonInterp and PythonLibs, we have to
+# make sure that these modules find the same Python version that was found by
+# FindPython.
+find_package(PythonInterp ${Python_VERSION} REQUIRED)
+find_package(PythonLibs ${Python_VERSION} REQUIRED)
+find_package(PythonExtensions REQUIRED)
 
 find_package(Cython 0.29 REQUIRED)
 

--- a/src/rewriter/CMakeLists.txt
+++ b/src/rewriter/CMakeLists.txt
@@ -32,7 +32,7 @@ add_custom_command(
       rewrites.cpp
       rewrites.h
     COMMAND
-      ${PYTHON_EXECUTABLE}
+      ${Python_EXECUTABLE}
       ${mkrewrites_script}
       rewrite-db
       ${CMAKE_CURRENT_LIST_DIR}


### PR DESCRIPTION
PythonExtensions does not yet support the new cmake FindPython module and still relies on FindPythonInterp and FindPythonLibs. Hence, we force these two modules to find the Python version found by FindPython.

Fixes more nightly issues.