### PR TITLE
Simplify areCareDisequal

### DIFF
--- a/src/theory/theory.cpp
+++ b/src/theory/theory.cpp
@@ -531,7 +531,7 @@ bool Theory::areCareDisequal(TNode x, TNode y)
   if (x.isConst() && y.isConst())
   {
     return true;
-  }    
+  }
   // first just check if they are disequal, which is sufficient for
   // non-shared terms.
   if (d_equalityEngine->areDisequal(x, y, false))

--- a/src/theory/theory.cpp
+++ b/src/theory/theory.cpp
@@ -531,18 +531,21 @@ bool Theory::areCareDisequal(TNode x, TNode y)
   if (x.isConst() && y.isConst())
   {
     return true;
+  }    
+  // first just check if they are disequal, which is sufficient for
+  // non-shared terms.
+  if (d_equalityEngine->areDisequal(x, y, false))
+  {
+    return true;
   }
+  // if we aren't shared, we are not disequal
   if (!d_equalityEngine->isTriggerTerm(x, d_id)
       || !d_equalityEngine->isTriggerTerm(y, d_id))
   {
-    // just check if they are disequal, which is the used in the case for
-    // non-shared terms.
-    if (d_equalityEngine->areDisequal(x, y, false))
-    {
-      return true;
-    }
     return false;
   }
+  // otherwise use getEqualityStatus to ask the appropriate theory whether
+  // x and y are disequal.
   TNode x_shared = d_equalityEngine->getTriggerTermRepresentative(x, d_id);
   TNode y_shared = d_equalityEngine->getTriggerTermRepresentative(y, d_id);
   EqualityStatus eqStatus = d_valuation.getEqualityStatus(x_shared, y_shared);
@@ -551,7 +554,6 @@ bool Theory::areCareDisequal(TNode x, TNode y)
   {
     return true;
   }
-  Assert(!d_equalityEngine->areDisequal(x, y, false));
   return false;
 }
 


### PR DESCRIPTION
We should always check disequality locally before checking the equality status for other theories.  This also makes `areCareDisequal` more precise in some rare corner cases where `getEqualityStatus` is incomplete.

Fixes https://github.com/cvc5/cvc5/issues/9315.