### PR TITLE
Catch failures when binding terms

### DIFF
--- a/src/parser/api/cpp/command.cpp
+++ b/src/parser/api/cpp/command.cpp
@@ -494,7 +494,10 @@ cvc5::Sort DeclareSygusVarCommand::getSort() const { return d_sort; }
 
 void DeclareSygusVarCommand::invoke(cvc5::Solver* solver, SymbolManager* sm)
 {
-  sm->bind(d_symbol, d_var, true);
+  if (!bindToTerm(sm, d_var, true))
+  {
+    return;
+  }
   d_commandStatus = CommandSuccess::instance();
 }
 
@@ -542,7 +545,10 @@ const cvc5::Grammar* SynthFunCommand::getGrammar() const { return d_grammar; }
 
 void SynthFunCommand::invoke(cvc5::Solver* solver, SymbolManager* sm)
 {
-  sm->bind(d_symbol, d_fun, true);
+  if (!bindToTerm(sm, d_fun, true))
+  {
+    return;
+  }
   sm->addFunctionToSynthesize(d_fun);
   d_commandStatus = CommandSuccess::instance();
 }
@@ -836,6 +842,21 @@ DeclarationDefinitionCommand::DeclarationDefinitionCommand(
 
 std::string DeclarationDefinitionCommand::getSymbol() const { return d_symbol; }
 
+bool DeclarationDefinitionCommand::bindToTerm(SymbolManager* sm,
+                                              cvc5::Term t,
+                                              bool doOverload)
+{
+  if (!sm->bind(d_symbol, t, true))
+  {
+    std::stringstream ss;
+    ss << "Cannot bind " << d_symbol << " to symbol of type " << t.getSort();
+    ss << ", maybe the symbol has already been defined?";
+    d_commandStatus = new CommandFailure(ss.str());
+    return false;
+  }
+  return true;
+}
+
 /* -------------------------------------------------------------------------- */
 /* class DeclareFunctionCommand                                               */
 /* -------------------------------------------------------------------------- */
@@ -852,7 +873,10 @@ cvc5::Sort DeclareFunctionCommand::getSort() const { return d_sort; }
 
 void DeclareFunctionCommand::invoke(cvc5::Solver* solver, SymbolManager* sm)
 {
-  sm->bind(d_symbol, d_func, true);
+  if (!bindToTerm(sm, d_func, true))
+  {
+    return;
+  }
   // mark that it will be printed in the model
   sm->addModelDeclarationTerm(d_func);
   d_commandStatus = CommandSuccess::instance();
@@ -893,7 +917,10 @@ const std::vector<cvc5::Term>& DeclarePoolCommand::getInitialValue() const
 
 void DeclarePoolCommand::invoke(cvc5::Solver* solver, SymbolManager* sm)
 {
-  sm->bind(d_symbol, d_func, true);
+  if (!bindToTerm(sm, d_func, true))
+  {
+    return;
+  }
   // Notice that the pool is already declared by the parser so that it the
   // symbol is bound eagerly. This is analogous to DeclareSygusVarCommand.
   // Hence, we do nothing here.
@@ -1084,7 +1111,10 @@ void DefineFunctionCommand::invoke(cvc5::Solver* solver, SymbolManager* sm)
     bool global = sm->getGlobalDeclarations();
     cvc5::Term fun =
         solver->defineFun(d_symbol, d_formals, d_sort, d_formula, global);
-    sm->bind(d_symbol, fun, global);
+    if (!bindToTerm(sm, fun, true))
+    {
+      return;
+    }
     d_commandStatus = CommandSuccess::instance();
   }
   catch (exception& e)

--- a/src/parser/api/cpp/command.h
+++ b/src/parser/api/cpp/command.h
@@ -319,8 +319,7 @@ class CVC5_EXPORT DeclarationDefinitionCommand : public Command
   std::string d_symbol;
   /**
    * Bind the symbol of this command to the given term. Return false if the
-   * binding was invalid. In this case, set to command status to
-   * CommandFailure.
+   * binding was invalid. In this case, set command status to CommandFailure.
    */
   bool bindToTerm(parser::SymbolManager* sm, cvc5::Term t, bool doOverload);
 

--- a/src/parser/api/cpp/command.h
+++ b/src/parser/api/cpp/command.h
@@ -317,6 +317,12 @@ class CVC5_EXPORT DeclarationDefinitionCommand : public Command
 {
  protected:
   std::string d_symbol;
+  /**
+   * Bind the symbol of this command to the given term. Return false if the
+   * binding was invalid. In this case, set to command status to
+   * CommandFailure.
+   */
+  bool bindToTerm(parser::SymbolManager* sm, cvc5::Term t, bool doOverload);
 
  public:
   DeclarationDefinitionCommand(const std::string& id);

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -979,6 +979,7 @@ set(regress_0_tests
   regress0/parser/dd.define-named.smt2
   regress0/parser/declarefun-emptyset-uf.smt2
   regress0/parser/define_sort.smt2
+  regress0/parser/double-bind.smt2
   regress0/parser/force_logic_set_logic.smt2
   regress0/parser/force_logic_success.smt2
   regress0/parser/get-model-sort-constructor.smt2

--- a/test/regress/cli/regress0/parser/double-bind.smt2
+++ b/test/regress/cli/regress0/parser/double-bind.smt2
@@ -1,5 +1,6 @@
-; EXIT: 1
 ; EXPECT: (error "Cannot bind x to symbol of type Bool, maybe the symbol has already been defined?")
+; EXIT: 1
+; DISABLE-TESTER: dump
 (set-logic ALL)
 (declare-const x Bool)
 (declare-const x Bool)

--- a/test/regress/cli/regress0/parser/double-bind.smt2
+++ b/test/regress/cli/regress0/parser/double-bind.smt2
@@ -1,0 +1,7 @@
+; EXIT: 1
+; EXPECT: (error "Cannot bind x to symbol of type Bool, maybe the symbol has already been defined?")
+(set-logic ALL)
+(declare-const x Bool)
+(declare-const x Bool)
+(assert (= x x))
+(check-sat)


### PR DESCRIPTION
A recent commit https://github.com/cvc5/cvc5/pull/9355 made it so that symbols are bound by commands and not by the parser.

This PR corrects an issue where we would not report errors for illegally overloaded symbols.