### PR TITLE
Add evaluators for bv to arith conversions

### DIFF
--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -954,7 +954,8 @@ EvalResult Evaluator::evalInternal(
         case kind::INT_TO_BITVECTOR:
         {
           Integer i = results[currNode[0]].d_rat.getNumerator();
-          const uint32_t size = currNodeVal.getOperator().getConst<IntToBitVector>().d_size;
+          const uint32_t size =
+              currNodeVal.getOperator().getConst<IntToBitVector>().d_size;
           results[currNode] = EvalResult(BitVector(size, i));
           break;
         }

--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -945,7 +945,19 @@ EvalResult Evaluator::evalInternal(
           }
           break;
         }
-
+        case kind::BITVECTOR_TO_NAT:
+        {
+          BitVector res = results[currNode[0]].d_bv;
+          results[currNode] = EvalResult(Rational(res.toInteger()));
+          break;
+        }
+        case kind::INT_TO_BITVECTOR:
+        {
+          Integer i = results[currNode[0]].d_rat.getNumerator();
+          const uint32_t size = currNodeVal.getOperator().getConst<IntToBitVector>().d_size;
+          results[currNode] = EvalResult(BitVector(size, i));
+          break;
+        }
         default:
         {
           Trace("evaluator") << "Kind " << currNodeVal.getKind()

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2908,6 +2908,7 @@ set(regress_1_tests
   regress1/sygus/array-grammar-store.sy
   regress1/sygus/array_search_5-Q-easy.sy
   regress1/sygus/array-uc.sy
+  regress1/sygus/bv2nat.sy
   regress1/sygus/bvudiv-by-2.sy
   regress1/sygus/cegar1.sy
   regress1/sygus/cegis-unif-inv-eq-fair.sy
@@ -2956,6 +2957,7 @@ set(regress_1_tests
   regress1/sygus/inv-example.sy
   regress1/sygus/inv-missed-sol-true.sy
   regress1/sygus/inv-unused.sy
+  regress1/sygus/int2bv.sy
   regress1/sygus/interpol1.smt2
   regress1/sygus/interpol1-push-pop.smt2
   regress1/sygus/interpol3.smt2

--- a/test/regress/cli/regress1/sygus/bv2nat.sy
+++ b/test/regress/cli/regress1/sygus/bv2nat.sy
@@ -1,0 +1,18 @@
+; EXPECT: feasible
+; COMMAND-LINE: --sygus-out=status
+(set-logic ALL)
+(synth-fun f ((x (_ BitVec 4))) Int
+  ((StartInt Int) (StartBv (_ BitVec 4)))
+  (
+  (StartInt Int (0 1 (+ StartInt StartInt) (bv2nat StartBv)))
+  (StartBv (_ BitVec 4) (#b0000 #b0001 x))
+  )
+)
+
+
+(constraint (= (f #b0011) 3))
+(constraint (= (f #b0010) 2))
+(constraint (= (f #b0001) 1))
+(constraint (= (f #b1011) 11))
+
+(check-synth)

--- a/test/regress/cli/regress1/sygus/int2bv.sy
+++ b/test/regress/cli/regress1/sygus/int2bv.sy
@@ -1,0 +1,18 @@
+; EXPECT: feasible
+; COMMAND-LINE: --sygus-out=status
+(set-logic ALL)
+(synth-fun f ((x Int)) (_ BitVec 4)
+  ((Start (_ BitVec 4)) (StartInt Int))
+  (
+  (Start (_ BitVec 4) (#b0000 #b0001 ((_ int2bv 4) StartInt)))
+  (StartInt Int (0 1 x (+ StartInt StartInt)))
+  )
+)
+
+
+(constraint (= (f 3) #b0011))
+(constraint (= (f 2) #b0010))
+(constraint (= (f 1) #b0001))
+(constraint (= (f 11) #b1011))
+
+(check-synth)


### PR DESCRIPTION
Likely to be important to performance of BV rewrite rule proof reconstruction, where conditions/constant expressions/bitvector sizes may be expressed using `bv2nat`.

Adds a few sygus regressions that exercise the evaluator.