### PR TITLE
Fixed brew link error from CI MacOS builds.

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -69,7 +69,6 @@ runs:
 
         # Temporary workaround while versions of python greater than 3.10 are not supported:
         # Hardcoding python version to 3.10 on macOS CI.
-        brew install python@3.10
         brew link --overwrite python@3.10
         ln -s -f /usr/local/bin/python3.10 /usr/local/bin/python3
 


### PR DESCRIPTION
MacOS builds started on February 02, 2023 to fail due to this error:
```==> Pouring python@3.10--3.10.10.monterey.bottle.tar.gz
  Error: The `brew link` step did not complete successfully
  The formula built, but is not symlinked into /usr/local
  Could not symlink bin/2to3
  Target /usr/local/bin/2to3
  already exists. You may want to remove it:
    rm '/usr/local/bin/2to3'

  To force the link and overwrite all conflicting files:
    brew link --overwrite python@3.10

  To list all files that would be deleted:
    brew link --overwrite --dry-run python@3.10
```
That seems related to a python version being released (3.10.10). Just removing the install command fixed the issue.   
