### PR TITLE
Improvements to user-facing parser API

### DIFF
--- a/src/main/driver_unified.cpp
+++ b/src/main/driver_unified.cpp
@@ -36,7 +36,7 @@
 #include "main/signal_handlers.h"
 #include "main/time_limit.h"
 #include "parser/api/cpp/command.h"
-#include "parser/input_parser.h"
+#include "parser/api/cpp/input_parser.h"
 #include "smt/solver_engine.h"
 #include "util/result.h"
 
@@ -221,7 +221,7 @@ int runCvc5(int argc, char* argv[], std::unique_ptr<cvc5::Solver>& solver)
       }
 
       std::unique_ptr<InputParser> parser(new InputParser(
-              pExecutor->getSolver(), pExecutor->getSymbolManager(), true));
+              pExecutor->getSolver(), pExecutor->getSymbolManager()));
       if( inputFromStdin ) {
         parser->setStreamInput(
             solver->getOption("input-language"), cin, filename);

--- a/src/main/driver_unified.cpp
+++ b/src/main/driver_unified.cpp
@@ -221,7 +221,7 @@ int runCvc5(int argc, char* argv[], std::unique_ptr<cvc5::Solver>& solver)
       }
 
       std::unique_ptr<InputParser> parser(new InputParser(
-              pExecutor->getSolver(), pExecutor->getSymbolManager()));
+          pExecutor->getSolver(), pExecutor->getSymbolManager()));
       if( inputFromStdin ) {
         parser->setStreamInput(
             solver->getOption("input-language"), cin, filename);

--- a/src/main/interactive_shell.cpp
+++ b/src/main/interactive_shell.cpp
@@ -44,8 +44,8 @@
 #include "base/output.h"
 #include "main/command_executor.h"
 #include "parser/api/cpp/command.h"
-#include "parser/api/cpp/symbol_manager.h"
 #include "parser/api/cpp/input_parser.h"
+#include "parser/api/cpp/symbol_manager.h"
 #include "theory/logic_info.h"
 
 using namespace std;

--- a/src/main/interactive_shell.cpp
+++ b/src/main/interactive_shell.cpp
@@ -45,7 +45,7 @@
 #include "main/command_executor.h"
 #include "parser/api/cpp/command.h"
 #include "parser/api/cpp/symbol_manager.h"
-#include "parser/input_parser.h"
+#include "parser/api/cpp/input_parser.h"
 #include "theory/logic_info.h"
 
 using namespace std;
@@ -99,7 +99,7 @@ InteractiveShell::InteractiveShell(main::CommandExecutor* cexec,
     d_symman->forceLogic(tmp.getLogicString());
   }
   /* Create parser with bogus input. */
-  d_parser.reset(new cvc5::parser::InputParser(d_solver, d_symman, true));
+  d_parser.reset(new cvc5::parser::InputParser(d_solver, d_symman));
   // initialize for incremental string input
   d_parser->setIncrementalStringInput(d_solver->getOption("input-language"),
                                       INPUT_FILENAME);

--- a/src/main/portfolio_driver.h
+++ b/src/main/portfolio_driver.h
@@ -23,7 +23,7 @@
 #include "base/check.h"
 #include "main/command_executor.h"
 #include "parser/api/cpp/command.h"
-#include "parser/input_parser.h"
+#include "parser/api/cpp/input_parser.h"
 
 namespace cvc5::main {
 

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -33,6 +33,8 @@ set(libcvc5parserapi_src_files
   api/cpp/command.h
   api/cpp/symbol_manager.cpp
   api/cpp/symbol_manager.h
+  api/cpp/input_parser.cpp
+  api/cpp/input_parser.h
 )
 
 set(libcvc5parser_src_files
@@ -53,8 +55,6 @@ set(libcvc5parser_src_files
   flex_parser.h
   input.cpp
   input.h
-  input_parser.cpp
-  input_parser.h
   line_buffer.cpp
   line_buffer.h
   parse_op.cpp

--- a/src/parser/api/cpp/command.h
+++ b/src/parser/api/cpp/command.h
@@ -19,8 +19,8 @@
 
 #include "cvc5_public.h"
 
-#ifndef CVC5__PARSER__COMMAND_H
-#define CVC5__PARSER__COMMAND_H
+#ifndef CVC5__PARSER__API__CPP__COMMAND_H
+#define CVC5__PARSER__API__CPP__COMMAND_H
 
 #include <iosfwd>
 #include <sstream>

--- a/src/parser/api/cpp/input_parser.cpp
+++ b/src/parser/api/cpp/input_parser.cpp
@@ -31,12 +31,16 @@ InputParser::InputParser(Solver* solver, SymbolManager* sm)
   initialize();
 }
 
-InputParser::InputParser(Solver* solver) : d_solver(solver), d_allocSm(new SymbolManager(solver)), d_sm(d_allocSm.get()) {
+InputParser::InputParser(Solver* solver)
+    : d_solver(solver),
+      d_allocSm(new SymbolManager(solver)),
+      d_sm(d_allocSm.get())
+{
   initialize();
 }
 
 void InputParser::initialize()
-{  
+{
   d_useFlex = d_solver->getOptionInfo("flex-parser").boolValue();
   // flex not supported with TPTP yet
   if (d_solver->getOption("input-language") == "LANG_TPTP")

--- a/src/parser/api/cpp/input_parser.cpp
+++ b/src/parser/api/cpp/input_parser.cpp
@@ -19,7 +19,6 @@
 #include "parser/api/cpp/command.h"
 #include "parser/input.h"
 #include "parser/parser_builder.h"
-#include "parser/smt2/smt2_lexer.h"
 #include "theory/logic_info.h"
 
 namespace cvc5 {

--- a/src/parser/api/cpp/input_parser.h
+++ b/src/parser/api/cpp/input_parser.h
@@ -48,13 +48,13 @@ class CVC5_EXPORT InputParser
    * @param solver The solver (e.g. for constructing terms and sorts)
    * @param sm The symbol manager, which contains a symbol table that maps
    * symbols to terms and sorts.
-   */ 
+   */
   InputParser(Solver* solver, SymbolManager* sm);
   /**
    * Construct an input parser with an initially empty symbol manager.
    *
    * @param solver The solver (e.g. for constructing terms and sorts)
-   */ 
+   */
   InputParser(Solver* solver);
 
   /** Get the underlying solver of this input parser */

--- a/src/parser/api/cpp/input_parser.h
+++ b/src/parser/api/cpp/input_parser.h
@@ -15,8 +15,8 @@
 
 #include "cvc5parser_public.h"
 
-#ifndef CVC5__PARSER__INPUT_PARSER_H
-#define CVC5__PARSER__INPUT_PARSER_H
+#ifndef CVC5__PARSER__API__CPP__INPUT_PARSER_H
+#define CVC5__PARSER__API__CPP__INPUT_PARSER_H
 
 #include <memory>
 
@@ -29,7 +29,6 @@ namespace cvc5 {
 namespace parser {
 
 class Command;
-class Parser;
 class SymbolManager;
 
 /**
@@ -39,16 +38,29 @@ class SymbolManager;
  * After construction, it is expected that an input is first set via e.g.
  * setFileInput, setStreamInput, or setStringInput. Then, the methods
  * nextCommand and nextExpression can be invoked to parse the input.
- *
- * It currently uses a (deprecated) implementation which relies on ANTLR.
  */
 class CVC5_EXPORT InputParser
 {
-  friend Parser;
-
  public:
-  InputParser(Solver* solver, SymbolManager* sm, bool useOptions);
+  /**
+   * Construct an input parser
+   *
+   * @param solver The solver (e.g. for constructing terms and sorts)
+   * @param sm The symbol manager, which contains a symbol table that maps
+   * symbols to terms and sorts.
+   */ 
+  InputParser(Solver* solver, SymbolManager* sm);
+  /**
+   * Construct an input parser with an initially empty symbol manager.
+   *
+   * @param solver The solver (e.g. for constructing terms and sorts)
+   */ 
+  InputParser(Solver* solver);
 
+  /** Get the underlying solver of this input parser */
+  Solver* getSolver();
+  /** Get the underlying symbol manager of this input parser */
+  SymbolManager* getSymbolManager();
   /** Set the input for the given file.
    *
    * @param lang the input language
@@ -94,12 +106,14 @@ class CVC5_EXPORT InputParser
   Term nextExpression();
 
  private:
+  /** Initialize this input parser, called during construction */
+  void initialize();
   /** Solver */
   Solver* d_solver;
+  /** The allocated symbol manager */
+  std::unique_ptr<SymbolManager> d_allocSm;
   /** Symbol manager */
   SymbolManager* d_sm;
-  /** use options */
-  bool d_useOptions;
   /** whether to use flex */
   bool d_useFlex;
   /** Incremental string input language */

--- a/src/parser/api/cpp/symbol_manager.h
+++ b/src/parser/api/cpp/symbol_manager.h
@@ -15,8 +15,8 @@
 
 #include "cvc5_public.h"
 
-#ifndef CVC5__EXPR__SYMBOL_MANAGER_H
-#define CVC5__EXPR__SYMBOL_MANAGER_H
+#ifndef CVC5__PARSER__API__CPP__SYMBOL_MANAGER_H
+#define CVC5__PARSER__API__CPP__SYMBOL_MANAGER_H
 
 #include <map>
 #include <memory>


### PR DESCRIPTION
This is in preparation for allowing the user to allocate parsers and parse terms from strings.

It makes it so that symbol manager is optional, moves the input parser to `parser/cpp/api` and simplifies a few things.