### PR TITLE
context: Use uint32_t for context level.

### DIFF
--- a/src/context/context.cpp
+++ b/src/context/context.cpp
@@ -54,6 +54,11 @@ Context::~Context() {
   }
 }
 
+uint32_t Context::getLevel() const
+{
+  Assert(d_scopeList.size() > 0);
+  return d_scopeList.size() - 1;
+}
 
 void Context::push() {
   Trace("pushpop") << std::string(2 * getLevel(), ' ') << "Push [to "
@@ -104,13 +109,11 @@ void Context::pop() {
                    << getLevel() << "] " << this << std::endl;
 }
 
-
-void Context::popto(int toLevel) {
+void Context::popto(uint32_t toLevel)
+{
   // Pop scopes until there are none left or toLevel is reached
-  if(toLevel < 0) toLevel = 0;
-  while(toLevel < getLevel()) pop();
+  while (toLevel < getLevel()) pop();
 }
-
 
 void Context::addNotifyObjPre(ContextNotifyObj* pCNO) {
   // Insert pCNO at *front* of list
@@ -294,7 +297,7 @@ std::ostream& operator<<(std::ostream& out, const Context& context)
 {
   static const std::string separator(79, '-');
 
-  int level = context.d_scopeList.size() - 1;
+  uint32_t level = context.d_scopeList.size() - 1;
   typedef std::vector<Scope*>::const_reverse_iterator const_reverse_iterator;
   for(const_reverse_iterator i = context.d_scopeList.rbegin();
       i != context.d_scopeList.rend();

--- a/src/context/context.h
+++ b/src/context/context.h
@@ -160,7 +160,7 @@ public:
   /**
    * Return the current Scope level.
    */
-  int getLevel() const { return d_scopeList.size() - 1; }
+  uint32_t getLevel() const;
 
   /**
    * Return the ContextMemoryManager associated with the context.
@@ -180,7 +180,7 @@ public:
   /**
    * Pop all the way back to given level
    */
-  void popto(int toLevel);
+  void popto(uint32_t toLevel);
 
   /**
    * Add pCNO to the list of objects notified before every pop
@@ -241,7 +241,7 @@ class Scope {
    * Scope level (total number of outstanding push() calls when this Scope was
    * created).
    */
-  int d_level;
+  uint32_t d_level;
 
   /**
    * Linked list of objects which changed in this scope,
@@ -264,7 +264,7 @@ class Scope {
    * Constructor: Create a new Scope; set the level and the previous Scope
    * if any.
    */
-  Scope(Context* pContext, ContextMemoryManager* pCMM, int level)
+  Scope(Context* pContext, ContextMemoryManager* pCMM, uint32_t level)
       : d_pContext(pContext),
         d_pCMM(pCMM),
         d_level(level),
@@ -292,7 +292,7 @@ class Scope {
   /**
    * Get the level of the current Scope
    */
-  int getLevel() const { return d_level; }
+  uint32_t getLevel() const { return d_level; }
 
   /**
    * Return true iff this Scope is the current top Scope
@@ -544,7 +544,7 @@ class CVC5_EXPORT ContextObj
    * ContextObj-derived class needs to compare the level of its last
    * update with another ContextObj.
    */
-  int getLevel() const { return d_pScope->getLevel(); }
+  uint32_t getLevel() const { return d_pScope->getLevel(); }
 
   /**
    * Returns true if the object is "current"-- that is, updated in the

--- a/src/prop/cadical.cpp
+++ b/src/prop/cadical.cpp
@@ -197,7 +197,7 @@ SatValue CadicalSolver::modelValue(SatLiteral l)
   return value(l);
 }
 
-unsigned CadicalSolver::getAssertionLevel() const
+uint32_t CadicalSolver::getAssertionLevel() const
 {
   Unreachable() << "CaDiCaL does not support assertion levels.";
 }

--- a/src/prop/cadical.h
+++ b/src/prop/cadical.h
@@ -58,7 +58,7 @@ class CadicalSolver : public SatSolver
 
   SatValue modelValue(SatLiteral l) override;
 
-  unsigned getAssertionLevel() const override;
+  uint32_t getAssertionLevel() const override;
 
   bool ok() const override;
 

--- a/src/prop/cryptominisat.cpp
+++ b/src/prop/cryptominisat.cpp
@@ -229,7 +229,8 @@ SatValue CryptoMinisatSolver::value(SatLiteral l){
 
 SatValue CryptoMinisatSolver::modelValue(SatLiteral l) { return value(l); }
 
-unsigned CryptoMinisatSolver::getAssertionLevel() const {
+uint32_t CryptoMinisatSolver::getAssertionLevel() const
+{
   Unreachable() << "No interface to get assertion level in Cryptominisat";
   return -1;
 }

--- a/src/prop/cryptominisat.h
+++ b/src/prop/cryptominisat.h
@@ -68,7 +68,7 @@ class CryptoMinisatSolver : public SatSolver
   SatValue value(SatLiteral l) override;
   SatValue modelValue(SatLiteral l) override;
 
-  unsigned getAssertionLevel() const override;
+  uint32_t getAssertionLevel() const override;
 
  private:
   class Statistics

--- a/src/prop/kissat.cpp
+++ b/src/prop/kissat.cpp
@@ -145,7 +145,7 @@ SatValue KissatSolver::modelValue(SatLiteral l)
   return value(l);
 }
 
-unsigned KissatSolver::getAssertionLevel() const
+uint32_t KissatSolver::getAssertionLevel() const
 {
   Unreachable() << "Kissat does not support assertion levels.";
 }

--- a/src/prop/kissat.h
+++ b/src/prop/kissat.h
@@ -59,7 +59,7 @@ class KissatSolver : public SatSolver
 
   SatValue modelValue(SatLiteral l) override;
 
-  unsigned getAssertionLevel() const override;
+  uint32_t getAssertionLevel() const override;
 
   bool ok() const override;
 

--- a/src/prop/minisat/core/Solver.cc
+++ b/src/prop/minisat/core/Solver.cc
@@ -394,7 +394,8 @@ CRef Solver::reason(Var x) {
   if (needProof() && explLevel < assertionLevel)
   {
     Trace("pf::sat") << "..user level is " << userContext()->getLevel() << "\n";
-    Assert(userContext()->getLevel() == (assertionLevel + 1));
+    Assert(userContext()->getLevel()
+           == static_cast<uint32_t>(assertionLevel + 1));
     d_proxy->notifyCurrPropagationInsertedAtLevel(explLevel);
   }
   // Construct the reason

--- a/src/prop/minisat/minisat.cpp
+++ b/src/prop/minisat/minisat.cpp
@@ -305,7 +305,8 @@ std::shared_ptr<ProofNode> MinisatSatSolver::getProof()
 
 /** Incremental interface */
 
-unsigned MinisatSatSolver::getAssertionLevel() const {
+uint32_t MinisatSatSolver::getAssertionLevel() const
+{
   return d_minisat->getAssertionLevel();
 }
 

--- a/src/prop/minisat/minisat.h
+++ b/src/prop/minisat/minisat.h
@@ -82,7 +82,7 @@ class MinisatSatSolver : public CDCLTSatSolverInterface, protected EnvObj
 
   /** Incremental interface */
 
-  unsigned getAssertionLevel() const override;
+  uint32_t getAssertionLevel() const override;
 
   void push() override;
 

--- a/src/prop/proof_cnf_stream.cpp
+++ b/src/prop/proof_cnf_stream.cpp
@@ -696,7 +696,7 @@ void ProofCnfStream::convertPropagation(TrustNode trn)
   }
 }
 
-void ProofCnfStream::notifyCurrPropagationInsertedAtLevel(int explLevel)
+void ProofCnfStream::notifyCurrPropagationInsertedAtLevel(uint32_t explLevel)
 {
   Assert(explLevel < (userContext()->getLevel() - 1));
   Assert(!d_currPropagationProcessed.isNull());
@@ -730,7 +730,7 @@ void ProofCnfStream::notifyCurrPropagationInsertedAtLevel(int explLevel)
 }
 
 void ProofCnfStream::notifyClauseInsertedAtLevel(const SatClause& clause,
-                                                 int clLevel)
+                                                 uint32_t clLevel)
 {
   Trace("cnf") << "Need to save clause " << clause << " in level "
                << clLevel + 1 << " despite being currently in level "

--- a/src/prop/proof_cnf_stream.h
+++ b/src/prop/proof_cnf_stream.h
@@ -127,12 +127,12 @@ class ProofCnfStream : protected EnvObj, public ProofGenerator
    * saved in d_optClausesPfs, so that it is not potentially lost when the user
    * context is popped.
    */
-  void notifyCurrPropagationInsertedAtLevel(int explLevel);
+  void notifyCurrPropagationInsertedAtLevel(uint32_t explLevel);
   /** Notify that added clause was inserted at lower level than current.
    *
    * As above, the proof of this clause is saved in  d_optClausesPfs.
    */
-  void notifyClauseInsertedAtLevel(const SatClause& clause, int clLevel);
+  void notifyClauseInsertedAtLevel(const SatClause& clause, uint32_t clLevel);
 
   /** Retrieve the proofs for clauses derived from the input */
   std::vector<std::shared_ptr<ProofNode>> getInputClausesProofs();

--- a/src/prop/prop_engine.cpp
+++ b/src/prop/prop_engine.cpp
@@ -619,7 +619,7 @@ void PropEngine::resetTrail()
   Trace("prop") << "resetTrail()" << std::endl;
 }
 
-unsigned PropEngine::getAssertionLevel() const
+uint32_t PropEngine::getAssertionLevel() const
 {
   return d_satSolver->getAssertionLevel();
 }

--- a/src/prop/prop_engine.h
+++ b/src/prop/prop_engine.h
@@ -264,7 +264,7 @@ class PropEngine : protected EnvObj
   /**
    * Get the assertion level of the SAT solver.
    */
-  unsigned getAssertionLevel() const;
+  uint32_t getAssertionLevel() const;
 
   /**
    * Return true if we are currently searching (either in this or

--- a/src/prop/sat_proof_manager.cpp
+++ b/src/prop/sat_proof_manager.cpp
@@ -155,7 +155,7 @@ void SatProofManager::endResChain(const Minisat::Clause& clause)
     clauseLits.insert(MinisatSatSolver::toSatLiteral(clause[i]));
   }
   Node conclusion = getClauseNode(clause);
-  int clauseLevel = clause.level() + 1;
+  uint32_t clauseLevel = clause.level() + 1;
   if (clauseLevel < userContext()->getLevel()
       && !d_resChains.hasGenerator(conclusion))
   {

--- a/src/prop/sat_solver.h
+++ b/src/prop/sat_solver.h
@@ -96,7 +96,7 @@ public:
   virtual SatValue modelValue(SatLiteral l) = 0;
 
   /** Get the current assertion level */
-  virtual unsigned getAssertionLevel() const = 0;
+  virtual uint32_t getAssertionLevel() const = 0;
 
   /** Check if the solver is in an inconsistent state */
   virtual bool ok() const = 0;

--- a/src/smt/context_manager.cpp
+++ b/src/smt/context_manager.cpp
@@ -134,7 +134,7 @@ void ContextManager::pop()
   context()->pop();
 }
 
-void ContextManager::popto(int toLevel)
+void ContextManager::popto(uint32_t toLevel)
 {
   context()->popto(toLevel);
   userContext()->popto(toLevel);

--- a/src/smt/context_manager.h
+++ b/src/smt/context_manager.h
@@ -112,7 +112,7 @@ class ContextManager : protected EnvObj
   /** Pops the user and SAT contexts */
   void pop();
   /** Pops the user and SAT contexts to the given level */
-  void popto(int toLevel);
+  void popto(uint32_t toLevel);
   /**
    * Internal push, which processes any pending pops, and pushes (if in
    * incremental mode).

--- a/src/smt/context_manager.h
+++ b/src/smt/context_manager.h
@@ -129,7 +129,7 @@ class ContextManager : protected EnvObj
   /** Pointer to the SmtDriver */
   SmtDriver* d_smt;
   /** The context levels of user pushes */
-  std::vector<int> d_userLevels;
+  std::vector<uint32_t> d_userLevels;
   /** Number of internal pops that have been deferred. */
   unsigned d_pendingPops;
   /**

--- a/src/theory/arith/linear/theory_arith_private.cpp
+++ b/src/theory/arith/linear/theory_arith_private.cpp
@@ -1812,7 +1812,7 @@ void TheoryArithPrivate::outputRestart() {
 }
 
 bool TheoryArithPrivate::attemptSolveInteger(Theory::Effort effortLevel, bool emmmittedLemmaOrSplit){
-  int level = context()->getLevel();
+  uint32_t level = context()->getLevel();
   Trace("approx")
     << "attemptSolveInteger " << d_qflraStatus
     << " " << emmmittedLemmaOrSplit
@@ -1851,7 +1851,8 @@ bool TheoryArithPrivate::attemptSolveInteger(Theory::Effort effortLevel, bool em
     return false;
   }
 
-  if (d_lastContextIntegerAttempted <= (level >> 2))
+  if (d_lastContextIntegerAttempted < 0
+      || static_cast<uint32_t>(d_lastContextIntegerAttempted) <= (level >> 2))
   {
     double d = (double)(d_solveIntMaybeHelp + 1)
                / (d_solveIntAttempts + 1 + level * level);
@@ -2697,7 +2698,7 @@ void TheoryArithPrivate::solveInteger(Theory::Effort effortLevel){
   Assert(options().arith.useApprox);
   Assert(ApproximateSimplex::enabled());
 
-  int level = context()->getLevel();
+  uint32_t level = context()->getLevel();
   d_lastContextIntegerAttempted = level;
 
   static constexpr int32_t mipLimit = 200000;


### PR DESCRIPTION
I checked if a negative level is ever used, and there is not, also not in `popto`. The only special case is theory arith, which initializes d_lastContextIntegerAttempted with -1, hence the special handling.