### PR TITLE
Fix special cases for channel options

### DIFF
--- a/src/options/managed_streams.cpp
+++ b/src/options/managed_streams.cpp
@@ -72,42 +72,26 @@ std::string cvc5_errno_failreason()
 
 namespace detail {
 
-std::string stripQuotes(const std::string& filename)
-{
-  if (filename.size() < 2 || filename[0] != '\"'
-      || filename[filename.size() - 1] != '\"')
-  {
-    throw OptionException(
-        "Stream names must be delimited by quotes, got invalid name `"
-        + filename + "`.");
-  }
-  std::string sfile = filename;
-  sfile = sfile.erase(0, 1);
-  return sfile.erase(sfile.size() - 1, 1);
-}
-
 std::unique_ptr<std::ostream> openOStream(const std::string& filename)
 {
-  std::string sfile = stripQuotes(filename);
   errno = 0;
-  std::unique_ptr<std::ostream> res = std::make_unique<std::ofstream>(sfile);
+  std::unique_ptr<std::ostream> res = std::make_unique<std::ofstream>(filename);
   if (!res || !*res)
   {
     std::stringstream ss;
-    ss << "Cannot open file: `" << sfile << "': " << cvc5_errno_failreason();
+    ss << "Cannot open file: `" << filename << "': " << cvc5_errno_failreason();
     throw OptionException(ss.str());
   }
   return res;
 }
 std::unique_ptr<std::istream> openIStream(const std::string& filename)
 {
-  std::string sfile = stripQuotes(filename);
   errno = 0;
-  std::unique_ptr<std::istream> res = std::make_unique<std::ifstream>(sfile);
+  std::unique_ptr<std::istream> res = std::make_unique<std::ifstream>(filename);
   if (!res || !*res)
   {
     std::stringstream ss;
-    ss << "Cannot open file: `" << sfile << "': " << cvc5_errno_failreason();
+    ss << "Cannot open file: `" << filename << "': " << cvc5_errno_failreason();
     throw OptionException(ss.str());
   }
   return res;
@@ -117,14 +101,14 @@ std::unique_ptr<std::istream> openIStream(const std::string& filename)
 ManagedErr::ManagedErr() : ManagedStream(&std::cerr, "stderr") {}
 bool ManagedErr::specialCases(const std::string& value)
 {
-  if (value == "\"stderr\"" || value == "--")
+  if (value == "stderr" || value == "--")
   {
     d_nonowned = &std::cerr;
     d_owned.reset();
     d_description = "stderr";
     return true;
   }
-  else if (value == "\"stdout\"")
+  else if (value == "stdout")
   {
     d_nonowned = &std::cout;
     d_owned.reset();
@@ -137,7 +121,7 @@ bool ManagedErr::specialCases(const std::string& value)
 ManagedIn::ManagedIn() : ManagedStream(&std::cin, "stdin") {}
 bool ManagedIn::specialCases(const std::string& value)
 {
-  if (value == "\"stdin\"" || value == "--")
+  if (value == "stdin" || value == "--")
   {
     d_nonowned = &std::cin;
     d_owned.reset();
@@ -150,14 +134,14 @@ bool ManagedIn::specialCases(const std::string& value)
 ManagedOut::ManagedOut() : ManagedStream(&std::cout, "stdout") {}
 bool ManagedOut::specialCases(const std::string& value)
 {
-  if (value == "\"stdout\"" || value == "--")
+  if (value == "stdout" || value == "--")
   {
     d_nonowned = &std::cout;
     d_owned.reset();
     d_description = "stdout";
     return true;
   }
-  else if (value == "\"stderr\"")
+  else if (value == "stderr")
   {
     d_nonowned = &std::cerr;
     d_owned.reset();

--- a/src/options/managed_streams.cpp
+++ b/src/options/managed_streams.cpp
@@ -72,26 +72,39 @@ std::string cvc5_errno_failreason()
 
 namespace detail {
 
+std::string stripQuotes(const std::string& filename)
+{
+  if (filename.size()<2 || filename[0]!='\"' || filename[filename.size()-1]!='\"')
+  {
+    throw OptionException("Stream names must be delimited by quotes, got invalid name `" + filename + "`.");
+  }
+  std::string sfile = filename;
+  sfile = sfile.erase(0, 1);
+  return sfile.erase(sfile.size() - 1, 1);
+}
+
 std::unique_ptr<std::ostream> openOStream(const std::string& filename)
 {
+  std::string sfile = stripQuotes(filename);
   errno = 0;
-  std::unique_ptr<std::ostream> res = std::make_unique<std::ofstream>(filename);
+  std::unique_ptr<std::ostream> res = std::make_unique<std::ofstream>(sfile);
   if (!res || !*res)
   {
     std::stringstream ss;
-    ss << "Cannot open file: `" << filename << "': " << cvc5_errno_failreason();
+    ss << "Cannot open file: `" << sfile << "': " << cvc5_errno_failreason();
     throw OptionException(ss.str());
   }
   return res;
 }
 std::unique_ptr<std::istream> openIStream(const std::string& filename)
 {
+  std::string sfile = stripQuotes(filename);
   errno = 0;
-  std::unique_ptr<std::istream> res = std::make_unique<std::ifstream>(filename);
+  std::unique_ptr<std::istream> res = std::make_unique<std::ifstream>(sfile);
   if (!res || !*res)
   {
     std::stringstream ss;
-    ss << "Cannot open file: `" << filename << "': " << cvc5_errno_failreason();
+    ss << "Cannot open file: `" << sfile << "': " << cvc5_errno_failreason();
     throw OptionException(ss.str());
   }
   return res;

--- a/src/options/managed_streams.cpp
+++ b/src/options/managed_streams.cpp
@@ -74,9 +74,12 @@ namespace detail {
 
 std::string stripQuotes(const std::string& filename)
 {
-  if (filename.size()<2 || filename[0]!='\"' || filename[filename.size()-1]!='\"')
+  if (filename.size() < 2 || filename[0] != '\"'
+      || filename[filename.size() - 1] != '\"')
   {
-    throw OptionException("Stream names must be delimited by quotes, got invalid name `" + filename + "`.");
+    throw OptionException(
+        "Stream names must be delimited by quotes, got invalid name `"
+        + filename + "`.");
   }
   std::string sfile = filename;
   sfile = sfile.erase(0, 1);

--- a/src/options/managed_streams.cpp
+++ b/src/options/managed_streams.cpp
@@ -101,14 +101,14 @@ std::unique_ptr<std::istream> openIStream(const std::string& filename)
 ManagedErr::ManagedErr() : ManagedStream(&std::cerr, "stderr") {}
 bool ManagedErr::specialCases(const std::string& value)
 {
-  if (value == "stderr" || value == "--")
+  if (value == "\"stderr\"" || value == "--")
   {
     d_nonowned = &std::cerr;
     d_owned.reset();
     d_description = "stderr";
     return true;
   }
-  else if (value == "stdout")
+  else if (value == "\"stdout\"")
   {
     d_nonowned = &std::cout;
     d_owned.reset();
@@ -121,7 +121,7 @@ bool ManagedErr::specialCases(const std::string& value)
 ManagedIn::ManagedIn() : ManagedStream(&std::cin, "stdin") {}
 bool ManagedIn::specialCases(const std::string& value)
 {
-  if (value == "stdin" || value == "--")
+  if (value == "\"stdin\"" || value == "--")
   {
     d_nonowned = &std::cin;
     d_owned.reset();
@@ -134,14 +134,14 @@ bool ManagedIn::specialCases(const std::string& value)
 ManagedOut::ManagedOut() : ManagedStream(&std::cout, "stdout") {}
 bool ManagedOut::specialCases(const std::string& value)
 {
-  if (value == "stdout" || value == "--")
+  if (value == "\"stdout\"" || value == "--")
   {
     d_nonowned = &std::cout;
     d_owned.reset();
     d_description = "stdout";
     return true;
   }
-  else if (value == "stderr")
+  else if (value == "\"stderr\"")
   {
     d_nonowned = &std::cerr;
     d_owned.reset();

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -862,12 +862,10 @@ std::wstring ParserState::processAdHocStringEsc(const std::string& s)
 
 std::string ParserState::stripQuotes(const std::string& s)
 {
-  if (s.size() < 2 || s[0] != '\"'
-      || s[s.size() - 1] != '\"')
+  if (s.size() < 2 || s[0] != '\"' || s[s.size() - 1] != '\"')
   {
-    parseError(
-        "Expected a string delimited by quotes, got invalid string `"
-        + s + "`.");
+    parseError("Expected a string delimited by quotes, got invalid string `" + s
+               + "`.");
   }
   std::string ss = s;
   ss = ss.erase(0, 1);

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -867,9 +867,7 @@ std::string ParserState::stripQuotes(const std::string& s)
     parseError("Expected a string delimited by quotes, got invalid string `" + s
                + "`.");
   }
-  std::string ss = s;
-  ss = ss.erase(0, 1);
-  return ss.erase(ss.size() - 1, 1);
+  return s.substr(1, s.size() - 2);
 }
 
 Term ParserState::mkCharConstant(const std::string& s)

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -860,6 +860,20 @@ std::wstring ParserState::processAdHocStringEsc(const std::string& s)
   return res;
 }
 
+std::string ParserState::stripQuotes(const std::string& s)
+{
+  if (s.size() < 2 || s[0] != '\"'
+      || s[s.size() - 1] != '\"')
+  {
+    parseError(
+        "Expected a string delimited by quotes, got invalid string `"
+        + s + "`.");
+  }
+  std::string ss = s;
+  ss = ss.erase(0, 1);
+  return ss.erase(ss.size() - 1, 1);
+}
+
 Term ParserState::mkCharConstant(const std::string& s)
 {
   Assert(s.find_first_not_of("0123456789abcdefABCDEF", 0) == std::string::npos

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -560,6 +560,11 @@ class CVC5_EXPORT ParserState
    * c1, c2, c3 are digits from 0 to 7.
    */
   std::wstring processAdHocStringEsc(const std::string& s);
+  
+  /**
+   * Strip quotes off a string, or return a parse error otherwise.
+   */
+  std::string stripQuotes(const std::string& s);
 
  protected:
   /** The API Solver object. */

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -560,7 +560,7 @@ class CVC5_EXPORT ParserState
    * c1, c2, c3 are digits from 0 to 7.
    */
   std::wstring processAdHocStringEsc(const std::string& s);
-  
+
   /**
    * Strip quotes off a string, or return a parse error otherwise.
    */

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -718,11 +718,11 @@ setOptionInternal[std::unique_ptr<cvc5::parser::Command>* cmd]
       std::string ss = sexprToString(sexpr);
       // special case: for channel settings, we are expected to parse e.g.
       // `"stdin"` which should be treated as `stdin`
-      if (key=="diagnostic-output-channel" || key=="regular-output-channel" || key=="in")
+      if (key == "diagnostic-output-channel" || key == "regular-output-channel"
+          || key == "in")
       {
         ss = PARSER_STATE->stripQuotes(ss);
       }
-      cmd->reset(new SetOptionCommand(key, ss));
       // Ugly that this changes the state of the parser; but
       // global-declarations affects parsing, so we can't hold off
       // on this until some SolverEngine eventually (if ever) executes it.

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -718,8 +718,10 @@ setOptionInternal[std::unique_ptr<cvc5::parser::Command>* cmd]
       std::string ss = sexprToString(sexpr);
       // special case: for channel settings, we are expected to parse e.g.
       // `"stdin"` which should be treated as `stdin`
+      // Note we could consider a more general solution where knowing whether
+      // this special case holds can be queried via OptionInfo.
       if (key == "diagnostic-output-channel" || key == "regular-output-channel"
-          || key == "in")
+          || key == "in" || key == "out")
       {
         ss = PARSER_STATE->stripQuotes(ss);
       }

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -723,6 +723,7 @@ setOptionInternal[std::unique_ptr<cvc5::parser::Command>* cmd]
       {
         ss = PARSER_STATE->stripQuotes(ss);
       }
+      cmd->reset(new SetOptionCommand(key, ss));
       // Ugly that this changes the state of the parser; but
       // global-declarations affects parsing, so we can't hold off
       // on this until some SolverEngine eventually (if ever) executes it.

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -713,11 +713,20 @@ setOptionInternal[std::unique_ptr<cvc5::parser::Command>* cmd]
   cvc5::Term sexpr;
 }
   : keyword[name] symbolicExpr[sexpr]
-    { cmd->reset(new SetOptionCommand(name.c_str() + 1, sexprToString(sexpr)));
+    { 
+      std::string key = name.c_str() + 1;
+      std::string ss = sexprToString(sexpr);
+      // special case: for channel settings, we are expected to parse e.g.
+      // `"stdin"` which should be treated as `stdin`
+      if (key=="diagnostic-output-channel" || key=="regular-output-channel" || key=="in")
+      {
+        ss = PARSER_STATE->stripQuotes(ss);
+      }
+      cmd->reset(new SetOptionCommand(key, ss));
       // Ugly that this changes the state of the parser; but
       // global-declarations affects parsing, so we can't hold off
       // on this until some SolverEngine eventually (if ever) executes it.
-      if(name == ":global-declarations")
+      if(key == "global-declarations")
       {
         SYM_MAN->setGlobalDeclarations(sexprToString(sexpr) == "true");
       }

--- a/src/parser/smt2/smt2_cmd_parser.cpp
+++ b/src/parser/smt2/smt2_cmd_parser.cpp
@@ -688,8 +688,10 @@ std::unique_ptr<Command> Smt2CmdParser::parseNextCommand()
       std::string ss = sexprToString(sexpr);
       // special case: for channel settings, we are expected to parse e.g.
       // `"stdin"` which should be treated as `stdin`
+      // Note we could consider a more general solution where knowing whether
+      // this special case holds can be queried via OptionInfo.
       if (key == "diagnostic-output-channel" || key == "regular-output-channel"
-          || key == "in")
+          || key == "in" || key == "out")
       {
         ss = d_state.stripQuotes(ss);
       }

--- a/src/parser/smt2/smt2_cmd_parser.cpp
+++ b/src/parser/smt2/smt2_cmd_parser.cpp
@@ -688,7 +688,8 @@ std::unique_ptr<Command> Smt2CmdParser::parseNextCommand()
       std::string ss = sexprToString(sexpr);
       // special case: for channel settings, we are expected to parse e.g.
       // `"stdin"` which should be treated as `stdin`
-      if (key=="diagnostic-output-channel" || key=="regular-output-channel" || key=="in")
+      if (key == "diagnostic-output-channel" || key == "regular-output-channel"
+          || key == "in")
       {
         ss = d_state.stripQuotes(ss);
       }

--- a/src/parser/smt2/smt2_cmd_parser.cpp
+++ b/src/parser/smt2/smt2_cmd_parser.cpp
@@ -686,6 +686,12 @@ std::unique_ptr<Command> Smt2CmdParser::parseNextCommand()
       std::string key = d_tparser.parseKeyword();
       Term sexpr = d_tparser.parseSymbolicExpr();
       std::string ss = sexprToString(sexpr);
+      // special case: for channel settings, we are expected to parse e.g.
+      // `"stdin"` which should be treated as `stdin`
+      if (key=="diagnostic-output-channel" || key=="regular-output-channel" || key=="in")
+      {
+        ss = d_state.stripQuotes(ss);
+      }
       cmd.reset(new SetOptionCommand(key, ss));
       // Ugly that this changes the state of the parser; but
       // global-declarations affects parsing, so we can't hold off

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1948,7 +1948,17 @@ void Smt2Printer::toStreamCmdSetOption(std::ostream& out,
                                        const std::string& flag,
                                        const std::string& value) const
 {
-  out << "(set-option :" << flag << ' ' << value << ')' << std::endl;
+  out << "(set-option :" << flag << ' ';
+  // special cases: output channels require surrounding quotes in smt2 format
+  if (flag=="diagnostic-output-channel" || flag=="regular-output-channel" || flag=="in")
+  {
+    out << "\"" << value << "\"";
+  }
+  else
+  {
+    out << value;
+  }
+  out << ')' << std::endl;
 }
 
 void Smt2Printer::toStreamCmdGetOption(std::ostream& out,

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1950,7 +1950,8 @@ void Smt2Printer::toStreamCmdSetOption(std::ostream& out,
 {
   out << "(set-option :" << flag << ' ';
   // special cases: output channels require surrounding quotes in smt2 format
-  if (flag=="diagnostic-output-channel" || flag=="regular-output-channel" || flag=="in")
+  if (flag == "diagnostic-output-channel" || flag == "regular-output-channel"
+      || flag == "in")
   {
     out << "\"" << value << "\"";
   }

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1007,6 +1007,7 @@ set(regress_0_tests
   regress0/parser/set-bag-left-associative.smt2
   regress0/parser/shadow_fun_symbol_all.smt2
   regress0/parser/shadow_fun_symbol_nirat.smt2
+  regress0/parser/stdout-diag.smt2
   regress0/parser/strings20.smt2
   regress0/parser/strings25.smt2
   regress0/parser/to_fp.smt2

--- a/test/regress/cli/regress0/options/stream-printing.smt2
+++ b/test/regress/cli/regress0/options/stream-printing.smt2
@@ -9,9 +9,9 @@
 (get-option :diagnostic-output-channel)
 (get-option :in)
 
-(set-option :regular-output-channel stderr)
-(set-option :diagnostic-output-channel stdout)
-(set-option :in stdin)
+(set-option :regular-output-channel "stderr")
+(set-option :diagnostic-output-channel "stdout")
+(set-option :in "stdin")
 
 (get-option :regular-output-channel)
 (get-option :diagnostic-output-channel)

--- a/test/regress/cli/regress0/parser/stdout-diag.smt2
+++ b/test/regress/cli/regress0/parser/stdout-diag.smt2
@@ -1,0 +1,10 @@
+; Ensure that no `stdout` or `"stdout"` file is created
+; SCRUBBER: ls stdout || ls \"stdout\" || echo success
+; EXPECT: success
+(set-option :global-declarations true)
+(set-option :diagnostic-output-channel "stdout")
+(set-option :produce-models true)
+(set-logic QF_BV)
+(declare-fun s0 () Bool)
+(assert s0)
+(check-sat)


### PR DESCRIPTION
Fixes #8900.

https://smtlib.cs.uiowa.edu/papers/smt-lib-reference-v2.6-r2021-05-12.pdf specifies that
`(set-option :regular-output-channel "stdout")`
should set the regular output channel to the standard out, whereas
`(set-option :regular-output-channel stdout)`
should result in a syntax error.

This would imply that our special cases are wrong in the option handlers for the channel options, which this PR corrects. 

Also note that:
`(set-option :regular-output-channel file.txt)`
would previously construct a file.txt, this is wrong, it should throw a syntax error, which it now does.
`(set-option :regular-output-channel "file.txt")`
will create the file `file.txt` now, whereas previously it incorrectly created `"file.txt"`.