### PR TITLE
Purify terms in branch and bound lemmas when necessary

### DIFF
--- a/src/theory/arith/branch_and_bound.cpp
+++ b/src/theory/arith/branch_and_bound.cpp
@@ -76,7 +76,7 @@ std::vector<TrustNode> BranchAndBound::branchIntegerVariable(TNode var,
     // Prioritize trying a simple rounding of the real solution first,
     // it that fails, fall back on original branch and bound strategy.
     Node ub = rewrite(nm->mkNode(LEQ, var, nm->mkConstInt(nearest - 1)));
-    Node ubatom = ub.getKind()==NOT ? ub[0] : ub;
+    Node ubatom = ub.getKind() == NOT ? ub[0] : ub;
     // if it rewrites to a non-arithmetic inequality, we must purify
     if (ubatom.getKind() != GEQ && !doPurify)
     {
@@ -143,7 +143,7 @@ std::vector<TrustNode> BranchAndBound::branchIntegerVariable(TNode var,
   else
   {
     Node ub = rewrite(nm->mkNode(LEQ, var, nm->mkConstInt(floor)));
-    Node ubatom = ub.getKind()==NOT ? ub[0] : ub;
+    Node ubatom = ub.getKind() == NOT ? ub[0] : ub;
     // if it rewrites to a non-arithmetic inequality, we must purify
     if (ubatom.getKind() != GEQ && !doPurify)
     {

--- a/src/theory/arith/branch_and_bound.cpp
+++ b/src/theory/arith/branch_and_bound.cpp
@@ -76,8 +76,9 @@ std::vector<TrustNode> BranchAndBound::branchIntegerVariable(TNode var,
     // Prioritize trying a simple rounding of the real solution first,
     // it that fails, fall back on original branch and bound strategy.
     Node ub = rewrite(nm->mkNode(LEQ, var, nm->mkConstInt(nearest - 1)));
+    Node ubatom = ub.getKind()==NOT ? ub[0] : ub;
     // if it rewrites to a non-arithmetic inequality, we must purify
-    if (ub.getKind() != GEQ && !doPurify)
+    if (ubatom.getKind() != GEQ && !doPurify)
     {
       return branchIntegerVariable(var, value, true);
     }
@@ -142,8 +143,9 @@ std::vector<TrustNode> BranchAndBound::branchIntegerVariable(TNode var,
   else
   {
     Node ub = rewrite(nm->mkNode(LEQ, var, nm->mkConstInt(floor)));
+    Node ubatom = ub.getKind()==NOT ? ub[0] : ub;
     // if it rewrites to a non-arithmetic inequality, we must purify
-    if (ub.getKind() != GEQ && !doPurify)
+    if (ubatom.getKind() != GEQ && !doPurify)
     {
       return branchIntegerVariable(var, value, true);
     }

--- a/src/theory/arith/branch_and_bound.cpp
+++ b/src/theory/arith/branch_and_bound.cpp
@@ -21,6 +21,7 @@
 #include "theory/arith/arith_utilities.h"
 #include "theory/rewriter.h"
 #include "theory/theory.h"
+#include "expr/skolem_manager.h"
 
 using namespace cvc5::internal::kind;
 
@@ -40,10 +41,25 @@ BranchAndBound::BranchAndBound(Env& env,
 {
 }
 
-TrustNode BranchAndBound::branchIntegerVariable(TNode var, Rational value)
+ std::vector<TrustNode> BranchAndBound::branchIntegerVariable(TNode var, Rational value, bool doPurify)
 {
-  TrustNode lem = TrustNode::null();
+  std::vector<TrustNode> lems;
   NodeManager* nm = NodeManager::currentNM();
+  if (doPurify)
+  {
+    Node k = nm->getSkolemManager()->mkPurifySkolem(var, "bbk");
+    Node eq = k.eqNode(var);
+    if (proofsEnabled())
+    {
+      // justified trivially by predicate introduction
+      lems.push_back(d_pfGen->mkTrustNode(eq, PfRule::MACRO_SR_PRED_INTRO,{},{eq}));
+    }
+    else
+    {
+      lems.push_back(TrustNode::mkTrustLemma(eq, nullptr));
+    }
+    var = k;
+  }
   Integer floor = value.floor();
   if (options().arith.brabTest)
   {
@@ -57,6 +73,11 @@ TrustNode BranchAndBound::branchIntegerVariable(TNode var, Rational value)
     // Prioritize trying a simple rounding of the real solution first,
     // it that fails, fall back on original branch and bound strategy.
     Node ub = rewrite(nm->mkNode(LEQ, var, nm->mkConstInt(nearest - 1)));
+    // if it rewrites to a non-arithmetic inequality, we must purify
+    if (ub.getKind()!=GEQ && !doPurify)
+    {
+      return branchIntegerVariable(var, value, true);
+    }
     Node lb = rewrite(nm->mkNode(GEQ, var, nm->mkConstInt(nearest + 1)));
     Node right = nm->mkNode(OR, ub, lb);
     Node rawEq = nm->mkNode(EQUAL, var, nm->mkConstInt(nearest));
@@ -108,30 +129,41 @@ TrustNode BranchAndBound::branchIntegerVariable(TNode var, Rational value)
       Pf pfL = pnm->mkNode(PfRule::MACRO_SR_PRED_TRANSFORM,
                            {pnm->mkNode(PfRule::NOT_AND, {pfNotAnd}, {})},
                            {l});
-      lem = d_pfGen->mkTrustNode(l, pfL);
+      lems.push_back(d_pfGen->mkTrustNode(l, pfL));
     }
     else
     {
-      lem = TrustNode::mkTrustLemma(l, nullptr);
+      lems.push_back(TrustNode::mkTrustLemma(l, nullptr));
     }
   }
   else
   {
     Node ub = rewrite(nm->mkNode(LEQ, var, nm->mkConstInt(floor)));
+    // if it rewrites to a non-arithmetic inequality, we must purify
+    if (ub.getKind()!=GEQ && !doPurify)
+    {
+      return branchIntegerVariable(var, value, true);
+    }
     Node lb = ub.notNode();
     if (proofsEnabled())
     {
-      lem =
-          d_pfGen->mkTrustNode(nm->mkNode(OR, ub, lb), PfRule::SPLIT, {}, {ub});
+      lems.push_back(d_pfGen->mkTrustNode(nm->mkNode(OR, ub, lb), PfRule::SPLIT, {}, {ub}));
     }
     else
     {
-      lem = TrustNode::mkTrustLemma(nm->mkNode(OR, ub, lb), nullptr);
+      lems.push_back(TrustNode::mkTrustLemma(nm->mkNode(OR, ub, lb), nullptr));
     }
   }
-
-  Trace("integers") << "integers: branch & bound: " << lem << std::endl;
-  return lem;
+  if (TraceIsOn("integers"))
+  {
+    Trace("integers") << "integers: branch & bound: ";
+    for (const TrustNode& tn : lems)
+    {
+      Trace("integers") << tn;
+    }
+    Trace("integers") << std::endl;
+  }
+  return lems;
 }
 
 bool BranchAndBound::proofsEnabled() const

--- a/src/theory/arith/branch_and_bound.cpp
+++ b/src/theory/arith/branch_and_bound.cpp
@@ -15,13 +15,13 @@
 
 #include "theory/arith/branch_and_bound.h"
 
+#include "expr/skolem_manager.h"
 #include "options/arith_options.h"
 #include "proof/eager_proof_generator.h"
 #include "proof/proof_node.h"
 #include "theory/arith/arith_utilities.h"
 #include "theory/rewriter.h"
 #include "theory/theory.h"
-#include "expr/skolem_manager.h"
 
 using namespace cvc5::internal::kind;
 
@@ -41,7 +41,9 @@ BranchAndBound::BranchAndBound(Env& env,
 {
 }
 
- std::vector<TrustNode> BranchAndBound::branchIntegerVariable(TNode var, Rational value, bool doPurify)
+std::vector<TrustNode> BranchAndBound::branchIntegerVariable(TNode var,
+                                                             Rational value,
+                                                             bool doPurify)
 {
   std::vector<TrustNode> lems;
   NodeManager* nm = NodeManager::currentNM();
@@ -52,7 +54,8 @@ BranchAndBound::BranchAndBound(Env& env,
     if (proofsEnabled())
     {
       // justified trivially by predicate introduction
-      lems.push_back(d_pfGen->mkTrustNode(eq, PfRule::MACRO_SR_PRED_INTRO,{},{eq}));
+      lems.push_back(
+          d_pfGen->mkTrustNode(eq, PfRule::MACRO_SR_PRED_INTRO, {}, {eq}));
     }
     else
     {
@@ -74,7 +77,7 @@ BranchAndBound::BranchAndBound(Env& env,
     // it that fails, fall back on original branch and bound strategy.
     Node ub = rewrite(nm->mkNode(LEQ, var, nm->mkConstInt(nearest - 1)));
     // if it rewrites to a non-arithmetic inequality, we must purify
-    if (ub.getKind()!=GEQ && !doPurify)
+    if (ub.getKind() != GEQ && !doPurify)
     {
       return branchIntegerVariable(var, value, true);
     }
@@ -140,14 +143,15 @@ BranchAndBound::BranchAndBound(Env& env,
   {
     Node ub = rewrite(nm->mkNode(LEQ, var, nm->mkConstInt(floor)));
     // if it rewrites to a non-arithmetic inequality, we must purify
-    if (ub.getKind()!=GEQ && !doPurify)
+    if (ub.getKind() != GEQ && !doPurify)
     {
       return branchIntegerVariable(var, value, true);
     }
     Node lb = ub.notNode();
     if (proofsEnabled())
     {
-      lems.push_back(d_pfGen->mkTrustNode(nm->mkNode(OR, ub, lb), PfRule::SPLIT, {}, {ub}));
+      lems.push_back(d_pfGen->mkTrustNode(
+          nm->mkNode(OR, ub, lb), PfRule::SPLIT, {}, {ub}));
     }
     else
     {

--- a/src/theory/arith/branch_and_bound.cpp
+++ b/src/theory/arith/branch_and_bound.cpp
@@ -61,6 +61,7 @@ std::vector<TrustNode> BranchAndBound::branchIntegerVariable(TNode var,
     {
       lems.push_back(TrustNode::mkTrustLemma(eq, nullptr));
     }
+    // now use the purification variable
     var = k;
   }
   Integer floor = value.floor();

--- a/src/theory/arith/branch_and_bound.cpp
+++ b/src/theory/arith/branch_and_bound.cpp
@@ -162,10 +162,10 @@ std::vector<TrustNode> BranchAndBound::branchIntegerVariable(TNode var,
   }
   if (TraceIsOn("integers"))
   {
-    Trace("integers") << "integers: branch & bound: ";
+    Trace("integers") << "integers: branch & bound:";
     for (const TrustNode& tn : lems)
     {
-      Trace("integers") << tn;
+      Trace("integers") << " " << tn;
     }
     Trace("integers") << std::endl;
   }

--- a/src/theory/arith/branch_and_bound.h
+++ b/src/theory/arith/branch_and_bound.h
@@ -54,6 +54,11 @@ class BranchAndBound : protected EnvObj
    * @param value Its current model value
    * @param doPurify If true, we send the lemma (= k var) and branch on k
    * instead, where k is the purification skolem for var.
+   *
+   * Note if doPurify is true, this method additionally includes a purification
+   * lemma as described above. If doPurify is false, this method may choose
+   * to set doPurify if necessary, in the case that the inequality is eliminated
+   * by rewriting. This can be the case when var is (bv2nat x).
    */
   std::vector<TrustNode> branchIntegerVariable(TNode var,
                                                Rational value,

--- a/src/theory/arith/branch_and_bound.h
+++ b/src/theory/arith/branch_and_bound.h
@@ -49,8 +49,13 @@ class BranchAndBound : protected EnvObj
   /**
    * Branch variable, called when integer var has given value
    * in the current model, returns a split to eliminate this model.
+   * 
+   * @param var The variable to branch on
+   * @param value Its current model value
+   * @param doPurify If true, we send the lemma (= k var) and branch on k
+   * instead, where k is the purification skolem for var.
    */
-  TrustNode branchIntegerVariable(TNode var, Rational value);
+  std::vector<TrustNode> branchIntegerVariable(TNode var, Rational value, bool doPurify = false);
 
  private:
   /** Are proofs enabled? */

--- a/src/theory/arith/branch_and_bound.h
+++ b/src/theory/arith/branch_and_bound.h
@@ -49,13 +49,15 @@ class BranchAndBound : protected EnvObj
   /**
    * Branch variable, called when integer var has given value
    * in the current model, returns a split to eliminate this model.
-   * 
+   *
    * @param var The variable to branch on
    * @param value Its current model value
    * @param doPurify If true, we send the lemma (= k var) and branch on k
    * instead, where k is the purification skolem for var.
    */
-  std::vector<TrustNode> branchIntegerVariable(TNode var, Rational value, bool doPurify = false);
+  std::vector<TrustNode> branchIntegerVariable(TNode var,
+                                               Rational value,
+                                               bool doPurify = false);
 
  private:
   /** Are proofs enabled? */

--- a/src/theory/arith/linear/theory_arith_private.cpp
+++ b/src/theory/arith/linear/theory_arith_private.cpp
@@ -2898,7 +2898,9 @@ bool TheoryArithPrivate::solveRelaxationOrPanic(Theory::Effort effortLevel)
     if (canBranch != ARITHVAR_SENTINEL)
     {
       ++d_statistics.d_panicBranches;
-      TrustNode branch = branchIntegerVariable(canBranch);
+      std::vector<TrustNode> branches = branchIntegerVariable(canBranch);
+      Assert (!branches.empty());
+      TrustNode branch = branches.back();
       Assert(branch.getNode().getKind() == kind::OR);
       Node rwbranch = rewrite(branch.getNode()[0]);
       if (!isSatLiteral(rwbranch))
@@ -3387,16 +3389,19 @@ bool TheoryArithPrivate::postCheck(Theory::Effort effortLevel)
     }
 
     if(!emmittedConflictOrSplit) {
-      TrustNode possibleLemma = roundRobinBranch();
-      if (!possibleLemma.getNode().isNull())
+      std::vector<TrustNode> possibleLemmas = roundRobinBranch();
+      if (!possibleLemmas.empty())
       {
         ++(d_statistics.d_externalBranchAndBounds);
         d_cutCount = d_cutCount + 1;
-        Trace("arith::lemma") << "rrbranch lemma"
-                              << possibleLemma << endl;
-        if (outputTrustedLemma(possibleLemma, InferenceId::ARITH_BB_LEMMA))
+        for (const TrustNode& possibleLemma : possibleLemmas)
         {
-          emmittedConflictOrSplit = true;
+          Trace("arith::lemma") << "rrbranch lemma"
+                                << possibleLemma << endl;
+          if (outputTrustedLemma(possibleLemma, InferenceId::ARITH_BB_LEMMA))
+          {
+            emmittedConflictOrSplit = true;
+          }
         }
       }
     }
@@ -3433,7 +3438,7 @@ bool TheoryArithPrivate::postCheck(Theory::Effort effortLevel)
 
 bool TheoryArithPrivate::foundNonlinear() const { return d_foundNl; }
 
-TrustNode TheoryArithPrivate::branchIntegerVariable(ArithVar x) const
+std::vector<TrustNode> TheoryArithPrivate::branchIntegerVariable(ArithVar x) const
 {
   const DeltaRational& d = d_partialModel.getAssignment(x);
   Assert(!d.isIntegral());
@@ -3442,9 +3447,11 @@ TrustNode TheoryArithPrivate::branchIntegerVariable(ArithVar x) const
   Trace("integers") << "integers: assignment to [[" << d_partialModel.asNode(x) << "]] is " << r << "[" << i << "]" << endl;
   Assert(!(r.getDenominator() == 1 && i.getNumerator() == 0));
   TNode var = d_partialModel.asNode(x);
-  TrustNode lem = d_bab.branchIntegerVariable(var, r);
+  std::vector<TrustNode> lems = d_bab.branchIntegerVariable(var, r);
+  Assert (!lems.empty());
   if (TraceIsOn("integers"))
   {
+    TrustNode lem = lems.back();
     Node l = lem.getNode();
     if (isSatLiteral(l[0]))
     {
@@ -3467,7 +3474,7 @@ TrustNode TheoryArithPrivate::branchIntegerVariable(ArithVar x) const
                         << endl;
     }
   }
-  return lem;
+  return lems;
 }
 
 std::vector<ArithVar> TheoryArithPrivate::cutAllBounded() const{
@@ -3492,10 +3499,10 @@ std::vector<ArithVar> TheoryArithPrivate::cutAllBounded() const{
 }
 
 /** Returns true if the roundRobinBranching() issues a lemma. */
-TrustNode TheoryArithPrivate::roundRobinBranch()
+std::vector<TrustNode> TheoryArithPrivate::roundRobinBranch()
 {
   if(hasIntegerModel()){
-    return TrustNode::null();
+    return std::vector<TrustNode>();
   }else{
     ArithVar v = d_nextIntegerCheckVar;
 

--- a/src/theory/arith/linear/theory_arith_private.cpp
+++ b/src/theory/arith/linear/theory_arith_private.cpp
@@ -2899,7 +2899,7 @@ bool TheoryArithPrivate::solveRelaxationOrPanic(Theory::Effort effortLevel)
     {
       ++d_statistics.d_panicBranches;
       std::vector<TrustNode> branches = branchIntegerVariable(canBranch);
-      Assert (!branches.empty());
+      Assert(!branches.empty());
       TrustNode branch = branches.back();
       Assert(branch.getNode().getKind() == kind::OR);
       Node rwbranch = rewrite(branch.getNode()[0]);
@@ -3396,8 +3396,7 @@ bool TheoryArithPrivate::postCheck(Theory::Effort effortLevel)
         d_cutCount = d_cutCount + 1;
         for (const TrustNode& possibleLemma : possibleLemmas)
         {
-          Trace("arith::lemma") << "rrbranch lemma"
-                                << possibleLemma << endl;
+          Trace("arith::lemma") << "rrbranch lemma" << possibleLemma << endl;
           if (outputTrustedLemma(possibleLemma, InferenceId::ARITH_BB_LEMMA))
           {
             emmittedConflictOrSplit = true;
@@ -3438,7 +3437,8 @@ bool TheoryArithPrivate::postCheck(Theory::Effort effortLevel)
 
 bool TheoryArithPrivate::foundNonlinear() const { return d_foundNl; }
 
-std::vector<TrustNode> TheoryArithPrivate::branchIntegerVariable(ArithVar x) const
+std::vector<TrustNode> TheoryArithPrivate::branchIntegerVariable(
+    ArithVar x) const
 {
   const DeltaRational& d = d_partialModel.getAssignment(x);
   Assert(!d.isIntegral());
@@ -3448,7 +3448,7 @@ std::vector<TrustNode> TheoryArithPrivate::branchIntegerVariable(ArithVar x) con
   Assert(!(r.getDenominator() == 1 && i.getNumerator() == 0));
   TNode var = d_partialModel.asNode(x);
   std::vector<TrustNode> lems = d_bab.branchIntegerVariable(var, r);
-  Assert (!lems.empty());
+  Assert(!lems.empty());
   if (TraceIsOn("integers"))
   {
     TrustNode lem = lems.back();

--- a/src/theory/arith/linear/theory_arith_private.h
+++ b/src/theory/arith/linear/theory_arith_private.h
@@ -557,7 +557,7 @@ private:
   /**
    * Issues branches for non-auxiliary integer variables with non-integer assignments.
    * Returns a cut for a lemma.
-   * If there is an integer model, this returns Node::null().
+   * If there is an integer model, this returns the empty vector.
    */
   std::vector<TrustNode> roundRobinBranch();
 

--- a/src/theory/arith/linear/theory_arith_private.h
+++ b/src/theory/arith/linear/theory_arith_private.h
@@ -559,7 +559,7 @@ private:
    * Returns a cut for a lemma.
    * If there is an integer model, this returns Node::null().
    */
-  TrustNode roundRobinBranch();
+  std::vector<TrustNode> roundRobinBranch();
 
   bool proofsEnabled() const { return d_pnm; }
 
@@ -716,7 +716,7 @@ private:
   /** Counts the number of fullCheck calls to arithmetic. */
   uint32_t d_fullCheckCounter;
   std::vector<ArithVar> cutAllBounded() const;
-  TrustNode branchIntegerVariable(ArithVar x) const;
+  std::vector<TrustNode> branchIntegerVariable(ArithVar x) const;
   void branchVector(const std::vector<ArithVar>& lemmas);
 
   context::CDO<unsigned> d_cutCount;

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -520,11 +520,14 @@ bool TheoryArith::sanityCheckIntegerModel()
                  "integer variable "
               << p.first << " : " << p.second << std::endl;
     // must branch and bound
-    TrustNode lem =
+    std::vector<TrustNode> lems =
         d_bab.branchIntegerVariable(p.first, p.second.getConst<Rational>());
-    if (d_im.trustedLemma(lem, InferenceId::ARITH_BB_LEMMA))
+    for (const TrustNode& lem : lems)
     {
-      addedLemma = true;
+      if (d_im.trustedLemma(lem, InferenceId::ARITH_BB_LEMMA))
+      {
+        addedLemma = true;
+      }
     }
     badAssignment = true;
   }


### PR DESCRIPTION
A recent commit https://github.com/cvc5/cvc5/commit/bede04650917dde903afc2c305b1d9d7989b4cb8 introduced rewrites for eliminating arithmetic inequalities.

This leads to a subtle issue where branch-and-bound lemmas may be ineffective, since splitting on (>= (bv2nat x) N) may be rewritten to a predicate involving (bvugt x bvN), which belongs to BV, meaning that the integer value of (bv2nat x) is not refined.

This corrects the issue by ensuring that branch-and-bound lemmas are purified when the inequality would otherwise be eliminated.  This is exclusively the case for bv2nat terms currently, although the test checks the rewritten form.

Fixes https://github.com/cvc5/cvc5/issues/9506.