### PR TITLE
Notify theory engine modules of conflicts

### DIFF
--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -212,7 +212,7 @@ name   = "SMT Layer"
   category   = "expert"
   long       = "difficulty-mode=MODE"
   type       = "DifficultyMode"
-  default    = "LEMMA_LITERAL"
+  default    = "LEMMA_LITERAL_ALL"
   help       = "choose output mode for get-difficulty, see --difficulty-mode=help"
   help_mode  = "difficulty output modes."
 [[option.mode.LEMMA_LITERAL]]

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -1171,13 +1171,14 @@ TrustNode TheoryEngine::getExplanation(TNode node)
   TNode atom = polarity ? node : node[0];
 
   // If we're not in shared mode, explanations are simple
+  TrustNode texplanation;
   if (!logicInfo().isSharingEnabled())
   {
     Trace("theory::explain")
         << "TheoryEngine::getExplanation: sharing is NOT enabled. "
         << " Responsible theory is: " << theoryOf(atom)->getId() << std::endl;
 
-    TrustNode texplanation = theoryOf(atom)->explain(node);
+    texplanation = theoryOf(atom)->explain(node);
     Node explanation = texplanation.getNode();
     Trace("theory::explain") << "TheoryEngine::getExplanation(" << node
                              << ") => " << explanation << endl;
@@ -1196,28 +1197,36 @@ TrustNode TheoryEngine::getExplanation(TNode node)
             TrustNode::mkTrustPropExp(node, explanation, d_lazyProof.get());
       }
     }
-    return texplanation;
   }
+  else
+  {
+    Trace("theory::explain")
+        << "TheoryEngine::getExplanation: sharing IS enabled" << std::endl;
 
-  Trace("theory::explain") << "TheoryEngine::getExplanation: sharing IS enabled"
-                           << std::endl;
+    // Initial thing to explain
+    NodeTheoryPair toExplain(
+        node, THEORY_SAT_SOLVER, d_propagationMapTimestamp);
+    Assert(d_propagationMap.find(toExplain) != d_propagationMap.end());
 
-  // Initial thing to explain
-  NodeTheoryPair toExplain(node, THEORY_SAT_SOLVER, d_propagationMapTimestamp);
-  Assert(d_propagationMap.find(toExplain) != d_propagationMap.end());
+    NodeTheoryPair nodeExplainerPair = d_propagationMap[toExplain];
+    Trace("theory::explain")
+        << "TheoryEngine::getExplanation: explainer for node "
+        << nodeExplainerPair.d_node
+        << " is theory: " << nodeExplainerPair.d_theory << std::endl;
 
-  NodeTheoryPair nodeExplainerPair = d_propagationMap[toExplain];
-  Trace("theory::explain")
-      << "TheoryEngine::getExplanation: explainer for node "
-      << nodeExplainerPair.d_node
-      << " is theory: " << nodeExplainerPair.d_theory << std::endl;
-
-  // Create the workplace for explanations
-  std::vector<NodeTheoryPair> vec{d_propagationMap[toExplain]};
-  // Process the explanation
-  TrustNode texplanation = getExplanation(vec);
-  Trace("theory::explain") << "TheoryEngine::getExplanation(" << node << ") => "
-                           << texplanation.getNode() << endl;
+    // Create the workplace for explanations
+    std::vector<NodeTheoryPair> vec{d_propagationMap[toExplain]};
+    // Process the explanation
+    texplanation = getExplanation(vec);
+    Trace("theory::explain") << "TheoryEngine::getExplanation(" << node
+                             << ") => " << texplanation.getNode() << endl;
+  }
+  // notify the conflict as a lemma
+  for (TheoryEngineModule* tem : d_modules)
+  {
+    tem->notifyLemma(
+        texplanation.getProven(), LemmaProperty::REMOVABLE, {}, {});
+  }
   return texplanation;
 }
 


### PR DESCRIPTION
This ensures we notify theory engine modules of conflict lemmas that originate from conflicting T-propagations, which was previously missing.

In particular, this should significantly improve the quality of difficulty measurements, as these lemmas were not being logged.

It furthermore updates the default difficulty mode to LEMMA_LITERAL_ALL, which takes into account these conflicts (which typically occur < FULL effort). This setting has been more useful in my recent experimentation with the difficulty feature.