### PR TITLE
theory engine: Add resource limit check point.

### DIFF
--- a/src/prop/cadical.cpp
+++ b/src/prop/cadical.cpp
@@ -93,7 +93,7 @@ class ResourceLimitTerminator : public CaDiCaL::Terminator
   bool terminate() override
   {
     d_resmgr.spendResource(Resource::BvSatStep);
-    return d_resmgr.outOfResources() || d_resmgr.outOfTime();
+    return d_resmgr.out();
   }
 
  private:

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -409,6 +409,8 @@ void TheoryEngine::check(Theory::Effort effort) {
       tem->check(effort);
     }
 
+    auto rm = d_env.getResourceManager();
+
     // Check until done
     while (d_factsAsserted && !d_inConflict && !d_lemmasAdded) {
 
@@ -464,6 +466,13 @@ void TheoryEngine::check(Theory::Effort effort) {
         Assert(effort == Theory::EFFORT_STANDARD);
         d_stats.d_stdEffortChecks++;
       }
+
+      // Interrupt in case we reached a resource limit.
+      if (rm->out())
+      {
+        interrupt();
+        return;
+      }
     }
 
     // Must consult quantifiers theory for last call to ensure sat, or otherwise add a lemma
@@ -475,13 +484,20 @@ void TheoryEngine::check(Theory::Effort effort) {
       }
       // reset the model in the combination engine
       d_tc->resetModel();
+      // Disable resource manager limit while building the model. This ensures
+      // that building the model is not interrupted (and shouldn't take too
+      // long).
+      rm->setEnabled(false);
       //checks for theories requiring the model go at last call
-      for (TheoryId theoryId = THEORY_FIRST; theoryId < THEORY_LAST; ++theoryId) {
-        if( theoryId!=THEORY_QUANTIFIERS ){
+      for (TheoryId theoryId = THEORY_FIRST; theoryId < THEORY_LAST; ++theoryId)
+      {
+        if (theoryId != THEORY_QUANTIFIERS)
+        {
           Theory* theory = d_theoryTable[theoryId];
           if (theory && isTheoryEnabled(theoryId))
           {
-            if( theory->needsCheckLastEffort() ){
+            if (theory->needsCheckLastEffort())
+            {
               if (!d_tc->buildModel())
               {
                 break;
@@ -504,6 +520,8 @@ void TheoryEngine::check(Theory::Effort effort) {
       {
         tem->notifyCandidateModel(getModel());
       }
+      // Enable resource management again.
+      rm->setEnabled(true);
     }
 
     Trace("theory") << "TheoryEngine::check(" << effort << "): done, we are " << (d_inConflict ? "unsat" : "sat") << (d_lemmasAdded ? " with new lemmas" : " with no new lemmas");


### PR DESCRIPTION
Further, disables resource manager while building a model in order to ensure a model is built. The new check point ensures that all theory solvers are actually able to build a model and where not interrupted during a check() call.

Fixes #9492.