### PR TITLE
Fixes for proof-annotate

### DIFF
--- a/src/proof/eager_proof_generator.cpp
+++ b/src/proof/eager_proof_generator.cpp
@@ -109,7 +109,9 @@ TrustNode EagerProofGenerator::mkTrustNode(Node conc,
   // if no children, its easy
   if (exp.empty())
   {
-    std::shared_ptr<ProofNode> pf = pnm->mkNode(id, {}, args, conc);
+    // do not use "conc" as expected here, instead this will be checked
+    // later in setProofFor, where conc may be negated if isConflict is true
+    std::shared_ptr<ProofNode> pf = pnm->mkNode(id, {}, args);
     return mkTrustNode(conc, pf, isConflict);
   }
   // otherwise, we use CDProof + SCOPE

--- a/src/proof/eager_proof_generator.h
+++ b/src/proof/eager_proof_generator.h
@@ -122,7 +122,8 @@ class EagerProofGenerator : protected EnvObj, public ProofGenerator
    * Make trust node from a single step proof. This is a convenience function
    * that avoids the need to explictly construct ProofNode by the caller.
    *
-   * @param conc The conclusion of the rule,
+   * @param conc The conclusion of the rule, or its negation if isConflict is
+   * true.
    * @param id The rule of the proof concluding conc
    * @param exp The explanation (premises) to the proof concluding conc,
    * @param args The arguments to the proof concluding conc,

--- a/src/theory/theory_inference_manager.cpp
+++ b/src/theory/theory_inference_manager.cpp
@@ -584,7 +584,7 @@ bool TheoryInferenceManager::cacheLemma(TNode lem, LemmaProperty p)
 
 TrustNode TheoryInferenceManager::annotateId(const TrustNode& trn,
                                              InferenceId id,
-                        bool isConflict)
+                                             bool isConflict)
 {
   Assert(d_iipa != nullptr && d_apg != nullptr);
   Node lemma = trn.getProven();

--- a/src/theory/theory_inference_manager.cpp
+++ b/src/theory/theory_inference_manager.cpp
@@ -150,7 +150,7 @@ void TheoryInferenceManager::trustedConflict(TrustNode tconf, InferenceId id)
   // annotate if the annotation proof generator is active
   if (d_apg != nullptr)
   {
-    tconf = annotateId(tconf, id);
+    tconf = annotateId(tconf, id, true);
   }
   d_out.trustedConflict(tconf);
   ++d_numConflicts;
@@ -583,7 +583,8 @@ bool TheoryInferenceManager::cacheLemma(TNode lem, LemmaProperty p)
 }
 
 TrustNode TheoryInferenceManager::annotateId(const TrustNode& trn,
-                                             InferenceId id)
+                                             InferenceId id,
+                        bool isConflict)
 {
   Assert(d_iipa != nullptr && d_apg != nullptr);
   Node lemma = trn.getProven();
@@ -594,7 +595,7 @@ TrustNode TheoryInferenceManager::annotateId(const TrustNode& trn,
     Node tidn =
         builtin::BuiltinProofRuleChecker::mkTheoryIdNode(d_theory.getId());
     trna = d_defaultPg->mkTrustNode(
-        lemma, PfRule::THEORY_LEMMA, {}, {lemma, tidn});
+        trn.getNode(), PfRule::THEORY_LEMMA, {}, {lemma, tidn}, isConflict);
   }
   d_iipa->setAnnotation(lemma, id);
   return d_apg->transform(trna, d_iipa.get());

--- a/src/theory/theory_inference_manager.h
+++ b/src/theory/theory_inference_manager.h
@@ -448,7 +448,8 @@ class TheoryInferenceManager : protected EnvObj
    * Return the trust node that is equivalent to trn, but its proof (if asked
    * for) will be wrapped in (ANNOTATE ... :args id).
    */
-  TrustNode annotateId(const TrustNode& trn, InferenceId id);
+  TrustNode annotateId(const TrustNode& trn, InferenceId id,
+                        bool isConflict = false);
   /** The theory object */
   Theory& d_theory;
   /** Reference to the state of theory */

--- a/src/theory/theory_inference_manager.h
+++ b/src/theory/theory_inference_manager.h
@@ -446,10 +446,12 @@ class TheoryInferenceManager : protected EnvObj
   virtual bool cacheLemma(TNode lem, LemmaProperty p);
   /**
    * Return the trust node that is equivalent to trn, but its proof (if asked
-   * for) will be wrapped in (ANNOTATE ... :args id).
+   * for) will be wrapped in (ANNOTATE ... :args id). We return a trust
+   * node of trust node kind CONFLICT if isConflict is true.
    */
-  TrustNode annotateId(const TrustNode& trn, InferenceId id,
-                        bool isConflict = false);
+  TrustNode annotateId(const TrustNode& trn,
+                       InferenceId id,
+                       bool isConflict = false);
   /** The theory object */
   Theory& d_theory;
   /** Reference to the state of theory */


### PR DESCRIPTION
This option is used for debugging the usefulness of theory lemmas.

Wasn't correct in the case of theory conflicts, which could lead to segfaults.