### PR TITLE
Rename CDCLTSatSolverInterface to CDCLTSatSolver.

### DIFF
--- a/src/decision/decision_engine.cpp
+++ b/src/decision/decision_engine.cpp
@@ -20,7 +20,7 @@ namespace cvc5::internal {
 namespace decision {
 
 DecisionEngine::DecisionEngine(Env& env,
-                               prop::CDCLTSatSolverInterface* ss,
+                               prop::CDCLTSatSolver* ss,
                                prop::CnfStream* cs)
     : EnvObj(env), d_satSolver(ss), d_cnfStream(cs)
 {

--- a/src/decision/decision_engine.h
+++ b/src/decision/decision_engine.h
@@ -31,9 +31,7 @@ class DecisionEngine : protected EnvObj
 {
  public:
   /** Constructor */
-  DecisionEngine(Env& env,
-                 prop::CDCLTSatSolverInterface* ss,
-                 prop::CnfStream* cs);
+  DecisionEngine(Env& env, prop::CDCLTSatSolver* ss, prop::CnfStream* cs);
   virtual ~DecisionEngine() {}
 
   /** Presolve, called at the beginning of each check-sat call */
@@ -71,7 +69,7 @@ class DecisionEngine : protected EnvObj
   /** Get next internal, the engine-specific implementation of getNext */
   virtual prop::SatLiteral getNextInternal(bool& stopSearch) = 0;
   /** Pointer to the SAT solver */
-  prop::CDCLTSatSolverInterface* d_satSolver;
+  prop::CDCLTSatSolver* d_satSolver;
   /** Pointer to the CNF stream */
   prop::CnfStream* d_cnfStream;
 };

--- a/src/decision/justification_strategy.cpp
+++ b/src/decision/justification_strategy.cpp
@@ -25,7 +25,7 @@ namespace cvc5::internal {
 namespace decision {
 
 JustificationStrategy::JustificationStrategy(Env& env,
-                                             prop::CDCLTSatSolverInterface* ss,
+                                             prop::CDCLTSatSolver* ss,
                                              prop::CnfStream* cs)
     : DecisionEngine(env, ss, cs),
       d_assertions(

--- a/src/decision/justification_strategy.h
+++ b/src/decision/justification_strategy.h
@@ -119,7 +119,7 @@ class JustificationStrategy : public DecisionEngine
  public:
   /** Constructor */
   JustificationStrategy(Env& env,
-                        prop::CDCLTSatSolverInterface* ss,
+                        prop::CDCLTSatSolver* ss,
                         prop::CnfStream* cs);
 
   /** Presolve, called at the beginning of each check-sat call */

--- a/src/decision/justify_cache.cpp
+++ b/src/decision/justify_cache.cpp
@@ -24,7 +24,7 @@ namespace cvc5::internal {
 namespace decision {
 
 JustifyCache::JustifyCache(context::Context* c,
-                           prop::CDCLTSatSolverInterface* ss,
+                           prop::CDCLTSatSolver* ss,
                            prop::CnfStream* cs)
     : d_justified(c), d_satSolver(ss), d_cnfStream(cs)
 {

--- a/src/decision/justify_cache.h
+++ b/src/decision/justify_cache.h
@@ -36,7 +36,7 @@ class JustifyCache
  public:
   /** Constructor */
   JustifyCache(context::Context* c,
-               prop::CDCLTSatSolverInterface* ss,
+               prop::CDCLTSatSolver* ss,
                prop::CnfStream* cs);
   /**
    * Returns the value TRUE/FALSE for n, or UNKNOWN otherwise.
@@ -64,7 +64,7 @@ class JustifyCache
   /** Mapping from non-negated nodes to their SAT value */
   context::CDInsertHashMap<Node, prop::SatValue> d_justified;
   /** Pointer to the SAT solver */
-  prop::CDCLTSatSolverInterface* d_satSolver;
+  prop::CDCLTSatSolver* d_satSolver;
   /** Pointer to the CNF stream */
   prop::CnfStream* d_cnfStream;
 };

--- a/src/prop/minisat/minisat.h
+++ b/src/prop/minisat/minisat.h
@@ -33,7 +33,7 @@ void toSatClause(const typename Solver::TClause& minisat_cl,
 
 namespace prop {
 
-class MinisatSatSolver : public CDCLTSatSolverInterface, protected EnvObj
+class MinisatSatSolver : public CDCLTSatSolver, protected EnvObj
 {
  public:
   MinisatSatSolver(Env& env, StatisticsRegistry& registry);

--- a/src/prop/prop_engine.h
+++ b/src/prop/prop_engine.h
@@ -45,7 +45,7 @@ class DecisionEngine;
 namespace prop {
 
 class CnfStream;
-class CDCLTSatSolverInterface;
+class CDCLTSatSolver;
 class ProofCnfStream;
 class PropPfManager;
 class TheoryProxy;
@@ -404,7 +404,7 @@ class PropEngine : protected EnvObj
   TheoryProxy* d_theoryProxy;
 
   /** The SAT solver proxy */
-  CDCLTSatSolverInterface* d_satSolver;
+  CDCLTSatSolver* d_satSolver;
 
   /** List of all of the assertions that need to be made */
   std::vector<Node> d_assertionList;

--- a/src/prop/prop_proof_manager.cpp
+++ b/src/prop/prop_proof_manager.cpp
@@ -26,7 +26,7 @@ namespace prop {
 
 PropPfManager::PropPfManager(Env& env,
                              context::UserContext* userContext,
-                             CDCLTSatSolverInterface* satSolver,
+                             CDCLTSatSolver* satSolver,
                              ProofCnfStream* cnfProof)
     : EnvObj(env),
       d_propProofs(userContext),

--- a/src/prop/prop_proof_manager.h
+++ b/src/prop/prop_proof_manager.h
@@ -31,7 +31,7 @@ namespace cvc5::internal {
 
 namespace prop {
 
-class CDCLTSatSolverInterface;
+class CDCLTSatSolver;
 
 /**
  * This class is responsible for managing the proof output of PropEngine, both
@@ -45,7 +45,7 @@ class PropPfManager : protected EnvObj
  public:
   PropPfManager(Env& env,
                 context::UserContext* userContext,
-                CDCLTSatSolverInterface* satSolver,
+                CDCLTSatSolver* satSolver,
                 ProofCnfStream* cnfProof);
 
   /** Saves assertion for later checking whether refutation proof is closed.
@@ -104,7 +104,7 @@ class PropPfManager : protected EnvObj
   /**
    * The SAT solver of this prop engine, which should provide a refutation
    * proof when requested */
-  CDCLTSatSolverInterface* d_satSolver;
+  CDCLTSatSolver* d_satSolver;
   /** Assertions corresponding to the leaves of the prop engine's proof.
    *
    * These are kept in a context-dependent manner since the prop engine's proof

--- a/src/prop/sat_solver.h
+++ b/src/prop/sat_solver.h
@@ -116,11 +116,10 @@ public:
 
 };/* class SatSolver */
 
-
-class CDCLTSatSolverInterface : public SatSolver
+class CDCLTSatSolver : public SatSolver
 {
  public:
-  virtual ~CDCLTSatSolverInterface(){};
+  virtual ~CDCLTSatSolver(){};
 
   virtual void initialize(context::Context* context,
                           prop::TheoryProxy* theoryProxy,
@@ -166,7 +165,7 @@ class CDCLTSatSolverInterface : public SatSolver
 
   virtual std::shared_ptr<ProofNode> getProof() = 0;
 
-}; /* class CDCLTSatSolverInterface */
+}; /* class CDCLTSatSolver */
 
 inline std::ostream& operator <<(std::ostream& out, prop::SatLiteral lit) {
   out << lit.toString();

--- a/src/prop/theory_preregistrar.cpp
+++ b/src/prop/theory_preregistrar.cpp
@@ -23,7 +23,7 @@ namespace prop {
 
 TheoryPreregistrar::TheoryPreregistrar(Env& env,
                                        TheoryEngine* te,
-                                       CDCLTSatSolverInterface* ss,
+                                       CDCLTSatSolver* ss,
                                        CnfStream* cs)
     : EnvObj(env), d_theoryEngine(te)
 {

--- a/src/prop/theory_preregistrar.h
+++ b/src/prop/theory_preregistrar.h
@@ -29,7 +29,7 @@ class TheoryEngine;
 
 namespace prop {
 
-class CDCLTSatSolverInterface;
+class CDCLTSatSolver;
 class CnfStream;
 
 /**
@@ -41,7 +41,7 @@ class TheoryPreregistrar : protected EnvObj
  public:
   TheoryPreregistrar(Env& env,
                      TheoryEngine* te,
-                     CDCLTSatSolverInterface* ss,
+                     CDCLTSatSolver* ss,
                      CnfStream* cs);
   ~TheoryPreregistrar();
   /** Do we need to be informed of activated skolem definitions? */

--- a/src/prop/theory_proxy.cpp
+++ b/src/prop/theory_proxy.cpp
@@ -72,7 +72,7 @@ TheoryProxy::~TheoryProxy() {
   /* nothing to do for now */
 }
 
-void TheoryProxy::finishInit(CDCLTSatSolverInterface* ss, CnfStream* cs)
+void TheoryProxy::finishInit(CDCLTSatSolver* ss, CnfStream* cs)
 {
   // make the decision engine, which requires pointers to the SAT solver and CNF
   // stream

--- a/src/prop/theory_proxy.h
+++ b/src/prop/theory_proxy.h
@@ -67,7 +67,7 @@ class TheoryProxy : protected EnvObj, public Registrar
   ~TheoryProxy();
 
   /** Finish initialize */
-  void finishInit(CDCLTSatSolverInterface* ss, CnfStream* cs);
+  void finishInit(CDCLTSatSolver* ss, CnfStream* cs);
 
   /** Presolve, which calls presolve for the modules managed by this class */
   void presolve();


### PR DESCRIPTION
This is to be consistent with SatSolver (both are abstract classes and as such, interfaces).