### PR TITLE
sat solver factory: Fix compiler warning.

### DIFF
--- a/src/prop/sat_solver_factory.cpp
+++ b/src/prop/sat_solver_factory.cpp
@@ -43,6 +43,7 @@ SatSolver* SatSolverFactory::createCryptoMinisat(StatisticsRegistry& registry,
   return res;
 #else
   Unreachable() << "cvc5 was not compiled with Cryptominisat support.";
+  return nullptr;
 #endif
 }
 
@@ -65,6 +66,7 @@ SatSolver* SatSolverFactory::createKissat(StatisticsRegistry& registry,
   return res;
 #else
   Unreachable() << "cvc5 was not compiled with Kissat support.";
+  return nullptr;
 #endif
 }
 


### PR DESCRIPTION
When Kissat and CMS are not configured, return nullptr.