### PR TITLE
Fix resource manager disabling on last call and add resource checks for sygus solver

### DIFF
--- a/src/theory/model_manager.cpp
+++ b/src/theory/model_manager.cpp
@@ -80,6 +80,14 @@ bool ModelManager::buildModel()
     // already computed
     return d_modelBuiltSuccess;
   }
+
+  ResourceManager* rm = d_env.getResourceManager();
+    
+  // Disable resource manager limit while building the model. This ensures
+  // that building the model is not interrupted (and shouldn't take too
+  // long).
+  rm->setEnabled(false);
+      
   // reset the flags now
   d_modelBuilt = true;
   d_modelBuiltSuccess = false;
@@ -88,21 +96,25 @@ bool ModelManager::buildModel()
   if (!prepareModel())
   {
     Trace("model-builder") << "ModelManager: fail prepare model" << std::endl;
-    return false;
   }
-
-  // now, finish building the model
-  d_modelBuiltSuccess = finishBuildModel();
-
-  if (TraceIsOn("model-final"))
+  else
   {
-    Trace("model-final") << "Final model:" << std::endl;
-    Trace("model-final") << d_model->debugPrintModelEqc() << std::endl;
+    // now, finish building the model
+    d_modelBuiltSuccess = finishBuildModel();
+
+    if (TraceIsOn("model-final"))
+    {
+      Trace("model-final") << "Final model:" << std::endl;
+      Trace("model-final") << d_model->debugPrintModelEqc() << std::endl;
+    }
+
+    Trace("model-builder") << "ModelManager: model built success is "
+                          << d_modelBuiltSuccess << std::endl;
   }
 
-  Trace("model-builder") << "ModelManager: model built success is "
-                         << d_modelBuiltSuccess << std::endl;
-
+  // Enable resource management again.
+  rm->setEnabled(true);
+      
   return d_modelBuiltSuccess;
 }
 

--- a/src/theory/model_manager.cpp
+++ b/src/theory/model_manager.cpp
@@ -82,12 +82,12 @@ bool ModelManager::buildModel()
   }
 
   ResourceManager* rm = d_env.getResourceManager();
-    
+
   // Disable resource manager limit while building the model. This ensures
   // that building the model is not interrupted (and shouldn't take too
   // long).
   rm->setEnabled(false);
-      
+
   // reset the flags now
   d_modelBuilt = true;
   d_modelBuiltSuccess = false;
@@ -109,12 +109,12 @@ bool ModelManager::buildModel()
     }
 
     Trace("model-builder") << "ModelManager: model built success is "
-                          << d_modelBuiltSuccess << std::endl;
+                           << d_modelBuiltSuccess << std::endl;
   }
 
   // Enable resource management again.
   rm->setEnabled(true);
-      
+
   return d_modelBuiltSuccess;
 }
 

--- a/src/theory/quantifiers/sygus/synth_engine.cpp
+++ b/src/theory/quantifiers/sygus/synth_engine.cpp
@@ -15,8 +15,8 @@
  */
 #include "theory/quantifiers/sygus/synth_engine.h"
 
-#include "options/quantifiers_options.h"
 #include "options/base_options.h"
+#include "options/quantifiers_options.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
 #include "theory/quantifiers/term_registry.h"
@@ -98,12 +98,14 @@ void SynthEngine::check(Theory::Effort e, QEffort quant_e)
       activeCheckConj.push_back(sc);
     }
   }
-  Trace("ajr-temp") << "tlimit-per is " << options().base.perCallMillisecondLimit << std::endl;
+  Trace("ajr-temp") << "tlimit-per is "
+                    << options().base.perCallMillisecondLimit << std::endl;
   std::vector<SynthConjecture*> acnext;
   ResourceManager* rm = d_env.getResourceManager();
   do
   {
-    Trace("ajr-temp")  << "remaining time: " << rm->getRemainingTime() << std::endl;
+    Trace("ajr-temp") << "remaining time: " << rm->getRemainingTime()
+                      << std::endl;
     rm->spendResource(Resource::SygusCheckStep);
     Trace("sygus-engine-debug") << "Checking " << activeCheckConj.size()
                                 << " active conjectures..." << std::endl;
@@ -118,7 +120,8 @@ void SynthEngine::check(Theory::Effort e, QEffort quant_e)
     activeCheckConj.clear();
     activeCheckConj = acnext;
     acnext.clear();
-  } while (!activeCheckConj.empty() && !d_qstate.getValuation().needCheck() && !rm->out());
+  } while (!activeCheckConj.empty() && !d_qstate.getValuation().needCheck()
+           && !rm->out());
   Trace("sygus-engine")
       << "Finished Counterexample Guided Instantiation engine." << std::endl;
 }

--- a/src/theory/quantifiers/sygus/synth_engine.cpp
+++ b/src/theory/quantifiers/sygus/synth_engine.cpp
@@ -15,7 +15,6 @@
  */
 #include "theory/quantifiers/sygus/synth_engine.h"
 
-#include "options/base_options.h"
 #include "options/quantifiers_options.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
@@ -98,14 +97,10 @@ void SynthEngine::check(Theory::Effort e, QEffort quant_e)
       activeCheckConj.push_back(sc);
     }
   }
-  Trace("ajr-temp") << "tlimit-per is "
-                    << options().base.perCallMillisecondLimit << std::endl;
   std::vector<SynthConjecture*> acnext;
   ResourceManager* rm = d_env.getResourceManager();
   do
   {
-    Trace("ajr-temp") << "remaining time: " << rm->getRemainingTime()
-                      << std::endl;
     rm->spendResource(Resource::SygusCheckStep);
     Trace("sygus-engine-debug") << "Checking " << activeCheckConj.size()
                                 << " active conjectures..." << std::endl;

--- a/src/theory/quantifiers/sygus/synth_engine.cpp
+++ b/src/theory/quantifiers/sygus/synth_engine.cpp
@@ -16,6 +16,7 @@
 #include "theory/quantifiers/sygus/synth_engine.h"
 
 #include "options/quantifiers_options.h"
+#include "options/base_options.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
 #include "theory/quantifiers/term_registry.h"
@@ -97,9 +98,13 @@ void SynthEngine::check(Theory::Effort e, QEffort quant_e)
       activeCheckConj.push_back(sc);
     }
   }
+  Trace("ajr-temp") << "tlimit-per is " << options().base.perCallMillisecondLimit << std::endl;
   std::vector<SynthConjecture*> acnext;
+  ResourceManager* rm = d_env.getResourceManager();
   do
   {
+    Trace("ajr-temp")  << "remaining time: " << rm->getRemainingTime() << std::endl;
+    rm->spendResource(Resource::SygusCheckStep);
     Trace("sygus-engine-debug") << "Checking " << activeCheckConj.size()
                                 << " active conjectures..." << std::endl;
     for (unsigned i = 0, size = activeCheckConj.size(); i < size; i++)
@@ -113,7 +118,7 @@ void SynthEngine::check(Theory::Effort e, QEffort quant_e)
     activeCheckConj.clear();
     activeCheckConj = acnext;
     acnext.clear();
-  } while (!activeCheckConj.empty() && !d_qstate.getValuation().needCheck());
+  } while (!activeCheckConj.empty() && !d_qstate.getValuation().needCheck() && !rm->out());
   Trace("sygus-engine")
       << "Finished Counterexample Guided Instantiation engine." << std::endl;
 }

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -495,10 +495,6 @@ void TheoryEngine::check(Theory::Effort effort) {
       }
       // reset the model in the combination engine
       d_tc->resetModel();
-      // Disable resource manager limit while building the model. This ensures
-      // that building the model is not interrupted (and shouldn't take too
-      // long).
-      rm->setEnabled(false);
       //checks for theories requiring the model go at last call
       for (TheoryId theoryId = THEORY_FIRST; theoryId < THEORY_LAST; ++theoryId)
       {
@@ -531,8 +527,6 @@ void TheoryEngine::check(Theory::Effort effort) {
       {
         tem->notifyCandidateModel(getModel());
       }
-      // Enable resource management again.
-      rm->setEnabled(true);
     }
 
     Trace("theory") << "TheoryEngine::check(" << effort << "): done, we are " << (d_inConflict ? "unsat" : "sat") << (d_lemmasAdded ? " with new lemmas" : " with no new lemmas");

--- a/src/util/resource_manager.cpp
+++ b/src/util/resource_manager.cpp
@@ -87,6 +87,7 @@ const char* toString(Resource r)
     case Resource::RestartStep: return "RestartStep";
     case Resource::RewriteStep: return "RewriteStep";
     case Resource::SatConflictStep: return "SatConflictStep";
+    case Resource::SygusEnumStep: return "SygusEnumStep";
     case Resource::TheoryCheckStep: return "TheoryCheckStep";
     default: return "?Resource?";
   }

--- a/src/util/resource_manager.cpp
+++ b/src/util/resource_manager.cpp
@@ -87,7 +87,7 @@ const char* toString(Resource r)
     case Resource::RestartStep: return "RestartStep";
     case Resource::RewriteStep: return "RewriteStep";
     case Resource::SatConflictStep: return "SatConflictStep";
-    case Resource::SygusEnumStep: return "SygusEnumStep";
+    case Resource::SygusCheckStep: return "SygusCheckStep";
     case Resource::TheoryCheckStep: return "TheoryCheckStep";
     default: return "?Resource?";
   }

--- a/src/util/resource_manager.h
+++ b/src/util/resource_manager.h
@@ -87,6 +87,7 @@ enum class Resource
   RestartStep,
   RewriteStep,
   SatConflictStep,
+  SygusEnumStep,
   TheoryCheckStep,
   Unknown
 };

--- a/src/util/resource_manager.h
+++ b/src/util/resource_manager.h
@@ -87,7 +87,7 @@ enum class Resource
   RestartStep,
   RewriteStep,
   SatConflictStep,
-  SygusEnumStep,
+  SygusCheckStep,
   TheoryCheckStep,
   Unknown
 };


### PR DESCRIPTION
Ensures that we respond to resource/timeouts when using `--sygus-enum=fast`, which runs entirely within a loop in the SyGuS solver.

This also ensures the resource manager is only disabled when model building, and not during LAST_CALL effort checks as well.

FYI @arjunvish 