### PR TITLE
Fix regular expression inclusion for ranges

### DIFF
--- a/src/theory/strings/regexp_entail.cpp
+++ b/src/theory/strings/regexp_entail.cpp
@@ -885,8 +885,8 @@ bool RegExpEntail::regExpIncludes(Node r1,
     {
       unsigned l1 = r1[0].getConst<String>().front();
       unsigned u1 = r1[1].getConst<String>().front();
-      unsigned l2 = r1[0].getConst<String>().front();
-      unsigned u2 = r1[1].getConst<String>().front();
+      unsigned l2 = r2[0].getConst<String>().front();
+      unsigned u2 = r2[1].getConst<String>().front();
       ret = l1 <= l2 && l2 <= u1 && l1 <= u2 && u2 <= u1;
     }
   }

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2854,6 +2854,7 @@ set(regress_1_tests
   regress1/strings/re-agg-total1.smt2
   regress1/strings/re-agg-total2.smt2
   regress1/strings/re-elim-exact.smt2
+  regress1/strings/re-inc-range.smt2
   regress1/strings/re-inter-stack-ovf.smt2
   regress1/strings/re-mod-eq.smt2
   regress1/strings/re-neg-concat-reduct.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2815,6 +2815,7 @@ set(regress_1_tests
   regress1/strings/issue9040-re-inter-comp.smt2
   regress1/strings/issue9269-rei-nconst.smt2
   regress1/strings/issue9287-trivial-deq-disl.smt2
+  regress1/strings/issue9543-re-inc.smt2
   regress1/strings/kaluza-fl.smt2
   regress1/strings/loop002.smt2
   regress1/strings/loop003.smt2

--- a/test/regress/cli/regress1/strings/issue9543-re-inc.smt2
+++ b/test/regress/cli/regress1/strings/issue9543-re-inc.smt2
@@ -1,0 +1,10 @@
+; COMMAND-LINE: -i
+; EXPECT: sat
+; EXPECT: sat
+(set-logic QF_S)
+(declare-fun s () String)
+(assert (distinct 0 (str.len s)))
+(assert (not (str.in_re s (re.+ (re.range "0" "9")))))
+(check-sat)
+(assert (not (str.in_re s (re.+ (re.range "0" "f")))))
+(check-sat)

--- a/test/regress/cli/regress1/strings/re-inc-range.smt2
+++ b/test/regress/cli/regress1/strings/re-inc-range.smt2
@@ -1,0 +1,6 @@
+; EXPECT: sat
+(set-logic ALL)
+(declare-fun a () String)
+(assert (str.in_re a (re.range "A" "Z")))
+(assert (str.in_re a (re.inter (re.comp (re.range "A" "J")) (re.range "A" "Z"))))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/9543.

Bug was introduced here: https://github.com/cvc5/cvc5/pull/9253.