### PR TITLE
Add `-o trusted-proof-steps`

### DIFF
--- a/src/options/base_options.toml
+++ b/src/options/base_options.toml
@@ -216,6 +216,11 @@ name   = "Base"
   help = "print lemmas as they are added to the SAT solver"
   description = "With ``-o lemmas``, cvc5 prints lemmas as they are added to the SAT solver."
   example-file = "regress0/printer/print_sat_lemmas.smt2"
+[[option.mode.TRUSTED_PROOF_STEPS]]
+  name = "trusted-proof-steps"
+  help = "print formulas corresponding to trusted proof steps in final proofs"
+  description = "With ``-o lemmas``, cvc5 prints formulas corresponding to trusted proof steps in final proofs."
+  example-file = "regress0/printer/print_trusted_proof_steps.smt2"
 
 # Stores then enabled output tags.
 [[option]]

--- a/src/smt/proof_final_callback.cpp
+++ b/src/smt/proof_final_callback.cpp
@@ -16,6 +16,7 @@
 #include "smt/proof_final_callback.h"
 
 #include "expr/skolem_manager.h"
+#include "options/base_options.h"
 #include "options/proof_options.h"
 #include "proof/proof_checker.h"
 #include "proof/proof_node_manager.h"
@@ -142,7 +143,8 @@ bool ProofFinalCallback::shouldUpdate(std::shared_ptr<ProofNode> pn,
       Trace("final-pf-hole") << "hole " << r << " : " << eq << std::endl;
     }
   }
-  if (options().proof.checkProofSteps)
+  
+  if (options().proof.checkProofSteps || isOutputOn(OutputTag::TRUSTED_PROOF_STEPS))
   {
     Node conc = pn->getResult();
     ProofChecker* pc = pnm->getChecker();
@@ -160,26 +162,33 @@ bool ProofFinalCallback::shouldUpdate(std::shared_ptr<ProofNode> pn,
       }
       NodeManager* nm = NodeManager::currentNM();
       Node query = nm->mkNode(IMPLIES, nm->mkAnd(premises), conc);
-      // trust the rewriter here, since the subsolver will rewrite anyways
-      query = rewrite(query);
-      // We use the original form of the query, which is a logically
-      // stronger formula. This may make it possible or easier to prove.
-      query = SkolemManager::getOriginalForm(query);
-      // set up the subsolver
-      Options subOptions;
-      subOptions.copyValues(d_env.getOptions());
-      smt::SetDefaults::disableChecking(subOptions);
-      SubsolverSetupInfo ssi(d_env, subOptions);
-      Trace("check-proof-steps")
-          << "Check: " << r << " : " << query << std::endl;
-      Result res = checkWithSubsolver(query.notNode(), ssi, true, 5000);
-      Trace("check-proof-steps") << "...got " << res << std::endl;
-      if (res != Result::UNSAT)
+      if (isOutputOn(OutputTag::TRUSTED_PROOF_STEPS))
       {
-        Warning() << "A proof step may not hold: " << r << " proving " << query;
-        Warning() << ", result from check-sat was: " << res << std::endl;
+        output(OutputTag::TRUSTED_PROOF_STEPS) << "(trusted-proof-step " << query << ")" << std::endl;
+      }
+      if (options().proof.checkProofSteps)
+      {
+        // trust the rewriter here, since the subsolver will rewrite anyways
+        query = rewrite(query);
+        // We use the original form of the query, which is a logically
+        // stronger formula. This may make it possible or easier to prove.
+        query = SkolemManager::getOriginalForm(query);
+        // set up the subsolver
+        Options subOptions;
+        subOptions.copyValues(d_env.getOptions());
+        smt::SetDefaults::disableChecking(subOptions);
+        SubsolverSetupInfo ssi(d_env, subOptions);
         Trace("check-proof-steps")
-            << "Original conclusion: " << conc << std::endl;
+            << "Check: " << r << " : " << query << std::endl;
+        Result res = checkWithSubsolver(query.notNode(), ssi, true, 5000);
+        Trace("check-proof-steps") << "...got " << res << std::endl;
+        if (res != Result::UNSAT)
+        {
+          Warning() << "A proof step may not hold: " << r << " proving " << query;
+          Warning() << ", result from check-sat was: " << res << std::endl;
+          Trace("check-proof-steps")
+              << "Original conclusion: " << conc << std::endl;
+        }
       }
     }
   }

--- a/src/smt/proof_final_callback.cpp
+++ b/src/smt/proof_final_callback.cpp
@@ -143,8 +143,9 @@ bool ProofFinalCallback::shouldUpdate(std::shared_ptr<ProofNode> pn,
       Trace("final-pf-hole") << "hole " << r << " : " << eq << std::endl;
     }
   }
-  
-  if (options().proof.checkProofSteps || isOutputOn(OutputTag::TRUSTED_PROOF_STEPS))
+
+  if (options().proof.checkProofSteps
+      || isOutputOn(OutputTag::TRUSTED_PROOF_STEPS))
   {
     Node conc = pn->getResult();
     ProofChecker* pc = pnm->getChecker();
@@ -164,7 +165,8 @@ bool ProofFinalCallback::shouldUpdate(std::shared_ptr<ProofNode> pn,
       Node query = nm->mkNode(IMPLIES, nm->mkAnd(premises), conc);
       if (isOutputOn(OutputTag::TRUSTED_PROOF_STEPS))
       {
-        output(OutputTag::TRUSTED_PROOF_STEPS) << "(trusted-proof-step " << query << ")" << std::endl;
+        output(OutputTag::TRUSTED_PROOF_STEPS)
+            << "(trusted-proof-step " << query << ")" << std::endl;
       }
       if (options().proof.checkProofSteps)
       {
@@ -184,7 +186,8 @@ bool ProofFinalCallback::shouldUpdate(std::shared_ptr<ProofNode> pn,
         Trace("check-proof-steps") << "...got " << res << std::endl;
         if (res != Result::UNSAT)
         {
-          Warning() << "A proof step may not hold: " << r << " proving " << query;
+          Warning() << "A proof step may not hold: " << r << " proving "
+                    << query;
           Warning() << ", result from check-sat was: " << res << std::endl;
           Trace("check-proof-steps")
               << "Original conclusion: " << conc << std::endl;

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1075,6 +1075,7 @@ set(regress_0_tests
   regress0/printer/pre-asserts-output.smt2
   regress0/printer/print_sat_lemmas.smt2
   regress0/printer/print_subs.smt2
+  regress0/printer/print_trusted_proof_steps.smt2
   regress0/printer/symbol_starting_w_digit.smt2
   regress0/printer/tuples_and_records.cvc.smt2
   regress0/proj-issue307-get-value-re.smt2

--- a/test/regress/cli/regress0/printer/print_trusted_proof_steps.smt2
+++ b/test/regress/cli/regress0/printer/print_trusted_proof_steps.smt2
@@ -1,0 +1,6 @@
+; COMMAND-LINE: --dump-proofs -o trusted-proof-steps
+; SCRUBBER: grep -E '\(trusted-proof-step'
+; EXPECT: (trusted-proof-step (=> true (= (= 0 1) false)))
+(set-logic ALL)
+(assert (= 0 1))
+(check-sat)


### PR DESCRIPTION
Can be used for summarizing the steps that are unproven in the final proof.