### PR TITLE
Small fix to Windows 'native' build code. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,14 +307,6 @@ enable_testing()
 #-----------------------------------------------------------------------------#
 # Check options, find packages and configure build.
 
-# On Windows, we need to have a shell interpreter to call 'configure'
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    find_program (SHELL "sh" REQUIRED)
-    message(STATUS "Found shell interpreter: ${SHELL}")
-else()
-    set(SHELL "")
-endif()
-
 if(BUILD_SHARED_LIBS)
   if (WIN32)
     set(CMAKE_FIND_LIBRARY_SUFFIXES .dll .lib .a)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,14 @@ enable_testing()
 #-----------------------------------------------------------------------------#
 # Check options, find packages and configure build.
 
+# On Windows, we need to have a shell interpreter to call 'configure'
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    find_program (SHELL "sh" REQUIRED)
+    message(STATUS "Found shell interpreter: ${SHELL}")
+else()
+    set(SHELL "")
+endif()
+
 if(BUILD_SHARED_LIBS)
   if (WIN32)
     set(CMAKE_FIND_LIBRARY_SUFFIXES .dll .lib .a)

--- a/cmake/FindANTLR3.cmake
+++ b/cmake/FindANTLR3.cmake
@@ -102,14 +102,6 @@ if(NOT ANTLR3_FOUND_SYSTEM)
     else()
         unset(64bit)
     endif()
-
-    # On Windows, we need to have a shell interpreter to call 'configure'
-    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-        find_program (SHELL "sh" REQUIRED)
-        message(STATUS "Found shell interpreter: ${SHELL}")
-    else()
-        set(SHELL "")
-    endif()
  
     set(compilers "")
     if (CMAKE_CROSSCOMPILING_MACOS)

--- a/cmake/FindCLN.cmake
+++ b/cmake/FindCLN.cmake
@@ -62,7 +62,7 @@ if(NOT CLN_FOUND_SYSTEM)
       ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> ./autogen.sh
     COMMAND
       ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> autoreconf -iv
-    COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --enable-shared
+    COMMAND ${SHELL} <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --enable-shared
             --enable-static --with-pic
     BUILD_BYPRODUCTS <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/libcln.a
                      <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/libcln${CMAKE_SHARED_LIBRARY_SUFFIX}

--- a/cmake/FindCoCoA.cmake
+++ b/cmake/FindCoCoA.cmake
@@ -61,7 +61,7 @@ if(NOT CoCoA_FOUND_SYSTEM)
     PATCH_COMMAND patch -p1 -d <SOURCE_DIR>
         -i ${CMAKE_CURRENT_LIST_DIR}/deps-utils/CoCoALib-0.99800-trace.patch
     BUILD_IN_SOURCE YES
-    CONFIGURE_COMMAND ./configure --prefix=<INSTALL_DIR>
+    CONFIGURE_COMMAND ${SHELL} ./configure --prefix=<INSTALL_DIR>
     BUILD_COMMAND ${make_cmd} library
   )
   # Remove install directory before make install. CoCoA will complain otherwise

--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -115,6 +115,14 @@ if(NOT GMP_FOUND_SYSTEM)
     endif()
   endif()
 
+  # On Windows, we need to have a shell interpreter to call 'configure'
+  if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+      find_program (SHELL "sh" REQUIRED)
+      message(STATUS "Found shell interpreter: ${SHELL}")
+  else()
+      set(SHELL "")
+  endif()
+
   # `CC_FOR_BUILD`, `--host`, and `--build` are passed to `configure` to ensure
   # that cross-compilation works (as suggested in the GMP documentation).
   # Without the `--build` flag, `configure` may fail for cross-compilation
@@ -126,7 +134,7 @@ if(NOT GMP_FOUND_SYSTEM)
     URL_HASH SHA1=2dcf34d4a432dbe6cce1475a835d20fe44f75822
     CONFIGURE_COMMAND
       ${CONFIGURE_ENV}
-          ${CONFIGURE_CMD_WRAPPER} <SOURCE_DIR>/configure
+          ${CONFIGURE_CMD_WRAPPER} ${SHELL} <SOURCE_DIR>/configure
           ${LINK_OPTS}
           --prefix=<INSTALL_DIR>
           --with-pic

--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -115,14 +115,6 @@ if(NOT GMP_FOUND_SYSTEM)
     endif()
   endif()
 
-  # On Windows, we need to have a shell interpreter to call 'configure'
-  if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-      find_program (SHELL "sh" REQUIRED)
-      message(STATUS "Found shell interpreter: ${SHELL}")
-  else()
-      set(SHELL "")
-  endif()
-
   # `CC_FOR_BUILD`, `--host`, and `--build` are passed to `configure` to ensure
   # that cross-compilation works (as suggested in the GMP documentation).
   # Without the `--build` flag, `configure` may fail for cross-compilation

--- a/cmake/deps-helper.cmake
+++ b/cmake/deps-helper.cmake
@@ -39,6 +39,14 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.14")
     )
 endif()
 
+# On Windows, we need to have a shell interpreter to call 'configure'
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    find_program (SHELL "sh" REQUIRED)
+    message(STATUS "Found shell interpreter: ${SHELL}")
+else()
+    set(SHELL "")
+endif()
+
 macro(force_static_library)
     if (WIN32)
         set(CMAKE_FIND_LIBRARY_SUFFIXES .lib .a)


### PR DESCRIPTION
On Windows, we need to have a shell interpreter to call GMP 'configure'.