### PR TITLE
Include cstdint as necessary for GCC 13

### DIFF
--- a/src/api/java/jni/option_info.cpp
+++ b/src/api/java/jni/option_info.cpp
@@ -13,6 +13,8 @@
  * The cvc5 Java API.
  */
 
+#include <cstdint>
+
 #include <cvc5/cvc5.h>
 
 #include "api_utilities.h"

--- a/src/api/java/jni/term.cpp
+++ b/src/api/java/jni/term.cpp
@@ -13,6 +13,8 @@
  * The cvc5 Java API.
  */
 
+#include <cstdint>
+
 #include <cvc5/cvc5.h>
 
 #include "api_utilities.h"

--- a/src/theory/arith/nl/icp/icp_solver.h
+++ b/src/theory/arith/nl/icp/icp_solver.h
@@ -16,6 +16,8 @@
 #ifndef CVC5__THEORY__ARITH__ICP__ICP_SOLVER_H
 #define CVC5__THEORY__ARITH__ICP__ICP_SOLVER_H
 
+#include <cstdint>
+
 #include "cvc5_private.h"
 
 #ifdef CVC5_POLY_IMP

--- a/src/theory/arith/nl/transcendental/exponential_solver.h
+++ b/src/theory/arith/nl/transcendental/exponential_solver.h
@@ -16,6 +16,7 @@
 #ifndef CVC5__THEORY__ARITH__NL__TRANSCENDENTAL__EXPONENTIAL_SOLVER_H
 #define CVC5__THEORY__ARITH__NL__TRANSCENDENTAL__EXPONENTIAL_SOLVER_H
 
+#include <cstdint>
 #include <map>
 
 #include "expr/node.h"

--- a/src/theory/arith/nl/transcendental/taylor_generator.h
+++ b/src/theory/arith/nl/transcendental/taylor_generator.h
@@ -16,6 +16,8 @@
 #ifndef CVC5__THEORY__ARITH__NL__TRANSCENDENTAL__TAYLOR_GENERATOR_H
 #define CVC5__THEORY__ARITH__NL__TRANSCENDENTAL__TAYLOR_GENERATOR_H
 
+#include <cstdint>
+
 #include "expr/node.h"
 
 namespace cvc5::internal {

--- a/src/util/didyoumean.cpp
+++ b/src/util/didyoumean.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/src/util/indexed_root_predicate.h
+++ b/src/util/indexed_root_predicate.h
@@ -13,6 +13,8 @@
  * Utils for indexed root predicates.
  */
 
+#include <cstdint>
+
 #include "cvc5_public.h"
 
 #ifndef CVC5__UTIL__INDEXED_ROOT_PREDICATE_H


### PR DESCRIPTION
I am preparing to retire the cvc4 package and introduce a cvc5 package into the Fedora Linux distribution.  Fedora Rawhide currently uses a prerelease of GCC 13 to build packages.  Some C++ headers have been streamlined.  As a result, cstdint is no longer implicitly included in some places where it was before.  This PR adds explicit `#include <cstdint>` directives as necessary for cvc5 to build with GCC 13.