### PR TITLE
Revert change to type checker

### DIFF
--- a/src/expr/type_checker_template.cpp
+++ b/src/expr/type_checker_template.cpp
@@ -66,7 +66,15 @@ TypeNode TypeChecker::computeType(NodeManager* nodeManager,
   // Infer the type
   switch (n.getKind())
   {
-    // clang-format off
+    case kind::VARIABLE:
+    case kind::SKOLEM:
+      typeNode = nodeManager->getAttribute(n, TypeAttr());
+      break;
+    case kind::BUILTIN:
+      typeNode = nodeManager->builtinOperatorType();
+      break;
+
+      // clang-format off
 ${typerules}
       // clang-format on
 
@@ -74,6 +82,11 @@ ${typerules}
       Trace("getType") << "FAILURE" << std::endl;
       Unhandled() << " " << n.getKind();
   }
+
+  nodeManager->setAttribute(n, TypeAttr(), typeNode);
+  nodeManager->setAttribute(n, TypeCheckedAttr(),
+                            check || nodeManager->getAttribute(n, TypeCheckedAttr()));
+
   return typeNode;
 
 } /* TypeChecker::computeType */


### PR DESCRIPTION
This temporarily reverts the change to the type checker in https://github.com/cvc5/cvc5/pull/9497 in preparation for the 1.0.5 release.

That change led to a ~35% slowdown on industrial benchmarks on average.