### PR TITLE
Readd new type check algorithm

### DIFF
--- a/src/expr/node_manager_template.cpp
+++ b/src/expr/node_manager_template.cpp
@@ -486,70 +486,75 @@ std::vector<NodeValue*> NodeManager::TopologicalSort(
 TypeNode NodeManager::getType(TNode n, bool check, std::ostream* errOut)
 {
   TypeNode typeNode;
-  bool hasType = getAttribute(n, TypeAttr(), typeNode);
-  bool needsCheck = check && !getAttribute(n, TypeCheckedAttr());
-
-  Trace("getType") << this << " getting type for " << &n << " " << n
-                   << ", check=" << check << ", needsCheck = " << needsCheck
-                   << ", hasType = " << hasType << endl;
-
-#ifdef CVC5_DEBUG
-  // already did type check eagerly upon creation in node builder
-  bool doTypeCheck = false;
-#else
-  bool doTypeCheck = true;
-#endif
-  if (needsCheck && doTypeCheck)
+  TypeAttr ta;
+  TypeCheckedAttr tca;
+  bool hasType = getAttribute(n, ta, typeNode);
+  bool needsCheck = check && !getAttribute(n, tca);
+  if (hasType && !needsCheck)
   {
-    /* Iterate and compute the children bottom up. This avoids stack
-       overflows in computeType() when the Node graph is really deep,
-       which should only affect us when we're type checking lazily. */
-    stack<TNode> worklist;
-    worklist.push(n);
-
-    while (!worklist.empty())
+    return typeNode;
+  }
+  std::unordered_map<TNode, bool> visited;
+  std::unordered_map<TNode, bool>::const_iterator it;
+  std::vector<TNode> visit;
+  TNode cur;
+  visit.push_back(n);
+  do
+  {
+    cur = visit.back();
+    visit.pop_back();
+    // already computed (and checked, if necessary) this type
+    if (!getAttribute(cur, ta).isNull() && (!check || getAttribute(cur, tca)))
     {
-      TNode m = worklist.top();
-
-      bool readyToCompute = true;
-
-      for (TNode::iterator it = m.begin(), end = m.end(); it != end; ++it)
+      continue;
+    }
+    it = visited.find(cur);
+    // we have yet to visit children
+    if (it == visited.end())
+    {
+      // See if it has a type inferrable at pre traversal. We only do this
+      // if we are not checking, since preComputeType by design does not
+      // check the children types.
+      if (!check)
       {
-        if (!hasAttribute(*it, TypeAttr())
-            || (check && !getAttribute(*it, TypeCheckedAttr())))
+        typeNode = TypeChecker::preComputeType(this, cur);
+        if (!typeNode.isNull())
         {
-          readyToCompute = false;
-          worklist.push(*it);
+          visited[cur] = true;
+          setAttribute(cur, ta, typeNode);
+          // note that the result of preComputeType is not cached
+          continue;
         }
       }
-
-      if (readyToCompute)
+      // we are checking, or pre-compute type is not available
+      visited[cur] = false;
+      visit.push_back(cur);
+      visit.insert(visit.end(), cur.begin(), cur.end());
+    }
+    else if (!it->second)
+    {
+      visited[cur] = true;
+      // children now have types assigned
+      typeNode = TypeChecker::computeType(this, cur, check, nullptr);
+      // if null, immediately return without further caching
+      if (typeNode.isNull())
       {
-        Assert(check || m.getMetaKind() != kind::metakind::NULLARY_OPERATOR);
-        /* All the children have types, time to compute */
-        typeNode = TypeChecker::computeType(this, m, check, errOut);
-        worklist.pop();
+        // !!!! temporary: recompute with an error stream
+        std::stringstream errOutTmp;
+        TypeChecker::computeType(this, cur, check, &errOutTmp);
+        throw TypeCheckingExceptionPrivate(cur, errOutTmp.str());
+        return typeNode;
       }
-    }  // end while
-
-    /* Last type computed in loop should be the type of n */
-    Assert(typeNode == getAttribute(n, TypeAttr()));
-  }
-  else if (!hasType || needsCheck)
-  {
-    /* We can compute the type top-down, without worrying about
-       deep recursion. */
-    Assert(check || n.getMetaKind() != kind::metakind::NULLARY_OPERATOR);
-    typeNode = TypeChecker::computeType(this, n, check);
-  }
+      setAttribute(cur, ta, typeNode);
+      setAttribute(cur, tca, check || getAttribute(cur, tca));
+    }
+  } while (!visit.empty());
 
   /* The type should be have been computed and stored. */
-  Assert(hasAttribute(n, TypeAttr()));
+  Assert(hasAttribute(n, ta));
   /* The check should have happened, if we asked for it. */
-  Assert(!check || getAttribute(n, TypeCheckedAttr()));
-
-  Trace("getType") << "type of " << &n << " " << n << " is " << typeNode
-                   << endl;
+  Assert(!check || getAttribute(n, tca));
+  // should be the last type computed in the above loop
   return typeNode;
 }
 

--- a/src/expr/type_checker_template.cpp
+++ b/src/expr/type_checker_template.cpp
@@ -47,9 +47,7 @@ TypeNode TypeChecker::preComputeType(NodeManager* nodeManager, TNode n)
       typeNode = nodeManager->builtinOperatorType();
       break;
 
-      // clang-format off
-${pretyperules}
-      // clang-format on
+      // !!! will auto-generate preComputeType rules when they are available
 
     default:
       // not handled

--- a/src/expr/type_checker_template.cpp
+++ b/src/expr/type_checker_template.cpp
@@ -47,7 +47,9 @@ TypeNode TypeChecker::preComputeType(NodeManager* nodeManager, TNode n)
       typeNode = nodeManager->builtinOperatorType();
       break;
 
-      // !!! will auto-generate preComputeType rules when they are available
+      // clang-format off
+${pretyperules}
+      // clang-format on
 
     default:
       // not handled
@@ -66,13 +68,6 @@ TypeNode TypeChecker::computeType(NodeManager* nodeManager,
   // Infer the type
   switch (n.getKind())
   {
-    case kind::VARIABLE:
-    case kind::SKOLEM:
-      typeNode = nodeManager->getAttribute(n, TypeAttr());
-      break;
-    case kind::BUILTIN:
-      typeNode = nodeManager->builtinOperatorType();
-      break;
 
       // clang-format off
 ${typerules}
@@ -82,10 +77,6 @@ ${typerules}
       Trace("getType") << "FAILURE" << std::endl;
       Unhandled() << " " << n.getKind();
   }
-
-  nodeManager->setAttribute(n, TypeAttr(), typeNode);
-  nodeManager->setAttribute(n, TypeCheckedAttr(),
-                            check || nodeManager->getAttribute(n, TypeCheckedAttr()));
 
   return typeNode;
 


### PR DESCRIPTION
This adds the change from https://github.com/cvc5/cvc5/pull/9497 again.

This time, we avoid the performance hit from constructing `std::stringstream` by only introducing it on demand.