### PR TITLE
fix type of `size` in `solve-int-as-bv`

### DIFF
--- a/src/preprocessing/passes/int_to_bv.cpp
+++ b/src/preprocessing/passes/int_to_bv.cpp
@@ -107,7 +107,8 @@ Node intToBVMakeBinary(TNode n, NodeMap& cache)
 
 Node IntToBV::intToBV(TNode n, NodeMap& cache)
 {
-  int size = options().smt.solveIntAsBV;
+  Assert(options().smt.solveIntAsBV <= 4294967295);
+  uint32_t size = options().smt.solveIntAsBV;
   AlwaysAssert(size > 0);
   AlwaysAssert(!options().base.incrementalSolving);
 

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -807,6 +807,7 @@ set(regress_0_tests
   regress0/int-to-bv/neg-consts.smt2
   regress0/int-to-bv/not-enough-bits.smt2
   regress0/int-to-bv/overflow.smt2
+  regress0/int-to-bv/proj-issue601.smt2
   regress0/issue1063-overloading-dt-cons.smt2
   regress0/issue1063-overloading-dt-fun.smt2
   regress0/issue1063-overloading-dt-sel.smt2

--- a/test/regress/cli/regress0/int-to-bv/proj-issue601.smt2
+++ b/test/regress/cli/regress0/int-to-bv/proj-issue601.smt2
@@ -1,0 +1,6 @@
+; EXPECT: sat
+(set-logic ALL)
+(set-option :solve-int-as-bv 3714675145)
+(declare-sort u 0)
+(define-fun f ((_f29_0 (Seq u))) (Seq u) _f29_0)
+(check-sat)


### PR DESCRIPTION
fixes https://github.com/cvc5/cvc5-projects/issues/543 .