### PR TITLE
Make CEGQI atom collection take into account rewriting

### DIFF
--- a/src/theory/bv/theory_bv_rewrite_rules_core.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_core.h
@@ -294,7 +294,7 @@ Node RewriteRule<SimplifyEq>::apply(TNode node) {
 
 template<> inline
 bool RewriteRule<ReflexivityEq>::applies(TNode node) {
-  return (node.getKind() == kind::EQUAL && node[0] < node[1]);
+  return (node.getKind() == kind::EQUAL && node[0] > node[1]);
 }
 
 template<> inline

--- a/src/theory/bv/theory_bv_rewrite_rules_core.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_core.h
@@ -294,7 +294,7 @@ Node RewriteRule<SimplifyEq>::apply(TNode node) {
 
 template<> inline
 bool RewriteRule<ReflexivityEq>::applies(TNode node) {
-  return (node.getKind() == kind::EQUAL && node[0] > node[1]);
+  return (node.getKind() == kind::EQUAL && node[0] < node[1]);
 }
 
 template<> inline

--- a/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
@@ -1513,32 +1513,25 @@ void CegInstantiator::markSolved(Node n, bool solved)
   }
 }
 
-void CegInstantiator::collectCeAtoms(Node n)
-{
+void CegInstantiator::collectCeAtoms( Node n ) {
   std::unordered_set<TNode> visited;
   std::vector<TNode> visit;
   TNode cur;
   visit.push_back(n);
-  do
-  {
+  do {
     cur = visit.back();
     visit.pop_back();
-    if (visited.find(cur) == visited.end())
-    {
+    if (visited.find(cur) == visited.end()) {
       visited.insert(cur);
-      if (n.getKind() == FORALL)
+      if (cur.getKind()==FORALL)
       {
         d_is_nested_quant = true;
       }
-      if (TermUtil::isBoolConnectiveTerm(n))
-      {
-        visit.insert(visit.end(), n.begin(), n.end());
-      }
-      else if (std::find(d_ce_atoms.begin(), d_ce_atoms.end(), n)
-               == d_ce_atoms.end())
-      {
-        Trace("cegqi-ce-atoms") << "CE atoms : " << n << std::endl;
-        d_ce_atoms.push_back( n );
+      if( TermUtil::isBoolConnectiveTerm( cur ) ){
+        visit.insert(visit.end(), cur.begin(), cur.end());
+      }else if( std::find( d_ce_atoms.begin(), d_ce_atoms.end(), cur )==d_ce_atoms.end() ){
+        Trace("cegqi-ce-atoms") << "CE atoms : " << cur << std::endl;
+        d_ce_atoms.push_back( cur );
       }
     }
   } while (!visit.empty());

--- a/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
@@ -1513,23 +1513,30 @@ void CegInstantiator::markSolved(Node n, bool solved)
   }
 }
 
-void CegInstantiator::collectCeAtoms( Node n ) {
+void CegInstantiator::collectCeAtoms(Node n)
+{
   std::unordered_set<TNode> visited;
   std::vector<TNode> visit;
   TNode cur;
   visit.push_back(n);
-  do {
+  do
+  {
     cur = visit.back();
     visit.pop_back();
-    if (visited.find(cur) == visited.end()) {
+    if (visited.find(cur) == visited.end())
+    {
       visited.insert(cur);
-      if (n.getKind()==FORALL)
+      if (n.getKind() == FORALL)
       {
         d_is_nested_quant = true;
       }
-      if( TermUtil::isBoolConnectiveTerm( n ) ){
+      if (TermUtil::isBoolConnectiveTerm(n))
+      {
         visit.insert(visit.end(), n.begin(), n.end());
-      }else if( std::find( d_ce_atoms.begin(), d_ce_atoms.end(), n )==d_ce_atoms.end() ){
+      }
+      else if (std::find(d_ce_atoms.begin(), d_ce_atoms.end(), n)
+               == d_ce_atoms.end())
+      {
         Trace("cegqi-ce-atoms") << "CE atoms : " << n << std::endl;
         d_ce_atoms.push_back( n );
       }

--- a/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
@@ -1513,22 +1513,28 @@ void CegInstantiator::markSolved(Node n, bool solved)
   }
 }
 
-void CegInstantiator::collectCeAtoms( Node n, std::map< Node, bool >& visited ) {
-  if( n.getKind()==FORALL ){
-    d_is_nested_quant = true;
-  }else if( visited.find( n )==visited.end() ){
-    visited[n] = true;
-    if( TermUtil::isBoolConnectiveTerm( n ) ){
-      for( unsigned i=0; i<n.getNumChildren(); i++ ){
-        collectCeAtoms( n[i], visited );
+void CegInstantiator::collectCeAtoms( Node n ) {
+  std::unordered_set<TNode> visited;
+  std::vector<TNode> visit;
+  TNode cur;
+  visit.push_back(n);
+  do {
+    cur = visit.back();
+    visit.pop_back();
+    if (visited.find(cur) == visited.end()) {
+      visited.insert(cur);
+      if (n.getKind()==FORALL)
+      {
+        d_is_nested_quant = true;
       }
-    }else{
-      if( std::find( d_ce_atoms.begin(), d_ce_atoms.end(), n )==d_ce_atoms.end() ){
+      if( TermUtil::isBoolConnectiveTerm( n ) ){
+        visit.insert(visit.end(), n.begin(), n.end());
+      }else if( std::find( d_ce_atoms.begin(), d_ce_atoms.end(), n )==d_ce_atoms.end() ){
         Trace("cegqi-ce-atoms") << "CE atoms : " << n << std::endl;
         d_ce_atoms.push_back( n );
       }
     }
-  }
+  } while (!visit.empty());
 }
 
 void CegInstantiator::registerCounterexampleLemma(Node lem,
@@ -1653,11 +1659,12 @@ void CegInstantiator::registerCounterexampleLemma(Node lem,
   // collect atoms from all lemmas: we will only solve for literals coming from
   // the original body
   d_is_nested_quant = false;
-  std::map< Node, bool > visited;
-  collectCeAtoms(lem, visited);
+  Node lemr = rewrite(lem);
+  collectCeAtoms(lemr);
   for (const Node& alem : auxLems)
   {
-    collectCeAtoms(alem, visited);
+    Node alemr = rewrite(alem);
+    collectCeAtoms(alemr);
   }
 }
 

--- a/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
@@ -1513,25 +1513,32 @@ void CegInstantiator::markSolved(Node n, bool solved)
   }
 }
 
-void CegInstantiator::collectCeAtoms( Node n ) {
+void CegInstantiator::collectCeAtoms(Node n)
+{
   std::unordered_set<TNode> visited;
   std::vector<TNode> visit;
   TNode cur;
   visit.push_back(n);
-  do {
+  do
+  {
     cur = visit.back();
     visit.pop_back();
-    if (visited.find(cur) == visited.end()) {
+    if (visited.find(cur) == visited.end())
+    {
       visited.insert(cur);
-      if (cur.getKind()==FORALL)
+      if (cur.getKind() == FORALL)
       {
         d_is_nested_quant = true;
       }
-      if( TermUtil::isBoolConnectiveTerm( cur ) ){
+      if (TermUtil::isBoolConnectiveTerm(cur))
+      {
         visit.insert(visit.end(), cur.begin(), cur.end());
-      }else if( std::find( d_ce_atoms.begin(), d_ce_atoms.end(), cur )==d_ce_atoms.end() ){
+      }
+      else if (std::find(d_ce_atoms.begin(), d_ce_atoms.end(), cur)
+               == d_ce_atoms.end())
+      {
         Trace("cegqi-ce-atoms") << "CE atoms : " << cur << std::endl;
-        d_ce_atoms.push_back( cur );
+        d_ce_atoms.push_back(cur);
       }
     }
   } while (!visit.empty());

--- a/src/theory/quantifiers/cegqi/ceg_instantiator.h
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.h
@@ -454,8 +454,8 @@ class CegInstantiator : protected EnvObj
   bool d_is_nested_quant;
   /** the atoms of the CE lemma */
   std::vector<Node> d_ce_atoms;
-  /** collect atoms */
-  void collectCeAtoms(Node n, std::map<Node, bool>& visited);
+  /** collect atoms in n, store in d_ce_atoms */
+  void collectCeAtoms(Node n);
   //-------------------------------end quantified formula info
 
   //-------------------------------current state


### PR DESCRIPTION
We currently make collect cex literals that are not rewritten.  This also makes the utility method non-recursive.

This prevents a timeout on a quantified regression when we change the equality ordering in the BV rewriter.