### PR TITLE
Disable lfsc on timeout regression

### DIFF
--- a/test/regress/cli/regress1/quantifiers/bug802.smt2
+++ b/test/regress/cli/regress1/quantifiers/bug802.smt2
@@ -1,3 +1,4 @@
+; DISABLE-TESTER: lfsc
 (set-logic BV)
 (set-info :source | 
 Hardware fixpoint check problems.


### PR DESCRIPTION
Fixes issues in the nightlies.