### PR TITLE
Move clone of ProofNodes from the ProofNodeManager to ProofNode

### DIFF
--- a/src/proof/proof_node.cpp
+++ b/src/proof/proof_node.cpp
@@ -64,6 +64,60 @@ void ProofNode::printDebug(std::ostream& os, bool printConclusion) const
   os << ps;
 }
 
+std::shared_ptr<ProofNode> ProofNode::clone() const
+{
+  std::unordered_map<const ProofNode*, std::shared_ptr<ProofNode>> visited;
+  std::unordered_map<const ProofNode*, std::shared_ptr<ProofNode>>::iterator it;
+  std::vector<const ProofNode*> visit;
+  std::shared_ptr<ProofNode> cloned;
+  visit.push_back(this);
+  const ProofNode* cur;
+  while (!visit.empty())
+  {
+    cur = visit.back();
+    it = visited.find(cur);
+    if (it == visited.end())
+    {
+      visited[cur] = nullptr;
+      const std::vector<std::shared_ptr<ProofNode>>& children =
+          cur->getChildren();
+      for (const std::shared_ptr<ProofNode>& cp : children)
+      {
+        visit.push_back(cp.get());
+      }
+      continue;
+    }
+    visit.pop_back();
+    if (it->second.get() == nullptr)
+    {
+      std::vector<std::shared_ptr<ProofNode>> cchildren;
+      const std::vector<std::shared_ptr<ProofNode>>& children =
+          cur->getChildren();
+      for (const std::shared_ptr<ProofNode>& cp : children)
+      {
+        it = visited.find(cp.get());
+        Assert(it != visited.end());
+        // if we encounter nullptr here, then this child is currently being
+        // traversed at a higher level, hence this corresponds to a cyclic
+        // proof.
+        if (it->second == nullptr)
+        {
+          Unreachable() << "Cyclic proof encountered when cloning a proof node";
+        }
+        cchildren.push_back(it->second);
+      }
+      cloned = std::make_shared<ProofNode>(
+          cur->getRule(), cchildren, cur->getArguments());
+      visited[cur] = cloned;
+      // we trust the above cloning does not change what is proven
+      cloned->d_proven = cur->d_proven;
+      cloned->d_provenChecked = cur->d_provenChecked;
+    }
+  }
+  Assert(visited.find(this) != visited.end());
+  return visited[this];
+}
+
 std::ostream& operator<<(std::ostream& out, const ProofNode& pn)
 {
   pn.printDebug(out);

--- a/src/proof/proof_node.h
+++ b/src/proof/proof_node.h
@@ -111,6 +111,14 @@ class ProofNode
    * @param printConclusion Whether to print conclusions
    */
   void printDebug(std::ostream& os, bool printConclusion = false) const;
+  /**
+   * Clone this proof node, which creates a deep copy of this proof node and
+   * returns it. The dag structure of pn is the same as that in the returned
+   * proof node.
+   *
+   * @return the cloned proof node.
+   */
+  std::shared_ptr<ProofNode> clone() const;
 
  private:
   /**

--- a/src/proof/proof_node_manager.cpp
+++ b/src/proof/proof_node_manager.cpp
@@ -345,62 +345,6 @@ Node ProofNodeManager::checkInternal(
 
 ProofChecker* ProofNodeManager::getChecker() const { return d_checker; }
 
-std::shared_ptr<ProofNode> ProofNodeManager::clone(
-    std::shared_ptr<ProofNode> pn) const
-{
-  const ProofNode* orig = pn.get();
-  std::unordered_map<const ProofNode*, std::shared_ptr<ProofNode>> visited;
-  std::unordered_map<const ProofNode*, std::shared_ptr<ProofNode>>::iterator it;
-  std::vector<const ProofNode*> visit;
-  std::shared_ptr<ProofNode> cloned;
-  visit.push_back(orig);
-  const ProofNode* cur;
-  while (!visit.empty())
-  {
-    cur = visit.back();
-    it = visited.find(cur);
-    if (it == visited.end())
-    {
-      visited[cur] = nullptr;
-      const std::vector<std::shared_ptr<ProofNode>>& children =
-          cur->getChildren();
-      for (const std::shared_ptr<ProofNode>& cp : children)
-      {
-        visit.push_back(cp.get());
-      }
-      continue;
-    }
-    visit.pop_back();
-    if (it->second.get() == nullptr)
-    {
-      std::vector<std::shared_ptr<ProofNode>> cchildren;
-      const std::vector<std::shared_ptr<ProofNode>>& children =
-          cur->getChildren();
-      for (const std::shared_ptr<ProofNode>& cp : children)
-      {
-        it = visited.find(cp.get());
-        Assert(it != visited.end());
-        // if we encounter nullptr here, then this child is currently being
-        // traversed at a higher level, hence this corresponds to a cyclic
-        // proof.
-        if (it->second == nullptr)
-        {
-          Unreachable() << "Cyclic proof encountered when cloning a proof node";
-        }
-        cchildren.push_back(it->second);
-      }
-      cloned = std::make_shared<ProofNode>(
-          cur->getRule(), cchildren, cur->getArguments());
-      visited[cur] = cloned;
-      // we trust the above cloning does not change what is proven
-      cloned->d_proven = cur->d_proven;
-      cloned->d_provenChecked = cur->d_provenChecked;
-    }
-  }
-  Assert(visited.find(orig) != visited.end());
-  return visited[orig];
-}
-
 ProofNode* ProofNodeManager::cancelDoubleSymm(ProofNode* pn)
 {
   // processed is almost always size <= 1

--- a/src/proof/proof_node_manager.h
+++ b/src/proof/proof_node_manager.h
@@ -177,14 +177,6 @@ class ProofNodeManager
   /** Get the underlying proof checker */
   ProofChecker* getChecker() const;
   /**
-   * Clone a proof node, which creates a deep copy of pn and returns it. The
-   * dag structure of pn is the same as that in the returned proof node.
-   *
-   * @param pn The proof node to clone
-   * @return the cloned proof node.
-   */
-  std::shared_ptr<ProofNode> clone(std::shared_ptr<ProofNode> pn) const;
-  /**
    * Cancel double SYMM. Returns a proof node that is not a double application
    * of SYMM, e.g. for (SYMM (SYMM (r P))), this returns (r P) where r != SYMM.
    */

--- a/src/prop/proof_cnf_stream.cpp
+++ b/src/prop/proof_cnf_stream.cpp
@@ -712,8 +712,7 @@ void ProofCnfStream::notifyCurrPropagationInsertedAtLevel(uint32_t explLevel)
   // It's also necessary to copy the proof node, so we prevent unintended
   // updates to the saved proof. Not doing this may also lead to open proofs.
   std::shared_ptr<ProofNode> currPropagationProcPf =
-      d_env.getProofNodeManager()->clone(
-          d_proof.getProofFor(d_currPropagationProcessed));
+      d_proof.getProofFor(d_currPropagationProcessed)->clone();
   Assert(currPropagationProcPf->getRule() != PfRule::ASSUME);
   Trace("cnf-debug") << "\t..saved pf {" << currPropagationProcPf << "} "
                      << *currPropagationProcPf.get() << "\n";
@@ -740,7 +739,7 @@ void ProofCnfStream::notifyClauseInsertedAtLevel(const SatClause& clause,
   Assert(clLevel < (userContext()->getLevel() - 1));
   // As above, also justify eagerly.
   std::shared_ptr<ProofNode> clauseCnfPf =
-      d_env.getProofNodeManager()->clone(d_proof.getProofFor(clauseNode));
+      d_proof.getProofFor(clauseNode)->clone();
   Assert(clauseCnfPf->getRule() != PfRule::ASSUME);
   d_optClausesPfs[clLevel + 1].push_back(clauseCnfPf);
   // Notify SAT proof manager that the propagation (which is a SAT assumption)

--- a/src/prop/sat_proof_manager.cpp
+++ b/src/prop/sat_proof_manager.cpp
@@ -821,7 +821,7 @@ void SatProofManager::notifyPop()
     // proof node saved to be restored of suffering unintended updates. This is
     // *necessary*.
     std::shared_ptr<ProofNode> clauseResPf =
-        d_env.getProofNodeManager()->clone(d_resChains.getProofFor(it->first));
+        d_resChains.getProofFor(it->first)->clone();
     Assert(clauseResPf && clauseResPf->getRule() != PfRule::ASSUME);
     d_optResProofs[it->second].push_back(clauseResPf);
   }

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -228,7 +228,7 @@ void PfManager::printProof(std::ostream& out,
   if (options().base.incrementalSolving
       && mode != options::ProofFormatMode::NONE)
   {
-    fp = d_pnm->clone(fp);
+    fp = fp->clone();
   }
 
   // according to the proof format, post process and print the proof node

--- a/src/theory/uf/proof_equality_engine.cpp
+++ b/src/theory/uf/proof_equality_engine.cpp
@@ -353,8 +353,7 @@ TrustNode ProofEqEngine::ensureProofForFact(Node conc,
     return TrustNode::null();
   }
   // clone it so that we have a fresh copy
-  ProofNodeManager* pnm = d_env.getProofNodeManager();
-  pfBody = pnm->clone(pfBody);
+  pfBody = pfBody->clone();
   Trace("pfee-proof") << "pfee::ensureProofForFact: add scope" << std::endl;
   // The free assumptions must be closed by assumps, which should be passed
   // as arguments of SCOPE. However, some of the free assumptions may not
@@ -378,6 +377,7 @@ TrustNode ProofEqEngine::ensureProofForFact(Node conc,
   }
   // Scope the proof constructed above, and connect the formula with the proof
   // minimize the assumptions.
+  ProofNodeManager* pnm = d_env.getProofNodeManager();
   pf = pnm->mkScope(pfBody, scopeAssumps, true, true);
   // If we have no assumptions, and are proving an explanation for propagation
   if (scopeAssumps.empty() && tnk == TrustNodeKind::PROP_EXP)


### PR DESCRIPTION
This is a relatively simple refactoring.  Currently there is a `clone` method in the `ProofNodeManager` that does a deep copy of a `ProofNode`.  That is, it generates a clone of a proof tree.  However, this method uses nothing specific to the `ProofNodeManager`, but requires the user to have access to a `ProofNodeManager`.

This pull request moves the `clone` method to the `ProofNode` itself.