### PR TITLE
cmake: Enable branch coverage for coverage builds.

### DIFF
--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -57,7 +57,7 @@ function(setup_code_coverage_fastcov)
   add_custom_target(${COVERAGE_NAME}-json
     COMMAND
       ${FASTCOV_BINARY}
-          -d ${COVERAGE_PATH} ${EXCLUDES} -o coverage.json
+          -b -d ${COVERAGE_PATH} ${EXCLUDES} -o coverage.json
           -j${FASTCOV_PARALLEL_JOBS} -X
     DEPENDS
       ${COVERAGE_DEPENDENCIES}
@@ -69,7 +69,7 @@ function(setup_code_coverage_fastcov)
     COMMAND
       ${FASTCOV_BINARY} -C coverage.json --lcov -o coverage.info
     COMMAND
-      ${GENHTML_BINARY} --demangle-cpp --no-prefix -o coverage coverage.info
+      ${GENHTML_BINARY} --branch-coverage --demangle-cpp --no-prefix -o coverage coverage.info
     DEPENDS
       coverage-json
     COMMENT


### PR DESCRIPTION
Enables branch coverage for coverage builds.