### PR TITLE
Add more documentation about the rewriter

### DIFF
--- a/src/rewriter/README.md
+++ b/src/rewriter/README.md
@@ -9,7 +9,7 @@ This document describe the syntax of the RARE language, which stands for
             | (define-cond-rule  <symbol> (<par>*) [<defs>] <expr> <expr> <expr>)
     <par> ::= (<symbol> <sort> [<attr>])
    <sort> ::= ? | <symbol> | ?<symbol> | (<symbol> <sort>+) | (<symbol> <idx>+)
-    <idx> ::= ? | <numeral>
+    <idx> ::= <numeral>
    <attr> ::= :list
    <expr> ::= <const> | <id> | (<id> <expr>+)
      <id> ::= <symbol> | (_ <id> <expr>+)

--- a/src/rewriter/README.md
+++ b/src/rewriter/README.md
@@ -101,15 +101,22 @@ reconstruction algorithms have sound types.
   (extract (+ i l) (+ i k) x))
 ```
 
-### Fixed-Point Rules and the list modifier
+### List Modifier
+
+The `:list` modifier represents an arbitrary number of arguments of the same
+type (gradual types are supported). In the below example, `xs` and `ys` match an
+arbitrary number of boolean arguments.
+
+``` lisp
+(define-rule bool-or-true ((xs Bool :list) (ys Bool :list)) (or xs true ys) true)
+```
+
+### Fixed-Point Rules
 
 The `*` in `define-rule*` indicates that the rule shall be executed by the
 reconstruction algorithm until the expression reaches a fixed point. This is an
 optimisation and useful for writing rules that iterate over the arguments of
 n-ary operators.
-
-The `:list` modifier represents an arbitrary number of arguments of the same
-type (gradual types are supported).
 
 Below is an example which uses gradual type and recursively flattens a concat
 using fixed-point rules.

--- a/src/rewriter/README.md
+++ b/src/rewriter/README.md
@@ -101,14 +101,19 @@ reconstruction algorithms have sound types.
   (extract (+ i l) (+ i k) x))
 ```
 
-### Fixed-Point Rules
+### Fixed-Point Rules and the list modifier
 
 The `*` in `define-rule*` indicates that the rule shall be executed by the
 reconstruction algorithm until the expression reaches a fixed point. This is an
 optimisation and useful for writing rules that iterate over the arguments of
 n-ary operators.
 
-Below is an example which recursively flattens a concat using fixed-point rules.
+The `:list` modifier represents an arbitrary number of arguments of the same
+type (gradual types are supported).
+
+Below is an example which uses gradual type and recursively flattens a concat
+using fixed-point rules.
+
 ``` lisp
 (define-rule* bv-concat-flatten
   ((xs ?BitVec :list)

--- a/src/rewriter/README.md
+++ b/src/rewriter/README.md
@@ -151,6 +151,14 @@ processing are controlled by `rewriter.py` and `parser.py`.
 The symbols usable in `(<id> <expr>+)` can be found in `node.py`. The sorts
 available can be found in `mkrewrites.py`.
 
+It is possible in the rewriter to enable parsing of rules of the form
+`define-cond-rule*`. However the condition may interact unexpectedly with the
+fixed-point rule.
+
+```
+<rule> ::= (define-cond-rule* <symbol> (<par>*) [<defs>] <expr> <expr> <expr> [<expr>])
+```
+
 ## Changes from Previous Works
 
 In comparison to


### PR DESCRIPTION
* Removed `define-cond-rule*` since its semantics are unclear and not used anywhere
* Add rationale about `:const` and how to handle its use cases