### PR TITLE
Fix typos in BV rewrite rules

### DIFF
--- a/src/theory/bv/rewrites
+++ b/src/theory/bv/rewrites
@@ -594,13 +594,13 @@
   (def (power (int.log2 v)))
   (and (int.ispow2 v) (> v 1))
   (bvurem x (bv v n))
-  (concat (bv 0 (- n 1)) (extract (- power 1) 0 x)))
+  (concat (bv 0 (- n power)) (extract (- power 1) 0 x)))
 (define-cond-rule bv-urem-pow2-2
   ((x ?BitVec) (v Int) (n Int))
   (def (power (int.log2 (- v))))
   (and (int.ispow2 (- v)) (< v (- 1)))
   (bvurem x (bv v n))
-  (concat (bv 0 (- n 1)) (extract (- power 1) 0 x)))
+  (concat (bv 0 (- n power)) (extract (- power 1) 0 x)))
 ; (x urem 1) = 0
 (define-rule bv-urem-one
   ((x ?BitVec))

--- a/src/theory/bv/rewrites
+++ b/src/theory/bv/rewrites
@@ -602,14 +602,19 @@
   (bvurem x (bv v n))
   (concat (bv 0 (- n power)) (extract (- power 1) 0 x)))
 ; (x urem 1) = 0
-(define-rule bv-urem-one
+(define-rule bv-urem-one-1
   ((x ?BitVec))
   (bvurem x (bv 1 (bvsize x)))
+  (bv 0 (bvsize x)))
+(define-cond-rule bv-urem-one-2
+  ((x ?BitVec) (v Int))
+  (= v (- 1))
+  (bvurem x (bv v (bvsize x)))
   (bv 0 (bvsize x)))
 ; (x urem x) = 0
 (define-rule bv-urem-self
   ((x ?BitVec))
-  (bvudiv x x)
+  (bvurem x x)
   (bv 0 (bvsize x)))
 ; ShiftZero rule
 ; (0_k >> a) = 0_k
@@ -868,11 +873,11 @@
 
 (define-rule* bv-and-simplify-1
   ((xs ?BitVec :list) (ys ?BitVec :list) (zs ?BitVec :list) (x ?BitVec))
-  (bvor xs x ys x zs)
-  (bvor xs x ys zs))
+  (bvand xs x ys x zs)
+  (bvand xs x ys zs))
 (define-rule* bv-and-simplify-2
   ((xs ?BitVec :list) (ys ?BitVec :list) (zs ?BitVec :list) (x ?BitVec))
-  (bvor xs x ys (bvnot x) zs)
+  (bvand xs x ys (bvnot x) zs)
   (bv 0 (bvsize x)))
 
 (define-rule* bv-or-simplify-1


### PR DESCRIPTION
1. `bv-urem-pow2` was missing the `-1` case. This is added as `bv-urem-one-2`
2. `bv-urem-self` had a typo
3. `bv-and-simplify` had a typo where it was `bvor`

Co-authored-by: Hanna Lachnitt [lachnitt@stanford.edu](mailto:lachnitt@stanford.edu)