### PR TITLE
Make getValue private to RealAlgebraicNumber

### DIFF
--- a/src/theory/arith/arith_evaluator.cpp
+++ b/src/theory/arith/arith_evaluator.cpp
@@ -41,7 +41,7 @@ std::optional<bool> isExpressionZero(Env& env, Node expr, const ArithSubs& subs)
   }
   if (expr.getKind() == Kind::REAL_ALGEBRAIC_NUMBER)
   {
-    return isZero(expr.getOperator().getConst<RealAlgebraicNumber>());
+    return expr.getOperator().getConst<RealAlgebraicNumber>().isZero();
   }
   return std::nullopt;
 }

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -575,7 +575,7 @@ RewriteResponse ArithRewriter::rewriteDiv(TNode t, bool pre)
     {
       return RewriteResponse(REWRITE_DONE,
                              rewriter::ensureReal(rewriter::mkConst(
-                                 left.getConst<Rational>() / den)));
+                                 RealAlgebraicNumber(left.getConst<Rational>()) / den)));
     }
     if (rewriter::isRAN(left))
     {
@@ -584,7 +584,7 @@ RewriteResponse ArithRewriter::rewriteDiv(TNode t, bool pre)
                                  rewriter::getRAN(left) / den)));
     }
 
-    Node result = rewriter::mkConst(inverse(den));
+    Node result = rewriter::mkConst(den.inverse());
     Node mult = rewriter::ensureReal(
         NodeManager::currentNM()->mkNode(kind::MULT, left, result));
     if (pre)

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -573,9 +573,10 @@ RewriteResponse ArithRewriter::rewriteDiv(TNode t, bool pre)
     // mkConst is applied to RAN in this block, which are always Real
     if (left.isConst())
     {
-      return RewriteResponse(REWRITE_DONE,
-                             rewriter::ensureReal(rewriter::mkConst(
-                                 RealAlgebraicNumber(left.getConst<Rational>()) / den)));
+      return RewriteResponse(
+          REWRITE_DONE,
+          rewriter::ensureReal(rewriter::mkConst(
+              RealAlgebraicNumber(left.getConst<Rational>()) / den)));
     }
     if (rewriter::isRAN(left))
     {

--- a/src/theory/arith/nl/poly_conversion.cpp
+++ b/src/theory/arith/nl/poly_conversion.cpp
@@ -806,8 +806,8 @@ poly::IntervalAssignment getBounds(VariableMapper& vm, const BoundInference& bi)
 }  // namespace arith
 }  // namespace theory
 
-
-Node PolyConverter::ran_to_node(const RealAlgebraicNumber& ran, const Node& ran_variable)
+Node PolyConverter::ran_to_node(const RealAlgebraicNumber& ran,
+                                const Node& ran_variable)
 {
   return theory::arith::nl::ran_to_node(ran.getValue(), ran_variable);
 }

--- a/src/theory/arith/nl/poly_conversion.cpp
+++ b/src/theory/arith/nl/poly_conversion.cpp
@@ -808,9 +808,11 @@ Node PolyConverter::ran_to_node(const RealAlgebraicNumber& ran,
   return theory::arith::nl::ran_to_node(ran.getValue(), ran_variable);
 }
 
-RealAlgebraicNumber PolyConverter::node_to_ran(const Node& n, const Node& ran_variable)
+RealAlgebraicNumber PolyConverter::node_to_ran(const Node& n,
+                                               const Node& ran_variable)
 {
-  return RealAlgebraicNumber(theory::arith::nl::node_to_poly_ran(n, ran_variable));
+  return RealAlgebraicNumber(
+      theory::arith::nl::node_to_poly_ran(n, ran_variable));
 }
 
 }  // namespace cvc5::internal

--- a/src/theory/arith/nl/poly_conversion.cpp
+++ b/src/theory/arith/nl/poly_conversion.cpp
@@ -703,10 +703,6 @@ poly::AlgebraicNumber node_to_poly_ran(const Node& n, const Node& ran_variable)
   return poly_utils::toPolyRanWithRefinement(
       std::move(pol), std::get<1>(encoding), std::get<2>(encoding));
 }
-RealAlgebraicNumber node_to_ran(const Node& n, const Node& ran_variable)
-{
-  return RealAlgebraicNumber(node_to_poly_ran(n, ran_variable));
-}
 
 poly::Value node_to_value(const Node& n, const Node& ran_variable)
 {
@@ -810,6 +806,11 @@ Node PolyConverter::ran_to_node(const RealAlgebraicNumber& ran,
                                 const Node& ran_variable)
 {
   return theory::arith::nl::ran_to_node(ran.getValue(), ran_variable);
+}
+
+RealAlgebraicNumber PolyConverter::node_to_ran(const Node& n, const Node& ran_variable)
+{
+  return RealAlgebraicNumber(theory::arith::nl::node_to_poly_ran(n, ran_variable));
 }
 
 }  // namespace cvc5::internal

--- a/src/theory/arith/nl/poly_conversion.cpp
+++ b/src/theory/arith/nl/poly_conversion.cpp
@@ -366,11 +366,6 @@ std::pair<poly::Polynomial, poly::SignCondition> as_poly_constraint(
   return {lhs, sc};
 }
 
-Node ran_to_node(const RealAlgebraicNumber& ran, const Node& ran_variable)
-{
-  return ran_to_node(ran.getValue(), ran_variable);
-}
-
 Node ran_to_node(const poly::AlgebraicNumber& an, const Node& ran_variable)
 {
   auto* nm = NodeManager::currentNM();
@@ -810,6 +805,13 @@ poly::IntervalAssignment getBounds(VariableMapper& vm, const BoundInference& bi)
 }  // namespace nl
 }  // namespace arith
 }  // namespace theory
+
+
+Node PolyConverter::ran_to_node(const RealAlgebraicNumber& ran, const Node& ran_variable)
+{
+  return theory::arith::nl::ran_to_node(ran.getValue(), ran_variable);
+}
+
 }  // namespace cvc5::internal
 
 #endif

--- a/src/theory/arith/nl/poly_conversion.h
+++ b/src/theory/arith/nl/poly_conversion.h
@@ -162,14 +162,15 @@ poly::IntervalAssignment getBounds(VariableMapper& vm, const BoundInference& bi)
 
 class PolyConverter
 {
-public:
+ public:
   /**
-  * Transforms a real algebraic number to a node suitable for putting it into a
-  * model. The resulting node can be either a constant (suitable for
-  * addSubstitution) or a witness term (suitable for
-  * addWitness).
-  */
-  static Node ran_to_node(const RealAlgebraicNumber& ran, const Node& ran_variable);
+   * Transforms a real algebraic number to a node suitable for putting it into a
+   * model. The resulting node can be either a constant (suitable for
+   * addSubstitution) or a witness term (suitable for
+   * addWitness).
+   */
+  static Node ran_to_node(const RealAlgebraicNumber& ran,
+                          const Node& ran_variable);
 };
 
 }  // namespace cvc5::internal

--- a/src/theory/arith/nl/poly_conversion.h
+++ b/src/theory/arith/nl/poly_conversion.h
@@ -168,9 +168,10 @@ class PolyConverter
    */
   static Node ran_to_node(const RealAlgebraicNumber& ran,
                           const Node& ran_variable);
-  
+
   /** Transforms a node to a RealAlgebraicNumber by calling node_to_poly_ran. */
-  static RealAlgebraicNumber node_to_ran(const Node& n, const Node& ran_variable);
+  static RealAlgebraicNumber node_to_ran(const Node& n,
+                                         const Node& ran_variable);
 };
 
 }  // namespace cvc5::internal

--- a/src/theory/arith/nl/poly_conversion.h
+++ b/src/theory/arith/nl/poly_conversion.h
@@ -139,9 +139,6 @@ Node excluding_interval_to_lemma(const Node& variable,
  */
 poly::AlgebraicNumber node_to_poly_ran(const Node& n, const Node& ran_variable);
 
-/** Transforms a node to a RealAlgebraicNumber by calling node_to_poly_ran. */
-RealAlgebraicNumber node_to_ran(const Node& n, const Node& ran_variable);
-
 /**
  * Transforms a node to a poly::Value.
  */
@@ -171,6 +168,9 @@ class PolyConverter
    */
   static Node ran_to_node(const RealAlgebraicNumber& ran,
                           const Node& ran_variable);
+  
+  /** Transforms a node to a RealAlgebraicNumber by calling node_to_poly_ran. */
+  RealAlgebraicNumber node_to_ran(const Node& n, const Node& ran_variable);
 };
 
 }  // namespace cvc5::internal

--- a/src/theory/arith/nl/poly_conversion.h
+++ b/src/theory/arith/nl/poly_conversion.h
@@ -170,7 +170,7 @@ class PolyConverter
                           const Node& ran_variable);
   
   /** Transforms a node to a RealAlgebraicNumber by calling node_to_poly_ran. */
-  RealAlgebraicNumber node_to_ran(const Node& n, const Node& ran_variable);
+  static RealAlgebraicNumber node_to_ran(const Node& n, const Node& ran_variable);
 };
 
 }  // namespace cvc5::internal

--- a/src/theory/arith/nl/poly_conversion.h
+++ b/src/theory/arith/nl/poly_conversion.h
@@ -99,14 +99,6 @@ cvc5::internal::Node as_cvc_polynomial(const poly::Polynomial& p, VariableMapper
 std::pair<poly::Polynomial, poly::SignCondition> as_poly_constraint(
     Node n, VariableMapper& vm);
 
-/**
- * Transforms a real algebraic number to a node suitable for putting it into a
- * model. The resulting node can be either a constant (suitable for
- * addSubstitution) or a witness term (suitable for
- * addWitness).
- */
-Node ran_to_node(const RealAlgebraicNumber& ran, const Node& ran_variable);
-
 Node ran_to_node(const poly::AlgebraicNumber& an, const Node& ran_variable);
 
 /**
@@ -167,6 +159,19 @@ poly::IntervalAssignment getBounds(VariableMapper& vm, const BoundInference& bi)
 }  // namespace nl
 }  // namespace arith
 }  // namespace theory
+
+class PolyConverter
+{
+public:
+  /**
+  * Transforms a real algebraic number to a node suitable for putting it into a
+  * model. The resulting node can be either a constant (suitable for
+  * addSubstitution) or a witness term (suitable for
+  * addWitness).
+  */
+  static Node ran_to_node(const RealAlgebraicNumber& ran, const Node& ran_variable);
+};
+
 }  // namespace cvc5::internal
 
 #endif

--- a/src/theory/arith/rewriter/addition.cpp
+++ b/src/theory/arith/rewriter/addition.cpp
@@ -96,7 +96,7 @@ void addToProduct(std::vector<Node>& product,
  */
 void addToSum(Sum& sum, TNode product, const RealAlgebraicNumber& multiplicity)
 {
-  if (isZero(multiplicity)) return;
+  if (multiplicity.isZero()) return;
   auto it = sum.find(product);
   if (it == sum.end())
   {
@@ -105,7 +105,7 @@ void addToSum(Sum& sum, TNode product, const RealAlgebraicNumber& multiplicity)
   else
   {
     it->second += multiplicity;
-    if (isZero(it->second))
+    if (it->second.isZero())
     {
       sum.erase(it);
     }
@@ -125,7 +125,7 @@ Node collectSumWithBase(const Sum& sum,
   NodeBuilder nb(Kind::ADD);
   for (const auto& summand : sum)
   {
-    Assert(!isZero(summand.second));
+    Assert(!summand.second.isZero());
     RealAlgebraicNumber mult = summand.second * basemultiplicity;
     std::vector<Node> product = baseproduct;
     rewriter::addToProduct(product, mult, summand.first);

--- a/src/theory/arith/rewriter/node_utils.cpp
+++ b/src/theory/arith/rewriter/node_utils.cpp
@@ -29,7 +29,7 @@ Node mkMultTerm(const Rational& multiplicity, TNode monomial)
   {
     return mkConst(multiplicity * monomial.getConst<Rational>());
   }
-  if (isOne(multiplicity))
+  if (multiplicity.isOne())
   {
     return monomial;
   }

--- a/src/theory/arith/rewriter/rewrite_atom.cpp
+++ b/src/theory/arith/rewriter/rewrite_atom.cpp
@@ -29,8 +29,8 @@ namespace {
  * Evaluate the given relation based on values l and r. Expects that the
  * relational operators `operator<(L,R)`, `operator==(L,R)`, etc are defined.
  */
-template <typename L, typename R>
-bool evaluateRelation(Kind rel, const L& l, const R& r)
+template <typename L>
+bool evaluateRelation(Kind rel, const L& l, const L& r)
 {
   switch (rel)
   {
@@ -70,17 +70,17 @@ void normalizeLCoeffAbsOne(Sum& sum)
   {
     auto& front = *sum.begin();
     // Trivial if there is only one summand
-    front.second = Integer(sgn(front.second) > 0 ? 1 : -1);
+    front.second = Integer(front.second.sgn() > 0 ? 1 : -1);
     return;
   }
   // LCoeff is first coefficient of non-constant monomial
   RealAlgebraicNumber lcoeff = getLTerm(sum).second;
   ;
-  if (sgn(lcoeff) < 0)
+  if (lcoeff.sgn() < 0)
   {
     lcoeff = -lcoeff;
   }
-  if (isOne(lcoeff)) return;
+  if (lcoeff.isOne()) return;
   for (auto& s : sum)
   {
     s.second = s.second / lcoeff;
@@ -124,7 +124,7 @@ bool normalizeGCDLCM(Sum& sum, bool followLCoeffSign = false)
   bool negate = false;
   if (followLCoeffSign)
   {
-    if (sgn(getLTerm(sum).second) < 0)
+    if (getLTerm(sum).second.sgn() < 0)
     {
       negate = true;
       mult = -mult;
@@ -204,7 +204,7 @@ std::optional<bool> tryEvaluateRelation(Kind rel, TNode left, TNode right)
     {
       const RealAlgebraicNumber& r =
           right.getOperator().getConst<RealAlgebraicNumber>();
-      return evaluateRelation(rel, l, r);
+      return evaluateRelation(rel, RealAlgebraicNumber(l), r);
     }
   }
   else if (left.getKind() == Kind::REAL_ALGEBRAIC_NUMBER)
@@ -214,7 +214,7 @@ std::optional<bool> tryEvaluateRelation(Kind rel, TNode left, TNode right)
     if (right.isConst())
     {
       const Rational& r = right.getConst<Rational>();
-      return evaluateRelation(rel, l, r);
+      return evaluateRelation(rel, l, RealAlgebraicNumber(r));
     }
     else if (right.getKind() == Kind::REAL_ALGEBRAIC_NUMBER)
     {
@@ -282,7 +282,7 @@ Node buildIntegerEquality(Sum&& sum)
   auto minabscoeff = removeMinAbsCoeff(sum);
   Trace("arith-rewriter::debug") << "\tremoved min abs coeff " << minabscoeff
                                  << ", left with " << sum << std::endl;
-  if (sgn(minabscoeff.second) < 0)
+  if (minabscoeff.second.sgn() < 0)
   {
     // move minabscoeff goes to the right and switch lhs and rhs
     minabscoeff.second = -minabscoeff.second;
@@ -307,7 +307,7 @@ Node buildRealEquality(Sum&& sum)
 {
   Trace("arith-rewriter") << "building real equality from " << sum << std::endl;
   auto lterm = removeLTerm(sum);
-  if (isZero(lterm.second))
+  if (lterm.second.isZero())
   {
     return buildRelation(Kind::EQUAL, mkConst(Integer(0)), collectSum(sum));
   }

--- a/src/util/real_algebraic_number_poly_imp.cpp
+++ b/src/util/real_algebraic_number_poly_imp.cpp
@@ -21,10 +21,10 @@
 #endif
 
 #include <limits>
+#include <sstream>
 
 #include "base/check.h"
 #include "util/poly_util.h"
-#include <sstream>
 
 #define RAN_UNREACHABLE \
   Unreachable() << "RealAlgebraicNumber is not available without libpoly."
@@ -149,38 +149,38 @@ std::string RealAlgebraicNumber::toString() const
   return ss.str();
 }
 
-bool RealAlgebraicNumber::operator==( const RealAlgebraicNumber& rhs) const
+bool RealAlgebraicNumber::operator==(const RealAlgebraicNumber& rhs) const
 {
   return getValue() == rhs.getValue();
 }
-bool RealAlgebraicNumber::operator!=( const RealAlgebraicNumber& rhs) const
+bool RealAlgebraicNumber::operator!=(const RealAlgebraicNumber& rhs) const
 {
   return getValue() != rhs.getValue();
 }
-bool RealAlgebraicNumber::operator<( const RealAlgebraicNumber& rhs) const
+bool RealAlgebraicNumber::operator<(const RealAlgebraicNumber& rhs) const
 {
   return getValue() < rhs.getValue();
 }
-bool RealAlgebraicNumber::operator<=( const RealAlgebraicNumber& rhs) const
+bool RealAlgebraicNumber::operator<=(const RealAlgebraicNumber& rhs) const
 {
   return getValue() <= rhs.getValue();
 }
-bool RealAlgebraicNumber::operator>( const RealAlgebraicNumber& rhs) const
+bool RealAlgebraicNumber::operator>(const RealAlgebraicNumber& rhs) const
 {
   return getValue() > rhs.getValue();
 }
-bool RealAlgebraicNumber::operator>=( const RealAlgebraicNumber& rhs) const
+bool RealAlgebraicNumber::operator>=(const RealAlgebraicNumber& rhs) const
 {
   return getValue() >= rhs.getValue();
 }
 
 RealAlgebraicNumber RealAlgebraicNumber::operator+(
-                              const RealAlgebraicNumber& rhs) const
+    const RealAlgebraicNumber& rhs) const
 {
   return getValue() + rhs.getValue();
 }
 RealAlgebraicNumber RealAlgebraicNumber::operator-(
-                              const RealAlgebraicNumber& rhs) const
+    const RealAlgebraicNumber& rhs) const
 {
   return getValue() - rhs.getValue();
 }
@@ -189,51 +189,54 @@ RealAlgebraicNumber RealAlgebraicNumber::operator-() const
   return -getValue();
 }
 RealAlgebraicNumber RealAlgebraicNumber::operator*(
-                              const RealAlgebraicNumber& rhs) const
+    const RealAlgebraicNumber& rhs) const
 {
   return getValue() * rhs.getValue();
 }
 RealAlgebraicNumber RealAlgebraicNumber::operator/(
-                              const RealAlgebraicNumber& rhs) const
+    const RealAlgebraicNumber& rhs) const
 {
   Assert(!isZero(rhs)) << "Can not divide by zero";
   return getValue() / rhs.getValue();
 }
 
 RealAlgebraicNumber& RealAlgebraicNumber::operator+=(
-                                const RealAlgebraicNumber& rhs)
+    const RealAlgebraicNumber& rhs)
 {
   getValue() = getValue() + rhs.getValue();
   return *this;
 }
 RealAlgebraicNumber& RealAlgebraicNumber::operator-=(
-                                const RealAlgebraicNumber& rhs)
+    const RealAlgebraicNumber& rhs)
 {
   getValue() = getValue() - rhs.getValue();
   return *this;
 }
 RealAlgebraicNumber& RealAlgebraicNumber::operator*=(
-                                const RealAlgebraicNumber& rhs)
+    const RealAlgebraicNumber& rhs)
 {
   getValue() = getValue() * rhs.getValue();
   return *this;
 }
 
-int RealAlgebraicNumber::sgn() const {
+int RealAlgebraicNumber::sgn() const
+{
 #ifdef CVC5_POLY_IMP
   return poly::sgn(getValue());
 #else
   return getValue().sgn();
 #endif
 }
-bool RealAlgebraicNumber::isZero() const{
+bool RealAlgebraicNumber::isZero() const
+{
 #ifdef CVC5_POLY_IMP
   return poly::is_zero(getValue());
 #else
   return getValue().isZero();
 #endif
 }
-bool RealAlgebraicNumber::isOne() const {
+bool RealAlgebraicNumber::isOne() const
+{
 #ifdef CVC5_POLY_IMP
   return poly::is_one(getValue());
 #else
@@ -263,7 +266,6 @@ std::ostream& operator<<(std::ostream& os, const RealAlgebraicNumber& ran)
 {
   return os << ran.toString();
 }
-
 
 }  // namespace cvc5::internal
 

--- a/src/util/real_algebraic_number_poly_imp.cpp
+++ b/src/util/real_algebraic_number_poly_imp.cpp
@@ -24,6 +24,7 @@
 
 #include "base/check.h"
 #include "util/poly_util.h"
+#include <sstream>
 
 #define RAN_UNREACHABLE \
   Unreachable() << "RealAlgebraicNumber is not available without libpoly."
@@ -141,111 +142,128 @@ Rational RealAlgebraicNumber::toRational() const
 #endif
 }
 
-std::ostream& operator<<(std::ostream& os, const RealAlgebraicNumber& ran)
+std::string RealAlgebraicNumber::toString() const
 {
-  return os << ran.getValue();
+  std::stringstream ss;
+  ss << getValue();
+  return ss.str();
 }
 
-bool operator==(const RealAlgebraicNumber& lhs, const RealAlgebraicNumber& rhs)
+bool RealAlgebraicNumber::operator==( const RealAlgebraicNumber& rhs) const
 {
-  return lhs.getValue() == rhs.getValue();
+  return getValue() == rhs.getValue();
 }
-bool operator!=(const RealAlgebraicNumber& lhs, const RealAlgebraicNumber& rhs)
+bool RealAlgebraicNumber::operator!=( const RealAlgebraicNumber& rhs) const
 {
-  return lhs.getValue() != rhs.getValue();
+  return getValue() != rhs.getValue();
 }
-bool operator<(const RealAlgebraicNumber& lhs, const RealAlgebraicNumber& rhs)
+bool RealAlgebraicNumber::operator<( const RealAlgebraicNumber& rhs) const
 {
-  return lhs.getValue() < rhs.getValue();
+  return getValue() < rhs.getValue();
 }
-bool operator<=(const RealAlgebraicNumber& lhs, const RealAlgebraicNumber& rhs)
+bool RealAlgebraicNumber::operator<=( const RealAlgebraicNumber& rhs) const
 {
-  return lhs.getValue() <= rhs.getValue();
+  return getValue() <= rhs.getValue();
 }
-bool operator>(const RealAlgebraicNumber& lhs, const RealAlgebraicNumber& rhs)
+bool RealAlgebraicNumber::operator>( const RealAlgebraicNumber& rhs) const
 {
-  return lhs.getValue() > rhs.getValue();
+  return getValue() > rhs.getValue();
 }
-bool operator>=(const RealAlgebraicNumber& lhs, const RealAlgebraicNumber& rhs)
+bool RealAlgebraicNumber::operator>=( const RealAlgebraicNumber& rhs) const
 {
-  return lhs.getValue() >= rhs.getValue();
+  return getValue() >= rhs.getValue();
 }
 
-RealAlgebraicNumber operator+(const RealAlgebraicNumber& lhs,
-                              const RealAlgebraicNumber& rhs)
+RealAlgebraicNumber RealAlgebraicNumber::operator+(
+                              const RealAlgebraicNumber& rhs) const
 {
-  return lhs.getValue() + rhs.getValue();
+  return getValue() + rhs.getValue();
 }
-RealAlgebraicNumber operator-(const RealAlgebraicNumber& lhs,
-                              const RealAlgebraicNumber& rhs)
+RealAlgebraicNumber RealAlgebraicNumber::operator-(
+                              const RealAlgebraicNumber& rhs) const
 {
-  return lhs.getValue() - rhs.getValue();
+  return getValue() - rhs.getValue();
 }
-RealAlgebraicNumber operator-(const RealAlgebraicNumber& ran)
+RealAlgebraicNumber RealAlgebraicNumber::operator-() const
 {
-  return -ran.getValue();
+  return -getValue();
 }
-RealAlgebraicNumber operator*(const RealAlgebraicNumber& lhs,
-                              const RealAlgebraicNumber& rhs)
+RealAlgebraicNumber RealAlgebraicNumber::operator*(
+                              const RealAlgebraicNumber& rhs) const
 {
-  return lhs.getValue() * rhs.getValue();
+  return getValue() * rhs.getValue();
 }
-RealAlgebraicNumber operator/(const RealAlgebraicNumber& lhs,
-                              const RealAlgebraicNumber& rhs)
+RealAlgebraicNumber RealAlgebraicNumber::operator/(
+                              const RealAlgebraicNumber& rhs) const
 {
   Assert(!isZero(rhs)) << "Can not divide by zero";
-  return lhs.getValue() / rhs.getValue();
+  return getValue() / rhs.getValue();
 }
 
-RealAlgebraicNumber& operator+=(RealAlgebraicNumber& lhs,
+RealAlgebraicNumber& RealAlgebraicNumber::operator+=(
                                 const RealAlgebraicNumber& rhs)
 {
-  lhs.getValue() = lhs.getValue() + rhs.getValue();
-  return lhs;
+  getValue() = getValue() + rhs.getValue();
+  return *this;
 }
-RealAlgebraicNumber& operator-=(RealAlgebraicNumber& lhs,
+RealAlgebraicNumber& RealAlgebraicNumber::operator-=(
                                 const RealAlgebraicNumber& rhs)
 {
-  lhs.getValue() = lhs.getValue() - rhs.getValue();
-  return lhs;
+  getValue() = getValue() - rhs.getValue();
+  return *this;
 }
-RealAlgebraicNumber& operator*=(RealAlgebraicNumber& lhs,
+RealAlgebraicNumber& RealAlgebraicNumber::operator*=(
                                 const RealAlgebraicNumber& rhs)
 {
-  lhs.getValue() = lhs.getValue() * rhs.getValue();
-  return lhs;
+  getValue() = getValue() * rhs.getValue();
+  return *this;
 }
 
-int sgn(const RealAlgebraicNumber& ran) {
+int RealAlgebraicNumber::sgn() const {
 #ifdef CVC5_POLY_IMP
-  return sgn(ran.getValue());
+  return poly::sgn(getValue());
 #else
-  return ran.getValue().sgn();
+  return getValue().sgn();
 #endif
 }
-bool isZero(const RealAlgebraicNumber& ran) {
+bool RealAlgebraicNumber::isZero() const{
 #ifdef CVC5_POLY_IMP
-  return is_zero(ran.getValue());
+  return poly::is_zero(getValue());
 #else
-  return ran.getValue().isZero();
+  return getValue().isZero();
 #endif
 }
-bool isOne(const RealAlgebraicNumber& ran) {
+bool RealAlgebraicNumber::isOne() const {
 #ifdef CVC5_POLY_IMP
-  return is_one(ran.getValue());
+  return poly::is_one(getValue());
 #else
-  return ran.getValue().isOne();
+  return getValue().isOne();
 #endif
 }
-RealAlgebraicNumber inverse(const RealAlgebraicNumber& ran)
+RealAlgebraicNumber RealAlgebraicNumber::inverse() const
 {
   Assert(!isZero(ran)) << "Can not invert zero";
 #ifdef CVC5_POLY_IMP
-  return inverse(ran.getValue());
+  return poly::inverse(getValue());
 #else
-  return ran.getValue().inverse();
+  return getValue().inverse();
 #endif
 }
+
+size_t RealAlgebraicNumber::hash() const
+{
+#ifdef CVC5_POLY_IMP
+  return lp_algebraic_number_hash_approx(getValue().get_internal(), 2);
+#else
+  return getValue().hash();
+#endif
+}
+
+std::ostream& operator<<(std::ostream& os, const RealAlgebraicNumber& ran)
+{
+  return os << ran.toString();
+}
+
 
 }  // namespace cvc5::internal
 
@@ -253,10 +271,7 @@ namespace std {
 size_t hash<cvc5::internal::RealAlgebraicNumber>::operator()(
     const cvc5::internal::RealAlgebraicNumber& ran) const
 {
-#ifdef CVC5_POLY_IMP
-  return lp_algebraic_number_hash_approx(ran.getValue().get_internal(), 2);
-#else
-  return ran.getValue().hash();
-#endif
+  return ran.hash();
 }
+
 }  // namespace std

--- a/src/util/real_algebraic_number_poly_imp.cpp
+++ b/src/util/real_algebraic_number_poly_imp.cpp
@@ -196,7 +196,7 @@ RealAlgebraicNumber RealAlgebraicNumber::operator*(
 RealAlgebraicNumber RealAlgebraicNumber::operator/(
     const RealAlgebraicNumber& rhs) const
 {
-  Assert(!isZero(rhs)) << "Can not divide by zero";
+  Assert(!rhs.isZero()) << "Can not divide by zero";
   return getValue() / rhs.getValue();
 }
 
@@ -245,7 +245,7 @@ bool RealAlgebraicNumber::isOne() const
 }
 RealAlgebraicNumber RealAlgebraicNumber::inverse() const
 {
-  Assert(!isZero(ran)) << "Can not invert zero";
+  Assert(!isZero()) << "Can not invert zero";
 #ifdef CVC5_POLY_IMP
   return poly::inverse(getValue());
 #else

--- a/src/util/real_algebraic_number_poly_imp.h
+++ b/src/util/real_algebraic_number_poly_imp.h
@@ -28,6 +28,8 @@
 #include "util/rational.h"
 
 namespace cvc5::internal {
+  
+class PolyConverter;
 
 /**
  * Represents a real algebraic number based on poly::AlgebraicNumber.
@@ -46,6 +48,7 @@ namespace cvc5::internal {
  */
 class RealAlgebraicNumber
 {
+  friend class PolyConverter;
  public:
   /** Construct as zero. */
   RealAlgebraicNumber() = default;
@@ -96,18 +99,6 @@ class RealAlgebraicNumber
   /** Move assignment. */
   RealAlgebraicNumber& operator=(RealAlgebraicNumber&& ran) = default;
 
-#ifdef CVC5_POLY_IMP
-  /** Get the internal value as a const reference. */
-  const poly::AlgebraicNumber& getValue() const { return d_value; }
-  /** Get the internal value as a non-const reference. */
-  poly::AlgebraicNumber& getValue() { return d_value; }
-#else
-  /** Get the internal value as a const reference. */
-  const Rational& getValue() const { return d_value; }
-  /** Get the internal value as a non-const reference. */
-  Rational& getValue() { return d_value; }
-#endif
-
   /**
    * Check if this real algebraic number is actually rational.
    * If true, the value is rational and toRational() can safely be called.
@@ -121,8 +112,72 @@ class RealAlgebraicNumber
    * rational approximation (of unknown precision).
    */
   Rational toRational() const;
+  
+  std::string toString() const;
 
+
+  /** Compare two real algebraic numbers. */
+  bool operator==( const RealAlgebraicNumber& rhs) const;
+  /** Compare two real algebraic numbers. */
+  bool operator!=( const RealAlgebraicNumber& rhs) const;
+  /** Compare two real algebraic numbers. */
+  bool operator<( const RealAlgebraicNumber& rhs) const;
+  /** Compare two real algebraic numbers. */
+  bool operator<=( const RealAlgebraicNumber& rhs) const;
+  /** Compare two real algebraic numbers. */
+  bool operator>( const RealAlgebraicNumber& rhs) const;
+  /** Compare two real algebraic numbers. */
+  bool operator>=( const RealAlgebraicNumber& rhs) const;
+
+  /** Add two real algebraic numbers. */
+  RealAlgebraicNumber operator+(
+                                const RealAlgebraicNumber& rhs) const;
+  /** Subtract two real algebraic numbers. */
+  RealAlgebraicNumber operator-(
+                                const RealAlgebraicNumber& rhs) const;
+  /** Negate a real algebraic number. */
+  RealAlgebraicNumber operator-() const;
+  /** Multiply two real algebraic numbers. */
+  RealAlgebraicNumber operator*(
+                                const RealAlgebraicNumber& rhs) const;
+  /** Divide two real algebraic numbers. */
+  RealAlgebraicNumber operator/(
+                                const RealAlgebraicNumber& rhs) const;
+
+  /** Add and assign two real algebraic numbers. */
+  RealAlgebraicNumber& operator+=(
+                                  const RealAlgebraicNumber& rhs);
+  /** Subtract and assign two real algebraic numbers. */
+  RealAlgebraicNumber& operator-=(
+                                  const RealAlgebraicNumber& rhs);
+  /** Multiply and assign two real algebraic numbers. */
+  RealAlgebraicNumber& operator*=(
+                                  const RealAlgebraicNumber& rhs);
+
+  /** Compute the sign of a real algebraic number. */
+  int sgn() const;
+
+  /** Check whether a real algebraic number is zero. */
+  bool isZero() const;
+  /** Check whether a real algebraic number is one. */
+  bool isOne() const;
+  /** Compute the inverse of a real algebraic number. */
+  RealAlgebraicNumber inverse() const;
+  /** Hash function */
+  size_t hash() const;
  private:
+
+#ifdef CVC5_POLY_IMP
+  /** Get the internal value as a const reference. */
+  const poly::AlgebraicNumber& getValue() const { return d_value; }
+  /** Get the internal value as a non-const reference. */
+  poly::AlgebraicNumber& getValue() { return d_value; }
+#else
+  /** Get the internal value as a const reference. */
+  const Rational& getValue() const { return d_value; }
+  /** Get the internal value as a non-const reference. */
+  Rational& getValue() { return d_value; }
+#endif
   /**
    * Stores the actual real algebraic number.
    */
@@ -133,57 +188,10 @@ class RealAlgebraicNumber
 #endif
 }; /* class RealAlgebraicNumber */
 
+
 /** Stream a real algebraic number to an output stream. */
 std::ostream& operator<<(std::ostream& os, const RealAlgebraicNumber& ran);
-
-/** Compare two real algebraic numbers. */
-bool operator==(const RealAlgebraicNumber& lhs, const RealAlgebraicNumber& rhs);
-/** Compare two real algebraic numbers. */
-bool operator!=(const RealAlgebraicNumber& lhs, const RealAlgebraicNumber& rhs);
-/** Compare two real algebraic numbers. */
-bool operator<(const RealAlgebraicNumber& lhs, const RealAlgebraicNumber& rhs);
-/** Compare two real algebraic numbers. */
-bool operator<=(const RealAlgebraicNumber& lhs, const RealAlgebraicNumber& rhs);
-/** Compare two real algebraic numbers. */
-bool operator>(const RealAlgebraicNumber& lhs, const RealAlgebraicNumber& rhs);
-/** Compare two real algebraic numbers. */
-bool operator>=(const RealAlgebraicNumber& lhs, const RealAlgebraicNumber& rhs);
-
-/** Add two real algebraic numbers. */
-RealAlgebraicNumber operator+(const RealAlgebraicNumber& lhs,
-                              const RealAlgebraicNumber& rhs);
-/** Subtract two real algebraic numbers. */
-RealAlgebraicNumber operator-(const RealAlgebraicNumber& lhs,
-                              const RealAlgebraicNumber& rhs);
-/** Negate a real algebraic number. */
-RealAlgebraicNumber operator-(const RealAlgebraicNumber& ran);
-/** Multiply two real algebraic numbers. */
-RealAlgebraicNumber operator*(const RealAlgebraicNumber& lhs,
-                              const RealAlgebraicNumber& rhs);
-/** Divide two real algebraic numbers. */
-RealAlgebraicNumber operator/(const RealAlgebraicNumber& lhs,
-                              const RealAlgebraicNumber& rhs);
-
-/** Add and assign two real algebraic numbers. */
-RealAlgebraicNumber& operator+=(RealAlgebraicNumber& lhs,
-                                const RealAlgebraicNumber& rhs);
-/** Subtract and assign two real algebraic numbers. */
-RealAlgebraicNumber& operator-=(RealAlgebraicNumber& lhs,
-                                const RealAlgebraicNumber& rhs);
-/** Multiply and assign two real algebraic numbers. */
-RealAlgebraicNumber& operator*=(RealAlgebraicNumber& lhs,
-                                const RealAlgebraicNumber& rhs);
-
-/** Compute the sign of a real algebraic number. */
-int sgn(const RealAlgebraicNumber& ran);
-
-/** Check whether a real algebraic number is zero. */
-bool isZero(const RealAlgebraicNumber& ran);
-/** Check whether a real algebraic number is one. */
-bool isOne(const RealAlgebraicNumber& ran);
-/** Compute the inverse of a real algebraic number. */
-RealAlgebraicNumber inverse(const RealAlgebraicNumber& ran);
-
+  
 using RealAlgebraicNumberHashFunction = std::hash<RealAlgebraicNumber>;
 
 }  // namespace cvc5::internal

--- a/src/util/real_algebraic_number_poly_imp.h
+++ b/src/util/real_algebraic_number_poly_imp.h
@@ -28,7 +28,7 @@
 #include "util/rational.h"
 
 namespace cvc5::internal {
-  
+
 class PolyConverter;
 
 /**
@@ -49,6 +49,7 @@ class PolyConverter;
 class RealAlgebraicNumber
 {
   friend class PolyConverter;
+
  public:
   /** Construct as zero. */
   RealAlgebraicNumber() = default;
@@ -112,47 +113,39 @@ class RealAlgebraicNumber
    * rational approximation (of unknown precision).
    */
   Rational toRational() const;
-  
+
   std::string toString() const;
 
-
   /** Compare two real algebraic numbers. */
-  bool operator==( const RealAlgebraicNumber& rhs) const;
+  bool operator==(const RealAlgebraicNumber& rhs) const;
   /** Compare two real algebraic numbers. */
-  bool operator!=( const RealAlgebraicNumber& rhs) const;
+  bool operator!=(const RealAlgebraicNumber& rhs) const;
   /** Compare two real algebraic numbers. */
-  bool operator<( const RealAlgebraicNumber& rhs) const;
+  bool operator<(const RealAlgebraicNumber& rhs) const;
   /** Compare two real algebraic numbers. */
-  bool operator<=( const RealAlgebraicNumber& rhs) const;
+  bool operator<=(const RealAlgebraicNumber& rhs) const;
   /** Compare two real algebraic numbers. */
-  bool operator>( const RealAlgebraicNumber& rhs) const;
+  bool operator>(const RealAlgebraicNumber& rhs) const;
   /** Compare two real algebraic numbers. */
-  bool operator>=( const RealAlgebraicNumber& rhs) const;
+  bool operator>=(const RealAlgebraicNumber& rhs) const;
 
   /** Add two real algebraic numbers. */
-  RealAlgebraicNumber operator+(
-                                const RealAlgebraicNumber& rhs) const;
+  RealAlgebraicNumber operator+(const RealAlgebraicNumber& rhs) const;
   /** Subtract two real algebraic numbers. */
-  RealAlgebraicNumber operator-(
-                                const RealAlgebraicNumber& rhs) const;
+  RealAlgebraicNumber operator-(const RealAlgebraicNumber& rhs) const;
   /** Negate a real algebraic number. */
   RealAlgebraicNumber operator-() const;
   /** Multiply two real algebraic numbers. */
-  RealAlgebraicNumber operator*(
-                                const RealAlgebraicNumber& rhs) const;
+  RealAlgebraicNumber operator*(const RealAlgebraicNumber& rhs) const;
   /** Divide two real algebraic numbers. */
-  RealAlgebraicNumber operator/(
-                                const RealAlgebraicNumber& rhs) const;
+  RealAlgebraicNumber operator/(const RealAlgebraicNumber& rhs) const;
 
   /** Add and assign two real algebraic numbers. */
-  RealAlgebraicNumber& operator+=(
-                                  const RealAlgebraicNumber& rhs);
+  RealAlgebraicNumber& operator+=(const RealAlgebraicNumber& rhs);
   /** Subtract and assign two real algebraic numbers. */
-  RealAlgebraicNumber& operator-=(
-                                  const RealAlgebraicNumber& rhs);
+  RealAlgebraicNumber& operator-=(const RealAlgebraicNumber& rhs);
   /** Multiply and assign two real algebraic numbers. */
-  RealAlgebraicNumber& operator*=(
-                                  const RealAlgebraicNumber& rhs);
+  RealAlgebraicNumber& operator*=(const RealAlgebraicNumber& rhs);
 
   /** Compute the sign of a real algebraic number. */
   int sgn() const;
@@ -165,8 +158,8 @@ class RealAlgebraicNumber
   RealAlgebraicNumber inverse() const;
   /** Hash function */
   size_t hash() const;
- private:
 
+ private:
 #ifdef CVC5_POLY_IMP
   /** Get the internal value as a const reference. */
   const poly::AlgebraicNumber& getValue() const { return d_value; }
@@ -188,10 +181,9 @@ class RealAlgebraicNumber
 #endif
 }; /* class RealAlgebraicNumber */
 
-
 /** Stream a real algebraic number to an output stream. */
 std::ostream& operator<<(std::ostream& os, const RealAlgebraicNumber& ran);
-  
+
 using RealAlgebraicNumberHashFunction = std::hash<RealAlgebraicNumber>;
 
 }  // namespace cvc5::internal

--- a/test/unit/theory/theory_arith_coverings_white.cpp
+++ b/test/unit/theory/theory_arith_coverings_white.cpp
@@ -476,8 +476,8 @@ TEST_F(TestTheoryWhiteArithCoverings, test_ran_conversion)
       std::vector<Rational>({-2, 0, 1}), Rational(1, 3), Rational(7, 3));
   {
     Node x = make_real_variable("x");
-    Node n = nl::ran_to_node(ran, x);
-    RealAlgebraicNumber back = nl::node_to_ran(n, x);
+    Node n = PolyConverter::ran_to_node(ran, x);
+    RealAlgebraicNumber back = PolyConverter::node_to_ran(n, x);
     EXPECT_TRUE(ran == back);
   }
 }

--- a/test/unit/util/real_algebraic_number_black.cpp
+++ b/test/unit/util/real_algebraic_number_black.cpp
@@ -29,9 +29,9 @@ class TestUtilBlackRealAlgebraicNumber : public TestInternal
 
 TEST_F(TestUtilBlackRealAlgebraicNumber, creation)
 {
-  ASSERT_TRUE(isZero(RealAlgebraicNumber()));
-  ASSERT_TRUE(isOne(RealAlgebraicNumber(Integer(1))));
-  ASSERT_FALSE(isOne(RealAlgebraicNumber(Rational(2))));
+  ASSERT_TRUE(RealAlgebraicNumber().isZero());
+  ASSERT_TRUE(RealAlgebraicNumber(Integer(1)).isOne());
+  ASSERT_FALSE(RealAlgebraicNumber(Rational(2)).isOne());
   RealAlgebraicNumber sqrt2({-2, 0, 1}, 1, 2);
   ASSERT_TRUE(RealAlgebraicNumber(Integer(1)) < sqrt2);
   ASSERT_TRUE(sqrt2 < RealAlgebraicNumber(Integer(2)));
@@ -63,9 +63,9 @@ TEST_F(TestUtilBlackRealAlgebraicNumber, sgn)
   RealAlgebraicNumber zero;
   RealAlgebraicNumber sqrt2({-2, 0, 1}, 1, 2);
 
-  ASSERT_EQ(sgn(msqrt2), -1);
-  ASSERT_EQ(sgn(zero), 0);
-  ASSERT_EQ(sgn(sqrt2), 1);
+  ASSERT_EQ(msqrt2.sgn(), -1);
+  ASSERT_EQ(zero.sgn(), 0);
+  ASSERT_EQ(sqrt2.sgn(), 1);
 }
 
 TEST_F(TestUtilBlackRealAlgebraicNumber, arithmetic)
@@ -87,7 +87,7 @@ TEST_F(TestUtilBlackRealAlgebraicNumber, division)
   RealAlgebraicNumber mone({1, 1}, -2, 0);
 
   ASSERT_EQ(msqrt2 / sqrt2, mone);
-  ASSERT_TRUE(isOne(sqrt2 / sqrt2));
+  ASSERT_TRUE((sqrt2 / sqrt2).isOne());
 }
 
 }  // namespace test


### PR DESCRIPTION
This is work towards ensuring we don't use libpoly for evaluating arithmetic expressions by default.

It makes `getValue` methods private and converts free functions to member functions, and ensures all external usage of RealAlgebraicNumber do not rely on getValue.