### PR TITLE
Simplify sygus enumerator callback

### DIFF
--- a/src/theory/quantifiers/sygus/enum_value_manager.cpp
+++ b/src/theory/quantifiers/sygus/enum_value_manager.cpp
@@ -114,8 +114,8 @@ Node EnumValueManager::getEnumeratedValue(bool& activeIncomplete)
             // use the default output for the output of sygusRewVerify
             out = options().base.out;
           }
-          d_secd = std::make_unique<SygusEnumeratorCallbackDefault>(
-              d_env, e, d_tds, &d_stats, d_eec.get(), d_samplerRrV.get(), out);
+          d_secd = std::make_unique<SygusEnumeratorCallback>(
+              d_env, d_tds, &d_stats, d_eec.get(), d_samplerRrV.get(), out);
         }
         // if sygus repair const is enabled, we enumerate terms with free
         // variables as arguments to any-constant constructors

--- a/src/theory/quantifiers/sygus/enum_value_manager.h
+++ b/src/theory/quantifiers/sygus/enum_value_manager.h
@@ -87,7 +87,7 @@ class EnumValueManager : protected EnvObj
   /** Sygus sampler (for --sygus-rr-verify) */
   std::unique_ptr<SygusSampler> d_samplerRrV;
   /** if we allocated a default sygus enumerator callback */
-  std::unique_ptr<SygusEnumeratorCallbackDefault> d_secd;
+  std::unique_ptr<SygusEnumeratorCallback> d_secd;
   /** enumerator generators for each actively-generated enumerator */
   std::unique_ptr<EnumValGenerator> d_evg;
   /** example evaluation cache utility for each enumerator */

--- a/src/theory/quantifiers/sygus/sygus_enumerator.cpp
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.cpp
@@ -60,8 +60,8 @@ void SygusEnumerator::initialize(Node e)
   if (d_sec == nullptr
       && options().datatypes.sygusRewriter != options::SygusRewriterMode::NONE)
   {
-    d_secd = std::make_unique<SygusEnumeratorCallbackDefault>(
-        d_env, e, d_tds, d_stats);
+    d_secd = std::make_unique<SygusEnumeratorCallback>(
+        d_env, d_tds, d_stats);
     d_sec = d_secd.get();
   }
   d_etype = d_enum.getType();
@@ -356,6 +356,7 @@ bool SygusEnumerator::TermCache::addTerm(Node n)
           << " due to callback" << std::endl;
       return false;
     }
+    Trace("sygus-enum-terms") << "tc(" << d_tn << "): term: " << n << std::endl;
   }
   if (d_stats != nullptr)
   {

--- a/src/theory/quantifiers/sygus/sygus_enumerator.cpp
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.cpp
@@ -60,8 +60,7 @@ void SygusEnumerator::initialize(Node e)
   if (d_sec == nullptr
       && options().datatypes.sygusRewriter != options::SygusRewriterMode::NONE)
   {
-    d_secd = std::make_unique<SygusEnumeratorCallback>(
-        d_env, d_tds, d_stats);
+    d_secd = std::make_unique<SygusEnumeratorCallback>(d_env, d_tds, d_stats);
     d_sec = d_secd.get();
   }
   d_etype = d_enum.getType();

--- a/src/theory/quantifiers/sygus/sygus_enumerator.h
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.h
@@ -98,7 +98,7 @@ class SygusEnumerator : public EnumValGenerator
   /** pointer to the enumerator callback we are using (if any) */
   SygusEnumeratorCallback* d_sec;
   /** if we allocated a default sygus enumerator callback */
-  std::unique_ptr<SygusEnumeratorCallbackDefault> d_secd;
+  std::unique_ptr<SygusEnumeratorCallback> d_secd;
   /** pointer to the statistics */
   SygusStatistics* d_stats;
   /** Whether we are enumerating shapes */

--- a/src/theory/quantifiers/sygus/sygus_enumerator_callback.cpp
+++ b/src/theory/quantifiers/sygus/sygus_enumerator_callback.cpp
@@ -60,14 +60,15 @@ bool SygusEnumeratorCallback::addTerm(const Node& n, std::unordered_set<Node>& b
   // check whether we should keep the term, which is based on the callback,
   // and the builtin terms
   // First, must be unique up to rewriting
-  if (bterms.find(bnr) != bterms.end())
+  Node cval = getCacheValue(n, bn, bnr);
+  if (bterms.find(cval) != bterms.end())
   {
     Trace("sygus-enum-exc") << "Exclude (by rewriting): " << bn << std::endl;
     return false;
   }
   // insert to builtin term cache, regardless of whether it is redundant
   // based on the callback
-  bterms.insert(bnr);
+  bterms.insert(cval);
 
   // callback-specific add term
   if (!addTermInternal(n, bn, bnr))
@@ -75,6 +76,13 @@ bool SygusEnumeratorCallback::addTerm(const Node& n, std::unordered_set<Node>& b
     return false;
   }
   return true;
+}
+
+Node SygusEnumeratorCallback::getCacheValue(const Node& n, const Node& bn, const Node& bnr)
+{
+  // By default, we cache based on the rewritten form.
+  // Further criteria for uniqueness (e.g. weights) may go here.
+  return bnr;
 }
 
 bool SygusEnumeratorCallback::addTermInternal(const Node& n, const Node& bn, const Node& bnr)

--- a/src/theory/quantifiers/sygus/sygus_enumerator_callback.cpp
+++ b/src/theory/quantifiers/sygus/sygus_enumerator_callback.cpp
@@ -26,22 +26,23 @@ namespace cvc5::internal {
 namespace theory {
 namespace quantifiers {
 
-
-SygusEnumeratorCallback::SygusEnumeratorCallback(
-    Env& env,
-    TermDbSygus* tds,
-    SygusStatistics* s,
-    ExampleEvalCache* eec,
-    SygusSampler* ssrv,
-    std::ostream* out)
-    : EnvObj(env), d_tds(tds), d_stats(s),
+SygusEnumeratorCallback::SygusEnumeratorCallback(Env& env,
+                                                 TermDbSygus* tds,
+                                                 SygusStatistics* s,
+                                                 ExampleEvalCache* eec,
+                                                 SygusSampler* ssrv,
+                                                 std::ostream* out)
+    : EnvObj(env),
+      d_tds(tds),
+      d_stats(s),
       d_eec(eec),
       d_samplerRrV(ssrv),
       d_out(out)
 {
 }
 
-bool SygusEnumeratorCallback::addTerm(const Node& n, std::unordered_set<Node>& bterms)
+bool SygusEnumeratorCallback::addTerm(const Node& n,
+                                      std::unordered_set<Node>& bterms)
 {
   Node bn = datatypes::utils::sygusToBuiltin(n);
   Node bnr = d_tds == nullptr ? extendedRewrite(bn) : d_tds->rewriteNode(bn);
@@ -78,14 +79,18 @@ bool SygusEnumeratorCallback::addTerm(const Node& n, std::unordered_set<Node>& b
   return true;
 }
 
-Node SygusEnumeratorCallback::getCacheValue(const Node& n, const Node& bn, const Node& bnr)
+Node SygusEnumeratorCallback::getCacheValue(const Node& n,
+                                            const Node& bn,
+                                            const Node& bnr)
 {
   // By default, we cache based on the rewritten form.
   // Further criteria for uniqueness (e.g. weights) may go here.
   return bnr;
 }
 
-bool SygusEnumeratorCallback::addTermInternal(const Node& n, const Node& bn, const Node& bnr)
+bool SygusEnumeratorCallback::addTermInternal(const Node& n,
+                                              const Node& bn,
+                                              const Node& bnr)
 {
   // if we are doing PBE symmetry breaking
   if (d_eec != nullptr)

--- a/src/theory/quantifiers/sygus/sygus_enumerator_callback.h
+++ b/src/theory/quantifiers/sygus/sygus_enumerator_callback.h
@@ -55,6 +55,8 @@ class SygusEnumeratorCallback : protected EnvObj
    */
   bool addTerm(const Node& n, std::unordered_set<Node>& bterms);
  protected:
+  /** Get the cache value for the given candidate */
+  Node getCacheValue(const Node& n, const Node& bn, const Node& bnr);
   /**
    * Callback-specific add term
    *

--- a/src/theory/quantifiers/sygus/sygus_enumerator_callback.h
+++ b/src/theory/quantifiers/sygus/sygus_enumerator_callback.h
@@ -33,19 +33,17 @@ class SygusStatistics;
 class SygusSampler;
 class TermDbSygus;
 
-/**
- * Base class for callbacks in the fast enumerator. This allows a user to
- * provide custom criteria for whether or not enumerated values should be
- * considered.
- */
 class SygusEnumeratorCallback : protected EnvObj
 {
  public:
   SygusEnumeratorCallback(Env& env,
-                          Node e,
-                          TermDbSygus* tds = nullptr,
-                          SygusStatistics* s = nullptr);
+                                 TermDbSygus* tds = nullptr,
+                                 SygusStatistics* s = nullptr,
+                                 ExampleEvalCache* eec = nullptr,
+                                 SygusSampler* ssrv = nullptr,
+                                 std::ostream* out = nullptr);
   virtual ~SygusEnumeratorCallback() {}
+
   /**
    * Add term, return true if the term should be considered in the enumeration.
    * Notice that returning false indicates that n should not be considered as a
@@ -55,17 +53,8 @@ class SygusEnumeratorCallback : protected EnvObj
    * @param bterms The (rewritten, builtin) terms we have already enumerated
    * @return true if n should be considered in the enumeration.
    */
-  virtual bool addTerm(Node n, std::unordered_set<Node>& bterms);
-
+  bool addTerm(const Node& n, std::unordered_set<Node>& bterms);
  protected:
-  /**
-   * Callback-specific notification of the above
-   *
-   * @param n The SyGuS term
-   * @param bn The builtin version of the enumerated term
-   * @param bnr The (extended) rewritten form of bn
-   */
-  virtual void notifyTermInternal(Node n, Node bn, Node bnr) {}
   /**
    * Callback-specific add term
    *
@@ -74,34 +63,11 @@ class SygusEnumeratorCallback : protected EnvObj
    * @param bnr The (extended) rewritten form of bn
    * @return true if the term should be considered in the enumeration.
    */
-  virtual bool addTermInternal(Node n, Node bn, Node bnr) { return true; }
-  /** The enumerator */
-  Node d_enum;
-  /** The type of enum */
-  TypeNode d_tn;
+  bool addTermInternal(const Node& n, const Node& bn, const Node& bnr);
   /** Term database sygus */
   TermDbSygus* d_tds;
   /** pointer to the statistics */
   SygusStatistics* d_stats;
-};
-
-class SygusEnumeratorCallbackDefault : public SygusEnumeratorCallback
-{
- public:
-  SygusEnumeratorCallbackDefault(Env& env,
-                                 Node e,
-                                 TermDbSygus* tds = nullptr,
-                                 SygusStatistics* s = nullptr,
-                                 ExampleEvalCache* eec = nullptr,
-                                 SygusSampler* ssrv = nullptr,
-                                 std::ostream* out = nullptr);
-  virtual ~SygusEnumeratorCallbackDefault() {}
-
- protected:
-  /** Notify that bn / bnr is an enumerated builtin, rewritten form of a term */
-  void notifyTermInternal(Node n, Node bn, Node bnr) override;
-  /** Add term, return true if n should be considered in the enumeration */
-  bool addTermInternal(Node n, Node bn, Node bnr) override;
   /**
    * Pointer to the example evaluation cache utility (used for symmetry
    * breaking).

--- a/src/theory/quantifiers/sygus/sygus_enumerator_callback.h
+++ b/src/theory/quantifiers/sygus/sygus_enumerator_callback.h
@@ -37,11 +37,11 @@ class SygusEnumeratorCallback : protected EnvObj
 {
  public:
   SygusEnumeratorCallback(Env& env,
-                                 TermDbSygus* tds = nullptr,
-                                 SygusStatistics* s = nullptr,
-                                 ExampleEvalCache* eec = nullptr,
-                                 SygusSampler* ssrv = nullptr,
-                                 std::ostream* out = nullptr);
+                          TermDbSygus* tds = nullptr,
+                          SygusStatistics* s = nullptr,
+                          ExampleEvalCache* eec = nullptr,
+                          SygusSampler* ssrv = nullptr,
+                          std::ostream* out = nullptr);
   virtual ~SygusEnumeratorCallback() {}
 
   /**
@@ -54,6 +54,7 @@ class SygusEnumeratorCallback : protected EnvObj
    * @return true if n should be considered in the enumeration.
    */
   bool addTerm(const Node& n, std::unordered_set<Node>& bterms);
+
  protected:
   /** Get the cache value for the given candidate */
   Node getCacheValue(const Node& n, const Node& bn, const Node& bnr);

--- a/src/theory/quantifiers/sygus/sygus_enumerator_callback.h
+++ b/src/theory/quantifiers/sygus/sygus_enumerator_callback.h
@@ -33,6 +33,10 @@ class SygusStatistics;
 class SygusSampler;
 class TermDbSygus;
 
+/**
+ * Class for callbacks in the fast enumerator. This class provides custom
+ * criteria for whether or not enumerated values should be considered.
+ */
 class SygusEnumeratorCallback : protected EnvObj
 {
  public:


### PR DESCRIPTION
Eliminates the inheritance and eliminates a few data members.

Also adds a method for getting a unique cache value, in preparation for symmetry breaking to account for weighted grammars.