### PR TITLE
Do not invoke rewriter when initializing transcendental solver

### DIFF
--- a/src/theory/arith/nl/transcendental/sine_solver.cpp
+++ b/src/theory/arith/nl/transcendental/sine_solver.cpp
@@ -46,10 +46,9 @@ SineSolver::SineSolver(Env& env, TranscendentalState* tstate)
   Node one = nm->mkConstReal(Rational(1));
   Node negOne = nm->mkConstReal(Rational(-1));
   d_pi = nm->mkNullaryOperator(nm->realType(), Kind::PI);
-  Node pi_2 = 
-      nm->mkNode(Kind::MULT, nm->mkConstReal(Rational(1,2)), d_pi);
-  Node pi_neg_2 = 
-      nm->mkNode(Kind::MULT, nm->mkConstReal(Rational(-1,2)), d_pi);
+  Node pi_2 = nm->mkNode(Kind::MULT, nm->mkConstReal(Rational(1, 2)), d_pi);
+  Node pi_neg_2 =
+      nm->mkNode(Kind::MULT, nm->mkConstReal(Rational(-1, 2)), d_pi);
   d_neg_pi = nm->mkNode(Kind::MULT, nm->mkConstInt(Rational(-1)), d_pi);
   d_mpoints.push_back(d_pi);
   d_mpointsSine[d_pi] = zero;

--- a/src/theory/arith/nl/transcendental/sine_solver.cpp
+++ b/src/theory/arith/nl/transcendental/sine_solver.cpp
@@ -46,11 +46,11 @@ SineSolver::SineSolver(Env& env, TranscendentalState* tstate)
   Node one = nm->mkConstReal(Rational(1));
   Node negOne = nm->mkConstReal(Rational(-1));
   d_pi = nm->mkNullaryOperator(nm->realType(), Kind::PI);
-  Node pi_2 = rewrite(
-      nm->mkNode(Kind::MULT, d_pi, nm->mkConstReal(Rational(1) / Rational(2))));
-  Node pi_neg_2 = rewrite(nm->mkNode(
-      Kind::MULT, d_pi, nm->mkConstReal(Rational(-1) / Rational(2))));
-  d_neg_pi = rewrite(nm->mkNode(Kind::MULT, d_pi, negOne));
+  Node pi_2 = 
+      nm->mkNode(Kind::MULT, nm->mkConstReal(Rational(1,2)), d_pi);
+  Node pi_neg_2 = 
+      nm->mkNode(Kind::MULT, nm->mkConstReal(Rational(-1,2)), d_pi);
+  d_neg_pi = nm->mkNode(Kind::MULT, nm->mkConstInt(Rational(-1)), d_pi);
   d_mpoints.push_back(d_pi);
   d_mpointsSine[d_pi] = zero;
   d_mpoints.push_back(pi_2);


### PR DESCRIPTION
We invoke the rewriter to ensure terms involving PI are rewritten in the transcendental solver.
This is counterintuitive when debugging issues with the rewriter, as the rewriter is always invoked upon construction of the SMT solver.