### PR TITLE
Adapt smt-comp scripts to option changes

### DIFF
--- a/contrib/competitions/smt-comp/run-script-smtcomp-current
+++ b/contrib/competitions/smt-comp/run-script-smtcomp-current
@@ -58,7 +58,6 @@ QF_LIA)
 QF_NIA)
   trywith 420 --nl-ext-tplanes --decision=justification
   trywith 60 --nl-ext-tplanes --decision=internal
-  trywith 60 --nl-ext-tplanes --decision=justification-old
   trywith 60 --no-nl-ext-tplanes --decision=internal
   trywith 60 --no-arith-brab --nl-ext-tplanes --decision=internal
   # this totals up to more than 20 minutes, although notice that smaller bit-widths may quickly fail
@@ -71,7 +70,7 @@ QF_NIA)
   ;;
 QF_NRA)
   trywith 600 --decision=justification
-  trywith 300 --decision=internal --no-nl-cad --nl-ext=full --nl-ext-tplanes
+  trywith 300 --decision=internal --no-nl-cov --nl-ext=full --nl-ext-tplanes
   finishwith --decision=internal --nl-ext=none
   ;;
 # all logics with UF + quantifiers should either fall under this or special cases below


### PR DESCRIPTION
Since last year some options changed.  This updates the competition scripts to take those changes into account

- `--no-nl-cad` is now `--no-nl-cov`
- `--decision=justification-old` was removed