### PR TITLE
Eliminate any trusted rules with DSL_REWRITE

### DIFF
--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -22,6 +22,8 @@
 #include "proof/alethe/alethe_post_processor.h"
 #include "proof/alethe/alethe_printer.h"
 #include "proof/dot/dot_printer.h"
+#include "proof/lean/lean_post_processor.h"
+#include "proof/lean/lean_printer.h"
 #include "proof/lfsc/lfsc_post_processor.h"
 #include "proof/lfsc/lfsc_printer.h"
 #include "proof/proof_checker.h"
@@ -92,7 +94,7 @@ PfManager::PfManager(Env& env)
           != options::ProofGranularityMode::THEORY_REWRITE)
       {
         // this eliminates theory rewriting steps with finer-grained DSL rules
-        d_pfpp->setEliminateRule(PfRule::THEORY_REWRITE);
+        d_pfpp->setEliminateAllTrustedRules();
       }
     }
     // theory-specific lazy proof reconstruction
@@ -134,14 +136,14 @@ std::shared_ptr<ProofNode> PfManager::connectProofToAssertions(
     Trace("smt-proof-debug") << *pfn.get() << std::endl;
     Trace("smt-proof-debug") << "=====" << std::endl;
   }
+  std::vector<Node> assertions;
+  getAssertions(as, assertions);
 
   if (TraceIsOn("smt-proof"))
   {
     Trace("smt-proof")
         << "SolverEngine::connectProofToAssertions(): get free assumptions..."
         << std::endl;
-    std::vector<Node> assertions;
-    getAssertions(as, assertions);
     std::vector<Node> fassumps;
     expr::getFreeAssumptions(pfn.get(), fassumps);
     Trace("smt-proof") << "SolverEngine::connectProofToAssertions(): initial "
@@ -178,8 +180,6 @@ std::shared_ptr<ProofNode> PfManager::connectProofToAssertions(
     {
       Trace("smt-proof") << "SolverEngine::connectProofToAssertions(): make "
                             "unified scope...\n";
-      std::vector<Node> assertions;
-      getAssertions(as, assertions);
       return d_pnm->mkScope(
           pfn, assertions, true, options().proof.proofPruneInput);
     }

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -22,8 +22,6 @@
 #include "proof/alethe/alethe_post_processor.h"
 #include "proof/alethe/alethe_printer.h"
 #include "proof/dot/dot_printer.h"
-#include "proof/lean/lean_post_processor.h"
-#include "proof/lean/lean_printer.h"
 #include "proof/lfsc/lfsc_post_processor.h"
 #include "proof/lfsc/lfsc_printer.h"
 #include "proof/proof_checker.h"

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -995,10 +995,9 @@ Node ProofPostprocessCallback::expandMacros(PfRule id,
       getMethodId(args[2], mid);
     }
     int64_t recLimit = options().proof.proofRewriteRconsRecLimit;
-    int64_t stepLimit = options().proof.proofRewriteRconsStepLimit;
     // attempt to reconstruct the proof of the equality into cdp using the
     // rewrite database proof reconstructor
-    if (d_rdbPc.prove(cdp, res[0], res[1], tid, mid, recLimit, stepLimit))
+    if (d_rdbPc.prove(cdp, res[0], res[1], tid, mid, recLimit))
     {
       if (reqTrueElim)
       {

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -981,6 +981,7 @@ Node ProofPostprocessCallback::expandMacros(PfRule id,
       Assert(!res.isNull());
     }
     bool reqTrueElim = false;
+    // if not an equality, make (= res true).
     if (res.getKind() != EQUAL)
     {
       res = res.eqNode(d_true);
@@ -999,6 +1000,7 @@ Node ProofPostprocessCallback::expandMacros(PfRule id,
     // rewrite database proof reconstructor
     if (d_rdbPc.prove(cdp, res[0], res[1], tid, mid, recLimit))
     {
+      // If we made (= res true) above, conclude the original res.
       if (reqTrueElim)
       {
         cdp->addStep(res[0], PfRule::TRUE_ELIM, {res}, {});

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -73,11 +73,7 @@ bool ProofPostprocessCallback::shouldUpdate(std::shared_ptr<ProofNode> pn,
                                             bool& continueUpdate)
 {
   PfRule id = pn->getRule();
-  if (d_elimRules.find(id) != d_elimRules.end())
-  {
-    return true;
-  }
-  if (d_elimAllTrusted && d_pc->getPedanticLevel(id) > 0)
+  if (shouldExpand(id))
   {
     return true;
   }
@@ -172,13 +168,26 @@ bool ProofPostprocessCallback::updateInternal(Node res,
   return update(res, id, children, args, cdp, continueUpdate);
 }
 
+bool ProofPostprocessCallback::shouldExpand(PfRule id) const
+{
+  if (d_elimRules.find(id) != d_elimRules.end())
+  {
+    return true;
+  }
+  if (d_elimAllTrusted && d_pc->getPedanticLevel(id) > 0)
+  {
+    return true;
+  }
+  return false;
+}
+
 Node ProofPostprocessCallback::expandMacros(PfRule id,
                                             const std::vector<Node>& children,
                                             const std::vector<Node>& args,
                                             CDProof* cdp,
                                             Node res)
 {
-  if (!d_elimAllTrusted && d_elimRules.find(id) == d_elimRules.end())
+  if (!shouldExpand(id))
   {
     // not eliminated
     return Node::null();

--- a/src/smt/proof_post_processor.h
+++ b/src/smt/proof_post_processor.h
@@ -23,8 +23,8 @@
 #include <unordered_set>
 
 #include "proof/proof_node_updater.h"
-#include "rewriter/rewrite_db.h"
 #include "rewriter/rewrite_db_proof_cons.h"
+#include "rewriter/rewrites.h"
 #include "smt/env_obj.h"
 #include "smt/proof_final_callback.h"
 #include "smt/witness_form.h"
@@ -60,6 +60,8 @@ class ProofPostprocessCallback : public ProofNodeUpdaterCallback, protected EnvO
    * has no effect.
    */
   void setEliminateRule(PfRule rule);
+  /** set eliminate all trusted rules via DSL */
+  void setEliminateAllTrustedRules();
   /** Should proof pn be updated? */
   bool shouldUpdate(std::shared_ptr<ProofNode> pn,
                     const std::vector<Node>& fa,
@@ -75,6 +77,8 @@ class ProofPostprocessCallback : public ProofNodeUpdaterCallback, protected EnvO
  private:
   /** Common constants */
   Node d_true;
+  /** The proof checker we are using */
+  ProofChecker* d_pc;
   /** The preprocessing proof generator */
   ProofGenerator* d_pppg;
   /** The rewrite database proof generator */
@@ -85,6 +89,8 @@ class ProofPostprocessCallback : public ProofNodeUpdaterCallback, protected EnvO
   std::vector<Node> d_wfAssumptions;
   /** Kinds of proof rules we are eliminating */
   std::unordered_set<PfRule, PfRuleHashFunction> d_elimRules;
+  /** Whether we are trying to eliminate any trusted rule via the DSL */
+  bool d_elimAllTrusted;
   /** Whether we post-process assumptions in scope. */
   bool d_updateScopedAssumptions;
   //---------------------------------reset at the begining of each update
@@ -106,7 +112,8 @@ class ProofPostprocessCallback : public ProofNodeUpdaterCallback, protected EnvO
   Node expandMacros(PfRule id,
                     const std::vector<Node>& children,
                     const std::vector<Node>& args,
-                    CDProof* cdp);
+                    CDProof* cdp,
+                    Node res = Node::null());
   /**
    * Update the proof rule application, called during expand macros when
    * we wish to apply the update method. This method has the same behavior
@@ -188,6 +195,8 @@ class ProofPostprocess : protected EnvObj
   void process(std::shared_ptr<ProofNode> pf, ProofGenerator* pppg);
   /** set eliminate rule */
   void setEliminateRule(PfRule rule);
+  /** set eliminate all trusted rules via DSL */
+  void setEliminateAllTrustedRules();
 
  private:
   /** The post process callback */

--- a/src/smt/proof_post_processor.h
+++ b/src/smt/proof_post_processor.h
@@ -97,6 +97,8 @@ class ProofPostprocessCallback : public ProofNodeUpdaterCallback, protected EnvO
   /** Mapping assumptions to their proof from preprocessing */
   std::map<Node, std::shared_ptr<ProofNode> > d_assumpToProof;
   //---------------------------------end reset at the begining of each update
+  /** Return true if id is a proof rule that we should expand */
+  bool shouldExpand(PfRule id) const;
   /**
    * Expand rules in the given application, add the expanded proof to cdp.
    * The set of rules we expand is configured by calls to setEliminateRule


### PR DESCRIPTION
Previously we were limited to THEORY_REWRITE only, although we could attempt DSL rewrite rule reconstruction on any trusted rule.

This fills holes such as THEORY_PREPROCESS_LEMMA or TRUST_FLATTEN_REWRITE.