### PR TITLE
Refactor initialization of logic in parser

### DIFF
--- a/src/parser/api/cpp/input_parser.cpp
+++ b/src/parser/api/cpp/input_parser.cpp
@@ -69,6 +69,14 @@ Solver* InputParser::getSolver() { return d_solver; }
 
 SymbolManager* InputParser::getSymbolManager() { return d_sm; }
 
+void InputParser::setLogic(const std::string& str)
+{
+  if (d_useFlex)
+  {
+    d_fparser->setLogic(str);
+  }
+}
+
 std::unique_ptr<Command> InputParser::nextCommand()
 {
   Trace("parser") << "nextCommand()" << std::endl;

--- a/src/parser/api/cpp/input_parser.cpp
+++ b/src/parser/api/cpp/input_parser.cpp
@@ -15,6 +15,7 @@
 
 #include "parser/api/cpp/input_parser.h"
 
+#include "base/check.h"
 #include "base/output.h"
 #include "parser/api/cpp/command.h"
 #include "parser/input.h"

--- a/src/parser/api/cpp/input_parser.cpp
+++ b/src/parser/api/cpp/input_parser.cpp
@@ -69,11 +69,16 @@ Solver* InputParser::getSolver() { return d_solver; }
 
 SymbolManager* InputParser::getSymbolManager() { return d_sm; }
 
-void InputParser::setLogic(const std::string& str)
+void InputParser::setLogic(const std::string& name)
 {
   if (d_useFlex)
   {
-    d_fparser->setLogic(str);
+    d_fparser->setLogic(name);
+  }
+  else
+  {
+    // not supported in ANTLR
+    Unhandled() << "set-logic not supported in input parser using ANTLR.";
   }
 }
 

--- a/src/parser/api/cpp/input_parser.h
+++ b/src/parser/api/cpp/input_parser.h
@@ -106,7 +106,8 @@ class CVC5_EXPORT InputParser
 
   /**
    * Parse and return the next command. Will initialize the logic to "ALL"
-   * or the forced logic if no logic is set prior to this point.
+   * or the forced logic if no logic is set prior to this point and a command
+   * is read that requires initializing the logic.
    */
   std::unique_ptr<Command> nextCommand();
 

--- a/src/parser/api/cpp/input_parser.h
+++ b/src/parser/api/cpp/input_parser.h
@@ -65,7 +65,7 @@ class CVC5_EXPORT InputParser
   SymbolManager* getSymbolManager();
   /**
    * Set the logic to use. This determines which builtin symbols are included.
-   * 
+   *
    * @param name The name of the logic.
    */
   void setLogic(const std::string& name);

--- a/src/parser/api/cpp/input_parser.h
+++ b/src/parser/api/cpp/input_parser.h
@@ -23,6 +23,7 @@
 
 #include <memory>
 
+#include "parser/api/cpp/command.h"
 #include "parser/flex_parser.h"
 #include "parser/parser_antlr.h"
 
@@ -62,6 +63,10 @@ class CVC5_EXPORT InputParser
   Solver* getSolver();
   /** Get the underlying symbol manager of this input parser */
   SymbolManager* getSymbolManager();
+  /**
+   * Set the logic to use. This determines which builtin symbols are included.
+   */
+  void setLogic(const std::string& str);
   /** Set the input for the given file.
    *
    * @param lang the input language
@@ -98,11 +103,15 @@ class CVC5_EXPORT InputParser
   void appendIncrementalStringInput(const std::string& input);
 
   /**
-   * Parse and return the next command.
+   * Parse and return the next command. Will initialize the logic to "ALL"
+   * or the forced logic if no logic is set prior to this point.
    */
   std::unique_ptr<Command> nextCommand();
 
-  /** Parse and return the next expression. */
+  /**
+   * Parse and return the next expression. Requires setting the logic prior
+   * to this point.
+   */
   Term nextExpression();
 
  private:

--- a/src/parser/api/cpp/input_parser.h
+++ b/src/parser/api/cpp/input_parser.h
@@ -65,8 +65,10 @@ class CVC5_EXPORT InputParser
   SymbolManager* getSymbolManager();
   /**
    * Set the logic to use. This determines which builtin symbols are included.
+   * 
+   * @param name The name of the logic.
    */
-  void setLogic(const std::string& str);
+  void setLogic(const std::string& name);
   /** Set the input for the given file.
    *
    * @param lang the input language

--- a/src/parser/flex_parser.cpp
+++ b/src/parser/flex_parser.cpp
@@ -30,6 +30,8 @@ FlexParser::FlexParser(Solver* solver, SymbolManager* sm)
 {
 }
 
+void FlexParser::setLogic(const std::string& name) {}
+
 void FlexParser::setFileInput(const std::string& filename)
 {
   d_flexInput = FlexInput::mkFileInput(filename);

--- a/src/parser/flex_parser.h
+++ b/src/parser/flex_parser.h
@@ -44,7 +44,7 @@ class FlexParser : public ParserStateCallback
   FlexParser(Solver* solver, SymbolManager* sm);
   virtual ~FlexParser() {}
   /**
-   * Set the logic 
+   * Set the logic
    *
    * @param name The name of the logic.
    */

--- a/src/parser/flex_parser.h
+++ b/src/parser/flex_parser.h
@@ -43,6 +43,12 @@ class FlexParser : public ParserStateCallback
  public:
   FlexParser(Solver* solver, SymbolManager* sm);
   virtual ~FlexParser() {}
+  /**
+   * Set the logic 
+   *
+   * @param name The name of the logic.
+   */
+  virtual void setLogic(const std::string& name);
   /** Set the input for the given file.
    *
    * @param filename the input filename

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -1514,19 +1514,12 @@ identifier[cvc5::ParseOp& p]
       }
     | functionName[opName, CHECK_NONE] nonemptyNumeralList[numerals]
       {
-        cvc5::Kind k = PARSER_STATE->getIndexedOpKind(opName);
-        if (k == cvc5::UNDEFINED_KIND)
-        {
-          // We don't know which kind to use until we know the type of the
-          // arguments. This case handles to_fp, tuple.select and tuple.update
-          p.d_name = opName;
-          p.d_indices = numerals;
-          p.d_kind = cvc5::UNDEFINED_KIND;
-        }
-        else
-        {
-          p.d_op = SOLVER->mkOp(k, numerals);
-        }
+        // In some cases, we don't know which kind to use until we know the
+        // type of the arguments. This case handles to_fp, tuple.select and
+        // tuple.update. For consistency, we always construct the op lazily.
+        p.d_name = opName;
+        p.d_indices = numerals;
+        p.d_kind = cvc5::UNDEFINED_KIND;
       }
     )
     RPAREN_TOK

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -976,7 +976,7 @@ void Smt2State::checkThatLogicIsSet()
 
         setLogic("ALL");
       }
-      // If not from a command, just set the logic directly. Notice this is
+      // Set the logic directly in the solver, without a command. Notice this is
       // important since we do not want to enqueue a set-logic command and
       // fully initialize the underlying SolverEngine in the meantime before the
       // command has a chance to execute, which would lead to an error.

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -651,7 +651,6 @@ void Smt2State::pushDefineFunRecScope(
 void Smt2State::reset()
 {
   d_logicSet = false;
-  d_seenSetLogic = false;
   d_logic = internal::LogicInfo();
   d_operatorKindMap.clear();
   d_lastNamedTerm = std::pair<Term, std::string>();
@@ -687,23 +686,13 @@ std::unique_ptr<Command> Smt2State::invConstraint(
   return std::unique_ptr<Command>(new SygusInvConstraintCommand(terms));
 }
 
-Command* Smt2State::setLogic(std::string name, bool fromCommand)
+void Smt2State::setLogic(std::string name)
 {
-  if (fromCommand)
+  // if logic is already set, this is an error
+  if (d_logicSet)
   {
-    if (d_seenSetLogic)
-    {
-      parseError("Only one set-logic is allowed.");
-    }
-    d_seenSetLogic = true;
-
-    if (logicIsForced())
-    {
-      // If the logic is forced, we ignore all set-logic requests from commands.
-      return new EmptyCommand();
-    }
+    parseError("Only one set-logic is allowed.");
   }
-
   d_logicSet = true;
   d_logic = name;
 
@@ -943,20 +932,7 @@ Command* Smt2State::setLogic(std::string name, bool fromCommand)
   // builtin symbols of the logic are declared at context level zero, hence
   // we push the outermost scope here
   pushScope(true);
-
-  std::string logic = sygus() ? d_logic.getLogicString() : name;
-  if (!fromCommand)
-  {
-    // If not from a command, just set the logic directly. Notice this is
-    // important since we do not want to enqueue a set-logic command and
-    // fully initialize the underlying SolverEngine in the meantime before the
-    // command has a chance to execute, which would lead to an error.
-    d_solver->setLogic(logic);
-    return nullptr;
-  }
-  Command* cmd = new SetBenchmarkLogicCommand(logic);
-  return cmd;
-} /* Smt2State::setLogic() */
+}
 
 Grammar* Smt2State::mkGrammar(const std::vector<Term>& boundVars,
                               const std::vector<Term>& ntSymbols)
@@ -987,7 +963,7 @@ void Smt2State::checkThatLogicIsSet()
       // the calls to setLogic below set the logic on the solver directly
       if (logicIsForced())
       {
-        setLogic(getForcedLogic(), false);
+        setLogic(getForcedLogic());
       }
       else
       {
@@ -998,8 +974,13 @@ void Smt2State::checkThatLogicIsSet()
             "performance.");
         warning("To suppress this warning in the future use (set-logic ALL).");
 
-        setLogic("ALL", false);
+        setLogic("ALL");
       }
+      // If not from a command, just set the logic directly. Notice this is
+      // important since we do not want to enqueue a set-logic command and
+      // fully initialize the underlying SolverEngine in the meantime before the
+      // command has a chance to execute, which would lead to an error.
+      d_solver->setLogic(d_logic.getLogicString());
     }
   }
 }

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -216,12 +216,8 @@ class Smt2State : public ParserState
    * theory symbols.
    *
    * @param name the name of the logic (e.g., QF_UF, AUFLIA)
-   * @param fromCommand should be set to true if the request originates from a
-   *                    set-logic command and false otherwise
-   * @return the command corresponding to setting the logic (if fromCommand
-   * is true), and nullptr otherwise.
    */
-  Command* setLogic(std::string name, bool fromCommand = true);
+  void setLogic(std::string name);
 
   /**
    * Get the logic.

--- a/src/parser/smt2/smt2_cmd_parser.cpp
+++ b/src/parser/smt2/smt2_cmd_parser.cpp
@@ -764,7 +764,11 @@ std::unique_ptr<Command> Smt2CmdParser::parseNextCommand()
     case Token::SET_LOGIC_TOK:
     {
       std::string name = d_tparser.parseSymbol(CHECK_NONE, SYM_SORT);
-      cmd.reset(d_state.setLogic(name));
+      // replace the logic with the forced logic, if applicable.
+      std::string lname =
+          d_state.logicIsForced() ? d_state.getForcedLogic() : name;
+      d_state.setLogic(lname);
+      cmd.reset(new SetBenchmarkLogicCommand(lname));
     }
     break;
     // (set-option <option>)

--- a/src/parser/smt2/smt2_parser.cpp
+++ b/src/parser/smt2/smt2_parser.cpp
@@ -34,6 +34,8 @@ Smt2Parser::Smt2Parser(Solver* solver,
   d_lex = &d_slex;
 }
 
+void Smt2Parser::setLogic(const std::string& logic) { d_state.setLogic(logic); }
+
 std::unique_ptr<Command> Smt2Parser::parseNextCommand()
 {
   return d_cmdParser.parseNextCommand();
@@ -47,6 +49,7 @@ Term Smt2Parser::parseNextExpression()
   {
     return Term();
   }
+  // Parse the term.
   return d_termParser.parseTerm();
 }
 

--- a/src/parser/smt2/smt2_parser.h
+++ b/src/parser/smt2/smt2_parser.h
@@ -48,7 +48,8 @@ class Smt2Parser : public FlexParser
  protected:
   /**
    * Parse and return the next command. Will initialize the logic to "ALL"
-   * if not already done so.
+   * or the forced logic if no logic is set prior to this point and a command
+   * is read that requires initializing the logic.
    */
   std::unique_ptr<Command> parseNextCommand() override;
 

--- a/src/parser/smt2/smt2_parser.h
+++ b/src/parser/smt2/smt2_parser.h
@@ -42,14 +42,20 @@ class Smt2Parser : public FlexParser
              bool strictMode = false,
              bool isSygus = false);
   virtual ~Smt2Parser() {}
+  /** Set the logic */
+  void setLogic(const std::string& logic) override;
 
  protected:
   /**
-   * Parse and return the next command.
+   * Parse and return the next command. Will initialize the logic to "ALL"
+   * if not already done so.
    */
   std::unique_ptr<Command> parseNextCommand() override;
 
-  /** Parse and return the next expression. */
+  /**
+   * Parse and return the next expression. Requires setting the logic
+   * beforehand.
+   */
   Term parseNextExpression() override;
   /** The lexer */
   Smt2Lexer d_slex;

--- a/test/unit/parser/parser_black.cpp
+++ b/test/unit/parser/parser_black.cpp
@@ -130,8 +130,7 @@ class TestParserBlackParser : public TestInternal
     if (d_lang == "LANG_SMTLIB_V2_6")
     {
       /* Use QF_LIA to make multiplication ("*") available */
-      std::unique_ptr<Command> cmd(
-          static_cast<Smt2*>(parser.get())->getSmt2State()->setLogic("QF_LIA"));
+      static_cast<Smt2*>(parser.get())->getSmt2State()->setLogic("QF_LIA");
     }
 
     ASSERT_FALSE(parser->done());


### PR DESCRIPTION
This is in preparation for new uses of the input parser, e.g. for parsing terms.

This adds the functionality to initialize the logic of the parser without reading commands.

It simplifies the handling of how logics were initialized previously.