### PR TITLE
Fix strict weak ordering in term_canonize

### DIFF
--- a/src/expr/term_canonize.cpp
+++ b/src/expr/term_canonize.cpp
@@ -87,7 +87,7 @@ bool TermCanonize::getTermOrder(Node a, Node b)
       }
       else
       {
-        return aop.getNumChildren() < bop.getNumChildren();
+        return a.getNumChildren() < b.getNumChildren();
       }
     }
     else

--- a/src/expr/term_canonize.cpp
+++ b/src/expr/term_canonize.cpp
@@ -76,10 +76,12 @@ bool TermCanonize::getTermOrder(Node a, Node b)
       {
         for (unsigned i = 0, size = a.getNumChildren(); i < size; i++)
         {
-          if (a[i] != b[i])
+          const bool a_b = getTermOrder(a[i], b[i]);
+          const bool b_a = getTermOrder(b[i], a[i]);
+          if (a_b || b_a)
           {
             // first distinct child determines the ordering
-            return getTermOrder(a[i], b[i]);
+            return a_b;
           }
         }
       }


### PR DESCRIPTION
[Transitivity of equivalence](https://www.boost.org/sgi/stl/StrictWeakOrdering.html) is violated for elements

`i = (>= (+ BOUND_VARIABLE_274 BOUND_VARIABLE_276) 1)`
`j = (>= (+ BOUND_VARIABLE_278 (* (- 1) BOUND_VARIABLE_280)) 6)`
`k = (>= (+ BOUND_VARIABLE_274 (* (- 1) BOUND_VARIABLE_276)) 1)`

That means that `!comp(i, j) && !comp(j, i) && !comp(j, k) && !comp(k, j)` but `comp(i, k)` holds.

That happens because the condition in the tree checks for `a[i] != b[i]` for BOUND_VARIABLE_274 (first child for elements `i` and `k`), then we compare the next child, however, we return always false when we compare with BOUND_VARIABLE_278 as they are different nodes.

I also fixed children count for the Node as we found a violation with it as well with `and, not` operators