### PR TITLE
Fix new GCC warning for zero length bounds

### DIFF
--- a/src/expr/node_manager_template.cpp
+++ b/src/expr/node_manager_template.cpp
@@ -1227,6 +1227,7 @@ NodeClass NodeManager::mkConstInternal(Kind k, const T& val)
     && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wzero-length-bounds"
 #endif
 
   nvStack.d_children[0] = const_cast<expr::NodeValue*>(


### PR DESCRIPTION
Newer versions of GCC give this warning (many times):
```
/tmp/ajreynol/pr-ajr/prod/src/expr/node_manager.cpp: In member function ‘NodeClass cvc5::internal::NodeManager::mkConstInternal(cvc5::internal::Kind, const T&) [with NodeClass = cvc5::internal::NodeTemplate<true>; T = cvc5::internal::UninterpretedSortValue]’:
/tmp/ajreynol/pr-ajr/prod/src/expr/node_manager.cpp:2115:23: warning: array subscript 0 is outside the bounds of an interior zero-length array ‘cvc5::internal::expr::NodeValue* [0]’ [-Wzero-length-bounds]
 2115 |   nvStack.d_children[0] = const_cast<expr::NodeValue*>(
      |   ~~~~~~~~~~~~~~~~~~~~^
/space/ajreynol/cvc5-pr-ajr/src/./expr/node_value.h:362:14: note: while referencing ‘cvc5::internal::expr::NodeValue::d_children’
  362 |   NodeValue* d_children[0];
