### PR TITLE
Removed -j option from command that builds tests.

### DIFF
--- a/test/api/cpp/CMakeLists.txt
+++ b/test/api/cpp/CMakeLists.txt
@@ -30,6 +30,7 @@ add_test(build_apitests_test
     "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" 
     --config "$<CONFIG>" --target build-apitests
 )
+set_property(TEST build_apitests_test PROPERTY ENVIRONMENT "CMAKE_BUILD_PARALLEL_LEVEL=${CTEST_NTHREADS}")
 set_tests_properties(build_apitests_test PROPERTIES FIXTURES_SETUP build_apitests_fixture)
 
 add_custom_target(apitests

--- a/test/api/cpp/CMakeLists.txt
+++ b/test/api/cpp/CMakeLists.txt
@@ -28,7 +28,7 @@ add_dependencies(build-tests build-apitests)
 # See the comment about 'make test' in test/regress/cli/CMakeLists.txt
 add_test(build_apitests_test 
     "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" 
-    --config "$<CONFIG>" --target build-apitests -j${CTEST_NTHREADS}
+    --config "$<CONFIG>" --target build-apitests
 )
 set_tests_properties(build_apitests_test PROPERTIES FIXTURES_SETUP build_apitests_fixture)
 

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -3587,7 +3587,7 @@ endforeach()
 # which builds the 'build_regress' target.
 add_test(build_regress_test 
     "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" 
-    --config "$<CONFIG>" --target build-regress -j${CTEST_NTHREADS}
+    --config "$<CONFIG>" --target build-regress
 )
 set_tests_properties(build_regress_test PROPERTIES FIXTURES_SETUP build_regress_fixture)
 

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -3589,6 +3589,7 @@ add_test(build_regress_test
     "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" 
     --config "$<CONFIG>" --target build-regress
 )
+set_property(TEST build_regress_test PROPERTY ENVIRONMENT "CMAKE_BUILD_PARALLEL_LEVEL=${CTEST_NTHREADS}")
 set_tests_properties(build_regress_test PROPERTIES FIXTURES_SETUP build_regress_fixture)
 
 macro(cvc5_add_regression_test level file)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -30,7 +30,7 @@ add_dependencies(build-tests build-units)
 # See the comment about 'make test' in test/regress/cli/CMakeLists.txt
 add_test(build_units_test 
     "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" 
-    --config "$<CONFIG>" --target build-units -j${CTEST_NTHREADS}
+    --config "$<CONFIG>" --target build-units
 )
 set_tests_properties(build_units_test PROPERTIES FIXTURES_SETUP build_units_fixture)
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -32,7 +32,7 @@ add_test(build_units_test
     "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" 
     --config "$<CONFIG>" --target build-units
 )
-set_property(TEST build_unit_test PROPERTY ENVIRONMENT "CMAKE_BUILD_PARALLEL_LEVEL=${CTEST_NTHREADS}")
+set_property(TEST build_units_test PROPERTY ENVIRONMENT "CMAKE_BUILD_PARALLEL_LEVEL=${CTEST_NTHREADS}")
 set_tests_properties(build_units_test PROPERTIES FIXTURES_SETUP build_units_fixture)
 
 add_custom_target(units

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -32,6 +32,7 @@ add_test(build_units_test
     "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" 
     --config "$<CONFIG>" --target build-units
 )
+set_property(TEST build_unit_test PROPERTY ENVIRONMENT "CMAKE_BUILD_PARALLEL_LEVEL=${CTEST_NTHREADS}")
 set_tests_properties(build_units_test PROPERTIES FIXTURES_SETUP build_units_fixture)
 
 add_custom_target(units


### PR DESCRIPTION
The parallel option `-j` does not seem to be accepted by cmake in some situations. This PR removes this option from commands that build tests. These commands were part of a recent workaround to have 'make test' work (#9750). 