### PR TITLE
Improvements for handling str.to_code

### DIFF
--- a/src/theory/strings/code_point_solver.cpp
+++ b/src/theory/strings/code_point_solver.cpp
@@ -35,7 +35,12 @@ CodePointSolver::CodePointSolver(Env& env,
                                  TermRegistry& tr,
                                  BaseSolver& bs,
                                  CoreSolver& cs)
-    : EnvObj(env), d_state(s), d_im(im), d_termReg(tr), d_bsolver(bs), d_csolver(cs)
+    : EnvObj(env),
+      d_state(s),
+      d_im(im),
+      d_termReg(tr),
+      d_bsolver(bs),
+      d_csolver(cs)
 {
   d_negOne = NodeManager::currentNM()->mkConstInt(Rational(-1));
 }
@@ -73,7 +78,7 @@ void CodePointSolver::checkCodes()
     else
     {
       EqcInfo* ei = d_state.getOrMakeEqcInfo(eqc, false);
-      if (ei==nullptr || ei->d_codeTerm.get().isNull())
+      if (ei == nullptr || ei->d_codeTerm.get().isNull())
       {
         continue;
       }
@@ -87,7 +92,7 @@ void CodePointSolver::checkCodes()
     }
     codes[eqc] = vc;
   }
-  if (d_im.hasProcessed() || codes.size()<=1)
+  if (d_im.hasProcessed() || codes.size() <= 1)
   {
     return;
   }
@@ -100,11 +105,11 @@ void CodePointSolver::checkCodes()
     bool foundCodePair = true;
     Node r[2];
     Node c[2];
-    for( size_t i=0; i<2; i++ )
+    for (size_t i = 0; i < 2; i++)
     {
-      r[i] = ee->getRepresentative( eq[i] );
+      r[i] = ee->getRepresentative(eq[i]);
       itc = codes.find(r[i]);
-      if (itc==codes.end())
+      if (itc == codes.end())
       {
         foundCodePair = false;
         break;

--- a/src/theory/strings/code_point_solver.cpp
+++ b/src/theory/strings/code_point_solver.cpp
@@ -54,8 +54,13 @@ void CodePointSolver::checkCodes()
     return;
   }
   NodeManager* nm = NodeManager::currentNM();
-  // str.code applied to the proxy variables for each equivalence classes that
-  // are constants of size one
+  // We construct a mapping from string equivalent classes to code point
+  // applications. This mapping contains entries:
+  // (1) r -> (str.to_code t) where r is the representative of t and
+  // term and this str.to_code term occurs in the equality engine.
+  // (2) c -> (str.to_code k) where c is a string constant of length one and
+  // c occurs in the equality engine (as a representative).
+  // This mapping omits str.to_code terms that are already equal to -1.
   std::map<Node, Node> codes;
   const std::vector<Node>& seqc = d_bsolver.getStringLikeEqc();
   for (const Node& eqc : seqc)
@@ -96,7 +101,9 @@ void CodePointSolver::checkCodes()
   {
     return;
   }
-  // now, ensure that str.code is injective
+  // Now, ensure that str.code is injective. We only apply injectivity for
+  // pairs of terms that are disequal. We check pairs of disequal terms by
+  // iterating over the disequalities in getRelevantDeq.
   eq::EqualityEngine* ee = d_state.getEqualityEngine();
   std::map<Node, Node>::iterator itc;
   const std::vector<Node>& rlvDeq = d_csolver.getRelevantDeq();

--- a/src/theory/strings/code_point_solver.cpp
+++ b/src/theory/strings/code_point_solver.cpp
@@ -56,8 +56,8 @@ void CodePointSolver::checkCodes()
   NodeManager* nm = NodeManager::currentNM();
   // We construct a mapping from string equivalent classes to code point
   // applications. This mapping contains entries:
-  // (1) r -> (str.to_code t) where r is the representative of t and
-  // term and this str.to_code term occurs in the equality engine.
+  // (1) r -> (str.to_code t) where r is the representative of t and the
+  // term (str.to_code t) occurs in the equality engine.
   // (2) c -> (str.to_code k) where c is a string constant of length one and
   // c occurs in the equality engine (as a representative).
   // This mapping omits str.to_code terms that are already equal to -1.

--- a/src/theory/strings/code_point_solver.h
+++ b/src/theory/strings/code_point_solver.h
@@ -42,7 +42,7 @@ class CodePointSolver : protected EnvObj
                   InferenceManager& im,
                   TermRegistry& tr,
                   BaseSolver& bs,
-                                 CoreSolver& cs);
+                  CoreSolver& cs);
   ~CodePointSolver() {}
   /** check codes
    *

--- a/src/theory/strings/code_point_solver.h
+++ b/src/theory/strings/code_point_solver.h
@@ -25,6 +25,7 @@ namespace theory {
 namespace strings {
 
 class BaseSolver;
+class CoreSolver;
 class InferenceManager;
 class TermRegistry;
 class SolverState;
@@ -40,7 +41,8 @@ class CodePointSolver : protected EnvObj
                   SolverState& s,
                   InferenceManager& im,
                   TermRegistry& tr,
-                  BaseSolver& bs);
+                  BaseSolver& bs,
+                                 CoreSolver& cs);
   ~CodePointSolver() {}
   /** check codes
    *
@@ -62,6 +64,8 @@ class CodePointSolver : protected EnvObj
   TermRegistry& d_termReg;
   /** reference to the base solver, used for certain queries */
   BaseSolver& d_bsolver;
+  /** The core solver */
+  CoreSolver& d_csolver;
   /** Commonly used constants */
   Node d_negOne;
 };

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -661,6 +661,11 @@ void CoreSolver::normalizeEquivalenceClass(Node eqc,
   }
 }
 
+const std::vector<Node>& CoreSolver::getRelevantDeq() const
+{
+  return d_rlvDeq;
+}
+
 NormalForm& CoreSolver::getNormalForm(Node n)
 {
   std::map<Node, NormalForm>::iterator itn = d_normal_form.find(n);
@@ -2508,7 +2513,7 @@ void CoreSolver::checkNormalFormsDeq()
   const context::CDList<Node>& deqs = d_state.getDisequalityList();
 
   Trace("str-deq") << "Process disequalites..." << std::endl;
-  std::vector<Node> relevantDeqs;
+  d_rlvDeq.clear();
   // for each pair of disequal strings, must determine whether their lengths
   // are equal or disequal
   for (const Node& eq : deqs)
@@ -2529,7 +2534,7 @@ void CoreSolver::checkNormalFormsDeq()
       if (d_state.areEqual(lt[0], lt[1]))
       {
         // if they have equal lengths, we must process the disequality below
-        relevantDeqs.push_back(eq);
+        d_rlvDeq.push_back(eq);
         Trace("str-deq") << "...relevant, lengths equal (" << lt[0] << " "
                          << lt[1] << ")" << std::endl;
       }
@@ -2554,7 +2559,7 @@ void CoreSolver::checkNormalFormsDeq()
     // added splitting lemma above
     return;
   }
-  for (const Node& eq : relevantDeqs)
+  for (const Node& eq : d_rlvDeq)
   {
     Assert(!d_state.isInConflict());
     // If using the sequence update solver, we always apply extensionality.

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -661,10 +661,7 @@ void CoreSolver::normalizeEquivalenceClass(Node eqc,
   }
 }
 
-const std::vector<Node>& CoreSolver::getRelevantDeq() const
-{
-  return d_rlvDeq;
-}
+const std::vector<Node>& CoreSolver::getRelevantDeq() const { return d_rlvDeq; }
 
 NormalForm& CoreSolver::getNormalForm(Node n)
 {

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -220,6 +220,8 @@ class CoreSolver : protected EnvObj
   //-----------------------end inference steps
 
   //--------------------------- query functions
+  /** Get relevant disequalities */
+  const std::vector<Node>& getRelevantDeq() const;
   /**
    * Get normal form for string term n. For details on this data structure,
    * see theory/strings/normal_form.h.
@@ -522,6 +524,8 @@ class CoreSolver : protected EnvObj
    * on the ordering described in checkCycles.
    */
   std::vector<Node> d_strings_eqc;
+  /** The relevant disequalities */
+  std::vector<Node> d_rlvDeq;
   /** map from terms to their normal forms */
   std::map<Node, NormalForm> d_normal_form;
   /**

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -220,7 +220,15 @@ class CoreSolver : protected EnvObj
   //-----------------------end inference steps
 
   //--------------------------- query functions
-  /** Get relevant disequalities */
+  /**
+   * Get relevant disequalities, which is a list of disequalities that are
+   * asserted in the current context between strings whose lengths are not
+   * already disequal. This list is filtered to not contain pairs of
+   * disequalities that are congruent.
+   *
+   * This list is used, e.g., when implementing the injectivity lemma schema
+   * for str.to_code.
+   */
   const std::vector<Node>& getRelevantDeq() const;
   /**
    * Get normal form for string term n. For details on this data structure,

--- a/src/theory/strings/term_registry.cpp
+++ b/src/theory/strings/term_registry.cpp
@@ -163,7 +163,6 @@ Node TermRegistry::lengthPositive(Node t)
   Node tlenEqZero = tlen.eqNode(zero);
   Node tEqEmp = t.eqNode(emp);
   Node caseEmpty = nm->mkNode(AND, tlenEqZero, tEqEmp);
-  // Node caseEmpty = tEqEmp;
   Node caseNEmpty = nm->mkNode(GT, tlen, zero);
   // (or (and (= (str.len t) 0) (= t "")) (> (str.len t) 0))
   return nm->mkNode(OR, caseEmpty, caseNEmpty);

--- a/src/theory/strings/term_registry.cpp
+++ b/src/theory/strings/term_registry.cpp
@@ -162,7 +162,7 @@ Node TermRegistry::lengthPositive(Node t)
   Node tlen = nm->mkNode(STRING_LENGTH, t);
   Node tlenEqZero = tlen.eqNode(zero);
   Node tEqEmp = t.eqNode(emp);
-  Node caseEmpty = nm->mkNode(AND, tlenEqZero, tEqEmp);
+  Node caseEmpty = tEqEmp;
   Node caseNEmpty = nm->mkNode(GT, tlen, zero);
   // (or (and (= (str.len t) 0) (= t "")) (> (str.len t) 0))
   return nm->mkNode(OR, caseEmpty, caseNEmpty);
@@ -289,18 +289,32 @@ void TermRegistry::registerTermInternal(Node n)
   else if (n.getKind() != STRING_CONTAINS)
   {
     // we don't send out eager reduction lemma for str.contains currently
-    Node eagerRedLemma = eagerReduce(n, &d_skCache, d_alphaCard);
-    if (!eagerRedLemma.isNull())
+    bool doEagerReduce = true;
+    Kind k = n.getKind();
+    if (k==STRING_CONTAINS)
     {
-      // if there was an eager reduction, we make the trust node for it
-      if (d_epg != nullptr)
+      doEagerReduce = false;
+    }
+    else if (k==STRING_TO_CODE)
+    {
+      //Node c = SkolemManager::getOriginalForm(n[0]);
+      //doEagerReduce = !c.isConst();
+    }
+    if (doEagerReduce)
+    {
+      Node eagerRedLemma = eagerReduce(n, &d_skCache, d_alphaCard);
+      if (!eagerRedLemma.isNull())
       {
-        regTermLem = d_epg->mkTrustNode(
-            eagerRedLemma, PfRule::STRING_EAGER_REDUCTION, {}, {n});
-      }
-      else
-      {
-        regTermLem = TrustNode::mkTrustLemma(eagerRedLemma, nullptr);
+        // if there was an eager reduction, we make the trust node for it
+        if (d_epg != nullptr)
+        {
+          regTermLem = d_epg->mkTrustNode(
+              eagerRedLemma, PfRule::STRING_EAGER_REDUCTION, {}, {n});
+        }
+        else
+        {
+          regTermLem = TrustNode::mkTrustLemma(eagerRedLemma, nullptr);
+        }
       }
     }
   }

--- a/src/theory/strings/term_registry.cpp
+++ b/src/theory/strings/term_registry.cpp
@@ -162,7 +162,8 @@ Node TermRegistry::lengthPositive(Node t)
   Node tlen = nm->mkNode(STRING_LENGTH, t);
   Node tlenEqZero = tlen.eqNode(zero);
   Node tEqEmp = t.eqNode(emp);
-  Node caseEmpty = tEqEmp;
+  Node caseEmpty = nm->mkNode(AND, tlenEqZero, tEqEmp);
+  //Node caseEmpty = tEqEmp;
   Node caseNEmpty = nm->mkNode(GT, tlen, zero);
   // (or (and (= (str.len t) 0) (= t "")) (> (str.len t) 0))
   return nm->mkNode(OR, caseEmpty, caseNEmpty);
@@ -286,7 +287,7 @@ void TermRegistry::registerTermInternal(Node n)
     //  for concat/const/replace, introduce proxy var and state length relation
     regTermLem = getRegisterTermLemma(n);
   }
-  else if (n.getKind() != STRING_CONTAINS)
+  else
   {
     // we don't send out eager reduction lemma for str.contains currently
     bool doEagerReduce = true;
@@ -297,8 +298,9 @@ void TermRegistry::registerTermInternal(Node n)
     }
     else if (k==STRING_TO_CODE)
     {
-      //Node c = SkolemManager::getOriginalForm(n[0]);
-      //doEagerReduce = !c.isConst();
+      // code for proxy are implied
+      Node c = SkolemManager::getOriginalForm(n[0]);
+      doEagerReduce = !c.isConst();
     }
     if (doEagerReduce)
     {

--- a/src/theory/strings/term_registry.cpp
+++ b/src/theory/strings/term_registry.cpp
@@ -163,7 +163,7 @@ Node TermRegistry::lengthPositive(Node t)
   Node tlenEqZero = tlen.eqNode(zero);
   Node tEqEmp = t.eqNode(emp);
   Node caseEmpty = nm->mkNode(AND, tlenEqZero, tEqEmp);
-  //Node caseEmpty = tEqEmp;
+  // Node caseEmpty = tEqEmp;
   Node caseNEmpty = nm->mkNode(GT, tlen, zero);
   // (or (and (= (str.len t) 0) (= t "")) (> (str.len t) 0))
   return nm->mkNode(OR, caseEmpty, caseNEmpty);
@@ -292,11 +292,11 @@ void TermRegistry::registerTermInternal(Node n)
     // we don't send out eager reduction lemma for str.contains currently
     bool doEagerReduce = true;
     Kind k = n.getKind();
-    if (k==STRING_CONTAINS)
+    if (k == STRING_CONTAINS)
     {
       doEagerReduce = false;
     }
-    else if (k==STRING_TO_CODE)
+    else if (k == STRING_TO_CODE)
     {
       // code for proxy are implied
       Node c = SkolemManager::getOriginalForm(n[0]);

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -79,7 +79,7 @@ TheoryStrings::TheoryStrings(Env& env, OutputChannel& out, Valuation valuation)
                 d_csolver,
                 d_extTheory,
                 d_statistics),
-      d_psolver(env, d_state, d_im, d_termReg, d_bsolver),
+      d_psolver(env, d_state, d_im, d_termReg, d_bsolver, d_csolver),
       d_asolver(env,
                 d_state,
                 d_im,

--- a/test/binary/interactive_shell.py
+++ b/test/binary/interactive_shell.py
@@ -52,7 +52,7 @@ def check_iteractive_shell():
     child.sendcontrol("m")
 
     # So we expect to see an error for 'BOOLE'
-    child.expect("Error")
+    child.expect("Expected SMT-LIBv2 symbol")
 
     # Send enter
     child.sendcontrol("m")
@@ -67,7 +67,7 @@ def check_iteractive_shell():
     child.sendcontrol("m")
 
     # We expect to see the previous error again
-    child.expect("Error")
+    child.expect("Expected SMT-LIBv2 symbol")
 
     return 0
 

--- a/test/binary/interactive_shell.py
+++ b/test/binary/interactive_shell.py
@@ -52,7 +52,7 @@ def check_iteractive_shell():
     child.sendcontrol("m")
 
     # So we expect to see an error for 'BOOLE'
-    child.expect("Expected SMT-LIBv2 symbol")
+    child.expect("Error")
 
     # Send enter
     child.sendcontrol("m")
@@ -67,7 +67,7 @@ def check_iteractive_shell():
     child.sendcontrol("m")
 
     # We expect to see the previous error again
-    child.expect("Expected SMT-LIBv2 symbol")
+    child.expect("Error")
 
     return 0
 


### PR DESCRIPTION
This PR changes when we apply injectivity (see C-Inj https://homepage.divms.uiowa.edu/~ajreynol/ijcar20a.pdf) for str.to_code.

In particular, it should only be necessary to apply injectivity for pairs of string equivalence classes that may have length 1 and that are disequal.  Previously we applied it to add pairs of equivalence classes, apart from pairs that both contain constants.

This allows us to send significantly fewer lemmas in some cases and has a positive effect on a small number of benchmarks of interest. 

It also changes so we don't do a reduction lemma (range constraint) for str.to_code applied to concrete strings, since we have a concrete integer equality in these cases.