### PR TITLE
Reverted CMAKE_BUILD_PARALLEL_LEVEL change.

### DIFF
--- a/test/api/cpp/CMakeLists.txt
+++ b/test/api/cpp/CMakeLists.txt
@@ -30,7 +30,6 @@ add_test(build_apitests_test
     "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" 
     --config "$<CONFIG>" --target build-apitests
 )
-set_property(TEST build_apitests_test PROPERTY ENVIRONMENT "CMAKE_BUILD_PARALLEL_LEVEL=${CTEST_NTHREADS}")
 set_tests_properties(build_apitests_test PROPERTIES FIXTURES_SETUP build_apitests_fixture)
 
 add_custom_target(apitests

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -3589,7 +3589,6 @@ add_test(build_regress_test
     "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" 
     --config "$<CONFIG>" --target build-regress
 )
-set_property(TEST build_regress_test PROPERTY ENVIRONMENT "CMAKE_BUILD_PARALLEL_LEVEL=${CTEST_NTHREADS}")
 set_tests_properties(build_regress_test PROPERTIES FIXTURES_SETUP build_regress_fixture)
 
 macro(cvc5_add_regression_test level file)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -32,7 +32,6 @@ add_test(build_units_test
     "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" 
     --config "$<CONFIG>" --target build-units
 )
-set_property(TEST build_units_test PROPERTY ENVIRONMENT "CMAKE_BUILD_PARALLEL_LEVEL=${CTEST_NTHREADS}")
 set_tests_properties(build_units_test PROPERTIES FIXTURES_SETUP build_units_fixture)
 
 add_custom_target(units


### PR DESCRIPTION
As discussed offline, I propose we do not change the CMAKE_BUILD_PARALLEL_LEVEL property of the "fake test" that builds other tests. 
Related to [#9750](https://github.com/cvc5/cvc5/pull/9750).