### PR TITLE
Revert corner case in branch and bound

### DIFF
--- a/cmake/Helpers.cmake
+++ b/cmake/Helpers.cmake
@@ -257,5 +257,23 @@ function(check_python_module module)
 endfunction()
 
 macro(find_supported_python_version)
-  find_package(Python 3.11 EXACT COMPONENTS Interpreter REQUIRED)
+  if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.19")
+    find_package(Python 3.6...<3.10.999 COMPONENTS Interpreter REQUIRED)
+  else()
+    # The version range syntax is only supported from CMake 3.19 on.
+    # So, for previous versions, we manually search for an allowed python version
+    foreach (python_version 3.10 3.9 3.8 3.7 3.6)
+      find_package(Python ${python_version} EXACT COMPONENTS Interpreter)
+      if(${Python_FOUND})
+        break()
+      endif()
+    endforeach()
+
+    if (NOT ${Python_FOUND})
+      message(FATAL_ERROR 
+         "Could not find a suitable Python version. Only Python versions <=3.10 are currently supported."
+      )
+    endif()
+
+  endif()
 endmacro()

--- a/cmake/Helpers.cmake
+++ b/cmake/Helpers.cmake
@@ -257,23 +257,5 @@ function(check_python_module module)
 endfunction()
 
 macro(find_supported_python_version)
-  if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.19")
-    find_package(Python 3.6...<3.10.999 COMPONENTS Interpreter REQUIRED)
-  else()
-    # The version range syntax is only supported from CMake 3.19 on.
-    # So, for previous versions, we manually search for an allowed python version
-    foreach (python_version 3.10 3.9 3.8 3.7 3.6)
-      find_package(Python ${python_version} EXACT COMPONENTS Interpreter)
-      if(${Python_FOUND})
-        break()
-      endif()
-    endforeach()
-
-    if (NOT ${Python_FOUND})
-      message(FATAL_ERROR 
-         "Could not find a suitable Python version. Only Python versions <=3.10 are currently supported."
-      )
-    endif()
-
-  endif()
+  find_package(Python 3.11 EXACT COMPONENTS Interpreter REQUIRED)
 endmacro()

--- a/src/theory/arith/branch_and_bound.cpp
+++ b/src/theory/arith/branch_and_bound.cpp
@@ -42,28 +42,10 @@ BranchAndBound::BranchAndBound(Env& env,
 }
 
 std::vector<TrustNode> BranchAndBound::branchIntegerVariable(TNode var,
-                                                             Rational value,
-                                                             bool doPurify)
+                                                             Rational value)
 {
   std::vector<TrustNode> lems;
   NodeManager* nm = NodeManager::currentNM();
-  if (doPurify)
-  {
-    Node k = nm->getSkolemManager()->mkPurifySkolem(var, "bbk");
-    Node eq = k.eqNode(var);
-    if (proofsEnabled())
-    {
-      // justified trivially by predicate introduction
-      lems.push_back(
-          d_pfGen->mkTrustNode(eq, PfRule::MACRO_SR_PRED_INTRO, {}, {eq}));
-    }
-    else
-    {
-      lems.push_back(TrustNode::mkTrustLemma(eq, nullptr));
-    }
-    // now use the purification variable
-    var = k;
-  }
   Integer floor = value.floor();
   if (options().arith.brabTest)
   {
@@ -77,12 +59,10 @@ std::vector<TrustNode> BranchAndBound::branchIntegerVariable(TNode var,
     // Prioritize trying a simple rounding of the real solution first,
     // it that fails, fall back on original branch and bound strategy.
     Node ub = rewrite(nm->mkNode(LEQ, var, nm->mkConstInt(nearest - 1)));
+    // The rewritten form should be a GEQ literal, otherwise the split returned
+    // by this method will not have its intended effect
+    Assert (ub.getKind()==GEQ ||( ub.getKind()==NOT && ub[0].getKind()==GEQ));
     Node ubatom = ub.getKind() == NOT ? ub[0] : ub;
-    // if it rewrites to a non-arithmetic inequality, we must purify
-    if (ubatom.getKind() != GEQ && !doPurify)
-    {
-      return branchIntegerVariable(var, value, true);
-    }
     Node lb = rewrite(nm->mkNode(GEQ, var, nm->mkConstInt(nearest + 1)));
     Node right = nm->mkNode(OR, ub, lb);
     Node rawEq = nm->mkNode(EQUAL, var, nm->mkConstInt(nearest));
@@ -144,12 +124,9 @@ std::vector<TrustNode> BranchAndBound::branchIntegerVariable(TNode var,
   else
   {
     Node ub = rewrite(nm->mkNode(LEQ, var, nm->mkConstInt(floor)));
-    Node ubatom = ub.getKind() == NOT ? ub[0] : ub;
-    // if it rewrites to a non-arithmetic inequality, we must purify
-    if (ubatom.getKind() != GEQ && !doPurify)
-    {
-      return branchIntegerVariable(var, value, true);
-    }
+    // Similar to above, the rewritten form should be a GEQ literal, otherwise
+    // the split returned by this method will not have its intended effect
+    Assert (ub.getKind()==GEQ ||( ub.getKind()==NOT && ub[0].getKind()==GEQ));
     Node lb = ub.notNode();
     if (proofsEnabled())
     {

--- a/src/theory/arith/branch_and_bound.cpp
+++ b/src/theory/arith/branch_and_bound.cpp
@@ -61,7 +61,8 @@ std::vector<TrustNode> BranchAndBound::branchIntegerVariable(TNode var,
     Node ub = rewrite(nm->mkNode(LEQ, var, nm->mkConstInt(nearest - 1)));
     // The rewritten form should be a GEQ literal, otherwise the split returned
     // by this method will not have its intended effect
-    Assert (ub.getKind()==GEQ ||( ub.getKind()==NOT && ub[0].getKind()==GEQ));
+    Assert(ub.getKind() == GEQ
+           || (ub.getKind() == NOT && ub[0].getKind() == GEQ));
     Node ubatom = ub.getKind() == NOT ? ub[0] : ub;
     Node lb = rewrite(nm->mkNode(GEQ, var, nm->mkConstInt(nearest + 1)));
     Node right = nm->mkNode(OR, ub, lb);
@@ -126,7 +127,8 @@ std::vector<TrustNode> BranchAndBound::branchIntegerVariable(TNode var,
     Node ub = rewrite(nm->mkNode(LEQ, var, nm->mkConstInt(floor)));
     // Similar to above, the rewritten form should be a GEQ literal, otherwise
     // the split returned by this method will not have its intended effect
-    Assert (ub.getKind()==GEQ ||( ub.getKind()==NOT && ub[0].getKind()==GEQ));
+    Assert(ub.getKind() == GEQ
+           || (ub.getKind() == NOT && ub[0].getKind() == GEQ));
     Node lb = ub.notNode();
     if (proofsEnabled())
     {

--- a/src/theory/arith/branch_and_bound.h
+++ b/src/theory/arith/branch_and_bound.h
@@ -53,8 +53,7 @@ class BranchAndBound : protected EnvObj
    * @param var The variable to branch on
    * @param value Its current model value
    */
-  std::vector<TrustNode> branchIntegerVariable(TNode var,
-                                               Rational value);
+  std::vector<TrustNode> branchIntegerVariable(TNode var, Rational value);
 
  private:
   /** Are proofs enabled? */

--- a/src/theory/arith/branch_and_bound.h
+++ b/src/theory/arith/branch_and_bound.h
@@ -52,17 +52,9 @@ class BranchAndBound : protected EnvObj
    *
    * @param var The variable to branch on
    * @param value Its current model value
-   * @param doPurify If true, we send the lemma (= k var) and branch on k
-   * instead, where k is the purification skolem for var.
-   *
-   * Note if doPurify is true, this method additionally includes a purification
-   * lemma as described above. If doPurify is false, this method may choose
-   * to set doPurify if necessary, in the case that the inequality is eliminated
-   * by rewriting. This can be the case when var is (bv2nat x).
    */
   std::vector<TrustNode> branchIntegerVariable(TNode var,
-                                               Rational value,
-                                               bool doPurify = false);
+                                               Rational value);
 
  private:
   /** Are proofs enabled? */


### PR DESCRIPTION
This special handling was added in https://github.com/cvc5/cvc5/pull/9507 as a way of being robust wrt inequalities involving `bv2nat` which may rewrite.

Since then, we have reverted to a policy where arithmetic inequalities never rewrite to non-arithmetic inequalities. 

This PR adds an assertion and reverts the case added in #9507.