### PR TITLE
Refactor interface for any constant constructors

### DIFF
--- a/src/expr/dtype_cons.cpp
+++ b/src/expr/dtype_cons.cpp
@@ -114,7 +114,7 @@ void DTypeConstructor::setSygus(Node op)
     // check if stands for the "any constant" constructor
     NodeManager* nm = NodeManager::currentNM();
     SkolemManager* sm = nm->getSkolemManager();
-    if (sm->getSkolemFunctionId(op) == SkolemFunId::SYGUS_ANY_CONSTANT)
+    if (sm->getId(op) == SkolemFunId::SYGUS_ANY_CONSTANT)
     {
       // mark with attribute, which is a faster lookup
       SygusAnyConstAttribute saca;

--- a/src/expr/dtype_cons.cpp
+++ b/src/expr/dtype_cons.cpp
@@ -26,6 +26,12 @@ using namespace cvc5::internal::theory;
 
 namespace cvc5::internal {
 
+/** Attribute true for variables that represent any constant */
+struct SygusAnyConstAttributeId
+{
+};
+typedef expr::Attribute<SygusAnyConstAttributeId, bool> SygusAnyConstAttribute;
+
 DTypeConstructor::DTypeConstructor(std::string name,
                                    unsigned weight)
     :  // We don't want to introduce a new data member, because eventually
@@ -103,6 +109,18 @@ void DTypeConstructor::setSygus(Node op)
 {
   Assert(!isResolved());
   d_sygusOp = op;
+  if (op.getKind() == SKOLEM)
+  {
+    // check if stands for the "any constant" constructor
+    NodeManager* nm = NodeManager::currentNM();
+    SkolemManager* sm = nm->getSkolemManager();
+    if (sm->getSkolemFunctionId(op) == SkolemFunId::SYGUS_ANY_CONSTANT)
+    {
+      // mark with attribute, which is a faster lookup
+      SygusAnyConstAttribute saca;
+      op.setAttribute(saca, true);
+    }
+  }
 }
 
 Node DTypeConstructor::getSygusOp() const
@@ -114,8 +132,16 @@ Node DTypeConstructor::getSygusOp() const
 bool DTypeConstructor::isSygusIdFunc() const
 {
   Assert(isResolved());
+  Assert(!d_sygusOp.isNull());
   return (d_sygusOp.getKind() == LAMBDA && d_sygusOp[0].getNumChildren() == 1
           && d_sygusOp[0][0] == d_sygusOp[1]);
+}
+
+bool DTypeConstructor::isSygusAnyConstant() const
+{
+  Assert(isResolved());
+  Assert(!d_sygusOp.isNull());
+  return d_sygusOp.getAttribute(SygusAnyConstAttribute());
 }
 
 unsigned DTypeConstructor::getWeight() const

--- a/src/expr/dtype_cons.h
+++ b/src/expr/dtype_cons.h
@@ -104,6 +104,11 @@ class DTypeConstructor
    * operator op.
    */
   void setSygus(Node op);
+  /**
+   * Set that this constructor is a sygus datatype constructor that encodes
+   * any constant.
+   */
+  void setSygusAnyConstant();
   /** get sygus op
    *
    * This method returns the operator or term that this constructor represents
@@ -117,6 +122,8 @@ class DTypeConstructor
    * of the form (lambda (x) x).
    */
   bool isSygusIdFunc() const;
+  /** is this the "any constant" constructor? */
+  bool isSygusAnyConstant() const;
   /** get weight
    *
    * Get the weight of this constructor. This value is used when computing the

--- a/src/expr/dtype_cons.h
+++ b/src/expr/dtype_cons.h
@@ -101,14 +101,10 @@ class DTypeConstructor
   /** set sygus
    *
    * Set that this constructor is a sygus datatype constructor that encodes
-   * operator op.
+   * operator op. If op is a skolem with id SYGUS_ANY_CONSTANT, then this
+   * is treated as the "any constant" constructor.
    */
   void setSygus(Node op);
-  /**
-   * Set that this constructor is a sygus datatype constructor that encodes
-   * any constant.
-   */
-  void setSygusAnyConstant();
   /** get sygus op
    *
    * This method returns the operator or term that this constructor represents

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -103,6 +103,7 @@ const char* toString(SkolemFunId id)
     case SkolemFunId::IEVAL_NONE: return "IEVAL_NONE";
     case SkolemFunId::IEVAL_SOME: return "IEVAL_SOME";
     case SkolemFunId::ABSTRACT_VALUE: return "ABSTRACT_VALUE";
+    case SkolemFunId::SYGUS_ANY_CONSTANT: return "SYGUS_ANY_CONSTANT";
     default: return "?";
   }
 }
@@ -206,6 +207,17 @@ bool SkolemManager::isSkolemFunction(TNode k,
   id = std::get<0>(it->second);
   cacheVal = std::get<2>(it->second);
   return true;
+}
+
+SkolemFunId SkolemManager::getSkolemFunctionId(TNode k) const
+{
+  SkolemFunId id;
+  Node cacheVal;
+  if (isSkolemFunction(k, id, cacheVal))
+  {
+    return id;
+  }
+  return SkolemFunId::NONE;
 }
 
 Node SkolemManager::mkDummySkolem(const std::string& prefix,

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -209,7 +209,7 @@ bool SkolemManager::isSkolemFunction(TNode k,
   return true;
 }
 
-SkolemFunId SkolemManager::getSkolemFunctionId(TNode k) const
+SkolemFunId SkolemManager::getId(TNode k) const
 {
   SkolemFunId id;
   Node cacheVal;

--- a/src/expr/skolem_manager.h
+++ b/src/expr/skolem_manager.h
@@ -229,7 +229,9 @@ enum class SkolemFunId
   /** the "none" term, for instantiation evaluation */
   IEVAL_NONE,
   /** the "some" term, for instantiation evaluation */
-  IEVAL_SOME
+  IEVAL_SOME,
+  /** sygus "any constant" placeholder */
+  SYGUS_ANY_CONSTANT
 };
 /** Converts a skolem function name to a string. */
 const char* toString(SkolemFunId id);
@@ -370,6 +372,10 @@ class SkolemManager
    * call. Updates the arguments to the values used when constructing it.
    */
   bool isSkolemFunction(TNode k, SkolemFunId& id, Node& cacheVal) const;
+  /**
+   * Get skolem function id
+   */
+  SkolemFunId getSkolemFunctionId(TNode k) const;
   /**
    * Create a skolem constant with the given name, type, and comment. This
    * should only be used if the definition of the skolem does not matter.

--- a/src/expr/skolem_manager.h
+++ b/src/expr/skolem_manager.h
@@ -375,7 +375,7 @@ class SkolemManager
   /**
    * Get skolem function id
    */
-  SkolemFunId getSkolemFunctionId(TNode k) const;
+  SkolemFunId getId(TNode k) const;
   /**
    * Create a skolem constant with the given name, type, and comment. This
    * should only be used if the definition of the skolem does not matter.

--- a/src/expr/sygus_datatype.cpp
+++ b/src/expr/sygus_datatype.cpp
@@ -42,17 +42,13 @@ void SygusDatatype::addAnyConstantConstructor(TypeNode tn)
 {
   SkolemManager* sm = NodeManager::currentNM()->getSkolemManager();
   // add an "any constant" proxy variable
-  Node av = sm->mkDummySkolem("_any_constant", tn);
-  // mark that it represents any constant
-  SygusAnyConstAttribute saca;
-  av.setAttribute(saca, true);
+  Node av = sm->mkSkolemFunction(SkolemFunId::SYGUS_ANY_CONSTANT, tn);
   std::stringstream ss;
   ss << getName() << "_any_constant";
   std::string cname(ss.str());
   std::vector<TypeNode> builtinArg;
   builtinArg.push_back(tn);
-  addConstructor(
-      av, cname, builtinArg, 0);
+  addConstructor(av, cname, builtinArg, 0);
 }
 void SygusDatatype::addConstructor(Kind k,
                                    const std::vector<TypeNode>& argTypes,

--- a/src/expr/sygus_datatype.h
+++ b/src/expr/sygus_datatype.h
@@ -27,12 +27,6 @@
 
 namespace cvc5::internal {
 
-/** Attribute true for variables that represent any constant */
-struct SygusAnyConstAttributeId
-{
-};
-typedef expr::Attribute<SygusAnyConstAttributeId, bool> SygusAnyConstAttribute;
-
 /**
  * Information necessary to specify a sygus constructor. Further detail on these
  * fields can be found in SygusDatatype below.

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -2026,31 +2026,31 @@ std::string Smt2Printer::sygusGrammarString(const TypeNode& t)
         const DTypeConstructor& cons = dt[i];
         if (cons.isSygusAnyConstant())
         {
-        types_list << "(Constant " << cons[0].getRangeType() << ") ";
+          types_list << "(Constant " << cons[0].getRangeType() << ") ";
         }
         else
         {
-        // make a sygus term
-        std::vector<Node> cchildren;
-        cchildren.push_back(cons.getConstructor());
-        for (size_t j = 0, nargs = cons.getNumArgs(); j < nargs; j++)
-        {
-          TypeNode argType = cons[j].getRangeType();
-          std::stringstream ss;
-          ss << argType;
-          Node bv = nm->mkBoundVar(ss.str(), argType);
-          cchildren.push_back(bv);
-          // if fresh type, store it for later processing
-          if (grammarTypes.insert(argType).second)
+          // make a sygus term
+          std::vector<Node> cchildren;
+          cchildren.push_back(cons.getConstructor());
+          for (size_t j = 0, nargs = cons.getNumArgs(); j < nargs; j++)
           {
-            typesToPrint.push_back(argType);
+            TypeNode argType = cons[j].getRangeType();
+            std::stringstream ss;
+            ss << argType;
+            Node bv = nm->mkBoundVar(ss.str(), argType);
+            cchildren.push_back(bv);
+            // if fresh type, store it for later processing
+            if (grammarTypes.insert(argType).second)
+            {
+              typesToPrint.push_back(argType);
+            }
           }
-        }
-        Node consToPrint = nm->mkNode(kind::APPLY_CONSTRUCTOR, cchildren);
-        // now, print it using the conversion to builtin with external
-        types_list << theory::datatypes::utils::sygusToBuiltin(consToPrint,
-                                                               true);
-        types_list << ' ';
+          Node consToPrint = nm->mkNode(kind::APPLY_CONSTRUCTOR, cchildren);
+          // now, print it using the conversion to builtin with external
+          types_list << theory::datatypes::utils::sygusToBuiltin(consToPrint,
+                                                                true);
+          types_list << ' ';
         }
       }
       types_list << "))\n";

--- a/src/theory/datatypes/sygus_datatype_utils.cpp
+++ b/src/theory/datatypes/sygus_datatype_utils.cpp
@@ -21,6 +21,7 @@
 #include "expr/dtype_cons.h"
 #include "expr/node_algorithm.h"
 #include "expr/sygus_datatype.h"
+#include "expr/skolem_manager.h"
 #include "smt/env.h"
 #include "theory/evaluator.h"
 #include "theory/rewriter.h"
@@ -150,6 +151,8 @@ Node mkSygusTerm(const Node& op,
                  const std::vector<Node>& children,
                  bool doBetaReduction)
 {
+  NodeManager * nm = NodeManager::currentNM();
+  Assert (nm->getSkolemManager()->getSkolemId(op)!=SkolemFunId::SYGUS_ANY_CONSTANT);
   Trace("dt-sygus-util") << "Operator is " << op << std::endl;
   if (children.empty())
   {
@@ -183,7 +186,7 @@ Node mkSygusTerm(const Node& op,
   Node ret;
   if (ok == BUILTIN)
   {
-    ret = NodeManager::currentNM()->mkNode(op, schildren);
+    ret = nm->mkNode(op, schildren);
     Trace("dt-sygus-util") << "...return (builtin) " << ret << std::endl;
     return ret;
   }
@@ -195,7 +198,7 @@ Node mkSygusTerm(const Node& op,
     // If it is an APPLY_UF operator, we should have at least an operator and
     // a child.
     Assert(otk != APPLY_UF || schildren.size() != 1);
-    ret = NodeManager::currentNM()->mkNode(otk, schildren);
+    ret = nm->mkNode(otk, schildren);
     Trace("dt-sygus-util") << "...return (op) " << ret << std::endl;
     return ret;
   }

--- a/src/theory/datatypes/sygus_datatype_utils.cpp
+++ b/src/theory/datatypes/sygus_datatype_utils.cpp
@@ -20,8 +20,8 @@
 #include "expr/dtype.h"
 #include "expr/dtype_cons.h"
 #include "expr/node_algorithm.h"
-#include "expr/sygus_datatype.h"
 #include "expr/skolem_manager.h"
+#include "expr/sygus_datatype.h"
 #include "smt/env.h"
 #include "theory/evaluator.h"
 #include "theory/rewriter.h"
@@ -151,8 +151,9 @@ Node mkSygusTerm(const Node& op,
                  const std::vector<Node>& children,
                  bool doBetaReduction)
 {
-  NodeManager * nm = NodeManager::currentNM();
-  Assert (nm->getSkolemManager()->getSkolemId(op)!=SkolemFunId::SYGUS_ANY_CONSTANT);
+  NodeManager* nm = NodeManager::currentNM();
+  Assert(nm->getSkolemManager()->getSkolemId(op)
+         != SkolemFunId::SYGUS_ANY_CONSTANT);
   Trace("dt-sygus-util") << "Operator is " << op << std::endl;
   if (children.empty())
   {

--- a/src/theory/datatypes/sygus_datatype_utils.cpp
+++ b/src/theory/datatypes/sygus_datatype_utils.cpp
@@ -152,8 +152,7 @@ Node mkSygusTerm(const Node& op,
                  bool doBetaReduction)
 {
   NodeManager* nm = NodeManager::currentNM();
-  Assert(nm->getSkolemManager()->getSkolemId(op)
-         != SkolemFunId::SYGUS_ANY_CONSTANT);
+  Assert(nm->getSkolemManager()->getId(op) != SkolemFunId::SYGUS_ANY_CONSTANT);
   Trace("dt-sygus-util") << "Operator is " << op << std::endl;
   if (children.empty())
   {

--- a/src/theory/datatypes/sygus_datatype_utils.h
+++ b/src/theory/datatypes/sygus_datatype_utils.h
@@ -104,7 +104,7 @@ Node mkSygusTerm(const DType& dt,
  * Same as above, but we already have the sygus operator op. The above method
  * is syntax sugar for calling this method on dt[i].getSygusOp().
  *
- * Note that this method should not be used on sygus operators that denote 
+ * Note that this method should not be used on sygus operators that denote
  * the "any constant" constructor.
  */
 Node mkSygusTerm(const Node& op,

--- a/src/theory/datatypes/sygus_datatype_utils.h
+++ b/src/theory/datatypes/sygus_datatype_utils.h
@@ -103,6 +103,9 @@ Node mkSygusTerm(const DType& dt,
 /**
  * Same as above, but we already have the sygus operator op. The above method
  * is syntax sugar for calling this method on dt[i].getSygusOp().
+ *
+ * Note that this method should not be used on sygus operators that denote 
+ * the "any constant" constructor.
  */
 Node mkSygusTerm(const Node& op,
                  const std::vector<Node>& children,

--- a/src/theory/datatypes/sygus_datatype_utils.h
+++ b/src/theory/datatypes/sygus_datatype_utils.h
@@ -104,7 +104,7 @@ Node mkSygusTerm(const DType& dt,
  * Same as above, but we already have the sygus operator op. The above method
  * is syntax sugar for calling this method on dt[i].getSygusOp().
  */
-Node mkSygusTerm(Node op,
+Node mkSygusTerm(const Node& op,
                  const std::vector<Node>& children,
                  bool doBetaReduction = true);
 /**

--- a/src/theory/datatypes/sygus_extension.cpp
+++ b/src/theory/datatypes/sygus_extension.cpp
@@ -589,7 +589,7 @@ Node SygusExtension::getSimpleSymBreakPred(Node e,
   // get the kind of the constructor operator
   Kind nk = ti.getConsNumKind(tindex);
   // is this the any-constant constructor?
-  bool isAnyConstant = sop.getAttribute(SygusAnyConstAttribute());
+  bool isAnyConstant = dt[tindex].isSygusAnyConstant();
 
   // conjunctive conclusion of lemma
   std::vector<Node> sbp_conj;

--- a/src/theory/quantifiers/sygus/sygus_eval_unfold.cpp
+++ b/src/theory/quantifiers/sygus/sygus_eval_unfold.cpp
@@ -272,8 +272,7 @@ Node SygusEvalUnfold::unfold(Node en,
     }
   }
   // if we are a symbolic constructor, unfolding returns the subterm itself
-  Node sop = dt[i].getSygusOp();
-  if (sop.getAttribute(SygusAnyConstAttribute()))
+  if (dt[i].isSygusAnyConstant())
   {
     Trace("sygus-eval-unfold-debug")
         << "...it is an any-constant constructor" << std::endl;
@@ -335,6 +334,7 @@ Node SygusEvalUnfold::unfold(Node en,
     pre[j] = argj;
   }
   Node ret = d_tds->mkGeneric(dt, i, pre);
+  Node sop = dt[i].getSygusOp();
   // apply the appropriate substitution to ret
   ret = datatypes::utils::applySygusArgs(dt, sop, ret, args);
   Trace("sygus-eval-unfold-debug")

--- a/src/theory/quantifiers/sygus/sygus_grammar_red.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_red.cpp
@@ -44,13 +44,13 @@ void SygusRedundantCons::initialize(TermDbSygus* tds, TypeNode tn)
   {
     Trace("sygus-red") << "  Is " << dt[i].getName() << " a redundant operator?"
                        << std::endl;
-    Node sop = dt[i].getSygusOp();
-    if (sop.getAttribute(SygusAnyConstAttribute()))
+    if (dt[i].isSygusAnyConstant())
     {
       // the any constant constructor is never redundant
       d_sygus_red_status.push_back(0);
       continue;
     }
+    Node sop = dt[i].getSygusOp();
     std::map<int, Node> pre;
     // We do not do beta reduction, since we want the arguments to match the
     // the types of the datatype.

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -324,8 +324,7 @@ bool SygusRepairConst::isRepairable(Node n, bool useConstantsAsHoles)
   }
   Node op = n.getOperator();
   unsigned cindex = datatypes::utils::indexOf(op);
-  Node sygusOp = dt[cindex].getSygusOp();
-  if (sygusOp.getAttribute(SygusAnyConstAttribute()))
+  if (dt[cindex].isSygusAnyConstant())
   {
     // if it represents "any constant" then it is repairable
     return true;
@@ -336,7 +335,7 @@ bool SygusRepairConst::isRepairable(Node n, bool useConstantsAsHoles)
   }
   if (useConstantsAsHoles && dt.getSygusAllowConst())
   {
-    if (sygusOp.isConst())
+    if (dt[cindex].getSygusOp().isConst())
     {
       // if a constant, it is repairable
       return true;

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -889,9 +889,8 @@ bool TermDbSygus::isSymbolicConsApp(Node n) const
   const DType& dt = tn.getDType();
   Assert(dt.isSygus());
   unsigned cindex = datatypes::utils::indexOf(n.getOperator());
-  Node sygusOp = dt[cindex].getSygusOp();
   // it is symbolic if it represents "any constant"
-  return sygusOp.getAttribute(SygusAnyConstAttribute());
+  return dt[cindex].isSygusAnyConstant();
 }
 
 bool TermDbSygus::canConstructKind(TypeNode tn,

--- a/src/theory/quantifiers/sygus/type_info.cpp
+++ b/src/theory/quantifiers/sygus/type_info.cpp
@@ -153,7 +153,7 @@ void SygusTypeInfo::initialize(TermDbSygus* tds, TypeNode tn)
       d_arg_kind[i] = builtinKind;
     }
     // symbolic constructors
-    if (sop.getAttribute(SygusAnyConstAttribute()))
+    if (dt[i].isSygusAnyConstant())
     {
       d_sym_cons_any_constant = i;
       d_has_subterm_sym_cons = true;

--- a/test/regress/cli/regress0/sygus/print-grammar.sy
+++ b/test/regress/cli/regress0/sygus/print-grammar.sy
@@ -2,8 +2,8 @@
 ; COMMAND-LINE: -o sygus-grammar
 ; EXPECT: (sygus-grammar f
 ; EXPECT: ((f_Int Int) (f_Bool Bool) )
-; EXPECT: ((f_Int Int ((Constant Int) x y 0 1 (+ f_Int f_Int) (- f_Int f_Int) (ite f_Bool f_Int f_Int) ))
-; EXPECT: (f_Bool Bool ((Constant Bool) true false (= f_Int f_Int) (<= f_Int f_Int) (not f_Bool) (and f_Bool f_Bool) (or f_Bool f_Bool) ))
+; EXPECT: ((f_Int Int (x y 0 1 (+ f_Int f_Int) (- f_Int f_Int) (ite f_Bool f_Int f_Int) ))
+; EXPECT: (f_Bool Bool (true false (= f_Int f_Int) (<= f_Int f_Int) (not f_Bool) (and f_Bool f_Bool) (or f_Bool f_Bool) ))
 ; EXPECT: ))
 ; EXPECT: (
 ; EXPECT: (define-fun f ((x Int) (y Int)) Int 0)


### PR DESCRIPTION
This cleans how "any constant" constructors are processed in preparation for the new utilities for internal grammar construction.

This also corrects two issues in the smt2 printer for grammars, which printed "any constant" constructors when they didn't exist (based on the type property) and crashed when printing "any constant" constructors when they did exist.