### PR TITLE
Automatically include skolem definitions in timeout core

### DIFF
--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -793,7 +793,13 @@ std::pair<Result, std::vector<Node>> SolverEngine::getTimeoutCore()
   {
     passerts.push_back(a);
   }
-  std::pair<Result, std::vector<Node>> ret = tcm.getTimeoutCore(passerts);
+  const context::CDHashMap<size_t, Node>& ppsm = d_smtSolver->getPreprocessedSkolemMap();
+  std::map<size_t, Node> ppSkolemMap;
+  for (auto& pk : ppsm)
+  {
+    ppSkolemMap[pk.first] = pk.second;
+  }
+  std::pair<Result, std::vector<Node>> ret = tcm.getTimeoutCore(passerts, ppSkolemMap);
   // convert the preprocessed assertions to input assertions
   std::vector<Node> core = convertPreprocessedToInput(ret.second, true);
   endCall();

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -793,13 +793,15 @@ std::pair<Result, std::vector<Node>> SolverEngine::getTimeoutCore()
   {
     passerts.push_back(a);
   }
-  const context::CDHashMap<size_t, Node>& ppsm = d_smtSolver->getPreprocessedSkolemMap();
+  const context::CDHashMap<size_t, Node>& ppsm =
+      d_smtSolver->getPreprocessedSkolemMap();
   std::map<size_t, Node> ppSkolemMap;
   for (auto& pk : ppsm)
   {
     ppSkolemMap[pk.first] = pk.second;
   }
-  std::pair<Result, std::vector<Node>> ret = tcm.getTimeoutCore(passerts, ppSkolemMap);
+  std::pair<Result, std::vector<Node>> ret =
+      tcm.getTimeoutCore(passerts, ppSkolemMap);
   // convert the preprocessed assertions to input assertions
   std::vector<Node> core = convertPreprocessedToInput(ret.second, true);
   endCall();

--- a/src/smt/timeout_core_manager.cpp
+++ b/src/smt/timeout_core_manager.cpp
@@ -45,7 +45,7 @@ TimeoutCoreManager::TimeoutCoreManager(Env& env)
 
 std::pair<Result, std::vector<Node>> TimeoutCoreManager::getTimeoutCore(
     const std::vector<Node>& ppAsserts,
-                                                      const std::map<size_t, Node>& ppSkolemMap)
+    const std::map<size_t, Node>& ppSkolemMap)
 {
   initializePreprocessedAssertions(ppAsserts, ppSkolemMap);
 
@@ -167,7 +167,7 @@ void TimeoutCoreManager::getNextAssertions(std::vector<Node>& nextAsserts)
     std::unordered_set<Node>& syms = d_syms[d_nextIndexToInclude];
     d_asymbols.insert(syms.begin(), syms.end());
   }
-  
+
   // include the skolem definitions
   getActiveSkolemDefinitions(nextAsserts);
 
@@ -177,7 +177,8 @@ void TimeoutCoreManager::getNextAssertions(std::vector<Node>& nextAsserts)
       << ", #asserts and skolem defs=" << nextAsserts.size() << std::endl;
 }
 
-void TimeoutCoreManager::getActiveSkolemDefinitions(std::vector<Node>& nextAsserts)
+void TimeoutCoreManager::getActiveSkolemDefinitions(
+    std::vector<Node>& nextAsserts)
 {
   if (!d_skolemToAssert.empty())
   {
@@ -185,7 +186,7 @@ void TimeoutCoreManager::getActiveSkolemDefinitions(std::vector<Node>& nextAsser
     for (const Node& s : d_asymbols)
     {
       itk = d_skolemToAssert.find(s);
-      if (itk!=d_skolemToAssert.end())
+      if (itk != d_skolemToAssert.end())
       {
         nextAsserts.push_back(itk->second);
       }
@@ -269,14 +270,14 @@ Result TimeoutCoreManager::checkSatNext(const std::vector<Node>& nextAssertions)
 
 void TimeoutCoreManager::initializePreprocessedAssertions(
     const std::vector<Node>& ppAsserts,
-                                                      const std::map<size_t, Node>& ppSkolemMap)
+    const std::map<size_t, Node>& ppSkolemMap)
 {
   d_ppAsserts.clear();
 
   Trace("smt-to-core") << "initializePreprocessedAssertions" << std::endl;
   Trace("smt-to-core") << "# asserts = " << ppAsserts.size() << std::endl;
   std::map<size_t, Node>::const_iterator itc;
-  for (size_t i=0, nasserts = ppAsserts.size(); i<nasserts; i++)
+  for (size_t i = 0, nasserts = ppAsserts.size(); i < nasserts; i++)
   {
     const Node& pa = ppAsserts[i];
     if (pa.isConst())
@@ -295,7 +296,7 @@ void TimeoutCoreManager::initializePreprocessedAssertions(
       }
     }
     itc = ppSkolemMap.find(i);
-    if (itc==ppSkolemMap.end())
+    if (itc == ppSkolemMap.end())
     {
       d_ppAsserts.push_back(pa);
     }

--- a/src/smt/timeout_core_manager.cpp
+++ b/src/smt/timeout_core_manager.cpp
@@ -310,7 +310,9 @@ void TimeoutCoreManager::initializePreprocessedAssertions(
   {
     expr::getSymbols(d_ppAsserts[i], d_syms[i]);
   }
-  Trace("smt-to-core") << "after processing, #asserts = " << d_ppAsserts.size() << ", #skolem-defs = " << d_skolemToAssert.size() << std::endl;
+  Trace("smt-to-core") << "after processing, #asserts = " << d_ppAsserts.size()
+                       << ", #skolem-defs = " << d_skolemToAssert.size()
+                       << std::endl;
 }
 
 bool TimeoutCoreManager::recordCurrentModel(bool& allAssertsSat,

--- a/src/smt/timeout_core_manager.cpp
+++ b/src/smt/timeout_core_manager.cpp
@@ -44,9 +44,10 @@ TimeoutCoreManager::TimeoutCoreManager(Env& env)
 }
 
 std::pair<Result, std::vector<Node>> TimeoutCoreManager::getTimeoutCore(
-    const std::vector<Node>& ppAsserts)
+    const std::vector<Node>& ppAsserts,
+                                                      const std::map<size_t, Node>& ppSkolemMap)
 {
-  initializePreprocessedAssertions(ppAsserts);
+  initializePreprocessedAssertions(ppAsserts, ppSkolemMap);
 
   std::vector<Node> nextAssertions;
   Result result;
@@ -69,10 +70,12 @@ std::pair<Result, std::vector<Node>> TimeoutCoreManager::getTimeoutCore(
   std::vector<Node> toCore;
   for (std::pair<const size_t, AssertInfo>& a : d_ainfo)
   {
-    Assert(a.first < d_asserts.size());
+    Assert(a.first < d_ppAsserts.size());
     Trace("smt-to-core-asserts") << "...return #" << a.first << std::endl;
-    toCore.push_back(d_asserts[a.first]);
+    toCore.push_back(d_ppAsserts[a.first]);
   }
+  // include the skolem definitions
+  getActiveSkolemDefinitions(toCore);
   return std::pair<Result, std::vector<Node>>(result, toCore);
 }
 
@@ -164,11 +167,30 @@ void TimeoutCoreManager::getNextAssertions(std::vector<Node>& nextAsserts)
     std::unordered_set<Node>& syms = d_syms[d_nextIndexToInclude];
     d_asymbols.insert(syms.begin(), syms.end());
   }
+  
+  // include the skolem definitions
+  getActiveSkolemDefinitions(nextAsserts);
 
   Trace("smt-to-core")
       << "...finished get next assertions, #current assertions = "
       << d_ainfo.size() << ", #free variables = " << d_asymbols.size()
-      << std::endl;
+      << ", #asserts and skolem defs=" << nextAsserts.size() << std::endl;
+}
+
+void TimeoutCoreManager::getActiveSkolemDefinitions(std::vector<Node>& nextAsserts)
+{
+  if (!d_skolemToAssert.empty())
+  {
+    std::map<Node, Node>::const_iterator itk;
+    for (const Node& s : d_asymbols)
+    {
+      itk = d_skolemToAssert.find(s);
+      if (itk!=d_skolemToAssert.end())
+      {
+        nextAsserts.push_back(itk->second);
+      }
+    }
+  }
 }
 
 Result TimeoutCoreManager::checkSatNext(const std::vector<Node>& nextAssertions)
@@ -246,15 +268,17 @@ Result TimeoutCoreManager::checkSatNext(const std::vector<Node>& nextAssertions)
 }
 
 void TimeoutCoreManager::initializePreprocessedAssertions(
-    const std::vector<Node>& ppAsserts)
+    const std::vector<Node>& ppAsserts,
+                                                      const std::map<size_t, Node>& ppSkolemMap)
 {
   d_ppAsserts.clear();
 
   Trace("smt-to-core") << "initializePreprocessedAssertions" << std::endl;
   Trace("smt-to-core") << "# asserts = " << ppAsserts.size() << std::endl;
-  theory::SubstitutionMap& sm = d_env.getTopLevelSubstitutions().get();
-  for (const Node& pa : ppAsserts)
+  std::map<size_t, Node>::const_iterator itc;
+  for (size_t i=0, nasserts = ppAsserts.size(); i<nasserts; i++)
   {
+    const Node& pa = ppAsserts[i];
     if (pa.isConst())
     {
       if (pa.getConst<bool>())
@@ -265,24 +289,19 @@ void TimeoutCoreManager::initializePreprocessedAssertions(
       else
       {
         // false assertion, we are done
-        d_asserts.clear();
         d_ppAsserts.clear();
-        d_asserts.push_back(pa);
         d_ppAsserts.push_back(pa);
         return;
       }
     }
-    // remember the unpreprocessed version
-    d_asserts.push_back(pa);
-    // apply top-level substitutions
-    Node pas = sm.apply(pa);
-    if (pas != pa)
+    itc = ppSkolemMap.find(i);
+    if (itc==ppSkolemMap.end())
     {
-      d_ppAsserts.push_back(rewrite(pas));
+      d_ppAsserts.push_back(pa);
     }
     else
     {
-      d_ppAsserts.push_back(pa);
+      d_skolemToAssert[itc->second] = pa;
     }
   }
   Trace("smt-to-core") << "get symbols..." << std::endl;

--- a/src/smt/timeout_core_manager.cpp
+++ b/src/smt/timeout_core_manager.cpp
@@ -275,7 +275,7 @@ void TimeoutCoreManager::initializePreprocessedAssertions(
   d_ppAsserts.clear();
 
   Trace("smt-to-core") << "initializePreprocessedAssertions" << std::endl;
-  Trace("smt-to-core") << "# asserts = " << ppAsserts.size() << std::endl;
+  Trace("smt-to-core") << "#asserts = " << ppAsserts.size() << std::endl;
   std::map<size_t, Node>::const_iterator itc;
   for (size_t i = 0, nasserts = ppAsserts.size(); i < nasserts; i++)
   {
@@ -310,6 +310,7 @@ void TimeoutCoreManager::initializePreprocessedAssertions(
   {
     expr::getSymbols(d_ppAsserts[i], d_syms[i]);
   }
+  Trace("smt-to-core") << "after processing, #asserts = " << d_ppAsserts.size() << ", #skolem-defs = " << d_skolemToAssert.size() << std::endl;
 }
 
 bool TimeoutCoreManager::recordCurrentModel(bool& allAssertsSat,

--- a/src/smt/timeout_core_manager.h
+++ b/src/smt/timeout_core_manager.h
@@ -80,12 +80,13 @@ class TimeoutCoreManager : protected EnvObj
    */
   std::pair<Result, std::vector<Node>> getTimeoutCore(
       const std::vector<Node>& ppAsserts,
-                                                      const std::map<size_t, Node>& ppSkolemMap);
+      const std::map<size_t, Node>& ppSkolemMap);
 
  private:
   /** initialize assertions */
-  void initializePreprocessedAssertions(const std::vector<Node>& ppAsserts,
-                                                      const std::map<size_t, Node>& ppSkolemMap);
+  void initializePreprocessedAssertions(
+      const std::vector<Node>& ppAsserts,
+      const std::map<size_t, Node>& ppSkolemMap);
   /** get next assertions */
   void getNextAssertions(std::vector<Node>& nextAssertions);
   /** check sat next */
@@ -105,7 +106,7 @@ class TimeoutCoreManager : protected EnvObj
   bool hasCurrentSharedSymbol(size_t i) const;
   /** Add skolem definitions */
   void getActiveSkolemDefinitions(std::vector<Node>& nextAssertions);
-  
+
   /** Common nodes */
   Node d_true;
   Node d_false;

--- a/src/smt/timeout_core_manager.h
+++ b/src/smt/timeout_core_manager.h
@@ -79,11 +79,13 @@ class TimeoutCoreManager : protected EnvObj
    * result has the same guarantees as a response to checkSat.
    */
   std::pair<Result, std::vector<Node>> getTimeoutCore(
-      const std::vector<Node>& ppAsserts);
+      const std::vector<Node>& ppAsserts,
+                                                      const std::map<size_t, Node>& ppSkolemMap);
 
  private:
   /** initialize assertions */
-  void initializePreprocessedAssertions(const std::vector<Node>& ppAsserts);
+  void initializePreprocessedAssertions(const std::vector<Node>& ppAsserts,
+                                                      const std::map<size_t, Node>& ppSkolemMap);
   /** get next assertions */
   void getNextAssertions(std::vector<Node>& nextAssertions);
   /** check sat next */
@@ -101,16 +103,20 @@ class TimeoutCoreManager : protected EnvObj
   /** Does the i^th assertion have a current shared symbol (a free symbol in
    * d_asymbols). */
   bool hasCurrentSharedSymbol(size_t i) const;
+  /** Add skolem definitions */
+  void getActiveSkolemDefinitions(std::vector<Node>& nextAssertions);
+  
   /** Common nodes */
   Node d_true;
   Node d_false;
-  /** The original assertions */
-  std::vector<Node> d_asserts;
   /**
    * The preprocessed assertions, which we have run substitutions and
    * rewriting on
    */
   std::vector<Node> d_ppAsserts;
+  /**
+   */
+  std::map<Node, Node> d_skolemToAssert;
   /**
    * The cache of models, we store a model as the model value of each assertion
    * in d_ppAsserts.


### PR DESCRIPTION
Leads to scalable handling of inputs with many ITE skolems introduced in preprocessing. 