### PR TITLE
Throw parser error for empty list of terms in get-value

### DIFF
--- a/src/parser/smt2/smt2_cmd_parser.cpp
+++ b/src/parser/smt2/smt2_cmd_parser.cpp
@@ -688,7 +688,7 @@ std::unique_ptr<Command> Smt2CmdParser::parseNextCommand()
       cmd.reset(new GetUnsatCoreCommand);
     }
     break;
-    // (get-value (<term>*))
+    // (get-value (<term>+))
     case Token::GET_VALUE_TOK:
     {
       d_state.checkThatLogicIsSet();
@@ -696,6 +696,10 @@ std::unique_ptr<Command> Smt2CmdParser::parseNextCommand()
       // values
       d_state.pushGetValueScope();
       std::vector<Term> terms = d_tparser.parseTermList();
+      if (terms.empty())
+      {
+        d_lex.parseError("Expected non-empty list of terms for get-value");
+      }
       cmd.reset(new GetValueCommand(terms));
       d_state.popScope();
     }

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -993,6 +993,7 @@ set(regress_0_tests
   regress0/parser/force_logic_set_logic.smt2
   regress0/parser/force_logic_success.smt2
   regress0/parser/get-model-sort-constructor.smt2
+  regress0/parser/get-value-empty-err.smt2
   regress0/parser/issue5163.smt2
   regress0/parser/issue6908-get-value-uc.smt2
   regress0/parser/issue7274.smt2

--- a/test/regress/cli/regress0/parser/get-value-empty-err.smt2
+++ b/test/regress/cli/regress0/parser/get-value-empty-err.smt2
@@ -1,0 +1,7 @@
+; DISABLE-TESTER: dump
+; REQUIRES: no-competition
+; SCRUBBER: grep -o "Expected non-empty list of terms for get-value"
+; EXPECT: Expected non-empty list of terms for get-value
+; EXIT: 1
+(set-logic ALL)
+(get-value ())


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/9849.