### PR TITLE
Simplify use of DT_SIZE in sygus

### DIFF
--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -346,6 +346,20 @@ void TheoryDatatypes::preRegisterTerm(TNode n)
 TrustNode TheoryDatatypes::ppRewrite(TNode in, std::vector<SkolemLemma>& lems)
 {
   Trace("datatypes") << "TheoryDatatypes::ppRewrite(" << in << ")" << endl;
+  // Eliminate DT_SIZE, which is only used for enforcing fairness in sygus.
+  // We only assume that DT_SIZE terms are greater than or equal to zero.
+  if (in.getKind() == DT_SIZE)
+  {
+    NodeManager* nm = NodeManager::currentNM();
+    SkolemManager* sm = nm->getSkolemManager();
+    Node k = sm->mkPurifySkolem(in);
+    Node lem = nm->mkNode(LEQ, d_zero, k);
+    Trace("datatypes-infer")
+        << "DtInfer : size geq zero : " << lem << std::endl;
+    TrustNode tlem = TrustNode::mkTrustLemma(lem);
+    lems.emplace_back(tlem, k);
+    return TrustNode::mkTrustRewrite(in, k);
+  }
   // first, see if we need to expand definitions
   TrustNode texp = d_rewriter.expandDefinition(in);
   if (!texp.isNull())
@@ -397,7 +411,7 @@ void TheoryDatatypes::eqNotifyNewClass(TNode n)
       d_functionTerms.push_back(n);
     }
   }
-  if (nk == APPLY_SELECTOR || nk == DT_SIZE || nk == DT_HEIGHT_BOUND)
+  if (nk == APPLY_SELECTOR || nk == DT_HEIGHT_BOUND)
   {
     d_functionTerms.push_back(n);
     // we must also record which selectors exist
@@ -1127,14 +1141,7 @@ void TheoryDatatypes::registerInitialLemmas(Node n)
 
   NodeManager* nm = NodeManager::currentNM();
   Kind nk = n.getKind();
-  if (nk == DT_SIZE)
-  {
-    Node lem = nm->mkNode(LEQ, d_zero, n);
-    Trace("datatypes-infer")
-        << "DtInfer : size geq zero : " << lem << std::endl;
-    d_im.addPendingLemma(lem, InferenceId::DATATYPES_SIZE_POS);
-  }
-  else if (nk == DT_HEIGHT_BOUND && n[1].getConst<Rational>().isZero())
+  if (nk == DT_HEIGHT_BOUND && n[1].getConst<Rational>().isZero())
   {
     std::vector<Node> children;
     const DType& dt = n[0].getType().getDType();

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -348,6 +348,8 @@ TrustNode TheoryDatatypes::ppRewrite(TNode in, std::vector<SkolemLemma>& lems)
   Trace("datatypes") << "TheoryDatatypes::ppRewrite(" << in << ")" << endl;
   // Eliminate DT_SIZE, which is only used for enforcing fairness in sygus.
   // We only assume that DT_SIZE terms are greater than or equal to zero.
+  // Note that this ensures that spurious check-model failures are not
+  // generated.
   if (in.getKind() == DT_SIZE)
   {
     NodeManager* nm = NodeManager::currentNM();

--- a/test/regress/cli/regress0/quantifiers/issue8159-3-qext-nterm.smt2
+++ b/test/regress/cli/regress0/quantifiers/issue8159-3-qext-nterm.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE: --no-debug-check-models
 ; EXPECT: sat
 (set-logic NIA)
 (set-option :ext-rewrite-quant true)

--- a/test/regress/cli/regress1/quantifiers/issue5766-wrong-sel-trigger.smt2
+++ b/test/regress/cli/regress1/quantifiers/issue5766-wrong-sel-trigger.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --sygus-inst -q --no-debug-check-models
+; COMMAND-LINE: --sygus-inst -q
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/sygus/commutative-stream.sy
+++ b/test/regress/cli/regress1/sygus/commutative-stream.sy
@@ -1,4 +1,4 @@
-; EXPECT: (define-fun comm ((x Int) (y Int)) Int (+ x y))
+; EXPECT: (define-fun comm ((x Int) (y Int)) Int (+ y x))
 ; EXPECT: (define-fun comm ((x Int) (y Int)) Int (- x x))
 ; EXPECT: (error "Maximum term size (2) for enumerative SyGuS exceeded.")
 ; EXIT: 1


### PR DESCRIPTION
This avoids possibilities for debug-check-model failures, e.g. when using `--sygus-inst`.