### PR TITLE
Prefer ld.mold if available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,16 +237,30 @@ if (WIN32)
 endif ()
 
 #-----------------------------------------------------------------------------#
-# Use ld.gold if available
+# Use ld.mold if available, otherwise use ld.gold if available
 
+set(USE_EXPLICIT_LINKER_FLAG FALSE)
 execute_process(COMMAND ${CMAKE_C_COMPILER}
-                -fuse-ld=gold
-                -Wl,--version ERROR_QUIET OUTPUT_VARIABLE LD_VERSION)
-if ("${LD_VERSION}" MATCHES "GNU gold")
-  string(APPEND CMAKE_EXE_LINKER_FLAGS " -fuse-ld=gold")
-  string(APPEND CMAKE_SHARED_LINKER_FLAGS " -fuse-ld=gold")
-  string(APPEND CMAKE_MODULE_LINKER_FLAGS " -fuse-ld=gold")
-  message(STATUS "Using GNU gold linker.")
+                -fuse-ld=mold
+                -Wl,--version ERROR_QUIET OUTPUT_VARIABLE LD_MOLD_VERSION)
+if ("${LD_MOLD_VERSION}" MATCHES "mold")
+  set(USE_EXPLICIT_LINKER_FLAG TRUE)
+  set(EXPLICIT_LINKER_FLAG " -fuse-ld=mold")
+  message(STATUS "Using mold linker.")
+else ()
+  execute_process(COMMAND ${CMAKE_C_COMPILER}
+                  -fuse-ld=gold
+                  -Wl,--version ERROR_QUIET OUTPUT_VARIABLE LD_GOLD_VERSION)
+  if ("${LD_GOLD_VERSION}" MATCHES "GNU gold")
+    set(USE_EXPLICIT_LINKER_FLAG TRUE)
+    set(EXPLICIT_LINKER_FLAG " -fuse-ld=gold")
+    message(STATUS "Using GNU gold linker.")
+  endif ()
+endif ()
+if (USE_EXPLICIT_LINKER_FLAG)
+  string(APPEND CMAKE_EXE_LINKER_FLAGS ${EXPLICIT_LINKER_FLAG})
+  string(APPEND CMAKE_SHARED_LINKER_FLAGS ${EXPLICIT_LINKER_FLAG})
+  string(APPEND CMAKE_MODULE_LINKER_FLAGS ${EXPLICIT_LINKER_FLAG})
 endif ()
 
 #-----------------------------------------------------------------------------#


### PR DESCRIPTION
With gold, `rm ./src/libcvc5.so.1 && time make -j 14` takes ~19s on my machine.
With mold, the command takes only ~1s.