### PR TITLE
Upgrade CI MacOS version to macos-latest. 

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -65,6 +65,9 @@ runs:
       shell: bash
       run: |
         echo "::group::Install macOS software"
+        brew config
+        brew untap homebrew/core homebrew/cask
+        brew config
         brew update --quiet
 
         brew install \

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -68,7 +68,6 @@ runs:
         brew config
         brew untap homebrew/core homebrew/cask
         brew config
-        brew update --quiet
 
         brew install \
           ccache \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 on: [push, pull_request]
 name: CI
 
+# Prevents github from relying of clones of homebrew-core or homebrew-cask.
+# https://github.com/orgs/Homebrew/discussions/4612
+env:
+    HOMEBREW_NO_INSTALL_FROM_API: ""
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 on: [push, pull_request]
 name: CI
 
-# Prevents github from relying of clones of homebrew-core or homebrew-cask.
+# Prevents github from relying on clones of homebrew-core or homebrew-cask.
 # https://github.com/orgs/Homebrew/discussions/4612
 env:
     HOMEBREW_NO_INSTALL_FROM_API: ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
           - name: macos:production
-            os: macos-11
+            os: macos-latest
             config: production --auto-download --editline
             # config: production --auto-download --python-bindings --editline
             cache-key: production
@@ -31,7 +31,7 @@ jobs:
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
  
           - name: macos:production-arm64
-            os: macos-12
+            os: macos-latest
             config: production --auto-download --editline --arm64
             # config: production --auto-download --python-bindings --editline --arm64
             cache-key: production-arm64


### PR DESCRIPTION
We have been having problems with homebrew/core and homebrew/cask that block CI. 

This PR uses a workaround found [here](https://github.com/orgs/Homebrew/discussions/4612) to fix the issue.