### PR TITLE
Use tomllib or tomli instead of toml

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -30,7 +30,7 @@ runs:
           flex \
           libfl-dev \
           flexc++
-        python3 -m pip install --user pexpect setuptools toml
+        python3 -m pip install --user pexpect setuptools tomli
         # Make ImageVersion accessible as env.image_version. Environment
         # variables of the runner are not automatically imported:
         #
@@ -76,7 +76,7 @@ runs:
           pkgconfig \
           flex \
           gnu-sed
-        python3 -m pip install --user pexpect setuptools toml pyparsing
+        python3 -m pip install --user pexpect setuptools tomli pyparsing
         # Make ImageVersion accessible as env.image_version. Environment
         # variables of the runner are not automatically imported:
         #

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -118,8 +118,8 @@ versions; more recent versions should be compatible.
 - `GNU C and C++ (gcc and g++, >= 7) <https://gcc.gnu.org>`_
   or `Clang (>= 5) <https://clang.llvm.org>`_
 - `CMake >= 3.9 <https://cmake.org>`_
-- `Python >= 3.6 <https://www.python.org>`_
-  + module `toml <https://pypi.org/project/toml/>`_
+- `Python >= 3.6 and <= 3.10 <https://www.python.org>`_
+  + module `tomli <https://pypi.org/project/tomli/>`_
   + module `pyparsing <https://pypi.org/project/pyparsing/>`_
 - `GMP v6.1 (GNU Multi-Precision arithmetic library) <https://gmplib.org>`_
 - `CaDiCaL (SAT solver) <https://github.com/arminbiere/cadical>`_

--- a/contrib/packaging_python/mk_clean_wheel.sh
+++ b/contrib/packaging_python/mk_clean_wheel.sh
@@ -35,7 +35,7 @@ source ./$ENVDIR/bin/activate
 
 # install packages
 pip install -q --upgrade pip setuptools auditwheel
-pip install -q Cython pytest toml scikit-build flex pyparsing 
+pip install -q Cython pytest tomli scikit-build flex pyparsing 
 if [ "$(uname)" == "Darwin" ]; then
     # Mac version of auditwheel
     pip install -q delocate

--- a/docs/api/python/python.rst
+++ b/docs/api/python/python.rst
@@ -47,7 +47,7 @@ Before building and installing, the following dependencies should be installed, 
 .. code:: bash
 
   brew install cmake python cython gmp java
-  pip3 install toml scikit-build pyparsing
+  pip3 install tomli scikit-build pyparsing
 
 
 Then `cvc5` can be installed from source as follows:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1259,7 +1259,9 @@ include_directories(. ${CMAKE_CURRENT_BINARY_DIR})
 #-----------------------------------------------------------------------------#
 # Take care of options
 
-check_python_module("toml")
+if (Python_VERSION VERSION_LESS "3.11.0")
+  check_python_module("tomli")
+endif()
 
 set(options_toml_files
   options/arith_options.toml

--- a/src/options/mkoptions.py
+++ b/src/options/mkoptions.py
@@ -50,7 +50,10 @@ import os
 import re
 import sys
 import textwrap
-import toml
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
 
 ### Allowed attributes for module/option
 
@@ -1162,7 +1165,8 @@ def mkoptions_main():
     checker = Checker()
     modules = []
     for filename in filenames:
-        data = toml.load(filename)
+        with open(filename, "rb") as f:
+            data = tomllib.load(f)
         module = checker.check_module(data, filename)
         if 'option' in data:
             module.options = sorted(


### PR DESCRIPTION
The toml module does not support the latest TOML standard and has not released a new version since 2020.  This PR moves from toml to tomli for python < 3.11.0.  For 3.11.0 and later, python ships with a tomllib module, based on tomli.