### PR TITLE
Upgraded setup-python to v4 to avoid CI deprecations.

### DIFF
--- a/.github/actions/package-python-wheel-macos/action.yml
+++ b/.github/actions/package-python-wheel-macos/action.yml
@@ -6,7 +6,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       if: runner.os == 'macOS'
       with:
         python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
setup-python@v2 used node-12 which is being deprecated by github. To fix the deprecation warnings, I increased it to the latest version v4.