### PR TITLE
Removing support for python 3.6.

### DIFF
--- a/.github/actions/package-python-wheel-macos/action.yml
+++ b/.github/actions/package-python-wheel-macos/action.yml
@@ -6,7 +6,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v4
+    - id: setup-python
+      uses: actions/setup-python@v4
       if: runner.os == 'macOS'
       with:
         python-version: ${{ inputs.python-version }}

--- a/.github/actions/package-python-wheel-macos/action.yml
+++ b/.github/actions/package-python-wheel-macos/action.yml
@@ -19,7 +19,7 @@ runs:
         MACOSX_DEPLOYMENT_TARGET: 10.13
       run: |
         echo "::group::Build macOS wheel for ${{ inputs.python-version }}"
-        ./contrib/packaging_python/mk_clean_wheel.sh ${{ steps.setup-python.outputs.python-path }} "production --auto-download -DCMAKE_FIND_FRAMEWORK=NEVER"
+        ./contrib/packaging_python/mk_clean_wheel.sh ${{ steps.setup-python.outputs.python-path }} "production --auto-download"
 
         ls *.whl
         echo "::endgroup::"

--- a/.github/actions/package-python-wheel-macos/action.yml
+++ b/.github/actions/package-python-wheel-macos/action.yml
@@ -19,7 +19,7 @@ runs:
         MACOSX_DEPLOYMENT_TARGET: 10.13
       run: |
         echo "::group::Build macOS wheel for ${{ inputs.python-version }}"
-        ./contrib/packaging_python/mk_clean_wheel.sh ${{ steps.setup-python.outputs.python-path }} "production --auto-download"
+        ./contrib/packaging_python/mk_clean_wheel.sh ${{ steps.setup-python.outputs.python-path }} "production --auto-download -DCMAKE_FIND_FRAMEWORK=NEVER"
 
         ls *.whl
         echo "::endgroup::"

--- a/.github/actions/package-python-wheel-macos/action.yml
+++ b/.github/actions/package-python-wheel-macos/action.yml
@@ -18,7 +18,7 @@ runs:
         MACOSX_DEPLOYMENT_TARGET: 10.13
       run: |
         echo "::group::Build macOS wheel for ${{ inputs.python-version }}"
-        ./contrib/packaging_python/mk_clean_wheel.sh python "production --auto-download"
+        ./contrib/packaging_python/mk_clean_wheel.sh ${{ steps.setup-python.outputs.python-path }} "production --auto-download"
 
         ls *.whl
         echo "::endgroup::"

--- a/.github/actions/package-python-wheel/action.yml
+++ b/.github/actions/package-python-wheel/action.yml
@@ -24,7 +24,7 @@ runs:
         echo "::endgroup::"
 
         OPTS="production --auto-download"
-        for version in cp37 cp38 cp39 cp310 pp37 pp38
+        for version in cp37 cp38 cp39 cp310 cp311 pp37 pp38 pp39 pp310
         do
           echo "::group::Build extension for python $version"
           docker run --rm \
@@ -64,6 +64,12 @@ runs:
       if: runner.os == 'macOS'
       uses: ./.github/actions/package-python-wheel-macos
       with:
+        python-version: '3.11'
+
+    - name: Build wheels for macOS
+      if: runner.os == 'macOS'
+      uses: ./.github/actions/package-python-wheel-macos
+      with:
         python-version: 'pypy-3.7'
         
     - name: Build wheels for macOS
@@ -71,6 +77,18 @@ runs:
       uses: ./.github/actions/package-python-wheel-macos
       with:
         python-version: 'pypy-3.8'
+
+    - name: Build wheels for macOS
+      if: runner.os == 'macOS'
+      uses: ./.github/actions/package-python-wheel-macos
+      with:
+        python-version: 'pypy-3.9'
+
+    - name: Build wheels for macOS
+      if: runner.os == 'macOS'
+      uses: ./.github/actions/package-python-wheel-macos
+      with:
+        python-version: 'pypy-3.10'
 
     - name: Upload wheels to pypi.org
       if: inputs.upload-to-pypi == 'true'

--- a/.github/actions/package-python-wheel/action.yml
+++ b/.github/actions/package-python-wheel/action.yml
@@ -30,8 +30,7 @@ runs:
           docker run --rm \
             -v `pwd`:/home/pycvc5 \
             pycvc5-manylinux2014 \
-            ./configure.sh $OPTS --python-bindings --name=build_wheel -DPython_ROOT_DIR:PATH=/opt/python/${version}*/
-            # ./contrib/packaging_python/mk_clean_wheel.sh /opt/python/${version}*/bin/python "$OPTS"
+            ./contrib/packaging_python/mk_clean_wheel.sh /opt/python/${version}*/bin/python "$OPTS"
           echo "::endgroup::"
         done
 

--- a/.github/actions/package-python-wheel/action.yml
+++ b/.github/actions/package-python-wheel/action.yml
@@ -24,7 +24,7 @@ runs:
         echo "::endgroup::"
 
         OPTS="production --auto-download"
-        for version in cp37 cp38 cp39 cp310 cp311 pp37 pp38 pp39 pp310
+        for version in cp38 cp39 cp310 cp311 pp38 pp39 pp310
         do
           echo "::group::Build extension for python $version"
           docker run --rm \
@@ -35,12 +35,6 @@ runs:
         done
 
         ls *.whl
-
-    - name: Build wheels for macOS
-      if: runner.os == 'macOS'
-      uses: ./.github/actions/package-python-wheel-macos
-      with:
-        python-version: '3.7'
 
     - name: Build wheels for macOS
       if: runner.os == 'macOS'
@@ -65,12 +59,6 @@ runs:
       uses: ./.github/actions/package-python-wheel-macos
       with:
         python-version: '3.11'
-
-    - name: Build wheels for macOS
-      if: runner.os == 'macOS'
-      uses: ./.github/actions/package-python-wheel-macos
-      with:
-        python-version: 'pypy-3.7'
         
     - name: Build wheels for macOS
       if: runner.os == 'macOS'

--- a/.github/actions/package-python-wheel/action.yml
+++ b/.github/actions/package-python-wheel/action.yml
@@ -30,7 +30,8 @@ runs:
           docker run --rm \
             -v `pwd`:/home/pycvc5 \
             pycvc5-manylinux2014 \
-            ./contrib/packaging_python/mk_clean_wheel.sh /opt/python/${version}*/bin/python "$OPTS"
+            ./configure.sh $OPTS --python-bindings --name=build_wheel -DPython_ROOT_DIR:PATH=/opt/python/${version}*/
+            # ./contrib/packaging_python/mk_clean_wheel.sh /opt/python/${version}*/bin/python "$OPTS"
           echo "::endgroup::"
         done
 

--- a/.github/actions/package-python-wheel/action.yml
+++ b/.github/actions/package-python-wheel/action.yml
@@ -24,7 +24,7 @@ runs:
         echo "::endgroup::"
 
         OPTS="production --auto-download"
-        for version in cp38 cp39 cp310 cp311 pp38 pp39 pp310
+        for version in cp37 cp38 cp39 cp310 cp311 pp37 pp38 pp39 pp310
         do
           echo "::group::Build extension for python $version"
           docker run --rm \
@@ -35,6 +35,12 @@ runs:
         done
 
         ls *.whl
+
+    - name: Build wheels for macOS
+      if: runner.os == 'macOS'
+      uses: ./.github/actions/package-python-wheel-macos
+      with:
+        python-version: '3.7'
 
     - name: Build wheels for macOS
       if: runner.os == 'macOS'

--- a/.github/actions/package-python-wheel/action.yml
+++ b/.github/actions/package-python-wheel/action.yml
@@ -24,7 +24,7 @@ runs:
         echo "::endgroup::"
 
         OPTS="production --auto-download"
-        for version in cp36 cp37 cp38 cp39 cp310 pp37 pp38
+        for version in cp37 cp38 cp39 cp310 pp37 pp38
         do
           echo "::group::Build extension for python $version"
           docker run --rm \
@@ -35,12 +35,6 @@ runs:
         done
 
         ls *.whl
-      
-    - name: Build wheels for macOS
-      if: runner.os == 'macOS'
-      uses: ./.github/actions/package-python-wheel-macos
-      with:
-        python-version: '3.6'
 
     - name: Build wheels for macOS
       if: runner.os == 'macOS'

--- a/.github/actions/package-python-wheel/action.yml
+++ b/.github/actions/package-python-wheel/action.yml
@@ -65,7 +65,13 @@ runs:
       uses: ./.github/actions/package-python-wheel-macos
       with:
         python-version: '3.11'
-        
+
+    - name: Build wheels for macOS
+      if: runner.os == 'macOS'
+      uses: ./.github/actions/package-python-wheel-macos
+      with:
+        python-version: 'pypy-3.7'
+
     - name: Build wheels for macOS
       if: runner.os == 'macOS'
       uses: ./.github/actions/package-python-wheel-macos

--- a/.github/workflows/package_pypi.yml
+++ b/.github/workflows/package_pypi.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   release:
     types: [published]
   schedule:

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -118,7 +118,7 @@ versions; more recent versions should be compatible.
 - `GNU C and C++ (gcc and g++, >= 7) <https://gcc.gnu.org>`_
   or `Clang (>= 5) <https://clang.llvm.org>`_
 - `CMake >= 3.9 <https://cmake.org>`_
-- `Python >= 3.6 and <= 3.10 <https://www.python.org>`_
+- `Python >= 3.7 and <= 3.10 <https://www.python.org>`_
   + module `tomli <https://pypi.org/project/tomli/>`_
   + module `pyparsing <https://pypi.org/project/pyparsing/>`_
 - `GMP v6.1 (GNU Multi-Precision arithmetic library) <https://gmplib.org>`_

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -118,7 +118,7 @@ versions; more recent versions should be compatible.
 - `GNU C and C++ (gcc and g++, >= 7) <https://gcc.gnu.org>`_
   or `Clang (>= 5) <https://clang.llvm.org>`_
 - `CMake >= 3.9 <https://cmake.org>`_
-- `Python >= 3.7 and <= 3.10 <https://www.python.org>`_
+- `Python >= 3.7 and <= 3.11 <https://www.python.org>`_
   + module `tomli <https://pypi.org/project/tomli/>`_
   + module `pyparsing <https://pypi.org/project/pyparsing/>`_
 - `GMP v6.1 (GNU Multi-Precision arithmetic library) <https://gmplib.org>`_

--- a/cmake/Helpers.cmake
+++ b/cmake/Helpers.cmake
@@ -257,5 +257,5 @@ function(check_python_module module)
 endfunction()
 
 macro(find_supported_python_version)
-  find_package(Python COMPONENTS Interpreter REQUIRED)
+  find_package(Python 3.7 COMPONENTS Interpreter REQUIRED)
 endmacro()

--- a/contrib/packaging_python/mk_build_dir.py
+++ b/contrib/packaging_python/mk_build_dir.py
@@ -17,17 +17,20 @@
 
 import subprocess
 import sys
-import sysconfig
 
+from skbuild.cmaker import CMaker
+
+python_version = CMaker.get_python_version()
 args = [
+	'-DBUILD_BINDINGS_PYTHON_VERSION:STRING=' + python_version,
 	'-DPython_INCLUDE_DIR:PATH=' +
-			sysconfig.get_path("scripts"),
+			CMaker.get_python_include_dir(python_version),
 	'-DPython_LIBRARY:FILEPATH=' +
-			sysconfig.get_path("platlib"),
+			CMaker.get_python_library(python_version),
 	'-DPYTHON_INCLUDE_DIR:PATH=' +
-			sysconfig.get_path("scripts"),
+			CMaker.get_python_include_dir(python_version),
 	'-DPYTHON_LIBRARY:FILEPATH=' +
-			sysconfig.get_path("platlib"),
+			CMaker.get_python_library(python_version),
 ]
 
 subprocess.check_call(['./configure.sh', *sys.argv[1:], *args])

--- a/contrib/packaging_python/mk_build_dir.py
+++ b/contrib/packaging_python/mk_build_dir.py
@@ -24,11 +24,11 @@ args = [
 	'-DPython_INCLUDE_DIR:PATH=' +
 			sysconfig.get_path("include"),
 	'-DPython_LIBRARY:FILEPATH=' +
-			sysconfig.get_path("libdir"),
+			sysconfig.get_path("platlib"),
 	'-DPYTHON_INCLUDE_DIR:PATH=' +
 			sysconfig.get_path("include"),
 	'-DPYTHON_LIBRARY:FILEPATH=' +
-			sysconfig.get_path("libdir"),
+			sysconfig.get_path("platlib"),
 ]
 
 subprocess.check_call(['./configure.sh', *sys.argv[1:], *args])

--- a/contrib/packaging_python/mk_build_dir.py
+++ b/contrib/packaging_python/mk_build_dir.py
@@ -17,20 +17,18 @@
 
 import subprocess
 import sys
+import sysconfig
 
-from skbuild.cmaker import CMaker
-
-python_version = CMaker.get_python_version()
 args = [
-	'-DBUILD_BINDINGS_PYTHON_VERSION:STRING=' + python_version,
+	'-DBUILD_BINDINGS_PYTHON_VERSION:STRING=' + sysconfig.get_python_version(),
 	'-DPython_INCLUDE_DIR:PATH=' +
-			CMaker.get_python_include_dir(python_version),
+			sysconfig.get_path("include"),
 	'-DPython_LIBRARY:FILEPATH=' +
-			CMaker.get_python_library(python_version),
+			sysconfig.get_path("libdir"),
 	'-DPYTHON_INCLUDE_DIR:PATH=' +
-			CMaker.get_python_include_dir(python_version),
+			sysconfig.get_path("include"),
 	'-DPYTHON_LIBRARY:FILEPATH=' +
-			CMaker.get_python_library(python_version),
+			sysconfig.get_path("libdir"),
 ]
 
 subprocess.check_call(['./configure.sh', *sys.argv[1:], *args])

--- a/contrib/packaging_python/mk_build_dir.py
+++ b/contrib/packaging_python/mk_build_dir.py
@@ -22,11 +22,11 @@ import sysconfig
 args = [
 	'-DBUILD_BINDINGS_PYTHON_VERSION:STRING=' + sysconfig.get_python_version(),
 	'-DPython_INCLUDE_DIR:PATH=' +
-			sysconfig.get_path("include"),
+			sysconfig.get_path("scripts"),
 	'-DPython_LIBRARY:FILEPATH=' +
 			sysconfig.get_path("platlib"),
 	'-DPYTHON_INCLUDE_DIR:PATH=' +
-			sysconfig.get_path("include"),
+			sysconfig.get_path("scripts"),
 	'-DPYTHON_LIBRARY:FILEPATH=' +
 			sysconfig.get_path("platlib"),
 ]

--- a/contrib/packaging_python/mk_build_dir.py
+++ b/contrib/packaging_python/mk_build_dir.py
@@ -20,7 +20,6 @@ import sys
 import sysconfig
 
 args = [
-	'-DBUILD_BINDINGS_PYTHON_VERSION:STRING=' + sysconfig.get_python_version(),
 	'-DPython_INCLUDE_DIR:PATH=' +
 			sysconfig.get_path("scripts"),
 	'-DPython_LIBRARY:FILEPATH=' +

--- a/contrib/packaging_python/mk_clean_wheel.sh
+++ b/contrib/packaging_python/mk_clean_wheel.sh
@@ -34,17 +34,17 @@ $PYTHONBIN -m venv ./$ENVDIR
 source ./$ENVDIR/bin/activate
 
 # install packages
-$PYTHONBIN -m pip install -q --upgrade pip setuptools auditwheel
-$PYTHONBIN -m pip install -q Cython pytest tomli scikit-build flex pyparsing 
+pip install -q --upgrade pip setuptools auditwheel
+pip install -q Cython pytest tomli scikit-build flex pyparsing 
 if [ "$(uname)" == "Darwin" ]; then
     # Mac version of auditwheel
-    $PYTHONBIN -m pip install -q delocate
+    pip install -q delocate
 fi
 
 # configure cvc5
 echo "Configuring"
 rm -rf build_wheel/
-python contrib/packaging_python/mk_build_dir.py $CONFIG --python-bindings --name=build_wheel
+python contrib/packaging_python/mk_build_dir.py $CONFIG --python-bindings --name=build_wheel -DPython_FIND_VIRTUALENV=ONLY
 
 # building wheel
 echo "Building pycvc5 wheel"

--- a/contrib/packaging_python/mk_clean_wheel.sh
+++ b/contrib/packaging_python/mk_clean_wheel.sh
@@ -41,13 +41,6 @@ if [ "$(uname)" == "Darwin" ]; then
     pip install -q delocate
 fi
 
-$PYTHONBIN -m pip install -q --upgrade pip setuptools auditwheel
-$PYTHONBIN -m pip install -q Cython pytest tomli scikit-build flex pyparsing 
-if [ "$(uname)" == "Darwin" ]; then
-    # Mac version of auditwheel
-    $PYTHONBIN -m pip install -q delocate
-fi
-
 # configure cvc5
 echo "Configuring"
 rm -rf build_wheel/

--- a/contrib/packaging_python/mk_clean_wheel.sh
+++ b/contrib/packaging_python/mk_clean_wheel.sh
@@ -44,7 +44,7 @@ fi
 # configure cvc5
 echo "Configuring"
 rm -rf build_wheel/
-./configure $CONFIG --python-bindings --name=build_wheel -DPython_ROOT_DIR:PATH=./$ENVDIR
+./configure.sh $CONFIG --python-bindings --name=build_wheel -DPython_ROOT_DIR:PATH=./$ENVDIR
 # python contrib/packaging_python/mk_build_dir.py $CONFIG --python-bindings --name=build_wheel
 
 # building wheel

--- a/contrib/packaging_python/mk_clean_wheel.sh
+++ b/contrib/packaging_python/mk_clean_wheel.sh
@@ -33,6 +33,8 @@ ENVDIR=env$PYVERSION
 $PYTHONBIN -m venv ./$ENVDIR
 source ./$ENVDIR/bin/activate
 
+export CMAKE_PREFIX_PATH=./$ENVDIR/bin:$CMAKE_PREFIX_PATH
+
 # install packages
 pip install -q --upgrade pip setuptools auditwheel
 pip install -q Cython pytest tomli scikit-build flex pyparsing 

--- a/contrib/packaging_python/mk_clean_wheel.sh
+++ b/contrib/packaging_python/mk_clean_wheel.sh
@@ -34,11 +34,11 @@ $PYTHONBIN -m venv ./$ENVDIR
 source ./$ENVDIR/bin/activate
 
 # install packages
-python -m pip install -q --upgrade pip setuptools auditwheel
-python -m pip install -q Cython pytest tomli scikit-build flex pyparsing 
+pip install -q --upgrade pip setuptools auditwheel
+pip install -q Cython pytest tomli scikit-build flex pyparsing 
 if [ "$(uname)" == "Darwin" ]; then
     # Mac version of auditwheel
-    python -m pip install -q delocate
+    pip install -q delocate
 fi
 
 # configure cvc5

--- a/contrib/packaging_python/mk_clean_wheel.sh
+++ b/contrib/packaging_python/mk_clean_wheel.sh
@@ -44,7 +44,8 @@ fi
 # configure cvc5
 echo "Configuring"
 rm -rf build_wheel/
-python contrib/packaging_python/mk_build_dir.py $CONFIG --python-bindings --name=build_wheel
+./configure $CONFIG --python-bindings --name=build_wheel -DPython_ROOT_DIR:PATH=./$ENVDIR
+# python contrib/packaging_python/mk_build_dir.py $CONFIG --python-bindings --name=build_wheel
 
 # building wheel
 echo "Building pycvc5 wheel"

--- a/contrib/packaging_python/mk_clean_wheel.sh
+++ b/contrib/packaging_python/mk_clean_wheel.sh
@@ -44,7 +44,8 @@ fi
 # configure cvc5
 echo "Configuring"
 rm -rf build_wheel/
-python contrib/packaging_python/mk_build_dir.py $CONFIG --python-bindings --name=build_wheel
+./configure.sh $CONFIG --python-bindings --name=build_wheel
+# python contrib/packaging_python/mk_build_dir.py $CONFIG --python-bindings --name=build_wheel
 
 # building wheel
 echo "Building pycvc5 wheel"

--- a/contrib/packaging_python/mk_clean_wheel.sh
+++ b/contrib/packaging_python/mk_clean_wheel.sh
@@ -44,7 +44,8 @@ fi
 # configure cvc5
 echo "Configuring"
 rm -rf build_wheel/
-python contrib/packaging_python/mk_build_dir.py $CONFIG --python-bindings --name=build_wheel -DPython_FIND_VIRTUALENV=ONLY
+./configure.sh $CONFIG --python-bindings --name=build_wheel -DPython_FIND_VIRTUALENV=ONLY
+# python contrib/packaging_python/mk_build_dir.py $CONFIG --python-bindings --name=build_wheel -DPython_FIND_VIRTUALENV=ONLY
 
 # building wheel
 echo "Building pycvc5 wheel"

--- a/contrib/packaging_python/mk_clean_wheel.sh
+++ b/contrib/packaging_python/mk_clean_wheel.sh
@@ -29,13 +29,19 @@ PYVERSION=$($PYTHONBIN -c "import sys; print(sys.implementation.name + sys.versi
 
 # setup and activate venv
 echo "Making venv with $PYTHONBIN"
-ENVDIR=env$PYVERSION
-$PYTHONBIN -m venv ./$ENVDIR
-source ./$ENVDIR/bin/activate
+ENVDIR=./env$PYVERSION
+$PYTHONBIN -m venv $ENVDIR
+source $ENVDIR/bin/activate
+
+echo "Cmake version:"
+cmake --version
+
+echo "venv: $ENVDIR"
+ls $ENVDIR
 
 # install packages
-pip install -q --upgrade pip setuptools auditwheel
-pip install -q Cython pytest tomli scikit-build flex pyparsing 
+pip install --upgrade pip setuptools auditwheel
+pip install Cython pytest tomli scikit-build flex pyparsing 
 if [ "$(uname)" == "Darwin" ]; then
     # Mac version of auditwheel
     pip install -q delocate
@@ -44,8 +50,7 @@ fi
 # configure cvc5
 echo "Configuring"
 rm -rf build_wheel/
-./configure.sh $CONFIG --python-bindings --name=build_wheel -DPython_ROOT_DIR:PATH=./$ENVDIR
-# python contrib/packaging_python/mk_build_dir.py $CONFIG --python-bindings --name=build_wheel
+./configure.sh $CONFIG --python-bindings --name=build_wheel -DPython_ROOT_DIR=$EVNDIR -DPython_FIND_STRATEGY=LOCATION -DPython_FIND_REGISTRY=NEVER -DPython_FIND_FRAMEWORK=NEVER -DPython_FIND_VIRTUALENV=ONLY
 
 # building wheel
 echo "Building pycvc5 wheel"

--- a/contrib/packaging_python/mk_clean_wheel.sh
+++ b/contrib/packaging_python/mk_clean_wheel.sh
@@ -41,11 +41,17 @@ if [ "$(uname)" == "Darwin" ]; then
     pip install -q delocate
 fi
 
+$PYTHONBIN -m pip install -q --upgrade pip setuptools auditwheel
+$PYTHONBIN -m pip install -q Cython pytest tomli scikit-build flex pyparsing 
+if [ "$(uname)" == "Darwin" ]; then
+    # Mac version of auditwheel
+    $PYTHONBIN -m pip install -q delocate
+fi
+
 # configure cvc5
 echo "Configuring"
 rm -rf build_wheel/
-./configure.sh $CONFIG --python-bindings --name=build_wheel -DPython_FIND_VIRTUALENV=ONLY
-# python contrib/packaging_python/mk_build_dir.py $CONFIG --python-bindings --name=build_wheel -DPython_FIND_VIRTUALENV=ONLY
+python contrib/packaging_python/mk_build_dir.py $CONFIG --python-bindings --name=build_wheel
 
 # building wheel
 echo "Building pycvc5 wheel"

--- a/contrib/packaging_python/mk_clean_wheel.sh
+++ b/contrib/packaging_python/mk_clean_wheel.sh
@@ -34,18 +34,17 @@ $PYTHONBIN -m venv ./$ENVDIR
 source ./$ENVDIR/bin/activate
 
 # install packages
-pip install -q --upgrade pip setuptools auditwheel
-pip install -q Cython pytest tomli scikit-build flex pyparsing 
+$PYTHONBIN -m pip install -q --upgrade pip setuptools auditwheel
+$PYTHONBIN -m pip install -q Cython pytest tomli scikit-build flex pyparsing 
 if [ "$(uname)" == "Darwin" ]; then
     # Mac version of auditwheel
-    pip install -q delocate
+    $PYTHONBIN -m pip install -q delocate
 fi
 
 # configure cvc5
 echo "Configuring"
 rm -rf build_wheel/
-./configure.sh $CONFIG --python-bindings --name=build_wheel
-# python contrib/packaging_python/mk_build_dir.py $CONFIG --python-bindings --name=build_wheel
+python contrib/packaging_python/mk_build_dir.py $CONFIG --python-bindings --name=build_wheel
 
 # building wheel
 echo "Building pycvc5 wheel"

--- a/contrib/packaging_python/mk_clean_wheel.sh
+++ b/contrib/packaging_python/mk_clean_wheel.sh
@@ -33,14 +33,12 @@ ENVDIR=env$PYVERSION
 $PYTHONBIN -m venv ./$ENVDIR
 source ./$ENVDIR/bin/activate
 
-export CMAKE_PREFIX_PATH=./$ENVDIR/bin:$CMAKE_PREFIX_PATH
-
 # install packages
-pip install -q --upgrade pip setuptools auditwheel
-pip install -q Cython pytest tomli scikit-build flex pyparsing 
+python -m pip install -q --upgrade pip setuptools auditwheel
+python -m pip install -q Cython pytest tomli scikit-build flex pyparsing 
 if [ "$(uname)" == "Darwin" ]; then
     # Mac version of auditwheel
-    pip install -q delocate
+    python -m pip install -q delocate
 fi
 
 # configure cvc5

--- a/examples/api/python/CMakeLists.txt
+++ b/examples/api/python/CMakeLists.txt
@@ -35,8 +35,6 @@ set(EXAMPLES_API_PYTHON
   transcendentals
 )
 
-find_package(Python ${CVC5_BINDINGS_PYTHON_VERSION} EXACT REQUIRED)
-
 # Find Python bindings in the corresponding python-*/site-packages directory.
 # Lookup Python module directory and store path in PYTHON_MODULE_PATH.
 execute_process(COMMAND

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -43,18 +43,6 @@ endif()
 # Required for Cython target below
 list(APPEND CMAKE_MODULE_PATH ${SKBUILD_CMAKE_MODULE_PATH})
 
-find_package(Python ${BUILD_BINDINGS_PYTHON_VERSION} EXACT COMPONENTS Development)
-# Some cmake packages are not compatible with the newest version
-# of FindPython, introduced in cmake 3.12.
-# We define the symbols below to be backward compatible.
-# FindPython Development sets Python_INCLUDE_DIRS and Python_LIBRARIES
-if (NOT DEFINED PYTHON_INCLUDE_DIRS)
-  set(PYTHON_INCLUDE_DIRS "${Python_INCLUDE_DIRS}")
-endif()
-if (NOT DEFINED PYTHON_LIBRARIES)
-  set(PYTHON_LIBRARIES "${Python_LIBRARIES}")
-endif()
-
 find_package(PythonExtensions REQUIRED)
 find_package(Cython 0.29 REQUIRED)
 


### PR DESCRIPTION
Our PyPi packaging jobs failed because module `tomli` is not supported in python 3.6. As discussed offline, since 3.6 reached end-of-life in 2021, we should drop support for it. 