### PR TITLE
ci: Fix uploading release documentation.

### DIFF
--- a/.github/workflows/docs_upload.yml
+++ b/.github/workflows/docs_upload.yml
@@ -137,6 +137,9 @@ jobs:
         continue-on-error: true
         run: |
           if [ "$ISRELEASE" = true ]; then
+            eval $(ssh-agent -s)
+            ssh-add - <<< "${{ secrets.CVC5_DOCS_RELEASE_TOKEN }}"
+
             cd target-releases/
 
             rm -f latest


### PR DESCRIPTION
Each Github actions step has it's own environment and consequently ssh-add is not persistent over multiple steps resulting in a permission denied error when pushing the release documentation. This commit should fix the issue.