### PR TITLE
Always use extensionality for sequence disequalities

### DIFF
--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2559,11 +2559,11 @@ void CoreSolver::checkNormalFormsDeq()
   for (const Node& eq : d_rlvDeq)
   {
     Assert(!d_state.isInConflict());
-    // If using the sequence update solver, we always apply extensionality.
+    // If using sequences, we always apply extensionality.
     // This is required for model soundness currently, although we could
     // investigate determining cases where the disequality is already
     // satisfied (for optimization).
-    if (options().strings.stringsDeqExt
+    if (eq[0].getType().isSequence() || options().strings.stringsDeqExt
         || options().strings.seqArray != options::SeqArrayMode::NONE)
     {
       processDeqExtensionality(eq[0], eq[1]);

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1397,6 +1397,7 @@ set(regress_0_tests
   regress0/seq/proj-issue586-nth-update-no-fact-2.smt2
   regress0/seq/proj-issue604-reg-closure.smt2
   regress0/seq/proj-issue642-cycle-irr.smt2
+  regress0/seq/proj-issue653.smt2
   regress0/seq/quant_len_trigger.smt2
   regress0/seq/query0-subtype-skel.smt2
   regress0/seq/query1-subtype.smt2

--- a/test/regress/cli/regress0/seq/proj-issue653.smt2
+++ b/test/regress/cli/regress0/seq/proj-issue653.smt2
@@ -1,0 +1,7 @@
+(set-logic ALL)
+(set-info :status sat)
+(declare-const x (Set Bool))
+(declare-const x1 (Seq (Set Bool)))
+(declare-const x4 (Set (Seq (Set Bool))))
+(assert (distinct (set.choose x4) (set.choose (set.singleton x1)) (seq.unit (set.minus x (set.singleton false)))))
+(check-sat)

--- a/test/regress/cli/regress0/seq/proj-issue653.smt2
+++ b/test/regress/cli/regress0/seq/proj-issue653.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: -q
+; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)
 (declare-const x (Set Bool))


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5-projects/issues/653.

When using the optimized version of disequality handling, model construction could be wrong for sequences when there were finite types nested within infinite ones, e.g. `(Seq (Set Bool))`, in particular when model construction makes two skeletons that are made equal in the core model construction.  The extensionality handling of disequalities ensures this never happens.