### PR TITLE
Add a few set.map regressions and remove an unsound optimization

### DIFF
--- a/src/theory/sets/theory_sets_private.cpp
+++ b/src/theory/sets/theory_sets_private.cpp
@@ -831,37 +831,25 @@ void TheorySetsPrivate::checkMapDown()
       exp.push_back(pair.second);
       d_state.addEqualityToExp(B, term, exp);
       Node y = pair.first;
-      if (y.getKind() == APPLY_UF && y.getOperator() == f)
-      {
-        // special case
-        // (=>
-        //   (set.member (f x) (set.map f A))
-        //   (set.member x A))
-        Node x = y[0];
-        Node memberA = nm->mkNode(SET_MEMBER, x, A);
-        d_im.assertInference(memberA, InferenceId::SETS_MAP_DOWN_POSITIVE, exp);
-      }
-      else
-      {
-        // general case
-        // (=>
-        //   (and
-        //     (set.member y B)
-        //     (= B (set.map f A)))
-        //   (and
-        //     (set.member x A)
-        //     (= (f x) y))
-        // )
-        Node x = sm->mkSkolemFunction(
-            SkolemFunId::SETS_MAP_DOWN_ELEMENT, elementType, {term, y});
 
-        d_state.registerMapSkolemElement(term, x);
-        Node memberA = nm->mkNode(kind::SET_MEMBER, x, A);
-        Node f_x = nm->mkNode(APPLY_UF, f, x);
-        Node equal = f_x.eqNode(y);
-        Node fact = memberA.andNode(equal);
-        d_im.assertInference(fact, InferenceId::SETS_MAP_DOWN_POSITIVE, exp);
-      }
+      // general case
+      // (=>
+      //   (and
+      //     (set.member y B)
+      //     (= B (set.map f A)))
+      //   (and
+      //     (set.member x A)
+      //     (= (f x) y))
+      // )
+      Node x = sm->mkSkolemFunction(
+          SkolemFunId::SETS_MAP_DOWN_ELEMENT, elementType, {term, y});
+
+      d_state.registerMapSkolemElement(term, x);
+      Node memberA = nm->mkNode(kind::SET_MEMBER, x, A);
+      Node f_x = nm->mkNode(APPLY_UF, f, x);
+      Node equal = f_x.eqNode(y);
+      Node fact = memberA.andNode(equal);
+      d_im.assertInference(fact, InferenceId::SETS_MAP_DOWN_POSITIVE, exp);
       if (d_state.isInConflict())
       {
         return;

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2771,6 +2771,8 @@ set(regress_1_tests
   regress1/sets/set_map_negative_members.smt2
   regress1/sets/set_map_positive_members.smt2
   regress1/sets/set_map_unsat1.smt2
+  regress1/sets/set-map-test.smt2
+  regress1/sets/set-map-test2.smt2
   regress1/sets/sharingbug.smt2
   regress1/sets/univ-set-uf-elim.smt2
   regress1/simplification_bug4.smt2

--- a/test/regress/cli/regress1/sets/set-map-test.smt2
+++ b/test/regress/cli/regress1/sets/set-map-test.smt2
@@ -1,0 +1,12 @@
+(set-logic HO_ALL)
+(set-info :status sat)
+(define-fun iabs ((x Int)) Int (ite (< x 0) (- x) x))
+
+(declare-fun S () (Set Int))
+(declare-fun T () (Set Int))
+(declare-fun x () Int)
+
+(assert (not (= T S)))
+(assert (= (set.map iabs T) (set.map iabs S)))
+
+(check-sat)

--- a/test/regress/cli/regress1/sets/set-map-test2.smt2
+++ b/test/regress/cli/regress1/sets/set-map-test2.smt2
@@ -1,0 +1,11 @@
+(set-logic HO_ALL)
+(set-info :status sat)
+(declare-fun f (Int) Int)
+
+(declare-fun S () (Set Int))
+(declare-fun x () Int)
+
+(assert (not (set.member x S)))
+(assert (set.member (f x) (set.map f S)))
+
+(check-sat)


### PR DESCRIPTION
The special case of `SETS_MAP_DOWN_POSITIVE` seems wrong, i.e. if `f` is not injective.  I've added a regression that exhibited the issue but now is (correctly) sat.