### PR TITLE
bv: bitblast solver: Fix misuse of SatSolver::value().

### DIFF
--- a/src/theory/bv/bv_solver_bitblast.cpp
+++ b/src/theory/bv/bv_solver_bitblast.cpp
@@ -320,7 +320,7 @@ bool BVSolverBitblast::collectModelValues(TheoryModel* m,
     {
       Assert(d_cnfStream->hasLiteral(var));
       prop::SatLiteral bit = d_cnfStream->getLiteral(var);
-      prop::SatValue value = d_satSolver->value(bit);
+      prop::SatValue value = d_satSolver->modelValue(bit);
       Assert(value != prop::SAT_VALUE_UNKNOWN);
       if (!m->assertEquality(
               var, nm->mkConst(value == prop::SAT_VALUE_TRUE), true))


### PR DESCRIPTION
Previously, in collectModelValues(), the bitblast solver queried the model value of a bit via SatSolver::value() (which is to be called during the search) rather than SatSolver::modelValue() (which is to be called after the search).