### PR TITLE
Rename requirePhase to preferPhase.

### DIFF
--- a/src/prop/minisat/minisat.cpp
+++ b/src/prop/minisat/minisat.cpp
@@ -252,9 +252,12 @@ SatValue MinisatSatSolver::modelValue(SatLiteral l){
   return toSatLiteralValue(d_minisat->modelValue(toMinisatLit(l)));
 }
 
-void MinisatSatSolver::requirePhase(SatLiteral lit) {
+void MinisatSatSolver::preferPhase(SatLiteral lit)
+{
   Assert(!d_minisat->rnd_pol);
-  Trace("minisat") << "requirePhase(" << lit << ")" << " " <<  lit.getSatVariable() << " " << lit.isNegated() << std::endl;
+  Trace("minisat") << "preferPhase(" << lit << ")"
+                   << " " << lit.getSatVariable() << " " << lit.isNegated()
+                   << std::endl;
   SatVariable v = lit.getSatVariable();
   d_minisat->freezePolarity(v, lit.isNegated());
 }

--- a/src/prop/minisat/minisat.h
+++ b/src/prop/minisat/minisat.h
@@ -86,7 +86,7 @@ class MinisatSatSolver : public CDCLTSatSolver, protected EnvObj
 
   void resetTrail() override;
 
-  void requirePhase(SatLiteral lit) override;
+  void preferPhase(SatLiteral lit) override;
 
   bool isDecision(SatVariable decn) const override;
 

--- a/src/prop/prop_engine.cpp
+++ b/src/prop/prop_engine.cpp
@@ -334,12 +334,13 @@ void PropEngine::assertLemmasInternal(
   Trace("prop") << "Finish " << trn << std::endl;
 }
 
-void PropEngine::requirePhase(TNode n, bool phase) {
-  Trace("prop") << "requirePhase(" << n << ", " << phase << ")" << std::endl;
+void PropEngine::preferPhase(TNode n, bool phase)
+{
+  Trace("prop") << "preferPhase(" << n << ", " << phase << ")" << std::endl;
 
   Assert(n.getType().isBoolean());
   SatLiteral lit = d_cnfStream->getLiteral(n);
-  d_satSolver->requirePhase(phase ? lit : ~lit);
+  d_satSolver->preferPhase(phase ? lit : ~lit);
 }
 
 bool PropEngine::isDecision(Node lit) const {

--- a/src/prop/prop_engine.h
+++ b/src/prop/prop_engine.h
@@ -135,15 +135,22 @@ class PropEngine : protected EnvObj
   void assertLemma(TrustNode tlemma, theory::LemmaProperty p);
 
   /**
-   * If ever n is decided upon, it must be in the given phase.  This
-   * occurs *globally*, i.e., even if the literal is untranslated by
-   * user pop and retranslated, it keeps this phase.  The associated
-   * variable will _always_ be phase-locked.
+   * Configure the preferred phase of a decision variable. This occurs
+   * *globally*, i.e., even if the literal is untranslated by user pop and
+   * retranslated, it keeps this phase.
+   *
+   * @note This phase is always enforced when the SAT solver decides to make a
+   *       decision on this variable on its own. If a decision is injected into
+   *       the SAT solver via TheoryProxy::getNextDecisionRequest(), the
+   *       preferred phase will only be considered if the decision was derived
+   *       by the decision engine. It will be ignored if the decision was
+   *       derived from a theory (the phase enforced by the theory overrides
+   *       the preferred phase).
    *
    * @param n the node in question; must have an associated SAT literal
    * @param phase the phase to use
    */
-  void requirePhase(TNode n, bool phase);
+  void preferPhase(TNode n, bool phase);
 
   /**
    * Return whether the given literal is a SAT decision.  Either phase

--- a/src/prop/sat_solver.h
+++ b/src/prop/sat_solver.h
@@ -130,13 +130,26 @@ class CDCLTSatSolver : public SatSolver
 
   virtual void pop() = 0;
 
-  /*
+  /**
    * Reset the decisions in the DPLL(T) SAT solver at the current assertion
    * level.
    */
   virtual void resetTrail() = 0;
 
-  virtual void requirePhase(SatLiteral lit) = 0;
+  /**
+   * Configure the preferred phase for a decision literal.
+   *
+   * @note This phase is always enforced when the SAT solver decides to make a
+   *       decision on this variable on its own. If a decision is injected into
+   *       the SAT solver via TheoryProxy::getNextDecisionRequest(), the
+   *       preferred phase will only be considered if the decision was derived
+   *       by the decision engine. It will be ignored if the decision was
+   *       derived from a theory (the phase enforced by the theory overrides
+   *       the preferred phase).
+   *
+   * @param lit The literal.
+   */
+  virtual void preferPhase(SatLiteral lit) = 0;
 
   virtual bool isDecision(SatVariable decn) const = 0;
 

--- a/src/theory/arith/branch_and_bound.cpp
+++ b/src/theory/arith/branch_and_bound.cpp
@@ -78,7 +78,7 @@ std::vector<TrustNode> BranchAndBound::branchIntegerVariable(TNode var,
     }
     Node literal = d_astate.getValuation().ensureLiteral(eq);
     Trace("integers") << "eq: " << eq << "\nto: " << literal << std::endl;
-    d_im.requirePhase(literal, true);
+    d_im.preferPhase(literal, true);
     Node l = nm->mkNode(OR, literal, right);
     Trace("integers") << "l: " << l << std::endl;
     if (proofsEnabled())

--- a/src/theory/arrays/theory_arrays.cpp
+++ b/src/theory/arrays/theory_arrays.cpp
@@ -1869,7 +1869,7 @@ void TheoryArrays::queueRowLemma(RowLemmaType lem)
 #if 0
     i_eq_j = i.eqNode(j);
 #endif
-    getOutputChannel().requirePhase(i_eq_j, true);
+    getOutputChannel().preferPhase(i_eq_j, true);
     d_decisionRequests.push(i_eq_j);
   }
 

--- a/src/theory/combination_care_graph.cpp
+++ b/src/theory/combination_care_graph.cpp
@@ -89,7 +89,7 @@ void CombinationCareGraph::combineTheories()
     // already have but it doesn't seem to make a big difference - need to
     // explore more -Clark
     Node e = d_valuation.ensureLiteral(equality);
-    propEngine->requirePhase(e, true);
+    propEngine->preferPhase(e, true);
   }
 }
 

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -1684,7 +1684,7 @@ void TheoryDatatypes::checkSplit()
         nb << test << test.notNode();
         Node lemma = nb;
         d_im.lemma(lemma, InferenceId::DATATYPES_BINARY_SPLIT);
-        d_im.requirePhase(test, true);
+        d_im.preferPhase(test, true);
       }
       else
       {

--- a/src/theory/engine_output_channel.cpp
+++ b/src/theory/engine_output_channel.cpp
@@ -29,7 +29,7 @@ EngineOutputChannel::Statistics::Statistics(StatisticsRegistry& sr,
     : conflicts(sr.registerInt(statPrefix + "conflicts")),
       propagations(sr.registerInt(statPrefix + "propagations")),
       lemmas(sr.registerInt(statPrefix + "lemmas")),
-      requirePhase(sr.registerInt(statPrefix + "requirePhase")),
+      preferPhase(sr.registerInt(statPrefix + "preferPhase")),
       trustedConflicts(sr.registerInt(statPrefix + "trustedConflicts")),
       trustedLemmas(sr.registerInt(statPrefix + "trustedLemmas"))
 {
@@ -89,12 +89,12 @@ void EngineOutputChannel::conflict(TNode conflictNode)
   d_engine->conflict(tConf, d_theory);
 }
 
-void EngineOutputChannel::requirePhase(TNode n, bool phase)
+void EngineOutputChannel::preferPhase(TNode n, bool phase)
 {
-  Trace("theory") << "EngineOutputChannel::requirePhase(" << n << ", " << phase
+  Trace("theory") << "EngineOutputChannel::preferPhase(" << n << ", " << phase
                   << ")" << std::endl;
-  ++d_statistics.requirePhase;
-  d_engine->getPropEngine()->requirePhase(n, phase);
+  ++d_statistics.preferPhase;
+  d_engine->getPropEngine()->preferPhase(n, phase);
 }
 
 void EngineOutputChannel::setModelUnsound(IncompleteId id)

--- a/src/theory/engine_output_channel.h
+++ b/src/theory/engine_output_channel.h
@@ -60,7 +60,7 @@ class EngineOutputChannel : public theory::OutputChannel
 
   void lemma(TNode lemma, LemmaProperty p = LemmaProperty::NONE) override;
 
-  void requirePhase(TNode n, bool phase) override;
+  void preferPhase(TNode n, bool phase) override;
 
   void setModelUnsound(IncompleteId id) override;
 
@@ -92,8 +92,8 @@ class EngineOutputChannel : public theory::OutputChannel
   {
    public:
     Statistics(StatisticsRegistry& sr, const std::string& statPrefix);
-    /** Number of calls to conflict, propagate, lemma, requirePhase */
-    IntStat conflicts, propagations, lemmas, requirePhase, trustedConflicts,
+    /** Number of calls to conflict, propagate, lemma, preferPhase */
+    IntStat conflicts, propagations, lemmas, preferPhase, trustedConflicts,
         trustedLemmas;
   };
   /** The theory engine we're communicating with. */

--- a/src/theory/inference_manager_buffered.cpp
+++ b/src/theory/inference_manager_buffered.cpp
@@ -135,7 +135,7 @@ void InferenceManagerBuffered::doPendingPhaseRequirements()
   // process the pending require phase calls
   for (const std::pair<const Node, bool>& prp : d_pendingReqPhase)
   {
-    requirePhase(prp.first, prp.second);
+    preferPhase(prp.first, prp.second);
   }
   d_pendingReqPhase.clear();
 }

--- a/src/theory/output_channel.h
+++ b/src/theory/output_channel.h
@@ -122,9 +122,9 @@ class OutputChannel {
   virtual void lemma(TNode n, LemmaProperty p = LemmaProperty::NONE) = 0;
 
   /**
-   * If a decision is made on n, it must be in the phase specified.
-   * Note that this is enforced *globally*, i.e., it is completely
-   * context-INdependent.  If you ever requirePhase() on a literal,
+   * If a decision is made on n that is not requested from a theory, it must be
+   * in the phase specified. Note that this is enforced *globally*, i.e., it is
+   * completely context-INdependent.  If you ever preferPhase() on a literal,
    * it is phase-locked forever and ever.  If it is to ever have the
    * other phase as its assignment, it will be because it has been
    * propagated that way (or it's a unit, at decision level 0).
@@ -133,7 +133,7 @@ class OutputChannel {
    * been pre-registered
    * @param phase - the phase to decide on n
    */
-  virtual void requirePhase(TNode n, bool phase) = 0;
+  virtual void preferPhase(TNode n, bool phase) = 0;
 
   /**
    * Notification from a theory that it realizes it is model unsound at

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -572,7 +572,7 @@ void TermDbSygus::registerEnumerator(Node e,
     ag = d_qstate.getValuation().ensureLiteral(ag);
     // must ensure that it is asserted as a literal before we begin solving
     Node lem = nm->mkNode(OR, ag, ag.negate());
-    d_qim->requirePhase(ag, true);
+    d_qim->preferPhase(ag, true);
     d_qim->lemma(lem, InferenceId::QUANTIFIERS_SYGUS_ENUM_ACTIVE_GUARD_SPLIT);
     d_enum_to_active_guard[e] = ag;
   }

--- a/src/theory/sets/inference_manager.cpp
+++ b/src/theory/sets/inference_manager.cpp
@@ -181,7 +181,7 @@ void InferenceManager::split(Node n, InferenceId id, int reqPol)
   {
     Trace("sets-lemma") << "Sets::Require phase " << n << " " << (reqPol > 0)
                         << std::endl;
-    requirePhase(n, reqPol > 0);
+    preferPhase(n, reqPol > 0);
   }
 }
 

--- a/src/theory/strings/term_registry.cpp
+++ b/src/theory/strings/term_registry.cpp
@@ -182,7 +182,7 @@ void TermRegistry::preRegisterTerm(TNode n)
   Kind k = n.getKind();
   if (k == STRING_IN_REGEXP)
   {
-    d_im->requirePhase(n, true);
+    d_im->preferPhase(n, true);
   }
   else if (k == STRING_TO_CODE)
   {
@@ -440,7 +440,7 @@ void TermRegistry::registerTermAtomic(Node n, LengthStatus s)
   }
   for (const std::pair<const Node, bool>& rp : reqPhase)
   {
-    d_im->requirePhase(rp.first, rp.second);
+    d_im->preferPhase(rp.first, rp.second);
   }
 }
 
@@ -527,7 +527,7 @@ TrustNode TermRegistry::getRegisterTermAtomicLemma(
   if (!case_emptyr.isConst())
   {
     // prefer trying the empty case first
-    // notice that requirePhase must only be called on rewritten literals that
+    // notice that preferPhase must only be called on rewritten literals that
     // occur in the CNF stream.
     n_len_eq_z = rewrite(n_len_eq_z);
     Assert(!n_len_eq_z.isConst());

--- a/src/theory/strings/term_registry.h
+++ b/src/theory/strings/term_registry.h
@@ -138,7 +138,7 @@ class TermRegistry : protected EnvObj
    * If the status is LENGTH_SPLIT, we send a send a lemma of the form:
    *   ( n = "" ^ len( n ) = 0 ) OR len( n ) > 0
    * This method also ensures that, when applicable, the left branch is taken
-   * first via calls to requirePhase.
+   * first via calls to preferPhase.
    *
    * If the status is LENGTH_IGNORE, then no lemma is sent. This status is used
    * e.g. when the length of n is already implied by other constraints.

--- a/src/theory/theory_inference_manager.cpp
+++ b/src/theory/theory_inference_manager.cpp
@@ -606,10 +606,10 @@ DecisionManager* TheoryInferenceManager::getDecisionManager()
   return d_decManager;
 }
 
-void TheoryInferenceManager::requirePhase(TNode n, bool pol)
+void TheoryInferenceManager::preferPhase(TNode n, bool pol)
 {
   Node en = d_theoryState.getValuation().ensureLiteral(n);
-  return d_out.requirePhase(en, pol);
+  return d_out.preferPhase(en, pol);
 }
 
 void TheoryInferenceManager::spendResource(Resource r)

--- a/src/theory/theory_inference_manager.h
+++ b/src/theory/theory_inference_manager.h
@@ -359,9 +359,9 @@ class TheoryInferenceManager : protected EnvObj
   DecisionManager* getDecisionManager();
   /**
    * Set that literal n has SAT phase requirement pol, that is, it should be
-   * decided with polarity pol, for details see OutputChannel::requirePhase.
+   * decided with polarity pol, for details see OutputChannel::preferPhase.
    */
-  void requirePhase(TNode n, bool pol);
+  void preferPhase(TNode n, bool pol);
 
   /**
    * Forward to OutputChannel::spendResource() to spend resources.

--- a/src/theory/uf/cardinality_extension.cpp
+++ b/src/theory/uf/cardinality_extension.cpp
@@ -1054,7 +1054,7 @@ int SortModel::addSplit(Region* r)
     {
       Trace("uf-ss-lemma") << "*** Split on " << s << std::endl;
       //tell the sat solver to explore the equals branch first
-      d_im.requirePhase(ss, true);
+      d_im.preferPhase(ss, true);
       ++( d_thss->d_statistics.d_split_lemmas );
     }
     return 1;
@@ -1540,7 +1540,7 @@ void CardinalityExtension::check(Theory::Effort level)
                     Node lem = NodeManager::currentNM()->mkNode( kind::OR, eq, eq.negate() );
                     Trace("uf-ss-lemma") << "*** Split (no-minimal) : " << lem << std::endl;
                     d_im.lemma(lem, InferenceId::UF_CARD_SPLIT);
-                    d_im.requirePhase(eq, true);
+                    d_im.preferPhase(eq, true);
                     type_proc[tn] = true;
                     break;
                   }

--- a/test/unit/test_smt.h
+++ b/test/unit/test_smt.h
@@ -128,7 +128,7 @@ class DummyOutputChannel : public theory::OutputChannel
     push(LEMMA, n.getNode());
   }
 
-  void requirePhase(TNode, bool) override {}
+  void preferPhase(TNode, bool) override {}
   void setModelUnsound(theory::IncompleteId id) override {}
   void setRefutationUnsound(theory::IncompleteId id) override {}
 


### PR DESCRIPTION
The name of function SatSolver::requirePhase() (and friends) is misleading. It implies that the configured phase is always enforced, which is not the case: it is only enforced when the SAT solver decides to make a decision on the given variable on its own, or if the decision was derived by a DecisionEngine. Decisions derived by a theory ignore this configure phase (theories require that the phase they require overrides the phase configured via requirePhase()). Thus it is now renamed to preferPhase().