### PR TITLE
CI fix: Hardcoded versions of python modules used by documentation jobs.

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -119,6 +119,6 @@ runs:
         sudo apt-get install -y doxygen python3-docutils python3-jinja2
         python3 -m pip install --user \
           sphinx==7.1.2 \
-          sphinxcontrib-bibtex==2.6.0 sphinx-tabs==3.4.1 sphinx-rtd-theme==1.3.0 breathe==4.35.0 \
+          sphinxcontrib-bibtex==2.5.0 sphinx-tabs==3.4.1 sphinx-rtd-theme==1.3.0 breathe==4.35.0 \
           sphinxcontrib-programoutput==0.17
         echo "::endgroup::"

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -119,6 +119,6 @@ runs:
         sudo apt-get install -y doxygen python3-docutils python3-jinja2
         python3 -m pip install --user \
           sphinx==7.1.2 \
-          sphinxcontrib-bibtex sphinx-tabs sphinx-rtd-theme breathe \
-          sphinxcontrib-programoutput
+          sphinxcontrib-bibtex==2.6.0 sphinx-tabs==3.4.1 sphinx-rtd-theme==1.3.0 breathe==4.35.0 \
+          sphinxcontrib-programoutput==0.17
         echo "::endgroup::"


### PR DESCRIPTION
Some of the python modules we use for building documentation have been having updates recently. This caused an incompatibility between modules and our required version of sphinx 7.1.2. 