### PR TITLE
Possible fix for scrubber

### DIFF
--- a/test/regress/cli/regress0/proofs/proof-components.smt2
+++ b/test/regress/cli/regress0/proofs/proof-components.smt2
@@ -1,4 +1,4 @@
-; SCRUBBER: grep -v -E '(\(|\)|\:proves)'
+; SCRUBBER: grep -v -E '(\(|\)|:proves)'
 ; COMMAND-LINE: --simplification=none
 ; EXPECT: unsat
 ; DISABLE-TESTER: lfsc


### PR DESCRIPTION
This benchmark is giving regression failures for me locally after https://github.com/cvc5/cvc5/commit/a2276cb4a4017cf9f10ee15fe6811c5c427a5dcc.
with:
```
✖ The scrubber's error output is not empty

  Command: grep -v -E '(\(|\)|\:proves)'

  Error output
  ==============================================================================
b'grep: warning: stray \\ before :\n'
  ==============================================================================
Traceback (most recent call last):
  File "/space/ajreynol/cvc5-pr-ajr/test/regress/cli/run_regression.py", line 850, in <module>
    exit_code = main()
                ^^^^^^
  File "/space/ajreynol/cvc5-pr-ajr/test/regress/cli/run_regression.py", line 838, in main
    return run_regression(
           ^^^^^^^^^^^^^^^
  File "/space/ajreynol/cvc5-pr-ajr/test/regress/cli/run_regression.py", line 776, in run_regression
    test_exit_code = tester.run(benchmark_info)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/space/ajreynol/cvc5-pr-ajr/test/regress/cli/run_regression.py", line 79, in run
    return self.run_internal(benchmark_info)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/space/ajreynol/cvc5-pr-ajr/test/regress/cli/run_regression.py", line 128, in run_internal
    return super().run_internal(benchmark_info)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/space/ajreynol/cvc5-pr-ajr/test/regress/cli/run_regression.py", line 84, in run_internal
    output, error, exit_status = run_benchmark(benchmark_info)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: cannot unpack non-iterable int object

```
This change fixes it.