### PR TITLE
Fix cyclicity issue in sets+cardinality explanations

### DIFF
--- a/src/theory/sets/cardinality_extension.cpp
+++ b/src/theory/sets/cardinality_extension.cpp
@@ -544,7 +544,8 @@ void CardinalityExtension::checkCardCyclesRec(Node eqc,
         d_state.addEqualityToExp(cpk, eqccSingleton, exps);
         if (d_state.areDisequal(n, emp_set))
         {
-          exps.push_back(n.eqNode(emp_set).negate());
+          // ensure we can explain the disequality
+          d_state.explainDisequal(n, emp_set, exps);
           eq_parent = true;
         }
         else

--- a/src/theory/theory_state.cpp
+++ b/src/theory/theory_state.cpp
@@ -125,16 +125,16 @@ void TheoryState::explainDisequal(TNode a, TNode b, std::vector<Node>& exp)
   }
   // otherwise, add equalities to the (disequal) values
   Node ar = getRepresentative(a);
-  if (ar!=a)
+  if (ar != a)
   {
     exp.push_back(a.eqNode(ar));
   }
   Node br = getRepresentative(b);
-  if (br!=b)
+  if (br != b)
   {
     exp.push_back(b.eqNode(br));
   }
-  Assert (ar!=br && ar.isConst() && br.isConst());
+  Assert(ar != br && ar.isConst() && br.isConst());
 }
 
 void TheoryState::getEquivalenceClass(Node a, std::vector<Node>& eqc) const

--- a/src/theory/theory_state.cpp
+++ b/src/theory/theory_state.cpp
@@ -116,6 +116,27 @@ bool TheoryState::areDisequal(TNode a, TNode b) const
   return d_ee->areDisequal(a, b, false);
 }
 
+void TheoryState::explainDisequal(TNode a, TNode b, std::vector<Node>& exp)
+{
+  if (hasTerm(a) && hasTerm(b) && d_ee->areDisequal(a, b, true))
+  {
+    exp.push_back(a.eqNode(b).notNode());
+    return;
+  }
+  // otherwise, add equalities to the (disequal) values
+  Node ar = getRepresentative(a);
+  if (ar!=a)
+  {
+    exp.push_back(a.eqNode(ar));
+  }
+  Node br = getRepresentative(b);
+  if (br!=b)
+  {
+    exp.push_back(b.eqNode(br));
+  }
+  Assert (ar!=br && ar.isConst() && br.isConst());
+}
+
 void TheoryState::getEquivalenceClass(Node a, std::vector<Node>& eqc) const
 {
   if (d_ee->hasTerm(a))

--- a/src/theory/theory_state.h
+++ b/src/theory/theory_state.h
@@ -62,7 +62,7 @@ class TheoryState : protected EnvObj
    * returns true if the representative of a and b are distinct constants.
    */
   virtual bool areDisequal(TNode a, TNode b) const;
-  /** 
+  /**
    * Get the explanation for why a and b are disequal, store it in exp. This
    * assumes that areDisequal(a,b) returns true in the current context and
    * ensures the equality engine has a proof of what it is in exp.

--- a/src/theory/theory_state.h
+++ b/src/theory/theory_state.h
@@ -62,6 +62,12 @@ class TheoryState : protected EnvObj
    * returns true if the representative of a and b are distinct constants.
    */
   virtual bool areDisequal(TNode a, TNode b) const;
+  /** 
+   * Get the explanation for why a and b are disequal, store it in exp. This
+   * assumes that areDisequal(a,b) returns true in the current context and
+   * ensures the equality engine has a proof of what it is in exp.
+   */
+  void explainDisequal(TNode a, TNode b, std::vector<Node>& exp);
   /** get list of members in the equivalence class of a */
   virtual void getEquivalenceClass(Node a, std::vector<Node>& eqc) const;
   /**


### PR DESCRIPTION
This fixes cyclic explanations originating in the sets+cardinality theory solver that was uncovered in the cadical integration.

In particular, sets was using `TheoryState::areDisequal` which intentionally does not ensure the disequality can be explained by the EqualityEngine (often this is only used to query the disequality, not to prepare to explain it). 

However, one of the inferences in sets (SETS_CARD_GRAPH_PARENT_SINGLETON) was using a disequality in an explanation of a fact. This was leading to a cyclic explanation where a disequality could be its own explanation.

In particular, we had equivalence classes { emptyset } { (singleton 0), y } { x, z } where (z != emptyset) is asserted. Sets+cardinality asked whether x != emptyset, this said true and it inferred a fact `A ^ x != emptyset => x = y`.  When we asked for the explanation of `x != emptyset`, it returned `x=y ^ y=emptyset`, which is explained via `A ^ x != emptyset ^ y=emptyset`.