### PR TITLE
cmake: Download GMP from ftp.gnu.org.

### DIFF
--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -122,7 +122,7 @@ if(NOT GMP_FOUND_SYSTEM)
   ExternalProject_Add(
     GMP-EP
     ${COMMON_EP_CONFIG}
-    URL https://github.com/cvc5/cvc5-deps/blob/main/gmp-${GMP_VERSION}.tar.bz2?raw=true
+    URL https://ftp.gnu.org/gnu/gmp/gmp-${GMP_VERSION}.tar.bz2
     URL_HASH SHA1=2dcf34d4a432dbe6cce1475a835d20fe44f75822
     CONFIGURE_COMMAND
       ${CONFIGURE_ENV}


### PR DESCRIPTION
Earlier this year we encountered timeouts when downloading GMP from gmplib.org. The reason for that was that GitHub actions was banned from gmplib.org since the server was not able to handle all the requests from GitHub actions. As a workaround, we hosted our own version of GMP on GitHub, which is not necessary since we can just download GMP from ftp.gnu.org.