### PR TITLE
docs: Some minor fixes in the API documentation.

### DIFF
--- a/include/cvc5/cvc5.h
+++ b/include/cvc5/cvc5.h
@@ -2941,7 +2941,7 @@ class CVC5_EXPORT Grammar
  private:
   /**
    * Constructor.
-   * @param slv The solver that created this grammar.
+   * @param nm        The associated node manager.
    * @param sygusVars The input variables to synth-fun/synth-var.
    * @param ntSymbols The non-terminals of this grammar.
    */
@@ -4913,6 +4913,7 @@ class CVC5_EXPORT Solver
    * \endverbatim
    *
    * @warning This function is experimental and may change in future versions.
+   * @param terms The model values to block.
    */
   void blockModelValues(const std::vector<Term>& terms) const;
 
@@ -5309,7 +5310,7 @@ class CVC5_EXPORT Solver
   /**
    * Helper for mk-functions that call d_nm->mkConst().
    * @param nm The associated node manager.
-   * @pram t The value.
+   * @param t The value.
    */
   template <typename T>
   static Term mkValHelper(internal::NodeManager* nm, const T& t);
@@ -5319,9 +5320,9 @@ class CVC5_EXPORT Solver
    * @param r The value (either int or real).
    * @param isInt True to create an integer value.
    */
-  static Term mkRationalValHelper(internal::NodeManager*,
-                                  const internal::Rational&,
-                                  bool);
+  static Term mkRationalValHelper(internal::NodeManager* nm,
+                                  const internal::Rational& r,
+                                  bool isInt);
 
   /*
    * Constructs a solver with the given original options. This should only be

--- a/include/cvc5/cvc5_kind.h
+++ b/include/cvc5/cvc5_kind.h
@@ -5957,7 +5957,7 @@ struct CVC5_EXPORT hash<cvc5::SortKind>
 {
   /**
    * Hashes a SortKind to a size_t.
-   * @param The kind.
+   * @param kind The kind.
    * @return The hash value.
    */
   size_t operator()(cvc5::SortKind kind) const;

--- a/include/cvc5/cvc5_types.h
+++ b/include/cvc5/cvc5_types.h
@@ -467,8 +467,8 @@ const char* cvc5_find_synthesis_target_to_string(Cvc5FindSynthTarget target);
 #else
 /**
  * Serialize a FindSynthTarget to given stream.
- * @param out The output stream
- * @param targetThe synthesis find target.
+ * @param out    The output stream
+ * @param target The synthesis find target.
  * @return The output stream
  */
 std::ostream& operator<<(std::ostream& out, FindSynthTarget target) CVC5_EXPORT;

--- a/src/api/java/io/github/cvc5/DatatypeDecl.java
+++ b/src/api/java/io/github/cvc5/DatatypeDecl.java
@@ -62,7 +62,10 @@ public class DatatypeDecl extends AbstractPointer
 
   private native void addConstructor(long pointer, long declPointer);
 
-  /** Get the number of constructors (so far) for this Datatype declaration. */
+  /**
+   * Get the number of constructors (so far) for this Datatype declaration.
+   * @return The number of constructors.
+   */
   public int getNumConstructors()
   {
     return getNumConstructors(pointer);
@@ -71,6 +74,7 @@ public class DatatypeDecl extends AbstractPointer
   private native int getNumConstructors(long pointer);
 
   /**
+   * Determine if this datatype declaration is parametric.
    * @return True if this DatatypeDecl is parametric.
    *
    * @api.note This method is experimental and may change in future versions.

--- a/src/api/java/io/github/cvc5/Op.java
+++ b/src/api/java/io/github/cvc5/Op.java
@@ -117,6 +117,7 @@ public class Op extends AbstractPointer
    * Get the index at position {@code i}.
    * @param i The position of the index to return.
    * @return The index at position {@code i}.
+   * @throws CVC5ApiException
    */
   public Term get(int i) throws CVC5ApiException
   {

--- a/src/api/java/io/github/cvc5/OptionInfo.java
+++ b/src/api/java/io/github/cvc5/OptionInfo.java
@@ -181,7 +181,9 @@ public class OptionInfo extends AbstractPointer
   }
 
   /**
-   * Obtain the current value as a boolean. Asserts that valueInfo holds a boolean.
+   * Obtain the current value as a Boolean.
+   * Asserts that valueInfo holds a Boolean.
+   * @return The Boolean value.
    */
   public boolean booleanValue()
   {
@@ -191,8 +193,9 @@ public class OptionInfo extends AbstractPointer
   private native boolean booleanValue(long pointer);
 
   /**
-   * Obtain the current value as a string. Asserts that valueInfo holds a
-   * string.
+   * Obtain the current value as a string.
+   * Asserts that valueInfo holds a string.
+   * @return The string value.
    */
   public String stringValue()
   {
@@ -202,7 +205,9 @@ public class OptionInfo extends AbstractPointer
   private native String stringValue(long pointer);
 
   /**
-   * Obtain the current value as as int. Asserts that valueInfo holds an int.
+   * Obtain the current value as as int.
+   * Asserts that valueInfo holds an int.
+   * @return The integer value.
    */
   public BigInteger intValue()
   {
@@ -212,8 +217,9 @@ public class OptionInfo extends AbstractPointer
   private native BigInteger intValue(long pointer);
 
   /**
-   * Obtain the current value as a double. Asserts that valueInfo holds a
-   * double.
+   * Obtain the current value as a double.
+   * Asserts that valueInfo holds a double.
+   * @return The double value.
    */
   public double doubleValue()
   {

--- a/src/api/java/io/github/cvc5/Solver.java
+++ b/src/api/java/io/github/cvc5/Solver.java
@@ -69,6 +69,7 @@ public class Solver implements IPointer
   /* .................................................................... */
 
   /**
+   * Get the Boolean sort.
    * @return Sort Boolean.
    */
   public Sort getBooleanSort()
@@ -80,6 +81,7 @@ public class Solver implements IPointer
   private native long getBooleanSort(long pointer);
 
   /**
+   * Get the integer sort.
    * @return Sort Integer.
    */
   public Sort getIntegerSort()
@@ -90,6 +92,7 @@ public class Solver implements IPointer
 
   public native long getIntegerSort(long pointer);
   /**
+   * Get the real sort.
    * @return Sort Real.
    */
   public Sort getRealSort()
@@ -100,6 +103,7 @@ public class Solver implements IPointer
 
   private native long getRealSort(long pointer);
   /**
+   * Get the regular expression sort.
    * @return Sort RegExp.
    */
   public Sort getRegExpSort()
@@ -110,6 +114,7 @@ public class Solver implements IPointer
 
   private native long getRegExpSort(long pointer);
   /**
+   * Get the floating-point rounding mode sort.
    * @return Sort RoundingMode.
    * @throws CVC5ApiException
    */
@@ -120,7 +125,9 @@ public class Solver implements IPointer
   }
 
   private native long getRoundingModeSort(long pointer) throws CVC5ApiException;
+
   /**
+   * Get the string sort.
    * @return Sort String.
    */
   public Sort getStringSort()
@@ -177,6 +184,7 @@ public class Solver implements IPointer
    * Create a floating-point sort.
    * @param exp The bit-width of the exponent of the floating-point sort.
    * @param sig The bit-width of the significand of the floating-point sort.
+   * @return The floating-point sort.
    * @throws CVC5ApiException
    */
   public Sort mkFloatingPointSort(int exp, int sig) throws CVC5ApiException
@@ -674,6 +682,7 @@ public class Solver implements IPointer
    *          in mkTerm directly without creating an op first.
    *
    * @param kind The kind to wrap.
+   * @return The operator.
    */
   public Op mkOp(Kind kind)
   {
@@ -692,6 +701,7 @@ public class Solver implements IPointer
    * See enum {@link Kind} for a description of the parameters.
    * @param kind The kind of the operator.
    * @param arg The string argument to this operator.
+   * @return The operator.
    */
   public Op mkOp(Kind kind, String arg)
   {
@@ -720,6 +730,7 @@ public class Solver implements IPointer
    * See enum {@link Kind} for a description of the parameters.
    * @param kind The kind of the operator.
    * @param arg The unsigned int argument to this operator.
+   * @return The operator.
    * @throws CVC5ApiException
    */
   public Op mkOp(Kind kind, int arg) throws CVC5ApiException
@@ -745,6 +756,7 @@ public class Solver implements IPointer
    * @param kind The kind of the operator.
    * @param arg1 The first unsigned int argument to this operator.
    * @param arg2 The second unsigned int argument to this operator.
+   * @return The operator.
    * @throws CVC5ApiException
    */
   public Op mkOp(Kind kind, int arg1, int arg2) throws CVC5ApiException
@@ -765,6 +777,7 @@ public class Solver implements IPointer
    * See enum {@link Kind} for a description of the parameters.
    * @param kind The kind of the operator.
    * @param args The arguments (indices) of the operator.
+   * @return The operator.
    * @throws CVC5ApiException
    */
   public Op mkOp(Kind kind, int[] args) throws CVC5ApiException
@@ -804,8 +817,8 @@ public class Solver implements IPointer
   private native long mkFalse(long pointer);
   /**
    * Create a Boolean constant.
-   * @return The Boolean constant.
    * @param val The value of the constant.
+   * @return The Boolean constant.
    */
   public Term mkBoolean(boolean val)
   {
@@ -1059,6 +1072,7 @@ public class Solver implements IPointer
    * Create a bit-vector constant of given size and value = 0.
    * @param size The bit-width of the bit-vector sort.
    * @return The bit-vector constant.
+   * @throws CVC5ApiException
    */
   public Term mkBitVector(int size) throws CVC5ApiException
   {
@@ -1226,6 +1240,7 @@ public class Solver implements IPointer
   /**
    * Create a rounding mode constant.
    * @param rm The floating point rounding mode this constant represents.
+   * @return The rounding mode.
    */
   public Term mkRoundingMode(RoundingMode rm)
   {
@@ -1917,6 +1932,7 @@ public class Solver implements IPointer
   /**
    * Get info from the solver.
    * SMT-LIB: {@code ( get-info <info_flag> ) }
+   * @param flag The {@code get-info} flag.
    * @return The info.
    */
   public String getInfo(String flag)
@@ -1962,6 +1978,7 @@ public class Solver implements IPointer
    * Check the {@link OptionInfo} class for more details on which information
    * is available.
    *
+   * @param option The name of the option.
    * @return Information about the given option.
    */
   public OptionInfo getOptionInfo(String option)
@@ -2359,6 +2376,7 @@ public class Solver implements IPointer
    * @param symbol The name of the pool.
    * @param sort The sort of the elements of the pool.
    * @param initValue The initial value of the pool.
+   * @return The pool.
    */
   public Term declarePool(String symbol, Sort sort, Term[] initValue)
   {
@@ -2639,6 +2657,8 @@ public class Solver implements IPointer
    * Requires enabling option {@code produce-models}.
    *
    * @api.note This method is experimental and may change in future versions.
+   *
+   * @param terms The model values to block.
    */
   public void blockModelValues(Term[] terms)
   {
@@ -2649,10 +2669,12 @@ public class Solver implements IPointer
   private native void blockModelValues(long pointer, long[] termPointers);
 
   /**
-   * Return a string that contains information about all instantiations made by
+   * Get a string that contains information about all instantiations made by
    * the quantifiers module.
    *
    * @api.note This method is experimental and may change in future versions.
+   *
+   * @return The string representing the information about all instantiations.
    */
   public String getInstantiations()
   {
@@ -2765,6 +2787,7 @@ public class Solver implements IPointer
    * @api.note Asserts isLogicSet().
    *
    * @return The logic used by the solver.
+   * @throws CVC5ApiException
    */
   public String getLogic() throws CVC5ApiException
   {
@@ -3116,9 +3139,10 @@ public class Solver implements IPointer
   private native long findSynthNext(long pointer);
 
   /**
-   * Returns a snapshot of the current state of the statistic values of this
+   * Get a snapshot of the current state of the statistic values of this
    * solver. The returned object is completely decoupled from the solver and
    * will not change when the solver is used again.
+   * @return A snapshot of the current state of the statistic values.
    */
   public Statistics getStatistics()
   {

--- a/src/api/java/io/github/cvc5/Sort.java
+++ b/src/api/java/io/github/cvc5/Sort.java
@@ -466,6 +466,7 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
    * @api.note This method is experimental and may change in future versions.
    *
    * @param params The list of sort parameters to instantiate with.
+   * @return The instantiated sort.
    */
   public Sort instantiate(Sort[] params)
   {
@@ -495,13 +496,15 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   /**
    * Substitution of Sorts.
    *
-   * Note that this replacement is applied during a pre-order traversal and
+   * @api.note This replacement is applied during a pre-order traversal and
    * only once to the sort. It is not run until fix point.
    *
    * @api.note This method is experimental and may change in future versions.
    *
    * @param sort The subsort to be substituted within this sort.
    * @param replacement The sort replacing the substituted subsort.
+   * @return The sort yielded by substituting the replacement sort within the
+   *         given sort.
    */
   public Sort substitute(Sort sort, Sort replacement)
   {
@@ -527,6 +530,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
    *
    * @param sorts The subsorts to be substituted within this sort.
    * @param replacements The sort replacing the substituted subsorts.
+   * @return The sorts yielded by substituting the replacement sort within the
+   *         given sorts.
    */
   public Sort substitute(Sort[] sorts, Sort[] replacements)
   {

--- a/src/api/java/io/github/cvc5/Term.java
+++ b/src/api/java/io/github/cvc5/Term.java
@@ -105,6 +105,7 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
    *
    * @param index The index of the child term to return.
    * @return The child term with the given index.
+   * @throws CVC5ApiException
    */
   public Term getChild(int index) throws CVC5ApiException
   {
@@ -127,6 +128,7 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
 
   /**
    * @return The kind of this term.
+   * @throws CVC5ApiException
    */
   public Kind getKind() throws CVC5ApiException
   {
@@ -150,6 +152,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   /**
    * Replace {@code term} with {@code replacement} in this term.
    *
+   * @param term        The term to replace.
+   * @param replacement The term to replace it with.
    * @return The result of replacing {@code term} with {@code replacement} in
    *         this term.
    *
@@ -177,6 +181,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
    * @api.note This replacement is applied during a pre-order traversal and
    *           only once (it is not run until fixed point).
    *
+   * @param terms        The terms to replace.
+   * @param replacements The replacement terms.
    * @return The result of simultaneously replacing {@code terms} with
    *         {@code replacements} in this term.
    */
@@ -494,6 +500,7 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
    * Asserts isBitVectorValue().
    * @return The representation of a bit-vector value in bit string
    *         representation.
+   * @throws CVC5ApiException
    */
   public String getBitVectorValue() throws CVC5ApiException
   {
@@ -508,7 +515,10 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
    *
    * @api.note Asserts {@code Term#isBitVectorValue()}.
    *
+   * @param base {@code 2} for binary, {@code 10} for decimal, and {@code 16}
+   *             for hexadecimal.
    * @return The string representation of a bit-vector value.
+   * @throws CVC5ApiException
    */
   public String getBitVectorValue(int base) throws CVC5ApiException
   {
@@ -534,6 +544,7 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
    * @api.note Asserts {@code Term#isFiniteFieldValue()}.
    *
    * @return The string representation of a finite field value.
+   * @throws CVC5ApiException
    */
   public String getFiniteFieldValue() throws CVC5ApiException
   {
@@ -576,6 +587,7 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   /**
    * Asserts isRoundingModeValue().
    * @return The floating-point rounding mode value held by the term.
+   * @throws CVC5ApiException
    */
   public RoundingMode getRoundingModeValue() throws CVC5ApiException
   {

--- a/src/api/java/io/github/cvc5/Utils.java
+++ b/src/api/java/io/github/cvc5/Utils.java
@@ -27,7 +27,7 @@ public class Utils
   }
 
   /**
-   * load cvc5 jni library
+   * Load cvc5 jni library.
    */
   public static void loadLibraries()
   {
@@ -38,7 +38,8 @@ public class Utils
   }
 
   /**
-   * return sorts array from array of pointers
+   * @return Sorts array from array of Sort pointers.
+   * @param pointers The array of pointers.
    */
   public static Sort[] getSorts(long[] pointers)
   {
@@ -51,7 +52,8 @@ public class Utils
   }
 
   /**
-   * return terms array from array of pointers
+   * @return Terms array from array of Term pointers.
+   * @param pointers The array of pointers.
    */
   public static Term[] getTerms(long[] pointers)
   {
@@ -64,7 +66,8 @@ public class Utils
   }
 
   /**
-   * get pointers from one dimensional array
+   * @return Pointers from one dimensional array.
+   * @param objects The one dimensional array of pointers.
    */
   public static long[] getPointers(IPointer[] objects)
   {
@@ -77,7 +80,8 @@ public class Utils
   }
 
   /**
-   * get pointers from two dimensional matrix
+   * @return Pointers from two dimensional matrix.
+   * @param objects The two dimensional array of pointers.
    */
   public static long[][] getPointers(IPointer[][] objects)
   {
@@ -145,8 +149,9 @@ public class Utils
   }
 
   /**
-    Convert a rational string a/b to a pair of BigIntegers
-  */
+   * Convert a rational string a/b to a pair of BigIntegers
+   * @return The pair of big integers.
+   */
   public static Pair<BigInteger, BigInteger> getRational(String rational)
   {
     if (rational.contains("/"))
@@ -158,7 +163,8 @@ public class Utils
   }
 
   /**
-     Convert a pair of BigIntegers to a rational string a/b
+   * Convert a pair of BigIntegers to a rational string a/b
+   * @return The rational string.
    */
   public static String getRational(Pair<BigInteger, BigInteger> pair)
   {

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -2839,17 +2839,17 @@ cdef class Solver:
         """
             Is logic set? Returns whether we called setLogic yet for this
             solver.
-            
+
             :return: whether we called setLogic yet for this solver.
         """
         return self.csolver.isLogicSet()
-        
+
     def getLogic(self):
         """
             Get the logic set the solver.
-   
+
             .. note:: Asserts isLogicSet().
-   
+
             :return: The logic used by the solver.
         """
         return self.csolver.getLogic().decode()


### PR DESCRIPTION
Note that we don't add a description to the `@throws` directive in Java, which will still produce warnings. Adding the description is tedious, and generally the consensus in the java community is to best not add it at all anyways.