### PR TITLE
prop: Fix compilation issues with CryptoMiniSat.

### DIFF
--- a/src/prop/sat_solver.h
+++ b/src/prop/sat_solver.h
@@ -25,7 +25,6 @@
 #include "expr/node.h"
 #include "proof/clause_id.h"
 #include "proof/proof_node_manager.h"
-#include "prop/sat_proof_manager.h"
 #include "prop/sat_solver_types.h"
 #include "util/statistics_stats.h"
 
@@ -33,6 +32,7 @@ namespace cvc5::internal {
 
 namespace prop {
 
+class SatProofManager;
 class TheoryProxy;
 
 class SatSolver {


### PR DESCRIPTION
Fixes the nightlies.
The issue was that `prop/sat_solver.h` pulled in `prop/sat_proof_manager.h`, which pulls in `prop/minisat/core/SolverTypes.h`, which then collides with CMS type declarations.