### PR TITLE
[proof-new] Add test cases to exercise bitvector proof reconstruction rules.

### DIFF
--- a/src/theory/bv/rewrites
+++ b/src/theory/bv/rewrites
@@ -601,31 +601,13 @@
   (bv 0 (+ 1 (- high low))))
 
 ; (a udiv 2^k) ==> 0_k a[n-1: k]
-(define-cond-rule bv-udiv-pow2-1p
+(define-cond-rule bv-udiv-pow2-not-one
   ((x ?BitVec) (v Int) (n Int))
   (def (power (int.log2 v)))
   (and (int.ispow2 v) (> v 1))
   (bvudiv x (bv v n))
   (concat (bv 0 power) (extract (- n 1) power x)))
 
-; Removed because these rules cannot be ever used - `UdivPow2` mandates that the divisor is positive.
-;(define-cond-rule bv-udiv-pow2-1n
-;  ((x ?BitVec) (v Int) (n Int))
-;  (def (power (int.log2 (- v))))
-;  (and (int.ispow2 (- v)) (< v (- 1)))
-;  (bvudiv x (bv v n))
-;  (bvneg (concat (bv 0 power) (extract (- n 1) power x))))
-(define-cond-rule bv-udiv-pow2-2p
-  ((x ?BitVec) (v Int) (n Int))
-  (= v 1)
-  (bvudiv x (bv v n))
-  x)
-;(define-cond-rule bv-udiv-pow2-2n
-;  ((x ?BitVec) (v Int) (n Int))
-;  (= v (- 1))
-;  (bvudiv x (bv v n))
-;  (bvneg x))
-; (x udiv 0) = 111...1
 (define-rule bv-udiv-zero
   ((x ?BitVec) (n Int))
   (bvudiv x (bv 0 n))
@@ -636,31 +618,17 @@
   x)
 ; (x urem 2^k) = 0_(n-k) x[k-1:0]
 ; The original version had power - 1, but I thought about it and it doesn't make sense to me, so I didn't put the -1 here.
-(define-cond-rule bv-urem-pow2-1
+(define-cond-rule bv-urem-pow2-not-one
   ((x ?BitVec) (v Int) (n Int))
   (def (power (int.log2 v)))
   (and (int.ispow2 v) (> v 1))
   (bvurem x (bv v n))
   (concat (bv 0 (- n power)) (extract (- power 1) 0 x)))
 
-; Same as udiv-pow2, the negative case is redundant.
-;(define-cond-rule bv-urem-pow2-2
-;  ((x ?BitVec) (v Int) (n Int))
-;  (def (power (int.log2 (- v))))
-;  (and (int.ispow2 (- v)) (< v (- 1)))
-;  (bvurem x (bv v n))
-;  (concat (bv 0 (- n power)) (extract (- power 1) 0 x)))
-; (x urem 1) = 0
-(define-rule bv-urem-one-1
+(define-rule bv-urem-one
   ((x ?BitVec) (n Int))
   (bvurem x (bv 1 n))
   (bv 0 n))
-;(define-cond-rule bv-urem-one-2
-;  ((x ?BitVec) (v Int) (n Int))
-;  (= v (- 1))
-;  (bvurem x (bv v n))
-;  (bv 0 n))
-; (x urem x) = 0
 (define-rule bv-urem-self
   ((x ?BitVec))
   (bvurem x x)

--- a/src/theory/bv/rewrites
+++ b/src/theory/bv/rewrites
@@ -607,22 +607,24 @@
   (and (int.ispow2 v) (> v 1))
   (bvudiv x (bv v n))
   (concat (bv 0 power) (extract (- n 1) power x)))
-(define-cond-rule bv-udiv-pow2-1n
-  ((x ?BitVec) (v Int) (n Int))
-  (def (power (int.log2 (- v))))
-  (and (int.ispow2 (- v)) (< v (- 1)))
-  (bvudiv x (bv v n))
-  (bvneg (concat (bv 0 power) (extract (- n 1) power x))))
+
+; Removed because these rules cannot be ever used - `UdivPow2` mandates that the divisor is positive.
+;(define-cond-rule bv-udiv-pow2-1n
+;  ((x ?BitVec) (v Int) (n Int))
+;  (def (power (int.log2 (- v))))
+;  (and (int.ispow2 (- v)) (< v (- 1)))
+;  (bvudiv x (bv v n))
+;  (bvneg (concat (bv 0 power) (extract (- n 1) power x))))
 (define-cond-rule bv-udiv-pow2-2p
   ((x ?BitVec) (v Int) (n Int))
   (= v 1)
   (bvudiv x (bv v n))
   x)
-(define-cond-rule bv-udiv-pow2-2n
-  ((x ?BitVec) (v Int) (n Int))
-  (= v (- 1))
-  (bvudiv x (bv v n))
-  (bvneg x))
+;(define-cond-rule bv-udiv-pow2-2n
+;  ((x ?BitVec) (v Int) (n Int))
+;  (= v (- 1))
+;  (bvudiv x (bv v n))
+;  (bvneg x))
 ; (x udiv 0) = 111...1
 (define-rule bv-udiv-zero
   ((x ?BitVec) (n Int))
@@ -640,22 +642,24 @@
   (and (int.ispow2 v) (> v 1))
   (bvurem x (bv v n))
   (concat (bv 0 (- n power)) (extract (- power 1) 0 x)))
-(define-cond-rule bv-urem-pow2-2
-  ((x ?BitVec) (v Int) (n Int))
-  (def (power (int.log2 (- v))))
-  (and (int.ispow2 (- v)) (< v (- 1)))
-  (bvurem x (bv v n))
-  (concat (bv 0 (- n power)) (extract (- power 1) 0 x)))
+
+; Same as udiv-pow2, the negative case is redundant.
+;(define-cond-rule bv-urem-pow2-2
+;  ((x ?BitVec) (v Int) (n Int))
+;  (def (power (int.log2 (- v))))
+;  (and (int.ispow2 (- v)) (< v (- 1)))
+;  (bvurem x (bv v n))
+;  (concat (bv 0 (- n power)) (extract (- power 1) 0 x)))
 ; (x urem 1) = 0
 (define-rule bv-urem-one-1
   ((x ?BitVec) (n Int))
   (bvurem x (bv 1 n))
   (bv 0 n))
-(define-cond-rule bv-urem-one-2
-  ((x ?BitVec) (v Int) (n Int))
-  (= v (- 1))
-  (bvurem x (bv v n))
-  (bv 0 n))
+;(define-cond-rule bv-urem-one-2
+;  ((x ?BitVec) (v Int) (n Int))
+;  (= v (- 1))
+;  (bvurem x (bv v n))
+;  (bv 0 n))
 ; (x urem x) = 0
 (define-rule bv-urem-self
   ((x ?BitVec))

--- a/src/theory/bv/rewrites
+++ b/src/theory/bv/rewrites
@@ -287,7 +287,7 @@
     (s (bvsub (zero_extend 1 x) (zero_extend 1 y)))
   )
   (bvusubo x y)
-  (= (extract (- n 1) (- n 1) s) (bv 1 1)))
+  (= (extract n n s) (bv 1 1)))
 ; Overflow occurs when
 ; 1. (N - P) = P
 ; 2. (P - N) = N

--- a/src/theory/bv/rewrites
+++ b/src/theory/bv/rewrites
@@ -591,10 +591,11 @@
   )
   (def
     (n (+ x1in (bvsize x2)))
-    (x0n (ite (= x1i 0) x1in (- x1in (int.log2 x1i))))
-    (y0n (ite (= y1i 0) y1in (- y1in (int.log2 y1i))))
+    ; length(n) = log2(n) + 1, so we subtract 1 to compensate
+    (x0n (ite (= x1i 0) x1in (- x1in 1 (int.log2 x1i))))
+    (y0n (ite (= y1i 0) y1in (- y1in 1 (int.log2 y1i))))
   )
-  (and (> n 64) (> (- (* 2 n) (+ x0n y0n)) low))
+  (and (> n 64) (<= (- (* 2 n) (+ x0n y0n)) low))
   (extract high low (bvmul
     (concat (bv x1i x1in) x2)
     (concat (bv y1i y1in) y2)))

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -463,33 +463,31 @@ set(regress_0_tests
   regress0/bv/fuzz40.smtv1.smt2
   regress0/bv/fuzz41.smtv1.smt2
   # Added to fill holes in regression tests
-  regress0/bv/holes/and-flatten.smt2
-  regress0/bv/holes/and-zero.smt2
-  regress0/bv/holes/commutative-xor.smt2
-  regress0/bv/holes/commutative-add.smt2 # Subsumed by ARITH_POLY_NORM
-  regress0/bv/holes/comp-eliminate.smt2
-  regress0/bv/holes/concat-extract-merge.smt2
   regress0/bv/holes/concat-flatten.smt2
-  regress0/bv/holes/extract-concat.smt2
+  regress0/bv/holes/concat-extract-merge.smt2
   regress0/bv/holes/extract-extract.smt2
+  regress0/bv/holes/extract-concat.smt2
   regress0/bv/holes/extract-whole.smt2
-  regress0/bv/holes/mult-distrib-const-neg.smt2
-  regress0/bv/holes/not-neq.smt2
-  regress0/bv/holes/repeat-eliminate-1.smt2 # Calculation may be too complicated
-  regress0/bv/holes/repeat-eliminate-2.smt2
-  regress0/bv/holes/rotate-left-eliminate-1.smt2
-  regress0/bv/holes/sgt-eliminate.smt2
-  regress0/bv/holes/shl-by-const-1.smt2
-  regress0/bv/holes/udiv-zero.smt2
+
   regress0/bv/holes/uge-eliminate.smt2
   regress0/bv/holes/ugt-eliminate.smt2
-  regress0/bv/holes/ult-one.smt2
+  regress0/bv/holes/sgt-eliminate.smt2
+  regress0/bv/holes/slt-eliminate.smt2 # Roundabout method used
+
+  regress0/bv/holes/comp-eliminate.smt2
   regress0/bv/holes/sdiv-eliminate-fewer-bitwise-ops.smt2 # Timeout!
   regress0/bv/holes/zero-extend-eliminate.smt2
   regress0/bv/holes/sign-extend-eliminate.smt2 # Roundabout method used
-  regress0/bv/holes/slt-eliminate.smt2 # Roundabout method used
+  regress0/bv/holes/repeat-eliminate-1.smt2 # Calculation may be too complicated
+  regress0/bv/holes/repeat-eliminate-2.smt2
+  regress0/bv/holes/sub-eliminate.smt2 # Subsumed by ARITH_POLY_NORM
   regress0/bv/holes/redor-eliminate.smt2
   regress0/bv/holes/redand-eliminate.smt2
+  regress0/bv/holes/srem-eliminate.smt2
+  regress0/bv/holes/srem-eliminate-fewer-bitwise-ops.smt2
+  regress0/bv/holes/usubo-eliminate.smt2
+  regress0/bv/holes/ssubo-eliminate.smt2
+
   regress0/bv/holes/ite-equal-children.smt2
   regress0/bv/holes/ite-const-children-1.smt2
   regress0/bv/holes/ite-const-children-2.smt2
@@ -500,6 +498,27 @@ set(regress_0_tests
   regress0/bv/holes/ite-merge-else-if.smt2
   regress0/bv/holes/ite-merge-then-else.smt2 # Roundabout method used
   regress0/bv/holes/ite-merge-else-else.smt2
+
+  regress0/bv/holes/extract-mult-leading-bit.smt2
+  regress0/bv/holes/merge-sign-extend-2.smt2
+  regress0/bv/holes/merge-sign-extend-3.smt2
+  regress0/bv/holes/shl-by-const-1.smt2
+  regress0/bv/holes/shl-zero.smt2
+  regress0/bv/holes/slt-zero.smt2
+
+  regress0/bv/holes/udiv-pow2-1p.smt2
+  regress0/bv/holes/urem-pow2.smt2
+  regress0/bv/holes/urem-self.smt2
+  regress0/bv/holes/udiv-zero.smt2
+
+  regress0/bv/holes/and-flatten.smt2
+  regress0/bv/holes/and-zero.smt2
+  regress0/bv/holes/commutative-xor.smt2
+  regress0/bv/holes/commutative-add.smt2 # Subsumed by ARITH_POLY_NORM
+  regress0/bv/holes/mult-distrib-const-neg.smt2
+  regress0/bv/holes/not-neq.smt2
+  regress0/bv/holes/rotate-left-eliminate-1.smt2
+  regress0/bv/holes/ult-one.smt2
   regress0/bv/holes/lshr-by-const-1.smt2
   regress0/bv/holes/ashr-by-const-0.smt2
   regress0/bv/holes/ashr-by-const-1.smt2 # Could not find rule
@@ -510,7 +529,6 @@ set(regress_0_tests
   regress0/bv/holes/not-ule.smt2 # Roundabout method (constant size, so it should be ok)
   regress0/bv/holes/not-sle.smt2 # Roundabout method (constant size, so it should be ok)
   regress0/bv/holes/mult-pow2-2b.smt2 # Could not find rule
-  regress0/bv/holes/sub-eliminate.smt2 # Subsumed by ARITH_POLY_NORM
   regress0/bv/holes/neg-idemp.smt2     # Subsumed by ARITH_POLY_NORM
   regress0/bv/holes/not-xor.smt2     # Roundabout method
   regress0/bv/holes/and-simplify-1.smt2
@@ -519,6 +537,7 @@ set(regress_0_tests
   regress0/bv/holes/or-simplify-2.smt2
   regress0/bv/holes/xor-simplify-2.smt2
   regress0/bv/holes/xor-simplify-3.smt2
+
   regress0/bv/incorrect1.delta01.smtv1.smt2
   regress0/bv/inequality00.smt2
   regress0/bv/inequality01.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -555,6 +555,12 @@ set(regress_0_tests
   regress0/bv/holes/mult-distrib-const-sub.smt2
   regress0/bv/holes/mult-distrib-1.smt2
   regress0/bv/holes/mult-distrib-2.smt2
+
+
+  regress0/bv/holes/ult-add-one.smt2
+  regress0/bv/holes/concat-to-mult.smt2
+  regress0/bv/holes/mult-slt-mult-1.smt2
+  regress0/bv/holes/mult-slt-mult-2.smt2
   regress0/bv/holes/commutative-add.smt2
   regress0/bv/holes/mul-one.smt2
   regress0/bv/holes/mul-zero.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -472,17 +472,17 @@ set(regress_0_tests
   regress0/bv/holes/uge-eliminate.smt2
   regress0/bv/holes/ugt-eliminate.smt2
   regress0/bv/holes/sgt-eliminate.smt2
-  regress0/bv/holes/slt-eliminate.smt2 # Roundabout method used
+  regress0/bv/holes/slt-eliminate.smt2 # O(exp) Roundabout method used
+  regress0/bv/holes/sub-eliminate.smt2 # O(1) ARITH_POLY_NORM
 
-  regress0/bv/holes/comp-eliminate.smt2
-  regress0/bv/holes/sdiv-eliminate-fewer-bitwise-ops.smt2 # Timeout!
+  regress0/bv/holes/comp-eliminate.smt2 # Redundant, does not test bv-comp-eliminate
+  regress0/bv/holes/repeat-eliminate-1.smt2 # O(1) roundabout
+  regress0/bv/holes/repeat-eliminate-2.smt2 # O(1) roundabout
   regress0/bv/holes/zero-extend-eliminate.smt2
   regress0/bv/holes/sign-extend-eliminate.smt2 # Roundabout method used
-  regress0/bv/holes/repeat-eliminate-1.smt2 # Calculation may be too complicated
-  regress0/bv/holes/repeat-eliminate-2.smt2
-  regress0/bv/holes/sub-eliminate.smt2 # Subsumed by ARITH_POLY_NORM
   regress0/bv/holes/redor-eliminate.smt2
   regress0/bv/holes/redand-eliminate.smt2
+  regress0/bv/holes/sdiv-eliminate-fewer-bitwise-ops.smt2 # O(n) roundabout
   regress0/bv/holes/srem-eliminate.smt2
   regress0/bv/holes/srem-eliminate-fewer-bitwise-ops.smt2
   regress0/bv/holes/usubo-eliminate.smt2
@@ -537,6 +537,30 @@ set(regress_0_tests
   regress0/bv/holes/or-simplify-2.smt2
   regress0/bv/holes/xor-simplify-2.smt2
   regress0/bv/holes/xor-simplify-3.smt2
+
+  regress0/bv/holes/zero-extend-eq-const-1.smt2
+  regress0/bv/holes/zero-extend-eq-const-2.smt2
+  regress0/bv/holes/zero-extend-ult-const-1.smt2
+  regress0/bv/holes/zero-extend-ult-const-2.smt2
+  regress0/bv/holes/sign-extend-ult-const-1.smt2
+  regress0/bv/holes/sign-extend-ult-const-3.smt2
+  regress0/bv/holes/extract-bitwise-and.smt2
+  regress0/bv/holes/extract-bitwise-or.smt2
+  regress0/bv/holes/extract-bitwise-xor.smt2
+  regress0/bv/holes/extract-sign-extend-3.smt2
+  regress0/bv/holes/neg-mult.smt2 # O(exp) roundabout
+  regress0/bv/holes/neg-sub.smt2
+  regress0/bv/holes/neg-add.smt2
+  regress0/bv/holes/mult-distrib-const-add.smt2
+  regress0/bv/holes/mult-distrib-const-sub.smt2
+  regress0/bv/holes/mult-distrib-1.smt2
+  regress0/bv/holes/mult-distrib-2.smt2
+  regress0/bv/holes/commutative-add.smt2
+  regress0/bv/holes/mul-one.smt2
+  regress0/bv/holes/mul-zero.smt2
+  regress0/bv/holes/add-zero.smt2
+  regress0/bv/holes/add-two.smt2
+  regress0/bv/holes/mul-flatten.smt2
 
   regress0/bv/incorrect1.delta01.smtv1.smt2
   regress0/bv/inequality00.smt2

--- a/test/regress/cli/regress0/bv/holes/add-two.smt2
+++ b/test/regress/cli/regress0/bv/holes/add-two.smt2
@@ -3,10 +3,7 @@
 (set-logic QF_BV)
 (set-info :status unsat)
 
-(declare-const x (_ BitVec 10))
-(assert (not (=
-	((_ repeat 5) x)
-	(concat x ((_ repeat 4) x))
-	)))
+(declare-const x (_ BitVec 5))
+(assert (not (= (bvadd x x) (bvmul x #b00010))))
 (check-sat)
 (exit)

--- a/test/regress/cli/regress0/bv/holes/add-zero.smt2
+++ b/test/regress/cli/regress0/bv/holes/add-zero.smt2
@@ -3,10 +3,7 @@
 (set-logic QF_BV)
 (set-info :status unsat)
 
-(declare-const x (_ BitVec 10))
-(assert (not (=
-	((_ repeat 5) x)
-	(concat x ((_ repeat 4) x))
-	)))
+(declare-const x (_ BitVec 5))
+(assert (not (= (bvadd x #b00000) x)))
 (check-sat)
 (exit)

--- a/test/regress/cli/regress0/bv/holes/concat-to-mult.smt2
+++ b/test/regress/cli/regress0/bv/holes/concat-to-mult.smt2
@@ -1,0 +1,12 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 10))
+(declare-const y (_ BitVec 5))
+(assert (not (=
+	(concat ((_ extract 4 0) x) #b00000)
+	(bvmul x (bvshl #b0000000001 #b0000000101)))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/extract-bitwise-and.smt2
+++ b/test/regress/cli/regress0/bv/holes/extract-bitwise-and.smt2
@@ -3,11 +3,11 @@
 (set-logic QF_BV)
 (set-info :status unsat)
 
-; This should be unsat but it is sat. What is going on here?
 (declare-const x (_ BitVec 5))
 (declare-const y (_ BitVec 5))
 (assert (not (=
-	(bvusubo x y)
-  (= ((_ extract 5 5) (bvsub ((_ zero_extend 1) x) ((_ zero_extend 1) y))) #b1))))
+	((_ extract 4 3) (bvand x y))
+	(bvand ((_ extract 4 3) x) ((_ extract 4 3) y))
+	)))
 (check-sat)
 (exit)

--- a/test/regress/cli/regress0/bv/holes/extract-bitwise-or.smt2
+++ b/test/regress/cli/regress0/bv/holes/extract-bitwise-or.smt2
@@ -3,11 +3,11 @@
 (set-logic QF_BV)
 (set-info :status unsat)
 
-; This should be unsat but it is sat. What is going on here?
 (declare-const x (_ BitVec 5))
 (declare-const y (_ BitVec 5))
 (assert (not (=
-	(bvusubo x y)
-  (= ((_ extract 5 5) (bvsub ((_ zero_extend 1) x) ((_ zero_extend 1) y))) #b1))))
+	((_ extract 4 3) (bvor x y))
+	(bvor ((_ extract 4 3) x) ((_ extract 4 3) y))
+	)))
 (check-sat)
 (exit)

--- a/test/regress/cli/regress0/bv/holes/extract-bitwise-xor.smt2
+++ b/test/regress/cli/regress0/bv/holes/extract-bitwise-xor.smt2
@@ -3,11 +3,11 @@
 (set-logic QF_BV)
 (set-info :status unsat)
 
-; This should be unsat but it is sat. What is going on here?
 (declare-const x (_ BitVec 5))
 (declare-const y (_ BitVec 5))
 (assert (not (=
-	(bvusubo x y)
-  (= ((_ extract 5 5) (bvsub ((_ zero_extend 1) x) ((_ zero_extend 1) y))) #b1))))
+	((_ extract 4 3) (bvxor x y))
+	(bvxor ((_ extract 4 3) x) ((_ extract 4 3) y))
+	)))
 (check-sat)
 (exit)

--- a/test/regress/cli/regress0/bv/holes/extract-mult-leading-bit.smt2
+++ b/test/regress/cli/regress0/bv/holes/extract-mult-leading-bit.smt2
@@ -1,0 +1,19 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 25))
+(declare-const y (_ BitVec 25))
+(assert (not (=
+	; Top 5 bits
+	((_ extract 64 60) (bvmul
+		; 40 zeros on top
+		(concat #b0000000000000000000000000000000000000000 x)
+		(concat #b0000000000000000000000000000000000000000 y)
+	))
+	; Should be all 0
+	#b00000
+	)))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/extract-sign-extend-3.smt2
+++ b/test/regress/cli/regress0/bv/holes/extract-sign-extend-3.smt2
@@ -3,10 +3,10 @@
 (set-logic QF_BV)
 (set-info :status unsat)
 
-(declare-const x (_ BitVec 10))
+(declare-const x (_ BitVec 5))
 (assert (not (=
-	((_ repeat 5) x)
-	(concat x ((_ repeat 4) x))
+	((_ extract 8 7) ((_ sign_extend 5) x))
+	((_ repeat 2) ((_ extract 4 4) x))
 	)))
 (check-sat)
 (exit)

--- a/test/regress/cli/regress0/bv/holes/merge-sign-extend-2.smt2
+++ b/test/regress/cli/regress0/bv/holes/merge-sign-extend-2.smt2
@@ -1,0 +1,11 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 10))
+(assert (not (=
+	((_ sign_extend 5) ((_ zero_extend 5) x))
+	((_ zero_extend 10) x))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/merge-sign-extend-3.smt2
+++ b/test/regress/cli/regress0/bv/holes/merge-sign-extend-3.smt2
@@ -1,0 +1,11 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 10))
+(assert (not (=
+	((_ sign_extend 10) ((_ zero_extend 0) x))
+	((_ sign_extend 10) x))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/mul-flatten.smt2
+++ b/test/regress/cli/regress0/bv/holes/mul-flatten.smt2
@@ -3,11 +3,12 @@
 (set-logic QF_BV)
 (set-info :status unsat)
 
-; This should be unsat but it is sat. What is going on here?
 (declare-const x (_ BitVec 5))
 (declare-const y (_ BitVec 5))
+(declare-const z (_ BitVec 5))
+(declare-const w (_ BitVec 5))
 (assert (not (=
-	(bvusubo x y)
-  (= ((_ extract 5 5) (bvsub ((_ zero_extend 1) x) ((_ zero_extend 1) y))) #b1))))
+	(bvmul x (bvmul y z) w)
+	(bvmul x y z w))))
 (check-sat)
 (exit)

--- a/test/regress/cli/regress0/bv/holes/mul-one.smt2
+++ b/test/regress/cli/regress0/bv/holes/mul-one.smt2
@@ -3,10 +3,7 @@
 (set-logic QF_BV)
 (set-info :status unsat)
 
-(declare-const x (_ BitVec 10))
-(assert (not (=
-	((_ repeat 5) x)
-	(concat x ((_ repeat 4) x))
-	)))
+(declare-const x (_ BitVec 5))
+(assert (not (= (bvmul x #b00001) x)))
 (check-sat)
 (exit)

--- a/test/regress/cli/regress0/bv/holes/mul-zero.smt2
+++ b/test/regress/cli/regress0/bv/holes/mul-zero.smt2
@@ -3,10 +3,7 @@
 (set-logic QF_BV)
 (set-info :status unsat)
 
-(declare-const x (_ BitVec 10))
-(assert (not (=
-	((_ repeat 5) x)
-	(concat x ((_ repeat 4) x))
-	)))
+(declare-const x (_ BitVec 5))
+(assert (not (= (bvmul x #b00000) #b00000)))
 (check-sat)
 (exit)

--- a/test/regress/cli/regress0/bv/holes/mult-distrib-1.smt2
+++ b/test/regress/cli/regress0/bv/holes/mult-distrib-1.smt2
@@ -1,0 +1,13 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x1 (_ BitVec 4))
+(declare-const x2 (_ BitVec 4))
+(declare-const y (_ BitVec 4))
+(assert (not (=
+	(bvmul (bvadd x1 x2) y)
+	(bvadd (bvmul x1 y) (bvmul x2 y)))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/mult-distrib-2.smt2
+++ b/test/regress/cli/regress0/bv/holes/mult-distrib-2.smt2
@@ -1,0 +1,13 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x1 (_ BitVec 4))
+(declare-const x2 (_ BitVec 4))
+(declare-const y (_ BitVec 4))
+(assert (not (=
+	(bvmul y (bvadd x1 x2))
+	(bvadd (bvmul y x1) (bvmul y x2)))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/mult-distrib-const-add.smt2
+++ b/test/regress/cli/regress0/bv/holes/mult-distrib-const-add.smt2
@@ -1,0 +1,12 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 4))
+(declare-const y (_ BitVec 4))
+(assert (not (=
+	(bvmul (bvadd x y) #b0100)
+	(bvadd (bvmul x #b0100) (bvmul y #b0100)))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/mult-distrib-const-sub.smt2
+++ b/test/regress/cli/regress0/bv/holes/mult-distrib-const-sub.smt2
@@ -1,0 +1,12 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 4))
+(declare-const y (_ BitVec 4))
+(assert (not (=
+	(bvmul (bvsub x y) #b0100)
+	(bvsub (bvmul x #b0100) (bvmul y #b0100)))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/mult-slt-mult-1.smt2
+++ b/test/regress/cli/regress0/bv/holes/mult-slt-mult-1.smt2
@@ -1,0 +1,20 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 5))
+(declare-const t (_ BitVec 5))
+(declare-const a (_ BitVec 3))
+(assert (not (=
+	(bvslt
+		(bvmul ((_ sign_extend 5) (bvadd x t)) ((_ sign_extend 7) a))
+		(bvmul ((_ sign_extend 5) x) ((_ sign_extend 7) a))
+	)
+	(and
+		(not (= t #b00000))
+		(not (= a #b000))
+		(= (bvslt (bvadd x t) x) (bvsgt a #b000))
+	))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/mult-slt-mult-2.smt2
+++ b/test/regress/cli/regress0/bv/holes/mult-slt-mult-2.smt2
@@ -1,0 +1,20 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 5))
+(declare-const t (_ BitVec 5))
+(declare-const a (_ BitVec 3))
+(assert (not (=
+	(bvslt
+		(bvmul ((_ zero_extend 5) (bvadd x t)) ((_ sign_extend 7) a))
+		(bvmul ((_ zero_extend 5) x) ((_ sign_extend 7) a))
+	)
+	(and
+		(not (= t #b00000))
+		(not (= a #b000))
+		(= (bvult (bvadd x t) x) (bvsgt a #b000))
+	))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/neg-add.smt2
+++ b/test/regress/cli/regress0/bv/holes/neg-add.smt2
@@ -3,11 +3,11 @@
 (set-logic QF_BV)
 (set-info :status unsat)
 
-; This should be unsat but it is sat. What is going on here?
 (declare-const x (_ BitVec 5))
 (declare-const y (_ BitVec 5))
+(declare-const z (_ BitVec 5))
 (assert (not (=
-	(bvusubo x y)
-  (= ((_ extract 5 5) (bvsub ((_ zero_extend 1) x) ((_ zero_extend 1) y))) #b1))))
+	(bvneg (bvadd x y z))
+	(bvadd (bvneg x) (bvneg y) (bvneg z)))))
 (check-sat)
 (exit)

--- a/test/regress/cli/regress0/bv/holes/neg-mult.smt2
+++ b/test/regress/cli/regress0/bv/holes/neg-mult.smt2
@@ -3,10 +3,10 @@
 (set-logic QF_BV)
 (set-info :status unsat)
 
-(declare-const x (_ BitVec 10))
+(declare-const x (_ BitVec 5))
+(declare-const y (_ BitVec 5))
 (assert (not (=
-	((_ repeat 5) x)
-	(concat x ((_ repeat 4) x))
-	)))
+	(bvneg (bvmul x #b10101 y))
+	(bvmul x #b01011 y))))
 (check-sat)
 (exit)

--- a/test/regress/cli/regress0/bv/holes/neg-sub.smt2
+++ b/test/regress/cli/regress0/bv/holes/neg-sub.smt2
@@ -3,10 +3,10 @@
 (set-logic QF_BV)
 (set-info :status unsat)
 
-(declare-const x (_ BitVec 10))
+(declare-const x (_ BitVec 5))
+(declare-const y (_ BitVec 5))
 (assert (not (=
-	((_ repeat 5) x)
-	(concat x ((_ repeat 4) x))
-	)))
+	(bvneg (bvsub x y))
+	(bvsub y x))))
 (check-sat)
 (exit)

--- a/test/regress/cli/regress0/bv/holes/shl-zero.smt2
+++ b/test/regress/cli/regress0/bv/holes/shl-zero.smt2
@@ -1,0 +1,12 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 10))
+(assert (not (=
+	(bvshl #b0000000000 x)
+	#b0000000000
+	)))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/sign-extend-ult-const-1.smt2
+++ b/test/regress/cli/regress0/bv/holes/sign-extend-ult-const-1.smt2
@@ -3,10 +3,10 @@
 (set-logic QF_BV)
 (set-info :status unsat)
 
-(declare-const x (_ BitVec 10))
+(declare-const x (_ BitVec 3))
 (assert (not (=
-	((_ repeat 5) x)
-	(concat x ((_ repeat 4) x))
+	(bvult ((_ sign_extend 3) x) #b000010)
+	(bvult x #b010)
 	)))
 (check-sat)
 (exit)

--- a/test/regress/cli/regress0/bv/holes/sign-extend-ult-const-3.smt2
+++ b/test/regress/cli/regress0/bv/holes/sign-extend-ult-const-3.smt2
@@ -3,10 +3,10 @@
 (set-logic QF_BV)
 (set-info :status unsat)
 
-(declare-const x (_ BitVec 10))
+(declare-const x (_ BitVec 3))
 (assert (not (=
-	((_ repeat 5) x)
-	(concat x ((_ repeat 4) x))
+	(bvult #b000010 ((_ sign_extend 3) x))
+	(bvult #b010 x)
 	)))
 (check-sat)
 (exit)

--- a/test/regress/cli/regress0/bv/holes/slt-zero.smt2
+++ b/test/regress/cli/regress0/bv/holes/slt-zero.smt2
@@ -1,0 +1,12 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 10))
+(assert (not (=
+	(bvslt x #b0000000000)
+	(= ((_ extract 9 9) x) #b1)
+	)))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/srem-eliminate-fewer-bitwise-ops.smt2
+++ b/test/regress/cli/regress0/bv/holes/srem-eliminate-fewer-bitwise-ops.smt2
@@ -1,0 +1,12 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 5))
+(declare-const y (_ BitVec 5))
+(assert (and (bvsgt x #b00000) (bvsgt y #b00000) (not (=
+	(bvsrem x y)
+  (ite (bvuge x #b10000) (bvneg (bvurem x y)) (bvurem x y))))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/srem-eliminate.smt2
+++ b/test/regress/cli/regress0/bv/holes/srem-eliminate.smt2
@@ -1,0 +1,12 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 5))
+(declare-const y (_ BitVec 5))
+(assert (and (bvsgt x #b00000) (bvsgt y #b00000) (not (=
+	(bvsrem x y)
+  (bvite ((_ extract 4 4) x) (bvneg (bvurem x y)) (bvurem x y))))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/ssubo-eliminate.smt2
+++ b/test/regress/cli/regress0/bv/holes/ssubo-eliminate.smt2
@@ -1,0 +1,24 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+; This should be unsat but it is sat. What is going on here?
+(declare-const x (_ BitVec 5))
+(declare-const y (_ BitVec 5))
+(assert (not (=
+	(bvssubo x y)
+	(or
+		(and
+			(= ((_ extract 4 4) x) #b1) ; x < 0
+			(not (= ((_ extract 4 4) y) #b1)) ; !(y < 0)
+			(not (= ((_ extract 4 4) (bvsub x y)) #b1)) ; !(s < 0)
+		)
+		(and
+			(not (= ((_ extract 4 4) x) #b1)) ; !(x < 0)
+			(= ((_ extract 4 4) y) #b1) ; y < 0
+			(= ((_ extract 4 4) (bvsub x y)) #b1) ; s < 0
+		)
+	))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/udiv-pow2-1p.smt2
+++ b/test/regress/cli/regress0/bv/holes/udiv-pow2-1p.smt2
@@ -1,0 +1,11 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 5))
+(assert (not (=
+	(bvudiv x #b01000)
+	(concat #b000 ((_ extract 4 3) x)))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/ult-add-one.smt2
+++ b/test/regress/cli/regress0/bv/holes/ult-add-one.smt2
@@ -1,0 +1,15 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 5))
+(declare-const y (_ BitVec 5))
+(assert (not (=
+	(bvult x (bvadd y #b00001))
+	(and
+		(not (bvult y x))
+		(not (= y #b11111))
+	))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/urem-pow2.smt2
+++ b/test/regress/cli/regress0/bv/holes/urem-pow2.smt2
@@ -1,0 +1,11 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 5))
+(assert (not (=
+	(bvurem x #b01000)
+	(concat #b00 ((_ extract 2 0) x)))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/urem-self.smt2
+++ b/test/regress/cli/regress0/bv/holes/urem-self.smt2
@@ -1,0 +1,11 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 5))
+(assert (not (=
+	(bvurem x x)
+	#b00000)))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/usubo-eliminate.smt2
+++ b/test/regress/cli/regress0/bv/holes/usubo-eliminate.smt2
@@ -1,0 +1,13 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+; This should be unsat but it is sat. What is going on here?
+(declare-const x (_ BitVec 5))
+(declare-const y (_ BitVec 5))
+(assert (not (=
+	(bvusubo x y)
+  (= ((_ extract 4 4) (bvsub ((_ zero_extend 1) x) ((_ zero_extend 1) y))) #b1))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/zero-extend-eq-const-1.smt2
+++ b/test/regress/cli/regress0/bv/holes/zero-extend-eq-const-1.smt2
@@ -1,0 +1,14 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 3))
+(assert (not (=
+	(= ((_ zero_extend 3) x) #b000111)
+	(and
+		(= ((_ extract 5 3) #b000111) #b000)
+		(= x ((_ extract 2 0) #b000111))
+	))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/zero-extend-eq-const-2.smt2
+++ b/test/regress/cli/regress0/bv/holes/zero-extend-eq-const-2.smt2
@@ -1,0 +1,14 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 3))
+(assert (not (=
+	(= #b000111 ((_ zero_extend 3) x))
+	(and
+		(= ((_ extract 5 3) #b000111) #b000)
+		(= x ((_ extract 2 0) #b000111))
+	))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/zero-extend-ult-const-1.smt2
+++ b/test/regress/cli/regress0/bv/holes/zero-extend-ult-const-1.smt2
@@ -3,10 +3,10 @@
 (set-logic QF_BV)
 (set-info :status unsat)
 
-(declare-const x (_ BitVec 10))
+(declare-const x (_ BitVec 3))
 (assert (not (=
-	((_ repeat 5) x)
-	(concat x ((_ repeat 4) x))
+	(bvult ((_ zero_extend 3) x) #b000110)
+	(bvult x #b110)
 	)))
 (check-sat)
 (exit)

--- a/test/regress/cli/regress0/bv/holes/zero-extend-ult-const-2.smt2
+++ b/test/regress/cli/regress0/bv/holes/zero-extend-ult-const-2.smt2
@@ -3,10 +3,10 @@
 (set-logic QF_BV)
 (set-info :status unsat)
 
-(declare-const x (_ BitVec 10))
+(declare-const x (_ BitVec 3))
 (assert (not (=
-	((_ repeat 5) x)
-	(concat x ((_ repeat 4) x))
+	(bvult #b000110 ((_ zero_extend 3) x))
+	(bvult #b110 x)
 	)))
 (check-sat)
 (exit)


### PR DESCRIPTION
1. Remove `bvurem` and `bvudiv` RARE rules that handle negative cases - they are never invoked. More specifically, the corresponding rules `UremPow2` and `UdivPow2` require the divisor to be non-negative. The negative cases are removed, and the cases for dividing by 1 are handled by `bv-{udiv,urem}-one`.
2. Add some test cases that are supposed to be filled by exisitng rules, but either a roundabout method is used or the hole doesn't get filled.
3. Fixed a bug in `bv-usubo-eliminate`
4. Fixed a bug in `bv-extract-mult-leading-bit`

There remain 3 cases of bv reconstruction rules unable to fill holes generated by the rewriter.