### PR TITLE
Partition Generator Updates Part 1

### DIFF
--- a/src/options/parallel_options.toml
+++ b/src/options/parallel_options.toml
@@ -39,15 +39,12 @@ name   = "Parallel"
   category   = "expert"
   long       = "partition-strategy=MODE"
   type       = "PartitionMode"
-  default    = "REVISED"
+  default    = "DECISION_SCATTER"
   help       = "choose partition strategy mode"
   help_mode  = "Partition strategy modes."
-[[option.mode.REVISED]]
-  name = "revised"
-  help = "For 4 partitions, creates cubes C1, C2, C3, !C1 & !C2 & !C3"
-[[option.mode.STRICT_CUBE]]
-  name = "strict-cube"
-  help = "For 4 partitions, creates cubes C1, !C1 & C2, !C1 & !C2 & C3, !C1 & !C2 & !C3"
+[[option.mode.DECISION_SCATTER]]
+  name = "decision-scatter"
+  help = "For 4 partitions, creates partitions C1, !C1 & C2, !C1 & !C2 & C3, !C1 & !C2 & !C3, from decisions" 
 [[option.mode.DECISION_TRAIL]]
   name = "decision-trail"
   help = "Creates mutually exclusive cubes from the decisions in the SAT solver."

--- a/src/smt/smt_solver.cpp
+++ b/src/smt/smt_solver.cpp
@@ -17,6 +17,7 @@
 
 #include "options/base_options.h"
 #include "options/main_options.h"
+#include "options/parallel_options.h"
 #include "options/smt_options.h"
 #include "preprocessing/assertion_pipeline.h"
 #include "prop/prop_engine.h"
@@ -150,6 +151,17 @@ Result SmtSolver::checkSatInternal()
     }
     Trace("smt") << "SmtSolver::global negate returned " << result << std::endl;
   }
+
+  // Handle emitting pending partitions.
+  // This can be triggered by a scatter strategy that produces
+  // fewer than the requested number of partitions before solving
+  // the remainder of the problem.
+  if (options().parallel.computePartitions > 1
+      && result.getStatus() == Result::UNSAT)
+  {
+    d_theoryEngine->emitPendingPartitions();
+  }
+
   return result;
 }
 

--- a/src/theory/partition_generator.h
+++ b/src/theory/partition_generator.h
@@ -77,7 +77,7 @@ class PartitionGenerator : public TheoryEngineModule
    * emitZLL is set to true, then zero-level learned literals will be appended
    * to the cubes.
    */
-  Node makeRevisedPartitions(bool strict, bool emitZLL);
+  Node makeRevisedPartitions(bool emitZLL);
 
   /**
    * Partition by taking a list of literals and emitting mutually exclusive

--- a/src/theory/partition_generator.h
+++ b/src/theory/partition_generator.h
@@ -41,6 +41,11 @@ class PartitionGenerator : public TheoryEngineModule
                      prop::PropEngine* propEngine);
 
   /**
+   * Emit any remaining partitions that were not emitted during solving.
+   */
+  void emitRemainingPartitions(bool solved);
+
+  /**
    * Make partitions for parallel solving. e communicates the effort at which
    * check was called. Returns a lemma blocking off the emitted cube from the
    * search.
@@ -63,7 +68,7 @@ class PartitionGenerator : public TheoryEngineModule
    * Increment d_numPartitionsSoFar and print the cube to 
    * the output file specified by --write-partitions-to. 
    */
-  void emitCube(Node toEmit);
+  void emitPartition(Node toEmit);
 
   /**
    * Partition using the "revised" strategy, which emits cubes such as C1, C2,
@@ -95,7 +100,7 @@ class PartitionGenerator : public TheoryEngineModule
   /**
    * Stop partitioning and return unsat.
    */
-  Node stopPartitioning() const;
+  Node stopPartitioning();
 
   /**
    * Get a list of literals.
@@ -153,15 +158,25 @@ std::vector<Node> d_assertedLemmas;
 std::vector<Node> d_cubes;
 
 /**
- * List of the strict cubes that have been created.
+ * List of the scatter partitions that have been created.
  */
-std::vector<Node> d_strict_cubes;
+std::vector<Node> d_scatterPartitions;
 
 /**
  * Minimum number of literals required in the list of decisions for cubes to
  * be made.
  */
 uint64_t d_conflictSize;
+
+/**
+ * Track whether any partitions have been emitted.
+ */
+bool d_createdAnyPartitions;
+
+/**
+ * Track whether all partitions have been emitted.
+ */
+bool d_emittedAllPartitions;
 };
 }  // namespace theory
 }  // namespace cvc5::internal

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -2017,6 +2017,11 @@ void TheoryEngine::checkTheoryAssertionsWithModel(bool hardFailure) {
   }
 }
 
+void TheoryEngine::emitPendingPartitions()
+{
+  d_partitionGen->emitRemainingPartitions(/*solved=*/true);
+}
+
 std::pair<bool, Node> TheoryEngine::entailmentCheck(options::TheoryOfMode mode,
                                                     TNode lit)
 {

--- a/src/theory/theory_engine.h
+++ b/src/theory/theory_engine.h
@@ -419,6 +419,11 @@ class TheoryEngine : protected EnvObj
    */
   void checkTheoryAssertionsWithModel(bool hardFailure);
 
+  /**
+   * Emit any pending partitions via the partition generator.
+   */
+  void emitPendingPartitions();
+
  private:
   typedef context::
       CDHashMap<NodeTheoryPair, NodeTheoryPair, NodeTheoryPairHashFunction>


### PR DESCRIPTION
This PR updates a few naming schemes but mainly focuses on adding in the ability to emit pending partitions. Emitting pending partitions is important for any scatter strategy because while the user may request 64 partitions, it is possible that through blocking the search, only 40 (or some other number less than 64) partitions are created before the solver arrives at some solution. In this case, we need to dump all of the partitions that were created. 

Note that d_emittedAnyPartitions is unused for now, but it will be used in future PRs. 