### PR TITLE
[proof-new] Remove constants from bv rewrite rule match expressions

### DIFF
--- a/src/rewriter/mkrewrites.py
+++ b/src/rewriter/mkrewrites.py
@@ -173,7 +173,7 @@ def validate_rule(rule):
 
     # Perform type checking
     lhsHasConst = type_check(rule.lhs)
-    if lhsHasConst:
+    if os.getenv('CVC5_RARE_CHECK_CONST', None) is not None and lhsHasConst:
         print(f"Warning: Rule {rule.name} has constants in its match expression", file=sys.stderr)
     type_check(rule.rhs)
     type_check(rule.cond)

--- a/src/rewriter/mkrewrites.py
+++ b/src/rewriter/mkrewrites.py
@@ -110,16 +110,21 @@ class Rewrites:
         self.rules = rules
 
 
-def type_check(expr):
-    for child in expr.children:
-        type_check(child)
+def type_check(expr) -> bool:
+    """
+    Returns true if a const subexpression exists
+    """
+    hasConst = any([type_check(child) for child in expr.children])
 
     if isinstance(expr, CBool):
         expr.sort = Sort(BaseSort.Bool, is_const=True)
+        hasConst = True
     elif isinstance(expr, CString):
         expr.sort = Sort(BaseSort.String, is_const=True)
+        hasConst = True
     elif isinstance(expr, CInt):
         expr.sort = Sort(BaseSort.Int, is_const=True)
+        hasConst = True
     elif isinstance(expr, App):
         sort = None
         if expr.op == Op.NEG:
@@ -131,6 +136,9 @@ def type_check(expr):
             sort.is_const = all(child.sort and child.sort.is_const
                                 for child in expr.children)
             expr.sort = sort
+            hasConst = sort.is_const
+
+    return hasConst
 
 
 def validate_rule(rule):
@@ -164,7 +172,9 @@ def validate_rule(rule):
         to_visit.extend(curr.children)
 
     # Perform type checking
-    type_check(rule.lhs)
+    lhsHasConst = type_check(rule.lhs)
+    if lhsHasConst:
+        print(f"Warning: Rule {rule.name} has constants in its match expression", file=sys.stderr)
     type_check(rule.rhs)
     type_check(rule.cond)
 

--- a/src/theory/bv/rewrites
+++ b/src/theory/bv/rewrites
@@ -1,4 +1,3 @@
-
 ; -- Core Normalization Rules --
 
 (define-rule* bv-concat-flatten
@@ -24,9 +23,9 @@
   (extract l k (extract j i x))
   (extract (+ i l) (+ i k) x))
 (define-cond-rule bv-extract-whole
-  ((x ?BitVec) (n Int) (c0 Int))
-  (and (>= n (- (bvsize x) 1)) (= c0 0))
-  (extract n c0 x)
+  ((x ?BitVec) (n Int))
+  (>= n (- (bvsize x) 1))
+  (extract n 0 x)
   x)
 ; Case 1: (< j n) so the extract is self contained
 (define-cond-rule bv-extract-concat-1
@@ -310,19 +309,15 @@
 ; -- Simplification Rules --
 
 (define-rule bv-ite-equal-children ((c (_ BitVec 1)) (x ?BitVec)) (bvite c x x) x)
-(define-cond-rule bv-ite-const-children-1 (
+(define-rule bv-ite-const-children-1 (
     (c (_ BitVec 1))
-    (c0 (_ BitVec 1)) (c1 (_ BitVec 1))
   )
-  (and (= c0 (bv 0 1)) (= c1 (bv 1 1)))
-  (bvite c c0 c1)
+  (bvite c (bv 0 1) (bv 1 1))
   (bvnot c))
-(define-cond-rule bv-ite-const-children-2 (
+(define-rule bv-ite-const-children-2 (
     (c (_ BitVec 1))
-    (c0 (_ BitVec 1)) (c1 (_ BitVec 1))
   )
-  (and (= c0 (bv 0 1)) (= c1 (bv 1 1)))
-  (bvite c c1 c0)
+  (bvite c (bv 1 1) (bv 0 1))
   c)
 (define-rule bv-ite-equal-cond-1 (
     (c0 (_ BitVec 1))
@@ -383,10 +378,9 @@
   (bvite (bvand (bvnot c0) c1) t1 t0))
 
 
-(define-cond-rule bv-shl-by-const-0
-  ((x ?BitVec) (c0 ?BitVec))
-  (= c0 (bv 0 (bvsize c0)))
-  (bvshl x c0)
+(define-rule bv-shl-by-const-0
+  ((x ?BitVec) (sz Int))
+  (bvshl x (bv 0 sz))
   x)
 (define-cond-rule bv-shl-by-const-1
   ((x ?BitVec) (amount Int) (sz Int))
@@ -399,10 +393,9 @@
   (>= amount (bvsize x))
   (bvshl x (bv amount sz))
   (bv 0 (bvsize x)))
-(define-cond-rule bv-lshr-by-const-0
-  ((x ?BitVec) (c0 ?BitVec))
-  (= c0 (bv 0 (bvsize c0)))
-  (bvlshr x c0)
+(define-rule bv-lshr-by-const-0
+  ((x ?BitVec) (sz Int))
+  (bvlshr x (bv 0 sz))
   x)
 (define-cond-rule bv-lshr-by-const-1
   ((x ?BitVec) (amount Int) (sz Int))
@@ -415,10 +408,9 @@
   (>= amount (bvsize x))
   (bvlshr x (bv amount sz))
   (bv 0 sz))
-(define-cond-rule bv-ashr-by-const-0
-  ((x ?BitVec) (c0 ?BitVec))
-  (= c0 (bv 0 (bvsize c0)))
-  (bvashr x c0)
+(define-rule bv-ashr-by-const-0
+  ((x ?BitVec) (sz Int))
+  (bvashr x (bv 0 sz))
   x)
 (define-cond-rule bv-ashr-by-const-1
   ((x ?BitVec) (amount Int) (sz Int))
@@ -477,10 +469,9 @@
 (define-rule bv-bitwise-idemp-1 ((x ?BitVec)) (bvand x x) x)
 (define-rule bv-bitwise-idemp-2 ((x ?BitVec)) (bvor x x) x)
 
-(define-cond-rule bv-and-zero ((x ?BitVec) (c0 ?BitVec))
-  (= c0 (bv 0 (bvsize c0)))
-  (bvand x c0)
-  (bv 0 (bvsize x)))
+(define-rule bv-and-zero ((x ?BitVec) (n Int))
+  (bvand x (bv 0 n))
+  (bv 0 n))
 (define-cond-rule bv-and-one ((x ?BitVec) (y ?BitVec))
   (= y (bvnot (bv 0 (bvsize y))))
   (bvand x y)
@@ -496,9 +487,8 @@
   (= y (bvnot (bv 0 (bvsize y))))
   (bvxor x y)
   (bvnot x))
-(define-cond-rule bv-xor-zero ((x ?BitVec) (c0 ?BitVec))
-  (= c0 (bv 0 (bvsize c0)))
-  (bvxor x c0)
+(define-rule bv-xor-zero ((x ?BitVec) (n Int))
+  (bvxor x (bv 0 n))
   x)
 
 (define-rule bv-bitwise-not-and ((x ?BitVec))
@@ -512,28 +502,24 @@
 (define-rule bv-not-idemp ((x ?BitVec))
   (bvnot (bvnot x)) x)
 
-(define-cond-rule bv-ult-zero-1
-  ((x ?BitVec) (c0 ?BitVec))
-  (= c0 (bv 0 (bvsize c0)))
-  (bvult c0 x)
-  (not (= x (bv 0 (bvsize x)))))
-(define-cond-rule bv-ult-zero-2
-  ((x ?BitVec) (c0 ?BitVec))
-  (= c0 (bv 0 (bvsize c0)))
-  (bvult x c0)
+(define-rule bv-ult-zero-1
+  ((x ?BitVec) (n Int))
+  (bvult (bv 0 n) x)
+  (not (= x (bv 0 n))))
+(define-rule bv-ult-zero-2
+  ((x ?BitVec) (n Int))
+  (bvult x (bv 0 n))
   false)
 (define-rule bv-ult-self ((x ?BitVec)) (bvult x x) false)
 (define-rule bv-lt-self ((x ?BitVec)) (bvslt x x) false)
 (define-rule bv-ule-self ((x ?BitVec)) (bvule x x) true)
-(define-cond-rule bv-ule-zero
-  ((x ?BitVec) (c0 ?BitVec))
-  (= c0 (bv 0 (bvsize c0)))
-  (bvule x c0)
-  (= x (bv 0 (bvsize x))))
-(define-cond-rule bv-zero-ule
-  ((x ?BitVec) (c0 ?BitVec))
-  (= c0 (bv 0 (bvsize c0)))
-  (bvule c0 x)
+(define-rule bv-ule-zero
+  ((x ?BitVec) (n Int))
+  (bvule x (bv 0 n))
+  (= x (bv 0 n)))
+(define-rule bv-zero-ule
+  ((x ?BitVec) (n Int))
+  (bvule (bv 0 n) x)
   true)
 (define-rule bv-sle-self ((x ?BitVec)) (bvsle x x) true)
 
@@ -623,15 +609,13 @@
   (bvudiv x (bv v n))
   (concat (bv 0 power) (extract (- n 1) power x)))
 
-(define-cond-rule bv-udiv-zero
-  ((x ?BitVec) (c0 ?BitVec))
-  (= c0 (bv 0 (bvsize c0)))
-  (bvudiv x c0)
-  (bvnot (bv 0 (bvsize x))))
+(define-rule bv-udiv-zero
+  ((x ?BitVec) (n Int))
+  (bvudiv x (bv 0 n))
+  (bvnot (bv 0 n)))
 ; (x udiv 1) = x
-(define-cond-rule bv-udiv-one ((x ?BitVec) (c1 ?BitVec))
-  (= c1 (bv 1 (bvsize c1)))
-  (bvudiv x c1)
+(define-rule bv-udiv-one ((x ?BitVec) (n Int))
+  (bvudiv x (bv 1 n))
   x)
 ; (x urem 2^k) = 0_(n-k) x[k-1:0]
 ; The original version had power - 1, but I thought about it and it doesn't make sense to me, so I didn't put the -1 here.
@@ -642,32 +626,28 @@
   (bvurem x (bv v n))
   (concat (bv 0 (- n power)) (extract (- power 1) 0 x)))
 
-(define-cond-rule bv-urem-one
-  ((x ?BitVec) (c1 ?BitVec))
-  (= c1 (bv 1 (bvsize c1)))
-  (bvurem x c1)
-  (bv 0 (bvsize x)))
+(define-rule bv-urem-one
+  ((x ?BitVec) (n Int))
+  (bvurem x (bv 1 n))
+  (bv 0 n))
 (define-rule bv-urem-self
   ((x ?BitVec))
   (bvurem x x)
   (bv 0 (bvsize x)))
 ; ShiftZero rule
 ; (0_k >> a) = 0_k
-(define-cond-rule bv-shl-zero
-  ((a ?BitVec) (c0 ?BitVec))
-  (= c0 (bv 0 (bvsize c0)))
-  (bvshl c0 a)
-  (bv 0 (bvsize c0)))
-(define-cond-rule bv-lshr-zero
-  ((a ?BitVec) (c0 ?BitVec))
-  (= c0 (bv 0 (bvsize c0)))
-  (bvlshr c0 a)
-  (bv 0 (bvsize c0)))
-(define-cond-rule bv-ashr-zero
-  ((a ?BitVec) (c0 ?BitVec))
-  (= c0 (bv 0 (bvsize c0)))
-  (bvashr c0 a)
-  (bv 0 (bvsize c0)))
+(define-rule bv-shl-zero
+  ((a ?BitVec) (n Int))
+  (bvshl (bv 0 n) a)
+  (bv 0 n))
+(define-rule bv-lshr-zero
+  ((a ?BitVec) (n Int))
+  (bvlshr (bv 0 n) a)
+  (bv 0 n))
+(define-rule bv-ashr-zero
+  ((a ?BitVec) (n Int))
+  (bvashr (bv 0 n) a)
+  (bv 0 n))
 
 ; (bvugt (bvurem T x) x)
 ;   ==>  (ite (= x 0_k) (bvugt T x) false)
@@ -683,16 +663,14 @@
     (bvugt y (bv 0 (bvsize y)))
   ))
 
-(define-cond-rule bv-ult-one
-  ((x ?BitVec) (c1 ?BitVec))
-  (= c1 (bv 1 (bvsize c1)))
-  (bvult x c1)
-  (= x (bv 0 (bvsize x))))
-(define-cond-rule bv-slt-zero
-  ((x ?BitVec) (c0 ?BitVec))
-  (= c0 (bv 0 (bvsize c0)))
-  (bvslt x c0)
-  (= (extract (- (bvsize x) 1) (- (bvsize x) 1) x) (bv 1 1)))
+(define-rule bv-ult-one
+  ((x ?BitVec) (n Int))
+  (bvult x (bv 1 n))
+  (= x (bv 0 n)))
+(define-rule bv-slt-zero
+  ((x ?BitVec) (n Int))
+  (bvslt x (bv 0 n))
+  (= (extract (- n 1) (- n 1) x) (bv 1 1)))
 
 (define-rule bv-merge-sign-extend-1
   ((x ?BitVec) (i Int) (j Int))
@@ -997,9 +975,8 @@
 
 
 ; -- Hole filling rules --
-(define-cond-rule bv-or-zero ((x ?BitVec) (c0 ?BitVec))
-  (= c0 (bv 0 (bvsize c0)))
-  (bvor x c0)
+(define-rule bv-or-zero ((x ?BitVec) (n Int))
+  (bvor x (bv 0 n))
   x)
 (define-cond-rule bv-mul-one ((x ?BitVec) (c1 ?BitVec))
   (= c1 (bv 1 (bvsize c1)))
@@ -1018,15 +995,13 @@
   (bvmul x (bv 2 (bvsize x))))
 
 
-(define-cond-rule bv-zero-extend-eliminate-0
-  ((x ?BitVec) (n0 Int))
-  (= n0 0)
-  (zero_extend n0 x)
+(define-rule bv-zero-extend-eliminate-0
+  ((x ?BitVec))
+  (zero_extend 0 x)
   x)
-(define-cond-rule bv-sign-extend-eliminate-0
-  ((x ?BitVec) (n0 Int))
-  (= n0 0)
-  (sign_extend n0 x)
+(define-rule bv-sign-extend-eliminate-0
+  ((x ?BitVec))
+  (sign_extend 0 x)
   x)
 (define-cond-rule bv-not-neq ((x ?BitVec))
   (> (bvsize x) 0)

--- a/src/theory/bv/rewrites
+++ b/src/theory/bv/rewrites
@@ -24,9 +24,9 @@
   (extract l k (extract j i x))
   (extract (+ i l) (+ i k) x))
 (define-cond-rule bv-extract-whole
-  ((x ?BitVec) (n Int))
-  (>= n (- (bvsize x) 1))
-  (extract n 0 x)
+  ((x ?BitVec) (n Int) (c0 Int))
+  (and (>= n (- (bvsize x) 1)) (= c0 0))
+  (extract n c0 x)
   x)
 ; Case 1: (< j n) so the extract is self contained
 (define-cond-rule bv-extract-concat-1
@@ -310,15 +310,19 @@
 ; -- Simplification Rules --
 
 (define-rule bv-ite-equal-children ((c (_ BitVec 1)) (x ?BitVec)) (bvite c x x) x)
-(define-rule bv-ite-const-children-1 (
+(define-cond-rule bv-ite-const-children-1 (
     (c (_ BitVec 1))
+    (c0 (_ BitVec 1)) (c1 (_ BitVec 1))
   )
-  (bvite c (bv 0 1) (bv 1 1))
+  (and (= c0 (bv 0 1)) (= c1 (bv 1 1)))
+  (bvite c c0 c1)
   (bvnot c))
-(define-rule bv-ite-const-children-2 (
+(define-cond-rule bv-ite-const-children-2 (
     (c (_ BitVec 1))
+    (c0 (_ BitVec 1)) (c1 (_ BitVec 1))
   )
-  (bvite c (bv 1 1) (bv 0 1))
+  (and (= c0 (bv 0 1)) (= c1 (bv 1 1)))
+  (bvite c c1 c0)
   c)
 (define-rule bv-ite-equal-cond-1 (
     (c0 (_ BitVec 1))

--- a/src/theory/bv/rewrites
+++ b/src/theory/bv/rewrites
@@ -383,9 +383,10 @@
   (bvite (bvand (bvnot c0) c1) t1 t0))
 
 
-(define-rule bv-shl-by-const-0
-  ((x ?BitVec) (sz Int))
-  (bvshl x (bv 0 sz))
+(define-cond-rule bv-shl-by-const-0
+  ((x ?BitVec) (c0 ?BitVec))
+  (= c0 (bv 0 (bvsize c0)))
+  (bvshl x c0)
   x)
 (define-cond-rule bv-shl-by-const-1
   ((x ?BitVec) (amount Int) (sz Int))
@@ -398,9 +399,10 @@
   (>= amount (bvsize x))
   (bvshl x (bv amount sz))
   (bv 0 (bvsize x)))
-(define-rule bv-lshr-by-const-0
-  ((x ?BitVec) (sz Int))
-  (bvlshr x (bv 0 sz))
+(define-cond-rule bv-lshr-by-const-0
+  ((x ?BitVec) (c0 ?BitVec))
+  (= c0 (bv 0 (bvsize c0)))
+  (bvlshr x c0)
   x)
 (define-cond-rule bv-lshr-by-const-1
   ((x ?BitVec) (amount Int) (sz Int))
@@ -413,9 +415,10 @@
   (>= amount (bvsize x))
   (bvlshr x (bv amount sz))
   (bv 0 sz))
-(define-rule bv-ashr-by-const-0
-  ((x ?BitVec) (sz Int))
-  (bvashr x (bv 0 sz))
+(define-cond-rule bv-ashr-by-const-0
+  ((x ?BitVec) (c0 ?BitVec))
+  (= c0 (bv 0 (bvsize c0)))
+  (bvashr x c0)
   x)
 (define-cond-rule bv-ashr-by-const-1
   ((x ?BitVec) (amount Int) (sz Int))
@@ -474,9 +477,10 @@
 (define-rule bv-bitwise-idemp-1 ((x ?BitVec)) (bvand x x) x)
 (define-rule bv-bitwise-idemp-2 ((x ?BitVec)) (bvor x x) x)
 
-(define-rule bv-and-zero ((x ?BitVec) (n Int))
-  (bvand x (bv 0 n))
-  (bv 0 n))
+(define-cond-rule bv-and-zero ((x ?BitVec) (c0 ?BitVec))
+  (= c0 (bv 0 (bvsize c0)))
+  (bvand x c0)
+  (bv 0 (bvsize x)))
 (define-cond-rule bv-and-one ((x ?BitVec) (y ?BitVec))
   (= y (bvnot (bv 0 (bvsize y))))
   (bvand x y)
@@ -492,8 +496,9 @@
   (= y (bvnot (bv 0 (bvsize y))))
   (bvxor x y)
   (bvnot x))
-(define-rule bv-xor-zero ((x ?BitVec) (n Int))
-  (bvxor x (bv 0 n))
+(define-cond-rule bv-xor-zero ((x ?BitVec) (c0 ?BitVec))
+  (= c0 (bv 0 (bvsize c0)))
+  (bvxor x c0)
   x)
 
 (define-rule bv-bitwise-not-and ((x ?BitVec))
@@ -507,24 +512,28 @@
 (define-rule bv-not-idemp ((x ?BitVec))
   (bvnot (bvnot x)) x)
 
-(define-rule bv-ult-zero-1
-  ((x ?BitVec) (n Int))
-  (bvult (bv 0 n) x)
-  (not (= x (bv 0 n))))
-(define-rule bv-ult-zero-2
-  ((x ?BitVec) (n Int))
-  (bvult x (bv 0 n))
+(define-cond-rule bv-ult-zero-1
+  ((x ?BitVec) (c0 ?BitVec))
+  (= c0 (bv 0 (bvsize c0)))
+  (bvult c0 x)
+  (not (= x (bv 0 (bvsize x)))))
+(define-cond-rule bv-ult-zero-2
+  ((x ?BitVec) (c0 ?BitVec))
+  (= c0 (bv 0 (bvsize c0)))
+  (bvult x c0)
   false)
 (define-rule bv-ult-self ((x ?BitVec)) (bvult x x) false)
 (define-rule bv-lt-self ((x ?BitVec)) (bvslt x x) false)
 (define-rule bv-ule-self ((x ?BitVec)) (bvule x x) true)
-(define-rule bv-ule-zero
-  ((x ?BitVec) (n Int))
-  (bvule x (bv 0 n))
-  (= x (bv 0 n)))
-(define-rule bv-zero-ule
-  ((x ?BitVec) (n Int))
-  (bvule (bv 0 n) x)
+(define-cond-rule bv-ule-zero
+  ((x ?BitVec) (c0 ?BitVec))
+  (= c0 (bv 0 (bvsize c0)))
+  (bvule x c0)
+  (= x (bv 0 (bvsize x))))
+(define-cond-rule bv-zero-ule
+  ((x ?BitVec) (c0 ?BitVec))
+  (= c0 (bv 0 (bvsize c0)))
+  (bvule c0 x)
   true)
 (define-rule bv-sle-self ((x ?BitVec)) (bvsle x x) true)
 
@@ -614,13 +623,15 @@
   (bvudiv x (bv v n))
   (concat (bv 0 power) (extract (- n 1) power x)))
 
-(define-rule bv-udiv-zero
-  ((x ?BitVec) (n Int))
-  (bvudiv x (bv 0 n))
-  (bvnot (bv 0 n)))
+(define-cond-rule bv-udiv-zero
+  ((x ?BitVec) (c0 ?BitVec))
+  (= c0 (bv 0 (bvsize c0)))
+  (bvudiv x c0)
+  (bvnot (bv 0 (bvsize x))))
 ; (x udiv 1) = x
-(define-rule bv-udiv-one ((x ?BitVec) (n Int))
-  (bvudiv x (bv 1 n))
+(define-cond-rule bv-udiv-one ((x ?BitVec) (c1 ?BitVec))
+  (= c1 (bv 1 (bvsize c1)))
+  (bvudiv x c1)
   x)
 ; (x urem 2^k) = 0_(n-k) x[k-1:0]
 ; The original version had power - 1, but I thought about it and it doesn't make sense to me, so I didn't put the -1 here.
@@ -631,28 +642,32 @@
   (bvurem x (bv v n))
   (concat (bv 0 (- n power)) (extract (- power 1) 0 x)))
 
-(define-rule bv-urem-one
-  ((x ?BitVec) (n Int))
-  (bvurem x (bv 1 n))
-  (bv 0 n))
+(define-cond-rule bv-urem-one
+  ((x ?BitVec) (c1 ?BitVec))
+  (= c1 (bv 1 (bvsize c1)))
+  (bvurem x c1)
+  (bv 0 (bvsize x)))
 (define-rule bv-urem-self
   ((x ?BitVec))
   (bvurem x x)
   (bv 0 (bvsize x)))
 ; ShiftZero rule
 ; (0_k >> a) = 0_k
-(define-rule bv-shl-zero
-  ((a ?BitVec) (n Int))
-  (bvshl (bv 0 n) a)
-  (bv 0 n))
-(define-rule bv-lshr-zero
-  ((a ?BitVec) (n Int))
-  (bvlshr (bv 0 n) a)
-  (bv 0 n))
-(define-rule bv-ashr-zero
-  ((a ?BitVec) (n Int))
-  (bvashr (bv 0 n) a)
-  (bv 0 n))
+(define-cond-rule bv-shl-zero
+  ((a ?BitVec) (c0 ?BitVec))
+  (= c0 (bv 0 (bvsize c0)))
+  (bvshl c0 a)
+  (bv 0 (bvsize c0)))
+(define-cond-rule bv-lshr-zero
+  ((a ?BitVec) (c0 ?BitVec))
+  (= c0 (bv 0 (bvsize c0)))
+  (bvlshr c0 a)
+  (bv 0 (bvsize c0)))
+(define-cond-rule bv-ashr-zero
+  ((a ?BitVec) (c0 ?BitVec))
+  (= c0 (bv 0 (bvsize c0)))
+  (bvashr c0 a)
+  (bv 0 (bvsize c0)))
 
 ; (bvugt (bvurem T x) x)
 ;   ==>  (ite (= x 0_k) (bvugt T x) false)
@@ -668,14 +683,16 @@
     (bvugt y (bv 0 (bvsize y)))
   ))
 
-(define-rule bv-ult-one
-  ((x ?BitVec) (n Int))
-  (bvult x (bv 1 n))
-  (= x (bv 0 n)))
-(define-rule bv-slt-zero
-  ((x ?BitVec) (n Int))
-  (bvslt x (bv 0 n))
-  (= (extract (- n 1) (- n 1) x) (bv 1 1)))
+(define-cond-rule bv-ult-one
+  ((x ?BitVec) (c1 ?BitVec))
+  (= c1 (bv 1 (bvsize c1)))
+  (bvult x c1)
+  (= x (bv 0 (bvsize x))))
+(define-cond-rule bv-slt-zero
+  ((x ?BitVec) (c0 ?BitVec))
+  (= c0 (bv 0 (bvsize c0)))
+  (bvslt x c0)
+  (= (extract (- (bvsize x) 1) (- (bvsize x) 1) x) (bv 1 1)))
 
 (define-rule bv-merge-sign-extend-1
   ((x ?BitVec) (i Int) (j Int))
@@ -688,9 +705,10 @@
   (sign_extend i (zero_extend j x))
   (zero_extend (+ i j) x)
   )
-(define-rule bv-merge-sign-extend-3
-  ((x ?BitVec) (i Int))
-  (sign_extend i (zero_extend 0 x))
+(define-cond-rule bv-merge-sign-extend-3
+  ((x ?BitVec) (i Int) (n0 Int))
+  (= n0 0)
+  (sign_extend i (zero_extend n0 x))
   (sign_extend i x)
   )
 (define-rule bv-sign-extend-eq-const-1
@@ -923,16 +941,17 @@
 ;(define-rule bv-bb-add-neg )
 
 ; x < y + 1 <=> (not y < x) and y != 1...1
-(define-rule bv-ult-add-one
-  ((x ?BitVec) (y ?BitVec) (n Int))
-  (bvult x (bvadd y (bv 1 n)))
+(define-cond-rule bv-ult-add-one
+  ((x ?BitVec) (y ?BitVec) (c1 ?BitVec))
+  (= c1 (bv 1 (bvsize c1)))
+  (bvult x (bvadd y c1))
   (and
     (not (bvult y x))
-    (not (= y (bvnot (bv 0 n))))))
+    (not (= y (bvnot (bv 0 (bvsize y)))))))
 (define-cond-rule bv-concat-to-mult
-  ((x ?BitVec) (i Int) (m Int))
-  (= (+ 1 i m) (bvsize x))
-  (concat (extract i 0 x) (bv 0 m))
+  ((x ?BitVec) (i Int) (m Int) (n0 Int))
+  (and (= (+ 1 i m) (bvsize x)) (= n0 0))
+  (concat (extract i n0 x) (bv n0 m))
   (bvmul x (bvshl (bv 1 (bvsize x)) (bv m (bvsize x)))))
 
 ; Currently bugged due to not being able to match n.
@@ -978,30 +997,36 @@
 
 
 ; -- Hole filling rules --
-(define-rule bv-or-zero ((x ?BitVec) (n Int))
-  (bvor x (bv 0 n))
+(define-cond-rule bv-or-zero ((x ?BitVec) (c0 ?BitVec))
+  (= c0 (bv 0 (bvsize c0)))
+  (bvor x c0)
   x)
-(define-rule bv-mul-one ((x ?BitVec) (n Int))
-  (bvmul x (bv 1 n))
+(define-cond-rule bv-mul-one ((x ?BitVec) (c1 ?BitVec))
+  (= c1 (bv 1 (bvsize c1)))
+  (bvmul x c1)
   x)
-(define-rule bv-mul-zero ((x ?BitVec) (n Int))
-  (bvmul x (bv 0 n))
-  (bv 0 n))
-(define-rule bv-add-zero ((x ?BitVec) (n Int))
-  (bvadd x (bv 0 n))
+(define-cond-rule bv-mul-zero ((x ?BitVec) (c0 ?BitVec))
+  (= c0 (bv 0 (bvsize c0)))
+  (bvmul x c0)
+  (bv 0 (bvsize x)))
+(define-cond-rule bv-add-zero ((x ?BitVec) (c0 ?BitVec))
+  (= c0 (bv 0 (bvsize c0)))
+  (bvadd x c0)
   x)
 (define-rule bv-add-two ((x ?BitVec))
   (bvadd x x)
   (bvmul x (bv 2 (bvsize x))))
 
 
-(define-rule bv-zero-extend-eliminate-0
-  ((x ?BitVec))
-  (zero_extend 0 x)
+(define-cond-rule bv-zero-extend-eliminate-0
+  ((x ?BitVec) (n0 Int))
+  (= n0 0)
+  (zero_extend n0 x)
   x)
-(define-rule bv-sign-extend-eliminate-0
-  ((x ?BitVec))
-  (sign_extend 0 x)
+(define-cond-rule bv-sign-extend-eliminate-0
+  ((x ?BitVec) (n0 Int))
+  (= n0 0)
+  (sign_extend n0 x)
   x)
 (define-cond-rule bv-not-neq ((x ?BitVec))
   (> (bvsize x) 0)

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -499,6 +499,8 @@ set(regress_0_tests
   regress0/bv/holes/ite-merge-then-else.smt2 # Roundabout method used
   regress0/bv/holes/ite-merge-else-else.smt2
 
+  regress0/bv/holes/bitwise-not-or.smt2
+  regress0/bv/holes/xor-duplicate.smt2
   regress0/bv/holes/extract-mult-leading-bit.smt2
   regress0/bv/holes/merge-sign-extend-2.smt2
   regress0/bv/holes/merge-sign-extend-3.smt2
@@ -519,7 +521,11 @@ set(regress_0_tests
   regress0/bv/holes/not-neq.smt2
   regress0/bv/holes/rotate-left-eliminate-1.smt2
   regress0/bv/holes/ult-one.smt2
+  regress0/bv/holes/shl-by-const-0.smt2
+  regress0/bv/holes/shl-by-const-2.smt2
+  regress0/bv/holes/lshr-by-const-0.smt2
   regress0/bv/holes/lshr-by-const-1.smt2
+  regress0/bv/holes/lshr-by-const-2.smt2
   regress0/bv/holes/ashr-by-const-0.smt2
   regress0/bv/holes/ashr-by-const-1.smt2 # Could not find rule
   regress0/bv/holes/ashr-by-const-2.smt2 # Could not find rule?

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -538,6 +538,7 @@ set(regress_0_tests
   regress0/bv/holes/xor-simplify-2.smt2
   regress0/bv/holes/xor-simplify-3.smt2
 
+  regress0/bv/holes/ashr-zero.smt2
   regress0/bv/holes/zero-extend-eq-const-1.smt2
   regress0/bv/holes/zero-extend-eq-const-2.smt2
   regress0/bv/holes/zero-extend-ult-const-1.smt2

--- a/test/regress/cli/regress0/bv/holes/ashr-zero.smt2
+++ b/test/regress/cli/regress0/bv/holes/ashr-zero.smt2
@@ -1,0 +1,12 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 5))
+(assert (not (=
+  (bvashr #b00000 x)
+  #b00000
+	)))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/bitwise-not-or.smt2
+++ b/test/regress/cli/regress0/bv/holes/bitwise-not-or.smt2
@@ -1,0 +1,12 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 10))
+(assert (not (=
+	(bvor x (bvnot x))
+	#b1111111111
+	)))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/lshr-by-const-0.smt2
+++ b/test/regress/cli/regress0/bv/holes/lshr-by-const-0.smt2
@@ -1,0 +1,12 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 5))
+(assert (not (=
+  (bvlshr x #b00000)
+	x
+	)))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/lshr-by-const-2.smt2
+++ b/test/regress/cli/regress0/bv/holes/lshr-by-const-2.smt2
@@ -1,0 +1,12 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 5))
+(assert (not (=
+  (bvlshr x #b01000)
+	#b00000
+	)))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/shl-by-const-0.smt2
+++ b/test/regress/cli/regress0/bv/holes/shl-by-const-0.smt2
@@ -1,0 +1,12 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 10))
+(assert (not (=
+	(bvshl x #b0000000000)
+	x
+	)))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/shl-by-const-2.smt2
+++ b/test/regress/cli/regress0/bv/holes/shl-by-const-2.smt2
@@ -1,0 +1,12 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 10))
+(assert (not (=
+	(bvshl x #b0100000000)
+	#b0000000000
+	)))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/xor-duplicate.smt2
+++ b/test/regress/cli/regress0/bv/holes/xor-duplicate.smt2
@@ -1,0 +1,12 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x (_ BitVec 10))
+(assert (not (=
+	(bvxor x x)
+	#b0000000000
+	)))
+(check-sat)
+(exit)


### PR DESCRIPTION
1. Added a check in RARE compiler to warn about constants in the match expression
2. Removed constants, following the warnings of (1). Constants are only removed if the rule does not show up in regression tests previously
3. Added some test cases for rules that stopped showing up for some reason

The list of warnings:
```
Warning: Rule arith-plus-zero has constants in its match expression
Warning: Rule arith-mul-one has constants in its match expression
Warning: Rule arith-mul-zero has constants in its match expression
Warning: Rule arith-int-div-one has constants in its match expression
Warning: Rule arith-neg-neg-one has constants in its match expression
Warning: Rule arith-plus-cancel1 has constants in its match expression
Warning: Rule arith-plus-cancel2 has constants in its match expression
Warning: Rule bool-eq-true has constants in its match expression
Warning: Rule bool-eq-false has constants in its match expression
Warning: Rule bool-impl-false1 has constants in its match expression
Warning: Rule bool-impl-false2 has constants in its match expression
Warning: Rule bool-impl-true1 has constants in its match expression
Warning: Rule bool-impl-true2 has constants in its match expression
Warning: Rule bool-or-true has constants in its match expression
Warning: Rule bool-or-false has constants in its match expression
Warning: Rule bool-and-true has constants in its match expression
Warning: Rule bool-and-false has constants in its match expression
Warning: Rule bool-xor-false has constants in its match expression
Warning: Rule bool-xor-true has constants in its match expression
Warning: Rule ite-then-true has constants in its match expression
Warning: Rule ite-else-false has constants in its match expression
Warning: Rule ite-then-false has constants in its match expression
Warning: Rule ite-else-true has constants in its match expression
Warning: Rule ite-true-cond has constants in its match expression
Warning: Rule ite-false-cond has constants in its match expression
Warning: Rule bv-shl-by-const-0 has constants in its match expression
Warning: Rule bv-lshr-by-const-0 has constants in its match expression
Warning: Rule bv-ashr-by-const-0 has constants in its match expression
Warning: Rule bv-and-zero has constants in its match expression
Warning: Rule bv-xor-zero has constants in its match expression
Warning: Rule bv-ult-zero-1 has constants in its match expression
Warning: Rule bv-ult-zero-2 has constants in its match expression
Warning: Rule bv-ule-zero has constants in its match expression
Warning: Rule bv-zero-ule has constants in its match expression
Warning: Rule bv-udiv-zero has constants in its match expression
Warning: Rule bv-udiv-one has constants in its match expression
Warning: Rule bv-urem-one has constants in its match expression
Warning: Rule bv-shl-zero has constants in its match expression
Warning: Rule bv-lshr-zero has constants in its match expression
Warning: Rule bv-ashr-zero has constants in its match expression
Warning: Rule bv-ult-one has constants in its match expression
Warning: Rule bv-slt-zero has constants in its match expression
Warning: Rule bv-merge-sign-extend-3 has constants in its match expression
Warning: Rule bv-ult-add-one has constants in its match expression
Warning: Rule bv-concat-to-mult has constants in its match expression
Warning: Rule bv-or-zero has constants in its match expression
Warning: Rule bv-mul-one has constants in its match expression
Warning: Rule bv-mul-zero has constants in its match expression
Warning: Rule bv-add-zero has constants in its match expression
Warning: Rule bv-zero-extend-eliminate-0 has constants in its match expression
Warning: Rule bv-sign-extend-eliminate-0 has constants in its match expression
Warning: Rule str-substr-empty-str has constants in its match expression
Warning: Rule str-substr-eq-empty has constants in its match expression
Warning: Rule str-substr-full has constants in its match expression
Warning: Rule str-concat-emp has constants in its match expression
Warning: Rule re-concat-emp has constants in its match expression
Warning: Rule seq-nth-unit has constants in its match expression
```