### PR TITLE
Add some RARE bitvector hole filling tests

### DIFF
--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -467,6 +467,7 @@ set(regress_0_tests
   regress0/bv/holes/concat-extract-merge.smt2
   regress0/bv/holes/extract-extract.smt2
   regress0/bv/holes/extract-concat.smt2
+  regress0/bv/holes/extract-concat-4.smt2
   regress0/bv/holes/extract-whole.smt2
 
   regress0/bv/holes/uge-eliminate.smt2
@@ -483,6 +484,7 @@ set(regress_0_tests
   regress0/bv/holes/redor-eliminate.smt2
   regress0/bv/holes/redand-eliminate.smt2
   regress0/bv/holes/sdiv-eliminate-fewer-bitwise-ops.smt2 # O(n) roundabout
+  regress0/bv/holes/smod-eliminate-fewer-bitwise-ops.smt2
   regress0/bv/holes/srem-eliminate.smt2
   regress0/bv/holes/srem-eliminate-fewer-bitwise-ops.smt2
   regress0/bv/holes/usubo-eliminate.smt2

--- a/test/regress/cli/regress0/bv/holes/extract-concat-4.smt2
+++ b/test/regress/cli/regress0/bv/holes/extract-concat-4.smt2
@@ -1,0 +1,16 @@
+; EXPECT: unsat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-const x1 (_ BitVec 10))
+(declare-const x2 (_ BitVec 10))
+(declare-const x3 (_ BitVec 10))
+(declare-const x4 (_ BitVec 10))
+(declare-const y (_ BitVec 10))
+(assert (not (=
+	((_ extract 20 0) (concat x3 x2 x1 x4))
+	(concat ((_ extract 0 0) x2) x1 x4))))
+	;(concat ((_ extract 5 0) x1) ((_ extract 9 5) x4)))))
+(check-sat)
+(exit)

--- a/test/regress/cli/regress0/bv/holes/smod-eliminate-fewer-bitwise-ops.smt2
+++ b/test/regress/cli/regress0/bv/holes/smod-eliminate-fewer-bitwise-ops.smt2
@@ -1,0 +1,30 @@
+; EXPECT: unsat
+(set-logic  QF_BV)
+
+(set-info :status unsat)
+
+(define-fun bvsmod_def ((s (_ BitVec 13)) (t (_ BitVec 13))) (_ BitVec 13)
+     (let ((sLt0 (bvuge s #b1000000000000))
+           (tLt0 (bvuge t #b1000000000000))
+          )
+       (let ((abs_s (ite sLt0 (bvneg s) s))
+             (abs_t (ite tLt0 (bvneg t) t)))
+         (let ((u (bvurem abs_s abs_t)))
+           (ite (= u (_ bv0 13))
+                u
+           (ite (and (not sLt0) (not tLt0) )
+                u
+           (ite (and sLt0 (not tLt0))
+                (bvadd (bvneg u) t)
+           (ite (and (not sLt0) tLt0)
+                (bvadd u t)
+                (bvneg u)))))))))
+
+(define-fun a () (_ BitVec 13) (_ bv30 13))
+(define-fun b () (_ BitVec 13) (_ bv8190 13))
+
+(assert (not (= (bvsmod_def a b) (bvsmod a b))))
+
+(check-sat)
+
+(exit)


### PR DESCRIPTION
1. `extract-concat-4` has a hole that currently cannot be filled (in alethe mode)
2. `smod-eliminate-fewer-bitwise-ops.smt2` uses a roundabout with `smod-eliminate`