### PR TITLE
[proof-new] Remove misleading comment and add test cases

### DIFF
--- a/src/theory/bv/rewrites
+++ b/src/theory/bv/rewrites
@@ -618,7 +618,6 @@
   (bvudiv x (bv 1 n))
   x)
 ; (x urem 2^k) = 0_(n-k) x[k-1:0]
-; The original version had power - 1, but I thought about it and it doesn't make sense to me, so I didn't put the -1 here.
 (define-cond-rule bv-urem-pow2-not-one
   ((x ?BitVec) (v Int) (n Int))
   (def (power (int.log2 v)))

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -484,6 +484,7 @@ set(regress_0_tests
   regress0/bv/holes/redor-eliminate.smt2
   regress0/bv/holes/redand-eliminate.smt2
   regress0/bv/holes/sdiv-eliminate-fewer-bitwise-ops.smt2 # O(n) roundabout
+  regress0/bv/holes/smod-eliminate-fewer-bitwise-ops.smt2
   regress0/bv/holes/srem-eliminate.smt2
   regress0/bv/holes/srem-eliminate-fewer-bitwise-ops.smt2
   regress0/bv/holes/usubo-eliminate.smt2

--- a/test/regress/cli/regress0/bv/holes/smod-eliminate-fewer-bitwise-ops.smt2
+++ b/test/regress/cli/regress0/bv/holes/smod-eliminate-fewer-bitwise-ops.smt2
@@ -1,0 +1,30 @@
+; EXPECT: unsat
+(set-logic  QF_BV)
+
+(set-info :status unsat)
+
+(define-fun bvsmod_def ((s (_ BitVec 13)) (t (_ BitVec 13))) (_ BitVec 13)
+     (let ((sLt0 (bvuge s #b1000000000000))
+           (tLt0 (bvuge t #b1000000000000))
+          )
+       (let ((abs_s (ite sLt0 (bvneg s) s))
+             (abs_t (ite tLt0 (bvneg t) t)))
+         (let ((u (bvurem abs_s abs_t)))
+           (ite (= u (_ bv0 13))
+                u
+           (ite (and (not sLt0) (not tLt0) )
+                u
+           (ite (and sLt0 (not tLt0))
+                (bvadd (bvneg u) t)
+           (ite (and (not sLt0) tLt0)
+                (bvadd u t)
+                (bvneg u)))))))))
+
+(define-fun a () (_ BitVec 13) (_ bv30 13))
+(define-fun b () (_ BitVec 13) (_ bv8190 13))
+
+(assert (not (= (bvsmod_def a b) (bvsmod a b))))
+
+(check-sat)
+
+(exit)


### PR DESCRIPTION
1. Remove the misleading comment about UremPow2: The -1 is necessary in C++ since the isPow2 function has a +1 offset relative to log2
2. Add a test case for [smod-eliminate-fewer-bitwise-ops.smt2](https://github.com/cvc5/cvc5/compare/proof-new...vleni:cvc5:proof-new?expand=1#diff-03d47d1914a7616d9c759afa3799f0ab3566ad359e286094a47b7d0ad3577c31)