### PR TITLE
Fix getEqualityStatus for non-linear multiplication

### DIFF
--- a/src/theory/arith/arith_evaluator.cpp
+++ b/src/theory/arith/arith_evaluator.cpp
@@ -23,7 +23,7 @@ namespace cvc5::internal {
 namespace theory {
 namespace arith {
 
-std::optional<bool> isExpressionZero(Env& env, Node expr, const ArithSubs& subs)
+std::optional<bool> isExpressionZero(Env& env, Node expr, const ArithSubs& subs, bool traverseNlMult )
 {
   // Substitute constants and rewrite
   expr = env.getRewriter()->rewrite(expr);
@@ -33,7 +33,7 @@ std::optional<bool> isExpressionZero(Env& env, Node expr, const ArithSubs& subs)
   }
   // we use an arithmetic substitution, which does not traverse into
   // terms that do not belong to the core theory of arithmetic.
-  expr = subs.applyArith(expr);
+  expr = subs.applyArith(expr, traverseNlMult);
   expr = env.getRewriter()->rewrite(expr);
   if (expr.isConst())
   {

--- a/src/theory/arith/arith_evaluator.cpp
+++ b/src/theory/arith/arith_evaluator.cpp
@@ -23,7 +23,10 @@ namespace cvc5::internal {
 namespace theory {
 namespace arith {
 
-std::optional<bool> isExpressionZero(Env& env, Node expr, const ArithSubs& subs, bool traverseNlMult )
+std::optional<bool> isExpressionZero(Env& env,
+                                     Node expr,
+                                     const ArithSubs& subs,
+                                     bool traverseNlMult)
 {
   // Substitute constants and rewrite
   expr = env.getRewriter()->rewrite(expr);

--- a/src/theory/arith/arith_evaluator.h
+++ b/src/theory/arith/arith_evaluator.h
@@ -40,7 +40,7 @@ namespace arith {
 std::optional<bool> isExpressionZero(Env& env,
                                      Node expr,
                                      const ArithSubs& subs,
-                                     bool traverseNlMult );
+                                     bool traverseNlMult);
 }
 }  // namespace theory
 }  // namespace cvc5::internal

--- a/src/theory/arith/arith_evaluator.h
+++ b/src/theory/arith/arith_evaluator.h
@@ -39,7 +39,8 @@ namespace arith {
  */
 std::optional<bool> isExpressionZero(Env& env,
                                      Node expr,
-                                     const ArithSubs& subs);
+                                     const ArithSubs& subs,
+                                     bool traverseNlMult );
 }
 }  // namespace theory
 }  // namespace cvc5::internal

--- a/src/theory/arith/arith_subs.cpp
+++ b/src/theory/arith/arith_subs.cpp
@@ -59,7 +59,7 @@ Node ArithSubs::applyArith(const Node& n) const
         TheoryId ctid = theory::kindToTheoryId(ck);
         if ((ctid != THEORY_ARITH && ctid != THEORY_BOOL
              && ctid != THEORY_BUILTIN)
-            || isTranscendentalKind(ck))
+            || isTranscendentalKind(ck) || ck==Kind::NONLINEAR_MULT)
         {
           // Do not traverse beneath applications that belong to another theory
           // besides (core) arithmetic. Notice that transcendental function

--- a/src/theory/arith/arith_subs.cpp
+++ b/src/theory/arith/arith_subs.cpp
@@ -29,7 +29,7 @@ void ArithSubs::addArith(const Node& v, const Node& s)
   d_subs.push_back(s);
 }
 
-Node ArithSubs::applyArith(const Node& n) const
+Node ArithSubs::applyArith(const Node& n, bool traverseNlMult) const
 {
   NodeManager* nm = NodeManager::currentNM();
   std::unordered_map<TNode, Node> visited;
@@ -59,7 +59,7 @@ Node ArithSubs::applyArith(const Node& n) const
         TheoryId ctid = theory::kindToTheoryId(ck);
         if ((ctid != THEORY_ARITH && ctid != THEORY_BOOL
              && ctid != THEORY_BUILTIN)
-            || isTranscendentalKind(ck) || ck==Kind::NONLINEAR_MULT)
+            || isTranscendentalKind(ck) || (!traverseNlMult && ck==Kind::NONLINEAR_MULT))
         {
           // Do not traverse beneath applications that belong to another theory
           // besides (core) arithmetic. Notice that transcendental function

--- a/src/theory/arith/arith_subs.cpp
+++ b/src/theory/arith/arith_subs.cpp
@@ -59,7 +59,8 @@ Node ArithSubs::applyArith(const Node& n, bool traverseNlMult) const
         TheoryId ctid = theory::kindToTheoryId(ck);
         if ((ctid != THEORY_ARITH && ctid != THEORY_BOOL
              && ctid != THEORY_BUILTIN)
-            || isTranscendentalKind(ck) || (!traverseNlMult && ck==Kind::NONLINEAR_MULT))
+            || isTranscendentalKind(ck)
+            || (!traverseNlMult && ck == Kind::NONLINEAR_MULT))
         {
           // Do not traverse beneath applications that belong to another theory
           // besides (core) arithmetic. Notice that transcendental function

--- a/src/theory/arith/arith_subs.h
+++ b/src/theory/arith/arith_subs.h
@@ -42,7 +42,7 @@ class ArithSubs : public Subs
   /** Add v -> s to the substitution */
   void addArith(const Node& v, const Node& s);
   /** Return the result of this substitution on n */
-  Node applyArith(const Node& n) const;
+  Node applyArith(const Node& n, bool traverseNlMult = true) const;
 };
 
 }  // namespace arith

--- a/src/theory/arith/arith_subs.h
+++ b/src/theory/arith/arith_subs.h
@@ -41,7 +41,11 @@ class ArithSubs : public Subs
  public:
   /** Add v -> s to the substitution */
   void addArith(const Node& v, const Node& s);
-  /** Return the result of this substitution on n */
+  /**
+   * Return the result of this substitution on n.
+   * @param n The node to apply the substitution
+   * @param traverseNlMult Whether to traverse applications of NONLINEAR_MULT.
+   */
   Node applyArith(const Node& n, bool traverseNlMult = true) const;
 };
 

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -384,8 +384,8 @@ bool TheoryArith::collectModelValues(TheoryModel* m,
     {
       continue;
     }
-    AlwaysAssert(false) << "A model equality could not be asserted: " << p.first
-                        << " == " << p.second << std::endl;
+    Assert(false) << "A model equality could not be asserted: " << p.first
+                  << " == " << p.second << std::endl;
     // If we failed to assert an equality, it is likely due to theory
     // combination, namely the repaired model for non-linear changed
     // an equality status that was agreed upon by both (linear) arithmetic
@@ -489,9 +489,8 @@ void TheoryArith::finalizeModelCache()
   for (const auto& [node, repl] : d_arithModelCache)
   {
     Assert(repl.getType().isRealOrInt());
-    // we only keep the domain of the substitution that is for leafs of
-    // arithmetic; otherwise we are using the value of the abstraction of
-    // non-linear term from the linear solver, which can be incorrect.
+    // note that node may be an application of non-linear arithmetic, which will get
+    // applied as a substitution in getEqualityStatus.
     d_arithModelCacheSubs.add(node, repl);
   }
 }

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -489,8 +489,8 @@ void TheoryArith::finalizeModelCache()
   for (const auto& [node, repl] : d_arithModelCache)
   {
     Assert(repl.getType().isRealOrInt());
-    // note that node may be an application of non-linear arithmetic, which will get
-    // applied as a substitution in getEqualityStatus.
+    // note that node may be an application of non-linear arithmetic, which will
+    // get applied as a substitution in getEqualityStatus.
     d_arithModelCacheSubs.add(node, repl);
   }
 }

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -384,7 +384,7 @@ bool TheoryArith::collectModelValues(TheoryModel* m,
     {
       continue;
     }
-    Assert(false) << "A model equality could not be asserted: " << p.first
+    AlwaysAssert(false) << "A model equality could not be asserted: " << p.first
                         << " == " << p.second << std::endl;
     // If we failed to assert an equality, it is likely due to theory
     // combination, namely the repaired model for non-linear changed
@@ -490,10 +490,7 @@ void TheoryArith::finalizeModelCache()
     // we only keep the domain of the substitution that is for leafs of
     // arithmetic; otherwise we are using the value of the abstraction of
     // non-linear term from the linear solver, which can be incorrect.
-    if (Theory::isLeafOf(node, TheoryId::THEORY_ARITH))
-    {
-      d_arithModelCacheSubs.add(node, repl);
-    }
+    d_arithModelCacheSubs.add(node, repl);
   }
 }
 

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -429,8 +429,8 @@ EqualityStatus TheoryArith::getEqualityStatus(TNode a, TNode b) {
   Trace("arith-eq-status") << "Evaluate under " << d_arithModelCacheSubs.d_vars << " / "
                  << d_arithModelCacheSubs.d_subs << std::endl;
   Node diff = NodeManager::currentNM()->mkNode(Kind::SUB, a, b);
-  // do not traverse non-linear multiplication here, since the value of multiplication
-  // may not be accurate
+  // do not traverse non-linear multiplication here, since the value of
+  // multiplication may not be accurate
   std::optional<bool> isZero =
       isExpressionZero(d_env, diff, d_arithModelCacheSubs, false);
   if (isZero)

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -430,7 +430,8 @@ EqualityStatus TheoryArith::getEqualityStatus(TNode a, TNode b) {
                  << d_arithModelCacheSubs.d_subs << std::endl;
   Node diff = NodeManager::currentNM()->mkNode(Kind::SUB, a, b);
   // do not traverse non-linear multiplication here, since the value of
-  // multiplication may not be accurate
+  // multiplication in this method should consider the value of the
+  // non-linear multiplication term, and not its evaluation.
   std::optional<bool> isZero =
       isExpressionZero(d_env, diff, d_arithModelCacheSubs, false);
   if (isZero)

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -429,8 +429,10 @@ EqualityStatus TheoryArith::getEqualityStatus(TNode a, TNode b) {
   Trace("arith-eq-status") << "Evaluate under " << d_arithModelCacheSubs.d_vars << " / "
                  << d_arithModelCacheSubs.d_subs << std::endl;
   Node diff = NodeManager::currentNM()->mkNode(Kind::SUB, a, b);
+  // do not traverse non-linear multiplication here, since the value of multiplication
+  // may not be accurate
   std::optional<bool> isZero =
-      isExpressionZero(d_env, diff, d_arithModelCacheSubs);
+      isExpressionZero(d_env, diff, d_arithModelCacheSubs, false);
   if (isZero)
   {
     EqualityStatus es =

--- a/src/theory/care_pair_argument_callback.cpp
+++ b/src/theory/care_pair_argument_callback.cpp
@@ -22,6 +22,7 @@ CarePairArgumentCallback::CarePairArgumentCallback(Theory& t) : d_theory(t) {}
 
 bool CarePairArgumentCallback::considerPath(TNode a, TNode b)
 {
+  Trace("ajr-temp") << "considerPath " << a << " " << b << std::endl;
   // builtin cases for when a is clearly equal/disequal to b
   if (a == b)
   {

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -552,8 +552,8 @@ EqualityStatus TheoryUF::getEqualityStatus(TNode a, TNode b) {
 
 bool TheoryUF::areCareDisequal(TNode x, TNode y)
 {
-  if (d_equalityEngine->hasTerm(x) && d_equalityEngine->hasTerm(y) &&
-    d_equalityEngine->areDisequal(x, y, false))
+  if (d_equalityEngine->hasTerm(x) && d_equalityEngine->hasTerm(y)
+      && d_equalityEngine->areDisequal(x, y, false))
   {
     return true;
   }

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -552,7 +552,8 @@ EqualityStatus TheoryUF::getEqualityStatus(TNode a, TNode b) {
 
 bool TheoryUF::areCareDisequal(TNode x, TNode y)
 {
-  if (d_equalityEngine->areDisequal(x, y, false))
+  if (d_equalityEngine->hasTerm(x) && d_equalityEngine->hasTerm(y) &&
+    d_equalityEngine->areDisequal(x, y, false))
   {
     return true;
   }

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -552,6 +552,7 @@ EqualityStatus TheoryUF::getEqualityStatus(TNode a, TNode b) {
 
 bool TheoryUF::areCareDisequal(TNode x, TNode y)
 {
+  // check for disequality first, as an optimization
   if (d_equalityEngine->hasTerm(x) && d_equalityEngine->hasTerm(y)
       && d_equalityEngine->areDisequal(x, y, false))
   {

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -552,6 +552,10 @@ EqualityStatus TheoryUF::getEqualityStatus(TNode a, TNode b) {
 
 bool TheoryUF::areCareDisequal(TNode x, TNode y)
 {
+  if (d_equalityEngine->areDisequal(x, y, false))
+  {
+    return true;
+  }
   if (d_equalityEngine->isTriggerTerm(x, THEORY_UF)
       && d_equalityEngine->isTriggerTerm(y, THEORY_UF))
   {


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/10108.

In detail, getEqualityStatus should not traverse non-linear multiplication, as theory combination should consider these as atomic terms.  

This also fixes a minor performance issue in TheoryUF::computeCareGraph, which did not implement an optimization we use in Theory::computeCareGraph.

The benchmark on https://github.com/cvc5/cvc5/issues/10108 now times out.