### PR TITLE
ci: Setup Python virtual env.

### DIFF
--- a/.github/actions/configure-and-build/action.yml
+++ b/.github/actions/configure-and-build/action.yml
@@ -29,18 +29,22 @@ runs:
       # https://github.com/actions/runner/issues/1483
       if: inputs.build-shared == '' || inputs.build-shared == 'true'
       shell: bash
+      # Note: Python_FIND_FRAMEWORK=NEVER is used here to ensure that the
+      # Python version from the virtual env is used
       run: |
         echo "::group::Shared build"
-        ${{ inputs.configure-env }} ./configure.sh ${{ inputs.configure-config }} \
-          --prefix=$(pwd)/build-shared/install --werror --name=build-shared
-        
+        ${{ inputs.configure-env }} \
+          ./configure.sh ${{ inputs.configure-config }} \
+            --prefix=$(pwd)/build-shared/install --werror --name=build-shared \
+            -DPython_FIND_FRAMEWORK=NEVER
+
         # can not use `ccache --set-config=base_dir=` due to ccache bug, fixed with 3.7.10
         cd build-shared/ && pwd=$(pwd)
         $SED -i.orig -n -e '/^base_dir = /!p' -e "\$abase_dir = $pwd" $CCACHE_CONFIGPATH
-        
+
         make -j${{ env.num_proc }}
 
-        echo "build-dir=$pwd" >> $GITHUB_OUTPUT 
+        echo "build-dir=$pwd" >> $GITHUB_OUTPUT
         echo "::endgroup::"
 
     - name: Static build
@@ -49,10 +53,15 @@ runs:
       # https://github.com/actions/runner/issues/1483
       if: inputs.build-static == '' || inputs.build-static == 'true'
       shell: bash
+      # Note: Python_FIND_FRAMEWORK=NEVER is used here to ensure that the
+      # Python version from the virtual env is used
       run: |
         echo "::group::Static build"
-        ${{ inputs.configure-env }} ./configure.sh ${{ inputs.configure-config }} \
-          --prefix=$(pwd)/build-static/install --werror --static --name=build-static --no-java-bindings
+        ${{ inputs.configure-env }} \
+          ./configure.sh ${{ inputs.configure-config }} \
+            --prefix=$(pwd)/build-static/install --werror --static \
+            --name=build-static --no-java-bindings \
+            -DPython_FIND_FRAMEWORK=NEVER
 
         cd build-static/ && pwd=$(pwd)
         $SED -i.orig -n -e '/^base_dir = /!p' -e "\$abase_dir = $pwd" $CCACHE_CONFIGPATH
@@ -65,7 +74,7 @@ runs:
 
         echo "build-dir=$pwd" >> $GITHUB_OUTPUT
         echo "::endgroup::"
-        
+
     - name: Reset ccache base_dir
       shell: bash
       run: |

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -29,8 +29,8 @@ runs:
           libtinfo-dev \
           flex \
           libfl-dev \
-          flexc++
-        python3 -m pip install --user pexpect setuptools tomli
+          flexc++ \
+          python3-venv
         # Make ImageVersion accessible as env.image_version. Environment
         # variables of the runner are not automatically imported:
         #
@@ -76,7 +76,6 @@ runs:
           pkgconfig \
           flex \
           gnu-sed
-        python3 -m pip install --user pexpect setuptools tomli pyparsing
         # Make ImageVersion accessible as env.image_version. Environment
         # variables of the runner are not automatically imported:
         #
@@ -88,17 +87,27 @@ runs:
         echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
         echo "::endgroup::"
 
+    - name: Setup and Activate Python Environment
+      shell: bash
+      run: |
+        python3 -m venv cvc5-python-env
+        source cvc5-python-env/bin/activate
+        echo "PATH=$PATH" >> $GITHUB_ENV
+
+    - name: Install Python Dependencies
+      shell: bash
+      run: |
+        python3 -m pip install pexpect setuptools tomli pyparsing
+
     - name: Install software for Python bindings
       if: inputs.with-python-bindings == 'true'
       shell: bash
       run: |
         echo "::group::Install software for Python bindings"
         python3 -m pip install -q --upgrade pip
-        python3 -m pip install --user pytest scikit-build
+        python3 -m pip install pytest scikit-build
         python3 -m pytest --version
-        python3 -m pip install --user Cython==3.*
-        # Add binary path of user site-packages to PATH
-        echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
+        python3 -m pip install Cython==3.*
         echo "::endgroup::"
 
     - name: Install software for Python packaging
@@ -107,8 +116,8 @@ runs:
       run: |
         echo "::group::Install software for Python packaging"
         python3 -m pip install -q --upgrade pip
-        python3 -m pip install --user twine
-        python3 -m pip install --user -U urllib3 requests
+        python3 -m pip install twine
+        python3 -m pip install -U urllib3 requests
         echo "::endgroup::"
     
     - name: Install software for documentation
@@ -117,7 +126,7 @@ runs:
       run: |
         echo "::group::Install software for documentation"
         sudo apt-get install -y doxygen python3-docutils python3-jinja2
-        python3 -m pip install --user \
+        python3 -m pip install \
           sphinx==7.1.2 \
           sphinxcontrib-bibtex==2.5.0 sphinx-tabs==3.4.1 sphinx-rtd-theme==1.3.0 breathe==4.35.0 \
           sphinxcontrib-programoutput==0.17

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -10,6 +10,9 @@ inputs:
   windows-build:
     default: false
     type: boolean
+  setup-venv:
+    defualt: false
+    type: boolean
 runs:
   using: composite
   steps:
@@ -88,6 +91,7 @@ runs:
         echo "::endgroup::"
 
     - name: Setup and Activate Python Environment
+      if: inputs.setup-venv == 'true'
       shell: bash
       run: |
         python3 -m venv cvc5-python-env

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -110,7 +110,6 @@ runs:
         echo "::group::Install software for Python bindings"
         python3 -m pip install -q --upgrade pip
         python3 -m pip install pytest scikit-build
-        python3 -m pytest --version
         python3 -m pip install Cython==3.*
         echo "::endgroup::"
 

--- a/.github/actions/package-python-wheel-macos/action.yml
+++ b/.github/actions/package-python-wheel-macos/action.yml
@@ -6,7 +6,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       if: runner.os == 'macOS'
       with:
         python-version: ${{ inputs.python-version }}

--- a/.github/actions/package-python-wheel-macos/action.yml
+++ b/.github/actions/package-python-wheel-macos/action.yml
@@ -6,7 +6,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v3
       if: runner.os == 'macOS'
       with:
         python-version: ${{ inputs.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
         with-documentation: ${{ matrix.build-documentation }}
         with-python-bindings: ${{ matrix.python-bindings }}
         windows-build: ${{ matrix.windows-build }}
+        setup-venv: true
 
     - name: Setup caches
       uses: ./.github/actions/setup-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
           - name: macos:production
-            os: macos-latest
+            os: macos-13
             config: production --auto-download --editline
             # config: production --auto-download --python-bindings --editline
             cache-key: production
@@ -36,7 +36,7 @@ jobs:
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
  
           - name: macos:production-arm64
-            os: macos-latest
+            os: macos-13
             config: production --auto-download --editline --arm64
             # config: production --auto-download --python-bindings --editline --arm64
             cache-key: production-arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
           - name: macos:production
-            os: macos-13
+            os: macos-latest
             config: production --auto-download --editline
             # config: production --auto-download --python-bindings --editline
             cache-key: production
@@ -36,7 +36,7 @@ jobs:
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
  
           - name: macos:production-arm64
-            os: macos-13
+            os: macos-latest
             config: production --auto-download --editline --arm64
             # config: production --auto-download --python-bindings --editline --arm64
             cache-key: production-arm64

--- a/.github/workflows/package_pypi.yml
+++ b/.github/workflows/package_pypi.yml
@@ -1,6 +1,8 @@
 on:
   release:
     types: [published]
+  push:
+  pull_request:
   schedule:
     - cron: '0 1 * * *'
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 # The build system configuration.
 ##
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.15)
 
 #-----------------------------------------------------------------------------#
 # Project configuration


### PR DESCRIPTION
Sets up and uses Python venv for building cvc5. This ensures that the Python version used for installing packages and building cvc5 is the same. Further bumps the required cmake version to 3.15, which is still supported by Ubuntu 20.04.