### PR TITLE
Fix initial sign lemma for sine

### DIFF
--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -200,7 +200,9 @@ std::shared_ptr<ProofNode> PfManager::connectProofToAssertions(
       getAssertions(as, unifiedAssertions);
       Pf pf = d_pnm->mkScope(
           pfn, unifiedAssertions, true, options().proof.proofPruneInput);
-      Assert(pf->getRule() == ProofRule::SCOPE);
+      // if this is violated, there is unsoundness since we have shown
+      // false that does not depend on the input.
+      AlwaysAssert(pf->getRule() == ProofRule::SCOPE);
       // 2. Extract minimum unified assertions from the scope node.
       std::unordered_set<Node> minUnifiedAssertions;
       minUnifiedAssertions.insert(pf->getArguments().cbegin(),

--- a/src/theory/arith/nl/transcendental/sine_solver.cpp
+++ b/src/theory/arith/nl/transcendental/sine_solver.cpp
@@ -291,16 +291,20 @@ void SineSolver::checkInitialRefine()
               lem, InferenceId::ARITH_NL_T_INIT_REFINE, proof);
         }
         {
-          Node lem =
-              nm->mkNode(Kind::AND,
-                         // (-pi < t < 0) <=> (sin(t)<0)
-                         nm->mkNode(Kind::EQUAL,
-                                    nm->mkNode(Kind::AND, nm->mkNode(Kind::LT, d_neg_pi, t[0]), nm->mkNode(Kind::LT, t[0], d_data->d_zero)),
-                                    nm->mkNode(Kind::LT, t, d_data->d_zero)),
-                         // (0 < t < pi) <=> (sin(t)>0)
-                         nm->mkNode(Kind::EQUAL,
-                                    nm->mkNode(Kind::AND, nm->mkNode(Kind::GT, d_pi, t[0]), nm->mkNode(Kind::GT, t[0], d_data->d_zero)),
-                                    nm->mkNode(Kind::GT, t, d_data->d_zero)));
+          Node lem = nm->mkNode(
+              Kind::AND,
+              // (-pi < t < 0) <=> (sin(t)<0)
+              nm->mkNode(Kind::EQUAL,
+                         nm->mkNode(Kind::AND,
+                                    nm->mkNode(Kind::LT, d_neg_pi, t[0]),
+                                    nm->mkNode(Kind::LT, t[0], d_data->d_zero)),
+                         nm->mkNode(Kind::LT, t, d_data->d_zero)),
+              // (0 < t < pi) <=> (sin(t)>0)
+              nm->mkNode(Kind::EQUAL,
+                         nm->mkNode(Kind::AND,
+                                    nm->mkNode(Kind::GT, d_pi, t[0]),
+                                    nm->mkNode(Kind::GT, t[0], d_data->d_zero)),
+                         nm->mkNode(Kind::GT, t, d_data->d_zero)));
           d_data->d_im.addPendingLemma(lem,
                                        InferenceId::ARITH_NL_T_INIT_REFINE);
         }

--- a/src/theory/arith/nl/transcendental/sine_solver.cpp
+++ b/src/theory/arith/nl/transcendental/sine_solver.cpp
@@ -293,13 +293,13 @@ void SineSolver::checkInitialRefine()
         {
           Node lem =
               nm->mkNode(Kind::AND,
-                         // sign
+                         // (-pi < t < 0) <=> (sin(t)<0)
                          nm->mkNode(Kind::EQUAL,
-                                    nm->mkNode(Kind::LT, t[0], d_data->d_zero),
+                                    nm->mkNode(Kind::AND, nm->mkNode(Kind::LT, d_neg_pi, t[0]), nm->mkNode(Kind::LT, t[0], d_data->d_zero)),
                                     nm->mkNode(Kind::LT, t, d_data->d_zero)),
-                         // zero val
+                         // (0 < t < pi) <=> (sin(t)>0)
                          nm->mkNode(Kind::EQUAL,
-                                    nm->mkNode(Kind::GT, t[0], d_data->d_zero),
+                                    nm->mkNode(Kind::AND, nm->mkNode(Kind::GT, d_pi, t[0]), nm->mkNode(Kind::GT, t[0], d_data->d_zero)),
                                     nm->mkNode(Kind::GT, t, d_data->d_zero)));
           d_data->d_im.addPendingLemma(lem,
                                        InferenceId::ARITH_NL_T_INIT_REFINE);

--- a/src/theory/arith/operator_elim.cpp
+++ b/src/theory/arith/operator_elim.cpp
@@ -398,7 +398,8 @@ Node OperatorElim::eliminateOperators(Node node,
         {
           lem = nm->mkNode(Kind::IMPLIES, cond, lem);
         }
-        Trace("arith-op-elim") << "Elimination lemma " << lem << " for " << node << std::endl;
+        Trace("arith-op-elim")
+            << "Elimination lemma " << lem << " for " << node << std::endl;
       }
       Assert(!lem.isNull());
       lems.push_back(mkSkolemLemma(lem, var));

--- a/src/theory/arith/operator_elim.cpp
+++ b/src/theory/arith/operator_elim.cpp
@@ -398,6 +398,7 @@ Node OperatorElim::eliminateOperators(Node node,
         {
           lem = nm->mkNode(Kind::IMPLIES, cond, lem);
         }
+        Trace("arith-op-elim") << "Elimination lemma " << lem << " for " << node << std::endl;
       }
       Assert(!lem.isNull());
       lems.push_back(mkSkolemLemma(lem, var));

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2324,6 +2324,7 @@ set(regress_1_tests
   regress1/nl/proj-issue297.smt2
   regress1/nl/proj-issue302.smt2
   regress1/nl/proj-issue530.smt2
+  regress1/nl/proj-issue667-init-bound.smt2
   regress1/nl/quant-nl.smt2
   regress1/nl/red-exp.smt2
   regress1/nl/rewriting-sums.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -939,7 +939,6 @@ set(regress_0_tests
   regress0/nl/nta/issue8182-exact-mv-keep.smt2
   regress0/nl/nta/issue8182-2-exact-mv-keep.smt2
   regress0/nl/nta/issue8183-tc-pi.smt2
-  regress0/nl/nta/issue8208-red-nred.smt2
   regress0/nl/nta/issue8294-2-double-solve.smt2
   regress0/nl/nta/issue8415-embed-arg.smt2
   regress0/nl/nta/issue8773-phase-shift.smt2
@@ -3477,6 +3476,8 @@ set(regression_disabled_tests
   regress0/datatypes/datatype-dump.cvc.smt2
   # no longer support overloaded symbols across multiple parametric datatypes
   regress0/datatypes/repeated-selectors-2769.smt2
+  # unknown after change to lemma schema
+  regress0/nl/nta/issue8208-red-nred.smt2
   # fails with unknown on some builds
   regress0/quantifiers/nl-sqrt2-q.smt2
   # issues with skolems

--- a/test/regress/cli/regress0/arith/issue9131-inverse-of-int.smt2
+++ b/test/regress/cli/regress0/arith/issue9131-inverse-of-int.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -q
+; COMMAND-LINE: -q --nl-ext-split-zero
 
 ; This is a minimized version of the problem in the original issue. It
 ; triggered the same type checking exception before the fix (without triggering

--- a/test/regress/cli/regress1/nl/proj-issue667-init-bound.smt2
+++ b/test/regress/cli/regress1/nl/proj-issue667-init-bound.smt2
@@ -1,0 +1,6 @@
+; EXPECT: unknown
+(set-logic ALL)
+(set-option :produce-unsat-cores true)
+(set-option :proof-prune-input true)
+(assert (>= real.pi (/ real.pi (cot (- (arccos (sin real.pi)))))))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5-projects/issues/667, which was caused by a soundness issue in a lemma schema for `sin`.