### PR TITLE
Fix missing case of terminating due to conflict in preprocessing

### DIFF
--- a/src/preprocessing/assertion_pipeline.cpp
+++ b/src/preprocessing/assertion_pipeline.cpp
@@ -53,6 +53,10 @@ void AssertionPipeline::push_back(Node n,
                                   bool isInput,
                                   ProofGenerator* pgen)
 {
+  if (d_conflict)
+  {
+    return;
+  }
   if (n == d_false)
   {
     markConflict();

--- a/src/preprocessing/assertion_pipeline.cpp
+++ b/src/preprocessing/assertion_pipeline.cpp
@@ -55,6 +55,8 @@ void AssertionPipeline::push_back(Node n,
 {
   if (d_conflict)
   {
+    // if we are already in conflict, we skip. This is required to handle the
+    // case where "false" was already seen as an input assertion.
     return;
   }
   if (n == d_false)

--- a/src/preprocessing/passes/static_rewrite.cpp
+++ b/src/preprocessing/passes/static_rewrite.cpp
@@ -41,6 +41,10 @@ PreprocessingPassResult StaticRewrite::applyInternal(
     {
       // replace based on the trust node
       assertions->replaceTrusted(i, trn);
+      if (assertions->isInConflict())
+      {
+        return PreprocessingPassResult::CONFLICT;
+      }
     }
   }
   return PreprocessingPassResult::NO_CONFLICT;

--- a/src/preprocessing/passes/theory_preprocess.cpp
+++ b/src/preprocessing/passes/theory_preprocess.cpp
@@ -50,6 +50,10 @@ PreprocessingPassResult TheoryPreprocess::applyInternal(
     {
       // process
       assertions->replaceTrusted(i, trn);
+      if (assertions->isInConflict())
+      {
+        return PreprocessingPassResult::CONFLICT;
+      }
     }
     for (const SkolemLemma& lem : newAsserts)
     {

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1068,6 +1068,7 @@ set(regress_0_tests
   regress0/precedence/xor-assoc.cvc.smt2
   regress0/precedence/xor-or.cvc.smt2
   regress0/preprocess/circuit-prop.smt2
+  regress0/preprocess/issue10148.smt2
   regress0/preprocess/issue5729-rewritten-assertions.smt2
   regress0/preprocess/issue5943-non-clausal-simp.smt2
   regress0/preprocess/issue6754-tpp.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1095,6 +1095,11 @@ set(regress_0_tests
   regress0/preprocess/proj-issue305-circuit-prop-ite-d.smt2
   regress0/preprocess/proj-issue309-circuit-prop-ite.smt2
   regress0/preprocess/proj-issue332-circuit-prop-xor.smt2
+  regress0/preprocess/proj-issue679.smt2
+  regress0/preprocess/proj-issue678.smt2
+  regress0/preprocess/proj-issue681.smt2
+  regress0/preprocess/proj-issue684.smt2
+  regress0/preprocess/proj-issue683.smt2
   regress0/preprocess/real-as-int-unk.smt2
   regress0/print_define_fun_internal.smt2
   regress0/print_lambda.cvc.smt2

--- a/test/regress/cli/regress0/preprocess/issue10148.smt2
+++ b/test/regress/cli/regress0/preprocess/issue10148.smt2
@@ -1,0 +1,6 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-const x Int)
+(declare-fun v () String)
+(assert (and (> 0 x) (distinct 0 (ite (= "\n" (str.at v 0)) 1 0))))
+(check-sat)

--- a/test/regress/cli/regress0/preprocess/proj-issue678.smt2
+++ b/test/regress/cli/regress0/preprocess/proj-issue678.smt2
@@ -1,0 +1,5 @@
+; EXPECT: unsat
+(set-logic ALL)
+(assert false)
+(assert (<= real.pi (sec real.pi)))
+(check-sat)

--- a/test/regress/cli/regress0/preprocess/proj-issue679.smt2
+++ b/test/regress/cli/regress0/preprocess/proj-issue679.smt2
@@ -1,0 +1,4 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-const x (Seq Real))
+(check-sat-assuming ((= x (seq.++ x (seq.unit 0.0))) (= x (seq.++ x (seq.unit 0.0)))))

--- a/test/regress/cli/regress0/preprocess/proj-issue681.smt2
+++ b/test/regress/cli/regress0/preprocess/proj-issue681.smt2
@@ -1,0 +1,7 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-const x (Array Bool Bool))
+(declare-const x4 (Array Bool (Array Bool Bool)))
+(assert false)
+(assert (not (set.subset (set.singleton x4) (set.singleton (store x4 (select (store x false false) false) x)))))
+(check-sat)

--- a/test/regress/cli/regress0/preprocess/proj-issue683.smt2
+++ b/test/regress/cli/regress0/preprocess/proj-issue683.smt2
@@ -1,0 +1,3 @@
+; EXPECT: unsat
+(set-logic ALL)
+(check-sat-assuming (false (= (- 0.0) 0.0)))

--- a/test/regress/cli/regress0/preprocess/proj-issue684.smt2
+++ b/test/regress/cli/regress0/preprocess/proj-issue684.smt2
@@ -1,0 +1,5 @@
+; EXPECT: unsat
+(set-logic ALL)
+(assert false)
+(assert (xor false (not (not (not false)))))
+(check-sat)


### PR DESCRIPTION
Was introduced in https://github.com/cvc5/cvc5/commit/e579c9094ec9772596afa0c39b1c2c9608766bdf.

Fixes https://github.com/cvc5/cvc5/issues/10148.
Fixes https://github.com/cvc5/cvc5-projects/issues/683.
Fixes https://github.com/cvc5/cvc5-projects/issues/684.
Fixes https://github.com/cvc5/cvc5-projects/issues/682.
Fixes https://github.com/cvc5/cvc5-projects/issues/681.
Fixes https://github.com/cvc5/cvc5-projects/issues/680.
Fixes https://github.com/cvc5/cvc5-projects/issues/679.
Fixes https://github.com/cvc5/cvc5-projects/issues/678.
Fixes https://github.com/cvc5/cvc5-projects/issues/677.