### PR TITLE
Ignore status when partitioning

### DIFF
--- a/src/smt/solver_engine_state.cpp
+++ b/src/smt/solver_engine_state.cpp
@@ -19,6 +19,7 @@
 #include "options/base_options.h"
 #include "options/main_options.h"
 #include "options/option_exception.h"
+#include "options/parallel_options.h"
 #include "options/smt_options.h"
 #include "smt/env.h"
 
@@ -75,7 +76,8 @@ void SolverEngineState::notifyCheckSatResult(const Result& r)
   {
     // unknown results don't give an error
     if (!d_expectedStatus.isUnknown() && !d_status.isUnknown()
-        && d_status != d_expectedStatus)
+        && d_status != d_expectedStatus
+        && !options().parallel.computePartitionsWasSetByUser)
     {
       CVC5_FATAL() << "Expected result " << d_expectedStatus << " but got "
                    << d_status;


### PR DESCRIPTION
When partitioning, we emit unsat, which can trigger an error if (set-info :status sat) was set in the original file. This fix changes it so that we ignore the status when partitioning. 