### PR TITLE
Enable sygus as input language in interactive mode

### DIFF
--- a/src/main/interactive_shell.cpp
+++ b/src/main/interactive_shell.cpp
@@ -100,6 +100,10 @@ InteractiveShell::InteractiveShell(main::CommandExecutor* cexec,
   {
     lang = modes::InputLanguage::SMT_LIB_2_6;
   }
+  else if (langs == "LANG_SYGUS_V2")
+  {
+    lang = modes::InputLanguage::SYGUS_2_1;
+  }
   else
   {
     throw Exception("internal error: unhandled language " + langs);


### PR DESCRIPTION
This allows SyGuS commands to be used when running in interactive mode (`cvc5 --interactive --lang=sygus2`). Previously, trying to use sygus as the input language would produce an error. See [this discussion](https://github.com/cvc5/cvc5/discussions/10111). 