### PR TITLE
Refactor pattern selection utility

### DIFF
--- a/src/theory/quantifiers/ematching/inst_strategy_e_matching_user.cpp
+++ b/src/theory/quantifiers/ematching/inst_strategy_e_matching_user.cpp
@@ -122,7 +122,8 @@ void InstStrategyUserPatterns::addUserPattern(Node q, Node pat)
   Assert(pat.getKind() == Kind::INST_PATTERN);
   // add to generators
   std::vector<Node> nodes;
-  const Options& opts = d_env.getOptions();
+  PatternTermSelector pts(options(), q, options::TriggerSelMode::ALL);
+  // for each pattern in the list
   for (const Node& p : pat)
   {
     if (std::find(nodes.begin(), nodes.end(), p) != nodes.end())
@@ -130,11 +131,13 @@ void InstStrategyUserPatterns::addUserPattern(Node q, Node pat)
       // skip duplicate pattern term
       continue;
     }
-    Node pat_use = PatternTermSelector::getIsUsableTrigger(opts, p, q);
+    // check if usable
+    Node pat_use = pts.getIsUsableTrigger(p, q);
     if (pat_use.isNull())
     {
       Trace("trigger-warn") << "User-provided trigger is not usable : " << pat
                             << " because of " << p << std::endl;
+      // this may be part of a multi-pattern, where we terminate now
       return;
     }
     nodes.push_back(pat_use);

--- a/src/theory/quantifiers/ematching/pattern_term_selector.h
+++ b/src/theory/quantifiers/ematching/pattern_term_selector.h
@@ -52,6 +52,13 @@ class PatternTermSelector
                       options::TriggerSelMode tstrt,
                       const std::vector<Node>& exc = {},
                       bool filterInst = true);
+  /** Custom version with options specified manually */
+  PatternTermSelector(Node q,
+                      options::TriggerSelMode tstrt,
+                      const std::vector<Node>& exc = {},
+                      bool filterInst = true,
+                      bool purifyTriggers = false,
+                      bool relationalTriggers = false);
   ~PatternTermSelector();
   /** collect pattern terms
    *
@@ -75,7 +82,7 @@ class PatternTermSelector
    * (2) Relational triggers are put into solved form, e.g.
    *      getIsUsableTrigger( (= (+ x a) 5), q ) may return (= x (- 5 a)).
    */
-  static Node getIsUsableTrigger(const Options& opts, Node n, Node q);
+  Node getIsUsableTrigger(Node n, Node q) const;
   /** get the variable associated with an inversion for n
    *
    * A term n with an inversion variable x has the following property :
@@ -109,21 +116,21 @@ class PatternTermSelector
    * A usable trigger is one that is matchable and contains free variables only
    * from q.
    */
-  static bool isUsableTrigger(const Options& opts, Node n, Node q);
+  bool isUsableTrigger(Node n, Node q) const;
   /** Is n a usable atomic trigger?
    *
    * A usable atomic trigger is a term that is both a useable trigger and an
    * atomic trigger.
    */
-  static bool isUsableAtomicTrigger(const Options& opts, Node n, Node q);
+  bool isUsableAtomicTrigger(Node n, Node q) const;
   /** is subterm of trigger usable (helper function for isUsableTrigger) */
-  static bool isUsable(const Options& opts, Node n, Node q);
+  bool isUsable(Node n, Node q) const;
   /** returns an equality that is equivalent to the equality eq and
    * is a usable trigger for q if one exists, otherwise returns Node::null().
    */
-  static Node getIsUsableEq(const Options& opts, Node q, Node eq);
+  Node getIsUsableEq(Node q, Node eq) const;
   /** returns whether n1 == n2 is a usable (relational) trigger for q. */
-  static bool isUsableEqTerms(const Options& opts, Node q, Node n1, Node n2);
+  bool isUsableEqTerms(Node q, Node n1, Node n2) const;
   /** Helper for collect, with a fixed strategy for selection and filtering */
   void collectInternal(Node n,
                        std::vector<Node>& patTerms,
@@ -162,7 +169,7 @@ class PatternTermSelector
    * stored in nodes. This updates nodes so that no pairs of distinct nodes
    * (i,j) is such that i is a trigger instance of j or vice versa (see below).
    */
-  static void filterInstances(std::vector<Node>& nodes);
+  void filterInstances(std::vector<Node>& nodes) const;
 
   /** is instance of
    *
@@ -181,12 +188,10 @@ class PatternTermSelector
    *
    * Notice that n1 and n2 are in instantiation constant form.
    */
-  static int isInstanceOf(Node n1,
-                          Node n2,
-                          const std::vector<Node>& fv1,
-                          const std::vector<Node>& fv2);
-  /** Reference to options */
-  const Options& d_opts;
+  int isInstanceOf(Node n1,
+                   Node n2,
+                   const std::vector<Node>& fv1,
+                   const std::vector<Node>& fv2) const;
   /** The quantified formula this trigger is for. */
   Node d_quant;
   /** The trigger selection strategy */
@@ -195,6 +200,10 @@ class PatternTermSelector
   std::vector<Node> d_excluded;
   /** Whether we are filtering instances */
   bool d_filterInst;
+  /** Whether we are purifying triggers */
+  bool d_purifyTriggers;
+  /** Whether we are using relational triggers */
+  bool d_relTriggers;
 };
 
 }  // namespace inst


### PR DESCRIPTION
Makes it so that options can be provided manually.

Also avoids a tree traversal in `isUsable` and corrects a case where relational triggers could be selected when they are disabled. 