### PR TITLE
[proof-new] Make BV rewrite rules subordinate to THEORY_REWRITE

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -345,6 +345,7 @@ enum ENUM(ProofRule) : uint32_t
    * \endverbatim
    */
   EVALUE(TRUST_THEORY_REWRITE),
+  EVALUE(THEORY_REWRITE),
   /**
    * \verbatim embed:rst:leading-asterisk
    * **SAT Refutation for assumption-based unsat cores**
@@ -1185,16 +1186,6 @@ enum ENUM(ProofRule) : uint32_t
    * \endverbatim
    */
   EVALUE(BV_EAGER_ATOM),
-
-  EVALUE(BV_UMULO_ELIMINATE),
-  EVALUE(BV_SMULO_ELIMINATE),
-  EVALUE(BV_FLATTEN_ASSOC_COMMUTE),
-  EVALUE(BV_FLATTEN_ASSOC_COMMUTE_NO_DUPLICATES),
-  EVALUE(BV_ADD_COMBINE_LIKE_TERMS),
-  EVALUE(BV_MULT_SIMPLIFY),
-  EVALUE(BV_SOLVE_EQ),
-  EVALUE(BV_BITWISE_EQ),
-  EVALUE(BV_BITWISE_SLICING),
 
   /**
    * \verbatim embed:rst:leading-asterisk

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -220,6 +220,8 @@ libcvc5_add_sources(
   proof/trust_id.h
   proof/trust_node.cpp
   proof/trust_node.h
+  proof/trust_rewrite_id.cpp
+  proof/trust_rewrite_id.h
   proof/theory_proof_step_buffer.cpp
   proof/theory_proof_step_buffer.h
   proof/unsat_core.cpp

--- a/src/api/cpp/cvc5_proof_rule.cpp
+++ b/src/api/cpp/cvc5_proof_rule.cpp
@@ -40,6 +40,7 @@ const char* toString(ProofRule id)
     //================================================= Trusted rules
     case ProofRule::TRUST: return "TRUST";
     case ProofRule::TRUST_THEORY_REWRITE: return "TRUST_THEORY_REWRITE";
+    case ProofRule::THEORY_REWRITE: return "THEORY_REWRITE";
     case ProofRule::SAT_REFUTATION: return "SAT_REFUTATION";
     //================================================= Boolean rules
     case ProofRule::RESOLUTION: return "RESOLUTION";
@@ -117,16 +118,6 @@ const char* toString(ProofRule id)
     case ProofRule::MACRO_BV_BITBLAST: return "MACRO_BV_BITBLAST";
     case ProofRule::BV_BITBLAST_STEP: return "BV_BITBLAST_STEP";
     case ProofRule::BV_EAGER_ATOM: return "BV_EAGER_ATOM";
-    //
-    case ProofRule::BV_UMULO_ELIMINATE: return "BV_UMULO_ELIMINATE";
-    case ProofRule::BV_SMULO_ELIMINATE: return "BV_SMULO_ELIMINATE";
-    case ProofRule::BV_FLATTEN_ASSOC_COMMUTE: return "BV_FLATTEN_ASSOC_COMMUTE";
-    case ProofRule::BV_FLATTEN_ASSOC_COMMUTE_NO_DUPLICATES: return "BV_FLATTEN_ASSOC_COMMUTE_NO_DUPLICATES";
-    case ProofRule::BV_ADD_COMBINE_LIKE_TERMS: return "BV_ADD_COMBINE_LIKE_TERMS";
-    case ProofRule::BV_MULT_SIMPLIFY: return "BV_MULT_SIMPLIFY";
-    case ProofRule::BV_SOLVE_EQ: return "BV_SOLVE_EQ";
-    case ProofRule::BV_BITWISE_EQ: return "BV_BITWISE_EQ";
-    case ProofRule::BV_BITWISE_SLICING: return "BV_BITWISE_SLICING";
     //================================================= Datatype rules
     case ProofRule::DT_UNIF: return "DT_UNIF";
     case ProofRule::DT_INST: return "DT_INST";

--- a/src/proof/trust_rewrite_id.cpp
+++ b/src/proof/trust_rewrite_id.cpp
@@ -1,0 +1,67 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2023 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Implementation of trust identifier
+ */
+
+#include "proof/trust_rewrite_id.h"
+
+#include "proof/proof_checker.h"
+#include "util/rational.h"
+
+using namespace cvc5::internal::kind;
+
+namespace cvc5::internal {
+
+const char* toString(TrustRewriteId id)
+{
+  switch (id)
+  {
+#define TRUST_REWRITE_ID_CASE(name) \
+  case TrustRewriteId::name: return #name;
+    TRUST_REWRITE_ID_CASE(NONE)
+    TRUST_REWRITE_ID_CASE(BV_UMULO_ELIMINATE)
+    TRUST_REWRITE_ID_CASE(BV_SMULO_ELIMINATE)
+    TRUST_REWRITE_ID_CASE(BV_FLATTEN_ASSOC_COMMUTE)
+    TRUST_REWRITE_ID_CASE(BV_FLATTEN_ASSOC_COMMUTE_NO_DUPLICATES)
+    TRUST_REWRITE_ID_CASE(BV_ADD_COMBINE_LIKE_TERMS)
+    TRUST_REWRITE_ID_CASE(BV_MULT_SIMPLIFY)
+    TRUST_REWRITE_ID_CASE(BV_SOLVE_EQ)
+    TRUST_REWRITE_ID_CASE(BV_BITWISE_EQ)
+    TRUST_REWRITE_ID_CASE(BV_BITWISE_SLICING)
+  };
+}
+
+std::ostream& operator<<(std::ostream& out, TrustRewriteId id)
+{
+  out << toString(id);
+  return out;
+}
+
+Node mkTrustRewriteId(TrustRewriteId id)
+{
+  return NodeManager::currentNM()->mkConstInt(
+      Rational(static_cast<uint32_t>(id)));
+}
+
+bool getTrustRewriteId(TNode n, TrustRewriteId& i)
+{
+  uint32_t index;
+  if (!ProofRuleChecker::getUInt32(n, index))
+  {
+    return false;
+  }
+  i = static_cast<TrustRewriteId>(index);
+  return true;
+}
+
+}  // namespace cvc5::internal

--- a/src/proof/trust_rewrite_id.h
+++ b/src/proof/trust_rewrite_id.h
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2023 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Trust identifier enumeration
+ */
+
+#include "cvc5_private.h"
+
+#ifndef CVC5__PROOF__TRUST_REWRITE_ID_H
+#define CVC5__PROOF__TRUST_REWRITE_ID_H
+
+#include "expr/node.h"
+
+namespace cvc5::internal {
+
+/**
+ * Identifiers for trusted steps in proofs.
+ */
+enum class TrustRewriteId : uint32_t
+{
+  NONE,
+  BV_UMULO_ELIMINATE,
+  BV_SMULO_ELIMINATE,
+  BV_FLATTEN_ASSOC_COMMUTE,
+  BV_FLATTEN_ASSOC_COMMUTE_NO_DUPLICATES,
+  BV_ADD_COMBINE_LIKE_TERMS,
+  BV_MULT_SIMPLIFY,
+  BV_SOLVE_EQ,
+  BV_BITWISE_EQ,
+  BV_BITWISE_SLICING,
+
+};
+/** Converts a trust rewrite id to a string. */
+const char* toString(TrustRewriteId id);
+/** Write a trust rewrite id to out */
+std::ostream& operator<<(std::ostream& out, TrustRewriteId id);
+/** Make a trust rewrite id node */
+Node mkTrustRewriteId(TrustRewriteId id);
+/** get a trust identifier from a node, return false if we fail */
+bool getTrustRewriteId(TNode n, TrustRewriteId& i);
+
+}  // namespace cvc5::internal
+
+#endif /* CVC5__PROOF__TRUST_REWRITE_ID_H */

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -72,28 +72,13 @@ bool BasicRewriteRCons::prove(
 bool BasicRewriteRCons::postProve(
     CDProof* cdp, Node a, Node b, theory::TheoryId tid, MethodId mid)
 {
-  if (tid == theory::THEORY_BV)
-  {
     Node eq = a.eqNode(b);
-#define POST_PROVE_CASE(name) \
-    if (tryRule(cdp, eq, ProofRule::name, {eq[0]})) \
-    { \
-      Trace("trewrite-rcons") << "Reconstruct " << eq << " (from " << tid << ", " \
-                              << mid << ")"  << std::endl; \
-      return true; \
-    } \
-    /* end of macro */
-
-    POST_PROVE_CASE(BV_UMULO_ELIMINATE)
-    POST_PROVE_CASE(BV_SMULO_ELIMINATE)
-    POST_PROVE_CASE(BV_FLATTEN_ASSOC_COMMUTE)
-    POST_PROVE_CASE(BV_FLATTEN_ASSOC_COMMUTE_NO_DUPLICATES)
-    POST_PROVE_CASE(BV_ADD_COMBINE_LIKE_TERMS)
-    POST_PROVE_CASE(BV_MULT_SIMPLIFY)
-    POST_PROVE_CASE(BV_SOLVE_EQ)
-    POST_PROVE_CASE(BV_BITWISE_EQ)
-    POST_PROVE_CASE(BV_BITWISE_SLICING)
-  }
+    if (tryRule(cdp, eq, ProofRule::THEORY_REWRITE, {eq[0]}))
+    {
+      Trace("trewrite-rcons") << "Reconstruct " << eq << " (from " << tid << ", "
+                              << mid << ")"  << std::endl;
+      return true;
+    }
 
   Trace("trewrite-rcons") << "...(fail)" << std::endl;
   return false;

--- a/src/theory/bv/proof_checker.cpp
+++ b/src/theory/bv/proof_checker.cpp
@@ -17,6 +17,7 @@
 #include "theory/bv/theory_bv_rewrite_rules.h"
 #include "theory/bv/theory_bv_rewrite_rules_operator_elimination.h"
 #include "theory/bv/theory_bv_rewrite_rules_normalization.h"
+#include "proof/trust_rewrite_id.h"
 
 namespace cvc5::internal {
 namespace theory {
@@ -27,15 +28,6 @@ void BVProofRuleChecker::registerTo(ProofChecker* pc)
   pc->registerTrustedChecker(ProofRule::MACRO_BV_BITBLAST, this, 2);
   pc->registerTrustedChecker(ProofRule::BV_BITBLAST_STEP, this, 2);
   pc->registerChecker(ProofRule::BV_EAGER_ATOM, this);
-  pc->registerChecker(ProofRule::BV_UMULO_ELIMINATE, this);
-  pc->registerChecker(ProofRule::BV_SMULO_ELIMINATE, this);
-  pc->registerChecker(ProofRule::BV_FLATTEN_ASSOC_COMMUTE, this);
-  pc->registerChecker(ProofRule::BV_FLATTEN_ASSOC_COMMUTE_NO_DUPLICATES, this);
-  pc->registerChecker(ProofRule::BV_ADD_COMBINE_LIKE_TERMS, this);
-  pc->registerChecker(ProofRule::BV_MULT_SIMPLIFY, this);
-  pc->registerChecker(ProofRule::BV_SOLVE_EQ, this);
-  pc->registerChecker(ProofRule::BV_BITWISE_EQ, this);
-  pc->registerChecker(ProofRule::BV_BITWISE_SLICING, this);
 }
 
 Node BVProofRuleChecker::checkInternal(ProofRule id,
@@ -63,26 +55,26 @@ Node BVProofRuleChecker::checkInternal(ProofRule id,
     Assert(args[0].getKind() == Kind::BITVECTOR_EAGER_ATOM);
     return args[0].eqNode(args[0][0]);
   }
-
+  else if (id == ProofRule::TRUST_THEORY_REWRITE)
+  {
+    Assert(children.empty());
+    Assert(args.size() == 1);
+    auto const& node = args[0];
 #define BV_PROOF_CASE(rule, name) \
-  else if (id == ProofRule::rule && RewriteRule<name>::applies(args[0])) \
-  { \
-    Assert(children.empty()); \
-    Assert(args.size() == 1); \
-    auto const& node = args[0]; \
-    return node.eqNode(RewriteRule<name>::run<false>(node)); \
-  } \
-  /* end macro */
-
-  BV_PROOF_CASE(BV_UMULO_ELIMINATE, UmuloEliminate)
-  BV_PROOF_CASE(BV_SMULO_ELIMINATE, SmuloEliminate)
-  BV_PROOF_CASE(BV_FLATTEN_ASSOC_COMMUTE, FlattenAssocCommut)
-  BV_PROOF_CASE(BV_FLATTEN_ASSOC_COMMUTE_NO_DUPLICATES, FlattenAssocCommutNoDuplicates)
-  BV_PROOF_CASE(BV_ADD_COMBINE_LIKE_TERMS, AddCombineLikeTerms)
-  BV_PROOF_CASE(BV_MULT_SIMPLIFY, MultSimplify)
-  BV_PROOF_CASE(BV_SOLVE_EQ, SolveEq)
-  BV_PROOF_CASE(BV_BITWISE_EQ, BitwiseEq)
-  BV_PROOF_CASE(BV_BITWISE_SLICING, BitwiseSlicing)
+    if (RewriteRule<name>::applies(args[0])) { \
+      return node.eqNode(RewriteRule<name>::run<false>(node)); \
+    } \
+    /* end of macro */
+    BV_PROOF_CASE(BV_UMULO_ELIMINATE, UmuloEliminate)
+    BV_PROOF_CASE(BV_SMULO_ELIMINATE, SmuloEliminate)
+    BV_PROOF_CASE(BV_FLATTEN_ASSOC_COMMUTE, FlattenAssocCommut)
+    BV_PROOF_CASE(BV_FLATTEN_ASSOC_COMMUTE_NO_DUPLICATES, FlattenAssocCommutNoDuplicates)
+    BV_PROOF_CASE(BV_ADD_COMBINE_LIKE_TERMS, AddCombineLikeTerms)
+    BV_PROOF_CASE(BV_MULT_SIMPLIFY, MultSimplify)
+    BV_PROOF_CASE(BV_SOLVE_EQ, SolveEq)
+    BV_PROOF_CASE(BV_BITWISE_EQ, BitwiseEq)
+    BV_PROOF_CASE(BV_BITWISE_SLICING, BitwiseSlicing)
+  }
 
   return Node::null();
 }

--- a/src/theory/bv/proof_checker.cpp
+++ b/src/theory/bv/proof_checker.cpp
@@ -55,7 +55,7 @@ Node BVProofRuleChecker::checkInternal(ProofRule id,
     Assert(args[0].getKind() == Kind::BITVECTOR_EAGER_ATOM);
     return args[0].eqNode(args[0][0]);
   }
-  else if (id == ProofRule::TRUST_THEORY_REWRITE)
+  else if (id == ProofRule::THEORY_REWRITE)
   {
     Assert(children.empty());
     Assert(args.size() == 1);


### PR DESCRIPTION
1. Added `TrustTheoryId` enum class
2. Added `ProofRule::THEORY_REWRITE`
3. Removed BV proof rules from `ProofRule::`
4. `BVProofRuleChecker::checkInternal` now checks every BV proof rule when the id is `THEORY_REWRITE`