### PR TITLE
Make CoCoA use cvc5's libgmp path

### DIFF
--- a/cmake/FindCoCoA.cmake
+++ b/cmake/FindCoCoA.cmake
@@ -51,6 +51,8 @@ if(NOT CoCoA_FOUND_SYSTEM)
     set(make_cmd "make")
   endif()
 
+  get_target_property(GMP_LIBRARY GMP IMPORTED_LOCATION)
+
   ExternalProject_Add(
     CoCoA-EP
     ${COMMON_EP_CONFIG}
@@ -61,7 +63,7 @@ if(NOT CoCoA_FOUND_SYSTEM)
     PATCH_COMMAND patch -p1 -d <SOURCE_DIR>
         -i ${CMAKE_CURRENT_LIST_DIR}/deps-utils/CoCoALib-0.99800-trace.patch
     BUILD_IN_SOURCE YES
-    CONFIGURE_COMMAND ${SHELL} ./configure --prefix=<INSTALL_DIR>
+    CONFIGURE_COMMAND ${SHELL} ./configure --prefix=<INSTALL_DIR> --with-libgmp=${GMP_LIBRARY}
     BUILD_COMMAND ${make_cmd} library
     BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libcocoa.a
   )

--- a/cmake/deps-utils/CoCoALib-0.99800-trace.patch
+++ b/cmake/deps-utils/CoCoALib-0.99800-trace.patch
@@ -112,3 +112,36 @@ index ea250d4..3447d86 100644
      myUpdateLenLPPLCDegComp();
      myAge = the_age;
      // MAX: do these things only if necessary.
+diff --git a/configuration/gmp-check-cxxflags.sh b/configuration/gmp-check-cxxflags.sh
+index f34c10d..6c167a3 100755
+--- a/configuration/gmp-check-cxxflags.sh
++++ b/configuration/gmp-check-cxxflags.sh
+@@ -59,7 +59,7 @@ fi
+ 
+ 
+ GMP_LDLIB=-lgmp
+-if [ -f "$COCOA_EXTLIB_DIR"/lib/libgmp-symlink.a ]
++if [ -f "$COCOA_EXTLIB_DIR"/lib/libgmp-symlink."$GMP_LIB_EXTN" ]
+ then
+   GMP_LDLIB=-lgmp-symlink
+ fi
+diff --git a/configure b/configure
+index 769750d..5ac5e90 100755
+--- a/configure
++++ b/configure
+@@ -336,6 +336,7 @@ fi
+ # Next two lines required by the scripts which check GMP (see below).
+ export CXX
+ export CXXFLAGS
++export GMP_LIB_EXTN
+ 
+ # Check compiler and flags are sane.
+ # If all is well, result is either "gnu" or "not gnu" & return code is 0.
+@@ -467,6 +468,7 @@ else
+       # gmp-find.sh script worked, so message is full path of GMP library
+       /bin/ln -s "$GMP_MESG" $EXTLIBS/lib/libgmp-symlink.a
+       GMP_LIB="$GMP_MESG"
++      GMP_LIB_EXTN="a"
+     fi
+   fi
+ fi


### PR DESCRIPTION
(Edited)

Prior this PR, CoCoA tries to discover libgmp on its own.
This will usually fail on systems like Mac M1/2, where libgmp via
Homebrew installation is usually located at a non-standard location.
This PR passes an explicit libgmp path that cvc5 already computed
to CoCoA, which fixes the issue.

We need to also manually patch CoCoA because CoCoA is buggy:
it made an assumption that libgmp is statically-linked,
so when cvc5 is compiled in the dynamically linked mode
(i.e. without `--static`), CoCoA will fail to compile.
The patch fixes this issue.