### PR TITLE
Eagerly lift lambdas involving free functions that could induce cycles

### DIFF
--- a/src/expr/CMakeLists.txt
+++ b/src/expr/CMakeLists.txt
@@ -72,6 +72,7 @@ libcvc5_add_sources(
   node_visitor.h
   skolem_manager.cpp
   skolem_manager.h
+  sort_type_size.h
   subtype_elim_node_converter.cpp
   subtype_elim_node_converter.h
   term_canonize.cpp

--- a/src/expr/CMakeLists.txt
+++ b/src/expr/CMakeLists.txt
@@ -72,6 +72,7 @@ libcvc5_add_sources(
   node_visitor.h
   skolem_manager.cpp
   skolem_manager.h
+  sort_type_size.cpp
   sort_type_size.h
   subtype_elim_node_converter.cpp
   subtype_elim_node_converter.h

--- a/src/expr/sort_type_size.cpp
+++ b/src/expr/sort_type_size.cpp
@@ -1,0 +1,54 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds,
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2023 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Sort type size utility. Used for model construction for higher-order.
+ */
+
+#include "expr/sort_type_size.h"
+
+namespace cvc5::internal {
+
+// compares the type size of i and j
+// returns true iff the size of i is less than that of j
+// tiebreaks are determined by node value
+bool SortTypeSize::operator()(Node i, Node j)
+{
+  int si = getTypeSize(i.getType());
+  int sj = getTypeSize(j.getType());
+  if (si < sj)
+  {
+    return true;
+  }
+  else if (si == sj)
+  {
+    return i < j;
+  }
+  return false;
+}
+/** get the size of type tn */
+size_t SortTypeSize::getTypeSize(const TypeNode& tn)
+{
+  std::map<TypeNode, size_t>::iterator it = d_type_size.find(tn);
+  if (it != d_type_size.end())
+  {
+    return it->second;
+  }
+  size_t sum = 1;
+  for (const TypeNode& tnc : tn)
+  {
+    sum += getTypeSize(tnc);
+  }
+  d_type_size[tn] = sum;
+  return sum;
+}
+
+}  // namespace cvc5::internal

--- a/src/expr/sort_type_size.h
+++ b/src/expr/sort_type_size.h
@@ -1,0 +1,76 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds,
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2023 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Sort type size utility. Used for model construction for higher-order.
+ */
+
+#ifndef CVC5__EXPR__SORT_TYPE_SIZE_H
+#define CVC5__EXPR__SORT_TYPE_SIZE_H
+
+#include <map>
+#include <optional>
+#include <vector>
+
+#include "expr/node.h"
+
+namespace cvc5::internal {
+
+/**
+ * This struct is used to sort terms by the "size" of their type
+ *   The size of the type is the number of nodes in the type, for example
+ *  size of Int is 1
+ *  size of Function( Int, Int ) is 3
+ *  size of Function( Function( Bool, Int ), Int ) is 5
+ */
+struct SortTypeSize
+{
+  // stores the size of the type
+  std::map<TypeNode, size_t> d_type_size;
+ public:
+  // compares the type size of i and j
+  // returns true iff the size of i is less than that of j
+  // tiebreaks are determined by node value
+  bool operator()(Node i, Node j)
+  {
+    int si = getTypeSize(i.getType());
+    int sj = getTypeSize(j.getType());
+    if (si < sj)
+    {
+      return true;
+    }
+    else if (si == sj)
+    {
+      return i < j;
+    }
+    return false;
+  }
+  /** get the size of type tn */
+  size_t getTypeSize(const TypeNode& tn)
+  {
+    std::map<TypeNode, size_t>::iterator it = d_type_size.find(tn);
+    if (it != d_type_size.end())
+    {
+      return it->second;
+    }
+    size_t sum = 1;
+    for (const TypeNode& tnc : tn)
+    {
+      sum += getTypeSize(tnc);
+    }
+    d_type_size[tn] = sum;
+    return sum;
+  }
+};
+
+}  // namespace cvc5::internal
+
+#endif /* CVC5__EXPR__SORT_TYPE_SIZE_H */

--- a/src/expr/sort_type_size.h
+++ b/src/expr/sort_type_size.h
@@ -39,36 +39,9 @@ struct SortTypeSize
   // compares the type size of i and j
   // returns true iff the size of i is less than that of j
   // tiebreaks are determined by node value
-  bool operator()(Node i, Node j)
-  {
-    int si = getTypeSize(i.getType());
-    int sj = getTypeSize(j.getType());
-    if (si < sj)
-    {
-      return true;
-    }
-    else if (si == sj)
-    {
-      return i < j;
-    }
-    return false;
-  }
+  bool operator()(Node i, Node j);
   /** get the size of type tn */
-  size_t getTypeSize(const TypeNode& tn)
-  {
-    std::map<TypeNode, size_t>::iterator it = d_type_size.find(tn);
-    if (it != d_type_size.end())
-    {
-      return it->second;
-    }
-    size_t sum = 1;
-    for (const TypeNode& tnc : tn)
-    {
-      sum += getTypeSize(tnc);
-    }
-    d_type_size[tn] = sum;
-    return sum;
-  }
+  size_t getTypeSize(const TypeNode& tn);
 };
 
 }  // namespace cvc5::internal

--- a/src/theory/uf/ho_extension.cpp
+++ b/src/theory/uf/ho_extension.cpp
@@ -66,7 +66,7 @@ TrustNode HoExtension::ppRewrite(Node node, std::vector<SkolemLemma>& lems)
     {
       Node op = node[0];
       Node opl = d_ll.getLambdaFor(op);
-      if (!opl.isNull())
+      if (!opl.isNull() && !d_ll.isLifted(opl))
       {
         NodeManager* nm = NodeManager::currentNM();
         Node app = nm->mkNode(Kind::HO_APPLY, opl, node[1]);
@@ -90,7 +90,7 @@ TrustNode HoExtension::ppRewrite(Node node, std::vector<SkolemLemma>& lems)
       // immediately
       Node op = node.getOperator();
       Node opl = d_ll.getLambdaFor(op);
-      if (!opl.isNull())
+      if (!opl.isNull() && !d_ll.isLifted(opl))
       {
         Assert(opl.getKind() == Kind::LAMBDA);
         std::vector<Node> args(node.begin(), node.end());
@@ -504,7 +504,7 @@ unsigned HoExtension::checkLazyLambda()
       Node n = *eqc_i;
       ++eqc_i;
       Node lam = d_ll.getLambdaFor(n);
-      if (lam.isNull())
+      if (lam.isNull() || d_ll.isLifted(lam))
       {
         if (!lamRep.isNull())
         {

--- a/src/theory/uf/lambda_lift.cpp
+++ b/src/theory/uf/lambda_lift.cpp
@@ -78,9 +78,18 @@ TrustNode LambdaLift::ppRewrite(Node node, std::vector<SkolemLemma>& lems)
   {
     Trace("uf-lazy-ll") << "Lift " << lam << "?" << std::endl;
     shouldLift = false;
-    // model construction considers types in order of their type size
+    // Model construction considers types in order of their type size
     // (SortTypeSize::getTypeSize). If the lambda has a free variable, that
     // comes later in the model construction, it must be lifted eagerly.
+    // As an example, say f : Int -> Int, g : Int x Int -> Int
+    // The following lambdas require eager lifting:
+    // - (lambda ((x Int)) (g x x))
+    // - (lambda ((x Int) (y Int)) (f (g x y)))
+    // The following lambads do not require eager lifting:
+    // - (lambda ((x Int)) (+ x 1)), since it has no free symbols.
+    // - (lambda ((x Int) (y Int)) (f x)), since its free symbol f has a type
+    // Int -> Int which is processed before the type of the lambda, i.e.
+    // Int x Int -> Int.
     std::unordered_set<Node> syms;
     expr::getSymbols(lam[1], syms);
     SortTypeSize sts;

--- a/src/theory/uf/lambda_lift.cpp
+++ b/src/theory/uf/lambda_lift.cpp
@@ -82,7 +82,7 @@ TrustNode LambdaLift::ppRewrite(Node node, std::vector<SkolemLemma>& lems)
     // (SortTypeSize::getTypeSize). If the lambda has a free variable, that
     // comes later in the model construction, it must be lifted eagerly.
     std::unordered_set<Node> syms;
-    expr::getSymbols(node[1], syms);
+    expr::getSymbols(lam[1], syms);
     SortTypeSize sts;
     size_t lsize = sts.getTypeSize(lam.getType());
     for (const Node& v : syms)

--- a/src/theory/uf/lambda_lift.cpp
+++ b/src/theory/uf/lambda_lift.cpp
@@ -99,7 +99,10 @@ TrustNode LambdaLift::ppRewrite(Node node, std::vector<SkolemLemma>& lems)
   if (shouldLift)
   {
     TrustNode trn = lift(lam);
-    lems.push_back(SkolemLemma(trn, skolem));
+    if (!trn.isNull())
+    {
+      lems.push_back(SkolemLemma(trn, skolem));
+    }
   }
   // if no proofs, return lemma with no generator
   if (d_epg == nullptr)

--- a/src/theory/uf/lambda_lift.h
+++ b/src/theory/uf/lambda_lift.h
@@ -50,6 +50,8 @@ class LambdaLift : protected EnvObj
    * the lambda lifting lemma has already been generated in this context.
    */
   TrustNode lift(Node node);
+  /** Have we lifted node? */
+  bool isLifted(const Node& node) const;
 
   /**
    * This method has the same contract as Theory::ppRewrite.

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -800,7 +800,10 @@ set(regress_0_tests
   regress0/ho/issue6526.smt2
   regress0/ho/issue6536.smt2
   regress0/ho/ite-apply-eq.smt2
+  regress0/ho/lambda-cycle.smt2
   regress0/ho/lambda-equality-non-canon.smt2
+  regress0/ho/lambda-test-deps.smt2
+  regress0/ho/lambda-test-deps-simple.smt2
   regress0/ho/lazy-lambda-model.smt2
   regress0/ho/match-middle.smt2
   regress0/ho/modulo-func-equality.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2209,7 +2209,6 @@ set(regress_1_tests
   regress1/get-learned-literals.smt2
   regress1/get-learned-literals-types.smt2
   regress1/ho/bug_freeVar_BDD_General_data_270.smt2
-  regress1/ho/bug_freevar_PHI004^4-delta.smt2
   regress1/ho/bound_var_bug.smt2
   regress1/ho/fta0328.lfho.smt2
   regress1/ho/ho-fun-sharing-dd.smt2
@@ -3529,6 +3528,8 @@ set(regression_disabled_tests
   regress1/ho/nested_lambdas-AGT034^2.smt2
   regress1/ho/nested_lambdas-sat-SYO056^1-delta.smt2
   regress1/ho/SYO056^1.smt2
+  # timeout after fixes to uf-lazy-ll for cyclic lambda construction
+  regress1/ho/bug_freevar_PHI004^4-delta.smt2
   # times out after update to circuit propagator
   regress1/nl/dumortier_llibre_artes_ex_5_13.transcendental.k2.smt2
   # times out after update to tangent planes

--- a/test/regress/cli/regress0/ho/dd.shadowing-defs.smt2
+++ b/test/regress/cli/regress0/ho/dd.shadowing-defs.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-lazy-ll -q
+; COMMAND-LINE: --uf-lazy-ll -q --mbqi
 ; EXPECT: sat
 (set-logic HO_ALL)
 (declare-sort u 0)

--- a/test/regress/cli/regress0/ho/lambda-cycle.smt2
+++ b/test/regress/cli/regress0/ho/lambda-cycle.smt2
@@ -1,0 +1,6 @@
+; COMMAND-LINE: --mbqi
+; EXPECT: sat
+(set-logic HO_ALL)
+(declare-fun f (Int Int) Int)
+(assert (= f (lambda ((x Int) (y Int)) (f y x))))
+(check-sat)

--- a/test/regress/cli/regress0/ho/lambda-test-deps-simple.smt2
+++ b/test/regress/cli/regress0/ho/lambda-test-deps-simple.smt2
@@ -1,0 +1,6 @@
+; COMMAND-LINE: --enum-inst
+; EXPECT: unsat
+(set-logic HO_ALL)
+(declare-fun f (Int Int) Int)
+(assert (= f (lambda ((x Int) (y Int)) (+ 1 (f x y)))))
+(check-sat)

--- a/test/regress/cli/regress0/ho/lambda-test-deps.smt2
+++ b/test/regress/cli/regress0/ho/lambda-test-deps.smt2
@@ -1,0 +1,8 @@
+; COMMAND-LINE: --enum-inst
+; EXPECT: unsat
+(set-logic HO_ALL)
+(declare-fun f (Int Int) Int)
+(declare-fun g (Int Int) Int)
+(assert (or (= g (lambda ((x Int) (y Int)) (+ 1 (f y x)))) (= g (lambda ((x Int) (y Int)) (+ 2 (f y x))))))
+(assert (or (= f (lambda ((x Int) (y Int)) (+ 1 (g y x)))) (= f (lambda ((x Int) (y Int)) (+ 2 (g y x))))))
+(check-sat)


### PR DESCRIPTION
Currently we have numerous model soundness issues for QF_UF + lambdas since the model construction does not take cycles into account.

This avoids cyclic model construction in a basic way by always lifting lambdas that containing function symbols that will be considered after the model for symbols of their type is constructed.