### PR TITLE
Add another strings regression

### DIFF
--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -3034,6 +3034,7 @@ set(regress_1_tests
   regress1/strings/str-code-unsat-2.smt2
   regress1/strings/str-code-unsat-3.smt2
   regress1/strings/str-code-unsat.smt2
+  regress1/strings/str-pred-small-rw_392.smt2
   regress1/strings/str-rev-simple-s.smt2
   regress1/strings/str001.smt2
   regress1/strings/str002.smt2

--- a/test/regress/cli/regress1/strings/str-pred-small-rw_392.smt2
+++ b/test/regress/cli/regress1/strings/str-pred-small-rw_392.smt2
@@ -1,0 +1,8 @@
+(set-logic QF_SLIA)
+(set-info :status unsat)
+(declare-fun x () String)
+(declare-fun y () String)
+(declare-fun z () Int)
+(assert (not (= (str.suffixof "A" (str.replace x "A" "")) (str.suffixof "A" (str.replace x "A" "B")))))
+(check-sat)
+(exit)


### PR DESCRIPTION
We were incorrectly "sat" on this benchmark from:
https://github.com/cvc5/cvc5/pull/9978 (introduced bug)
https://github.com/cvc5/cvc5/pull/10199 (fixed)