### PR TITLE
Fix build for libcxx (macOS, clang 15)

### DIFF
--- a/src/expr/node_traversal.h
+++ b/src/expr/node_traversal.h
@@ -55,8 +55,8 @@ class NodeDfsIterator
   // Move/copy construction and assignment. Destructor.
   NodeDfsIterator(NodeDfsIterator&&) = default;
   NodeDfsIterator& operator=(NodeDfsIterator&&) = default;
-  NodeDfsIterator(NodeDfsIterator&) = default;
-  NodeDfsIterator& operator=(NodeDfsIterator&) = default;
+  NodeDfsIterator(const NodeDfsIterator&) = default;
+  NodeDfsIterator& operator=(const NodeDfsIterator&) = default;
   ~NodeDfsIterator() = default;
 
   // Preincrement
@@ -132,8 +132,8 @@ class NodeDfsIterable
   // Move/copy construction and assignment. Destructor.
   NodeDfsIterable(NodeDfsIterable&&) = default;
   NodeDfsIterable& operator=(NodeDfsIterable&&) = default;
-  NodeDfsIterable(NodeDfsIterable&) = default;
-  NodeDfsIterable& operator=(NodeDfsIterable&) = default;
+  NodeDfsIterable(const NodeDfsIterable&) = default;
+  NodeDfsIterable& operator=(const NodeDfsIterable&) = default;
   ~NodeDfsIterable() = default;
 
   NodeDfsIterator begin() const;


### PR DESCRIPTION
Our copy constructor for NodeDfsIterator took its argument by reference. std::copy technically requires the iterator type to CopyConstructible[1], which requires the copy constructor to work given a constant lvalue or rvalue.

For older LLVM libcxx versions and for GNU libc++, this deviation from CoCopyConstructible's requirements was not a problem. But now, it leads to a compiler error with libcxx.

We fix the problem by strengthening the signature of the copy constructor so that it takes a constant reference.

We fix the assignment constructor and both constructors for NodeDfsIterable while we're at it.

I tested the fix on a mac with clang 15.0.0 and libcxx. I also tested it using Godbolt's Compiler Explorer with clang 15.0.0 and `-stdlib=libc++`.

fixes #10218

[1]: https://en.cppreference.com/w/cpp/named_req/CopyConstructible