### PR TITLE
ci: Use LLVM-15 for building arm64 macOS binaries.

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -86,6 +86,8 @@ runs:
         echo "image_version=$ImageVersion" >> $GITHUB_ENV
         echo "num_proc=$(( $(sysctl -n hw.logicalcpu) + 1 ))" >> $GITHUB_ENV
         echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
+        echo "CC=$(brew --prefix llvm@15)/bin/clang" >> $GITHUB_ENV
+        echo "CXX=$(brew --prefix llvm@15)/bin/clang++" >> $GITHUB_ENV
         echo "::endgroup::"
 
     - name: Install software for Python bindings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,12 @@ jobs:
         build-static: ${{ matrix.build-static }}
         strip-bin: ${{ matrix.strip-bin }}
 
+    - name: Store Binary
+      uses: actions/upload-artifact@v3
+      with:
+        name: binary
+        path: ${{ steps.configure-and-build.outputs.static-build-dir }}/bin/cvc5
+
     - name: ccache Statistics
       run: ccache -s
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
     - name: Store Binary
       uses: actions/upload-artifact@v3
       with:
-        name: binary
+        name: binary-${{ matrix.name }}
         path: ${{ steps.configure-and-build.outputs.static-build-dir }}/bin/cvc5
 
     - name: ccache Statistics

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,12 +112,6 @@ jobs:
         build-static: ${{ matrix.build-static }}
         strip-bin: ${{ matrix.strip-bin }}
 
-    - name: Store Binary
-      uses: actions/upload-artifact@v3
-      with:
-        name: binary-${{ matrix.name }}
-        path: ${{ steps.configure-and-build.outputs.static-build-dir }}/bin/cvc5
-
     - name: ccache Statistics
       run: ccache -s
 

--- a/src/preprocessing/util/ite_utilities.cpp
+++ b/src/preprocessing/util/ite_utilities.cpp
@@ -481,8 +481,6 @@ Node ITECompressor::compressTerm(Node toCompress)
 
 Node ITECompressor::compressBoolean(Node toCompress)
 {
-  static int instance = 0;
-  ++instance;
   if (toCompress.isConst() || toCompress.isVar())
   {
     return toCompress;
@@ -1523,13 +1521,8 @@ Node ITESimplifier::simpITE(TNode assertion)
   vector<preprocess_stack_element> toVisit;
   toVisit.push_back(assertion);
 
-  static int call = 0;
-  ++call;
-  int iteration = 0;
-
   while (!toVisit.empty())
   {
-    iteration++;
     // cout << "call  " << call << " : " << iteration << endl;
     // The current node we are processing
     preprocess_stack_element& stackHead = toVisit.back();

--- a/src/theory/quantifiers/ieval/state.cpp
+++ b/src/theory/quantifiers/ieval/state.cpp
@@ -571,6 +571,7 @@ std::string State::toStringDebugSearch() const
     }
   }
   ss << " ]";
+  (void) nqc;
   Assert(nqc == d_numActiveQuant.get()) << "Active quant mismatch " << ss.str();
   return ss.str();
 }

--- a/src/theory/quantifiers/quantifiers_rewriter.cpp
+++ b/src/theory/quantifiers/quantifiers_rewriter.cpp
@@ -1613,7 +1613,6 @@ Node QuantifiersRewriter::computeSplit(std::vector<Node>& args,
                                        QAttributes& qa) const
 {
   Assert(body.getKind() == Kind::OR);
-  size_t var_found_count = 0;
   size_t eqc_count = 0;
   size_t eqc_active = 0;
   std::map< Node, int > var_to_eqc;
@@ -1642,7 +1641,6 @@ Node QuantifiersRewriter::computeSplit(std::vector<Node>& args,
             eqcs.push_back(eqc);
           }
         }else{
-          var_found_count++;
           lit_new_args.push_back(lit_args[j]);
         }
       }


### PR DESCRIPTION
Note: Removes some unused code due to compilation warnings (i.e., errors with -Werror) on newer LLVM versions.

Fixes #10174