### PR TITLE
prop: cadical: Fix check_found_model_handling() when rejecting without reason.

### DIFF
--- a/src/prop/cadical.cpp
+++ b/src/prop/cadical.cpp
@@ -258,6 +258,20 @@ class CadicalPropagator : public CaDiCaL::ExternalPropagator
     // checking the model.
     if (!d_new_clauses.empty())
     {
+      Trace("cadical::propagator") << "cb::check_found_model end: new "
+                                      "variables added via theory decision"
+                                   << std::endl;
+      // CaDiCaL expects us to be able to provide a reason for rejecting the
+      // model (it asserts that after this call, cb_has_external_clause()
+      // returns true). However, in this particular case, we want to force
+      // CaDiCaL to give us model values for the new variables that were
+      // introduced (to kick off the assignment notification machinery), we
+      // don't have a reason clause for rejecting the model. CaDiCaL's
+      // expectation will be weakened in the future to allow for this, but for
+      // now we simply add a tautology as reason to pacify CaDiCaL.
+      d_new_clauses.push_back(1);
+      d_new_clauses.push_back(-1);
+      d_new_clauses.push_back(0);
       return false;
     }
 
@@ -307,6 +321,19 @@ class CadicalPropagator : public CaDiCaL::ExternalPropagator
       }
     } while (d_var_info.size() == size && recheck);
 
+    if (d_var_info.size() != size)
+    {
+      Trace("cadical::propagator") << "cb::check_found_model end: new "
+                                      "variables added via theory check"
+                                   << std::endl;
+      // Same as above, until CaDiCaL's assertion that we have to have
+      // a reason clause for rejecting the model is weakened, we need to
+      // pacify it with a tautology.
+      d_new_clauses.push_back(1);
+      d_new_clauses.push_back(-1);
+      d_new_clauses.push_back(0);
+      return false;
+    }
     bool res = done();
     Trace("cadical::propagator")
         << "cb::check_found_model end: done: " << res << std::endl;


### PR DESCRIPTION
When checking the SAT model, it can happen that we introduce new variables via getNextDecisionRequest() or theoryCheck(). If so, we force CaDiCaL to give us a model for these new variables before we actually check the model for consistency. We rely on CaDiCaL here to kick off the whole assignment notification machinery. At the moment (for the currently configured CaDiCaL 1.7.4 up to version 1.9.3), CaDiCaL expects us to provide a reason clause when we reject the model, which we don't have for these cases. For now, until this assertion is weakened in CaDiCaL, for these cases we pacify it with a tautology instead.