### PR TITLE
Do not eagerly lift lambads due to constructors

### DIFF
--- a/src/theory/uf/lambda_lift.cpp
+++ b/src/theory/uf/lambda_lift.cpp
@@ -96,7 +96,13 @@ TrustNode LambdaLift::ppRewrite(Node node, std::vector<SkolemLemma>& lems)
     size_t lsize = sts.getTypeSize(lam.getType());
     for (const Node& v : syms)
     {
-      size_t vsize = sts.getTypeSize(v.getType());
+      TypeNode tn = v.getType();
+      if (!tn.isFirstClass())
+      {
+        // don't need to worry about constructor/selector/testers/etc.
+        continue;
+      }
+      size_t vsize = sts.getTypeSize(tn);
       if (vsize>=lsize)
       {
         shouldLift = true;

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2025,6 +2025,7 @@ set(regress_1_tests
   regress1/bags/choose2.smt2
   regress1/bags/choose3.smt2
   regress1/bags/choose4.smt2
+  regress1/bags/ctor_previous_sat.smt2
   regress1/bags/difference_remove1.smt2
   regress1/bags/disequality.smt2
   regress1/bags/duplicate_removal1.smt2

--- a/test/regress/cli/regress1/bags/ctor_previous_sat.smt2
+++ b/test/regress/cli/regress1/bags/ctor_previous_sat.smt2
@@ -1,0 +1,7 @@
+; EXPECT: sat
+(set-logic HO_ALL)
+(declare-const a (Table Int Int))
+(declare-const b (Table Int))
+(define-fun p ((t (Tuple Int Int Int))) Bool (= ((_ tuple.select 1) t) ((_ tuple.select 0) t)))
+(assert (= ((_ table.project 0) (table.product a b)) ((_ table.project 0) (bag.filter p (table.product a b)))))
+(check-sat)


### PR DESCRIPTION
Would cause us to say "unknown" for some "sat" problems when lambdas involved e.g. datatype constructors.