### PR TITLE
Throw logic exception for POW during prepregistration

### DIFF
--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -346,15 +346,7 @@ RewriteResponse ArithRewriter::postRewriteTerm(TNode t){
           }
           return RewriteResponse(REWRITE_AGAIN, ret);
         }
-
-        // Todo improve the exception thrown
-        std::stringstream ss;
-        ss << "The exponent of the POW(^) operator can only be a positive "
-              "integral constant below "
-           << (expr::NodeValue::MAX_CHILDREN + 1) << ". ";
-        ss << "Exception occurred in:" << std::endl;
-        ss << "  " << t;
-        throw LogicException(ss.str());
+        return RewriteResponse(REWRITE_DONE, t);
       }
       case Kind::PI: return RewriteResponse(REWRITE_DONE, t);
       default: Unreachable();

--- a/src/theory/arith/linear/normal_form.h
+++ b/src/theory/arith/linear/normal_form.h
@@ -241,6 +241,7 @@ public:
      case Kind::DIVISION_TOTAL: return isDivMember(n);
      case Kind::IAND:
      case Kind::POW2:
+     case Kind::POW:
      case Kind::EXPONENTIAL:
      case Kind::SINE:
      case Kind::COSINE:

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -111,6 +111,16 @@ void TheoryArith::preRegisterTerm(TNode n)
 {
   // handle logic exceptions
   Kind k = n.getKind();
+  if (k == Kind::POW)
+  {
+    std::stringstream ss;
+    ss << "The exponent of the POW(^) operator can only be a positive "
+          "integral constant below "
+       << (expr::NodeValue::MAX_CHILDREN + 1) << ". ";
+    ss << "Exception occurred in:" << std::endl;
+    ss << "  " << n;
+    throw LogicException(ss.str());
+  }
   bool isTransKind = isTranscendentalKind(k);
   // note that we don't throw an exception for non-linear multiplication in
   // linear logics, since this is caught in the linear solver with a more

--- a/test/regress/cli/regress1/arith/bug716.1.cvc.smt2
+++ b/test/regress/cli/regress1/arith/bug716.1.cvc.smt2
@@ -5,4 +5,4 @@
 (set-option :incremental false)
 (declare-fun x () Int)
 (assert (= (^ 3 x) 27))
-(check-sat-assuming ( (= x 3) ))
+(check-sat-assuming ( (> x 3) ))

--- a/test/regress/cli/regress1/arith/bug716.2.cvc.smt2
+++ b/test/regress/cli/regress1/arith/bug716.2.cvc.smt2
@@ -5,4 +5,4 @@
 (set-option :incremental false)
 (declare-fun x () Int)
 (assert (= (^ x 67108864) 8))
-(check-sat-assuming ( (= x 3) ))
+(check-sat-assuming ( (> x 3) ))

--- a/test/unit/api/cpp/solver_black.cpp
+++ b/test/unit/api/cpp/solver_black.cpp
@@ -107,7 +107,8 @@ TEST_F(TestApiBlackSolver, pow2Large3)
   Term t262 = d_solver.mkTerm(Kind::POW2, {t203});
   Term t536 =
       d_solver.mkTerm(d_solver.mkOp(Kind::INT_TO_BITVECTOR, {49}), {t262});
-  ASSERT_THROW(d_solver.simplify(t536), CVC5ApiException);
+  // should not throw an exception, will not simplify.
+  ASSERT_NO_THROW(d_solver.simplify(t536));
 }
 
 TEST_F(TestApiBlackSolver, recoverableException)


### PR DESCRIPTION
We currently throw a logic exception for POW during rewriting if it cannot be eliminated.

This is wrong, and leads to spurious exceptions e.g. when doing rewrite generalization analysis (e.g. for proof minimization).

This PR changes the behavior so we throw an exception during preregistration instead.