### PR TITLE
Revert "ci: Use LLVM-15 for building arm64 macOS binaries. (#10240)"

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -86,8 +86,6 @@ runs:
         echo "image_version=$ImageVersion" >> $GITHUB_ENV
         echo "num_proc=$(( $(sysctl -n hw.logicalcpu) + 1 ))" >> $GITHUB_ENV
         echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
-        echo "CC=$(brew --prefix llvm@15)/bin/clang" >> $GITHUB_ENV
-        echo "CXX=$(brew --prefix llvm@15)/bin/clang++" >> $GITHUB_ENV
         echo "::endgroup::"
 
     - name: Install software for Python bindings


### PR DESCRIPTION
This partially reverts commit a287aabdadbead4b5bbebaa4c57818cc4c3f207e.