### PR TITLE
Always use stream input when piping from stdin

### DIFF
--- a/src/main/driver_unified.cpp
+++ b/src/main/driver_unified.cpp
@@ -107,16 +107,12 @@ int runCvc5(int argc, char* argv[], std::unique_ptr<cvc5::Solver>& solver)
   // If no file supplied we will read from standard input
   const bool inputFromStdin = filenames.empty() || filenames[0] == "-";
 
-  // If we're reading from stdin, use interactive mode if stdin-input-per-line
-  // is true, or if we are a TTY.
+  // If we're reading from stdin, use interactive mode if we are a TTY.
   if (!solver->getOptionInfo("interactive").setByUser)
   {
-    bool inputPerLine =
-        solver->getOptionInfo("stdin-input-per-line").boolValue();
     pExecutor->setOptionInternal(
         "interactive",
-        (inputFromStdin && (inputPerLine || isatty(fileno(stdin)))) ? "true"
-                                                                    : "false");
+        (inputFromStdin && isatty(fileno(stdin))) ? "true"  : "false");
   }
 
   // Auto-detect input language by filename extension

--- a/src/options/main_options.toml
+++ b/src/options/main_options.toml
@@ -182,11 +182,3 @@ name   = "Driver"
   type       = "bool"
   default    = "false"
   help       = "print the \"success\" output required of SMT-LIBv2"
-
-[[option]]
-  name       = "stdinInputPerLine"
-  category   = "expert"
-  long       = "stdin-input-per-line"
-  type       = "bool"
-  default    = "true"
-  help       = "when piping from stdin, feed the input to the parser one line at a time."


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/10258.

This removes the option `stdin-input-per-line` which was used as a way of avoiding stream inputs with the old Flex parser when piping from stdin.

This fixes issues when piping from stdin, in terms of performance, ddiagnostic information, and spurious error reporting.