### PR TITLE
cmake: Require GMP 6.3.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,7 +360,7 @@ if(NOT DEFINED PYTHON_EXECUTABLE)
   set(PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
 endif()
 
-find_package(GMP 6.1 REQUIRED)
+find_package(GMP 6.3 REQUIRED)
 
 if(ENABLE_ASAN)
   # -fsanitize=address requires CMAKE_REQUIRED_FLAGS to be explicitely set,

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -121,7 +121,7 @@ versions; more recent versions should be compatible.
 - `Python >= 3.6 and <= 3.10 <https://www.python.org>`_
   + module `tomli <https://pypi.org/project/tomli/>`_
   + module `pyparsing <https://pypi.org/project/pyparsing/>`_
-- `GMP v6.1 (GNU Multi-Precision arithmetic library) <https://gmplib.org>`_
+- `GMP v6.3 (GNU Multi-Precision arithmetic library) <https://gmplib.org>`_
 - `CaDiCaL (SAT solver) <https://github.com/arminbiere/cadical>`_
 - `Java >= 1.6 <https://www.java.com>`_
 - `SymFPU <https://github.com/martin-cs/symfpu/tree/CVC4>`_


### PR DESCRIPTION
Versions prior to 6.3 have issues on arm64 platforms, which led to multiple segfault issues in cvc5.