### PR TITLE
ci: Downgrade ubuntu and macOS versions

### DIFF
--- a/.github/actions/add-package/action.yml
+++ b/.github/actions/add-package/action.yml
@@ -40,7 +40,7 @@ runs:
         python3 -m pip install pyGithub
 
     - name: Store to latest
-      if: github.ref == 'refs/heads/main'
+      #if: github.ref == 'refs/heads/main'
       shell: 'python3 {0}'
       env:
         GITHUB_TOKEN: ${{ inputs.github-token-latest }}

--- a/.github/actions/add-package/action.yml
+++ b/.github/actions/add-package/action.yml
@@ -40,7 +40,7 @@ runs:
         python3 -m pip install pyGithub
 
     - name: Store to latest
-      #if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       shell: 'python3 {0}'
       env:
         GITHUB_TOKEN: ${{ inputs.github-token-latest }}

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -30,7 +30,7 @@ runs:
           flex \
           libfl-dev \
           flexc++
-        python3 -m pip install --user pexpect setuptools tomli
+        python3 -m pip install --user pexpect setuptools tomli pyparsing
         # Make ImageVersion accessible as env.image_version. Environment
         # variables of the runner are not automatically imported:
         #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         build-dir: ${{ steps.configure-and-build.outputs.shared-build-dir }}
 
     - name: Create and add shared package to latest and release
-      if: matrix.package-name && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+      if: matrix.package-name #&& (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
       uses: ./.github/actions/add-package
       with:
         build-dir: ${{ steps.configure-and-build.outputs.shared-build-dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         include:
           - name: ubuntu:production
-            os: ubuntu-latest
+            os: ubuntu-20.04
             config: production --auto-download --all-bindings --editline --docs
             cache-key: production
             strip-bin: strip
@@ -24,7 +24,7 @@ jobs:
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
           - name: macos:production
-            os: macos-latest
+            os: macos-11
             config: production --auto-download --editline
             # config: production --auto-download --python-bindings --editline
             cache-key: production
@@ -36,7 +36,7 @@ jobs:
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
  
           - name: macos:production-arm64
-            os: macos-latest
+            os: macos-11
             config: production --auto-download --editline --arm64
             # config: production --auto-download --python-bindings --editline --arm64
             cache-key: production-arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         build-dir: ${{ steps.configure-and-build.outputs.shared-build-dir }}
 
     - name: Create and add shared package to latest and release
-      if: matrix.package-name #&& (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+      if: matrix.package-name && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
       uses: ./.github/actions/add-package
       with:
         build-dir: ${{ steps.configure-and-build.outputs.shared-build-dir }}

--- a/src/expr/node_manager_template.cpp
+++ b/src/expr/node_manager_template.cpp
@@ -1272,6 +1272,8 @@ NodeClass NodeManager::mkConstInternal(Kind k, const T& val)
     && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+#if defined(__GNUC__) && (__GNUC__ > 9)
 #pragma GCC diagnostic ignored "-Wzero-length-bounds"
 #endif
 


### PR DESCRIPTION
This PR builds cvc5 on Ubuntu 20.04 and macOS 11 to ensure compatibility of the dynamically linked binaries with these older OS versions.