### PR TITLE
ci: Do not include Python bindings in cvc5 package

### DIFF
--- a/.github/actions/add-package/action.yml
+++ b/.github/actions/add-package/action.yml
@@ -21,6 +21,11 @@ runs:
         make install
         popd
 
+        # Remove Python bindings (if any).
+        # They are built for testing purposes, but
+        # only work for the specific CI Python version.
+        rm -rf ${{ inputs.build-dir }}/install/lib/python*
+
         # Copy COPYING file to install directory
         cp COPYING ${{ inputs.build-dir }}/install/
 


### PR DESCRIPTION
Python bindings are built for testing purposes, but only work for the specific Python version used in CI.