### PR TITLE
Always clone proofs when printing

### DIFF
--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -232,10 +232,10 @@ void PfManager::printProof(std::ostream& out,
                            options::ProofFormatMode mode)
 {
   Trace("smt-proof") << "PfManager::printProof: start" << std::endl;
-  // if we are in incremental mode, we don't want to invalidate the proof
-  // nodes in fp, since these may be reused in further check-sat calls
-  if (options().base.incrementalSolving
-      && mode != options::ProofFormatMode::NONE)
+  // We don't want to invalidate the proof nodes in fp, since these may be
+  // reused in further check-sat calls, or they may be used again if the
+  // user asks for the proof again (in non-incremental mode).
+  if (mode != options::ProofFormatMode::NONE)
   {
     fp = fp->clone();
   }

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1667,7 +1667,8 @@ std::vector<std::shared_ptr<ProofNode>> SolverEngine::getProof(
     modes::ProofComponent c)
 {
   Trace("smt") << "SMT getProof()\n";
-  if (!d_env->getOptions().smt.produceProofs)
+  const Options& opts = d_env->getOptions();
+  if (!opts.smt.produceProofs || opts.smt.proofMode != options::ProofMode::FULL)
   {
     throw ModalException("Cannot get a proof when proof option is off.");
   }

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1145,6 +1145,7 @@ set(regress_0_tests
   regress0/proofs/alethe-res-need-or-step.smt2
   regress0/proofs/cyclic-ucp.smt2
   regress0/proofs/issue277-circuit-propagator.smt2
+  regress0/proofs/issue10278-pf-clone.smt2
   regress0/proofs/issue8983-trust-subs.smt2
   regress0/proofs/issue9156-doublePropProof.smt2
   regress0/proofs/issue9172-doublePropProof.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1156,6 +1156,7 @@ set(regress_0_tests
   regress0/proofs/issue9669-clause-level-opt-incremental.smt2
   regress0/proofs/lfsc-test-1.smt2
   regress0/proofs/nomerge-alethe-pf.smt2
+  regress0/proofs/no-proof-uc.smt2
   regress0/proofs/open-pf-datatypes.smt2
   regress0/proofs/open-pf-if-unordered-iff.smt2
   regress0/proofs/open-pf-rederivation.smt2

--- a/test/regress/cli/regress0/proofs/issue10278-pf-clone.smt2
+++ b/test/regress/cli/regress0/proofs/issue10278-pf-clone.smt2
@@ -1,8 +1,9 @@
+; COMMAND-LINE: --produce-proofs
 ; DISABLE-TESTER: dump
+; DISABLE-TESTER: unsat-core
 ; REQUIRES: no-competition
 ; SCRUBBER: grep -o "unsat"
 ; EXPECT: unsat
-; EXIT: 1
 (set-logic ALL)
 (declare-const x Int)
 (declare-const y Int)

--- a/test/regress/cli/regress0/proofs/issue10278-pf-clone.smt2
+++ b/test/regress/cli/regress0/proofs/issue10278-pf-clone.smt2
@@ -1,0 +1,16 @@
+; DISABLE-TESTER: dump
+; REQUIRES: no-competition
+; SCRUBBER: grep -o "unsat"
+; EXPECT: unsat
+; EXIT: 1
+(set-logic ALL)
+(declare-const x Int)
+(declare-const y Int)
+(assert (<= 0 x))
+(assert (<= 0 y))
+(assert (< x 2))
+(assert (< y 2))
+(assert (not (< (* x y) 2)))
+(check-sat)
+(get-proof)
+(get-proof)

--- a/test/regress/cli/regress0/proofs/no-proof-uc.smt2
+++ b/test/regress/cli/regress0/proofs/no-proof-uc.smt2
@@ -1,0 +1,16 @@
+; DISABLE-TESTER: dump
+; DISABLE-TESTER: proof
+; COMMAND-LINE: --check-unsat-cores
+; EXPECT: unsat
+; EXPECT: (error "Cannot get a proof when proof option is off.")
+; EXIT: 1
+(set-logic ALL)
+(declare-const x Int)
+(declare-const y Int)
+(assert (<= 0 x))
+(assert (<= 0 y))
+(assert (< x 2))
+(assert (< y 2))
+(assert (not (< (* x y) 2)))
+(check-sat)
+(get-proof)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/10279.

Also fixes an issue where we would segfault if unsat cores but not proofs were enabled, adds a test for this.