### PR TITLE
Update sygus URL in docu

### DIFF
--- a/docs/binary/binary.rst
+++ b/docs/binary/binary.rst
@@ -8,7 +8,7 @@ interface.
 The cvc5 binary supports the following input languages:
 
 * `SMT-LIB v2 <http://smtlib.cs.uiowa.edu/language.shtml>`_
-* `SyGuS-IF <https://sygus.org/language/>`_
+* `SyGuS-IF <https://sygus-org.github.io/language/>`_
 
 
 Alternatively, cvc5 features :doc:`several APIs <../api/api>` for different programming languages.


### PR DESCRIPTION
The old sygus domain seems to be squatted now.

In response to issue https://github.com/cvc5/cvc5/issues/10285