### PR TITLE
Generalize ALF node converter

### DIFF
--- a/proofs/alf/theories/FiniteFields.smt3
+++ b/proofs/alf/theories/FiniteFields.smt3
@@ -19,3 +19,7 @@
     (-> (! Int :var p :implicit)
         (FiniteField p) (FiniteField p) (FiniteField p)) :right-assoc-nil
 )
+(declare-const ff.bitsum
+    (-> (! Int :var p :implicit)
+        (FiniteField p) (FiniteField p) (FiniteField p)) :right-assoc-nil
+)

--- a/src/proof/alf/alf_node_converter.cpp
+++ b/src/proof/alf/alf_node_converter.cpp
@@ -303,6 +303,13 @@ Node AlfNodeConverter::postConvert(Node n)
     ss << "@fp." << printer::smt2::Smt2Printer::smtKindString(k);
     return mkInternalApp(ss.str(), {tnn}, tn);
   }
+  else if (k==Kind::SEXPR)
+  {
+    // use generic list
+    std::vector<Node> args;
+    args.insert(args.end(), n.begin(), n.end());
+    return mkInternalApp("@list", args, tn);
+  }
   else if (GenericOp::isIndexedOperatorKind(k))
   {
     // return app of?

--- a/src/proof/alf/alf_node_converter.cpp
+++ b/src/proof/alf/alf_node_converter.cpp
@@ -303,7 +303,7 @@ Node AlfNodeConverter::postConvert(Node n)
     ss << "@fp." << printer::smt2::Smt2Printer::smtKindString(k);
     return mkInternalApp(ss.str(), {tnn}, tn);
   }
-  else if (k==Kind::SEXPR)
+  else if (k == Kind::SEXPR)
   {
     // use generic list
     std::vector<Node> args;

--- a/src/proof/alf/alf_node_converter.h
+++ b/src/proof/alf/alf_node_converter.h
@@ -27,13 +27,12 @@
 namespace cvc5::internal {
 namespace proof {
 
-  
 class BaseAlfNodeConverter : public NodeConverter
 {
-public:
+ public:
   virtual Node typeAsNode(TypeNode tni) = 0;
 };
-  
+
 /**
  * This is a helper class for the ALF printer that converts nodes into
  * form that ALF expects. It should only be used by the ALF printer.

--- a/src/proof/alf/alf_node_converter.h
+++ b/src/proof/alf/alf_node_converter.h
@@ -27,11 +27,18 @@
 namespace cvc5::internal {
 namespace proof {
 
+  
+class BaseAlfNodeConverter : public NodeConverter
+{
+public:
+  virtual Node typeAsNode(TypeNode tni) = 0;
+};
+  
 /**
  * This is a helper class for the ALF printer that converts nodes into
  * form that ALF expects. It should only be used by the ALF printer.
  */
-class AlfNodeConverter : public NodeConverter
+class AlfNodeConverter : public BaseAlfNodeConverter
 {
  public:
   AlfNodeConverter();
@@ -80,7 +87,7 @@ class AlfNodeConverter : public NodeConverter
    * interpret as the type tni. This method is required since types can be
    * passed as arguments to terms.
    */
-  Node typeAsNode(TypeNode tni);
+  Node typeAsNode(TypeNode tni) override;
   /**
    * Number of children for closure that we should process. In particular,
    * we ignore patterns for FORALL, so this method returns 2, indicating we

--- a/src/proof/alf/alf_node_converter.h
+++ b/src/proof/alf/alf_node_converter.h
@@ -27,9 +27,18 @@
 namespace cvc5::internal {
 namespace proof {
 
+/**
+ * Base class for node converters used in the ALF printer. Extends node
+ * conversion with a typeAsNode routine.
+ */
 class BaseAlfNodeConverter : public NodeConverter
 {
  public:
+  /**
+   * Type as node, returns a node that prints in the form that ALF will
+   * interpret as the type tni. This method is required since types can be
+   * passed as arguments to terms and proof rules.
+   */
   virtual Node typeAsNode(TypeNode tni) = 0;
 };
 
@@ -84,7 +93,7 @@ class AlfNodeConverter : public BaseAlfNodeConverter
   /**
    * Type as node, returns a node that prints in the form that ALF will
    * interpret as the type tni. This method is required since types can be
-   * passed as arguments to terms.
+   * passed as arguments to terms and proof rules.
    */
   Node typeAsNode(TypeNode tni) override;
   /**

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -35,7 +35,7 @@ namespace cvc5::internal {
 
 namespace proof {
 
-AlfPrinter::AlfPrinter(Env& env, AlfNodeConverter& atp)
+AlfPrinter::AlfPrinter(Env& env, BaseAlfNodeConverter& atp)
     : EnvObj(env), d_tproc(atp), d_termLetPrefix("@t")
 {
   d_pfType = NodeManager::currentNM()->mkSort("proofType");
@@ -611,20 +611,6 @@ size_t AlfPrinter::allocateProofId(const ProofNode* pn, bool& wasAlloc)
   d_pfIdCounter++;
   d_pletMap[pn] = d_pfIdCounter;
   return d_pfIdCounter;
-}
-
-Node AlfPrinter::allocatePremise(size_t id)
-{
-  std::map<size_t, Node>::iterator itan = d_passumeNodeMap.find(id);
-  if (itan != d_passumeNodeMap.end())
-  {
-    return itan->second;
-  }
-  std::stringstream ss;
-  ss << "@p" << id;
-  Node n = d_tproc.mkInternalSymbol(ss.str(), d_pfType);
-  d_passumeNodeMap[id] = n;
-  return n;
 }
 
 }  // namespace proof

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -474,8 +474,10 @@ void AlfPrinter::getArgsFromProofRule(const ProofNode* pn,
         Assert(i < pargs.size());
         targs.push_back(d_tproc.convert(pargs[i]));
       }
-      // package as list
-      Node ts = d_tproc.mkList(targs);
+      // package as SEXPR
+      NodeManager* nm = NodeManager::currentNM();
+      Node tsp = nm->mkNode(Kind::SEXPR, targs);
+      Node ts = d_tproc.convert(tsp);
       args.push_back(ts);
       return;
     }

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -474,7 +474,7 @@ void AlfPrinter::getArgsFromProofRule(const ProofNode* pn,
         Assert(i < pargs.size());
         targs.push_back(d_tproc.convert(pargs[i]));
       }
-      // package as SEXPR
+      // package as SEXPR, which will subsequently be converted to list
       NodeManager* nm = NodeManager::currentNM();
       Node tsp = nm->mkNode(Kind::SEXPR, targs);
       Node ts = d_tproc.convert(tsp);

--- a/src/proof/alf/alf_printer.h
+++ b/src/proof/alf/alf_printer.h
@@ -36,7 +36,7 @@ namespace proof {
 class AlfPrinter : protected EnvObj
 {
  public:
-  AlfPrinter(Env& env, AlfNodeConverter& atp);
+  AlfPrinter(Env& env, BaseAlfNodeConverter& atp);
   ~AlfPrinter() {}
 
   /**
@@ -96,13 +96,10 @@ class AlfPrinter : protected EnvObj
    * Allocate (if necessary) the identifier for step
    */
   size_t allocateProofId(const ProofNode* pn, bool& wasAlloc);
-  /** Mapping from proof identifiers X to nodes named @pX which represent
-   * premises */
-  Node allocatePremise(size_t id);
   /** Print let list to output stream out */
   void printLetList(std::ostream& out, LetBinding& lbind);
   /** Reference to the term processor */
-  AlfNodeConverter& d_tproc;
+  BaseAlfNodeConverter& d_tproc;
   /** Assume id counter */
   size_t d_pfIdCounter;
   /** Mapping scope proofs to identifiers */

--- a/test/regress/cli/regress0/proofs/issue10278-pf-clone.smt2
+++ b/test/regress/cli/regress0/proofs/issue10278-pf-clone.smt2
@@ -1,6 +1,7 @@
 ; COMMAND-LINE: --produce-proofs
 ; DISABLE-TESTER: dump
 ; DISABLE-TESTER: unsat-core
+; DISABLE-TESTER: alf
 ; REQUIRES: no-competition
 ; SCRUBBER: grep -o "unsat"
 ; EXPECT: unsat


### PR DESCRIPTION
In preparation for other calculi (e.g. classic Alethe) to be used in the AlfPrinter.

Also corrects a few issues in the ALF regression tests, including one introduced in https://github.com/cvc5/cvc5/commit/c3404e56e90400df758f08076fba40b6b9351cf5 that would fail the nightlies.