### PR TITLE
Fix global negate for functions

### DIFF
--- a/src/preprocessing/passes/global_negate.cpp
+++ b/src/preprocessing/passes/global_negate.cpp
@@ -19,6 +19,7 @@
 
 #include "expr/node.h"
 #include "preprocessing/assertion_pipeline.h"
+#include "expr/node_algorithm.h"
 #include "theory/rewriter.h"
 
 using namespace std;
@@ -35,33 +36,14 @@ Node GlobalNegate::simplify(const std::vector<Node>& assertions,
   Assert(!assertions.empty());
   Trace("cegqi-gn") << "Global negate : " << std::endl;
   // collect free variables in all assertions
-  std::vector<Node> free_vars;
-  std::vector<TNode> visit;
+  std::unordered_set<Node> syms;
   std::unordered_set<TNode> visited;
   for (const Node& as : assertions)
   {
     Trace("cegqi-gn") << "  " << as << std::endl;
-    TNode cur = as;
-    // compute free variables
-    visit.push_back(cur);
-    do
-    {
-      cur = visit.back();
-      visit.pop_back();
-      if (visited.find(cur) == visited.end())
-      {
-        visited.insert(cur);
-        if (cur.isVar() && cur.getKind() != Kind::BOUND_VARIABLE)
-        {
-          free_vars.push_back(cur);
-        }
-        for (const TNode& cn : cur)
-        {
-          visit.push_back(cn);
-        }
-      }
-    } while (!visit.empty());
+    expr::getSymbols(as, syms, visited);
   }
+  std::vector<Node> free_vars(syms.begin(), syms.end());
 
   Node body;
   if (assertions.size() == 1)


### PR DESCRIPTION
Makes the preprocessing pass use a standard utility for collecting free variables, which also corrects an issue where the pass is applied in an HO setting.