### PR TITLE
Formalize typing rules for several bag.map skolems

### DIFF
--- a/proofs/alf/theories/Bags.smt3
+++ b/proofs/alf/theories/Bags.smt3
@@ -34,6 +34,7 @@
 (declare-const @k.BAGS_MAP_PREIMAGE (-> (! Type :var T :implicit) (! Type :var U :implicit) (-> T U) (Bag T) U Int T))
 (declare-const @k.BAGS_MAP_SUM (-> (! Type :var T :implicit) (! Type :var U :implicit) (-> T U) (Bag T) U Int Int))
 (declare-const @k.BAGS_MAP_PREIMAGE_SIZE (-> (! Type :var T :implicit) (! Type :var U :implicit) (-> T U) (Bag T) U Int))
+(declare-const @k.BAGS_MAP_PREIMAGE_INJECTIVE (-> (! Type :var T :implicit) (! Type :var U :implicit) (-> T U) (Bag T) U T))
 
 ;(declare-const bag.from_set (# x term (apply f_bag.from_set x)))
 ;(declare-const bag.to_set (# x term (apply f_bag.to_set x)))

--- a/proofs/alf/theories/Bags.smt3
+++ b/proofs/alf/theories/Bags.smt3
@@ -31,6 +31,9 @@
 (declare-const @k.BAGS_DEQ_DIFF (-> (! Type :var T :implicit) (Bag T) (Bag T) T))
 (declare-const @k.TABLES_GROUP_PART (-> (! Type :var T :implicit) (Bag (Bag T)) T (Bag T)))
 (declare-const @k.TABLES_GROUP_PART_ELEMENT (-> (! Type :var T :implicit) (Bag (Bag T)) (Bag T) T))
+(declare-const @k.BAGS_MAP_PREIMAGE (-> (! Type :var T :implicit) (! Type :var U :implicit) (-> T U) (Bag T) U Int T))
+(declare-const @k.BAGS_MAP_SUM (-> (! Type :var T :implicit) (! Type :var U :implicit) (-> T U) (Bag T) U Int Int))
+(declare-const @k.BAGS_MAP_PREIMAGE_SIZE (-> (! Type :var T :implicit) (! Type :var U :implicit) (-> T U) (Bag T) U Int))
 
 ;(declare-const bag.from_set (# x term (apply f_bag.from_set x)))
 ;(declare-const bag.to_set (# x term (apply f_bag.to_set x)))

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -449,6 +449,7 @@ TypeNode SkolemManager::getTypeFor(SkolemFunId id,
     case SkolemFunId::STRINGS_OCCUR_LEN_RE:
     case SkolemFunId::STRINGS_STOI_RESULT:
     case SkolemFunId::STRINGS_ITOS_RESULT:
+    case SkolemFunId::BAGS_MAP_SUM:
     {
       TypeNode itype = nm->integerType();
       return nm->mkFunctionType(itype, itype);
@@ -466,7 +467,10 @@ TypeNode SkolemManager::getTypeFor(SkolemFunId id,
     case SkolemFunId::STRINGS_DEQ_DIFF:
     case SkolemFunId::STRINGS_STOI_NON_DIGIT:
     case SkolemFunId::BAGS_FOLD_CARD:
-    case SkolemFunId::SETS_FOLD_CARD: return nm->integerType();
+    case SkolemFunId::SETS_FOLD_CARD: 
+    case SkolemFunId::BAGS_MAP_PREIMAGE_SIZE:
+    case SkolemFunId::BAGS_MAP_PREIMAGE_INDEX:
+      return nm->integerType();
     // string skolems
     case SkolemFunId::RE_FIRST_MATCH_PRE:
     case SkolemFunId::RE_FIRST_MATCH:
@@ -562,6 +566,12 @@ TypeNode SkolemManager::getTypeFor(SkolemFunId id,
       Assert(cacheVals.size() == 3);
       TypeNode itype = nm->integerType();
       return nm->mkFunctionType(itype, cacheVals[1].getType());
+    }
+    case SkolemFunId::BAGS_MAP_PREIMAGE:
+    {
+      TypeNode itype = nm->integerType();
+      TypeNode retType = cacheVals[0].getType().getArgTypes()[0];
+      return nm->mkFunctionType(itype, retType);
     }
     default: break;
   }

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -83,6 +83,7 @@ const char* toString(SkolemFunId id)
     case SkolemFunId::BAGS_FOLD_ELEMENTS: return "BAGS_FOLD_ELEMENTS";
     case SkolemFunId::BAGS_FOLD_UNION_DISJOINT: return "BAGS_FOLD_UNION_DISJOINT";
     case SkolemFunId::BAGS_MAP_PREIMAGE: return "BAGS_MAP_PREIMAGE";
+    case SkolemFunId::BAGS_MAP_PREIMAGE_INJECTIVE: return "BAGS_MAP_PREIMAGE_INJECTIVE";
     case SkolemFunId::BAGS_MAP_PREIMAGE_SIZE: return "BAGS_MAP_PREIMAGE_SIZE";
     case SkolemFunId::BAGS_MAP_PREIMAGE_INDEX: return "BAGS_MAP_PREIMAGE_INDEX";
     case SkolemFunId::BAGS_MAP_SUM: return "BAGS_MAP_SUM";
@@ -571,6 +572,10 @@ TypeNode SkolemManager::getTypeFor(SkolemFunId id,
       TypeNode itype = nm->integerType();
       TypeNode retType = cacheVals[0].getType().getArgTypes()[0];
       return nm->mkFunctionType(itype, retType);
+    }
+    case SkolemFunId::BAGS_MAP_PREIMAGE_INJECTIVE:
+    {
+      return cacheVals[0].getType().getArgTypes()[0];
     }
     default: break;
   }

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -467,10 +467,9 @@ TypeNode SkolemManager::getTypeFor(SkolemFunId id,
     case SkolemFunId::STRINGS_DEQ_DIFF:
     case SkolemFunId::STRINGS_STOI_NON_DIGIT:
     case SkolemFunId::BAGS_FOLD_CARD:
-    case SkolemFunId::SETS_FOLD_CARD: 
+    case SkolemFunId::SETS_FOLD_CARD:
     case SkolemFunId::BAGS_MAP_PREIMAGE_SIZE:
-    case SkolemFunId::BAGS_MAP_PREIMAGE_INDEX:
-      return nm->integerType();
+    case SkolemFunId::BAGS_MAP_PREIMAGE_INDEX: return nm->integerType();
     // string skolems
     case SkolemFunId::RE_FIRST_MATCH_PRE:
     case SkolemFunId::RE_FIRST_MATCH:

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -83,7 +83,8 @@ const char* toString(SkolemFunId id)
     case SkolemFunId::BAGS_FOLD_ELEMENTS: return "BAGS_FOLD_ELEMENTS";
     case SkolemFunId::BAGS_FOLD_UNION_DISJOINT: return "BAGS_FOLD_UNION_DISJOINT";
     case SkolemFunId::BAGS_MAP_PREIMAGE: return "BAGS_MAP_PREIMAGE";
-    case SkolemFunId::BAGS_MAP_PREIMAGE_INJECTIVE: return "BAGS_MAP_PREIMAGE_INJECTIVE";
+    case SkolemFunId::BAGS_MAP_PREIMAGE_INJECTIVE:
+      return "BAGS_MAP_PREIMAGE_INJECTIVE";
     case SkolemFunId::BAGS_MAP_PREIMAGE_SIZE: return "BAGS_MAP_PREIMAGE_SIZE";
     case SkolemFunId::BAGS_MAP_PREIMAGE_INDEX: return "BAGS_MAP_PREIMAGE_INDEX";
     case SkolemFunId::BAGS_MAP_SUM: return "BAGS_MAP_SUM";

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -571,11 +571,13 @@ TypeNode SkolemManager::getTypeFor(SkolemFunId id,
     case SkolemFunId::BAGS_MAP_PREIMAGE:
     {
       TypeNode itype = nm->integerType();
+      Assert (cacheVals[0].getType().isFunction());
       TypeNode retType = cacheVals[0].getType().getArgTypes()[0];
       return nm->mkFunctionType(itype, retType);
     }
     case SkolemFunId::BAGS_MAP_PREIMAGE_INJECTIVE:
     {
+      Assert (cacheVals[0].getType().isFunction());
       return cacheVals[0].getType().getArgTypes()[0];
     }
     default: break;

--- a/src/expr/skolem_manager.h
+++ b/src/expr/skolem_manager.h
@@ -165,6 +165,11 @@ enum class SkolemFunId
    */
   BAGS_MAP_PREIMAGE,
   /**
+   * Same as above, but used when f is injective. In this case this is not
+   * indexed, and the returned skolem has type E.
+   */
+  BAGS_MAP_PREIMAGE_INJECTIVE,
+  /**
    * A skolem variable for the size of the preimage of {y} that is unique per
    * terms (bag.map f A), y which might be an element in (bag.map f A). (see the
    * documentation for BAGS_MAP_PREIMAGE)

--- a/src/theory/bags/inference_generator.cpp
+++ b/src/theory/bags/inference_generator.cpp
@@ -415,16 +415,10 @@ std::tuple<InferInfo, Node, Node> InferenceGenerator::mapDown(Node n, Node e)
   Node f = n[0];
   Node A = n[1];
   // declare an uninterpreted function uf: Int -> T
-  TypeNode domainType = f.getType().getArgTypes()[0];
-  TypeNode ufType = d_nm->mkFunctionType(d_nm->integerType(), domainType);
   Node uf = d_sm->mkSkolemFunction(SkolemFunId::BAGS_MAP_PREIMAGE, {f, A, e});
-  AlwaysAssert(uf.getType() == ufType);
 
   // declare uninterpreted function sum: Int -> Int
-  TypeNode sumType =
-      d_nm->mkFunctionType(d_nm->integerType(), d_nm->integerType());
   Node sum = d_sm->mkSkolemFunction(SkolemFunId::BAGS_MAP_SUM, {f, A, e});
-  AlwaysAssert(sum.getType() == sumType);
 
   // (= (sum 0) 0)
   Node sum_zero = d_nm->mkNode(Kind::APPLY_UF, sum, d_zero);
@@ -517,8 +511,7 @@ InferInfo InferenceGenerator::mapDownInjective(Node n, Node y)
   Node f = n[0];
   Node A = n[1];
   // declare a fresh skolem of type T
-  TypeNode domainType = f.getType().getArgTypes()[0];
-  Node x = d_sm->mkSkolemFunction(SkolemFunId::BAGS_MAP_PREIMAGE, {f, A, y});
+  Node x = d_sm->mkSkolemFunction(SkolemFunId::BAGS_MAP_PREIMAGE_INJECTIVE, {f, A, y});
 
   Node mapSkolem = registerAndAssertSkolemLemma(n);
   Node countY = getMultiplicityTerm(y, mapSkolem);

--- a/src/theory/bags/inference_generator.cpp
+++ b/src/theory/bags/inference_generator.cpp
@@ -417,25 +417,23 @@ std::tuple<InferInfo, Node, Node> InferenceGenerator::mapDown(Node n, Node e)
   // declare an uninterpreted function uf: Int -> T
   TypeNode domainType = f.getType().getArgTypes()[0];
   TypeNode ufType = d_nm->mkFunctionType(d_nm->integerType(), domainType);
-  Node uf = d_sm->mkSkolemFunction(
-      SkolemFunId::BAGS_MAP_PREIMAGE, {f, A, e});
-  AlwaysAssert(uf.getType()==ufType);
+  Node uf = d_sm->mkSkolemFunction(SkolemFunId::BAGS_MAP_PREIMAGE, {f, A, e});
+  AlwaysAssert(uf.getType() == ufType);
 
   // declare uninterpreted function sum: Int -> Int
   TypeNode sumType =
       d_nm->mkFunctionType(d_nm->integerType(), d_nm->integerType());
-  Node sum =
-      d_sm->mkSkolemFunction(SkolemFunId::BAGS_MAP_SUM, {f, A, e});
-  AlwaysAssert(sum.getType()==sumType);
+  Node sum = d_sm->mkSkolemFunction(SkolemFunId::BAGS_MAP_SUM, {f, A, e});
+  AlwaysAssert(sum.getType() == sumType);
 
   // (= (sum 0) 0)
   Node sum_zero = d_nm->mkNode(Kind::APPLY_UF, sum, d_zero);
   Node baseCase = d_nm->mkNode(Kind::EQUAL, sum_zero, d_zero);
 
   // guess the size of the preimage of e
-  Node preImageSize = d_sm->mkSkolemFunction(
-      SkolemFunId::BAGS_MAP_PREIMAGE_SIZE, {f, A, e});
-  AlwaysAssert(preImageSize.getType()==d_nm->integerType());
+  Node preImageSize =
+      d_sm->mkSkolemFunction(SkolemFunId::BAGS_MAP_PREIMAGE_SIZE, {f, A, e});
+  AlwaysAssert(preImageSize.getType() == d_nm->integerType());
 
   // (= (sum preImageSize) (bag.count e skolem))
   Node mapSkolem = registerAndAssertSkolemLemma(n);
@@ -520,8 +518,7 @@ InferInfo InferenceGenerator::mapDownInjective(Node n, Node y)
   Node A = n[1];
   // declare a fresh skolem of type T
   TypeNode domainType = f.getType().getArgTypes()[0];
-  Node x = d_sm->mkSkolemFunction(
-      SkolemFunId::BAGS_MAP_PREIMAGE, {f, A, y});
+  Node x = d_sm->mkSkolemFunction(SkolemFunId::BAGS_MAP_PREIMAGE, {f, A, y});
 
   Node mapSkolem = registerAndAssertSkolemLemma(n);
   Node countY = getMultiplicityTerm(y, mapSkolem);
@@ -577,7 +574,7 @@ InferInfo InferenceGenerator::mapUp2(
       d_nm->mkNode(Kind::EQUAL, d_nm->mkNode(Kind::APPLY_UF, f, x), y).negate();
 
   Node k = d_sm->mkSkolemFunction(SkolemFunId::BAGS_MAP_PREIMAGE_INDEX,
-                                       {n, uf, preImageSize, y, x});
+                                  {n, uf, preImageSize, y, x});
   Node inRange = d_nm->mkNode(Kind::AND,
                               d_nm->mkNode(Kind::GEQ, k, d_one),
                               d_nm->mkNode(Kind::LEQ, k, preImageSize));

--- a/src/theory/bags/inference_generator.cpp
+++ b/src/theory/bags/inference_generator.cpp
@@ -427,7 +427,6 @@ std::tuple<InferInfo, Node, Node> InferenceGenerator::mapDown(Node n, Node e)
   // guess the size of the preimage of e
   Node preImageSize =
       d_sm->mkSkolemFunction(SkolemFunId::BAGS_MAP_PREIMAGE_SIZE, {f, A, e});
-  AlwaysAssert(preImageSize.getType() == d_nm->integerType());
 
   // (= (sum preImageSize) (bag.count e skolem))
   Node mapSkolem = registerAndAssertSkolemLemma(n);

--- a/src/theory/bags/inference_generator.cpp
+++ b/src/theory/bags/inference_generator.cpp
@@ -417,22 +417,25 @@ std::tuple<InferInfo, Node, Node> InferenceGenerator::mapDown(Node n, Node e)
   // declare an uninterpreted function uf: Int -> T
   TypeNode domainType = f.getType().getArgTypes()[0];
   TypeNode ufType = d_nm->mkFunctionType(d_nm->integerType(), domainType);
-  Node uf = d_sm->mkSkolemFunctionTyped(
-      SkolemFunId::BAGS_MAP_PREIMAGE, ufType, {n, e});
+  Node uf = d_sm->mkSkolemFunction(
+      SkolemFunId::BAGS_MAP_PREIMAGE, {f, A, e});
+  AlwaysAssert(uf.getType()==ufType);
 
   // declare uninterpreted function sum: Int -> Int
   TypeNode sumType =
       d_nm->mkFunctionType(d_nm->integerType(), d_nm->integerType());
   Node sum =
-      d_sm->mkSkolemFunctionTyped(SkolemFunId::BAGS_MAP_SUM, sumType, {n, e});
+      d_sm->mkSkolemFunction(SkolemFunId::BAGS_MAP_SUM, {f, A, e});
+  AlwaysAssert(sum.getType()==sumType);
 
   // (= (sum 0) 0)
   Node sum_zero = d_nm->mkNode(Kind::APPLY_UF, sum, d_zero);
   Node baseCase = d_nm->mkNode(Kind::EQUAL, sum_zero, d_zero);
 
   // guess the size of the preimage of e
-  Node preImageSize = d_sm->mkSkolemFunctionTyped(
-      SkolemFunId::BAGS_MAP_PREIMAGE_SIZE, d_nm->integerType(), {n, e});
+  Node preImageSize = d_sm->mkSkolemFunction(
+      SkolemFunId::BAGS_MAP_PREIMAGE_SIZE, {f, A, e});
+  AlwaysAssert(preImageSize.getType()==d_nm->integerType());
 
   // (= (sum preImageSize) (bag.count e skolem))
   Node mapSkolem = registerAndAssertSkolemLemma(n);
@@ -517,8 +520,8 @@ InferInfo InferenceGenerator::mapDownInjective(Node n, Node y)
   Node A = n[1];
   // declare a fresh skolem of type T
   TypeNode domainType = f.getType().getArgTypes()[0];
-  Node x = d_sm->mkSkolemFunctionTyped(
-      SkolemFunId::BAGS_MAP_PREIMAGE, domainType, {n, y});
+  Node x = d_sm->mkSkolemFunction(
+      SkolemFunId::BAGS_MAP_PREIMAGE, {f, A, y});
 
   Node mapSkolem = registerAndAssertSkolemLemma(n);
   Node countY = getMultiplicityTerm(y, mapSkolem);
@@ -573,8 +576,7 @@ InferInfo InferenceGenerator::mapUp2(
   Node notEqual =
       d_nm->mkNode(Kind::EQUAL, d_nm->mkNode(Kind::APPLY_UF, f, x), y).negate();
 
-  Node k = d_sm->mkSkolemFunctionTyped(SkolemFunId::BAGS_MAP_PREIMAGE_INDEX,
-                                       d_nm->integerType(),
+  Node k = d_sm->mkSkolemFunction(SkolemFunId::BAGS_MAP_PREIMAGE_INDEX,
                                        {n, uf, preImageSize, y, x});
   Node inRange = d_nm->mkNode(Kind::AND,
                               d_nm->mkNode(Kind::GEQ, k, d_one),

--- a/src/theory/bags/inference_generator.cpp
+++ b/src/theory/bags/inference_generator.cpp
@@ -511,7 +511,8 @@ InferInfo InferenceGenerator::mapDownInjective(Node n, Node y)
   Node f = n[0];
   Node A = n[1];
   // declare a fresh skolem of type T
-  Node x = d_sm->mkSkolemFunction(SkolemFunId::BAGS_MAP_PREIMAGE_INJECTIVE, {f, A, y});
+  Node x = d_sm->mkSkolemFunction(SkolemFunId::BAGS_MAP_PREIMAGE_INJECTIVE,
+                                  {f, A, y});
 
   Node mapSkolem = registerAndAssertSkolemLemma(n);
   Node countY = getMultiplicityTerm(y, mapSkolem);


### PR DESCRIPTION
Fixes ALF proof checking fails introduced in https://github.com/cvc5/cvc5/commit/fffe72027c9a401cfc3619cf59c9e19a02a00ddd.