### PR TITLE
Add assertion to lexer

### DIFF
--- a/src/parser/lexer.cpp
+++ b/src/parser/lexer.cpp
@@ -88,13 +88,16 @@ Token Lexer::nextToken()
     // Call the derived yylex() and convert it to a token
     return nextTokenInternal();
   }
-  Token t = d_peeked[0];
-  d_peeked.erase(d_peeked.begin());
+  Token t = d_peeked.back();
+  d_peeked.pop_back();
   return t;
 }
 
 Token Lexer::peekToken()
 {
+  // since d_peeked is first in, last out, we should not peek more than once
+  // or the order is swapped.
+  Assert(d_peeked.empty());
   // parse next token
   Token t = nextTokenInternal();
   // reinsert it immediately

--- a/src/parser/lexer.cpp
+++ b/src/parser/lexer.cpp
@@ -88,8 +88,8 @@ Token Lexer::nextToken()
     // Call the derived yylex() and convert it to a token
     return nextTokenInternal();
   }
-  Token t = d_peeked.back();
-  d_peeked.pop_back();
+  Token t = d_peeked[0];
+  d_peeked.erase(d_peeked.begin());
   return t;
 }
 


### PR DESCRIPTION
This prevents peeking more than one token at a time, which leads to incorrect order of tokens.

The alf checker uses a similar lexer and had encountered a bug due to this issue in a corner case. 