### PR TITLE
Check that system CaDiCaL is at least >= 1.6

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -124,7 +124,7 @@ versions; more recent versions should be compatible.
   + module `tomli <https://pypi.org/project/tomli/>`_
   + module `pyparsing <https://pypi.org/project/pyparsing/>`_
 - `GMP v6.3 (GNU Multi-Precision arithmetic library) <https://gmplib.org>`_
-- `CaDiCaL (SAT solver) <https://github.com/arminbiere/cadical>`_
+- `CaDiCaL >= 1.6.0 (SAT solver) <https://github.com/arminbiere/cadical>`_
 - `SymFPU <https://github.com/martin-cs/symfpu/tree/CVC4>`_
 
 For Python, to install these dependencies automatically, please use:

--- a/cmake/FindCaDiCaL.cmake
+++ b/cmake/FindCaDiCaL.cmake
@@ -23,18 +23,37 @@ find_library(CaDiCaL_LIBRARIES NAMES cadical)
 
 set(CaDiCaL_FOUND_SYSTEM FALSE)
 if(CaDiCaL_INCLUDE_DIR AND CaDiCaL_LIBRARIES)
-  set(CaDiCaL_FOUND_SYSTEM TRUE)
+  # Try to compile our version file
+  try_run(RUN_RESULT_VAR
+    COMPILE_RESULT_VAR
+    SOURCE_FROM_CONTENT CaDiCaL_version.cpp
+    "
+    #include <cadical.hpp>
+    #include <iostream>
 
-  # Unfortunately it is not part of the headers
-  find_program(CaDiCaL_BINARY NAMES cadical)
-  if(CaDiCaL_BINARY)
-    execute_process(
-      COMMAND ${CaDiCaL_BINARY} --version OUTPUT_VARIABLE CaDiCaL_VERSION
-    )
-  else()
+    int main(void)
+    {
+      std::cout << CaDiCaL::Solver::version() << std::endl;
+      return 0;
+    }
+    "
+    LINK_LIBRARIES ${CaDiCaL_LIBRARIES}
+    RUN_OUTPUT_VARIABLE CaDiCaL_VERSION
+  )
+
+  # If this failed to compile or run, we have bigger issues
+  if (NOT ${RUN_RESULT_VAR} EQUAL 0 OR NOT ${COMPILE_RESULT_VAR})
     set(CaDiCaL_VERSION "")
   endif()
 
+  # Minimum supported version
+  set(CaDiCaL_FIND_VERSION "1.6.0")
+
+  # Set FOUND_SYSTEM to true; check_system_version will unset this if the
+  # version is less than the minimum required
+  set(CaDiCaL_FOUND_SYSTEM TRUE)
+
+  # Check the version against the required version
   check_system_version("CaDiCaL")
 endif()
 


### PR DESCRIPTION
The minimum version of CaDiCaL that cvc5 supports is 1.6 (due to the use of `CaDiCaL::ExternalPropagator`). However, this version is neither checked or documented.

This PR makes two changes:

1) It updates `cmake/FindCaDiCaL.cmake` to do a configure-time `try_run` check to obtain the version of CaDiCaL; if the version of CaDiCaL is too low, it will fall back to the `--auto-download` behaviour (if that flag is passed)
2) It documents in `INSTALL.rst` that this version is required
