### PR TITLE
Fix incorrect static casts on variables on 32-bit platforms

### DIFF
--- a/src/util/gmp_util.h
+++ b/src/util/gmp_util.h
@@ -20,6 +20,13 @@
 
 #include <gmpxx.h>
 
+// the following includes are only required if CVC5_NEED_INT64_T_OVERLOADS is
+// defined.
+#ifdef CVC5_NEED_INT64_T_OVERLOADS
+#include <string>
+#include <type_traits>
+#endif /* CVC5_NEED_INT64_T_OVERLOADS */
+
 namespace cvc5::internal {
 
 /** Hashes the gmp integer primitive in a word by word fashion. */
@@ -33,6 +40,49 @@ inline size_t gmpz_hash(const mpz_t toHash) {
   return hash;
 }/* gmpz_hash() */
 
+#ifdef CVC5_NEED_INT64_T_OVERLOADS
+/*
+ * Before converting an int64_t/uint64_t to a GMP value, we need to check if
+ * the input value will fit inside of a (un)signed long, which is the largest
+ * overload supported by GMP's C++ API.
+ *
+ * If the input value is *larger* than (un)signed long, then we use GMP's
+ * string-based API to construct the value.
+ *
+ * The following function looks-up the largest matching type against the input
+ * type, checks the range, and then decides to use the string-based overloads
+ * if the value does not fit.
+ */
+template <typename T>
+mpz_class construct_mpz(T z)
+{
+  /* only use this with int64_t or uint64_t */
+  static_assert(
+      std::is_same<T, int64_t>::value || std::is_same<T, uint64_t>::value,
+      "construct_mpz only supports int64_t or uint64_t");
+
+  /* what's the largest GMP-supported type? */
+  using gmp_type = typename std::
+      conditional<std::is_signed<T>::value, signed long, unsigned long>::type;
+
+  /* result value */
+  mpz_class result;
+
+  /* if our input fits inside of the range of the largest GMP-support type, we
+   * construct result based on the value */
+  if (std::numeric_limits<gmp_type>::min() <= z
+      && z <= std::numeric_limits<gmp_type>::max())
+  {
+    result = static_cast<gmp_type>(z);
+  }
+  else
+  {
+    /* otherwise, use the string-based methods */
+    result = std::to_string(z);
+  }
+  return result;
+}
+#endif /* CVC5_NEED_INT64_T_OVERLOADS */
 }  // namespace cvc5::internal
 
 #endif /* CVC5__GMP_UTIL_H */

--- a/src/util/integer_cln_imp.h
+++ b/src/util/integer_cln_imp.h
@@ -74,8 +74,8 @@ class Integer
   Integer(unsigned long int z) : d_value(z) {}
 
 #ifdef CVC5_NEED_INT64_T_OVERLOADS
-  Integer(int64_t z) : d_value(static_cast<long>(z)) {}
-  Integer(uint64_t z) : d_value(static_cast<unsigned long>(z)) {}
+  Integer(int64_t z) : d_value(z) {}
+  Integer(uint64_t z) : d_value(z) {}
 #endif /* CVC5_NEED_INT64_T_OVERLOADS */
 
   /** Destructor. */

--- a/src/util/integer_gmp_imp.cpp
+++ b/src/util/integer_gmp_imp.cpp
@@ -40,30 +40,8 @@ Integer::Integer(const std::string& s, unsigned base)
 {}
 
 #ifdef CVC5_NEED_INT64_T_OVERLOADS
-Integer::Integer(int64_t z)
-{
-  if (std::numeric_limits<signed long int>::min() <= z
-      && z <= std::numeric_limits<signed long int>::max())
-  {
-    d_value = static_cast<signed long int>(z);
-  }
-  else
-  {
-    d_value = std::to_string(z);
-  }
-}
-Integer::Integer(uint64_t z)
-{
-  if (std::numeric_limits<unsigned long int>::min() <= z
-      && z <= std::numeric_limits<unsigned long int>::max())
-  {
-    d_value = static_cast<unsigned long int>(z);
-  }
-  else
-  {
-    d_value = std::to_string(z);
-  }
-}
+Integer::Integer(int64_t z) : d_value(construct_mpz(z)) {}
+Integer::Integer(uint64_t z) : d_value(construct_mpz(z)) {}
 #endif /* CVC5_NEED_INT64_T_OVERLOADS */
 
 Integer& Integer::operator=(const Integer& x)

--- a/src/util/rational_cln_imp.h
+++ b/src/util/rational_cln_imp.h
@@ -93,8 +93,8 @@ class Rational
   Rational(unsigned long int n) : d_value(n) {}
 
 #ifdef CVC5_NEED_INT64_T_OVERLOADS
-  Rational(int64_t n) : d_value(static_cast<long>(n)) {}
-  Rational(uint64_t n) : d_value(static_cast<unsigned long>(n)) {}
+  Rational(int64_t n) : d_value(n) {}
+  Rational(uint64_t n) : d_value(n) {}
 #endif /* CVC5_NEED_INT64_T_OVERLOADS */
 
   /**
@@ -118,14 +118,8 @@ class Rational
   }
 
 #ifdef CVC5_NEED_INT64_T_OVERLOADS
-  Rational(int64_t n, int64_t d) : d_value(static_cast<long>(n))
-  {
-    d_value /= cln::cl_I(d);
-  }
-  Rational(uint64_t n, uint64_t d) : d_value(static_cast<unsigned long>(n))
-  {
-    d_value /= cln::cl_I(d);
-  }
+  Rational(int64_t n, int64_t d) : d_value(n) { d_value /= cln::cl_I(d); }
+  Rational(uint64_t n, uint64_t d) : d_value(n) { d_value /= cln::cl_I(d); }
 #endif /* CVC5_NEED_INT64_T_OVERLOADS */
 
   Rational(const Integer& n, const Integer& d) : d_value(n.get_cl_I())

--- a/src/util/rational_gmp_imp.h
+++ b/src/util/rational_gmp_imp.h
@@ -95,11 +95,10 @@ class Rational
   Rational(unsigned long int n) : d_value(n, 1) { d_value.canonicalize(); }
 
 #ifdef CVC5_NEED_INT64_T_OVERLOADS
-  Rational(int64_t n) : d_value(static_cast<long>(n), 1)
-  {
-    d_value.canonicalize();
-  }
-  Rational(uint64_t n) : d_value(static_cast<unsigned long>(n), 1)
+  // to avoid truncation, we convert the input value to an mpz and then build
+  // the mpq.
+  Rational(int64_t n) : d_value(construct_mpz(n), 1) { d_value.canonicalize(); }
+  Rational(uint64_t n) : d_value(construct_mpz(n), 1)
   {
     d_value.canonicalize();
   }
@@ -126,13 +125,13 @@ class Rational
   }
 
 #ifdef CVC5_NEED_INT64_T_OVERLOADS
-  Rational(int64_t n, int64_t d)
-      : d_value(static_cast<long>(n), static_cast<long>(d))
+  // to avoid truncation, we convert the input value to an mpz and then build
+  // the mpq.
+  Rational(int64_t n, int64_t d) : d_value(construct_mpz(n), construct_mpz(d))
   {
     d_value.canonicalize();
   }
-  Rational(uint64_t n, uint64_t d)
-      : d_value(static_cast<unsigned long>(n), static_cast<unsigned long>(d))
+  Rational(uint64_t n, uint64_t d) : d_value(construct_mpz(n), construct_mpz(d))
   {
     d_value.canonicalize();
   }


### PR DESCRIPTION
Before this PR, there is code inside of `cvc5` for both CLN and GMP, which is guarded by `CVC5_NEED_INT64_T_OVERLOADS`, that can lead to a loss of precision, due to unconditionally cast types such as `int64_t` into `long` without checking if the values fit.

For GMP, there were places (e.g., `Rational(int64_t n, int64_t d)`) where larger types (e.g., `int64_t`) got truncated into shorter types (e.g., `long`). This PR refactors and centralises the code to convert an `(u)int64_t` to an `mpz`, and makes sure all values that do not fit inside of `(un)signed long` go through `std::to_string`. Construction of an `mpq` goes through the same code path, and uses the `mpq_class(mpz_class)` constructor to avoid duplicated code (this is because the input term is an integer, so starting with an `mpz` is valid).

For CLN, there were places (e.g., `Rational(int64_t n)`) where larger types (e.g., `int64_t`) were truncated into shorter types (e.g., `long`). These casts were unnecessary as CLN has the required overloads to immediately support `int64_t` without requiring a cast to a different type, so have been removed.

I have tested this on the same 32-bit platform that exhibits the error for #9366 and confirm it resolves the issue.

Closes #9366.

Signed-off-by: Andrew V. Teylu <andrew@tey.lu>