### PR TITLE
Proper implementation of skolem intro in ALF

### DIFF
--- a/proofs/alf/rules/Quantifiers.smt3
+++ b/proofs/alf/rules/Quantifiers.smt3
@@ -28,12 +28,14 @@
 )
 
 (declare-rule skolem_intro ((T Type) (t T))
-  :args ((skolem t))
-  :conclusion (= (skolem t) t)
-)
-
-; special case for now
-(declare-rule skolem_witness_intro ((T Type) (x T) (F Bool))
-  :args ((witness x F))
-  :conclusion (= (skolem (@k.QUANTIFIERS_SKOLEMIZE (exists (@list x) F) x)) (witness x F))
+  :args (t)
+  :conclusion 
+    (alf.match ((T Type) (x T) (F Bool))
+      t
+      (
+        ; special case for witness
+        ((skolem (@k.QUANTIFIERS_SKOLEMIZE (exists (@list x) F) x)) (= t (witness x F)))
+        ((skolem x)                                                 (= t x))
+      )
+   )
 )

--- a/src/proof/alf/alf_post_processor.cpp
+++ b/src/proof/alf/alf_post_processor.cpp
@@ -241,17 +241,6 @@ bool AlfProofPostprocessCallback::update(Node res,
       addAlfStep(AlfRule::CONCAT_CONFLICT_DEQ, res, children, newArgs, *cdp);
     }
     break;
-    case ProofRule::SKOLEM_INTRO:
-    {
-      Node t = SkolemManager::getUnpurifiedForm(args[0]);
-      if (t.getKind() != Kind::WITNESS)
-      {
-        // no change necessary
-        return false;
-      }
-      addAlfStep(AlfRule::SKOLEM_WITNESS_INTRO, res, {}, {t}, *cdp);
-    }
-    break;
     default: return false;
   }
   return true;

--- a/src/proof/alf/alf_proof_rule.cpp
+++ b/src/proof/alf/alf_proof_rule.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Top contributors (to current version):
- *   Hanna Lachnitt, Haniel Barbosa
+ *   Andrew Reynolds
  *
  * This file is part of the cvc5 project.
  *
@@ -20,7 +20,6 @@
 #include "proof/proof_checker.h"
 
 namespace cvc5::internal {
-
 namespace proof {
 
 const char* AlfRuleToString(AlfRule id)
@@ -32,7 +31,6 @@ const char* AlfRuleToString(AlfRule id)
     case AlfRule::SCOPE: return "scope";
     case AlfRule::PROCESS_SCOPE: return "process_scope";
     case AlfRule::CONCAT_CONFLICT_DEQ: return "concat_conflict_deq";
-    case AlfRule::SKOLEM_WITNESS_INTRO: return "skolem_witness_intro";
     //================================================= Undefined rule
     case AlfRule::UNDEFINED: return "undefined";
     default: return "?";
@@ -56,5 +54,4 @@ AlfRule getAlfRule(Node n)
 }
 
 }  // namespace proof
-
 }  // namespace cvc5::internal

--- a/src/proof/alf/alf_proof_rule.h
+++ b/src/proof/alf/alf_proof_rule.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Top contributors (to current version):
- *   Hanna Lachnitt, Haniel Barbosa
+ *   Andrew Reynolds
  *
  * This file is part of the cvc5 project.
  *
@@ -24,35 +24,41 @@
 #include "expr/node.h"
 
 namespace cvc5::internal {
-
 namespace proof {
 
+/**
+ * Custom rules that vary from the internal signature of cvc5.
+ * For details, see signatures defined in proofs/alf/Cvc5.smt3.
+ */
 enum class AlfRule : uint32_t
 {
+  // congruence
   CONG,
+  // n-ary congruence
   NARY_CONG,
+  // scope
   SCOPE,
+  // process_scope
   PROCESS_SCOPE,
+  // concat conflict disequality
   CONCAT_CONFLICT_DEQ,
-  SKOLEM_WITNESS_INTRO,
-  // ======== undefined
   // Used in case that a step in the proof rule could not be translated.
   UNDEFINED
 };
 
 /**
- * Converts an Alethe proof rule to a string.
+ * Converts an ALF proof rule to a string.
  *
- * @param id The Alethe proof rule
- * @return The name of the Alethe proof rule
+ * @param id The ALF proof rule
+ * @return The name of the ALF proof rule
  */
 const char* AlfRuleToString(AlfRule id);
 
 /**
- * Writes an Alf proof rule name to a stream.
+ * Writes an ALF proof rule name to a stream.
  *
  * @param out The stream to write to
- * @param id The Alf proof rule to write to the stream
+ * @param id The ALF proof rule to write to the stream
  * @return The stream
  */
 std::ostream& operator<<(std::ostream& out, AlfRule id);
@@ -61,7 +67,6 @@ std::ostream& operator<<(std::ostream& out, AlfRule id);
 AlfRule getAlfRule(Node n);
 
 }  // namespace proof
-
 }  // namespace cvc5::internal
 
 #endif /* CVC5__PROOF__ALF__ALF_PROOF_RULE_H */


### PR DESCRIPTION
Eliminates the need to special case the internal -> ALF translation.

Also updates some doc from the alf branch.