### PR TITLE
Simplify ProofRule::ARITH_TRICHOTOMY

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -1744,7 +1744,7 @@ enum ENUM(ProofRule) : uint32_t
    * **Arithmetic -- Trichotomy of the reals**
    *
    * .. math::
-   *   \inferrule{A, B \mid C}{C}
+   *   \inferrule{A, B \mid -}{C}
    *
    * where :math:`\neg A, \neg B, C` are :math:`x < c, x = c, x > c` in some order.
    * Note that :math:`\neg` here denotes arithmetic negation, i.e., flipping :math:`\geq` to :math:`<` etc.

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -442,9 +442,6 @@ void AlfPrinter::getArgsFromProofRule(const ProofNode* pn,
       // provide the target constant explicitly
       args.push_back(d_tproc.convert(res[1]));
       break;
-    case ProofRule::ARITH_TRICHOTOMY:
-      // argument is redundant
-      return;
     case ProofRule::INSTANTIATE:
     {
       // ignore arguments past the term vector, collect them into an sexpr

--- a/src/theory/arith/branch_and_bound.cpp
+++ b/src/theory/arith/branch_and_bound.cpp
@@ -105,7 +105,8 @@ std::vector<TrustNode> BranchAndBound::branchIntegerVariable(TNode var,
           pnm->mkNode(ProofRule::CONTRA,
                       {pnm->mkNode(ProofRule::ARITH_TRICHOTOMY,
                                    {pnm->mkAssume(less.negate()), pfNotRawEq},
-                                   {}),
+                                   {},
+                                   greater),
                        pnm->mkAssume(greater.negate())},
                       {});
       std::vector<Node> assumptions = {

--- a/src/theory/arith/branch_and_bound.cpp
+++ b/src/theory/arith/branch_and_bound.cpp
@@ -105,7 +105,7 @@ std::vector<TrustNode> BranchAndBound::branchIntegerVariable(TNode var,
           pnm->mkNode(ProofRule::CONTRA,
                       {pnm->mkNode(ProofRule::ARITH_TRICHOTOMY,
                                    {pnm->mkAssume(less.negate()), pfNotRawEq},
-                                   {greater}),
+                                   {}),
                        pnm->mkAssume(greater.negate())},
                       {});
       std::vector<Node> assumptions = {

--- a/src/theory/arith/linear/congruence_manager.cpp
+++ b/src/theory/arith/linear/congruence_manager.cpp
@@ -601,7 +601,7 @@ void ArithCongruenceManager::equalsConstant(ConstraintCP lb, ConstraintCP ub){
   std::shared_ptr<ProofNode> pf;
   if (isProofEnabled())
   {
-    pf = d_pnm->mkNode(ProofRule::ARITH_TRICHOTOMY, {pfLb, pfUb}, {eq});
+    pf = d_pnm->mkNode(ProofRule::ARITH_TRICHOTOMY, {pfLb, pfUb}, {}, eq);
   }
   d_keepAlive.push_back(eq);
   d_keepAlive.push_back(reason);

--- a/src/theory/arith/linear/congruence_manager.cpp
+++ b/src/theory/arith/linear/congruence_manager.cpp
@@ -188,8 +188,8 @@ void ArithCongruenceManager::watchedVariableIsZero(ConstraintCP lb, ConstraintCP
   if (isProofEnabled())
   {
     pf = d_pnm->mkNode(
-        ProofRule::ARITH_TRICHOTOMY, {pfLb, pfUb}, {eqC->getProofLiteral()});
-    pf = d_pnm->mkNode(ProofRule::MACRO_SR_PRED_TRANSFORM, {pf}, {eq});
+        ProofRule::ARITH_TRICHOTOMY, {pfLb, pfUb}, {}, eqC->getProofLiteral());
+    pf = d_pnm->mkNode(ProofRule::MACRO_SR_PRED_TRANSFORM, {pf}, {eq}, eq);
   }
 
   d_keepAlive.push_back(reason);

--- a/src/theory/arith/linear/constraint.cpp
+++ b/src/theory/arith/linear/constraint.cpp
@@ -1849,10 +1849,8 @@ std::shared_ptr<ProofNode> Constraint::externalExplain(
         }
         case ArithProofType::TrichotomyAP:
         {
-          pf = pnm->mkNode(ProofRule::ARITH_TRICHOTOMY,
-                           children,
-                           {},
-                           getProofLiteral());
+          pf = pnm->mkNode(
+              ProofRule::ARITH_TRICHOTOMY, children, {}, getProofLiteral());
           break;
         }
         case ArithProofType::InternalAssumeAP:

--- a/src/theory/arith/linear/constraint.cpp
+++ b/src/theory/arith/linear/constraint.cpp
@@ -1851,7 +1851,7 @@ std::shared_ptr<ProofNode> Constraint::externalExplain(
         {
           pf = pnm->mkNode(ProofRule::ARITH_TRICHOTOMY,
                            children,
-                           {getProofLiteral()},
+                           {},
                            getProofLiteral());
           break;
         }

--- a/src/theory/arith/nl/ext/monomial_bounds_check.cpp
+++ b/src/theory/arith/nl/ext/monomial_bounds_check.cpp
@@ -399,10 +399,8 @@ void MonomialBoundsCheck::checkBounds(const std::vector<Node>& asserts,
                                  {exp[1][0]},
                                  {rb});
                 }
-                proof->addStep(simpleeq,
-                               ProofRule::ARITH_TRICHOTOMY,
-                               {lb, rb},
-                               {});
+                proof->addStep(
+                    simpleeq, ProofRule::ARITH_TRICHOTOMY, {lb, rb}, {});
                 proof->addStep(
                     tmplem[0], ProofRule::AND_INTRO, {exp[0], simpleeq}, {});
                 proof->addStep(tmplem[1],

--- a/src/theory/arith/nl/ext/monomial_bounds_check.cpp
+++ b/src/theory/arith/nl/ext/monomial_bounds_check.cpp
@@ -402,7 +402,7 @@ void MonomialBoundsCheck::checkBounds(const std::vector<Node>& asserts,
                 proof->addStep(simpleeq,
                                ProofRule::ARITH_TRICHOTOMY,
                                {lb, rb},
-                               {simpleeq});
+                               {});
                 proof->addStep(
                     tmplem[0], ProofRule::AND_INTRO, {exp[0], simpleeq}, {});
                 proof->addStep(tmplem[1],

--- a/src/theory/arith/proof_checker.cpp
+++ b/src/theory/arith/proof_checker.cpp
@@ -322,18 +322,20 @@ Node ArithProofRuleChecker::checkInternal(ProofRule id,
         }
         if (cmps.count(Kind::GT) == 0)
         {
-          if (retk!=Kind::UNDEFINED_KIND)
+          if (retk != Kind::UNDEFINED_KIND)
           {
-            Trace("arith::pf::check") << "Error: No GT and " << retk << std::endl;
+            Trace("arith::pf::check")
+                << "Error: No GT and " << retk << std::endl;
             return Node::null();
           }
           retk = Kind::GT;
         }
         if (cmps.count(Kind::LT) == 0)
         {
-          if (retk!=Kind::UNDEFINED_KIND)
+          if (retk != Kind::UNDEFINED_KIND)
           {
-            Trace("arith::pf::check") << "Error: No LT and " << retk << std::endl;
+            Trace("arith::pf::check")
+                << "Error: No LT and " << retk << std::endl;
             return Node::null();
           }
           retk = Kind::LT;

--- a/src/theory/arith/proof_checker.cpp
+++ b/src/theory/arith/proof_checker.cpp
@@ -310,29 +310,35 @@ Node ArithProofRuleChecker::checkInternal(ProofRule id,
     {
       Node a = negateProofLiteral(children[0]);
       Node b = negateProofLiteral(children[1]);
-      Node c = args[0];
-      if (a[0] == b[0] && b[0] == c[0] && a[1] == b[1] && b[1] == c[1])
+      if (a[0] == b[0] && a[1] == b[1])
       {
         std::set<Kind> cmps;
         cmps.insert(a.getKind());
         cmps.insert(b.getKind());
-        cmps.insert(c.getKind());
+        Kind retk = Kind::UNDEFINED_KIND;
         if (cmps.count(Kind::EQUAL) == 0)
         {
-          Trace("arith::pf::check") << "Error: No = " << std::endl;
-          return Node::null();
+          retk = Kind::EQUAL;
         }
         if (cmps.count(Kind::GT) == 0)
         {
-          Trace("arith::pf::check") << "Error: No > " << std::endl;
-          return Node::null();
+          if (retk!=Kind::UNDEFINED_KIND)
+          {
+            Trace("arith::pf::check") << "Error: No GT and " << retk << std::endl;
+            return Node::null();
+          }
+          retk = Kind::GT;
         }
         if (cmps.count(Kind::LT) == 0)
         {
-          Trace("arith::pf::check") << "Error: No < " << std::endl;
-          return Node::null();
+          if (retk!=Kind::UNDEFINED_KIND)
+          {
+            Trace("arith::pf::check") << "Error: No LT and " << retk << std::endl;
+            return Node::null();
+          }
+          retk = Kind::LT;
         }
-        return args[0];
+        return nm->mkNode(retk, a[0], a[1]);
       }
       else
       {
@@ -340,7 +346,6 @@ Node ArithProofRuleChecker::checkInternal(ProofRule id,
             << "Error: Different polynomials / values" << std::endl;
         Trace("arith::pf::check") << "  a: " << a << std::endl;
         Trace("arith::pf::check") << "  b: " << b << std::endl;
-        Trace("arith::pf::check") << "  c: " << c << std::endl;
         return Node::null();
       }
       // Check that all have the same constant:


### PR DESCRIPTION
Towards unifying the internal calculus to the cvc5 ALF proof signature.
