### PR TITLE
Provide premises for trust steps in ALF proofs

### DIFF
--- a/contrib/get-alf-checker
+++ b/contrib/get-alf-checker
@@ -24,7 +24,7 @@ ALFC_DIR="$BASE_DIR/alf-checker"
 mkdir -p $ALFC_DIR
 
 # download and unpack ALFC
-ALF_VERSION="57b34b6b5c130eb44332149b110bed130b3281e3"
+ALF_VERSION="39e663ef965ba42da68504cf6ae9ee75a00e51ff"
 download "https://github.com/cvc5/alfc/archive/$ALF_VERSION.tar.gz" $BASE_DIR/tmp/alfc.tgz
 tar --strip 1 -xzf $BASE_DIR/tmp/alfc.tgz -C $ALFC_DIR
 

--- a/proofs/alf/rules/Builtin.smt3
+++ b/proofs/alf/rules/Builtin.smt3
@@ -49,3 +49,8 @@
     :args (F)
     :conclusion F
 )
+
+(declare-rule identity ((F Bool))
+    :premises (F)
+    :conclusion F
+)

--- a/proofs/alf/rules/Builtin.smt3
+++ b/proofs/alf/rules/Builtin.smt3
@@ -48,6 +48,13 @@
     :conclusion F
 )
 
+; trust, but with an arbitrary list of premises
+(declare-rule trust_step ((P Bool) (F Bool))
+    :premise-list P and
+    :args (F)
+    :conclusion F
+)
+
 (declare-rule identity ((F Bool))
     :premises (F)
     :conclusion F

--- a/proofs/alf/rules/Builtin.smt3
+++ b/proofs/alf/rules/Builtin.smt3
@@ -43,19 +43,9 @@
   :conclusion
     (let ((k (ite b t1 t2))) (ite b (= k t1) (= k t2))))
 
-(declare-rule trust ((F Bool))
-    :args (F)
-    :conclusion F
-)
-
-; trust, but with an arbitrary list of premises
-(declare-rule trust_step ((P Bool) (F Bool))
+; trust with an arbitrary list of premises
+(declare-rule trust ((P Bool) (F Bool))
     :premise-list P and
     :args (F)
-    :conclusion F
-)
-
-(declare-rule identity ((F Bool))
-    :premises (F)
     :conclusion F
 )

--- a/src/proof/alf/alf_print_channel.cpp
+++ b/src/proof/alf/alf_print_channel.cpp
@@ -67,7 +67,7 @@ void AlfPrintChannelOut::printStepInternal(const std::string& rname,
                                            const std::vector<size_t>& premises,
                                            const std::vector<Node>& args,
                                            bool isPop,
-                                           bool isTrust)
+                                           bool reqPremises)
 {
   d_out << "(" << (isPop ? "step-pop" : "step") << " @p" << i;
   if (!n.isNull())
@@ -76,8 +76,8 @@ void AlfPrintChannelOut::printStepInternal(const std::string& rname,
   }
   d_out << " :rule " << rname;
   bool firstTime = true;
-  // trust takes a premise-list which must be specified even if empty
-  if (!premises.empty() || isTrust)
+  // if reqPremises is true, we print even if empty
+  if (!premises.empty() || reqPremises)
   {
     d_out << " :premises (";
     for (size_t p : premises)
@@ -128,6 +128,7 @@ void AlfPrintChannelOut::printTrustStep(ProofRule r,
     d_warnedRules.insert(r);
   }
   d_out << "; trust " << r << std::endl;
+  // trust takes a premise-list which must be specified even if empty
   printStepInternal("trust", n, i, premises, {nc}, false, true);
 }
 

--- a/src/proof/alf/alf_print_channel.cpp
+++ b/src/proof/alf/alf_print_channel.cpp
@@ -62,12 +62,12 @@ void AlfPrintChannelOut::printStep(const std::string& rname,
 }
 
 void AlfPrintChannelOut::printStepInternal(const std::string& rname,
-                      TNode n,
-                      size_t i,
-                      const std::vector<size_t>& premises,
-                      const std::vector<Node>& args,
-                      bool isPop,
-                      bool isTrust)
+                                           TNode n,
+                                           size_t i,
+                                           const std::vector<size_t>& premises,
+                                           const std::vector<Node>& args,
+                                           bool isPop,
+                                           bool isTrust)
 {
   d_out << "(" << (isPop ? "step-pop" : "step") << " @p" << i;
   if (!n.isNull())
@@ -115,8 +115,11 @@ void AlfPrintChannelOut::printStepInternal(const std::string& rname,
   d_out << ")" << std::endl;
 }
 
-void AlfPrintChannelOut::printTrustStep(ProofRule r, TNode n, size_t i,
-                         const std::vector<size_t>& premises, TNode nc)
+void AlfPrintChannelOut::printTrustStep(ProofRule r,
+                                        TNode n,
+                                        size_t i,
+                                        const std::vector<size_t>& premises,
+                                        TNode nc)
 {
   Assert(!nc.isNull());
   if (d_warnedRules.find(r) == d_warnedRules.end())
@@ -181,8 +184,11 @@ void AlfPrintChannelPre::printStep(const std::string& rname,
   }
 }
 
-void AlfPrintChannelPre::printTrustStep(ProofRule r, TNode n, size_t i,
-                         const std::vector<size_t>& premises, TNode nc)
+void AlfPrintChannelPre::printTrustStep(ProofRule r,
+                                        TNode n,
+                                        size_t i,
+                                        const std::vector<size_t>& premises,
+                                        TNode nc)
 {
   Assert(!nc.isNull());
   processInternal(nc);

--- a/src/proof/alf/alf_print_channel.cpp
+++ b/src/proof/alf/alf_print_channel.cpp
@@ -58,6 +58,17 @@ void AlfPrintChannelOut::printStep(const std::string& rname,
                                    const std::vector<Node>& args,
                                    bool isPop)
 {
+  printStepInternal(rname, n, i, premises, args, isPop, false);
+}
+
+void AlfPrintChannelOut::printStepInternal(const std::string& rname,
+                      TNode n,
+                      size_t i,
+                      const std::vector<size_t>& premises,
+                      const std::vector<Node>& args,
+                      bool isPop,
+                      bool isTrust)
+{
   d_out << "(" << (isPop ? "step-pop" : "step") << " @p" << i;
   if (!n.isNull())
   {
@@ -65,7 +76,8 @@ void AlfPrintChannelOut::printStep(const std::string& rname,
   }
   d_out << " :rule " << rname;
   bool firstTime = true;
-  if (!premises.empty())
+  // trust takes a premise-list which must be specified even if empty
+  if (!premises.empty() || isTrust)
   {
     d_out << " :premises (";
     for (size_t p : premises)
@@ -113,14 +125,7 @@ void AlfPrintChannelOut::printTrustStep(ProofRule r, TNode n, size_t i,
     d_warnedRules.insert(r);
   }
   d_out << "; trust " << r << std::endl;
-  if (premises.empty())
-  {
-    printStep("trust", n, i, premises, {nc}, false);
-  }
-  else
-  {
-    printStep("trust_step", n, i, premises, {nc}, false);
-  }
+  printStepInternal("trust", n, i, premises, {nc}, false, true);
 }
 
 void AlfPrintChannelOut::printNodeInternal(std::ostream& out, Node n)

--- a/src/proof/alf/alf_print_channel.cpp
+++ b/src/proof/alf/alf_print_channel.cpp
@@ -103,7 +103,8 @@ void AlfPrintChannelOut::printStep(const std::string& rname,
   d_out << ")" << std::endl;
 }
 
-void AlfPrintChannelOut::printTrustStep(ProofRule r, TNode n, size_t i, TNode nc)
+void AlfPrintChannelOut::printTrustStep(ProofRule r, TNode n, size_t i,
+                         const std::vector<size_t>& premises, TNode nc)
 {
   Assert(!nc.isNull());
   if (d_warnedRules.find(r) == d_warnedRules.end())
@@ -112,7 +113,14 @@ void AlfPrintChannelOut::printTrustStep(ProofRule r, TNode n, size_t i, TNode nc
     d_warnedRules.insert(r);
   }
   d_out << "; trust " << r << std::endl;
-  printStep("trust", n, i, {}, {nc}, false);
+  if (premises.empty())
+  {
+    printStep("trust", n, i, premises, {nc}, false);
+  }
+  else
+  {
+    printStep("trust_step", n, i, premises, {nc}, false);
+  }
 }
 
 void AlfPrintChannelOut::printNodeInternal(std::ostream& out, Node n)
@@ -168,7 +176,8 @@ void AlfPrintChannelPre::printStep(const std::string& rname,
   }
 }
 
-void AlfPrintChannelPre::printTrustStep(ProofRule r, TNode n, size_t i, TNode nc)
+void AlfPrintChannelPre::printTrustStep(ProofRule r, TNode n, size_t i,
+                         const std::vector<size_t>& premises, TNode nc)
 {
   Assert(!nc.isNull());
   processInternal(nc);

--- a/src/proof/alf/alf_print_channel.h
+++ b/src/proof/alf/alf_print_channel.h
@@ -63,7 +63,8 @@ class AlfPrintChannel
   {
   }
   /** Print trust step */
-  virtual void printTrustStep(ProofRule r, TNode n, size_t i, TNode conc) {}
+  virtual void printTrustStep(ProofRule r, TNode n, size_t i,
+                         const std::vector<size_t>& premises, TNode conc) {}
 };
 
 /** Prints the proof to output stream d_out */
@@ -82,7 +83,8 @@ class AlfPrintChannelOut : public AlfPrintChannel
                  const std::vector<size_t>& premises,
                  const std::vector<Node>& args,
                  bool isPop = false) override;
-  void printTrustStep(ProofRule r, TNode n, size_t i, TNode conc) override;
+  void printTrustStep(ProofRule r, TNode n, size_t i,
+                         const std::vector<size_t>& premises, TNode conc) override;
 
   /**
    * Print node to stream in the expected format of ALF.
@@ -124,7 +126,8 @@ class AlfPrintChannelPre : public AlfPrintChannel
                  const std::vector<size_t>& premises,
                  const std::vector<Node>& args,
                  bool isPop = false) override;
-  void printTrustStep(ProofRule r, TNode n, size_t i, TNode conc) override;
+  void printTrustStep(ProofRule r, TNode n, size_t i,
+                         const std::vector<size_t>& premises, TNode conc) override;
 
   /** Get variables we encountered in printing */
   const std::unordered_set<TNode>& getVariables() const;

--- a/src/proof/alf/alf_print_channel.h
+++ b/src/proof/alf/alf_print_channel.h
@@ -96,6 +96,14 @@ class AlfPrintChannelOut : public AlfPrintChannel
   void printTypeNodeInternal(std::ostream& out, TypeNode tn);
 
  private:
+  /** Helper for print steps */
+  void printStepInternal(const std::string& rname,
+                        TNode n,
+                        size_t i,
+                        const std::vector<size_t>& premises,
+                        const std::vector<Node>& args,
+                        bool isPop,
+                        bool isTrust);
   /** The output stream */
   std::ostream& d_out;
   /** The let binding */

--- a/src/proof/alf/alf_print_channel.h
+++ b/src/proof/alf/alf_print_channel.h
@@ -104,14 +104,17 @@ class AlfPrintChannelOut : public AlfPrintChannel
   void printTypeNodeInternal(std::ostream& out, TypeNode tn);
 
  private:
-  /** Helper for print steps */
+  /** 
+   * Helper for print steps. We set reqPremises to true if we require printing
+   * premises even if empty.
+   */
   void printStepInternal(const std::string& rname,
                          TNode n,
                          size_t i,
                          const std::vector<size_t>& premises,
                          const std::vector<Node>& args,
                          bool isPop,
-                         bool isTrust);
+                         bool reqPremises);
   /** The output stream */
   std::ostream& d_out;
   /** The let binding */

--- a/src/proof/alf/alf_print_channel.h
+++ b/src/proof/alf/alf_print_channel.h
@@ -63,8 +63,13 @@ class AlfPrintChannel
   {
   }
   /** Print trust step */
-  virtual void printTrustStep(ProofRule r, TNode n, size_t i,
-                         const std::vector<size_t>& premises, TNode conc) {}
+  virtual void printTrustStep(ProofRule r,
+                              TNode n,
+                              size_t i,
+                              const std::vector<size_t>& premises,
+                              TNode conc)
+  {
+  }
 };
 
 /** Prints the proof to output stream d_out */
@@ -83,8 +88,11 @@ class AlfPrintChannelOut : public AlfPrintChannel
                  const std::vector<size_t>& premises,
                  const std::vector<Node>& args,
                  bool isPop = false) override;
-  void printTrustStep(ProofRule r, TNode n, size_t i,
-                         const std::vector<size_t>& premises, TNode conc) override;
+  void printTrustStep(ProofRule r,
+                      TNode n,
+                      size_t i,
+                      const std::vector<size_t>& premises,
+                      TNode conc) override;
 
   /**
    * Print node to stream in the expected format of ALF.
@@ -98,12 +106,12 @@ class AlfPrintChannelOut : public AlfPrintChannel
  private:
   /** Helper for print steps */
   void printStepInternal(const std::string& rname,
-                        TNode n,
-                        size_t i,
-                        const std::vector<size_t>& premises,
-                        const std::vector<Node>& args,
-                        bool isPop,
-                        bool isTrust);
+                         TNode n,
+                         size_t i,
+                         const std::vector<size_t>& premises,
+                         const std::vector<Node>& args,
+                         bool isPop,
+                         bool isTrust);
   /** The output stream */
   std::ostream& d_out;
   /** The let binding */
@@ -134,8 +142,11 @@ class AlfPrintChannelPre : public AlfPrintChannel
                  const std::vector<size_t>& premises,
                  const std::vector<Node>& args,
                  bool isPop = false) override;
-  void printTrustStep(ProofRule r, TNode n, size_t i,
-                         const std::vector<size_t>& premises, TNode conc) override;
+  void printTrustStep(ProofRule r,
+                      TNode n,
+                      size_t i,
+                      const std::vector<size_t>& premises,
+                      TNode conc) override;
 
   /** Get variables we encountered in printing */
   const std::unordered_set<TNode>& getVariables() const;

--- a/src/proof/alf/alf_print_channel.h
+++ b/src/proof/alf/alf_print_channel.h
@@ -104,7 +104,7 @@ class AlfPrintChannelOut : public AlfPrintChannel
   void printTypeNodeInternal(std::ostream& out, TypeNode tn);
 
  private:
-  /** 
+  /**
    * Helper for print steps. We set reqPremises to true if we require printing
    * premises even if empty.
    */

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -522,7 +522,8 @@ void AlfPrinter::printStepPost(AlfPrintChannel* out, const ProofNode* pn)
   // if we don't handle the rule, print trust
   if (!handled)
   {
-    out->printTrustStep(pn->getRule(), conclusionPrint, id, premises, conclusion);
+    out->printTrustStep(
+        pn->getRule(), conclusionPrint, id, premises, conclusion);
     return;
   }
   std::string rname = getRuleName(pn);

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -497,12 +497,6 @@ void AlfPrinter::printStepPost(AlfPrintChannel* out, const ProofNode* pn)
     getArgsFromProofRule(pn, args);
   }
   size_t id = allocateProofId(pn, wasAlloc);
-  // if we don't handle the rule, print trust
-  if (!handled)
-  {
-    out->printTrustStep(pn->getRule(), conclusionPrint, id, conclusion);
-    return;
-  }
   std::vector<size_t> premises;
   // get the premises
   std::map<Node, size_t>::iterator ita;
@@ -524,6 +518,12 @@ void AlfPrinter::printStepPost(AlfPrintChannel* out, const ProofNode* pn)
       pid = itp->second;
     }
     premises.push_back(pid);
+  }
+  // if we don't handle the rule, print trust
+  if (!handled)
+  {
+    out->printTrustStep(pn->getRule(), conclusionPrint, id, premises, conclusion);
+    return;
   }
   std::string rname = getRuleName(pn);
   if (r == ProofRule::SCOPE)


### PR DESCRIPTION
This makes it clearer what the actual missing step is.

This updates the ALF checker version to accept empty premise lists if the trust step has no premises.