### PR TITLE
Sort to term kind and utility

### DIFF
--- a/src/expr/CMakeLists.txt
+++ b/src/expr/CMakeLists.txt
@@ -97,6 +97,8 @@ libcvc5_add_sources(
   dtype_selector.cpp
   sequence.cpp
   sequence.h
+  sort_to_term.cpp
+  sort_to_term.h
   subs.cpp
   subs.h
   sygus_datatype.cpp

--- a/src/expr/dtype.cpp
+++ b/src/expr/dtype.cpp
@@ -20,6 +20,7 @@
 #include "expr/node_algorithm.h"
 #include "expr/skolem_manager.h"
 #include "expr/type_matcher.h"
+#include "expr/sort_to_term.h"
 #include "util/rational.h"
 
 using namespace cvc5::internal::kind;
@@ -925,9 +926,11 @@ Node DType::getSharedSelector(TypeNode dtt, TypeNode t, size_t index) const
   std::stringstream ss;
   ss << "sel_" << index;
   SkolemManager* sm = nm->getSkolemManager();
-  TypeNode stype = nm->mkSelectorType(dtt, t);
-  Node nindex = nm->mkConstInt(Rational(index));
-  s = sm->mkSkolemFunctionTyped(SkolemFunId::SHARED_SELECTOR, stype, nindex);
+  std::vector<Node> cacheVals;
+  cacheVals.push_back(nm->mkConst(SortToTerm(dtt)));
+  cacheVals.push_back(nm->mkConst(SortToTerm(t)));
+  cacheVals.push_back(nm->mkConstInt(Rational(index)));
+  s = sm->mkSkolemFunction(SkolemFunId::SHARED_SELECTOR, cacheVals);
   d_sharedSel[dtt][t][index] = s;
   Trace("dt-shared-sel") << "Made " << s << " of type " << dtt << " -> " << t
                          << std::endl;

--- a/src/expr/dtype.cpp
+++ b/src/expr/dtype.cpp
@@ -19,8 +19,8 @@
 #include "expr/dtype_cons.h"
 #include "expr/node_algorithm.h"
 #include "expr/skolem_manager.h"
-#include "expr/type_matcher.h"
 #include "expr/sort_to_term.h"
+#include "expr/type_matcher.h"
 #include "util/rational.h"
 
 using namespace cvc5::internal::kind;

--- a/src/expr/emptybag.cpp
+++ b/src/expr/emptybag.cpp
@@ -52,17 +52,4 @@ bool EmptyBag::operator==(const EmptyBag& es) const
   return getType() == es.getType();
 }
 
-bool EmptyBag::operator!=(const EmptyBag& es) const { return !(*this == es); }
-bool EmptyBag::operator<(const EmptyBag& es) const
-{
-  return getType() < es.getType();
-}
-
-bool EmptyBag::operator<=(const EmptyBag& es) const
-{
-  return getType() <= es.getType();
-}
-
-bool EmptyBag::operator>(const EmptyBag& es) const { return !(*this <= es); }
-bool EmptyBag::operator>=(const EmptyBag& es) const { return !(*this < es); }
 }  // namespace cvc5::internal

--- a/src/expr/emptybag.h
+++ b/src/expr/emptybag.h
@@ -39,11 +39,6 @@ class EmptyBag
 
   const TypeNode& getType() const;
   bool operator==(const EmptyBag& es) const;
-  bool operator!=(const EmptyBag& es) const;
-  bool operator<(const EmptyBag& es) const;
-  bool operator<=(const EmptyBag& es) const;
-  bool operator>(const EmptyBag& es) const;
-  bool operator>=(const EmptyBag& es) const;
 
  private:
   EmptyBag();

--- a/src/expr/emptyset.cpp
+++ b/src/expr/emptyset.cpp
@@ -48,18 +48,4 @@ bool EmptySet::operator==(const EmptySet& es) const
 {
   return getType() == es.getType();
 }
-
-bool EmptySet::operator!=(const EmptySet& es) const { return !(*this == es); }
-bool EmptySet::operator<(const EmptySet& es) const
-{
-  return getType() < es.getType();
-}
-
-bool EmptySet::operator<=(const EmptySet& es) const
-{
-  return getType() <= es.getType();
-}
-
-bool EmptySet::operator>(const EmptySet& es) const { return !(*this <= es); }
-bool EmptySet::operator>=(const EmptySet& es) const { return !(*this < es); }
 }  // namespace cvc5::internal

--- a/src/expr/emptyset.cpp
+++ b/src/expr/emptyset.cpp
@@ -10,10 +10,7 @@
  * directory for licensing information.
  * ****************************************************************************
  *
- * [[ Add one-line brief description here ]]
- *
- * [[ Add lengthier description here ]]
- * \todo document this file
+ * Payload class for empty sets.
  */
 
 #include "expr/emptyset.h"

--- a/src/expr/emptyset.h
+++ b/src/expr/emptyset.h
@@ -39,12 +39,6 @@ class EmptySet
 
   const TypeNode& getType() const;
   bool operator==(const EmptySet& es) const;
-  bool operator!=(const EmptySet& es) const;
-  bool operator<(const EmptySet& es) const;
-  bool operator<=(const EmptySet& es) const;
-  bool operator>(const EmptySet& es) const;
-  bool operator>=(const EmptySet& es) const;
-
  private:
   EmptySet();
 

--- a/src/expr/emptyset.h
+++ b/src/expr/emptyset.h
@@ -39,6 +39,7 @@ class EmptySet
 
   const TypeNode& getType() const;
   bool operator==(const EmptySet& es) const;
+
  private:
   EmptySet();
 

--- a/src/expr/node_manager_template.cpp
+++ b/src/expr/node_manager_template.cpp
@@ -1100,8 +1100,7 @@ Node NodeManager::mkVar(const std::string& name,
   // variable is unique.
   std::vector<Node> cnodes;
   cnodes.push_back(mkConst(String(name, false)));
-  // Since we index only on Node, we must construct use mkGroundValue
-  // to construct a canonical node for the tn.
+  // Since we index only on Node, we must construct a SortToTerm here.
   Node gt = mkConst(SortToTerm(type));
   cnodes.push_back(gt);
   return d_skManager->mkSkolemFunction(SkolemFunId::INPUT_VARIABLE, cnodes);

--- a/src/expr/node_manager_template.cpp
+++ b/src/expr/node_manager_template.cpp
@@ -1102,7 +1102,7 @@ Node NodeManager::mkVar(const std::string& name,
   cnodes.push_back(mkConst(String(name, false)));
   // Since we index only on Node, we must construct use mkGroundValue
   // to construct a canonical node for the tn.
-  Node gt = mkGroundValue(type);
+  Node gt = mkConst(SortToTerm(type));
   cnodes.push_back(gt);
   return d_skManager->mkSkolemFunction(SkolemFunId::INPUT_VARIABLE, cnodes);
 }

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -432,7 +432,7 @@ TypeNode SkolemManager::getTypeFor(SkolemFunId id,
     // Type(cacheVals[1])
     case SkolemFunId::INPUT_VARIABLE:
       Assert(cacheVals.size() == 2
-             && cacheVals[1].getKind() == Kind::SORT_TO_TYPE);
+             && cacheVals[1].getKind() == Kind::SORT_TO_TERM);
       return cacheVals[1].getConst<SortToTerm>().getType();
       break;
     // real -> real function
@@ -585,8 +585,8 @@ TypeNode SkolemManager::getTypeFor(SkolemFunId id,
     case SkolemFunId::SHARED_SELECTOR:
     {
       Assert(cacheVals.size() == 3);
-      Assert(cacheVals[0].getKind() == Kind::SORT_TO_TYPE);
-      Assert(cacheVals[1].getKind() == Kind::SORT_TO_TYPE);
+      Assert(cacheVals[0].getKind() == Kind::SORT_TO_TERM);
+      Assert(cacheVals[1].getKind() == Kind::SORT_TO_TERM);
       TypeNode dtt = cacheVals[0].getConst<SortToTerm>().getType();
       TypeNode t = cacheVals[1].getConst<SortToTerm>().getType();
       return nm->mkSelectorType(dtt, t);

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -21,6 +21,7 @@
 #include "expr/bound_var_manager.h"
 #include "expr/node_algorithm.h"
 #include "expr/node_manager_attributes.h"
+#include "expr/sort_to_term.h"
 #include "util/rational.h"
 #include "util/string.h"
 
@@ -430,8 +431,8 @@ TypeNode SkolemManager::getTypeFor(SkolemFunId id,
       break;
     // Type(cacheVals[1])
     case SkolemFunId::INPUT_VARIABLE:
-      Assert(cacheVals.size() > 1);
-      return cacheVals[1].getType();
+      Assert(cacheVals.size()==2 && cacheVals[1].getKind()==Kind::SORT_TO_TYPE);
+      return cacheVals[1].getConst<SortToTerm>().getType();
       break;
     // real -> real function
     case SkolemFunId::DIV_BY_ZERO:
@@ -579,6 +580,15 @@ TypeNode SkolemManager::getTypeFor(SkolemFunId id,
     {
       Assert (cacheVals[0].getType().isFunction());
       return cacheVals[0].getType().getArgTypes()[0];
+    }
+    case SkolemFunId::SHARED_SELECTOR:
+    {
+      Assert (cacheVals.size()==3);
+      Assert(cacheVals[0].getKind()==Kind::SORT_TO_TYPE);
+      Assert(cacheVals[1].getKind()==Kind::SORT_TO_TYPE);
+      TypeNode dtt = cacheVals[0].getConst<SortToTerm>().getType();
+      TypeNode t = cacheVals[1].getConst<SortToTerm>().getType();
+      return nm->mkSelectorType(dtt, t);
     }
     default: break;
   }

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -431,7 +431,8 @@ TypeNode SkolemManager::getTypeFor(SkolemFunId id,
       break;
     // Type(cacheVals[1])
     case SkolemFunId::INPUT_VARIABLE:
-      Assert(cacheVals.size()==2 && cacheVals[1].getKind()==Kind::SORT_TO_TYPE);
+      Assert(cacheVals.size() == 2
+             && cacheVals[1].getKind() == Kind::SORT_TO_TYPE);
       return cacheVals[1].getConst<SortToTerm>().getType();
       break;
     // real -> real function
@@ -583,9 +584,9 @@ TypeNode SkolemManager::getTypeFor(SkolemFunId id,
     }
     case SkolemFunId::SHARED_SELECTOR:
     {
-      Assert (cacheVals.size()==3);
-      Assert(cacheVals[0].getKind()==Kind::SORT_TO_TYPE);
-      Assert(cacheVals[1].getKind()==Kind::SORT_TO_TYPE);
+      Assert(cacheVals.size() == 3);
+      Assert(cacheVals[0].getKind() == Kind::SORT_TO_TYPE);
+      Assert(cacheVals[1].getKind() == Kind::SORT_TO_TYPE);
       TypeNode dtt = cacheVals[0].getConst<SortToTerm>().getType();
       TypeNode t = cacheVals[1].getConst<SortToTerm>().getType();
       return nm->mkSelectorType(dtt, t);

--- a/src/expr/sort_to_term.cpp
+++ b/src/expr/sort_to_term.cpp
@@ -1,0 +1,40 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2023 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Payload that represents a sort to be represented as a term.
+ */
+
+#include "expr/sort_to_term.h"
+
+#include <iostream>
+
+#include "expr/type_node.h"
+
+namespace cvc5::internal {
+
+std::ostream& operator<<(std::ostream& out, const SortToTerm& asa) {
+  return out << "sort_to_term(" << asa.getType() << ')';
+}
+
+size_t SortToTermHashFunction::operator()(const SortToTerm& es) const {
+  return std::hash<TypeNode>()(es.getType());
+}
+
+SortToTerm::SortToTerm(const TypeNode& setType) : d_type(new TypeNode(setType)) {}
+
+SortToTerm::SortToTerm(const SortToTerm& es) : d_type(new TypeNode(es.getType())) {}
+
+SortToTerm::~SortToTerm() {}
+
+const TypeNode& SortToTerm::getType() const { return *d_type; }
+
+}  // namespace cvc5::internal

--- a/src/expr/sort_to_term.cpp
+++ b/src/expr/sort_to_term.cpp
@@ -21,17 +21,24 @@
 
 namespace cvc5::internal {
 
-std::ostream& operator<<(std::ostream& out, const SortToTerm& asa) {
+std::ostream& operator<<(std::ostream& out, const SortToTerm& asa)
+{
   return out << "sort_to_term(" << asa.getType() << ')';
 }
 
-size_t SortToTermHashFunction::operator()(const SortToTerm& es) const {
+size_t SortToTermHashFunction::operator()(const SortToTerm& es) const
+{
   return std::hash<TypeNode>()(es.getType());
 }
 
-SortToTerm::SortToTerm(const TypeNode& setType) : d_type(new TypeNode(setType)) {}
+SortToTerm::SortToTerm(const TypeNode& setType) : d_type(new TypeNode(setType))
+{
+}
 
-SortToTerm::SortToTerm(const SortToTerm& es) : d_type(new TypeNode(es.getType())) {}
+SortToTerm::SortToTerm(const SortToTerm& es)
+    : d_type(new TypeNode(es.getType()))
+{
+}
 
 SortToTerm::~SortToTerm() {}
 

--- a/src/expr/sort_to_term.cpp
+++ b/src/expr/sort_to_term.cpp
@@ -26,22 +26,27 @@ std::ostream& operator<<(std::ostream& out, const SortToTerm& asa)
   return out << "sort_to_term(" << asa.getType() << ')';
 }
 
-size_t SortToTermHashFunction::operator()(const SortToTerm& es) const
+size_t SortToTermHashFunction::operator()(const SortToTerm& stt) const
 {
-  return std::hash<TypeNode>()(es.getType());
+  return std::hash<TypeNode>()(stt.getType());
 }
 
 SortToTerm::SortToTerm(const TypeNode& setType) : d_type(new TypeNode(setType))
 {
 }
 
-SortToTerm::SortToTerm(const SortToTerm& es)
-    : d_type(new TypeNode(es.getType()))
+SortToTerm::SortToTerm(const SortToTerm& stt)
+    : d_type(new TypeNode(stt.getType()))
 {
 }
 
 SortToTerm::~SortToTerm() {}
 
 const TypeNode& SortToTerm::getType() const { return *d_type; }
+
+bool SortToTerm::operator==(const SortToTerm& stt) const
+{
+  return getType() == stt.getType();
+}
 
 }  // namespace cvc5::internal

--- a/src/expr/sort_to_term.cpp
+++ b/src/expr/sort_to_term.cpp
@@ -31,7 +31,7 @@ size_t SortToTermHashFunction::operator()(const SortToTerm& stt) const
   return std::hash<TypeNode>()(stt.getType());
 }
 
-SortToTerm::SortToTerm(const TypeNode& setType) : d_type(new TypeNode(setType))
+SortToTerm::SortToTerm(const TypeNode& sort) : d_type(new TypeNode(sort))
 {
 }
 

--- a/src/expr/sort_to_term.h
+++ b/src/expr/sort_to_term.h
@@ -39,7 +39,7 @@ class SortToTerm
    * Constructs an object representing a term corresponding to the specified
    * type.
    */
-  SortToTerm(const TypeNode& setType);
+  SortToTerm(const TypeNode& sort);
   SortToTerm(const SortToTerm& other);
   ~SortToTerm();
 

--- a/src/expr/sort_to_term.h
+++ b/src/expr/sort_to_term.h
@@ -38,6 +38,7 @@ class SortToTerm
 
   /** Get the type that this sort-to-term represents */
   const TypeNode& getType() const;
+
  private:
   SortToTerm();
   /** The type */

--- a/src/expr/sort_to_term.h
+++ b/src/expr/sort_to_term.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Top contributors (to current version):
- *   Tim King, Kshitij Bansal, Andres Noetzli
+ *   Andrew Reynolds
  *
  * This file is part of the cvc5 project.
  *
@@ -10,13 +10,13 @@
  * directory for licensing information.
  * ****************************************************************************
  *
- * Payload class for empty sets.
+ * Payload that represents a sort to be represented as a term.
  */
 
 #include "cvc5_public.h"
 
-#ifndef CVC5__EXPR__EMPTY_SET_H
-#define CVC5__EXPR__EMPTY_SET_H
+#ifndef CVC5__EXPR__SORT_TO_TERM_H
+#define CVC5__EXPR__SORT_TO_TERM_H
 
 #include <iosfwd>
 #include <memory>
@@ -25,39 +25,32 @@ namespace cvc5::internal {
 
 class TypeNode;
 
-class EmptySet
+class SortToTerm
 {
  public:
   /**
    * Constructs an emptyset of the specified type. Note that the argument
    * is the type of the set itself, NOT the type of the elements.
    */
-  EmptySet(const TypeNode& setType);
-  ~EmptySet();
-  EmptySet(const EmptySet& other);
-  EmptySet& operator=(const EmptySet& other);
+  SortToTerm(const TypeNode& setType);
+  SortToTerm(const SortToTerm& other);
+  ~SortToTerm();
 
+  /** Get the type that this sort-to-term represents */
   const TypeNode& getType() const;
-  bool operator==(const EmptySet& es) const;
-  bool operator!=(const EmptySet& es) const;
-  bool operator<(const EmptySet& es) const;
-  bool operator<=(const EmptySet& es) const;
-  bool operator>(const EmptySet& es) const;
-  bool operator>=(const EmptySet& es) const;
-
  private:
-  EmptySet();
-
+  SortToTerm();
+  /** The type */
   std::unique_ptr<TypeNode> d_type;
-}; /* class EmptySet */
+};
 
-std::ostream& operator<<(std::ostream& out, const EmptySet& es);
+std::ostream& operator<<(std::ostream& out, const SortToTerm& es);
 
-struct EmptySetHashFunction
+struct SortToTermHashFunction
 {
-  size_t operator()(const EmptySet& es) const;
-}; /* struct EmptySetHashFunction */
+  size_t operator()(const SortToTerm& es) const;
+};
 
 }  // namespace cvc5::internal
 
-#endif /* CVC5__EMPTY_SET_H */
+#endif /* CVC5__EXPR__SORT_TO_TERM_H */

--- a/src/expr/sort_to_term.h
+++ b/src/expr/sort_to_term.h
@@ -38,6 +38,8 @@ class SortToTerm
 
   /** Get the type that this sort-to-term represents */
   const TypeNode& getType() const;
+  /** True if equal */
+  bool operator==(const SortToTerm& stt) const;
 
  private:
   SortToTerm();
@@ -45,11 +47,11 @@ class SortToTerm
   std::unique_ptr<TypeNode> d_type;
 };
 
-std::ostream& operator<<(std::ostream& out, const SortToTerm& es);
+std::ostream& operator<<(std::ostream& out, const SortToTerm& stt);
 
 struct SortToTermHashFunction
 {
-  size_t operator()(const SortToTerm& es) const;
+  size_t operator()(const SortToTerm& stt) const;
 };
 
 }  // namespace cvc5::internal

--- a/src/expr/sort_to_term.h
+++ b/src/expr/sort_to_term.h
@@ -25,12 +25,19 @@ namespace cvc5::internal {
 
 class TypeNode;
 
+/**
+ * Sort-to-term utility, which is used to represent sorts as a term. Example
+ * use cases of this include passing sorts to the arguments of skolems (e.g.
+ * the n^th shared selector of a given datatype and selector type), or for
+ * representing SMT-LIB version 3 terms, where sorts and terms can be freely
+ * mixed.
+ */
 class SortToTerm
 {
  public:
   /**
-   * Constructs an emptyset of the specified type. Note that the argument
-   * is the type of the set itself, NOT the type of the elements.
+   * Constructs an object representing a term corresponding to the specified
+   * type.
    */
   SortToTerm(const TypeNode& setType);
   SortToTerm(const SortToTerm& other);
@@ -43,7 +50,7 @@ class SortToTerm
 
  private:
   SortToTerm();
-  /** The type */
+  /** The type the constant represents */
   std::unique_ptr<TypeNode> d_type;
 };
 

--- a/src/theory/builtin/kinds
+++ b/src/theory/builtin/kinds
@@ -339,4 +339,14 @@ parameterized APPLY_INDEXED_SYMBOLIC APPLY_INDEXED_SYMBOLIC_OP 1: "generic index
 typerule APPLY_INDEXED_SYMBOLIC_OP "SimpleTypeRule<RBuiltinOperator>"
 typerule APPLY_INDEXED_SYMBOLIC ::cvc5::internal::theory::builtin::ApplyIndexedSymbolicTypeRule
 
+
+# constants
+constant SORT_TO_TERM \
+  class \
+  SortToTerm \
+  ::cvc5::internal::SortToTermHashFunction \
+  "expr/sort_to_term.h" \
+  "term representing a sort; payload is an instance of the cvc5::internal::SortToTerm class"
+typerule SORT_TO_TERM "SimpleTypeRule<RBuiltinOperator>"
+
 endtheory


### PR DESCRIPTION
This will be used in the skolem API and in proofs.

Also does minor cleanup of previous utilities.