### PR TITLE
Fix FindCLN.cmake with CLN 1.3.7

### DIFF
--- a/cmake/FindCLN.cmake
+++ b/cmake/FindCLN.cmake
@@ -25,10 +25,8 @@ set(CLN_FOUND_SYSTEM FALSE)
 if(CLN_INCLUDE_DIR AND CLN_LIBRARIES)
   set(CLN_FOUND_SYSTEM TRUE)
 
-  file(STRINGS ${CLN_INCLUDE_DIR}/cln/version.h CLN_VERSION
-       REGEX "^#define[\t ]+CL_VERSION .*"
-  )
-  string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" CLN_VERSION "${CLN_VERSION}")
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(CLN cln)
 
   check_system_version("CLN")
 endif()


### PR DESCRIPTION
The format of CL_VERSION in CLN's version.h changed in v1.3.7 and isn't easily parsable using a regex.  So, just use pkg-config to get the version instead, which should be backwards compatible.

Fixes #10370.