### PR TITLE
Fix version detection code for CLN >= 1.3.7

### DIFF
--- a/cmake/FindCLN.cmake
+++ b/cmake/FindCLN.cmake
@@ -26,9 +26,14 @@ if(CLN_INCLUDE_DIR AND CLN_LIBRARIES)
   set(CLN_FOUND_SYSTEM TRUE)
 
   file(STRINGS ${CLN_INCLUDE_DIR}/cln/version.h CLN_VERSION
-       REGEX "^#define[\t ]+CL_VERSION .*"
+       REGEX "^#define[\t ]+CL_VERSION.*"
   )
-  string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" CLN_VERSION "${CLN_VERSION}")
+  if(CLN_VERSION MATCHES
+     "MAJOR ([0-9]+).*MINOR ([0-9]+).*PATCHLEVEL ([0-9]+)")
+    string(CONCAT CLN_VERSION ${CMAKE_MATCH_1} "." ${CMAKE_MATCH_2} "." ${CMAKE_MATCH_3})
+  else()
+    string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" CLN_VERSION "${CLN_VERSION}")
+  endif()
 
   check_system_version("CLN")
 endif()


### PR DESCRIPTION
The format of CL_VERSION in CLN's version.h changed in v1.3.7. Before v1.3.7, the version was available in a single line. Now, the major, minor, and patchlevel version numbers are specified in three separate lines. This PR fixes FindCLN.cmake so that the version number is parsed properly in all versions of the library.

Fixes #10370.