### PR TITLE
cmake: Specify missing dependency between cvc5parser and gen-options

### DIFF
--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -68,7 +68,7 @@ add_library(cvc5parserapi-objs OBJECT ${libcvc5parserapi_src_files})
 set_target_properties(cvc5parserapi-objs PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_compile_definitions(cvc5parserapi-objs PUBLIC -D__BUILDING_CVC5LIB -Dcvc5_obj_EXPORTS)
 
-add_dependencies(cvc5parser-objs gen-expr)
+add_dependencies(cvc5parser-objs gen-expr gen-options)
 add_dependencies(cvc5parserapi-objs cvc5parser-objs gen-expr)
 
 add_library(cvc5parser


### PR DESCRIPTION
This should fix a race condition that was causing sporadic failures in the PyPi packaging workflow (see [this](https://github.com/cvc5/cvc5/actions/runs/7866166124/job/21460092584#step:6:6449) for a recent example).