### PR TITLE
Make binary test more robust

### DIFF
--- a/test/binary/interactive_shell_parser_inc.py
+++ b/test/binary/interactive_shell_parser_inc.py
@@ -18,14 +18,17 @@
 import sys
 import pexpect
 
+def error_message(s):
+    return "Unexpected output '" + s + "'"
+
 def expect_exact(child, s):
     child.expect_exact(s)
-    assert child.before == b""
-    assert child.after == s.encode('UTF-8')
+    assert child.before == b"", error_message(child.before.decode('UTF-8'))
+    assert child.after == s.encode('UTF-8'), error_message(child.after)
 
 def sendline(child, s):
     child.sendline(s)
-    child.expect_exact(s+'\r\n')
+    expect_exact(child, s+'\r\n')
 
 def check_iteractive_shell_parser_inc():
     """


### PR DESCRIPTION
This PR updates `test/binary/interactive_shell_parser_inc.py` so that the `sendline` function does not match and ignore previous output. The revised Python script also prints the found output when an assertion fails.