### PR TITLE
[proof-new] Divide rewrite outputs to individual files

### DIFF
--- a/src/rewriter/CMakeLists.txt
+++ b/src/rewriter/CMakeLists.txt
@@ -16,10 +16,6 @@
 # Check if the pyparsing Python module is installed.
 check_python_module("pyparsing")
 
-libcvc5_add_sources(GENERATED
-  rewrites.cpp
-  rewrites.h
-)
 libcvc5_add_sources(
   basic_rewrite_rcons.cpp
   basic_rewrite_rcons.h
@@ -35,10 +31,29 @@ libcvc5_add_sources(
 
 set(mkrewrites_script ${CMAKE_CURRENT_LIST_DIR}/mkrewrites.py)
 
+function(to_rewrites_name input output)
+  cmake_path(GET input PARENT_PATH input_parent)
+  cmake_path(GET input_parent FILENAME output)
+  set(output ${output} PARENT_SCOPE)
+endfunction()
+
+set(REWRITE_OUTPUT_FILES
+  rewrites.cpp
+  rewrites.h
+)
+foreach(rewrite_in IN LISTS REWRITES_FILES)
+  cmake_path(GET rewrite_in PARENT_PATH rewrite_parent)
+  cmake_path(GET rewrite_parent FILENAME rewrite_name)
+  list(APPEND REWRITE_OUTPUT_FILES "rewrites-${rewrite_name}.cpp")
+endforeach()
+
+libcvc5_add_sources(GENERATED
+  ${REWRITE_OUTPUT_FILES}
+)
+
 add_custom_command(
     OUTPUT
-      rewrites.cpp
-      rewrites.h
+      ${REWRITE_OUTPUT_FILES}
     COMMAND
       ${Python_EXECUTABLE}
       ${mkrewrites_script}
@@ -48,6 +63,7 @@ add_custom_command(
     DEPENDS
       ${mkrewrites_script}
       ${REWRITES_FILES}
+      ${CMAKE_CURRENT_LIST_DIR}/individual_rewrites_template.cpp
       ${CMAKE_CURRENT_LIST_DIR}/rewrites_template.cpp
       ${CMAKE_CURRENT_LIST_DIR}/rewrites_template.h
     COMMENT
@@ -56,6 +72,5 @@ add_custom_command(
 
 add_custom_target(gen-rewrites
   DEPENDS
-    rewrites.cpp
-    rewrites.h
+    ${REWRITE_OUTPUT_FILES}
 )

--- a/src/rewriter/individual_rewrites_template.cpp
+++ b/src/rewriter/individual_rewrites_template.cpp
@@ -1,0 +1,33 @@
+#include "expr/node.h"
+#include "expr/node_manager.h"
+#include "proof/proof_checker.h"
+#include "rewriter/rewrite_db.h"
+#include "rewriter/rewrites.h"
+#include "theory/builtin/generic_op.h"
+#include "util/string.h"
+
+using namespace cvc5::internal::kind;
+
+namespace cvc5::internal {
+namespace rewriter {
+
+// clang-format off
+void ${rewrite_name}$(RewriteDb& db)
+// clang-format on
+{
+  NodeManager* nm = NodeManager::currentNM();
+
+  // Variables
+  // clang-format off
+${decls}$
+
+  // Definitions
+${defns}$
+
+  // Rules
+${rules}$
+  // clang-format on
+}
+
+}  // namespace rewriter
+}  // namespace cvc5::internal

--- a/src/rewriter/mkrewrites.py
+++ b/src/rewriter/mkrewrites.py
@@ -227,8 +227,8 @@ def preprocess_rule(rule, decls):
 class RewriteDb:
     name: str
     filename: str
-    ids: list[str]
-    printer_code: list[str]
+    ids: list
+    printer_code: list
 
     @property
     def function_name(self):

--- a/src/rewriter/mkrewrites.py
+++ b/src/rewriter/mkrewrites.py
@@ -252,8 +252,6 @@ def gen_individual_rewrite_db(rewrites_file: str, template):
         f"Rewrites name must be an identifier: {output_name}"
     output_file = f"rewrites-{output_name}.cpp"
 
-    print(f"Creating rewrites for: {rewrites_file}, name={output_name}")
-
     parser = Parser()
     with open(rewrites_file, 'r') as f:
         rules = parser.parse_rules(f.read())

--- a/src/rewriter/rewrites_template.cpp
+++ b/src/rewriter/rewrites_template.cpp
@@ -26,19 +26,15 @@ using namespace cvc5::internal::kind;
 namespace cvc5::internal {
 namespace rewriter {
 
+// clang-format off
+${decl_individual_rewrites}$
+// clang-format on
+
 void addRules(RewriteDb& db)
 {
-  NodeManager* nm = NodeManager::currentNM();
-
-  // Variables
+  // Calls to individual rewrites
   // clang-format off
-${decls}$
-
-  // Definitions
-${defns}$
-
-  // Rules
-${rules}$
+  ${call_individual_rewrites}$
   // clang-format on
 }
 


### PR DESCRIPTION
Previously, the rewrite database generated one gigantic file and it would take 1 minute to compile this file. This PR divides the rewrite database file into individual files (one for each theory) to eliminate this bottleneck.

Due to how rewrite code generation works, recompilation of all databases is unavoidable when each rewrite file is changed.

This change assumes every rewrites file has a path like `.../{theory}/rewrites`.