### PR TITLE
Fixes for the integration of RARE in ALF

### DIFF
--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -924,7 +924,6 @@ bool Smt2Printer::toStreamBase(std::ostream& out,
     }
     break;
     // kinds that don't print their operator
-    case Kind::APPLY_INDEXED_SYMBOLIC:  // operator is printed as kind
     case Kind::SEXPR:
     case Kind::INSTANTIATED_SORT_TYPE:
     case Kind::PARAMETRIC_DATATYPE:

--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -992,8 +992,8 @@ void RewriteDbProofCons::cacheProofSubPlaceholder(TNode context,
 
     for (TNode n : curr)
     {
-      auto [it, inserted] = parent.emplace(n, curr);
-      if (inserted)
+      // if we successfully inserted
+      if (parent.emplace(n, curr).second)
       {
         toVisit.emplace_back(n);
       }

--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -17,6 +17,7 @@
 
 #include "expr/node_algorithm.h"
 #include "options/proof_options.h"
+#include "proof/proof_node_algorithm.h"
 #include "rewriter/rewrite_db_term_process.h"
 #include "smt/env.h"
 #include "theory/arith/arith_poly_norm.h"
@@ -786,7 +787,10 @@ bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
       }
       else if (pcur.d_id == DslProofRule::CONG)
       {
-        cdp->addStep(cur, ProofRule::CONG, ps, pfArgs[cur]);
+        // get the appropriate CONG rule
+        std::vector<Node> cargs;
+        ProofRule cr = expr::getCongRule(cur[0], cargs);
+        cdp->addStep(cur, cr, ps, cargs);
       }
       else if (pcur.d_id == DslProofRule::CONG_EVAL)
       {

--- a/test/regress/cli/regress0/proofs/unused-def2.smt2
+++ b/test/regress/cli/regress0/proofs/unused-def2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --proof-prune-input --dump-proof --proof-format=lfsc
+; COMMAND-LINE: --proof-prune-input
 ; SCRUBBER: grep -E "define|unsat"
 ; EXPECT: unsat
 

--- a/test/regress/cli/run_regression.py
+++ b/test/regress/cli/run_regression.py
@@ -208,12 +208,12 @@ class LfscTester(Tester):
     def run_internal(self, benchmark_info):
         exit_code = EXIT_OK
         with tempfile.NamedTemporaryFile() as tmpf:
-            cvc5_args = benchmark_info.command_line_args + [
+            cvc5_args = [
                 "--dump-proofs",
                 "--proof-format=lfsc",
                 "--proof-granularity=theory-rewrite",
                 "--proof-check=lazy",
-            ]
+            ] + benchmark_info.command_line_args
             output, error, exit_status = run_process(
                 [benchmark_info.cvc5_binary]
                 + cvc5_args
@@ -265,12 +265,12 @@ class AlfTester(Tester):
     def run_internal(self, benchmark_info):
         exit_code = EXIT_OK
         with tempfile.NamedTemporaryFile() as tmpf:
-            cvc5_args = benchmark_info.command_line_args + [
+            cvc5_args = [
                 "--dump-proofs",
                 "--proof-format=alf",
                 "--proof-granularity=theory-rewrite",
                 "--proof-print-conclusion",
-            ]
+            ] + benchmark_info.command_line_args
             output, error, exit_status = run_process(
                 [benchmark_info.cvc5_binary]
                 + cvc5_args


### PR DESCRIPTION
Also changes `run_regression.py` so that `make regress-alf CVC5_REGRESSION_ARGS=--proof-granularity=dsl-rewrite` works (due to the order of command line args passed to cvc5).