### PR TITLE
Correct FindCaDiCaL.cmake to support CMake 3.12

### DIFF
--- a/cmake/FindCaDiCaL.cmake
+++ b/cmake/FindCaDiCaL.cmake
@@ -23,10 +23,10 @@ find_library(CaDiCaL_LIBRARIES NAMES cadical)
 
 set(CaDiCaL_FOUND_SYSTEM FALSE)
 if(CaDiCaL_INCLUDE_DIR AND CaDiCaL_LIBRARIES)
-  # Try to compile our version file
-  try_run(RUN_RESULT_VAR
-    COMPILE_RESULT_VAR
-    SOURCE_FROM_CONTENT CaDiCaL_version.cpp
+
+  # Generate our version check file in CMAKE_BINARY_DIR
+  set(CaDiCaL_version_src "${CMAKE_BINARY_DIR}/CaDiCaL_version.cpp")
+  file(WRITE ${CaDiCaL_version_src}
     "
     #include <cadical.hpp>
     #include <iostream>
@@ -37,9 +37,28 @@ if(CaDiCaL_INCLUDE_DIR AND CaDiCaL_LIBRARIES)
       return 0;
     }
     "
+  )
+
+  # `try_run` doesn't have a way to specify a specific include dirs, so we need
+  # to set (and then reset) `CMAKE_CXX_FLAGS`; our version file is a .cpp file,
+  # so CXX_FLAGS are the right flags
+  set(OLD_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+
+  # cvc5 doesn't support MSVC, so we're fine to hard-code `-I` as the include
+  # flag
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${CaDiCaL_INCLUDE_DIR}")
+
+  # Try to compile and run our version file
+  try_run(RUN_RESULT_VAR
+    COMPILE_RESULT_VAR
+    ${CMAKE_BINARY_DIR}
+    ${CaDiCaL_version_src}
     LINK_LIBRARIES ${CaDiCaL_LIBRARIES}
     RUN_OUTPUT_VARIABLE CaDiCaL_VERSION
   )
+
+  # Restore our CXX flags after checking with `try_run`
+  set(CMAKE_CXX_FLAGS ${OLD_CXX_FLAGS})
 
   # If this failed to compile or run, we have bigger issues
   if (NOT ${RUN_RESULT_VAR} EQUAL 0 OR NOT ${COMPILE_RESULT_VAR})


### PR DESCRIPTION
This PR fixes an issue introduced in #10330, where we use features from CMake 3.25, despite the fact we are targeting CMake 3.12 as the oldest-supported version.

Here's what the output looks like now in CMake 3.12:

```
-- Found GMP 6.2.1: /usr/lib/i386-linux-gnu/libgmp.so
VERBOSESystem version for CaDiCaL has incompatible version: required 1.6.0 but found sc2021

-- Looking for getc_unlocked
```

(the `VERBOSE` prefix is unrelated to this PR and is tracked in https://github.com/cvc5/cvc5/issues/10431).

Closes #10427

Signed-off-by: Andrew V. Teylu <andrew@tey.lu>