### PR TITLE
Performance fix for subsolver cbqi

### DIFF
--- a/src/theory/quantifiers/inst_strategy_sub_conflict.cpp
+++ b/src/theory/quantifiers/inst_strategy_sub_conflict.cpp
@@ -63,6 +63,10 @@ void InstStrategySubConflict::check(Theory::Effort e, QEffort quant_e)
   {
     return;
   }
+  if (e != Theory::EFFORT_LAST_CALL)
+  {
+    return;
+  }
   double clSet = 0;
   if (TraceIsOn("qscf-engine"))
   {


### PR DESCRIPTION
This was mistakenly removed in a cleanup commit and improves performance greatly.