### PR TITLE
Add SAT_EXTERNAL_SOLVE proof rule

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -369,6 +369,17 @@ enum ENUM(ProofRule) : uint32_t
   EVALUE(DRAT_REFUTATION),
   /**
    * \verbatim embed:rst:leading-asterisk
+   * **SAT external prove Refutation**
+   *
+   * .. math::
+   *   \inferrule{F_1 \dots F_n \mid D}{\bot}
+   *
+   * where :math:`F_1 \dots F_n` correspond to the input clauses in the
+   * DIMACS file `D`. \endverbatim
+   */
+  EVALUE(SAT_EXTERNAL_PROVE),
+  /**
+   * \verbatim embed:rst:leading-asterisk
    * **Boolean -- Resolution**
    *
    * .. math::

--- a/src/api/cpp/cvc5_proof_rule.cpp
+++ b/src/api/cpp/cvc5_proof_rule.cpp
@@ -42,6 +42,7 @@ const char* toString(ProofRule id)
     case ProofRule::TRUST_THEORY_REWRITE: return "TRUST_THEORY_REWRITE";
     case ProofRule::SAT_REFUTATION: return "SAT_REFUTATION";
     case ProofRule::DRAT_REFUTATION: return "DRAT_REFUTATION";
+    case ProofRule::SAT_EXTERNAL_PROVE: return "SAT_EXTERNAL_PROVE";
     //================================================= Boolean rules
     case ProofRule::RESOLUTION: return "RESOLUTION";
     case ProofRule::CHAIN_RESOLUTION: return "CHAIN_RESOLUTION";

--- a/src/theory/booleans/proof_checker.cpp
+++ b/src/theory/booleans/proof_checker.cpp
@@ -76,6 +76,7 @@ void BoolProofRuleChecker::registerTo(ProofChecker* pc)
   pc->registerChecker(ProofRule::CNF_ITE_NEG3, this);
   pc->registerTrustedChecker(ProofRule::SAT_REFUTATION, this, 1);
   pc->registerTrustedChecker(ProofRule::DRAT_REFUTATION, this, 1);
+  pc->registerTrustedChecker(ProofRule::SAT_EXTERNAL_PROVE, this, 1);
 }
 
 Node BoolProofRuleChecker::checkInternal(ProofRule id,
@@ -933,9 +934,13 @@ Node BoolProofRuleChecker::checkInternal(ProofRule id,
         args[0], args[0][1].notNode(), args[0][2].notNode()};
     return NodeManager::currentNM()->mkNode(Kind::OR, disjuncts);
   }
-  if (id == ProofRule::SAT_REFUTATION || id == ProofRule::DRAT_REFUTATION)
+  if (id == ProofRule::SAT_REFUTATION || id == ProofRule::DRAT_REFUTATION
+      || id == ProofRule::SAT_EXTERNAL_PROVE)
   {
-    Assert(args.size() == (id == ProofRule::SAT_REFUTATION ? 0 : 2));
+    Assert(args.size()
+           == (id == ProofRule::SAT_REFUTATION
+                   ? 0
+                   : (id == ProofRule::SAT_EXTERNAL_PROVE ? 1 : 2)));
     return NodeManager::currentNM()->mkConst(false);
   }
   // no rule


### PR DESCRIPTION
Towards proofs relying on external SAT calls.