### PR TITLE
Use setuptools to build Python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,14 +356,6 @@ else()
   find_package(Python COMPONENTS Interpreter REQUIRED)
 endif()
 
-# Some cmake packages are not compatible with the newest version
-# of FindPython, introduced in cmake 3.12.
-# We define the symbols below to be backward compatible.
-# FindPython Interpreter sets Python_EXECUTABLE
-if(NOT DEFINED PYTHON_EXECUTABLE) 
-  set(PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
-endif()
-
 find_package(GMP 6.3 REQUIRED)
 
 if(ENABLE_ASAN)

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -259,7 +259,6 @@ Dependencies for Language Bindings
 - Python
 
   - `Cython <https://cython.org/>`_ >= 3.0.0
-  - `scikit-build <https://pypi.org/project/scikit-build/>`_
   - `pytest <https://docs.pytest.org/en/6.2.x/>`_
   - The source for the `pythonic API <(https://github.com/cvc5/cvc5_pythonic_api)>`.
 

--- a/cmake/Helpers.cmake
+++ b/cmake/Helpers.cmake
@@ -255,3 +255,13 @@ function(check_python_module module)
         "Note: You need to have pip installed for this Python version.")
   endif()
 endfunction()
+
+macro(copy_file_from_src filename)
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${filename}
+    COMMAND ${CMAKE_COMMAND} -E copy
+      ${CMAKE_CURRENT_SOURCE_DIR}/${filename}
+      ${CMAKE_CURRENT_BINARY_DIR}/${filename}
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${filename}
+  )
+endmacro()

--- a/contrib/packaging_python/mk_clean_wheel.sh
+++ b/contrib/packaging_python/mk_clean_wheel.sh
@@ -28,10 +28,6 @@ CONFIG="$2"
 PLATFORM="$3"
 PYVERSION=$($PYTHONBIN -c "import sys; print(sys.implementation.name + sys.version.split()[0])")
 
-# This is needed because of scikit, otherwise it will include files from another
-# python version installed in the system. 
-PYINCLUDE=$($PYTHONBIN -c "import sysconfig; print(sysconfig.get_paths()['include'])")
-
 # setup and activate venv
 echo "Making venv with $PYTHONBIN"
 ENVDIR=env$PYVERSION
@@ -40,6 +36,7 @@ source ./$ENVDIR/bin/activate
 
 # install packages
 pip install -q --upgrade pip auditwheel
+pip install wheel
 pip install -r contrib/requirements_build.txt
 pip install -r contrib/requirements_python_dev.txt
 if [ "$(uname)" == "Darwin" ]; then
@@ -51,10 +48,7 @@ fi
 echo "Configuring"
 rm -rf build_wheel/
 
-# This new command like is supposed to ensure that we use the python 
-# version from the virtual environment that is activated. 
-# Once we remove scikit, this will not be necessary.
-./configure.sh $CONFIG --python-bindings --name=build_wheel -DPython_FIND_VIRTUALENV=ONLY -DPYTHON_LIBRARY=$VIRTUAL_ENV/lib -DPYTHON_INCLUDE_DIR=$PYINCLUDE
+./configure.sh $CONFIG --python-bindings --name=build_wheel -DPython_FIND_VIRTUALENV=ONLY
 
 # building wheel
 echo "Building pycvc5 wheel"
@@ -66,6 +60,11 @@ if [ -z "$PLATFORM" ] ; then
   python ../contrib/packaging_python/mk_wheel.py bdist_wheel -d dist
 else
   python ../contrib/packaging_python/mk_wheel.py bdist_wheel -d dist --plat-name $PLATFORM
+fi
+
+# Required by macOS CI
+if [ "$(uname)" == "Darwin" ]; then
+  export DYLD_LIBRARY_PATH=$(pwd)/src:$(pwd)/src/parser:$DYLD_LIBRARY_PATH
 fi
 
 cd dist

--- a/contrib/packaging_python/mk_clean_wheel.sh
+++ b/contrib/packaging_python/mk_clean_wheel.sh
@@ -48,7 +48,7 @@ fi
 echo "Configuring"
 rm -rf build_wheel/
 
-./configure.sh $CONFIG --python-bindings --name=build_wheel -DPython_FIND_VIRTUALENV=ONLY
+./configure.sh $CONFIG --python-bindings --name=build_wheel
 
 # building wheel
 echo "Building pycvc5 wheel"

--- a/contrib/requirements_python_dev.txt
+++ b/contrib/requirements_python_dev.txt
@@ -1,4 +1,3 @@
 setuptools
 Cython>=3.0.0
 pytest
-scikit-build

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -116,8 +116,7 @@ add_custom_command(
     ${CVC5_PYTHON_BASE_LIB}
   COMMAND
     # Force a new build if any dependency has changed
-    ${CMAKE_COMMAND} -E remove cvc5_python_base.cpp &&
-    ${CMAKE_COMMAND} -E remove cvc5/cvc5_python_base.${PYTHON_EXT}
+    ${CMAKE_COMMAND} -E remove cvc5_python_base.cpp cvc5/cvc5_python_base.${PYTHON_EXT}
   COMMAND
     "${Python_EXECUTABLE}" setup.py build_ext --inplace
   MAIN_DEPENDENCY

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -1,10 +1,10 @@
 ###############################################################################
 # Top contributors (to current version):
-#   Makai Mann, Mathias Preiner, Andres Noetzli
+#   Daniel Larraz, Makai Mann, Mathias Preiner, Andres Noetzli
 #
 # This file is part of the cvc5 project.
 #
-# Copyright (c) 2009-2023 by the authors listed in the file AUTHORS
+# Copyright (c) 2009-2024 by the authors listed in the file AUTHORS
 # in the top-level source directory and their institutional affiliations.
 # All rights reserved.  See the file COPYING in the top-level source
 # directory for licensing information.
@@ -13,59 +13,11 @@
 # The build system configuration.
 ##
 
-# Check that scikit-build is installed
-# Provides CMake files for Python bindings
-check_python_module("skbuild" "scikit-build")
-
-# setuptools for installing the module
-check_python_module("setuptools")
-
-# Find cmake modules distributed with scikit-build
-# They are distributed under <scikit-build directory>/resources/cmake
-
-# This 'sys.stdout' hack is needed because importing skbuild prints to stdout
-# in some versions, and this stores the wrong value to OUTPUT_VARIABLE. 
-# Once scikit is removed, this whole command will be removed too.
-execute_process(
-  COMMAND
-    ${Python_EXECUTABLE} -c "from __future__ import print_function; \
-      import os; import sys; \
-      sys.stdout = open(os.devnull, 'w'); \
-      import skbuild; \
-      sys.stdout = sys.__stdout__; \
-      cmake_module_path=os.path.join(os.path.dirname(skbuild.__file__), \
-        'resources', 'cmake'); print(cmake_module_path, end='')"
-  OUTPUT_VARIABLE
-    SKBUILD_CMAKE_MODULE_PATH
-  RESULT_VARIABLE
-    RET_SKBUILD_CMAKE_MODULE_PATH
-)
-
-if (NOT EXISTS ${SKBUILD_CMAKE_MODULE_PATH})
-  message(FATAL_ERROR "Expected CMake module path from
-                       scikit-build at ${SKBUILD_CMAKE_MODULE_PATH}")
-endif()
-
-# Add scikit-build cmake files to cmake module path
-# Required for Cython target below
-list(APPEND CMAKE_MODULE_PATH ${SKBUILD_CMAKE_MODULE_PATH})
-
 find_package(Python ${BUILD_BINDINGS_PYTHON_VERSION} EXACT COMPONENTS Development)
-# Some cmake packages are not compatible with the newest version
-# of FindPython, introduced in cmake 3.12.
-# We define the symbols below to be backward compatible.
-# FindPython Development sets Python_INCLUDE_DIRS and Python_LIBRARIES
-if (NOT DEFINED PYTHON_INCLUDE_DIRS)
-  set(PYTHON_INCLUDE_DIRS "${Python_INCLUDE_DIRS}")
-endif()
-if (NOT DEFINED PYTHON_LIBRARIES)
-  set(PYTHON_LIBRARIES "${Python_LIBRARIES}")
-endif()
 
-find_package(PythonExtensions REQUIRED)
-find_package(Cython 3.0.0 REQUIRED)
-
-set(CYTHON_FLAGS "-X embedsignature=True")
+# Python modules for building and installing
+check_python_module("setuptools")
+check_python_module("Cython")
 
 configure_file(genenums.py.in genenums.py)
 
@@ -129,53 +81,90 @@ add_custom_command(
 )
 add_custom_target(cvc5types DEPENDS ${GENERATED_TYPES_FILES})
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR})   # for cvc5kinds.pxi
-add_cython_target(cvc5_python_base CXX)
+copy_file_from_src(cvc5.pxi)
+copy_file_from_src(cvc5.pxd)
+copy_file_from_src(cvc5_python_base.pyx)
+copy_file_from_src(pyproject.toml)
 
-add_library(cvc5_python_base
-            MODULE
-            cvc5_python_base)
-add_dependencies(cvc5_python_base cvc5kinds cvc5types cvc5proofrules )
+# Set include_dirs and library_dirs variables that are used in setup.cfg.in
+if (WIN32)
+  set(PYTHON_EXT "pyd")
+  set(SETUP_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include;${CMAKE_BINARY_DIR}/include")
+  set(SETUP_LIBRARY_DIRS "${CMAKE_BINARY_DIR}/src;${CMAKE_BINARY_DIR}/src/parser")
+else()
+  set(PYTHON_EXT "so")
+  set(SETUP_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include:${CMAKE_BINARY_DIR}/include")
+  set(SETUP_LIBRARY_DIRS "${CMAKE_BINARY_DIR}/src:${CMAKE_BINARY_DIR}/src/parser")
+  # On Linux and macOS, set rpath variable too
+  set(SETUP_RPATH "rpath=${CMAKE_BINARY_DIR}/src:${CMAKE_BINARY_DIR}/src/parser")
+endif()
 
-target_include_directories(cvc5_python_base
-  PRIVATE
-  ${PYTHON_INCLUDE_DIRS}
-  ${PROJECT_SOURCE_DIR}/include   # for public API headers
-  ${CMAKE_BINARY_DIR}/include     # for cvc5_export.h
+# Set MACOS_ARCH variable that is used in setup.py.in
+if (CMAKE_CROSSCOMPILING_MACOS)
+  set(MACOS_ARCH "arm64")
+endif()
+
+configure_file(setup.py.in setup.py)
+configure_file(setup.cfg.in setup.cfg)
+configure_file(__init__.py.in cvc5/__init__.py)
+
+set(CVC5_PYTHON_BASE_LIB
+  "${CMAKE_CURRENT_BINARY_DIR}/cvc5/cvc5_python_base.${PYTHON_EXT}")
+
+add_custom_command(
+  OUTPUT
+    ${CVC5_PYTHON_BASE_LIB}
+  COMMAND
+    # Force a new build if any dependency has changed
+    ${CMAKE_COMMAND} -E remove cvc5_python_base.cpp &&
+    ${CMAKE_COMMAND} -E remove cvc5/cvc5_python_base.${PYTHON_EXT}
+  COMMAND
+    "${Python_EXECUTABLE}" setup.py build_ext --inplace
+  MAIN_DEPENDENCY
+    ${CMAKE_CURRENT_BINARY_DIR}/cvc5_python_base.pyx
+  DEPENDS
+    cvc5 cvc5parser
+    ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml
+    ${CMAKE_CURRENT_BINARY_DIR}/setup.cfg
+    ${CMAKE_CURRENT_BINARY_DIR}/setup.py
+    cvc5kinds cvc5types cvc5proofrules
+    ${CMAKE_CURRENT_BINARY_DIR}/cvc5.pxi
+    ${CMAKE_CURRENT_BINARY_DIR}/cvc5.pxd
+  COMMENT "Generating cvc5_python_base.${PYTHON_EXT}"
 )
-
-target_link_libraries(cvc5_python_base cvc5parser cvc5)
-
-# Disable -Werror and other warnings for code generated by Cython.
-set(PY_SRC_FLAGS "")
-check_cxx_compiler_flag("-Werror" HAVE_CXX_FLAGWerror)
-if(HAVE_CXX_FLAGWerror)
-  set(PY_SRC_FLAGS "${PY_SRC_FLAGS} -Wno-error")
-endif()
-check_cxx_compiler_flag("-Wshadow" HAVE_CXX_FLAGWshadow)
-if(HAVE_CXX_FLAGWshadow)
-  set(PY_SRC_FLAGS "${PY_SRC_FLAGS} -Wno-shadow")
-endif()
-check_cxx_compiler_flag("-Wimplicit-fallthrough" HAVE_CXX_FLAGWimplicit_fallthrough)
-if(HAVE_CXX_FLAGWimplicit_fallthrough)
-  set(PY_SRC_FLAGS "${PY_SRC_FLAGS} -Wno-implicit-fallthrough")
-endif()
-# Note: Visibility is reset to default here since otherwise the PyInit_...
-# function will not be exported correctly
-# (https://github.com/cython/cython/issues/3380).
-set_target_properties(cvc5_python_base
-                      PROPERTIES
-                      COMPILE_FLAGS "${PY_SRC_FLAGS}"
-                      CXX_VISIBILITY_PRESET default
-                      VISIBILITY_INLINES_HIDDEN 0
-                      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/cvc5")
-
-python_extension_module(cvc5_python_base)
 
 # Copy the pythonic API to the right place. It does not come with its own
 # installation routine and consists only of a few files that need to go to
 # the right place.
 find_package(CVC5PythonicAPI)
+
+set(LICENSE_FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/COPYING"
+  "${CMAKE_CURRENT_BINARY_DIR}/licenses/lgpl-3.0.txt"
+  "${CMAKE_CURRENT_BINARY_DIR}/licenses/pythonic-LICENSE"
+)
+
+add_custom_command(
+  OUTPUT
+    ${LICENSE_FILES}
+  COMMAND
+    ${CMAKE_COMMAND} -E copy
+    "${PROJECT_SOURCE_DIR}/COPYING"
+    "${CMAKE_CURRENT_BINARY_DIR}/COPYING"
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_directory
+    "${PROJECT_SOURCE_DIR}/licenses"
+    "${CMAKE_CURRENT_BINARY_DIR}/licenses"
+  COMMAND
+    ${CMAKE_COMMAND} -E copy
+    "${CVC5PythonicAPI_BASEDIR}/cvc5_pythonic_api/LICENSE.txt"
+    "${CMAKE_CURRENT_BINARY_DIR}/licenses/pythonic-LICENSE"
+  DEPENDS CVC5PythonicAPI
+)
+
+# Copy license files to build directory where setup() can find them
+# Called by contrib/packaging_python/mk_clean_wheel.sh
+add_custom_target(cvc5_python_licenses DEPENDS ${LICENSE_FILES})
 
 set(COPIED_PYTHONIC_FILES
   "${CMAKE_CURRENT_BINARY_DIR}/cvc5/pythonic/__init__.py"
@@ -195,42 +184,15 @@ add_custom_command(
   COMMAND
     ${CMAKE_COMMAND} -E remove
     "${CMAKE_CURRENT_BINARY_DIR}/cvc5/pythonic/LICENSE.txt"
-  DEPENDS cvc5_python_base CVC5PythonicAPI
-)
-
-add_custom_target(cvc5_python_api ALL DEPENDS ${COPIED_PYTHONIC_FILES})
-
-set(LICENSE_FILES
-  "${CMAKE_BINARY_DIR}/COPYING"
-  "${CMAKE_BINARY_DIR}/licenses/lgpl-3.0.txt"
-  "${CMAKE_BINARY_DIR}/licenses/pythonic-LICENSE"
-)
-
-add_custom_command(
-  OUTPUT
-    ${LICENSE_FILES}
-  COMMAND
-    ${CMAKE_COMMAND} -E copy
-    "${PROJECT_SOURCE_DIR}/COPYING"
-    "${CMAKE_BINARY_DIR}/COPYING"
-  COMMAND
-    ${CMAKE_COMMAND} -E copy_directory
-    "${PROJECT_SOURCE_DIR}/licenses"
-    "${CMAKE_BINARY_DIR}/licenses"
-  COMMAND
-    ${CMAKE_COMMAND} -E copy
-    "${CVC5PythonicAPI_BASEDIR}/cvc5_pythonic_api/LICENSE.txt"
-    "${CMAKE_BINARY_DIR}/licenses/pythonic-LICENSE"
   DEPENDS CVC5PythonicAPI
 )
 
-# Copy license files to build directory where setup() can find them
-add_custom_target(cvc5_python_licenses DEPENDS ${LICENSE_FILES})
-
-# Installation based on https://bloerg.net/2012/11/10/cmake-and-distutils.html
-# Create a wrapper python directory and generate a distutils setup.py file
-configure_file(setup.py.in setup.py)
-configure_file(__init__.py.in cvc5/__init__.py)
+add_custom_target(
+  cvc5_python_api ALL DEPENDS
+    ${CVC5_PYTHON_BASE_LIB}
+    ${COPIED_PYTHONIC_FILES}
+    ${LICENSE_FILES}
+)
 
 # figure out if we're in a virtualenv
 execute_process(OUTPUT_VARIABLE IN_VIRTUALENV
@@ -241,16 +203,11 @@ execute_process(OUTPUT_VARIABLE IN_VIRTUALENV
 print('YES' if 'VIRTUAL_ENV' in os.environ else 'NO', end='')")
 
 set(INSTALL_CMD
-    "${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py install")
+    "${Python_EXECUTABLE} -m pip install ${CMAKE_CURRENT_BINARY_DIR}")
 # if we're in a virtualenv, we install it in the virtualenv lib location
-# otherwise install in site-packages
-# option --single-version-externally-managed prevents it from being
-# an .egg distribution and --record records the list of installed files
+# otherwise install in prefix
 if ("${IN_VIRTUALENV}" STREQUAL "NO")
-  set(INSTALL_CMD "${INSTALL_CMD}
-          --prefix=${CMAKE_INSTALL_PREFIX}
-          --single-version-externally-managed
-          --record=cvc5-installed-files.txt")
+  set(INSTALL_CMD "${INSTALL_CMD} --prefix ${CMAKE_INSTALL_PREFIX}")
 endif()
 
 message("Python bindings install command: ${INSTALL_CMD}")

--- a/src/api/python/__init__.py.in
+++ b/src/api/python/__init__.py.in
@@ -1,3 +1,4 @@
 import sys
 from .cvc5_python_base import *
 __file__ = cvc5_python_base.__file__
+__version__ = "${CVC5_VERSION}"

--- a/src/api/python/genenums.py.in
+++ b/src/api/python/genenums.py.in
@@ -45,9 +45,7 @@ r"""cdef extern from "<{header}>" namespace "{namespace}":
 """
 
 ENUMS_PXI_TOP = \
-r'''# distutils: language = c++
-# distutils: extra_compile_args = -std=c++11
-
+r'''
 from {basename} cimport {enum} as c_{enum}
 from enum import Enum
 

--- a/src/api/python/pyproject.toml
+++ b/src/api/python/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools", "Cython>=3"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name="cvc5"
+description="Python bindings for cvc5"
+dynamic = ["version"]
+urls = {Homepage = "https://github.com/cvc5/cvc5"}
+license = {text = "BSD-3-Clause AND LGPL-3.0-or-later AND MIT"}
+# BSD-3-Clause      : cvc5 library and Python API
+# LGPL-3.0-or-later : LibPoly and GMP
+# MIT               : Pythonic API
+
+[tool.setuptools.dynamic]
+version = {attr = "cvc5.__version__"}

--- a/src/api/python/setup.cfg.in
+++ b/src/api/python/setup.cfg.in
@@ -1,0 +1,4 @@
+[build_ext]
+include_dirs=${SETUP_INCLUDE_DIRS}
+library_dirs=${SETUP_LIBRARY_DIRS}
+${SETUP_RPATH}

--- a/src/api/python/setup.py.in
+++ b/src/api/python/setup.py.in
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 ###############################################################################
 # Top contributors (to current version):
-#   Makai Mann, Alex Ozdemir, Mathias Preiner
+#   Daniel Larraz, Makai Mann, Alex Ozdemir, Mathias Preiner
 #
 # This file is part of the cvc5 project.
 #
-# Copyright (c) 2009-2023 by the authors listed in the file AUTHORS
+# Copyright (c) 2009-2024 by the authors listed in the file AUTHORS
 # in the top-level source directory and their institutional affiliations.
 # All rights reserved.  See the file COPYING in the top-level source
 # directory for licensing information.
@@ -13,23 +13,96 @@
 #
 # This script is automatically configured with cmake when cvc5
 # is built with --python-bindings. It is called during make
-# install to automatically install the python bindings using
-# distutils.
+# install to automatically install the python bindings using pip.
 # If it is called from a python virtualenv, the bindings are
 # installed in the virtualenv, otherwise, it respects the
 # configured install prefix using the setup.py --prefix option
 ##
 
+import os
 from setuptools import setup
 
-CVC5_VERSION='${CVC5_VERSION}'
+ext_suffix = 'pyd' if os.name == 'nt' else 'so'
+ext_filename = 'cvc5_python_base.' + ext_suffix
 
-setup(name='cvc5',
-      version=CVC5_VERSION,
-      long_description='Python bindings for cvc5 ' + CVC5_VERSION,
-      url='https://github.com/cvc5/cvc5',
-      zip_safe=False,
-      packages=['cvc5', 'cvc5.pythonic'],
-      package_dir={'':'${CMAKE_CURRENT_BINARY_DIR}'},
-      package_data={'': ['cvc5_python_base*.so']},
-      extras_require={'test': ['pytest']})
+packages=['cvc5', 'cvc5.pythonic']
+license_files=["COPYING", "licenses/*"]
+
+# If we have already compiled the Python extension module,
+# include the module directly instead of recompiling it.
+if os.path.isfile(os.path.join('cvc5', ext_filename)):
+    setup(
+        packages=packages,
+        package_data={'': [ext_filename]},
+        # Let setuptools know the package include an extension module
+        # so that the generated wheel name includes
+        # the python version, the ABI tag, and the platform name.
+        has_ext_modules=lambda: True,
+        license_files=license_files
+    )
+else:
+    import sys
+    import sysconfig
+    from setuptools.extension import Extension
+
+    from Cython.Distutils import build_ext
+    from Cython.Build import cythonize
+
+    if sys.platform == 'darwin':
+        import platform
+        mac_ver = os.environ.get("MACOSX_DEPLOYMENT_TARGET")
+        if mac_ver is None:
+          version_str, _, _ = platform.mac_ver()
+          major_minor = version_str.split(".")[:2]
+          mac_ver = ".".join(major_minor)
+          os.environ.setdefault("MACOSX_DEPLOYMENT_TARGET", mac_ver)
+        arch = "${MACOS_ARCH}" # Optionally set by CMake
+        arch = platform.machine() if arch == "" else arch
+        host_platform = "macosx-" + mac_ver + "-" + arch
+        os.environ.setdefault("_PYTHON_HOST_PLATFORM", host_platform)
+        arch_flags = "-arch " + arch
+        os.environ.setdefault("ARCHFLAGS", arch_flags)
+
+    compiler_directives = {
+        'language_level': 3,
+        'binding': False,
+    }
+
+    extra_compile_args = ["-std=c++17", "-fno-var-tracking"]
+
+    if sys.platform == 'win32':
+        # Compile argument '-DMS_WIN64' fixes a division by zero error
+        # See https://stackoverflow.com/q/64898146
+        extra_compile_args += ["-DMS_WIN64"]
+        # Add default MSYS2 installation path for local development
+        os.environ['PATH'] += r';C:\msys64\mingw64\bin'
+
+    ext_options = {
+        "libraries" : ["cvc5", "cvc5parser"],
+        "language" : "c++",
+        "extra_compile_args" : extra_compile_args
+    }
+
+    mod_name = "cvc5.cvc5_python_base"
+    mod_src_files = ["cvc5_python_base.pyx"]
+
+    ext_module = Extension(mod_name, mod_src_files, **ext_options)
+    ext_module.cython_directives = {"embedsignature": True}
+
+    class ExtensionBuilder(build_ext):
+        def get_ext_filename(self, ext_name):
+            # Do not include the python version, the ABI tag, and
+            # the platform name in the extension module name.
+            # This facilitates specifying the dependencies of
+            # the module in CMake.
+            filename = super().get_ext_filename(ext_name)
+            suffix = sysconfig.get_config_var('EXT_SUFFIX')
+            ext = os.path.splitext(filename)[1]
+            return filename.replace(suffix, "") + ext
+
+    setup(
+        cmdclass={'build_ext': ExtensionBuilder},
+        ext_modules=cythonize([ext_module], compiler_directives=compiler_directives),
+        packages=packages,
+        license_files=license_files
+    )

--- a/src/api/python/setup.py.in
+++ b/src/api/python/setup.py.in
@@ -57,7 +57,8 @@ else:
           mac_ver = ".".join(major_minor)
           os.environ.setdefault("MACOSX_DEPLOYMENT_TARGET", mac_ver)
         arch = "${MACOS_ARCH}" # Optionally set by CMake
-        arch = platform.machine() if arch == "" else arch
+        if not arch:
+            arch = platform.machine()
         host_platform = "macosx-" + mac_ver + "-" + arch
         os.environ.setdefault("_PYTHON_HOST_PLATFORM", host_platform)
         arch_flags = "-arch " + arch


### PR DESCRIPTION
This PR replaces scikit-build with setuptools to build the Python bindings. Our setup with scikit-build didn't work on Windows, and used the FindPythonInterp and FindPythonLibs modules that were removed in CMake 3.27 (see policy [CMP0148](https://cmake.org/cmake/help/v3.27/policy/CMP0148.html)). This PR also uses pip to install the Python bindings using the Wheel format instead of using the deprecated call to `setup.py install --single-version-externally-managed`, which used the obsolete .egg format.

A follow-up PR will leverage this new setup to package the Python bindings for all the supported platforms and Python implementation versions using [cibuildwheel](https://cibuildwheel.readthedocs.io/). In this PR, only a minimal number of changes to the current packaging scripts have been applied to keep the packaging process working in the meantime.