### PR TITLE
Fix FindCoCoA cmake file

### DIFF
--- a/cmake/FindCoCoA.cmake
+++ b/cmake/FindCoCoA.cmake
@@ -63,7 +63,7 @@ if(NOT CoCoA_FOUND_SYSTEM)
     PATCH_COMMAND patch -p1 -d <SOURCE_DIR>
         -i ${CMAKE_CURRENT_LIST_DIR}/deps-utils/CoCoALib-0.99800-trace.patch
     BUILD_IN_SOURCE YES
-    CONFIGURE_COMMAND ${SHELL} ./configure --prefix=<INSTALL_DIR> --with-libgmp=${GMP_LIBRARY}
+    CONFIGURE_COMMAND ${SHELL} ./configure --prefix=<INSTALL_DIR> --with-libgmp=${GMP_LIBRARY} --with-cxx=${CMAKE_CXX_COMPILER}
     BUILD_COMMAND ${make_cmd} library
     BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libcocoa.a
   )


### PR DESCRIPTION
Recently, when I tried to build cvc5 on the system that doesn't have `g++` binary(it has `g++-13` though). This modification is supposed to fix this problem.