### PR TITLE
Check for which skolems are handled in ALF printing

### DIFF
--- a/src/proof/alf/alf_node_converter.cpp
+++ b/src/proof/alf/alf_node_converter.cpp
@@ -25,7 +25,6 @@
 #include "expr/dtype_cons.h"
 #include "expr/nary_term_util.h"
 #include "expr/sequence.h"
-#include "expr/skolem_manager.h"
 #include "printer/smt2/smt2_printer.h"
 #include "theory/builtin/generic_op.h"
 #include "theory/bv/theory_bv_utils.h"
@@ -350,7 +349,7 @@ Node AlfNodeConverter::maybeMkSkolemFun(Node k)
       // special case: just use self
       app = convert(cacheVal);
     }
-    else
+    else if (isHandledSkolemId(sfi))
     {
       // convert every skolem function to its name applied to arguments
       std::stringstream ss;
@@ -387,8 +386,11 @@ Node AlfNodeConverter::maybeMkSkolemFun(Node k)
       // must convert all arguments
       app = mkInternalApp(ss.str(), args, k.getType());
     }
-    // wrap in "skolem" operator
-    return mkInternalApp("skolem", {app}, k.getType());
+    if (!app.isNull())
+    {
+      // wrap in "skolem" operator
+      return mkInternalApp("skolem", {app}, k.getType());
+    }
   }
   return Node::null();
 }
@@ -688,6 +690,47 @@ size_t AlfNodeConverter::getOrAssignIndexForConst(Node v)
   size_t id = d_constIndex.size();
   d_constIndex[v] = id;
   return id;
+}
+
+bool AlfNodeConverter::isHandledSkolemId(SkolemFunId id)
+{
+  switch(id)
+  {
+    case SkolemFunId::PURIFY:
+    case SkolemFunId::ARRAY_DEQ_DIFF:
+    case SkolemFunId::DIV_BY_ZERO:
+    case SkolemFunId::INT_DIV_BY_ZERO:
+    case SkolemFunId::MOD_BY_ZERO:
+    case SkolemFunId::SQRT:
+    case SkolemFunId::TRANSCENDENTAL_PURIFY_ARG:
+    case SkolemFunId::QUANTIFIERS_SKOLEMIZE:
+    case SkolemFunId::STRINGS_NUM_OCCUR:
+    case SkolemFunId::STRINGS_NUM_OCCUR_RE:
+    case SkolemFunId::STRINGS_OCCUR_INDEX:
+    case SkolemFunId::STRINGS_OCCUR_INDEX_RE:
+    case SkolemFunId::STRINGS_OCCUR_LEN:
+    case SkolemFunId::STRINGS_OCCUR_LEN_RE:
+    case SkolemFunId::STRINGS_DEQ_DIFF:
+    case SkolemFunId::STRINGS_REPLACE_ALL_RESULT:
+    case SkolemFunId::STRINGS_ITOS_RESULT:
+    case SkolemFunId::STRINGS_STOI_RESULT:
+    case SkolemFunId::STRINGS_STOI_NON_DIGIT:
+    case SkolemFunId::RE_FIRST_MATCH_PRE:
+    case SkolemFunId::RE_FIRST_MATCH:
+    case SkolemFunId::RE_FIRST_MATCH_POST:
+    case SkolemFunId::RE_UNFOLD_POS_COMPONENT:
+    case SkolemFunId::BAGS_DEQ_DIFF: 
+    case SkolemFunId::BAGS_MAP_PREIMAGE:
+    case SkolemFunId::BAGS_MAP_PREIMAGE_INJECTIVE:
+    case SkolemFunId::BAGS_MAP_PREIMAGE_SIZE:
+    case SkolemFunId::BAGS_MAP_SUM:
+    case SkolemFunId::TABLES_GROUP_PART:
+    case SkolemFunId::TABLES_GROUP_PART_ELEMENT:
+      return true;
+    default:
+      break;
+  }
+  return false;
 }
 
 }  // namespace proof

--- a/src/proof/alf/alf_node_converter.cpp
+++ b/src/proof/alf/alf_node_converter.cpp
@@ -694,7 +694,7 @@ size_t AlfNodeConverter::getOrAssignIndexForConst(Node v)
 
 bool AlfNodeConverter::isHandledSkolemId(SkolemFunId id)
 {
-  switch(id)
+  switch (id)
   {
     case SkolemFunId::PURIFY:
     case SkolemFunId::ARRAY_DEQ_DIFF:
@@ -719,16 +719,14 @@ bool AlfNodeConverter::isHandledSkolemId(SkolemFunId id)
     case SkolemFunId::RE_FIRST_MATCH:
     case SkolemFunId::RE_FIRST_MATCH_POST:
     case SkolemFunId::RE_UNFOLD_POS_COMPONENT:
-    case SkolemFunId::BAGS_DEQ_DIFF: 
+    case SkolemFunId::BAGS_DEQ_DIFF:
     case SkolemFunId::BAGS_MAP_PREIMAGE:
     case SkolemFunId::BAGS_MAP_PREIMAGE_INJECTIVE:
     case SkolemFunId::BAGS_MAP_PREIMAGE_SIZE:
     case SkolemFunId::BAGS_MAP_SUM:
     case SkolemFunId::TABLES_GROUP_PART:
-    case SkolemFunId::TABLES_GROUP_PART_ELEMENT:
-      return true;
-    default:
-      break;
+    case SkolemFunId::TABLES_GROUP_PART_ELEMENT: return true;
+    default: break;
   }
   return false;
 }

--- a/src/proof/alf/alf_node_converter.h
+++ b/src/proof/alf/alf_node_converter.h
@@ -22,8 +22,8 @@
 
 #include "expr/node.h"
 #include "expr/node_converter.h"
-#include "expr/type_node.h"
 #include "expr/skolem_manager.h"
+#include "expr/type_node.h"
 
 namespace cvc5::internal {
 namespace proof {

--- a/src/proof/alf/alf_node_converter.h
+++ b/src/proof/alf/alf_node_converter.h
@@ -23,6 +23,7 @@
 #include "expr/node.h"
 #include "expr/node_converter.h"
 #include "expr/type_node.h"
+#include "expr/skolem_manager.h"
 
 namespace cvc5::internal {
 namespace proof {
@@ -134,6 +135,8 @@ class AlfNodeConverter : public BaseAlfNodeConverter
   Node maybeMkSkolemFun(Node k);
   /** Is k a kind that is printed as an indexed operator in ALF? */
   static bool isIndexedOperatorKind(Kind k);
+  /** Do we handle the given skolem id? */
+  static bool isHandledSkolemId(SkolemFunId id);
   /** Get indices for printing the operator of n in the ALF format */
   static std::vector<Node> getOperatorIndices(Kind k, Node n);
   /** The set of all internally generated symbols */


### PR DESCRIPTION
Ensures we don't get failures when a new skolem appears in a proof in our regressions.

Fixes current issues in nightlies introduced in a recent commit.