### PR TITLE
Fix CONG_EVAL reconstruction for DSL

### DIFF
--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -818,7 +818,10 @@ bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
         Node eq1 = lhs.eqNode(lhsTgt);
         Node eq2 = lhsTgt.eqNode(rhs);
         std::vector<Node> transChildren = {eq1, eq2};
-        cdp->addStep(eq1, ProofRule::CONG, ps, pfArgs[cur]);
+        // get the appropriate CONG rule
+        std::vector<Node> cargs;
+        ProofRule cr = expr::getCongRule(eq1[0], cargs);
+        cdp->addStep(eq1, cr, ps, cargs);
         cdp->addStep(eq2, ProofRule::EVALUATE, {}, {lhsTgt});
         if (rhs != cur[1])
         {

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1250,7 +1250,7 @@ set(regress_0_tests
   regress0/proofs/bvrewrite-concat-merge.smt2
   regress0/proofs/bvrewrite-extract.smt2
   regress0/proofs/bvrewrite-ite.smt2
-  regress0/proofs/bvrewrite-shlbyconst.smt
+  regress0/proofs/bvrewrite-shlbyconst.smt2
   regress0/proofs/dsl-cong-eval-cr.smt2
   regress0/proofs/dsl-no-eval.smt2
   regress0/proofs/dsl-rule-comp-types.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1250,7 +1250,8 @@ set(regress_0_tests
   regress0/proofs/bvrewrite-concat-merge.smt2
   regress0/proofs/bvrewrite-extract.smt2
   regress0/proofs/bvrewrite-ite.smt2
-  regress0/proofs/bvrewrite-shlbyconst.smt2
+  regress0/proofs/bvrewrite-shlbyconst.smt
+  regress0/proofs/dsl-cong-eval-cr.smt2
   regress0/proofs/dsl-no-eval.smt2
   regress0/proofs/dsl-rule-comp-types.smt2
   regress0/proofs/fixed-point-rew.smt2

--- a/test/regress/cli/regress0/proofs/dsl-cong-eval-cr.smt2
+++ b/test/regress/cli/regress0/proofs/dsl-cong-eval-cr.smt2
@@ -1,0 +1,9 @@
+; EXPECT: unsat
+(set-logic QF_SLIA)
+(declare-fun  x1 () String )
+(declare-fun  x2 () String )
+(declare-fun  z () String )
+(declare-fun  t1 () String )
+(declare-fun  t2 () String )
+(assert ( =( str.++( str.++( str.++ "abc"  z  ) ( str.++( str.++ x1  "abvv"  )  x2  )  )  t2  ) ( str.++( str.++ z  "vba"  ) ( str.++( str.++( str.++ x2  "dcba"  )  x1  )  t1  )  )  ) )
+(check-sat)

--- a/test/regress/cli/regress0/proofs/dsl-cong-eval-cr.smt2
+++ b/test/regress/cli/regress0/proofs/dsl-cong-eval-cr.smt2
@@ -5,5 +5,5 @@
 (declare-fun  z () String )
 (declare-fun  t1 () String )
 (declare-fun  t2 () String )
-(assert ( =( str.++( str.++( str.++ "abc"  z  ) ( str.++( str.++ x1  "abvv"  )  x2  )  )  t2  ) ( str.++( str.++ z  "vba"  ) ( str.++( str.++( str.++ x2  "dcba"  )  x1  )  t1  )  )  ) )
+(assert (= (str.++ (str.++ (str.++ "abc" z) (str.++ (str.++ x1 "abvv") x2)) t2) (str.++ (str.++ z "vba") (str.++ (str.++ (str.++ x2 "dcba") x1) t1))))
 (check-sat)


### PR DESCRIPTION
Was using the wrong rule for CONG for n-ary operators.