### PR TITLE
Fix printing constant sequences

### DIFF
--- a/proofs/alf/cvc5/theories/Strings.smt3
+++ b/proofs/alf/cvc5/theories/Strings.smt3
@@ -81,9 +81,9 @@
 (declare-const seq.empty (-> (! Type :var T) T))
 (declare-const seq.unit (-> (! Type :var T :implicit) T (Seq T)))
 (declare-const seq.nth (-> (! Type :var T :implicit) (Seq T) Int (alf.ite (alf.is_eq T Char) Int T)))
-(declare-const seq.len (-> (! Type :var T :implicit) (Seq T) Int))
 
 ; Sequence operators are automatically translated to the string operators.
+(define seq.len () str.len)
 (define seq.++ () str.++)
 (define seq.extract () str.substr)
 (define seq.contains () str.contains)
@@ -93,6 +93,7 @@
 (define seq.suffixof () str.suffixof)
 (define seq.rev () str.rev)
 (define seq.update () str.update)
+(define seq.at () str.at)
 
 ; Skolem functions for strings and sequences.
 

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -930,6 +930,21 @@ bool Smt2Printer::toStreamBase(std::ostream& out,
     case Kind::INST_PATTERN:
     case Kind::INST_NO_PATTERN:
     case Kind::INST_PATTERN_LIST: printed = false; break;
+    case Kind::STRING_CONCAT:
+    case Kind::STRING_LENGTH:
+    case Kind::STRING_SUBSTR:
+    case Kind::STRING_UPDATE:
+    case Kind::STRING_CHARAT:
+    case Kind::STRING_CONTAINS:
+    case Kind::STRING_INDEXOF:
+    case Kind::STRING_REPLACE:
+    case Kind::STRING_REPLACE_ALL:
+    case Kind::STRING_REV:
+    case Kind::STRING_PREFIX:
+    case Kind::STRING_SUFFIX:
+      // maybe print seq. instead of str.
+      out << smtKindStringOf(n);
+      break;
     default:
       // by default, print the kind using the smtKindString utility
       if (n.getMetaKind() != kind::metakind::PARAMETERIZED)
@@ -1360,7 +1375,7 @@ std::string Smt2Printer::smtKindStringOf(const Node& n)
     // this method parallels cvc5::Term::getKind
     switch (k)
     {
-      case Kind::STRING_CONCAT: return "seq.concat";
+      case Kind::STRING_CONCAT: return "seq.++";
       case Kind::STRING_LENGTH: return "seq.len";
       case Kind::STRING_SUBSTR: return "seq.extract";
       case Kind::STRING_UPDATE: return "seq.update";

--- a/src/theory/strings/theory_strings_utils.cpp
+++ b/src/theory/strings/theory_strings_utils.cpp
@@ -226,9 +226,9 @@ Node mkConcatForConstSequence(const Node& c)
   const std::vector<Node>& charVec = c.getConst<Sequence>().getVec();
   std::vector<Node> vec;
   NodeManager* nm = NodeManager::currentNM();
-  for (size_t i = 0, size = charVec.size(); i < size; i++)
+  for (const Node& cc : charVec)
   {
-    vec.push_back(nm->mkNode(Kind::SEQ_UNIT, charVec[i]));
+    vec.push_back(nm->mkNode(Kind::SEQ_UNIT, cc));
   }
   return mkConcat(vec, c.getType());
 }

--- a/src/theory/strings/theory_strings_utils.cpp
+++ b/src/theory/strings/theory_strings_utils.cpp
@@ -228,7 +228,7 @@ Node mkConcatForConstSequence(const Node& c)
   NodeManager* nm = NodeManager::currentNM();
   for (size_t i = 0, size = charVec.size(); i < size; i++)
   {
-    vec.push_back(nm->mkNode(Kind::SEQ_UNIT, charVec[size - (i + 1)]));
+    vec.push_back(nm->mkNode(Kind::SEQ_UNIT, charVec[i]));
   }
   return mkConcat(vec, c.getType());
 }

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1229,6 +1229,7 @@ set(regress_0_tests
   regress0/printer/empty_symbol_name.smt2
   regress0/printer/get-value-no-letify.smt2
   regress0/printer/incomplete.smt2
+  regress0/printer/issue10478.smt2
   regress0/printer/issue9928.smt2
   regress0/printer/issue9938-1.smt2
   regress0/printer/issue9938-2.smt2

--- a/test/regress/cli/regress0/printer/issue10478.smt2
+++ b/test/regress/cli/regress0/printer/issue10478.smt2
@@ -3,7 +3,6 @@
 (set-option :produce-models true)
 (set-logic ALL)
 (declare-fun x () (Seq Int))
-(assert (seq.contains x (seq.unit 1)))
-(assert (seq.contains x (seq.unit 2)))
+(assert (= x (seq.++ (seq.unit 1) (seq.unit 2))))
 (check-sat)
 (get-value (x))

--- a/test/regress/cli/regress0/printer/issue10478.smt2
+++ b/test/regress/cli/regress0/printer/issue10478.smt2
@@ -1,0 +1,9 @@
+; EXPECT: sat
+; EXPECT: ((x (seq.++ (seq.unit 1) (seq.unit 2))))
+(set-option :produce-models true)
+(set-logic ALL)
+(declare-fun x () (Seq Int))
+(assert (seq.contains x (seq.unit 1)))
+(assert (seq.contains x (seq.unit 2)))
+(check-sat)
+(get-value (x))


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/10478.

Also fixes an issue where we were printing these constants in reverse order.

Update the ALF signature to account for these changes.