### PR TITLE
Simplify ProofRule::ARITH_MULT_TANGENT

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -1876,12 +1876,12 @@ enum ENUM(ProofRule) : uint32_t
    * **Arithmetic -- Multiplication tangent plane**
    *
    * .. math::
-   *   \inferruleSC{- \mid t, x, y, a, b, \sigma}{(t \leq tplane) \leftrightarrow ((x \leq a \land y \geq b) \lor (x \geq a \land y \leq b))}{if $\sigma = -1$}
+   *   \inferruleSC{- \mid x, y, a, b, \sigma}{(t \leq tplane) \leftrightarrow ((x \leq a \land y \geq b) \lor (x \geq a \land y \leq b))}{if $\sigma = -1$}
    *
-   *   \inferruleSC{- \mid t, x, y, a, b, \sigma}{(t \geq tplane) \leftrightarrow ((x \leq a \land y \leq b) \lor (x \geq a \land y \geq b))}{if $\sigma = 1$}
+   *   \inferruleSC{- \mid x, y, a, b, \sigma}{(t \geq tplane) \leftrightarrow ((x \leq a \land y \leq b) \lor (x \geq a \land y \geq b))}{if $\sigma = 1$}
    *
    * where :math:`x,y` are real terms (variables or extended terms),
-   * :math:`t = x \cdot y` (possibly under rewriting), :math:`a,b` are real
+   * :math:`t = x \cdot y`, :math:`a,b` are real
    * constants, :math:`\sigma \in \{ 1, -1\}` and :math:`tplane := b \cdot x + a \cdot y - a \cdot b` is the tangent plane of :math:`x \cdot y` at :math:`(a,b)`.
    * \endverbatim
    */

--- a/src/theory/arith/nl/ext/proof_checker.cpp
+++ b/src/theory/arith/nl/ext/proof_checker.cpp
@@ -122,14 +122,13 @@ Node ExtProofRuleChecker::checkInternal(ProofRule id,
     Assert(args[1].getType().isRealOrInt());
     Assert(args[2].getType().isRealOrInt());
     Assert(args[3].getType().isRealOrInt());
-    Assert(args[4].getType().isRealOrInt());
-    Assert(args[5].isConst() && args[5].getConst<Rational>().isIntegral());
-    Node t = args[0];
-    Node x = args[1];
-    Node y = args[2];
-    Node a = args[3];
-    Node b = args[4];
-    int sgn = args[5].getConst<Rational>().getNumerator().sgn();
+    Assert(args[4].isConst() && args[4].getConst<Rational>().isIntegral());
+    Node x = args[0];
+    Node y = args[1];
+    Node t = nm->mkNode(Kind::NONLINEAR_MULT, x, y);
+    Node a = args[2];
+    Node b = args[3];
+    int sgn = args[4].getConst<Rational>().getNumerator().sgn();
     Assert(sgn == -1 || sgn == 1);
     Node tplane = nm->mkNode(Kind::SUB,
                              nm->mkNode(Kind::ADD,

--- a/src/theory/arith/nl/ext/proof_checker.cpp
+++ b/src/theory/arith/nl/ext/proof_checker.cpp
@@ -117,7 +117,7 @@ Node ExtProofRuleChecker::checkInternal(ProofRule id,
   else if (id == ProofRule::ARITH_MULT_TANGENT)
   {
     Assert(children.empty());
-    Assert(args.size() == 6);
+    Assert(args.size() == 5);
     Assert(args[0].getType().isRealOrInt());
     Assert(args[1].getType().isRealOrInt());
     Assert(args[2].getType().isRealOrInt());

--- a/src/theory/arith/nl/ext/tangent_plane_check.cpp
+++ b/src/theory/arith/nl/ext/tangent_plane_check.cpp
@@ -134,9 +134,10 @@ void TangentPlaneCheck::check(bool asWaitingLemmas)
             {
               Node b1 = nm->mkNode(d == 0 ? Kind::GEQ : Kind::LEQ, b, b_v);
               Node b2 = nm->mkNode(d == 0 ? Kind::LEQ : Kind::GEQ, b, b_v);
+              Node t2 = nm->mkNode(Kind::NONLINEAR_MULT, a, b);
               Node tlem = nm->mkNode(
                   Kind::EQUAL,
-                  nm->mkNode(d == 0 ? Kind::LEQ : Kind::GEQ, t, tplane),
+                  nm->mkNode(d == 0 ? Kind::LEQ : Kind::GEQ, t2, tplane),
                   nm->mkNode(
                       Kind::OR,
                       nm->mkNode(Kind::AND, nm->mkNode(Kind::LEQ, a, a_v), b1),
@@ -151,8 +152,7 @@ void TangentPlaneCheck::check(bool asWaitingLemmas)
                 proof->addStep(tlem,
                                ProofRule::ARITH_MULT_TANGENT,
                                {},
-                               {t,
-                                a,
+                               {a,
                                 b,
                                 a_v,
                                 b_v,


### PR DESCRIPTION
Was previously not checking that t was the multiplication of a and b. This makes t = a*b by construction.