### PR TITLE
Fix placement of CVC5_EXPORT annotations

### DIFF
--- a/include/cvc5/cvc5.h
+++ b/include/cvc5/cvc5.h
@@ -283,7 +283,7 @@ class CVC5_EXPORT Result
  * @param r The result to be serialized to the given output stream.
  * @return The output stream.
  */
-std::ostream& operator<<(std::ostream& out, const Result& r) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, const Result& r);
 
 /* -------------------------------------------------------------------------- */
 /* SynthResult                                                                */
@@ -359,7 +359,7 @@ class CVC5_EXPORT SynthResult
  * @param r The result to be serialized to the given output stream.
  * @return The output stream.
  */
-std::ostream& operator<<(std::ostream& out, const SynthResult& r) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, const SynthResult& r);
 
 /* -------------------------------------------------------------------------- */
 /* Sort                                                                       */
@@ -943,7 +943,7 @@ class CVC5_EXPORT Sort
  * @param s The sort to be serialized to the given output stream.
  * @return The output stream.
  */
-std::ostream& operator<<(std::ostream& out, const Sort& s) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, const Sort& s);
 
 }  // namespace cvc5
 
@@ -1113,7 +1113,7 @@ class CVC5_EXPORT Op
  * @param op  The operator to be serialized to the given output stream.
  * @return The output stream.
  */
-std::ostream& operator<<(std::ostream& out, const Op& op) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, const Op& op);
 
 }  // namespace cvc5
 
@@ -1918,7 +1918,7 @@ class CVC5_EXPORT Term
  * @param t The term to be serialized to the given output stream.
  * @return The output stream.
  */
-std::ostream& operator<<(std::ostream& out, const Term& t) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, const Term& t);
 
 /**
  * Serialize a vector of terms to given stream.
@@ -1926,8 +1926,9 @@ std::ostream& operator<<(std::ostream& out, const Term& t) CVC5_EXPORT;
  * @param vector The vector of terms to be serialized to the given stream.
  * @return The output stream.
  */
+CVC5_EXPORT
 std::ostream& operator<<(std::ostream& out,
-                         const std::vector<Term>& vector) CVC5_EXPORT;
+                         const std::vector<Term>& vector);
 
 /**
  * Serialize a set of terms to the given stream.
@@ -1935,8 +1936,9 @@ std::ostream& operator<<(std::ostream& out,
  * @param set The set of terms to be serialized to the given stream.
  * @return The output stream.
  */
+CVC5_EXPORT
 std::ostream& operator<<(std::ostream& out,
-                         const std::set<Term>& set) CVC5_EXPORT;
+                         const std::set<Term>& set);
 
 /**
  * Serialize an unordered_set of terms to the given stream.
@@ -1945,9 +1947,9 @@ std::ostream& operator<<(std::ostream& out,
  * @param unordered_set The set of terms to be serialized to the given stream.
  * @return The output stream.
  */
+CVC5_EXPORT
 std::ostream& operator<<(std::ostream& out,
-                         const std::unordered_set<Term>& unordered_set)
-    CVC5_EXPORT;
+                         const std::unordered_set<Term>& unordered_set);
 
 /**
  * Serialize a map of terms to the given stream.
@@ -1957,8 +1959,9 @@ std::ostream& operator<<(std::ostream& out,
  * @return The output stream.
  */
 template <typename V>
+CVC5_EXPORT
 std::ostream& operator<<(std::ostream& out,
-                         const std::map<Term, V>& map) CVC5_EXPORT;
+                         const std::map<Term, V>& map);
 
 /**
  * Serialize an unordered_map of terms to the given stream.
@@ -1967,10 +1970,9 @@ std::ostream& operator<<(std::ostream& out,
  * @param unordered_map The map of terms to be serialized to the given stream.
  * @return The output stream.
  */
-template <typename V>
+template <typename V> CVC5_EXPORT
 std::ostream& operator<<(std::ostream& out,
-                         const std::unordered_map<Term, V>& unordered_map)
-    CVC5_EXPORT;
+                         const std::unordered_map<Term, V>& unordered_map);
 
 }  // namespace cvc5
 
@@ -2859,8 +2861,9 @@ class CVC5_EXPORT Datatype
  * @param dtdecl The datatype declaration to be serialized to the given stream.
  * @return The output stream.
  */
+CVC5_EXPORT
 std::ostream& operator<<(std::ostream& out,
-                         const DatatypeDecl& dtdecl) CVC5_EXPORT;
+                         const DatatypeDecl& dtdecl);
 
 /**
  * Serialize a datatype constructor declaration to given stream.
@@ -2868,8 +2871,9 @@ std::ostream& operator<<(std::ostream& out,
  * @param ctordecl The datatype constructor declaration to be serialized.
  * @return The output stream.
  */
+CVC5_EXPORT
 std::ostream& operator<<(std::ostream& out,
-                         const DatatypeConstructorDecl& ctordecl) CVC5_EXPORT;
+                         const DatatypeConstructorDecl& ctordecl);
 
 /**
  * Serialize a vector of datatype constructor declarations to given stream.
@@ -2878,9 +2882,9 @@ std::ostream& operator<<(std::ostream& out,
  * serialized to the given stream
  * @return The output stream.
  */
+CVC5_EXPORT
 std::ostream& operator<<(std::ostream& out,
-                         const std::vector<DatatypeConstructorDecl>& vector)
-    CVC5_EXPORT;
+                         const std::vector<DatatypeConstructorDecl>& vector);
 
 /**
  * Serialize a datatype to given stream.
@@ -2888,7 +2892,7 @@ std::ostream& operator<<(std::ostream& out,
  * @param dtype The datatype to be serialized to given stream.
  * @return The output stream.
  */
-std::ostream& operator<<(std::ostream& out, const Datatype& dtype) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, const Datatype& dtype);
 
 /**
  * Serialize a datatype constructor to given stream.
@@ -2896,8 +2900,9 @@ std::ostream& operator<<(std::ostream& out, const Datatype& dtype) CVC5_EXPORT;
  * @param ctor The datatype constructor to be serialized to given stream.
  * @return The output stream.
  */
+CVC5_EXPORT
 std::ostream& operator<<(std::ostream& out,
-                         const DatatypeConstructor& ctor) CVC5_EXPORT;
+                         const DatatypeConstructor& ctor);
 
 /**
  * Serialize a datatype selector to given stream.
@@ -2905,8 +2910,9 @@ std::ostream& operator<<(std::ostream& out,
  * @param stor The datatype selector to be serialized to given stream.
  * @return The output stream.
  */
+CVC5_EXPORT
 std::ostream& operator<<(std::ostream& out,
-                         const DatatypeSelector& stor) CVC5_EXPORT;
+                         const DatatypeSelector& stor);
 
 /* -------------------------------------------------------------------------- */
 /* Grammar                                                                    */
@@ -2993,7 +2999,7 @@ class CVC5_EXPORT Grammar
  * @param g The grammar to be serialized to the given output stream.
  * @return The output stream.
  */
-std::ostream& operator<<(std::ostream& out, const Grammar& g) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, const Grammar& g);
 
 /* -------------------------------------------------------------------------- */
 /* Options                                                                    */
@@ -3163,7 +3169,7 @@ struct CVC5_EXPORT OptionInfo
 /**
  * Print an `OptionInfo` object to an ``std::ostream``.
  */
-std::ostream& operator<<(std::ostream& os, const OptionInfo& oi) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& os, const OptionInfo& oi);
 
 /* -------------------------------------------------------------------------- */
 /* Statistics                                                                 */
@@ -3189,7 +3195,7 @@ class CVC5_EXPORT Stat
 
  public:
   friend class Statistics;
-  friend std::ostream& operator<<(std::ostream& os, const Stat& sv);
+  CVC5_EXPORT friend std::ostream& operator<<(std::ostream& os, const Stat& sv);
   /** Representation of a histogram: maps names to frequencies. */
   using HistogramData = std::map<std::string, uint64_t>;
   /**
@@ -3269,7 +3275,7 @@ class CVC5_EXPORT Stat
 /**
  * Print a `Stat` object to an ``std::ostream``.
  */
-std::ostream& operator<<(std::ostream& os, const Stat& sv) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& os, const Stat& sv);
 
 /**
  * \verbatim embed:rst:leading-asterisk
@@ -3347,8 +3353,8 @@ class CVC5_EXPORT Statistics
   /** Internal data */
   BaseType d_stats;
 };
-std::ostream& operator<<(std::ostream& out,
-                         const Statistics& stats) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out,
+                         const Statistics& stats);
 
 /* -------------------------------------------------------------------------- */
 /* Proof                                                                      */

--- a/include/cvc5/cvc5.h
+++ b/include/cvc5/cvc5.h
@@ -1927,8 +1927,7 @@ CVC5_EXPORT std::ostream& operator<<(std::ostream& out, const Term& t);
  * @return The output stream.
  */
 CVC5_EXPORT
-std::ostream& operator<<(std::ostream& out,
-                         const std::vector<Term>& vector);
+std::ostream& operator<<(std::ostream& out, const std::vector<Term>& vector);
 
 /**
  * Serialize a set of terms to the given stream.
@@ -1937,8 +1936,7 @@ std::ostream& operator<<(std::ostream& out,
  * @return The output stream.
  */
 CVC5_EXPORT
-std::ostream& operator<<(std::ostream& out,
-                         const std::set<Term>& set);
+std::ostream& operator<<(std::ostream& out, const std::set<Term>& set);
 
 /**
  * Serialize an unordered_set of terms to the given stream.
@@ -1959,9 +1957,8 @@ std::ostream& operator<<(std::ostream& out,
  * @return The output stream.
  */
 template <typename V>
-CVC5_EXPORT
-std::ostream& operator<<(std::ostream& out,
-                         const std::map<Term, V>& map);
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out,
+                                     const std::map<Term, V>& map);
 
 /**
  * Serialize an unordered_map of terms to the given stream.
@@ -1970,9 +1967,9 @@ std::ostream& operator<<(std::ostream& out,
  * @param unordered_map The map of terms to be serialized to the given stream.
  * @return The output stream.
  */
-template <typename V> CVC5_EXPORT
-std::ostream& operator<<(std::ostream& out,
-                         const std::unordered_map<Term, V>& unordered_map);
+template <typename V>
+CVC5_EXPORT std::ostream& operator<<(
+    std::ostream& out, const std::unordered_map<Term, V>& unordered_map);
 
 }  // namespace cvc5
 
@@ -2862,8 +2859,7 @@ class CVC5_EXPORT Datatype
  * @return The output stream.
  */
 CVC5_EXPORT
-std::ostream& operator<<(std::ostream& out,
-                         const DatatypeDecl& dtdecl);
+std::ostream& operator<<(std::ostream& out, const DatatypeDecl& dtdecl);
 
 /**
  * Serialize a datatype constructor declaration to given stream.
@@ -2901,8 +2897,7 @@ CVC5_EXPORT std::ostream& operator<<(std::ostream& out, const Datatype& dtype);
  * @return The output stream.
  */
 CVC5_EXPORT
-std::ostream& operator<<(std::ostream& out,
-                         const DatatypeConstructor& ctor);
+std::ostream& operator<<(std::ostream& out, const DatatypeConstructor& ctor);
 
 /**
  * Serialize a datatype selector to given stream.
@@ -2911,8 +2906,7 @@ std::ostream& operator<<(std::ostream& out,
  * @return The output stream.
  */
 CVC5_EXPORT
-std::ostream& operator<<(std::ostream& out,
-                         const DatatypeSelector& stor);
+std::ostream& operator<<(std::ostream& out, const DatatypeSelector& stor);
 
 /* -------------------------------------------------------------------------- */
 /* Grammar                                                                    */
@@ -3354,7 +3348,7 @@ class CVC5_EXPORT Statistics
   BaseType d_stats;
 };
 CVC5_EXPORT std::ostream& operator<<(std::ostream& out,
-                         const Statistics& stats);
+                                     const Statistics& stats);
 
 /* -------------------------------------------------------------------------- */
 /* Proof                                                                      */

--- a/include/cvc5/cvc5_kind.h
+++ b/include/cvc5/cvc5_kind.h
@@ -5630,15 +5630,15 @@ const char* cvc5_kind_to_string(Cvc5Kind kind);
  * @note This function is deprecated and replaced by
  *       `std::to_string(Kind kind)`. It will be removed in a future release.
  */
-[[deprecated("use std::to_string(Kind) instead.")]] std::string kindToString(
-    Kind kind) CVC5_EXPORT;
+[[deprecated("use std::to_string(Kind) instead.")]]
+CVC5_EXPORT std::string kindToString(Kind kind);
 /**
  * Serialize a kind to given stream.
  * @param out  The output stream.
  * @param kind The kind to be serialized to the given output stream.
  * @return The output stream.
  */
-std::ostream& operator<<(std::ostream& out, Kind kind) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, Kind kind);
 
 }  // namespace cvc5
 
@@ -5931,15 +5931,15 @@ const char* cvc5_sort_kind_to_string(Cvc5SortKind kind);
  *       `std::to_string(SortKind kind)`. It will be removed in a future
  *       release.
  */
-[[deprecated("use std::to_string(SortKind) instead.")]] std::string
-sortKindToString(SortKind k) CVC5_EXPORT;
+[[deprecated("use std::to_string(SortKind) instead.")]]
+CVC5_EXPORT std::string sortKindToString(SortKind k);
 /**
  * Serialize a kind to given stream.
  * @param out the output stream
  * @param k the sort kind to be serialized to the given output stream
  * @return the output stream
  */
-std::ostream& operator<<(std::ostream& out, SortKind k) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, SortKind k);
 
 }  // namespace cvc5
 

--- a/include/cvc5/cvc5_kind.h
+++ b/include/cvc5/cvc5_kind.h
@@ -5630,8 +5630,8 @@ const char* cvc5_kind_to_string(Cvc5Kind kind);
  * @note This function is deprecated and replaced by
  *       `std::to_string(Kind kind)`. It will be removed in a future release.
  */
-[[deprecated("use std::to_string(Kind) instead.")]]
-CVC5_EXPORT std::string kindToString(Kind kind);
+[[deprecated("use std::to_string(Kind) instead.")]] CVC5_EXPORT std::string
+kindToString(Kind kind);
 /**
  * Serialize a kind to given stream.
  * @param out  The output stream.
@@ -5931,8 +5931,8 @@ const char* cvc5_sort_kind_to_string(Cvc5SortKind kind);
  *       `std::to_string(SortKind kind)`. It will be removed in a future
  *       release.
  */
-[[deprecated("use std::to_string(SortKind) instead.")]]
-CVC5_EXPORT std::string sortKindToString(SortKind k);
+[[deprecated("use std::to_string(SortKind) instead.")]] CVC5_EXPORT std::string
+sortKindToString(SortKind k);
 /**
  * Serialize a kind to given stream.
  * @param out the output stream

--- a/include/cvc5/cvc5_types.h
+++ b/include/cvc5/cvc5_types.h
@@ -92,7 +92,7 @@ const char* cvc5_unknown_explanation_to_string(Cvc5UnknownExplanation exp);
  * @param e The explanation to be serialized to the given output stream
  * @return The output stream
  */
-std::ostream& operator<<(std::ostream& out, UnknownExplanation e) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, UnknownExplanation e);
 }  // namespace cvc5
 
 namespace std {
@@ -190,7 +190,7 @@ const char* cvc5_rm_to_string(Cvc5RoundingMode rm);
  * @param rm The rounding mode to be serialized to the given output stream
  * @return The output stream
  */
-std::ostream& operator<<(std::ostream& out, RoundingMode rm) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, RoundingMode rm);
 }  // namespace cvc5
 namespace std {
 std::string to_string(cvc5::RoundingMode rm);
@@ -248,7 +248,7 @@ const char* cvc5_modes_block_models_mode_to_string(Cvc5BlockModelsMode mode);
  * @param mode The mode.
  * @return The output stream
  */
-std::ostream& operator<<(std::ostream& out, BlockModelsMode mode) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, BlockModelsMode mode);
 }
 
 namespace std {
@@ -347,7 +347,7 @@ const char* cvc5_modes_learned_lit_type_to_string(Cvc5LearnedLitType type);
  * @param type The learned literal type.
  * @return The output stream
  */
-std::ostream& operator<<(std::ostream& out, LearnedLitType type) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, LearnedLitType type);
 }
 
 namespace std {
@@ -447,7 +447,7 @@ const char* cvc5_modes_proof_component_to_string(Cvc5ProofComponent pc);
  * @param pc The proof component.
  * @return The output stream
  */
-std::ostream& operator<<(std::ostream& out, ProofComponent pc) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, ProofComponent pc);
 }
 
 namespace std {
@@ -508,7 +508,7 @@ const char* cvc5_modes_proof_format_to_string(Cvc5ProofFormat format);
  * @param format The proof format.
  * @return The output stream
  */
-std::ostream& operator<<(std::ostream& out, ProofFormat format) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, ProofFormat format);
 }
 
 namespace std {
@@ -603,7 +603,7 @@ const char* cvc5_modes_find_synthesis_target_to_string(
  * @param target The synthesis find target.
  * @return The output stream
  */
-std::ostream& operator<<(std::ostream& out, FindSynthTarget target) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, FindSynthTarget target);
 }
 
 namespace std {
@@ -659,7 +659,7 @@ const char* cvc5_modes_input_language_to_string(Cvc5InputLanguage lang);
  * @param lang The language to be serialized to the given output stream
  * @return The output stream
  */
-std::ostream& operator<<(std::ostream& out, InputLanguage lang) CVC5_EXPORT;
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, InputLanguage lang);
 }  // namespace cvc5::modes
 
 namespace std {


### PR DESCRIPTION
The CVC5_EXPORT macro uses the extended attribute syntax `__declspec(...)`. According to the MSVC doc:
> The __declspec keywords should be placed at the beginning of a simple declaration.

This PR fixes the CVC5_EXPORT annotations that were misplaced. Resolves #10475.