### PR TITLE
Add missing handling of empty vars when configuring grammar for solveInterpolation.

### DIFF
--- a/src/theory/datatypes/sygus_datatype_utils.cpp
+++ b/src/theory/datatypes/sygus_datatype_utils.cpp
@@ -425,7 +425,11 @@ TypeNode substituteAndGeneralizeSygusType(TypeNode sdt,
     }
   }
   // make the sygus variable list for the formal argument list
-  Node abvl = nm->mkNode(Kind::BOUND_VAR_LIST, formalVars);
+  Node abvl;
+  if (!formalVars.empty())
+  {
+    abvl = nm->mkNode(Kind::BOUND_VAR_LIST, formalVars);
+  }
   Trace("sygus-abduct-debug") << "...finish" << std::endl;
 
   // must convert all constructors to version with variables in "vars"

--- a/test/unit/api/cpp/solver_black.cpp
+++ b/test/unit/api/cpp/solver_black.cpp
@@ -602,6 +602,22 @@ TEST_F(TestApiBlackSolver, getInterpolant)
   Term output2 = d_solver->getInterpolant(conj2, g);
   // interpolant must be true
   ASSERT_EQ(output2, truen);
+
+  TermManager tm;
+  Solver slv(tm);
+  slv.setOption("produce-interpolants", "true");
+  Term xx = tm.mkConst(intSort, "x");
+  Term yy = tm.mkConst(intSort, "y");
+  Term zzero = tm.mkInteger(0);
+  Term sstart = tm.mkVar(tm.getBooleanSort());
+  Grammar gg = slv.mkGrammar({}, {sstart});
+  gg.addRule(sstart, tm.mkTrue());
+  Term cconj2 = tm.mkTerm(Kind::EQUAL, {zzero, zzero});
+  ASSERT_NO_THROW(slv.getInterpolant(cconj2, gg));
+  // this will throw when NodeManager is not a singleton anymore
+  ASSERT_NO_THROW(slv.getInterpolant(conj2));
+  ASSERT_NO_THROW(slv.getInterpolant(conj2, gg));
+  ASSERT_NO_THROW(slv.getInterpolant(cconj2, g));
 }
 
 TEST_F(TestApiBlackSolver, getInterpolantNext)


### PR DESCRIPTION
In `datatypes::utils::substituteAndGeneralizeSygusType`, the case when the list of formal arguments is empty was not handled. This was triggered by a call to getInterpolant, added as unit test.