### PR TITLE
Fix ARITH_POLY_NORM in ALF signature

### DIFF
--- a/proofs/alf/cvc5/Cvc5.smt3
+++ b/proofs/alf/cvc5/Cvc5.smt3
@@ -134,13 +134,13 @@
 (program is_poly_norm ((T Type) (U Type) (a T) (b T) (a1 U) (a2 U) (b1 U) (b2 U))
   (T T) Bool
   (
-    ((is_poly_norm (> a1 a2) (> b1 b2))   (is_poly_norm_arith (- a1 a2) (- b1 b2)))
-    ((is_poly_norm (>= a1 a2) (>= b1 b2)) (is_poly_norm_arith (- a1 a2) (- b1 b2)))
-    ((is_poly_norm (<= a1 a2) (<= b1 b2)) (is_poly_norm_arith (- a1 a2) (- b1 b2)))
-    ((is_poly_norm (< a1 a2) (< b1 b2))   (is_poly_norm_arith (- a1 a2) (- b1 b2)))
+    ((is_poly_norm (> a1 a2) (> b1 b2))   (is_poly_norm_arith_mod_c (- a1 a2) (- b1 b2) true))
+    ((is_poly_norm (>= a1 a2) (>= b1 b2)) (is_poly_norm_arith_mod_c (- a1 a2) (- b1 b2) true))
+    ((is_poly_norm (<= a1 a2) (<= b1 b2)) (is_poly_norm_arith_mod_c (- a1 a2) (- b1 b2) true))
+    ((is_poly_norm (< a1 a2) (< b1 b2))   (is_poly_norm_arith_mod_c (- a1 a2) (- b1 b2) true))
     ((is_poly_norm (= a1 a2) (= b1 b2))   (alf.ite (is_arith_type (alf.typeof a1)) 
                                           (alf.ite (is_arith_type (alf.typeof b1))
-                                            (is_poly_norm_arith (- a1 a2) (- b1 b2))
+                                            (is_poly_norm_arith_mod_pos (- a1 a2) (- b1 b2) false)
                                             false)
                                           false)) ; TODO: bv
     ((is_poly_norm a b)                   (alf.ite (is_arith_type (alf.typeof a)) 

--- a/proofs/alf/cvc5/Cvc5.smt3
+++ b/proofs/alf/cvc5/Cvc5.smt3
@@ -140,7 +140,7 @@
     ((is_poly_norm (< a1 a2) (< b1 b2))   (is_poly_norm_arith_mod_c (- a1 a2) (- b1 b2) true))
     ((is_poly_norm (= a1 a2) (= b1 b2))   (alf.ite (is_arith_type (alf.typeof a1)) 
                                           (alf.ite (is_arith_type (alf.typeof b1))
-                                            (is_poly_norm_arith_mod_pos (- a1 a2) (- b1 b2) false)
+                                            (is_poly_norm_arith_mod_c (- a1 a2) (- b1 b2) false)
                                             false)
                                           false)) ; TODO: bv
     ((is_poly_norm a b)                   (alf.ite (is_arith_type (alf.typeof a)) 

--- a/proofs/alf/cvc5/programs/Arith.smt3
+++ b/proofs/alf/cvc5/programs/Arith.smt3
@@ -151,7 +151,7 @@
   (
     ((poly_is_equal_mod_c @poly.zero @poly.zero reqPos)                         true)
     ((poly_is_equal_mod_c (@poly (@mon a c1) p1) (@poly (@mon a c2) p2) reqPos) (let ((c (alf.qdiv c2 c1))) 
-                                                                                (alf.requires (alf.or reqPos (alf.not (alf.is_neg c))) true
+                                                                                (alf.requires (alf.and reqPos (alf.is_neg c)) false
                                                                                 (poly_is_equal_mod_c_rec c p1 p2))))
   )
 )

--- a/proofs/alf/cvc5/programs/Arith.smt3
+++ b/proofs/alf/cvc5/programs/Arith.smt3
@@ -141,14 +141,20 @@
 )
 
 ; Returns true if the two given polynomials are equivalent up to modulus by a (non-zero) coefficient.
-(program poly_is_equal_mod_c ((T Type) (c1 Real) (a T) (c2 Real) (p1 @Polynomial :list) (p2 @Polynomial :list))
-  (@Polynomial @Polynomial) Bool
+(program poly_is_equal_mod_c ((T Type) (c1 Real) (a T) (c2 Real) (p1 @Polynomial :list) (p2 @Polynomial :list) (reqPos Bool))
+  (@Polynomial @Polynomial Bool) Bool
   (
-    ((poly_is_equal_mod_c @poly.zero @poly.zero)                          true)
-    ((poly_is_equal_mod_c (@poly (@mon a c1) p1) (@poly (@mon a c2) p2))  (poly_is_equal_mod_c_rec (alf.qdiv c2 c1) p1 p2))
+    ((poly_is_equal_mod_c @poly.zero @poly.zero reqPos)                         true)
+    ((poly_is_equal_mod_c (@poly (@mon a c1) p1) (@poly (@mon a c2) p2) reqPos) (let ((c (alf.qdiv c2 c1))) 
+                                                                                (alf.requires (alf.or reqPos (alf.not (alf.is_neg c))) true
+                                                                                (poly_is_equal_mod_c_rec c p1 p2))
   )
 )
 
 (define is_poly_norm_arith ((T Type :implicit) (a T) (b T))
-  (poly_is_equal_mod_c (get_poly_norm a) (get_poly_norm b))
+  (alf.is_eq (get_poly_norm a) (get_poly_norm b))
+)
+
+(define is_poly_norm_arith_mod_c ((T Type :implicit) (a T) (b T) (reqPos Bool))
+  (poly_is_equal_mod_c (get_poly_norm a) (get_poly_norm b) reqPos)
 )

--- a/proofs/alf/cvc5/programs/Arith.smt3
+++ b/proofs/alf/cvc5/programs/Arith.smt3
@@ -140,21 +140,23 @@
   )
 )
 
-; Returns true if the two given polynomials are equivalent up to modulus by a (non-zero) coefficient.
+; Returns true if a and b normalize to the same polynomial
+(define is_poly_norm_arith ((T Type :implicit) (a T) (b T))
+  (alf.is_eq (get_poly_norm a) (get_poly_norm b))
+)
+
+; Returns true if the two given polynomials are equivalent up to modulus by a (non-zero, positive if reqPos is true) coefficient.
 (program poly_is_equal_mod_c ((T Type) (c1 Real) (a T) (c2 Real) (p1 @Polynomial :list) (p2 @Polynomial :list) (reqPos Bool))
   (@Polynomial @Polynomial Bool) Bool
   (
     ((poly_is_equal_mod_c @poly.zero @poly.zero reqPos)                         true)
     ((poly_is_equal_mod_c (@poly (@mon a c1) p1) (@poly (@mon a c2) p2) reqPos) (let ((c (alf.qdiv c2 c1))) 
                                                                                 (alf.requires (alf.or reqPos (alf.not (alf.is_neg c))) true
-                                                                                (poly_is_equal_mod_c_rec c p1 p2))
+                                                                                (poly_is_equal_mod_c_rec c p1 p2))))
   )
 )
 
-(define is_poly_norm_arith ((T Type :implicit) (a T) (b T))
-  (alf.is_eq (get_poly_norm a) (get_poly_norm b))
-)
-
+; Returns true if a and b normalize to polynomials that are same up to modulus by a (non-zero, positive if reqPos is true) coefficient.
 (define is_poly_norm_arith_mod_c ((T Type :implicit) (a T) (b T) (reqPos Bool))
   (poly_is_equal_mod_c (get_poly_norm a) (get_poly_norm b) reqPos)
 )


### PR DESCRIPTION
This may be further refactored if/when we split `ARITH_POLY_NORM` to `ARITH_POLY_NORM`/`ARITH_POLY_REL_NORM`.