### PR TITLE
Update alf version

### DIFF
--- a/contrib/get-alf-checker
+++ b/contrib/get-alf-checker
@@ -24,7 +24,7 @@ ALFC_DIR="$BASE_DIR/alf-checker"
 mkdir -p $ALFC_DIR
 
 # download and unpack ALFC
-ALF_VERSION="eca2cbd4e27712c35a9111a3c9c517f49c593500"
+ALF_VERSION="59264b18b70f1f93e2fda6a1ad10cf6c77c3bb91"
 download "https://github.com/cvc5/alfc/archive/$ALF_VERSION.tar.gz" $BASE_DIR/tmp/alfc.tgz
 tar --strip 1 -xzf $BASE_DIR/tmp/alfc.tgz -C $ALFC_DIR
 

--- a/proofs/alf/cvc5/Cvc5.smt3
+++ b/proofs/alf/cvc5/Cvc5.smt3
@@ -97,7 +97,7 @@
                                            (alf.ite (alf.is_eq d 0) 0 (alf.zdiv (run_evaluate x) d))))
 
       ; strings
-      ((run_evaluate (str.++ x))         (run_evaluate x))      ; don't evaluate alf.nil
+      ((run_evaluate (str.++ x))         (run_evaluate x))      ; don't evaluate alf.null
       ((run_evaluate (str.++ x ys))      (alf.concat (run_evaluate x) (run_evaluate ys)))
       ((run_evaluate (str.len x))        (alf.len (run_evaluate x)))
       ((run_evaluate (str.substr x n m)) (let ((r (run_evaluate n)))

--- a/proofs/alf/cvc5/programs/Strings.smt3
+++ b/proofs/alf/cvc5/programs/Strings.smt3
@@ -65,7 +65,7 @@
 )
 
 ; Return reverse of t if rev = true, return t unchanged otherwise.
-(define string_rev ((U Type :implicit) (rev Bool) (t U)) (alf.ite rev (nary.reverse str.++ alf.nil t) t))
+(define string_rev ((U Type :implicit) (rev Bool) (t U)) (alf.ite rev (nary.reverse str.++ alf.null t) t))
 
 ;;-------------------- Reductions
 
@@ -199,7 +199,7 @@
 (program re_unfold_pos_concat_rec ((t String) (r1 RegLan) (r2 RegLan :list) (ro RegLan) (i Int))
   (String RegLan RegLan Int) (@Pair String Bool)
   (
-    ((re_unfold_pos_concat_rec t alf.nil ro i)       (@pair alf.nil true))
+    ((re_unfold_pos_concat_rec t alf.null ro i)       (@pair alf.null true))
     ((re_unfold_pos_concat_rec t (re.++ r1 r2) ro i)
       ; match recursive call
       (alf.match ((c String :list) (M Bool :list))
@@ -234,7 +234,7 @@
 (program non_empty_concats ((U Type) (t U) (s U :list))
   (U Type) Bool
   (
-    ((non_empty_concats alf.nil U)       alf.nil)
+    ((non_empty_concats alf.null U)       alf.null)
     ((non_empty_concats (str.++ t s) U)  (alf.cons and (not (= t (mk_emptystr U))) (non_empty_concats s U)))
   )
 )
@@ -247,12 +247,12 @@
 
 ; Get first character or empty string from term t.
 ; If t is of the form (str.++ t ...), return t.
-; If t is of the form alf.nil, return alf.nil.
+; If t is of the form alf.null, return alf.null.
 (program string_head_or_empty ((U Type) (T Type) (t U) (tail U :list) (s T))
   (U) U
   (
     ((string_head_or_empty (str.++ t tail)) t)
-    ((string_head_or_empty alf.nil)         alf.nil)
+    ((string_head_or_empty alf.null)         alf.null)
   )
 )
 
@@ -270,29 +270,29 @@
 ; str.++ application corresponding to a string term in cvc5 rewritten form.
 ; It returns the flattened form such that there are no nested applications of
 ; str.++. For example, given input:
-;    (str.++ "AB" (str.++ x alf.nil))
+;    (str.++ "AB" (str.++ x alf.null))
 ; we return:
-;    (str.++ "A" (str.++ "B" (str.++ x alf.nil)))
+;    (str.++ "A" (str.++ "B" (str.++ x alf.null)))
 ; Notice that this is done for all word constants in the chain recursively.
 ; It does not insist that the nested concatenations are over characters only.
 ; This rule may fail if s is not a str.++ application corresponding to a term
 ; in cvc5 rewritten form.
 
 ; Helper for below, assumes t is a non-empty word constant.
-; For example, given "AB", this returns (str.++ "A" (str.++ "B" alf.nil)).
+; For example, given "AB", this returns (str.++ "A" (str.++ "B" alf.null)).
 (program string_flatten_word ((t String))
   (String) String
   (
     ((string_flatten_word t) 
       (alf.ite (string_check_length_one t)
-        (alf.cons str.++ t alf.nil)
+        (alf.cons str.++ t alf.null)
         (alf.cons str.++ (alf.extract t 0 0) (string_flatten_word (alf.extract t 1 (alf.len t))))))
   )
 )
 (program string_flatten ((U Type) (t U) (tail U :list) (tail2 U :list))
   (U) U
   (
-    ((string_flatten alf.nil) alf.nil)
+    ((string_flatten alf.null) alf.null)
     ; required for sequences
     ((string_flatten (str.++ (str.++ t tail2) tail)) 
         (alf.concat str.++ (str.++ t tail2) (string_flatten tail)))
@@ -311,9 +311,9 @@
 ; whose first component corresponds to a word constant, and whose second
 ; component is a str.++ application whose first element is not a character.
 ; For example, for:
-;   (str.++ "A" (str.++ "B" (str.++ x alf.nil)))
+;   (str.++ "A" (str.++ "B" (str.++ x alf.null)))
 ; We return:
-;   (@pair "AB" (str.++ x alf.nil))
+;   (@pair "AB" (str.++ x alf.null))
 (program string_collect_acc ((U Type) (t U) (tail String :list))
   (U) (@Pair U U)
   (
@@ -324,32 +324,32 @@
         (alf.match ((s1 U) (s2 U)) 
           (string_collect_acc tail)
           (
-            ((@pair alf.nil s2)  (@pair t s2))
+            ((@pair alf.null s2)  (@pair t s2))
             ((@pair s1 s2)       (@pair (alf.concat t s1) s2))    ; concatentate the constant
           )
         )
-        (@pair alf.nil (str.++ t tail))))
-    ((string_collect_acc alf.nil)            (@pair alf.nil alf.nil))
+        (@pair alf.null (str.++ t tail))))
+    ((string_collect_acc alf.null)            (@pair alf.null alf.null))
   )
 )
 
 ; Collect adjacent constants for the prefix of string s. For example:
-;    (str.++ "A" (str.++ "B" (str.++ x alf.nil)))
+;    (str.++ "A" (str.++ "B" (str.++ x alf.null)))
 ; we return:
-;    (str.++ (str.++ "A" (str.++ "B" alf.nil)) (str.++ x alf.nil))
+;    (str.++ (str.++ "A" (str.++ "B" alf.null)) (str.++ x alf.null))
 ; This side condition may fail if s is not a str.++ application.
 ; Notice that the collection of constants is done for all word constants in the
 ; term s recursively.
 (program string_collect ((U Type) (t U) (s U :list))
   (U) U
   (
-    ((string_collect alf.nil)       alf.nil)
+    ((string_collect alf.null)       alf.null)
     ((string_collect (str.++ t s))
       (alf.match ((s1 U) (s2 U))
         (string_collect_acc (str.++ t s))
         (
           ; did not strip a constant prefix, just append t to the result of processing s
-          ((@pair alf.nil s2)
+          ((@pair alf.null s2)
             (alf.cons str.++ t (string_collect s)))
           ; stripped a constant prefix, append it to second term in the pair
           ((@pair s1 s2)
@@ -382,7 +382,7 @@
 ; (3) (optionally) reverse.
 (define string_to_flat_form ((U Type :implicit) (s U) (rev Bool))
   ; intro, flatten, reverse
-  (string_rev rev (string_flatten (nary.intro str.++ (mk_emptystr (alf.typeof s)) alf.nil s)))
+  (string_rev rev (string_flatten (nary.intro str.++ (mk_emptystr (alf.typeof s)) alf.null s)))
 )
 
 ; Converts a term in "flat form" to a term that is in a form that corresponds
@@ -393,5 +393,5 @@
 ; (3) eliminate n-ary form to its element if the term is a singleton list.
 (define string_from_flat_form ((U Type :implicit) (s U) (rev Bool))
   ; reverse, collect, elim
-  (nary.elim str.++ alf.nil (mk_emptystr (alf.typeof s)) (string_collect (string_rev rev s)))
+  (nary.elim str.++ alf.null (mk_emptystr (alf.typeof s)) (string_collect (string_rev rev s)))
 )

--- a/proofs/alf/cvc5/rules/Strings.smt3
+++ b/proofs/alf/cvc5/rules/Strings.smt3
@@ -34,7 +34,7 @@
 (define string_is_prefix ((U Type :implicit) (s U) (s1 U) (rev Bool))
   (let ((sf (string_to_flat_form s rev)))
   (let ((sf1 (string_to_flat_form s1 rev)))
-  (nary.is_prefix str.++ alf.nil sf1 sf)))
+  (nary.is_prefix str.++ alf.null sf1 sf)))
 )
 
 ; ProofRule::CONCAT_UNIFY
@@ -79,10 +79,10 @@
           (let ((ct (string_head_or_empty ts)))
             ; ensure they are disequal, return false
             (alf.requires
-              (alf.ite (alf.is_eq cs alf.nil)
+              (alf.ite (alf.is_eq cs alf.null)
                 (string_check_length_one ct)
                 (alf.ite (string_check_length_one cs)
-                  (alf.ite (alf.is_eq ct alf.nil)
+                  (alf.ite (alf.is_eq ct alf.null)
                     true
                     (alf.ite (string_check_length_one ct)
                       (alf.not (alf.is_eq cs ct))

--- a/proofs/alf/cvc5/rules/Uf.smt3
+++ b/proofs/alf/cvc5/rules/Uf.smt3
@@ -63,14 +63,14 @@
     ((-> U U) Bool) Bool
     (
         ((mk_nary_cong_lhs f (and (= s1 s2) tail)) (f s1 (mk_nary_cong_lhs f tail)))
-        ((mk_nary_cong_lhs f true)                 (alf.emptylist f))
+        ((mk_nary_cong_lhs f true)                 (alf.nil f))
     )
 )
 (program mk_nary_cong_rhs ((U Type) (f (-> U U)) (s1 U) (s2 U) (tail Bool :list))
     ((-> U U) Bool) Bool
     (
         ((mk_nary_cong_rhs f (and (= s1 s2) tail)) (f s2 (mk_nary_cong_rhs f tail)))
-        ((mk_nary_cong_rhs f true)                 (alf.emptylist f))
+        ((mk_nary_cong_rhs f true)                 (alf.nil f))
     )
 )
 


### PR DESCRIPTION
Version uses syntax `alf.nil` instead of `alf.emptylist`.