### PR TITLE
Resolve TODO from in `cmake/FindCryptoMiniSat.cmake`

### DIFF
--- a/cmake/FindCryptoMiniSat.cmake
+++ b/cmake/FindCryptoMiniSat.cmake
@@ -26,12 +26,6 @@ if(cryptominisat5_FOUND)
   set(CryptoMiniSat_FOUND_SYSTEM TRUE)
   add_library(CryptoMiniSat INTERFACE IMPORTED GLOBAL)
   target_link_libraries(CryptoMiniSat INTERFACE cryptominisat5)
-  # TODO(gereon): remove this when
-  # https://github.com/msoos/cryptominisat/pull/645 is merged
-  set_target_properties(
-    CryptoMiniSat PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
-                             "${CRYPTOMINISAT5_INCLUDE_DIRS}"
-  )
 endif()
 
 if(NOT CryptoMiniSat_FOUND_SYSTEM)
@@ -85,10 +79,6 @@ if(NOT CryptoMiniSat_FOUND_SYSTEM)
   add_library(CryptoMiniSat STATIC IMPORTED GLOBAL)
   set_target_properties(
     CryptoMiniSat PROPERTIES IMPORTED_LOCATION "${CryptoMiniSat_LIBRARIES}"
-  )
-  set_target_properties(
-    CryptoMiniSat PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
-                             "${CryptoMiniSat_INCLUDE_DIR}"
   )
 endif()
 


### PR DESCRIPTION
When 39ea1d8a149 changed external SAT solvers from being `contrib` scripts to being `cmake` scripts, there was a workaround implemented due to:

- https://github.com/msoos/cryptominisat/pull/645

There was a TODO that stated the workaround should be removed once https://github.com/msoos/cryptominisat/pull/645 was resolved.

Given that https://github.com/msoos/cryptominisat/pull/645 is resolved, this PR addresses the TODO and removes the workaround.

Signed-off-by: Andrew V. Teylu <andrew@tey.lu>