### PR TITLE
Make exception types polymorphic

### DIFF
--- a/include/cvc5/cvc5.h
+++ b/include/cvc5/cvc5.h
@@ -96,6 +96,12 @@ class CVC5_EXPORT CVC5ApiException : public std::exception
    * @param stream The error message.
    */
   CVC5ApiException(const std::stringstream& stream) : d_msg(stream.str()) {}
+
+  /**
+   * Virtual default destructor.
+   */
+  virtual ~CVC5ApiException() = default;
+
   /**
    * Retrieve the message from this exception.
    * @return The error message.
@@ -145,6 +151,11 @@ class CVC5_EXPORT CVC5ApiRecoverableException : public CVC5ApiException
       : CVC5ApiException(stream.str())
   {
   }
+
+  /**
+   * Virtual default destructor.
+   */
+  virtual ~CVC5ApiRecoverableException() = default;
 };
 
 /**
@@ -171,6 +182,11 @@ class CVC5_EXPORT CVC5ApiUnsupportedException
       : CVC5ApiRecoverableException(stream.str())
   {
   }
+
+  /**
+   * Virtual default destructor.
+   */
+  virtual ~CVC5ApiUnsupportedException() = default;
 };
 
 /**
@@ -196,6 +212,11 @@ class CVC5_EXPORT CVC5ApiOptionException : public CVC5ApiRecoverableException
       : CVC5ApiRecoverableException(stream.str())
   {
   }
+
+  /**
+   * Virtual default destructor.
+   */
+  virtual ~CVC5ApiOptionException() = default;
 };
 
 /* -------------------------------------------------------------------------- */

--- a/include/cvc5/cvc5.h
+++ b/include/cvc5/cvc5.h
@@ -100,7 +100,7 @@ class CVC5_EXPORT CVC5ApiException : public std::exception
   /**
    * Virtual default destructor.
    */
-  virtual ~CVC5ApiException() = default;
+  virtual ~CVC5ApiException() override = default;
 
   /**
    * Retrieve the message from this exception.
@@ -155,7 +155,7 @@ class CVC5_EXPORT CVC5ApiRecoverableException : public CVC5ApiException
   /**
    * Virtual default destructor.
    */
-  virtual ~CVC5ApiRecoverableException() = default;
+  virtual ~CVC5ApiRecoverableException() override = default;
 };
 
 /**
@@ -186,7 +186,7 @@ class CVC5_EXPORT CVC5ApiUnsupportedException
   /**
    * Virtual default destructor.
    */
-  virtual ~CVC5ApiUnsupportedException() = default;
+  virtual ~CVC5ApiUnsupportedException() override = default;
 };
 
 /**
@@ -216,7 +216,7 @@ class CVC5_EXPORT CVC5ApiOptionException : public CVC5ApiRecoverableException
   /**
    * Virtual default destructor.
    */
-  virtual ~CVC5ApiOptionException() = default;
+  virtual ~CVC5ApiOptionException() override = default;
 };
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
Currently, exception types in the C++ API do not have any virtual functions and therefore are not *polymorphic*. 
This means that `catch()` blocks can only catch the type of exception literally specified but not any subclass.

For example, consider this:

```
try {
   cvc5::Solver slv;
   // ...
   if(slv.isSat())
      std::cout << "Victory!\n";
} catch (cvc5::CVC5ApiException const& ex) {
  std::cerr << ex.what() << "\n";
}
```

Here, any `CVC5ApiRecoverableException` or `CVC5ApiOptionException` etc. will **not** be caught by the `catch` block, even though these types inherit from `CVC5ApiException`. Even worse, although they all inherit from `std::exception`, a catch handler for the latter will not catch any of the cvc5 exception types.

This is especially nasty in code that is not specifically aware of the usage of CVC5 under the hood of some other API. For example, in our BLACK project, we support many solvers (Z3, cvc5, MathSAT, etc.), but users of our API cannot catch exceptions thrown by the underlying backends generically by catching `std::exception` because the cvc5 types cannot be caught that way. Another example is in the usage of test frameworks such as `Catch2`, that can automatically report the content of `ex.what()` in case of an exception thrown during a test, but cannot do that for cvc5 exception types (printing only "unknown exception"), because they cannot be caught by catching `std::exception`.

The solution is pretty simple and cheap: add a virtual destructor to the exception types, so they become polymorphic, and the above `catch` block will work. This is what I do in this short PR.