### PR TITLE
Make skolems for all extended transcendental functions have functional type

### DIFF
--- a/include/cvc5/cvc5_skolem_id.h
+++ b/include/cvc5/cvc5_skolem_id.h
@@ -134,13 +134,13 @@ enum ENUM(SkolemFunId) : uint32_t
    */
   EVALUE(MOD_BY_ZERO),
   /** 
-   * The function for square root, which is used for ensuring that sqrt is
-   * functional.
+   * A function introduced to eliminate extended trancendental functions.
    *
-   * - Number of skolem indices: ``0``
+   * - Number of skolem indices: ``1``
+   *   - ``1:`` A lambda for the.
    * - Type: ``(-> Real Real)``
    */
-  EVALUE(SQRT),
+  EVALUE(TRANSCENDENTAL_PURIFY),
   /**
    * Argument used to purify trancendental function app ``(f x)``.
    * For ``(sin x)``, this is a variable that is assumed to be in phase with

--- a/include/cvc5/cvc5_skolem_id.h
+++ b/include/cvc5/cvc5_skolem_id.h
@@ -135,9 +135,13 @@ enum ENUM(SkolemFunId) : uint32_t
   EVALUE(MOD_BY_ZERO),
   /** 
    * A function introduced to eliminate extended trancendental functions.
+   * Transcendental functions like sqrt, arccos, arcsin, etc. are replaced
+   * during processing with uninterpreted functions that are unique to
+   * each function.
    *
    * - Number of skolem indices: ``1``
-   *   - ``1:`` A lambda for the.
+   *   - ``1:`` A lambda corresponding to the function, e.g. 
+   *   `(lambda ((x Real)) (sqrt x))`.
    * - Type: ``(-> Real Real)``
    */
   EVALUE(TRANSCENDENTAL_PURIFY),

--- a/proofs/alf/cvc5/theories/Transcendentals.smt3
+++ b/proofs/alf/cvc5/theories/Transcendentals.smt3
@@ -19,5 +19,5 @@
 (declare-const sqrt (-> Real Real))
 
 ; skolems
-(declare-const @k.SQRT (-> Real Real))
+(declare-const @k.TRANSCENDENTAL_PURIFY (-> (-> Real Real) Real Real))
 (declare-const @k.TRANSCENDENTAL_PURIFY_ARG (-> Real Real))

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -419,6 +419,7 @@ TypeNode SkolemManager::getTypeFor(SkolemFunId id,
   {
     // Type(cacheVals[0]), i.e skolems that return same type as first argument
     case SkolemFunId::PURIFY:
+    case SkolemFunId::TRANSCENDENTAL_PURIFY:
       Assert(cacheVals.size() > 0);
       return cacheVals[0].getType();
       break;
@@ -430,7 +431,6 @@ TypeNode SkolemManager::getTypeFor(SkolemFunId id,
       break;
     // real -> real function
     case SkolemFunId::DIV_BY_ZERO:
-    case SkolemFunId::SQRT:
     {
       TypeNode rtype = nm->realType();
       return nm->mkFunctionType(rtype, rtype);

--- a/src/printer/enum_to_string.cpp
+++ b/src/printer/enum_to_string.cpp
@@ -28,7 +28,7 @@ const char* toString(cvc5::SkolemFunId id)
     case cvc5::SkolemFunId::DIV_BY_ZERO: return "DIV_BY_ZERO";
     case cvc5::SkolemFunId::INT_DIV_BY_ZERO: return "INT_DIV_BY_ZERO";
     case cvc5::SkolemFunId::MOD_BY_ZERO: return "MOD_BY_ZERO";
-    case cvc5::SkolemFunId::SQRT: return "SQRT";
+    case cvc5::SkolemFunId::TRANSCENDENTAL_PURIFY: return "TRANSCENDENTAL_PURIFY";
     case cvc5::SkolemFunId::TRANSCENDENTAL_PURIFY_ARG:
       return "TRANSCENDENTAL_PURIFY_ARG";
     case cvc5::SkolemFunId::SHARED_SELECTOR: return "SHARED_SELECTOR";

--- a/src/printer/enum_to_string.cpp
+++ b/src/printer/enum_to_string.cpp
@@ -28,7 +28,8 @@ const char* toString(cvc5::SkolemFunId id)
     case cvc5::SkolemFunId::DIV_BY_ZERO: return "DIV_BY_ZERO";
     case cvc5::SkolemFunId::INT_DIV_BY_ZERO: return "INT_DIV_BY_ZERO";
     case cvc5::SkolemFunId::MOD_BY_ZERO: return "MOD_BY_ZERO";
-    case cvc5::SkolemFunId::TRANSCENDENTAL_PURIFY: return "TRANSCENDENTAL_PURIFY";
+    case cvc5::SkolemFunId::TRANSCENDENTAL_PURIFY:
+      return "TRANSCENDENTAL_PURIFY";
     case cvc5::SkolemFunId::TRANSCENDENTAL_PURIFY_ARG:
       return "TRANSCENDENTAL_PURIFY_ARG";
     case cvc5::SkolemFunId::SHARED_SELECTOR: return "SHARED_SELECTOR";

--- a/src/proof/alf/alf_node_converter.cpp
+++ b/src/proof/alf/alf_node_converter.cpp
@@ -701,6 +701,7 @@ bool AlfNodeConverter::isHandledSkolemId(SkolemFunId id)
     case SkolemFunId::DIV_BY_ZERO:
     case SkolemFunId::INT_DIV_BY_ZERO:
     case SkolemFunId::MOD_BY_ZERO:
+    case SkolemFunId::TRANSCENDENTAL_PURIFY:
     case SkolemFunId::TRANSCENDENTAL_PURIFY_ARG:
     case SkolemFunId::QUANTIFIERS_SKOLEMIZE:
     case SkolemFunId::STRINGS_NUM_OCCUR:

--- a/src/proof/alf/alf_node_converter.cpp
+++ b/src/proof/alf/alf_node_converter.cpp
@@ -701,7 +701,6 @@ bool AlfNodeConverter::isHandledSkolemId(SkolemFunId id)
     case SkolemFunId::DIV_BY_ZERO:
     case SkolemFunId::INT_DIV_BY_ZERO:
     case SkolemFunId::MOD_BY_ZERO:
-    case SkolemFunId::SQRT:
     case SkolemFunId::TRANSCENDENTAL_PURIFY_ARG:
     case SkolemFunId::QUANTIFIERS_SKOLEMIZE:
     case SkolemFunId::STRINGS_NUM_OCCUR:

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -946,14 +946,13 @@ RewriteResponse ArithRewriter::postRewriteTranscendental(TNode t)
       {
         Node one = nm->mkConstReal(Rational(1));
         Rational r = t[0].getConst<Rational>();
-        if (r.sgn() >= 0 && t[0].getType().isInteger()
-            && t[0] != one)
+        if (r.sgn() >= 0 && t[0].getType().isInteger() && t[0] != one)
         {
           return RewriteResponse(
               REWRITE_AGAIN,
               nm->mkNode(Kind::POW, nm->mkNode(Kind::EXPONENTIAL, one), t[0]));
         }
-        else if (r.sgn()==0)
+        else if (r.sgn() == 0)
         {
           // (= (exp 0.0) 1.0)
           return RewriteResponse(REWRITE_DONE, one);

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -944,16 +944,10 @@ RewriteResponse ArithRewriter::postRewriteTranscendental(TNode t)
     {
       if (t[0].isConst())
       {
-        Node one = nm->mkConstReal(Rational(1));
         Rational r = t[0].getConst<Rational>();
-        if (r.sgn() >= 0 && t[0].getType().isInteger() && t[0] != one)
+        if (r.sgn() == 0)
         {
-          return RewriteResponse(
-              REWRITE_AGAIN,
-              nm->mkNode(Kind::POW, nm->mkNode(Kind::EXPONENTIAL, one), t[0]));
-        }
-        else if (r.sgn() == 0)
-        {
+          Node one = nm->mkConstReal(Rational(1));
           // (= (exp 0.0) 1.0)
           return RewriteResponse(REWRITE_DONE, one);
         }

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -945,12 +945,18 @@ RewriteResponse ArithRewriter::postRewriteTranscendental(TNode t)
       if (t[0].isConst())
       {
         Node one = nm->mkConstReal(Rational(1));
-        if (t[0].getConst<Rational>().sgn() >= 0 && t[0].getType().isInteger()
+        Rational r = t[0].getConst<Rational>();
+        if (r.sgn() >= 0 && t[0].getType().isInteger()
             && t[0] != one)
         {
           return RewriteResponse(
               REWRITE_AGAIN,
               nm->mkNode(Kind::POW, nm->mkNode(Kind::EXPONENTIAL, one), t[0]));
+        }
+        else if (r.sgn()==0)
+        {
+          // (= (exp 0.0) 1.0)
+          return RewriteResponse(REWRITE_DONE, one);
         }
         else
         {

--- a/src/theory/arith/nl/nonlinear_extension.cpp
+++ b/src/theory/arith/nl/nonlinear_extension.cpp
@@ -273,6 +273,15 @@ void NonlinearExtension::checkFullEffort(std::map<Node, Node>& arithModel,
     // no non-linear constraints, we are done
     return;
   }
+  if (TraceIsOn("nl-model-final"))
+  {
+    Trace("nl-model-final") << "MODEL INPUT:" << std::endl;
+    for (std::pair<const Node, Node>& m : arithModel)
+    {
+      Trace("nl-model-final") << "  " << m.first << " -> " << m.second << std::endl;
+    }
+    Trace("nl-model-final") << "END" << std::endl;
+  }
   Trace("nl-ext") << "NonlinearExtension::interceptModel begin" << std::endl;
   d_model.reset(arithModel);
   // run a last call effort check
@@ -288,6 +297,15 @@ void NonlinearExtension::checkFullEffort(std::map<Node, Node>& arithModel,
   // assign values for equivalence classes with transcendental function
   // applications
   d_trSlv.postProcessModel(arithModel, termSet);
+  if (TraceIsOn("nl-model-final"))
+  {
+    Trace("nl-model-final") << "MODEL OUTPUT:" << std::endl;
+    for (std::pair<const Node, Node>& m : arithModel)
+    {
+      Trace("nl-model-final") << "  " << m.first << " -> " << m.second << std::endl;
+    }
+    Trace("nl-model-final") << "END" << std::endl;
+  }
 }
 
 Result::Status NonlinearExtension::modelBasedRefinement(

--- a/src/theory/arith/nl/nonlinear_extension.cpp
+++ b/src/theory/arith/nl/nonlinear_extension.cpp
@@ -278,7 +278,8 @@ void NonlinearExtension::checkFullEffort(std::map<Node, Node>& arithModel,
     Trace("nl-model-final") << "MODEL INPUT:" << std::endl;
     for (std::pair<const Node, Node>& m : arithModel)
     {
-      Trace("nl-model-final") << "  " << m.first << " -> " << m.second << std::endl;
+      Trace("nl-model-final")
+          << "  " << m.first << " -> " << m.second << std::endl;
     }
     Trace("nl-model-final") << "END" << std::endl;
   }
@@ -302,7 +303,8 @@ void NonlinearExtension::checkFullEffort(std::map<Node, Node>& arithModel,
     Trace("nl-model-final") << "MODEL OUTPUT:" << std::endl;
     for (std::pair<const Node, Node>& m : arithModel)
     {
-      Trace("nl-model-final") << "  " << m.first << " -> " << m.second << std::endl;
+      Trace("nl-model-final")
+          << "  " << m.first << " -> " << m.second << std::endl;
     }
     Trace("nl-model-final") << "END" << std::endl;
   }

--- a/src/theory/arith/nl/transcendental/transcendental_solver.cpp
+++ b/src/theory/arith/nl/transcendental/transcendental_solver.cpp
@@ -487,7 +487,7 @@ void TranscendentalSolver::postProcessModel(std::map<Node, Node>& arithModel,
     if (d_tstate.d_trPurifyVars.find(am.first) != d_tstate.d_trPurifyVars.end())
     {
       Trace("nl-ext") << "...keep model value for purification variable "
-                      << am.first << std::endl;
+                      << am.first << " (" << am.second << ")" << std::endl;
       continue;
     }
     Node r = d_astate.getRepresentative(am.first);

--- a/src/theory/arith/operator_elim.cpp
+++ b/src/theory/arith/operator_elim.cpp
@@ -325,7 +325,7 @@ Node OperatorElim::eliminateOperators(Node node,
       checkNonLinearLogic(node);
       BoundVarManager* bvm = nm->getBoundVarManager();
       Node x = bvm->mkBoundVar<RealAlgebraicNumberVarAttribute>(
-          node, "x", nm->realType());
+          node.getOperator(), "x", nm->realType());
       Node lam = nm->mkNode(Kind::LAMBDA, nm->mkNode(Kind::BOUND_VAR_LIST, x), nm->mkNode(k, x));
       Node fun = sm->mkSkolemFunction(SkolemFunId::TRANSCENDENTAL_PURIFY, lam);
       // eliminate inverse functions here

--- a/src/theory/arith/operator_elim.cpp
+++ b/src/theory/arith/operator_elim.cpp
@@ -330,7 +330,8 @@ Node OperatorElim::eliminateOperators(Node node,
       BoundVarManager* bvm = nm->getBoundVarManager();
       Node x = bvm->mkBoundVar<RealAlgebraicNumberVarAttribute>(
           node.getOperator(), "x", nm->realType());
-      Node lam = nm->mkNode(Kind::LAMBDA, nm->mkNode(Kind::BOUND_VAR_LIST, x), nm->mkNode(k, x));
+      Node lam = nm->mkNode(
+          Kind::LAMBDA, nm->mkNode(Kind::BOUND_VAR_LIST, x), nm->mkNode(k, x));
       Node fun = sm->mkSkolemFunction(SkolemFunId::TRANSCENDENTAL_PURIFY, lam);
       // Make (@TRANSCENDENTAL_PURIFY t), where t is node[0]
       Node var = nm->mkNode(Kind::APPLY_UF, fun, node[0]);
@@ -489,7 +490,8 @@ Node OperatorElim::getArithSkolemApp(Node n, SkolemFunId id)
 bool OperatorElim::usePartialFunction(SkolemFunId id) const
 {
   // always use partial function for sqrt
-  return !options().arith.arithNoPartialFun || id == SkolemFunId::TRANSCENDENTAL_PURIFY;
+  return !options().arith.arithNoPartialFun
+         || id == SkolemFunId::TRANSCENDENTAL_PURIFY;
 }
 
 SkolemLemma OperatorElim::mkSkolemLemma(Node lem, Node k)

--- a/src/theory/arith/operator_elim.cpp
+++ b/src/theory/arith/operator_elim.cpp
@@ -323,22 +323,27 @@ Node OperatorElim::eliminateOperators(Node node,
         return node;
       }
       checkNonLinearLogic(node);
+      // We eliminate these functions using an uninterpreted function via
+      // the skolem id TRANSCENDENTAL_PURIFY.
+      // Make (lambda ((x Real)) (f x)) for this function, using the bound
+      // variable manager to ensure this function is always the same.
       BoundVarManager* bvm = nm->getBoundVarManager();
       Node x = bvm->mkBoundVar<RealAlgebraicNumberVarAttribute>(
           node.getOperator(), "x", nm->realType());
       Node lam = nm->mkNode(Kind::LAMBDA, nm->mkNode(Kind::BOUND_VAR_LIST, x), nm->mkNode(k, x));
       Node fun = sm->mkSkolemFunction(SkolemFunId::TRANSCENDENTAL_PURIFY, lam);
-      // eliminate inverse functions here
+      // Make (@TRANSCENDENTAL_PURIFY t), where t is node[0]
       Node var = nm->mkNode(Kind::APPLY_UF, fun, node[0]);
       Node lem;
       if (k == Kind::SQRT)
       {
         Node nonNeg = nm->mkNode(Kind::MULT, var, var).eqNode(node[0]);
 
-        // sqrt(x) reduces to:
-        // witness y. ite(x >= 0.0, y * y = x ^ y = Uf(x), y = Uf(x))
+        // (sqrt x) reduces to:
+        // (=> (>= x 0.0) (= (* y y) x))
+        // where y is (@TRANSCENDENTAL_PURIFY x).
         //
-        // Uf(x) makes sure that the reduction still behaves like a function,
+        // This makes sure that the reduction still behaves like a function,
         // otherwise the reduction of (x = 1) ^ (sqrt(x) != sqrt(1)) would be
         // satisfiable. On the original formula, this would require that we
         // simultaneously interpret sqrt(1) as 1 and -1, which is not a valid

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1042,6 +1042,7 @@ set(regress_0_tests
   regress0/nl/nta/exp-neg2-unsat-unsound.smt2
   regress0/nl/nta/exp1-ub.smt2
   regress0/nl/nta/issue10541.smt2
+  regress0/nl/nta/issue10542-2.smt2
   regress0/nl/nta/issue4693-inc-purify.smt2
   regress0/nl/nta/issue4693-4-inc-purify-sat.smt2
   regress0/nl/nta/issue4693-5-inc-purify.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1043,6 +1043,7 @@ set(regress_0_tests
   regress0/nl/nta/exp1-ub.smt2
   regress0/nl/nta/issue10541.smt2
   regress0/nl/nta/issue10542-2.smt2
+  regress0/nl/nta/issue10543-2.smt2
   regress0/nl/nta/issue4693-inc-purify.smt2
   regress0/nl/nta/issue4693-4-inc-purify-sat.smt2
   regress0/nl/nta/issue4693-5-inc-purify.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1041,6 +1041,7 @@ set(regress_0_tests
   regress0/nl/nta/exp-n0.5-ub.smt2
   regress0/nl/nta/exp-neg2-unsat-unsound.smt2
   regress0/nl/nta/exp1-ub.smt2
+  regress0/nl/nta/issue10541.smt2
   regress0/nl/nta/issue4693-inc-purify.smt2
   regress0/nl/nta/issue4693-4-inc-purify-sat.smt2
   regress0/nl/nta/issue4693-5-inc-purify.smt2

--- a/test/regress/cli/regress0/nl/nta/issue10541.smt2
+++ b/test/regress/cli/regress0/nl/nta/issue10541.smt2
@@ -1,3 +1,4 @@
+; COMMAND-LINE: -q
 ; EXPECT: sat
 (set-logic ALL)
 (declare-const a Real)

--- a/test/regress/cli/regress0/nl/nta/issue10541.smt2
+++ b/test/regress/cli/regress0/nl/nta/issue10541.smt2
@@ -1,0 +1,6 @@
+; EXPECT: sat
+(set-logic ALL)
+(declare-const a Real)
+(assert (<= (- 1.1) a 1.0))
+(assert (< (arccos a) 0.0))
+(check-sat)

--- a/test/regress/cli/regress0/nl/nta/issue10542-2.smt2
+++ b/test/regress/cli/regress0/nl/nta/issue10542-2.smt2
@@ -1,3 +1,4 @@
+; COMMAND-LINE: -q
 ; EXPECT: sat
 (set-logic ALL)
 (declare-const a Real)

--- a/test/regress/cli/regress0/nl/nta/issue10542-2.smt2
+++ b/test/regress/cli/regress0/nl/nta/issue10542-2.smt2
@@ -1,0 +1,6 @@
+; EXPECT: sat
+(set-logic ALL)
+(declare-const a Real)
+(declare-const b Real)
+(assert (> (arccos a) (arccos b)))
+(check-sat)

--- a/test/regress/cli/regress0/nl/nta/issue10543-2.smt2
+++ b/test/regress/cli/regress0/nl/nta/issue10543-2.smt2
@@ -1,0 +1,4 @@
+; EXPECT: sat
+(set-logic ALL)
+(assert (= 1.0 (exp 0.0)))
+(check-sat)


### PR DESCRIPTION
This ensures e.g. `arccos` is a function on intervals where it is undefined. This corrects invalid models on the 2nd and 3rd benchmarks https://github.com/cvc5/cvc5/issues/10542.  The solution is to generalize how `SQRT` is handled to all inverse transcendental functions.

It also adds the regression from https://github.com/cvc5/cvc5/issues/10541, which was a prior issue in cvc4. Fixes https://github.com/cvc5/cvc5/issues/10541.

Also changes the rewriter for `exp` slightly, which was bogus due to type issues, also adds `(exp 0.0) --> 1.0`, which fixes a warning from https://github.com/cvc5/cvc5/issues/10543.