### PR TITLE
ci: Set up Python virtual environment

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -128,8 +128,6 @@ runs:
         echo "::group::Install software for Python bindings"
         python3 -m pip install -q --upgrade pip
         python3 -m pip install -r contrib/requirements_python_dev.txt
-        # Add binary path of user site-packages to PATH
-        echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
         echo "::endgroup::"
 
     - name: Install software for Python packaging

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -103,12 +103,22 @@ runs:
         echo "num_proc=$(( $(sysctl -n hw.logicalcpu) + 1 ))" >> $GITHUB_ENV
         echo "::endgroup::"
 
+    # Required by PEP-668
+    - name: Set up Python virtual environment
+      if: runner.os == 'macOS'
+      shell: ${{ inputs.shell }}
+      run: |
+        echo "::group::Set up Python virtual environment"
+        python3 -m venv ~/.venv
+        echo "$HOME/.venv/bin" >> $GITHUB_PATH
+        echo "::endgroup::"
+
     - name: Install Python modules for building and testing
       shell: ${{ inputs.shell }}
       run: |
         echo "::group::Install Python modules for building and testing"
-        python3 -m pip install --user -r contrib/requirements_build.txt
-        python3 -m pip install --user pexpect # For interactive shell tests
+        python3 -m pip install -r contrib/requirements_build.txt
+        python3 -m pip install pexpect # For interactive shell tests
         echo "::endgroup::"
 
     - name: Install software for Python bindings
@@ -117,7 +127,7 @@ runs:
       run: |
         echo "::group::Install software for Python bindings"
         python3 -m pip install -q --upgrade pip
-        python3 -m pip install --user -r contrib/requirements_python_dev.txt
+        python3 -m pip install -r contrib/requirements_python_dev.txt
         # Add binary path of user site-packages to PATH
         echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
         echo "::endgroup::"
@@ -128,8 +138,8 @@ runs:
       run: |
         echo "::group::Install software for Python packaging"
         python3 -m pip install -q --upgrade pip
-        python3 -m pip install --user twine
-        python3 -m pip install --user -U urllib3 requests
+        python3 -m pip install twine
+        python3 -m pip install -U urllib3 requests
         echo "::endgroup::"
     
     - name: Install software for documentation
@@ -138,7 +148,7 @@ runs:
       run: |
         echo "::group::Install software for documentation"
         sudo apt-get install -y doxygen python3-docutils python3-jinja2
-        python3 -m pip install --user \
+        python3 -m pip install \
           sphinx==7.1.2 \
           sphinxcontrib-bibtex==2.5.0 sphinx-tabs==3.4.1 sphinx-rtd-theme==1.3.0 breathe==4.35.0 \
           sphinxcontrib-programoutput==0.17

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -50,7 +50,8 @@ runs:
       run: |
         if [[ "${{ inputs.check-examples }}" != "true" ]]; then exit 0; fi
         mkdir -p build && cd build
-        cmake .. -DCMAKE_PREFIX_PATH=${{ inputs.build-dir }}/install/lib/cmake
+        cmake .. -DCMAKE_PREFIX_PATH=${{ inputs.build-dir }}/install/lib/cmake \
+          -DPython_EXECUTABLE=$(command -v python3)
         make -j${{ env.num_proc }}
         ctest -j${{ env.num_proc }} --output-on-failure
       working-directory: examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             cache-key: production-arm64
             strip-bin: strip
             python-bindings: true
-            check-examples: true
+            check-examples: false # Temporary disabled because of removal of distutils in Python 3.12
             exclude_regress: 3-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             cache-key: production-arm64
             strip-bin: strip
             python-bindings: true
-            check-examples: false # Temporary disabled because of removal of distutils in Python 3.12
+            check-examples: true
             exclude_regress: 3-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 


### PR DESCRIPTION
This fixes the CI workflow. Starting with Python@3.12, Homebrew follows PEP 668 so we cannot use `python3 -m pip` directly anymore. We need to create a virtual environment first. In addition, this PR makes sure CMake finds the right version of Python on macOS for the examples.