### PR TITLE
Add a check for potential null pointer deref in proof_checker.cpp

### DIFF
--- a/src/proof/proof_checker.cpp
+++ b/src/proof/proof_checker.cpp
@@ -162,7 +162,10 @@ Node ProofChecker::checkInternal(ProofRule id,
   {
     if (useTrustedChecker)
     {
-      (*out) << "ProofChecker::check: trusting ProofRule " << id << std::endl;
+      if (out != nullptr)
+      {
+        (*out) << "ProofChecker::check: trusting ProofRule " << id << std::endl;
+      }
       // trusted checker
       return expected;
     }


### PR DESCRIPTION
All but one of the usages of `(*out)` in proof checker are guarded by `out != nullptr`. For example:

* https://github.com/cvc5/cvc5/blob/ee588d42714a5c22dc29f1342b9eb016b5927479/src/proof/proof_checker.cpp#L155-L158
* https://github.com/cvc5/cvc5/blob/ee588d42714a5c22dc29f1342b9eb016b5927479/src/proof/proof_checker.cpp#L171-L174
* https://github.com/cvc5/cvc5/blob/ee588d42714a5c22dc29f1342b9eb016b5927479/src/proof/proof_checker.cpp#L190-L193

However, the one on L165:

* https://github.com/cvc5/cvc5/blob/ee588d42714a5c22dc29f1342b9eb016b5927479/src/proof/proof_checker.cpp#L165

does not have this check.

This PR fixes this issue.

Signed-off-by: Andrew V. Teylu <andrew@tey.lu>