### PR TITLE
Add portfolio config option

### DIFF
--- a/src/base/configuration.cpp
+++ b/src/base/configuration.cpp
@@ -218,6 +218,8 @@ bool Configuration::isBuiltWithPoly()
 }
 bool Configuration::isBuiltWithCoCoA() { return IS_COCOA_BUILD; }
 
+bool Configuration::isBuiltWithPortfolio() { return IS_PORTFOLIO_BUILD; }
+
 const std::vector<std::string>& Configuration::getTraceTags()
 {
   return Trace_tags;

--- a/src/base/configuration.h
+++ b/src/base/configuration.h
@@ -109,6 +109,8 @@ public:
 
   static bool isBuiltWithCoCoA();
 
+  static bool isBuiltWithPortfolio();
+
   /* Return a sorted array of the trace tags name */
   static const std::vector<std::string>& getTraceTags();
   /* Test if the given argument is a known trace tag name */

--- a/src/base/configuration_private.h
+++ b/src/base/configuration_private.h
@@ -114,6 +114,12 @@ namespace cvc5::internal {
 #define IS_EDITLINE_BUILD false
 #endif /* HAVE_LIBEDITLINE */
 
+#if HAVE_SYS_WAIT_H
+#define IS_PORTFOLIO_BUILD true
+#else /* HAVE_SYS_WAIT_H */
+#define IS_PORTFOLIO_BUILD false
+#endif /* HAVE_SYS_WAIT_H */
+
 #if CVC5_GPL_DEPS
 #  define IS_GPL_BUILD true
 #else /* CVC5_GPL_DEPS */

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -364,6 +364,7 @@ void OptionsHandler::showConfiguration(const std::string& flag, bool value)
   print_config_cond("ubsan", Configuration::isUbsanBuild());
   print_config_cond("tsan", Configuration::isTsanBuild());
   print_config_cond("competition", Configuration::isCompetitionBuild());
+  print_config_cond("portfolio", Configuration::isBuiltWithPortfolio());
 
   std::cout << std::endl;
 

--- a/test/regress/cli/regress0/printer/portfolio-out.smt2
+++ b/test/regress/cli/regress0/printer/portfolio-out.smt2
@@ -1,3 +1,4 @@
+; REQUIRES: portfolio
 ; COMMAND-LINE: --use-portfolio -o portfolio
 ; SCRUBBER: grep -o "portfolio-success"
 ; EXPECT: portfolio-success


### PR DESCRIPTION
This also adds the new config option as a requirement for the portfolio-out.smt2 test so that it is skipped on Windows.