### PR TITLE
fp: Fix getEqualityStatus() for non-const values.

### DIFF
--- a/src/theory/fp/theory_fp.cpp
+++ b/src/theory/fp/theory_fp.cpp
@@ -878,8 +878,15 @@ EqualityStatus TheoryFp::getEqualityStatus(TNode a, TNode b)
     Trace("theory-fp") << EqualityStatus::EQUALITY_TRUE_IN_MODEL << std::endl;
     return EqualityStatus::EQUALITY_TRUE_IN_MODEL;
   }
-  Trace("theory-fp") << EqualityStatus::EQUALITY_FALSE_IN_MODEL << std::endl;
-  return EqualityStatus::EQUALITY_FALSE_IN_MODEL;
+  // We can get values that are not consts due to the fact that we word-blast
+  // to BV, value terms can be non-const bit-vector terms. We thus may only
+  // conclude false if the values are disequal consts.
+  if (value_a.isConst() && value_b.isConst())
+  {
+    Trace("theory-fp") << EqualityStatus::EQUALITY_FALSE_IN_MODEL << std::endl;
+    return EqualityStatus::EQUALITY_FALSE_IN_MODEL;
+  }
+  return EqualityStatus::EQUALITY_UNKNOWN;
 }
 
 bool TheoryFp::collectModelInfo(TheoryModel* m,

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -840,6 +840,8 @@ set(regress_0_tests
   regress0/fp/from_sbv.smt2
   regress0/fp/fp-set-comprehension-basic.smt2
   regress0/fp/issue-5524.smt2
+  regress0/fp/issue10144.smt2
+  regress0/fp/issue10507.smt2
   regress0/fp/issue3536.smt2
   regress0/fp/issue3582.smt2
   regress0/fp/issue3619.smt2
@@ -849,8 +851,12 @@ set(regress_0_tests
   regress0/fp/issue6164.smt2
   regress0/fp/issue7002.smt2
   regress0/fp/issue7569.smt2
+  regress0/fp/issue9854.smt2
   regress0/fp/issue9858.smt2
   regress0/fp/issue9864.smt2
+  regress0/fp/issue9966.smt2
+  regress0/fp/issue9972.smt2
+  regress0/fp/issue9972-2.smt2
   regress0/fp/issuepr650.smt2
   regress0/fp/proj-issue329-prereg-context.smt2
   regress0/fp/proj-issue477-fp-set-comprehension.smt2

--- a/test/regress/cli/regress0/fp/issue10144.smt2
+++ b/test/regress/cli/regress0/fp/issue10144.smt2
@@ -1,0 +1,9 @@
+; EXPECT: sat
+(set-logic ALL)
+(set-option :check-models true)
+(declare-const y Float32)
+(declare-const z Float32)
+(define-const _y_8 (_ BitVec 8) ((_ fp.to_ubv 8) RNE y))
+(define-const _z_8 (_ BitVec 8) ((_ fp.to_ubv 8) RNE z))
+(assert (distinct _y_8 _z_8))
+(check-sat)

--- a/test/regress/cli/regress0/fp/issue10507.smt2
+++ b/test/regress/cli/regress0/fp/issue10507.smt2
@@ -1,0 +1,9 @@
+; EXPECT: sat
+(set-logic ALL)
+(set-option :check-models true)
+(declare-const a Float64)
+(declare-const b Float64)
+(declare-const c Float64)
+(assert (= c (fp #b0 #b00000000000 #b0000000000000000000000000000000000000000000000000000)))
+(assert (= c (fp.min a (fp.min c b))))
+(check-sat)

--- a/test/regress/cli/regress0/fp/issue9854.smt2
+++ b/test/regress/cli/regress0/fp/issue9854.smt2
@@ -1,5 +1,5 @@
 ; EXPECT: unsat
-; REQUIRES: no-debug code
+; REQUIRES: no-assertions
 ; This regression test failed with a check-model failure prior to #10589 in
 ; production. In debug, this fails with a spurious assertion failure in SymFPU.
 ; We thus, for now, only test this for production.

--- a/test/regress/cli/regress0/fp/issue9854.smt2
+++ b/test/regress/cli/regress0/fp/issue9854.smt2
@@ -1,5 +1,5 @@
 ; EXPECT: unsat
-; REQUIRES: production
+; REQUIRES: no-debug code
 ; This regression test failed with a check-model failure prior to #10589 in
 ; production. In debug, this fails with a spurious assertion failure in SymFPU.
 ; We thus, for now, only test this for production.

--- a/test/regress/cli/regress0/fp/issue9854.smt2
+++ b/test/regress/cli/regress0/fp/issue9854.smt2
@@ -1,0 +1,4 @@
+; EXPECT: unsat
+(set-logic BVFP)
+(assert (forall ((n Float64)) (= (_ bv0 80) ((_ zero_extend 48) ((_ fp.to_sbv 32) roundNearestTiesToEven n)))))
+(check-sat)

--- a/test/regress/cli/regress0/fp/issue9854.smt2
+++ b/test/regress/cli/regress0/fp/issue9854.smt2
@@ -1,8 +1,8 @@
 ; EXPECT: unsat
 ; REQUIRES: no-assertions
-; This regression test failed with a check-model failure prior to #10589 in
-; production. In debug, this fails with a spurious assertion failure in SymFPU.
-; We thus, for now, only test this for production.
+; This regression test failed with a check-model failure prior to #10589 without
+; assertions. With assertions, this fails with a spurious assertion failure in
+; SymFPU. We thus, for now, only test this for builds without assertions.
 (set-logic BVFP)
 (assert (forall ((n Float64)) (= (_ bv0 80) ((_ zero_extend 48) ((_ fp.to_sbv 32) roundNearestTiesToEven n)))))
 (check-sat)

--- a/test/regress/cli/regress0/fp/issue9854.smt2
+++ b/test/regress/cli/regress0/fp/issue9854.smt2
@@ -1,4 +1,8 @@
 ; EXPECT: unsat
+; REQUIRES: production
+; This regression test failed with a check-model failure prior to #10589 in
+; production. In debug, this fails with a spurious assertion failure in SymFPU.
+; We thus, for now, only test this for production.
 (set-logic BVFP)
 (assert (forall ((n Float64)) (= (_ bv0 80) ((_ zero_extend 48) ((_ fp.to_sbv 32) roundNearestTiesToEven n)))))
 (check-sat)

--- a/test/regress/cli/regress0/fp/issue9966.smt2
+++ b/test/regress/cli/regress0/fp/issue9966.smt2
@@ -1,0 +1,15 @@
+; EXPECT: sat
+; EXPECT: sat
+(set-logic QF_AFP)
+(set-option :check-models true)
+(set-option :incremental true)
+(declare-fun a () (Array (_ BitVec 32) (_ BitVec 32)))
+(assert (fp.geq ((_ to_fp 8 24) (select a (_ bv0 32))) (_ +zero 8 24)))
+(assert (fp.leq ((_ to_fp 8 24) (select a (_ bv0 32))) (fp (_ bv0 1) (_ bv159 8) (_ bv0 23))))
+(assert (not (bvslt ((_ fp.to_ubv 32) RTZ ((_ to_fp 8 24) (select a (_ bv0 32)))) (_ bv5 32))))
+(assert (distinct (_ -oo 8 24) ((_ to_fp 8 24) (select a (_ bv2 32)))))
+(assert (fp.geq ((_ to_fp 8 24) (select a (_ bv2 32))) (_ +zero 8 24)))
+(assert (fp.leq ((_ to_fp 8 24) (select a (_ bv2 32))) (fp (_ bv0 1) (_ bv159 8) (_ bv0 23))))
+(check-sat)
+(assert (bvslt (_ bv0 32) ((_ fp.to_ubv 32) RTZ ((_ to_fp 8 24) (select a (_ bv2 32))))))
+(check-sat)

--- a/test/regress/cli/regress0/fp/issue9972-2.smt2
+++ b/test/regress/cli/regress0/fp/issue9972-2.smt2
@@ -1,0 +1,7 @@
+; EXPECT: sat
+(set-logic QF_BVFP)
+(set-option :check-models true)
+(declare-const a Float64)
+(declare-const b Float64)
+(assert (not (= (_ bv0 32) (bvlshr ((_ extract 31 0) ((_ sign_extend 32) ((_ fp.to_sbv 32) RTZ a))) ((_ extract 31 0) ((_ sign_extend 32) ((_ fp.to_sbv 32) RTZ b)))))))
+(check-sat)

--- a/test/regress/cli/regress0/fp/issue9972.smt2
+++ b/test/regress/cli/regress0/fp/issue9972.smt2
@@ -1,4 +1,8 @@
 ; EXPECT: sat
+; REQUIRES: no-assertions
+; This regression test failed with a check-model failure prior to #10589 without
+; assertions. With assertions, this fails with a spurious assertion failure in
+; SymFPU. We thus, for now, only test this for builds without assertions.
 (set-logic QF_BVFP)
 (set-option :check-models true)
 (declare-const a Float64)

--- a/test/regress/cli/regress0/fp/issue9972.smt2
+++ b/test/regress/cli/regress0/fp/issue9972.smt2
@@ -1,0 +1,8 @@
+; EXPECT: sat
+(set-logic QF_BVFP)
+(set-option :check-models true)
+(declare-const a Float64)
+(declare-const b Float64)
+(assert (= (_ bv0 32) ((_ fp.to_sbv 32) RTZ b)))
+(assert (bvuge ((_ fp.to_sbv 32) RTZ a) (_ bv1 32)))
+(check-sat)


### PR DESCRIPTION
Fixes #10144.
Fixes #10507.
Fixes #9854.
Fixes #9966.
Fixes #9972.