### PR TITLE
fp: Refactor skolem handling of FpExpandDefs.

### DIFF
--- a/include/cvc5/cvc5_skolem_id.h
+++ b/include/cvc5/cvc5_skolem_id.h
@@ -86,7 +86,7 @@ enum ENUM(SkolemId) : uint32_t
    * 
    * - Number of skolem indices: ``1``
    *   - ``1:`` The term t that this skolem purifies.
-   * - Type: The type of t.
+   * - Sort: The type of t.
    */
   EVALUE(PURIFY),
   /** 
@@ -96,7 +96,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``2``
    *   - ``1:`` The first array of type ``(Array T1 T2)``.
    *   - ``2:`` The second array of type ``(Array T1 T2)``.
-   * - Type: ``T2``
+   * - Sort: ``T2``
    */
   EVALUE(ARRAY_DEQ_DIFF),
   /** 
@@ -104,7 +104,7 @@ enum ENUM(SkolemId) : uint32_t
    * SMT-LIB term ``(lambda ((x Real)) (/ x 0.0))``.
    *
    * - Number of skolem indices: ``0``
-   * - Type: ``(-> Real Real)``
+   * - Sort: ``(-> Real Real)``
    */
   EVALUE(DIV_BY_ZERO),
   /** 
@@ -112,7 +112,7 @@ enum ENUM(SkolemId) : uint32_t
    * to the SMT-LIB term ``(lambda ((x Int)) (div x 0))``.
    *
    * - Number of skolem indices: ``0``
-   * - Type: ``(-> Int Int)``
+   * - Sort: ``(-> Int Int)``
    */
   EVALUE(INT_DIV_BY_ZERO),
   /** 
@@ -120,7 +120,7 @@ enum ENUM(SkolemId) : uint32_t
    * to the SMT-LIB term ``(lambda ((x Int)) (mod x 0))``.
    *
    * - Number of skolem indices: ``0``
-   * - Type: ``(-> Int Int)``
+   * - Sort: ``(-> Int Int)``
    */
   EVALUE(MOD_BY_ZERO),
   /** 
@@ -132,7 +132,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``1``
    *   - ``1:`` A lambda corresponding to the function, e.g. 
    *   `(lambda ((x Real)) (sqrt x))`.
-   * - Type: ``(-> Real Real)``
+   * - Sort: ``(-> Real Real)``
    */
   EVALUE(TRANSCENDENTAL_PURIFY),
   /**
@@ -142,7 +142,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` The application of a trancendental function.
-   * - Type: ``Real``
+   * - Sort: ``Real``
    */
   EVALUE(TRANSCENDENTAL_PURIFY_ARG),
   /** 
@@ -155,7 +155,7 @@ enum ENUM(SkolemId) : uint32_t
    *   - ``2:`` A term that represents the sort of field we are extracting.
    *   - ``3:`` An integer n such that this shared selector returns the n^th
    *            subfield term of the given sort.
-   * - Type: A selector sort whose domain is given by first index,
+   * - Sort: A selector sort whose domain is given by first index,
    *         and whose codomain is the given by the second index.
    */
   EVALUE(SHARED_SELECTOR),
@@ -165,7 +165,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``2``
    *   - ``1:`` The quantified formula Q.
    *   - ``2:`` The variable in the binder of Q to skolemize.
-   * - Type: The type of the second index.
+   * - Sort: The type of the second index.
    */
   EVALUE(QUANTIFIERS_SKOLEMIZE),
   /** 
@@ -175,7 +175,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``2``
    *   - ``1:`` The first string.
    *   - ``2:`` The second string.
-   * - Type: ``Int``
+   * - Sort: ``Int``
    */
   EVALUE(STRINGS_NUM_OCCUR),
   /** 
@@ -187,7 +187,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``2``
    *   - ``1:`` The first string.
    *   - ``2:`` The second string.
-   * - Type: ``(-> Int Int)``
+   * - Sort: ``(-> Int Int)``
    */
   EVALUE(STRINGS_OCCUR_INDEX),
   /**
@@ -198,7 +198,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``2``
    *   - ``1:`` The string to match.
    *   - ``2:`` The regular expression to find.
-   * - Type: ``Int``
+   * - Sort: ``Int``
    */
   EVALUE(STRINGS_NUM_OCCUR_RE),
   /** 
@@ -211,7 +211,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``2``
    *   - ``1:`` The string to match.
    *   - ``2:`` The regular expression to find.
-   * - Type: ``(-> Int Int)``
+   * - Sort: ``(-> Int Int)``
    */
   EVALUE(STRINGS_OCCUR_INDEX_RE),
   /**
@@ -223,7 +223,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``2``
    *   - ``1:`` The string to match.
    *   - ``2:`` The regular expression to find.
-   * - Type: ``(-> Int Int)``
+   * - Sort: ``(-> Int Int)``
    */
   EVALUE(STRINGS_OCCUR_LEN_RE),
   /**
@@ -235,7 +235,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``2``
    *   - ``1:`` The first string.
    *   - ``2:`` The second string.
-   * - Type: ``Int``
+   * - Sort: ``Int``
    */
   EVALUE(STRINGS_DEQ_DIFF),
   /**
@@ -247,7 +247,7 @@ enum ENUM(SkolemId) : uint32_t
    * 
    * - Number of skolem indices: ``1``
    *   - ``1:`` The application of replace_all or replace_all_re.
-   * - Type: ``(-> Int S)`` where S is either ``String`` or ``(Seq T)`` for
+   * - Sort: ``(-> Int S)`` where S is either ``String`` or ``(Seq T)`` for
    * some ``T``.
    */
   EVALUE(STRINGS_REPLACE_ALL_RESULT),
@@ -258,7 +258,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` The argument to str.from_int.
-   * - Type: ``(-> Int Int)``
+   * - Sort: ``(-> Int Int)``
    */
   EVALUE(STRINGS_ITOS_RESULT),
   /**
@@ -268,7 +268,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` The argument to str.to_int.
-   * - Type: ``(-> Int String)``
+   * - Sort: ``(-> Int String)``
    */
   EVALUE(STRINGS_STOI_RESULT),
   /**
@@ -278,7 +278,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` The argument to str.to_int.
-   * - Type: ``Int``
+   * - Sort: ``Int``
    */
   EVALUE(STRINGS_STOI_NON_DIGIT),
   /**
@@ -300,7 +300,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``2``
    *   - ``1:`` The string.
    *   - ``2:`` The regular expression to match.
-   * - Type: ``String``
+   * - Sort: ``String``
    */
   EVALUE(RE_FIRST_MATCH_PRE),
   /**
@@ -310,7 +310,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``2``
    *   - ``1:`` The string.
    *   - ``2:`` The regular expression to match.
-   * - Type: ``String``
+   * - Sort: ``String``
    */
   EVALUE(RE_FIRST_MATCH),
   /**
@@ -320,7 +320,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``2``
    *   - ``1:`` The string.
    *   - ``2:`` The regular expression to match.
-   * - Type: ``String``
+   * - Sort: ``String``
    */
   EVALUE(RE_FIRST_MATCH_POST),
   /**
@@ -333,7 +333,7 @@ enum ENUM(SkolemId) : uint32_t
    *   - ``1:`` The string.
    *   - ``2:`` The regular expression.
    *   - ``3:`` The index of the skolem.
-   * - Type: ``String``
+   * - Sort: ``String``
    */
   EVALUE(RE_UNFOLD_POS_COMPONENT),
   /**
@@ -349,7 +349,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` the bag argument A.
-   * - Type: ``(-> Int Int)``
+   * - Sort: ``(-> Int Int)``
    */
   EVALUE(BAGS_CARD_COMBINE),
   /**
@@ -366,7 +366,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` the bag argument A of type (Bag T).
-   * - Type: ``(-> Int (Bag T))``
+   * - Sort: ``(-> Int (Bag T))``
    */
   EVALUE(BAGS_DISTINCT_ELEMENTS_UNION_DISJOINT),
   /**
@@ -376,7 +376,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` the bag argument A.
-   * - Type: ``Int``
+   * - Sort: ``Int``
    */
   EVALUE(BAGS_FOLD_CARD),
   /**
@@ -395,7 +395,7 @@ enum ENUM(SkolemId) : uint32_t
    *   - ``1:`` the function f of type ``(-> T1 T2)``.
    *   - ``2:`` the initial value t of type ``T2``.
    *   - ``3:`` the bag argument A of type ``(Bag T1)``.
-   * - Type: ``(-> Int T2)``
+   * - Sort: ``(-> Int T2)``
    */
   EVALUE(BAGS_FOLD_COMBINE),
   /**
@@ -410,7 +410,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` a bag argument A of type ``(Bag T1)``
-   * - Type: ``(-> Int T1)``
+   * - Sort: ``(-> Int T1)``
    */
   EVALUE(BAGS_FOLD_ELEMENTS),
   /**
@@ -426,7 +426,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` the bag argument A of type ``(Bag T1)``.
-   * - Type: ``(-> Int (Bag T1))``
+   * - Sort: ``(-> Int (Bag T1))``
    */
   EVALUE(BAGS_FOLD_UNION_DISJOINT),
   /**
@@ -441,7 +441,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` the bag to chose from, of type (Bag T).
-   * - Type: ``(-> (Bag T) T)``
+   * - Sort: ``(-> (Bag T) T)``
    */
   EVALUE(BAGS_CHOOSE),
   /**
@@ -451,7 +451,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` the bag argument A of type ``(Bag T)``.
-   * - Type: ``(-> Int T)``
+   * - Sort: ``(-> Int T)``
    */
   EVALUE(BAGS_DISTINCT_ELEMENTS),
   /**
@@ -459,7 +459,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` the bag argument A.
-   * - Type: ``Int``
+   * - Sort: ``Int``
    */
   EVALUE(BAGS_DISTINCT_ELEMENTS_SIZE),
  /**
@@ -470,7 +470,7 @@ enum ENUM(SkolemId) : uint32_t
    *   - ``1:`` the function f of type ``(-> E T)``.
    *   - ``2:`` the bag argument A of ``(Bag E)``.
    *   - ``3:`` the element argument y type ``T``.
-   * - Type: ``E``
+   * - Sort: ``E``
    */
   EVALUE(BAGS_MAP_PREIMAGE_INJECTIVE),
   /**
@@ -487,7 +487,7 @@ enum ENUM(SkolemId) : uint32_t
    *   - ``3:`` a skolem function with id ``BAGS_DISTINCT_ELEMENTS_SIZE``.
    *   - ``4:`` an element y of type ``T`` representing the mapped value.
    *   - ``5:`` an element x of type ``E``.
-   * - Type: ``Int``
+   * - Sort: ``Int``
    */
   EVALUE(BAGS_MAP_INDEX),
   /**
@@ -502,7 +502,7 @@ enum ENUM(SkolemId) : uint32_t
    *   - ``1:`` the function f of type ``(-> E T)``.
    *   - ``2:`` the bag argument A of ``(Bag E)``.
    *   - ``3:`` the element argument e type ``E``.
-   * - Type: ``(-> Int Int)``
+   * - Sort: ``(-> Int Int)``
    */
   EVALUE(BAGS_MAP_SUM),
   /** 
@@ -512,7 +512,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``2``
    *   - ``1:`` The first bag of type ``(Bag T)``.
    *   - ``2:`` The second bag of type ``(Bag T)``.
-   * - Type: ``T``
+   * - Sort: ``T``
    */
   EVALUE(BAGS_DEQ_DIFF),
   /**
@@ -522,7 +522,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` a group term of the form ``((_ table.group n1 ... nk) A)``.
-   * - Type: ``(-> T (Table T))``
+   * - Sort: ``(-> T (Table T))``
    */
   EVALUE(TABLES_GROUP_PART),
   /**
@@ -533,7 +533,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``2``
    *   - ``1:`` a group term of the form ``((_ table.group n1 ... nk) A)``.
    *   - ``2:`` a table B of type ``(Table T)``.
-   * - Type: ``T``
+   * - Sort: ``T``
    */
   EVALUE(TABLES_GROUP_PART_ELEMENT),
   /**
@@ -543,7 +543,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` a relation of the form ``((_ rel.group n1 ... nk) A)``.
-   * - Type: ``(-> T (Relation T))``
+   * - Sort: ``(-> T (Relation T))``
    */
   EVALUE(RELATIONS_GROUP_PART),
   /**
@@ -554,7 +554,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``2``
    *   - ``1:`` a group term of the form ``((_ rel.group n1 ... nk) A)``.
    *   - ``2:`` a relation B of type ``(Relation T)``.
-   * - Type: ``T``
+   * - Sort: ``T``
    */
   EVALUE(RELATIONS_GROUP_PART_ELEMENT),
   /**
@@ -570,7 +570,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` a ground value for the type ``(Set E)``.
-   * - Type: ``E``
+   * - Sort: ``E``
    */
   EVALUE(SETS_CHOOSE),
   /** 
@@ -580,7 +580,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``2``
    *   - ``1:`` The first set of type ``(Set E)``.
    *   - ``2:`` The second set of type ``(Set E)``.
-   * - Type: ``E``
+   * - Sort: ``E``
    */
   EVALUE(SETS_DEQ_DIFF),
   /**
@@ -590,7 +590,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` the set argument A.
-   * - Type: ``Int``
+   * - Sort: ``Int``
    */
   EVALUE(SETS_FOLD_CARD),
   /**
@@ -609,7 +609,7 @@ enum ENUM(SkolemId) : uint32_t
    *   - ``1:`` the function f of type ``(-> T1 T2)``.
    *   - ``2:`` the initial value t of type ``T2``.
    *   - ``3:`` the set argument A of type ``(Set T1)``.
-   * - Type: ``(-> Int T2)``
+   * - Sort: ``(-> Int T2)``
    */
   EVALUE(SETS_FOLD_COMBINE),
   /**
@@ -624,7 +624,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` a set argument A of type ``(Set T)``.
-   * - Type: ``(-> Int T)``
+   * - Sort: ``(-> Int T)``
    */
   EVALUE(SETS_FOLD_ELEMENTS),
   /**
@@ -640,7 +640,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` a set argument A of type ``(Set E)``.
-   * - Type: ``(-> Int (Set E))``
+   * - Sort: ``(-> Int (Set E))``
    */
   EVALUE(SETS_FOLD_UNION),
   /**
@@ -651,7 +651,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``2``
    *   - ``1:`` a map term of the form ``(set.map f A)`` where A of type ``(Set E)``
    *   - ``2:`` the element argument y.
-   * - Type: ``E``
+   * - Sort: ``E``
    */
   EVALUE(SETS_MAP_DOWN_ELEMENT),
   /**
@@ -659,7 +659,8 @@ enum ENUM(SkolemId) : uint32_t
    * the undefined zero case of ``fp.min``.
    *
    * - Number of skolem indices: ``1``
-   *   - ``1:`` The Sort of the fp.min operator.
+   *   - ``1:`` The floating-point sort ``FP`` of the fp.min operator.
+   * - Sort: ``(-> (FP FP) (_ BitVector 1)``
    */
   EVALUE(FP_MIN_ZERO),
   /**
@@ -667,7 +668,8 @@ enum ENUM(SkolemId) : uint32_t
    * the undefined zero case of ``fp.max``.
    *
    * - Number of skolem indices: ``1``
-   *   - ``1:`` The floating-point sort of the fp.max operator.
+   *   - ``1:`` The floating-point sort ``FP`` of the fp.max operator.
+   * - Sort: ``(-> (FP FP) (_ BitVector 1)``
    */
   EVALUE(FP_MAX_ZERO),
   /**
@@ -676,8 +678,9 @@ enum ENUM(SkolemId) : uint32_t
    * arguments to the operator.
    *
    * - Number of skolem indices: ``2``
-   *   - ``1:`` The floating-point sort of operand of fp.to_ubv.
-   *   - ``2:`` The bit-vector sort to convert to.
+   *   - ``1:`` The floating-point sort ``FP`` of operand of fp.to_ubv.
+   *   - ``2:`` The bit-vector sort ``BV`` to convert to.
+   * - Sort: ``(-> (RoundingMode FP) BV)``
    */
   EVALUE(FP_TO_UBV),
   /**
@@ -686,8 +689,9 @@ enum ENUM(SkolemId) : uint32_t
    * arguments to the operator.
    *
    * - Number of skolem indices: ``2``
-   *   - ``1:`` The floating-point sort of operand of fp.to_sbv.
-   *   - ``2:`` The bit-vector sort to convert to.
+   *   - ``1:`` The floating-point sort ``FP`` of operand of fp.to_sbv.
+   *   - ``2:`` The bit-vector sort ``BV`` to convert to.
+   * - Sort: ``(-> (RoundingMode FP) BV)``
    */
   EVALUE(FP_TO_SBV),
   /**
@@ -695,7 +699,8 @@ enum ENUM(SkolemId) : uint32_t
    * unique per floating-point sort.
    *
    * - Number of skolem indices: ``1``
-   *   - ``1:`` The floating-point sort of the operand of fp.to_real.
+   *   - ``1:`` The floating-point sort ``FP`` of the operand of fp.to_real.
+   * - Sort: ``(-> FP Real)``
    */
   EVALUE(FP_TO_REAL),
   //================================================= Unknown rule

--- a/include/cvc5/cvc5_skolem_id.h
+++ b/include/cvc5/cvc5_skolem_id.h
@@ -654,6 +654,33 @@ enum ENUM(SkolemId) : uint32_t
    * - Type: ``E``
    */
   EVALUE(SETS_MAP_DOWN_ELEMENT),
+  /**
+   * A skolem function that is unique per floating-point sort, introduced for
+   * the undefined zero case of ``fp.min``.
+   */
+  EVALUE(FP_MIN_ZERO),
+  /**
+   * A skolem function that is unique per floating-point sort, introduced for
+   * the undefined zero case of ``fp.max``.
+   */
+  EVALUE(FP_MAX_ZERO),
+  /**
+   * A skolem function introduced for the undefined out-ouf-bounds case of
+   * ``fp.to_ubv`` that is unique per floating-point sort and sort of the
+   * arguments to the operator.
+   */
+  EVALUE(FP_TO_UBV),
+  /**
+   * A skolem function introduced for the undefined out-ouf-bounds case of
+   * ``fp.to_sbv`` that is unique per floating-point sort and sort of the
+   * arguments to the operator.
+   */
+  EVALUE(FP_TO_SBV),
+  /**
+   * A skolem function introduced for the undefined of ``fp.to_real`` that is
+   * unique per floating-point sort.
+   */
+  EVALUE(FP_TO_REAL),
   //================================================= Unknown rule
   /** Indicates this is not a skolem. */
   EVALUE(NONE),

--- a/include/cvc5/cvc5_skolem_id.h
+++ b/include/cvc5/cvc5_skolem_id.h
@@ -660,7 +660,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` The floating-point sort ``FP`` of the fp.min operator.
-   * - Sort: ``(-> (FP FP) (_ BitVector 1)``
+   * - Sort: ``(-> FP FP (_ BitVec 1))``
    */
   EVALUE(FP_MIN_ZERO),
   /**
@@ -669,7 +669,7 @@ enum ENUM(SkolemId) : uint32_t
    *
    * - Number of skolem indices: ``1``
    *   - ``1:`` The floating-point sort ``FP`` of the fp.max operator.
-   * - Sort: ``(-> (FP FP) (_ BitVector 1)``
+   * - Sort: ``(-> FP FP (_ BitVec 1))``
    */
   EVALUE(FP_MAX_ZERO),
   /**
@@ -680,7 +680,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``2``
    *   - ``1:`` The floating-point sort ``FP`` of operand of fp.to_ubv.
    *   - ``2:`` The bit-vector sort ``BV`` to convert to.
-   * - Sort: ``(-> (RoundingMode FP) BV)``
+   * - Sort: ``(-> RoundingMode FP BV)``
    */
   EVALUE(FP_TO_UBV),
   /**
@@ -691,7 +691,7 @@ enum ENUM(SkolemId) : uint32_t
    * - Number of skolem indices: ``2``
    *   - ``1:`` The floating-point sort ``FP`` of operand of fp.to_sbv.
    *   - ``2:`` The bit-vector sort ``BV`` to convert to.
-   * - Sort: ``(-> (RoundingMode FP) BV)``
+   * - Sort: ``(-> RoundingMode FP BV)``
    */
   EVALUE(FP_TO_SBV),
   /**

--- a/include/cvc5/cvc5_skolem_id.h
+++ b/include/cvc5/cvc5_skolem_id.h
@@ -657,28 +657,45 @@ enum ENUM(SkolemId) : uint32_t
   /**
    * A skolem function that is unique per floating-point sort, introduced for
    * the undefined zero case of ``fp.min``.
+   *
+   * - Number of skolem indices: ``1``
+   *   - ``1:`` The Sort of the fp.min operator.
    */
   EVALUE(FP_MIN_ZERO),
   /**
    * A skolem function that is unique per floating-point sort, introduced for
    * the undefined zero case of ``fp.max``.
+   *
+   * - Number of skolem indices: ``1``
+   *   - ``1:`` The floating-point sort of the fp.max operator.
    */
   EVALUE(FP_MAX_ZERO),
   /**
    * A skolem function introduced for the undefined out-ouf-bounds case of
    * ``fp.to_ubv`` that is unique per floating-point sort and sort of the
    * arguments to the operator.
+   *
+   * - Number of skolem indices: ``2``
+   *   - ``1:`` The floating-point sort of operand of fp.to_ubv.
+   *   - ``2:`` The bit-vector sort to convert to.
    */
   EVALUE(FP_TO_UBV),
   /**
    * A skolem function introduced for the undefined out-ouf-bounds case of
    * ``fp.to_sbv`` that is unique per floating-point sort and sort of the
    * arguments to the operator.
+   *
+   * - Number of skolem indices: ``2``
+   *   - ``1:`` The floating-point sort of operand of fp.to_sbv.
+   *   - ``2:`` The bit-vector sort to convert to.
    */
   EVALUE(FP_TO_SBV),
   /**
    * A skolem function introduced for the undefined of ``fp.to_real`` that is
    * unique per floating-point sort.
+   *
+   * - Number of skolem indices: ``1``
+   *   - ``1:`` The floating-point sort of the operand of fp.to_real.
    */
   EVALUE(FP_TO_REAL),
   //================================================= Unknown rule

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -563,17 +563,14 @@ TypeNode SkolemManager::getTypeFor(SkolemId id,
     case SkolemId::FP_TO_SBV:
     case SkolemId::FP_TO_UBV:
     {
-      Assert(cacheVals.size() == 3);
+      Assert(cacheVals.size() == 2);
       Assert(cacheVals[0].getKind() == Kind::SORT_TO_TERM);
-      TypeNode bvtype = cacheVals[0].getConst<SortToTerm>().getType();
-      Assert(bvtype.isBitVector());
-      Assert(cacheVals[1].getKind() == Kind::SORT_TO_TERM);
-      TypeNode rmtype = cacheVals[1].getConst<SortToTerm>().getType();
-      Assert(rmtype.isRoundingMode());
-      Assert(cacheVals[2].getKind() == Kind::SORT_TO_TERM);
-      TypeNode fptype = cacheVals[2].getConst<SortToTerm>().getType();
+      TypeNode fptype = cacheVals[0].getConst<SortToTerm>().getType();
       Assert(fptype.isFloatingPoint());
-      return nm->mkFunctionType({rmtype, fptype}, bvtype);
+      Assert(cacheVals[1].getKind() == Kind::SORT_TO_TERM);
+      TypeNode bvtype = cacheVals[1].getConst<SortToTerm>().getType();
+      Assert(bvtype.isBitVector());
+      return nm->mkFunctionType({nm->roundingModeType(), fptype}, bvtype);
     }
     case SkolemId::FP_TO_REAL:
     {

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -550,10 +550,43 @@ TypeNode SkolemManager::getTypeFor(SkolemId id,
       TypeNode t = cacheVals[1].getConst<SortToTerm>().getType();
       return nm->mkSelectorType(dtt, t);
     }
+    // fp skolems
+    case SkolemId::FP_MIN_ZERO:
+    case SkolemId::FP_MAX_ZERO:
+    {
+      Assert(cacheVals.size() == 1);
+      Assert(cacheVals[0].getKind() == Kind::SORT_TO_TERM);
+      TypeNode type = cacheVals[0].getConst<SortToTerm>().getType();
+      Assert(type.isFloatingPoint());
+      return nm->mkFunctionType({type, type}, nm->mkBitVectorType(1));
+    }
+    case SkolemId::FP_TO_SBV:
+    case SkolemId::FP_TO_UBV:
+    {
+      Assert(cacheVals.size() == 3);
+      Assert(cacheVals[0].getKind() == Kind::SORT_TO_TERM);
+      TypeNode bvtype = cacheVals[0].getConst<SortToTerm>().getType();
+      Assert(bvtype.isBitVector());
+      Assert(cacheVals[1].getKind() == Kind::SORT_TO_TERM);
+      TypeNode rmtype = cacheVals[1].getConst<SortToTerm>().getType();
+      Assert(rmtype.isRoundingMode());
+      Assert(cacheVals[2].getKind() == Kind::SORT_TO_TERM);
+      TypeNode fptype = cacheVals[2].getConst<SortToTerm>().getType();
+      Assert(fptype.isFloatingPoint());
+      return nm->mkFunctionType({rmtype, fptype}, bvtype);
+    }
+    case SkolemId::FP_TO_REAL:
+    {
+      Assert(cacheVals.size() == 1);
+      Assert(cacheVals[0].getKind() == Kind::SORT_TO_TERM);
+      TypeNode type = cacheVals[0].getConst<SortToTerm>().getType();
+      Assert(type.isFloatingPoint());
+      return nm->mkFunctionType({type}, nm->realType());
+    }
+    //
     default: break;
   }
-  TypeNode ret;
-  return ret;
+  return TypeNode();
 }
 
 }  // namespace cvc5::internal

--- a/src/printer/enum_to_string.cpp
+++ b/src/printer/enum_to_string.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Top contributors (to current version):
- *   Andrew Reynolds
+ *   Andrew Reynolds, Aina Niemetz
  *
  * This file is part of the cvc5 project.
  *
@@ -25,6 +25,11 @@ const char* toString(cvc5::SkolemId id)
     case cvc5::SkolemId::PURIFY: return "purify";
     case cvc5::SkolemId::ARRAY_DEQ_DIFF: return "array_deq_diff";
     case cvc5::SkolemId::DIV_BY_ZERO: return "div_by_zero";
+    case cvc5::SkolemId::FP_MIN_ZERO: return "fp_min_zero";
+    case cvc5::SkolemId::FP_MAX_ZERO: return "fp_max_zero";
+    case cvc5::SkolemId::FP_TO_SBV: return "fp_to_sbv";
+    case cvc5::SkolemId::FP_TO_UBV: return "fp_to_ubv";
+    case cvc5::SkolemId::FP_TO_REAL: return "fp_to_real";
     case cvc5::SkolemId::INT_DIV_BY_ZERO: return "int_div_by_zero";
     case cvc5::SkolemId::MOD_BY_ZERO: return "mod_by_zero";
     case cvc5::SkolemId::TRANSCENDENTAL_PURIFY:

--- a/src/theory/fp/fp_expand_defs.cpp
+++ b/src/theory/fp/fp_expand_defs.cpp
@@ -16,173 +16,67 @@
 #include "theory/fp/fp_expand_defs.h"
 
 #include "expr/skolem_manager.h"
+#include "expr/sort_to_term.h"
 #include "util/floatingpoint.h"
 
 namespace cvc5::internal {
 namespace theory {
 namespace fp {
 
-FpExpandDefs::FpExpandDefs(context::UserContext* u)
-    :
-
-      d_minMap(u),
-      d_maxMap(u),
-      d_toUBVMap(u),
-      d_toSBVMap(u),
-      d_toRealMap(u)
+Node FpExpandDefs::minMaxUF(TNode node)
 {
-}
+  Kind kind = node.getKind();
+  Assert(kind == Kind::FLOATINGPOINT_MIN || kind == Kind::FLOATINGPOINT_MAX);
 
-Node FpExpandDefs::minUF(Node node)
-{
-  Assert(node.getKind() == Kind::FLOATINGPOINT_MIN);
-  TypeNode t(node.getType());
-  Assert(t.getKind() == Kind::FLOATINGPOINT_TYPE);
+  TypeNode type = node.getType();
+  Assert(type.getKind() == Kind::FLOATINGPOINT_TYPE);
 
   NodeManager* nm = NodeManager::currentNM();
-  SkolemManager* sm = nm->getSkolemManager();
-  ComparisonUFMap::const_iterator i(d_minMap.find(t));
-
-  Node fun;
-  if (i == d_minMap.end())
-  {
-    std::vector<TypeNode> args(2);
-    args[0] = t;
-    args[1] = t;
-    fun = sm->mkDummySkolem("floatingpoint_min_zero_case",
-                            nm->mkFunctionType(args, nm->mkBitVectorType(1U)),
-                            "floatingpoint_min_zero_case");
-    d_minMap.insert(t, fun);
-  }
-  else
-  {
-    fun = (*i).second;
-  }
   return nm->mkNode(Kind::APPLY_UF,
-                    fun,
-                    node[1],
-                    node[0]);  // Application reverses the order or arguments
+                    nm->getSkolemManager()->mkSkolemFunction(
+                        kind == Kind::FLOATINGPOINT_MIN
+                                || kind == Kind::FLOATINGPOINT_MIN_TOTAL
+                            ? SkolemId::FP_MIN_ZERO
+                            : SkolemId::FP_MAX_ZERO,
+                        {nm->mkConst(SortToTerm(type))}),
+                    node[0],
+                    node[1]);
 }
 
-Node FpExpandDefs::maxUF(Node node)
+Node FpExpandDefs::toUbvSbvUF(TNode node)
 {
-  Assert(node.getKind() == Kind::FLOATINGPOINT_MAX);
-  TypeNode t(node.getType());
-  Assert(t.getKind() == Kind::FLOATINGPOINT_TYPE);
+  Kind kind = node.getKind();
+  Assert(kind == Kind::FLOATINGPOINT_TO_UBV
+         || kind == Kind::FLOATINGPOINT_TO_SBV);
+
+  TypeNode type = node.getType();
+  Assert(type.getKind() == Kind::BITVECTOR_TYPE);
 
   NodeManager* nm = NodeManager::currentNM();
-  SkolemManager* sm = nm->getSkolemManager();
-  ComparisonUFMap::const_iterator i(d_maxMap.find(t));
-
-  Node fun;
-  if (i == d_maxMap.end())
-  {
-    std::vector<TypeNode> args(2);
-    args[0] = t;
-    args[1] = t;
-    fun = sm->mkDummySkolem("floatingpoint_max_zero_case",
-                            nm->mkFunctionType(args, nm->mkBitVectorType(1U)),
-                            "floatingpoint_max_zero_case");
-    d_maxMap.insert(t, fun);
-  }
-  else
-  {
-    fun = (*i).second;
-  }
-  return nm->mkNode(Kind::APPLY_UF, fun, node[1], node[0]);
+  return nm->mkNode(
+      Kind::APPLY_UF,
+      nm->getSkolemManager()->mkSkolemFunction(
+          kind == Kind::FLOATINGPOINT_TO_SBV ? SkolemId::FP_TO_SBV
+                                             : SkolemId::FP_TO_UBV,
+          {nm->mkConst(SortToTerm(type)),
+           nm->mkConst(SortToTerm(node[0].getType())),
+           nm->mkConst(SortToTerm(node[1].getType()))}),
+      node[0],
+      node[1]);
 }
 
-Node FpExpandDefs::toUBVUF(Node node)
-{
-  Assert(node.getKind() == Kind::FLOATINGPOINT_TO_UBV);
-
-  TypeNode target(node.getType());
-  Assert(target.getKind() == Kind::BITVECTOR_TYPE);
-
-  TypeNode source(node[1].getType());
-  Assert(source.getKind() == Kind::FLOATINGPOINT_TYPE);
-
-  std::pair<TypeNode, TypeNode> p(source, target);
-  NodeManager* nm = NodeManager::currentNM();
-  SkolemManager* sm = nm->getSkolemManager();
-  ConversionUFMap::const_iterator i(d_toUBVMap.find(p));
-
-  Node fun;
-  if (i == d_toUBVMap.end())
-  {
-    std::vector<TypeNode> args(2);
-    args[0] = nm->roundingModeType();
-    args[1] = source;
-    fun = sm->mkDummySkolem("floatingpoint_to_ubv_out_of_range_case",
-                            nm->mkFunctionType(args, target),
-                            "floatingpoint_to_ubv_out_of_range_case");
-    d_toUBVMap.insert(p, fun);
-  }
-  else
-  {
-    fun = (*i).second;
-  }
-  return nm->mkNode(Kind::APPLY_UF, fun, node[0], node[1]);
-}
-
-Node FpExpandDefs::toSBVUF(Node node)
-{
-  Assert(node.getKind() == Kind::FLOATINGPOINT_TO_SBV);
-
-  TypeNode target(node.getType());
-  Assert(target.getKind() == Kind::BITVECTOR_TYPE);
-
-  TypeNode source(node[1].getType());
-  Assert(source.getKind() == Kind::FLOATINGPOINT_TYPE);
-
-  std::pair<TypeNode, TypeNode> p(source, target);
-  NodeManager* nm = NodeManager::currentNM();
-  SkolemManager* sm = nm->getSkolemManager();
-  ConversionUFMap::const_iterator i(d_toSBVMap.find(p));
-
-  Node fun;
-  if (i == d_toSBVMap.end())
-  {
-    std::vector<TypeNode> args(2);
-    args[0] = nm->roundingModeType();
-    args[1] = source;
-    fun = sm->mkDummySkolem("floatingpoint_to_sbv_out_of_range_case",
-                            nm->mkFunctionType(args, target),
-                            "floatingpoint_to_sbv_out_of_range_case");
-    d_toSBVMap.insert(p, fun);
-  }
-  else
-  {
-    fun = (*i).second;
-  }
-  return nm->mkNode(Kind::APPLY_UF, fun, node[0], node[1]);
-}
-
-Node FpExpandDefs::toRealUF(Node node)
+Node FpExpandDefs::toRealUF(TNode node)
 {
   Assert(node.getKind() == Kind::FLOATINGPOINT_TO_REAL);
-  TypeNode t(node[0].getType());
-  Assert(t.getKind() == Kind::FLOATINGPOINT_TYPE);
+  TypeNode type = node[0].getType();
+  Assert(type.getKind() == Kind::FLOATINGPOINT_TYPE);
 
   NodeManager* nm = NodeManager::currentNM();
-  SkolemManager* sm = nm->getSkolemManager();
-  ComparisonUFMap::const_iterator i(d_toRealMap.find(t));
 
-  Node fun;
-  if (i == d_toRealMap.end())
-  {
-    std::vector<TypeNode> args(1);
-    args[0] = t;
-    fun = sm->mkDummySkolem("floatingpoint_to_real_infinity_and_NaN_case",
-                            nm->mkFunctionType(args, nm->realType()),
-                            "floatingpoint_to_real_infinity_and_NaN_case");
-    d_toRealMap.insert(t, fun);
-  }
-  else
-  {
-    fun = (*i).second;
-  }
-  return nm->mkNode(Kind::APPLY_UF, fun, node[0]);
+  return nm->mkNode(Kind::APPLY_UF,
+                    nm->getSkolemManager()->mkSkolemFunction(
+                        SkolemId::FP_TO_REAL, {nm->mkConst(SortToTerm(type))}),
+                    node[0]);
 }
 
 TrustNode FpExpandDefs::expandDefinition(Node node)
@@ -192,45 +86,40 @@ TrustNode FpExpandDefs::expandDefinition(Node node)
 
   Node res = node;
   Kind kind = node.getKind();
+  NodeManager* nm = NodeManager::currentNM();
 
   if (kind == Kind::FLOATINGPOINT_MIN)
   {
-    res = NodeManager::currentNM()->mkNode(
-        Kind::FLOATINGPOINT_MIN_TOTAL, node[0], node[1], minUF(node));
+    res = nm->mkNode(
+        Kind::FLOATINGPOINT_MIN_TOTAL, node[0], node[1], minMaxUF(node));
   }
   else if (kind == Kind::FLOATINGPOINT_MAX)
   {
-    res = NodeManager::currentNM()->mkNode(
-        Kind::FLOATINGPOINT_MAX_TOTAL, node[0], node[1], maxUF(node));
+    res = nm->mkNode(
+        Kind::FLOATINGPOINT_MAX_TOTAL, node[0], node[1], minMaxUF(node));
   }
   else if (kind == Kind::FLOATINGPOINT_TO_UBV)
   {
-    FloatingPointToUBV info = node.getOperator().getConst<FloatingPointToUBV>();
-    FloatingPointToUBVTotal newInfo(info);
-
-    res =
-        NodeManager::currentNM()->mkNode(  // Kind::FLOATINGPOINT_TO_UBV_TOTAL,
-            NodeManager::currentNM()->mkConst(newInfo),
-            node[0],
-            node[1],
-            toUBVUF(node));
+    res = nm->mkNode(  // Kind::FLOATINGPOINT_TO_UBV_TOTAL,
+        nm->mkConst(FloatingPointToUBVTotal(
+            node.getOperator().getConst<FloatingPointToUBV>())),
+        node[0],
+        node[1],
+        toUbvSbvUF(node));
   }
   else if (kind == Kind::FLOATINGPOINT_TO_SBV)
   {
-    FloatingPointToSBV info = node.getOperator().getConst<FloatingPointToSBV>();
-    FloatingPointToSBVTotal newInfo(info);
-
-    res =
-        NodeManager::currentNM()->mkNode(  // Kind::FLOATINGPOINT_TO_SBV_TOTAL,
-            NodeManager::currentNM()->mkConst(newInfo),
-            node[0],
-            node[1],
-            toSBVUF(node));
+    res = nm->mkNode(  // Kind::FLOATINGPOINT_TO_SBV_TOTAL,
+        nm->mkConst(FloatingPointToSBVTotal(
+            node.getOperator().getConst<FloatingPointToSBV>())),
+        node[0],
+        node[1],
+        toUbvSbvUF(node));
   }
   else if (kind == Kind::FLOATINGPOINT_TO_REAL)
   {
-    res = NodeManager::currentNM()->mkNode(
-        Kind::FLOATINGPOINT_TO_REAL_TOTAL, node[0], toRealUF(node));
+    res =
+        nm->mkNode(Kind::FLOATINGPOINT_TO_REAL_TOTAL, node[0], toRealUF(node));
   }
 
   if (res != node)

--- a/src/theory/fp/fp_expand_defs.cpp
+++ b/src/theory/fp/fp_expand_defs.cpp
@@ -58,9 +58,8 @@ Node FpExpandDefs::toUbvSbvUF(TNode node)
       nm->getSkolemManager()->mkSkolemFunction(
           kind == Kind::FLOATINGPOINT_TO_SBV ? SkolemId::FP_TO_SBV
                                              : SkolemId::FP_TO_UBV,
-          {nm->mkConst(SortToTerm(type)),
-           nm->mkConst(SortToTerm(node[0].getType())),
-           nm->mkConst(SortToTerm(node[1].getType()))}),
+          {nm->mkConst(SortToTerm(node[1].getType())),
+           nm->mkConst(SortToTerm(type))}),
       node[0],
       node[1]);
 }

--- a/src/theory/fp/fp_expand_defs.h
+++ b/src/theory/fp/fp_expand_defs.h
@@ -42,24 +42,36 @@ class FpExpandDefs
       CDHashMap<std::pair<TypeNode, TypeNode>, Node, PairTypeNodeHashFunction>;
 
  public:
-  FpExpandDefs(context::UserContext* u);
+  FpExpandDefs() {}
   /** expand definitions in node */
   TrustNode expandDefinition(Node node);
 
  private:
-  /** TODO: document (projects issue #265) */
-  Node minUF(Node);
-  Node maxUF(Node);
-  Node toUBVUF(Node);
-  Node toSBVUF(Node);
-  Node toRealUF(Node);
-  Node abstractRealToFloat(Node);
-  Node abstractFloatToReal(Node);
-  ComparisonUFMap d_minMap;
-  ComparisonUFMap d_maxMap;
-  ConversionUFMap d_toUBVMap;
-  ConversionUFMap d_toSBVMap;
-  ComparisonUFMap d_toRealMap;
+  /**
+   * Helper to create a function application on a fresh UF for the undefined
+   * zero case of fp.min/fp.max. The UF is instantiated with the operands of
+   * the given node.
+   * @param node The fp.min/fp.maxnode to create the UF and its application for.
+   * @return The function application.
+   */
+  Node minMaxUF(TNode node);
+  /**
+   * Helper to create a function application on a fresh UF for the undefined
+   * cases of fp.to_ubv/fp.to_sbv. The UF is instantiated with the operands of
+   * the given node.
+   * @param node The fp.to_sbv/to_ubv node to create the UF and its application
+   *             for.
+   * @return The function application.
+   */
+  Node toUbvSbvUF(TNode node);
+  /**
+   * Helper to create a function application on a fresh UF for the undefined
+   * cases of fp.to_real. The UF is instantiated with the operands of the given
+   * fp.to_real node.
+   * @param node The fp.to_real node to create the UF and its application for.
+   * @return The function application.
+   */
+  Node toRealUF(TNode node);
 }; /* class TheoryFp */
 
 }  // namespace fp

--- a/src/theory/fp/theory_fp.cpp
+++ b/src/theory/fp/theory_fp.cpp
@@ -921,7 +921,7 @@ bool TheoryFp::collectModelValues(TheoryModel* m,
     // if FpWordBlaster::getValue() does not return a null node.
     if (!wordBlasted.isNull() && !m->assertEquality(node, wordBlasted, true))
     {
-      Trace("fp-collectModelInfo")
+      Trace("fp-collectModelValues")
           << "TheoryFp::collectModelValues(): ... not converted" << std::endl;
       return false;
     }

--- a/src/theory/fp/theory_fp_rewriter.cpp
+++ b/src/theory/fp/theory_fp_rewriter.cpp
@@ -1090,7 +1090,7 @@ RewriteResponse maxTotal(TNode node, bool isPreRewrite)
    * Initialize the rewriter.
    */
   TheoryFpRewriter::TheoryFpRewriter(NodeManager* nm, context::UserContext* u)
-      : TheoryRewriter(nm), d_fpExpDef(u)
+      : TheoryRewriter(nm), d_fpExpDef()
   {
     /* Set up the pre-rewrite dispatch table */
     for (uint32_t i = 0; i < static_cast<uint32_t>(Kind::LAST_KIND); ++i)


### PR DESCRIPTION
This refactors partial function handling to use the skolem infrastructure the right way (use mkSkolemFunction instead of mkDummySkolem).

Fixes cvc5/cvc5-projects#265.