### PR TITLE
Fix use of CONG for binder kinds in DSL reconstruction

### DIFF
--- a/src/proof/conv_proof_generator.cpp
+++ b/src/proof/conv_proof_generator.cpp
@@ -19,6 +19,7 @@
 
 #include "expr/term_context.h"
 #include "expr/term_context_stack.h"
+#include "printer/let_binding.h"
 #include "proof/proof_checker.h"
 #include "proof/proof_node.h"
 #include "proof/proof_node_algorithm.h"
@@ -497,7 +498,6 @@ Node TConvProofGenerator::getProofForRewriting(Node t,
             startIndex = 1;
             // The variable list should never change.
             Assert(cur[0] == ret[0]);
-            pfArgs.push_back(cur[0]);
           }
           else if (ck == Kind::APPLY_UF && children[0] != cur.getOperator())
           {

--- a/src/proof/proof_node_algorithm.cpp
+++ b/src/proof/proof_node_algorithm.cpp
@@ -260,6 +260,7 @@ ProofRule getCongRule(const Node& n, std::vector<Node>& args)
     case Kind::FLOATINGPOINT_GT:
     case Kind::FLOATINGPOINT_GEQ:
     case Kind::NULLABLE_LIFT:
+    case Kind::APPLY_INDEXED_SYMBOLIC:
       // takes arbitrary but we use CONG
       break;
     case Kind::HO_APPLY:
@@ -285,6 +286,11 @@ ProofRule getCongRule(const Node& n, std::vector<Node>& args)
   if (kind::metaKindOf(k) == kind::metakind::PARAMETERIZED)
   {
     args.push_back(n.getOperator());
+  }
+  else if (n.isClosure())
+  {
+    // bound variable list is an argument for closure over congruence
+    args.push_back(n[0]);
   }
   return r;
 }

--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -341,9 +341,9 @@ bool RewriteDbProofCons::proveWithRule(RewriteProofStatus id,
     {
       // for closures, their first argument (the bound variable list) must be
       // equivalent, and should not be given as a child proof.
-      if (i==0 && target[0].isClosure())
+      if (i == 0 && target[0].isClosure())
       {
-        if (target[0][0]!=target[1][0])
+        if (target[0][0] != target[1][0])
         {
           return false;
         }

--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -322,6 +322,16 @@ bool RewriteDbProofCons::proveWithRule(DslProofRule id,
     pic.d_id = id;
     for (size_t i = 0; i < nchild; i++)
     {
+      // for closures, their first argument (the bound variable list) must be
+      // equivalent, and should not be given as a child proof.
+      if (i==0 && target[0].isClosure())
+      {
+        if (target[0][0]!=target[1][0])
+        {
+          return false;
+        }
+        continue;
+      }
       if (!target[0][i].getType().isComparableTo(target[1][i].getType()))
       {
         // type error on children (required for certain polymorphic operators)


### PR DESCRIPTION
The DSL proof reconstruction was incorrect in the rare case it used congruence over a binder kind (e.g. FORALL).