### PR TITLE
Allow evaluation when concretizing generic ops

### DIFF
--- a/src/theory/builtin/generic_op.cpp
+++ b/src/theory/builtin/generic_op.cpp
@@ -19,6 +19,7 @@
 
 #include "expr/dtype.h"
 #include "expr/dtype_cons.h"
+#include "theory/evaluator.h"
 #include "theory/datatypes/project_op.h"
 #include "theory/datatypes/theory_datatypes_utils.h"
 #include "util/bitvector.h"
@@ -235,11 +236,23 @@ bool convertToNumeralList(const std::vector<Node>& indices,
 {
   for (const Node& i : indices)
   {
-    if (i.getKind() != Kind::CONST_INTEGER)
+    Node in = i;
+    if (in.getKind() != Kind::CONST_INTEGER)
     {
-      return false;
+      // If trivially evaluatable, take that as the numeral.
+      // This implies that we can concretize applications of
+      // APPLY_INDEXED_SYMBOLIC whose indices can evaluate. This in turn
+      // implies that e.g. (extract (+ 2 2) 2 x) concretizes via getConcreteApp
+      // to ((_ extract 4 2) x), which implies it has type (BitVec 3) based
+      // on the type rule for APPLY_INDEXED_SYMBOLIC.
+      theory::Evaluator e(nullptr);
+      in = e.eval(in, {}, {});
+      if (in.isNull() || in.getKind() != Kind::CONST_INTEGER)
+      {
+        return false;
+      }
     }
-    const Integer& ii = i.getConst<Rational>().getNumerator();
+    const Integer& ii = in.getConst<Rational>().getNumerator();
     if (!ii.fitsUnsignedInt())
     {
       return false;


### PR DESCRIPTION
This change is motivated by the ALF+RARE integration.

As a result of this PR, a term like `(APPLY_INDEXED_SYMBOL extract (+ 2 2) 2 x)` have type `(_ BitVec 3)`, whereas previously it had type `?`.  This led to errors in reconstruction where we did not know the correct bitwidth to use for a nil terminator.

In particular, we infer via evaluation that the above term can be concretized to `((_ extract 4 2) x)`, which can then be type checked.

This should lead to minor improvements in DSL proof reconstruction (in my testing the number of unfilled BV rewrites reduced 101 -> 99).