### PR TITLE
Track inference ids into prop engine

### DIFF
--- a/src/prop/prop_engine.cpp
+++ b/src/prop/prop_engine.cpp
@@ -165,14 +165,16 @@ void PropEngine::assertInputFormulas(
   for (const Node& node : assertions)
   {
     Trace("prop") << "assertFormula(" << node << ")" << std::endl;
-    assertInternal(node, false, false, true);
+    assertInternal(theory::InferenceId::INPUT, node, false, false, true);
   }
   int64_t natomsPost = d_cnfStream->d_stats.d_numAtoms.get();
   Assert(natomsPost >= natomsPre);
   d_stats.d_numInputAtoms += (natomsPost - natomsPre);
 }
 
-void PropEngine::assertLemma(TrustNode tlemma, theory::LemmaProperty p)
+void PropEngine::assertLemma(theory::InferenceId id,
+                             TrustNode tlemma,
+                             theory::LemmaProperty p)
 {
   bool removable = isLemmaPropertyRemovable(p);
   bool local = isLemmaPropertyLocal(p);
@@ -210,10 +212,12 @@ void PropEngine::assertLemma(TrustNode tlemma, theory::LemmaProperty p)
   }
 
   // now, assert the lemmas
-  assertLemmasInternal(tplemma, ppLemmas, removable, inprocess, local);
+  assertLemmasInternal(id, tplemma, ppLemmas, removable, inprocess, local);
 }
 
-void PropEngine::assertTrustedLemmaInternal(TrustNode trn, bool removable)
+void PropEngine::assertTrustedLemmaInternal(theory::InferenceId id,
+                                            TrustNode trn,
+                                            bool removable)
 {
   Node node = trn.getNode();
   Trace("prop::lemmas") << "assertLemma(" << node << ")" << std::endl;
@@ -222,6 +226,7 @@ void PropEngine::assertTrustedLemmaInternal(TrustNode trn, bool removable)
     output(OutputTag::LEMMAS) << "(lemma ";
     // use original form of the lemma here
     output(OutputTag::LEMMAS) << SkolemManager::getOriginalForm(node);
+    output(OutputTag::LEMMAS) << " :source " << id;
     output(OutputTag::LEMMAS) << ")" << std::endl;
   }
   bool negated = trn.getKind() == TrustNodeKind::CONFLICT;
@@ -237,11 +242,15 @@ void PropEngine::assertTrustedLemmaInternal(TrustNode trn, bool removable)
     d_theoryLemmaPg.addTrustedStep(actualNode, TrustId::THEORY_LEMMA, {}, {});
     trn = TrustNode::mkReplaceGenTrustNode(trn, &d_theoryLemmaPg);
   }
-  assertInternal(node, negated, removable, false, trn.getGenerator());
+  assertInternal(id, node, negated, removable, false, trn.getGenerator());
 }
 
-void PropEngine::assertInternal(
-    TNode node, bool negated, bool removable, bool input, ProofGenerator* pg)
+void PropEngine::assertInternal(theory::InferenceId id,
+                                TNode node,
+                                bool negated,
+                                bool removable,
+                                bool input,
+                                ProofGenerator* pg)
 {
   // Assert as (possibly) removable
   if (options().smt.unsatCoresMode == options::UnsatCoresMode::ASSUMPTIONS)
@@ -265,7 +274,7 @@ void PropEngine::assertInternal(
   }
   else if (isProofEnabled())
   {
-    d_ppm->convertAndAssert(node, negated, removable, input, pg);
+    d_ppm->convertAndAssert(id, node, negated, removable, input, pg);
   }
   else
   {
@@ -274,6 +283,7 @@ void PropEngine::assertInternal(
 }
 
 void PropEngine::assertLemmasInternal(
+    theory::InferenceId id,
     TrustNode trn,
     const std::vector<theory::SkolemLemma>& ppLemmas,
     bool removable,
@@ -297,11 +307,12 @@ void PropEngine::assertLemmasInternal(
     {
       trn = d_theoryProxy->inprocessLemma(trn);
     }
-    assertTrustedLemmaInternal(trn, removable);
+    assertTrustedLemmaInternal(id, trn, removable);
   }
   for (const theory::SkolemLemma& lem : ppLemmas)
   {
-    assertTrustedLemmaInternal(lem.d_lemma, removable);
+    assertTrustedLemmaInternal(
+        theory::InferenceId::THEORY_PP_SKOLEM_LEM, lem.d_lemma, removable);
   }
   // Note that this order is important for theories that send lemmas during
   // preregistration, as it impacts the order in which lemmas are processed
@@ -562,7 +573,12 @@ Node PropEngine::getPreprocessedTerm(TNode n)
   TrustNode tpn = d_theoryProxy->preprocess(n, newLemmas);
   // send lemmas corresponding to the skolems introduced by preprocessing n
   TrustNode trnNull;
-  assertLemmasInternal(trnNull, newLemmas, false, false, false);
+  assertLemmasInternal(theory::InferenceId::THEORY_PP_SKOLEM_LEM,
+                       trnNull,
+                       newLemmas,
+                       false,
+                       false,
+                       false);
   return tpn.isNull() ? Node(n) : tpn.getNode();
 }
 

--- a/src/prop/prop_engine.h
+++ b/src/prop/prop_engine.h
@@ -130,9 +130,9 @@ class PropEngine : protected EnvObj
    * The formula can be removed by the SAT solver after backtracking lower
    * than the (SAT and SMT) level at which it was asserted.
    *
-   * @param id the inference identifier
-   * @param trn the trust node storing the formula to assert
-   * @param p the properties of the lemma
+   * @param id The inference identifier.
+   * @param trn The trust node storing the formula to assert.
+   * @param p The properties of the lemma.
    */
   void assertLemma(theory::InferenceId id,
                    TrustNode tlemma,
@@ -374,21 +374,21 @@ class PropEngine : protected EnvObj
    * The formula can be removed by the SAT solver after backtracking lower
    * than the (SAT and SMT) level at which it was asserted.
    *
-   * @param id the inference identifier
-   * @param trn the trust node storing the formula to assert
-   * @param removable whether this lemma can be quietly removed based
-   * on an activity heuristic
+   * @param id The inference identifier.
+   * @param trn The trust node storing the formula to assert.
+   * @param removable Whether this lemma can be quietly removed based
+   * on an activity heuristic.
    */
   void assertTrustedLemmaInternal(theory::InferenceId id,
                                   TrustNode trn,
                                   bool removable);
   /**
    * Assert node as a formula to the CNF stream
-   * @param id the inference identifier
-   * @param node The formula to assert
-   * @param negated Whether to assert the negation of node
-   * @param removable Whether the formula is removable
-   * @param input Whether the formula came from the input
+   * @param id The inference identifier.
+   * @param node The formula to assert.
+   * @param negated Whether to assert the negation of node.
+   * @param removable Whether the formula is removable.
+   * @param input Whether the formula came from the input.
    * @param pg Pointer to a proof generator that can provide a proof of node
    * (or its negation if negated is true).
    */

--- a/src/prop/prop_engine.h
+++ b/src/prop/prop_engine.h
@@ -29,6 +29,7 @@
 #include "prop/learned_db.h"
 #include "prop/skolem_def_manager.h"
 #include "smt/env_obj.h"
+#include "theory/inference_id.h"
 #include "theory/output_channel.h"
 #include "theory/skolem_lemma.h"
 #include "util/result.h"
@@ -129,10 +130,13 @@ class PropEngine : protected EnvObj
    * The formula can be removed by the SAT solver after backtracking lower
    * than the (SAT and SMT) level at which it was asserted.
    *
+   * @param id the inference identifier
    * @param trn the trust node storing the formula to assert
    * @param p the properties of the lemma
    */
-  void assertLemma(TrustNode tlemma, theory::LemmaProperty p);
+  void assertLemma(theory::InferenceId id,
+                   TrustNode tlemma,
+                   theory::LemmaProperty p);
 
   /**
    * This is called when a theory propagation was explained with texp.
@@ -370,13 +374,17 @@ class PropEngine : protected EnvObj
    * The formula can be removed by the SAT solver after backtracking lower
    * than the (SAT and SMT) level at which it was asserted.
    *
+   * @param id the inference identifier
    * @param trn the trust node storing the formula to assert
    * @param removable whether this lemma can be quietly removed based
    * on an activity heuristic
    */
-  void assertTrustedLemmaInternal(TrustNode trn, bool removable);
+  void assertTrustedLemmaInternal(theory::InferenceId id,
+                                  TrustNode trn,
+                                  bool removable);
   /**
    * Assert node as a formula to the CNF stream
+   * @param id the inference identifier
    * @param node The formula to assert
    * @param negated Whether to assert the negation of node
    * @param removable Whether the formula is removable
@@ -384,7 +392,8 @@ class PropEngine : protected EnvObj
    * @param pg Pointer to a proof generator that can provide a proof of node
    * (or its negation if negated is true).
    */
-  void assertInternal(TNode node,
+  void assertInternal(theory::InferenceId id,
+                      TNode node,
                       bool negated,
                       bool removable,
                       bool input,
@@ -395,7 +404,8 @@ class PropEngine : protected EnvObj
    * obtained from preprocessing it, and removable is whether the lemma is
    * removable.
    */
-  void assertLemmasInternal(TrustNode trn,
+  void assertLemmasInternal(theory::InferenceId id,
+                            TrustNode trn,
                             const std::vector<theory::SkolemLemma>& ppLemmas,
                             bool removable,
                             bool inprocess,

--- a/src/prop/prop_proof_manager.cpp
+++ b/src/prop/prop_proof_manager.cpp
@@ -69,8 +69,12 @@ PropPfManager::PropPfManager(Env& env,
 
 void PropPfManager::ensureLiteral(TNode n) { d_pfCnfStream.ensureLiteral(n); }
 
-void PropPfManager::convertAndAssert(
-    TNode node, bool negated, bool removable, bool input, ProofGenerator* pg)
+void PropPfManager::convertAndAssert(theory::InferenceId id,
+                                     TNode node,
+                                     bool negated,
+                                     bool removable,
+                                     bool input,
+                                     ProofGenerator* pg)
 {
   d_pfCnfStream.convertAndAssert(node, negated, removable, input, pg);
   // if input, register the assertion in the proof manager

--- a/src/prop/prop_proof_manager.h
+++ b/src/prop/prop_proof_manager.h
@@ -63,11 +63,12 @@ class PropPfManager : protected EnvObj
    * goes through is saved as a concrete step in d_proof. This method makes a
    * call to the convertAndAssert method of d_pfCnfStream.
    *
-   * @param node formula to convert and assert
-   * @param negated whether we are asserting the node negated
-   * @param removable whether the SAT solver can choose to remove the clauses
-   * @param input whether the node is from the input
-   * @param pg a proof generator for node
+   * @param id The inference id indicating the source of the formula.
+   * @param node The formula to convert and assert.
+   * @param negated Whether we are asserting the node negated.
+   * @param removable Whether the SAT solver can choose to remove the clauses.
+   * @param input Whether the node is from the input.
+   * @param pg A proof generator for node.
    */
   void convertAndAssert(theory::InferenceId id,
                         TNode node,

--- a/src/prop/prop_proof_manager.h
+++ b/src/prop/prop_proof_manager.h
@@ -27,6 +27,7 @@
 #include "prop/proof_cnf_stream.h"
 #include "prop/proof_post_processor.h"
 #include "smt/env_obj.h"
+#include "theory/inference_id.h"
 
 namespace cvc5::internal {
 namespace prop {
@@ -68,8 +69,12 @@ class PropPfManager : protected EnvObj
    * @param input whether the node is from the input
    * @param pg a proof generator for node
    */
-  void convertAndAssert(
-      TNode node, bool negated, bool removable, bool input, ProofGenerator* pg);
+  void convertAndAssert(theory::InferenceId id,
+                        TNode node,
+                        bool negated,
+                        bool removable,
+                        bool input,
+                        ProofGenerator* pg);
   /** Saves assertion for later checking whether refutation proof is closed.
    *
    * The assertions registered via this interface are preprocessed assertions

--- a/src/theory/inference_id.cpp
+++ b/src/theory/inference_id.cpp
@@ -29,10 +29,12 @@ const char* toString(InferenceId i)
   switch (i)
   {
     case InferenceId::NONE: return "NONE";
+    case InferenceId::INPUT: return "INPUT";
     case InferenceId::EQ_CONSTANT_MERGE: return "EQ_CONSTANT_MERGE";
     case InferenceId::COMBINATION_SPLIT: return "COMBINATION_SPLIT";
     case InferenceId::CONFLICT_REWRITE_LIT: return "CONFLICT_REWRITE_LIT";
     case InferenceId::EXPLAINED_PROPAGATION: return "EXPLAINED_PROPAGATION";
+    case InferenceId::THEORY_PP_SKOLEM_LEM: return "THEORY_PP_SKOLEM_LEM";
     case InferenceId::EXTT_SIMPLIFY: return "EXTT_SIMPLIFY";
     case InferenceId::ARITH_BLACK_BOX: return "ARITH_BLACK_BOX";
     case InferenceId::ARITH_CONF_EQ: return "ARITH_CONF_EQ";

--- a/src/theory/inference_id.h
+++ b/src/theory/inference_id.h
@@ -42,6 +42,8 @@ enum class InferenceId
 {
   NONE,
   // ---------------------------------- core
+  // formulas coming from input
+  INPUT,
   // a conflict when two constants merge in the equality engine (of any theory)
   EQ_CONSTANT_MERGE,
   // a split from theory combination
@@ -50,6 +52,8 @@ enum class InferenceId
   CONFLICT_REWRITE_LIT,
   // an explained theory propagation
   EXPLAINED_PROPAGATION,
+  // a skolem lemma introduced by the theory preprocessor
+  THEORY_PP_SKOLEM_LEM,
   // ---------------------------------- ext theory
   // a simplification from the extended theory utility
   EXTT_SIMPLIFY,

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -1515,7 +1515,7 @@ void TheoryEngine::lemma(TrustNode tlemma,
   }
 
   // assert the lemma
-  d_propEngine->assertLemma(tlemma, p);
+  d_propEngine->assertLemma(id, tlemma, p);
 
   // If specified, we must add this lemma to the set of those that need to be
   // justified, where note we pass all auxiliary lemmas in skAsserts as well,

--- a/test/regress/cli/regress0/printer/print_sat_lemmas.smt2
+++ b/test/regress/cli/regress0/printer/print_sat_lemmas.smt2
@@ -1,6 +1,6 @@
 ; COMMAND-LINE: -o lemmas
 ; SCRUBBER: grep -E '\(lemma'
-; EXPECT: (lemma (=> (forall ((x Int)) (P x)) (P 5)))
+; EXPECT: (lemma (=> (forall ((x Int)) (P x)) (P 5)) :source QUANTIFIERS_INST_CBQI_CONFLICT)
 (set-logic ALL)
 (declare-fun P (Int) Bool)
 (assert (forall ((x Int)) (P x)))


### PR DESCRIPTION
This improves `-o lemmas` and will be used for new infrastructure for debugging soundness issues.