### PR TITLE
Add skolem id for arbitrary ground term

### DIFF
--- a/include/cvc5/cvc5_skolem_id.h
+++ b/include/cvc5/cvc5_skolem_id.h
@@ -86,16 +86,24 @@ enum ENUM(SkolemId) : uint32_t
    * 
    * - Number of skolem indices: ``1``
    *   - ``1:`` The term t that this skolem purifies.
-   * - Sort: The type of t.
+   * - Sort: The sort of t.
    */
   EVALUE(PURIFY),
+  /** 
+   * An arbitrary ground term of a given sort.
+   * 
+   * - Number of skolem indices: ``1``
+   *   - ``1:`` A term that represents the sort of the term.
+   * - Sort: The sort given by the index.
+   */
+  EVALUE(GROUND_TERM),
   /** 
    * The array diff skolem, which is the witness k for the inference
    * ``(=> (not (= A B)) (not (= (select A k) (select B k))))``.
    *
    * - Number of skolem indices: ``2``
-   *   - ``1:`` The first array of type ``(Array T1 T2)``.
-   *   - ``2:`` The second array of type ``(Array T1 T2)``.
+   *   - ``1:`` The first array of sort ``(Array T1 T2)``.
+   *   - ``2:`` The second array of sort ``(Array T1 T2)``.
    * - Sort: ``T2``
    */
   EVALUE(ARRAY_DEQ_DIFF),

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -408,6 +408,11 @@ TypeNode SkolemManager::getTypeFor(SkolemId id,
       Assert(cacheVals.size() > 0);
       return cacheVals[0].getType();
       break;
+    case SkolemId::GROUND_TERM:
+    {
+      Assert(cacheVals[0].getKind() == Kind::SORT_TO_TERM);
+      return cacheVals[0].getConst<SortToTerm>().getType();
+    }
     // real -> real function
     case SkolemId::DIV_BY_ZERO:
     {

--- a/src/printer/enum_to_string.cpp
+++ b/src/printer/enum_to_string.cpp
@@ -23,6 +23,7 @@ const char* toString(cvc5::SkolemId id)
   {
     case cvc5::SkolemId::INTERNAL: return "internal";
     case cvc5::SkolemId::PURIFY: return "purify";
+    case cvc5::SkolemId::GROUND_TERM: return "ground_term";
     case cvc5::SkolemId::ARRAY_DEQ_DIFF: return "array_deq_diff";
     case cvc5::SkolemId::DIV_BY_ZERO: return "div_by_zero";
     case cvc5::SkolemId::FP_MIN_ZERO: return "fp_min_zero";

--- a/src/theory/builtin/theory_builtin_type_rules.cpp
+++ b/src/theory/builtin/theory_builtin_type_rules.cpp
@@ -19,6 +19,7 @@
 #include "expr/skolem_manager.h"
 #include "theory/builtin/generic_op.h"
 #include "util/uninterpreted_sort_value.h"
+#include "expr/sort_to_term.h"
 
 namespace cvc5::internal {
 namespace theory {
@@ -186,10 +187,11 @@ TypeNode ApplyIndexedSymbolicTypeRule::computeType(NodeManager* nodeManager,
 
 Node SortProperties::mkGroundTerm(TypeNode type)
 {
-  SkolemManager* sm = NodeManager::currentNM()->getSkolemManager();
+  NodeManager * nm = NodeManager::currentNM();
+  SkolemManager* sm = nm->getSkolemManager();
   std::vector<Node> cacheVals;
   cacheVals.push_back(nm->mkConst(SortToTerm(type)));
-  return sm->mkSkolemFun(SkolemId::GROUND_TERM, cacheVals);
+  return sm->mkSkolemFunction(SkolemId::GROUND_TERM, cacheVals);
 }
 
 }  // namespace builtin

--- a/src/theory/builtin/theory_builtin_type_rules.cpp
+++ b/src/theory/builtin/theory_builtin_type_rules.cpp
@@ -183,29 +183,13 @@ TypeNode ApplyIndexedSymbolicTypeRule::computeType(NodeManager* nodeManager,
   // if we can make concrete, return its type
   return cn.getType();
 }
-/**
- * Attribute for caching the ground term for each type. Maps TypeNode to the
- * skolem to return for mkGroundTerm.
- */
-struct GroundTermAttributeId
-{
-};
-typedef expr::Attribute<GroundTermAttributeId, Node> GroundTermAttribute;
 
 Node SortProperties::mkGroundTerm(TypeNode type)
 {
-  // we typically use this method for sorts, although there are other types
-  // where it is used as well, e.g. arrays that are not closed enumerable.
-  GroundTermAttribute gta;
-  if (type.hasAttribute(gta))
-  {
-    return type.getAttribute(gta);
-  }
   SkolemManager* sm = NodeManager::currentNM()->getSkolemManager();
-  Node k = sm->mkDummySkolem(
-      "groundTerm", type, "a ground term created for type " + type.toString());
-  type.setAttribute(gta, k);
-  return k;
+  std::vector<Node> cacheVals;
+  cacheVals.push_back(nm->mkConst(SortToTerm(type)));
+  return sm->mkSkolemFun(SkolemId::GROUND_TERM, cacheVals);
 }
 
 }  // namespace builtin

--- a/src/theory/builtin/theory_builtin_type_rules.cpp
+++ b/src/theory/builtin/theory_builtin_type_rules.cpp
@@ -187,6 +187,8 @@ TypeNode ApplyIndexedSymbolicTypeRule::computeType(NodeManager* nodeManager,
 
 Node SortProperties::mkGroundTerm(TypeNode type)
 {
+  // we typically use this method for sorts, although there are other types
+  // where it is used as well, e.g. arrays that are not closed enumerable.
   NodeManager * nm = NodeManager::currentNM();
   SkolemManager* sm = nm->getSkolemManager();
   std::vector<Node> cacheVals;


### PR DESCRIPTION
This kind of skolem is introduced to represent an arbitrary constant of a given sort.

This simplifies the implementation and exports this id, as it may appear in lemmas (e.g. enumerative quantifier instantiation).