### PR TITLE
datatypes: Refactor hashing, add hashing and operator== on C++ API level.

### DIFF
--- a/include/cvc5/cvc5.h
+++ b/include/cvc5/cvc5.h
@@ -2029,6 +2029,7 @@ class CVC5_EXPORT DatatypeConstructorDecl
   friend class DatatypeDecl;
   friend class TermManager;
   friend class Solver;
+  friend struct std::hash<DatatypeConstructorDecl>;
 
  public:
   /** Constructor.  */
@@ -2038,6 +2039,14 @@ class CVC5_EXPORT DatatypeConstructorDecl
    * Destructor.
    */
   ~DatatypeConstructorDecl();
+
+  /**
+   * Equality operator.
+   * @param decl The datatype constructor declaration to compare to for
+   * equality.
+   * @return True if the datatype constructor declarations are equal.
+   */
+  bool operator==(const DatatypeConstructorDecl& decl) const;
 
   /**
    * Add datatype selector declaration.
@@ -2108,6 +2117,21 @@ class CVC5_EXPORT DatatypeConstructorDecl
   std::shared_ptr<internal::DTypeConstructor> d_ctor;
 };
 
+}  // namespace cvc5
+
+namespace std {
+/**
+ * Hash function for datatype constructor declarations.
+ */
+template <>
+struct CVC5_EXPORT hash<cvc5::DatatypeConstructorDecl>
+{
+  size_t operator()(const cvc5::DatatypeConstructorDecl& decl) const;
+};
+}  // namespace std
+
+namespace cvc5 {
+
 class Solver;
 
 /**
@@ -2127,6 +2151,7 @@ class CVC5_EXPORT DatatypeDecl
   friend class DatatypeConstructorArg;
   friend class TermManager;
   friend class Solver;
+  friend struct std::hash<DatatypeDecl>;
 
  public:
   /** Constructor.  */
@@ -2136,6 +2161,13 @@ class CVC5_EXPORT DatatypeDecl
    * Destructor.
    */
   ~DatatypeDecl();
+
+  /**
+   * Equality operator.
+   * @param decl The datatype declaration to compare to for equality.
+   * @return True if the datatype declarations are equal.
+   */
+  bool operator==(const DatatypeDecl& decll) const;
 
   /**
    * Add datatype constructor declaration.
@@ -2229,6 +2261,21 @@ class CVC5_EXPORT DatatypeDecl
   std::shared_ptr<internal::DType> d_dtype;
 };
 
+}  // namespace cvc5
+
+namespace std {
+/**
+ * Hash function for datatype declarations.
+ */
+template <>
+struct CVC5_EXPORT hash<cvc5::DatatypeDecl>
+{
+  size_t operator()(const cvc5::DatatypeDecl& decl) const;
+};
+}  // namespace std
+
+namespace cvc5 {
+
 /**
  * A cvc5 datatype selector.
  */
@@ -2237,6 +2284,7 @@ class CVC5_EXPORT DatatypeSelector
   friend class Datatype;
   friend class DatatypeConstructor;
   friend class TermManager;
+  friend struct std::hash<DatatypeSelector>;
 
  public:
   /**
@@ -2248,6 +2296,13 @@ class CVC5_EXPORT DatatypeSelector
    * Destructor.
    */
   ~DatatypeSelector();
+
+  /**
+   * Equality operator.
+   * @param sel The datatype selector to compare to for equality.
+   * @return True if the datatype selectors are equal.
+   */
+  bool operator==(const DatatypeSelector& sel) const;
 
   /**
    * Get the name of this datatype selector.
@@ -2322,6 +2377,21 @@ class CVC5_EXPORT DatatypeSelector
   std::shared_ptr<internal::DTypeSelector> d_stor;
 };
 
+}  // namespace cvc5
+
+namespace std {
+/**
+ * Hash function for datatype Selectors.
+ */
+template <>
+struct CVC5_EXPORT hash<cvc5::DatatypeSelector>
+{
+  size_t operator()(const cvc5::DatatypeSelector& sel) const;
+};
+}  // namespace std
+
+namespace cvc5 {
+
 /**
  * A cvc5 datatype constructor.
  */
@@ -2329,6 +2399,7 @@ class CVC5_EXPORT DatatypeConstructor
 {
   friend class Datatype;
   friend class TermManager;
+  friend struct std::hash<DatatypeConstructor>;
 
  public:
   /**
@@ -2340,6 +2411,13 @@ class CVC5_EXPORT DatatypeConstructor
    * Destructor.
    */
   ~DatatypeConstructor();
+
+  /**
+   * Equality operator.
+   * @param cons The datatype constructor to compare to for equality.
+   * @return True if the datatype constructors are equal.
+   */
+  bool operator==(const DatatypeConstructor& cons) const;
 
   /**
    * Get the name of this datatype constructor.
@@ -2603,6 +2681,21 @@ class CVC5_EXPORT DatatypeConstructor
   std::shared_ptr<internal::DTypeConstructor> d_ctor;
 };
 
+}  // namespace cvc5
+
+namespace std {
+/**
+ * Hash function for datatype constructors.
+ */
+template <>
+struct CVC5_EXPORT hash<cvc5::DatatypeConstructor>
+{
+  size_t operator()(const cvc5::DatatypeConstructor& cons) const;
+};
+}  // namespace std
+
+namespace cvc5 {
+
 /**
  * A cvc5 datatype.
  */
@@ -2610,6 +2703,7 @@ class CVC5_EXPORT Datatype
 {
   friend class TermManager;
   friend class Sort;
+  friend struct std::hash<Datatype>;
 
  public:
   /** Constructor. */
@@ -2619,6 +2713,13 @@ class CVC5_EXPORT Datatype
    * Destructor.
    */
   ~Datatype();
+
+  /**
+   * Equality operator.
+   * @param dt The datatype to compare to for equality.
+   * @return True if the datatypes are equal.
+   */
+  bool operator==(const Datatype& dt) const;
 
   /**
    * Get the datatype constructor at a given index.
@@ -2932,6 +3033,21 @@ std::ostream& operator<<(std::ostream& out, const DatatypeConstructor& ctor);
  */
 CVC5_EXPORT
 std::ostream& operator<<(std::ostream& out, const DatatypeSelector& stor);
+
+}  // namespace cvc5
+
+namespace std {
+/**
+ * Hash function for datatypes.
+ */
+template <>
+struct CVC5_EXPORT hash<cvc5::Datatype>
+{
+  size_t operator()(const cvc5::Datatype& dt) const;
+};
+}  // namespace std
+
+namespace cvc5 {
 
 /* -------------------------------------------------------------------------- */
 /* Grammar                                                                    */

--- a/include/cvc5/cvc5.h
+++ b/include/cvc5/cvc5.h
@@ -2043,7 +2043,7 @@ class CVC5_EXPORT DatatypeConstructorDecl
   /**
    * Equality operator.
    * @param decl The datatype constructor declaration to compare to for
-   * equality.
+   *             equality.
    * @return True if the datatype constructor declarations are equal.
    */
   bool operator==(const DatatypeConstructorDecl& decl) const;

--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -3761,6 +3761,17 @@ DatatypeConstructorDecl::~DatatypeConstructorDecl()
   }
 }
 
+bool DatatypeConstructorDecl::operator==(
+    const DatatypeConstructorDecl& decl) const
+{
+  CVC5_API_TRY_CATCH_BEGIN;
+  CVC5_API_CHECK_NOT_NULL;
+  //////// all checks before this line
+  return d_ctor == decl.d_ctor;
+  ////////
+  CVC5_API_TRY_CATCH_END;
+}
+
 void DatatypeConstructorDecl::addSelector(const std::string& name,
                                           const Sort& sort)
 {
@@ -3861,6 +3872,16 @@ DatatypeDecl::DatatypeDecl(TermManager* tm,
   std::vector<internal::TypeNode> tparams = Sort::sortVectorToTypeNodes(params);
   d_dtype = std::shared_ptr<internal::DType>(
       new internal::DType(name, tparams, isCoDatatype));
+}
+
+bool DatatypeDecl::operator==(const DatatypeDecl& decl) const
+{
+  CVC5_API_TRY_CATCH_BEGIN;
+  CVC5_API_CHECK_NOT_NULL;
+  //////// all checks before this line
+  return d_dtype == decl.d_dtype;
+  ////////
+  CVC5_API_TRY_CATCH_END;
 }
 
 bool DatatypeDecl::isNullHelper() const { return !d_dtype; }
@@ -3988,6 +4009,16 @@ DatatypeSelector::~DatatypeSelector()
   }
 }
 
+bool DatatypeSelector::operator==(const DatatypeSelector& sel) const
+{
+  CVC5_API_TRY_CATCH_BEGIN;
+  CVC5_API_CHECK_NOT_NULL;
+  //////// all checks before this line
+  return d_stor == sel.d_stor;
+  ////////
+  CVC5_API_TRY_CATCH_END;
+}
+
 std::string DatatypeSelector::getName() const
 {
   CVC5_API_TRY_CATCH_BEGIN;
@@ -4074,6 +4105,16 @@ DatatypeConstructor::~DatatypeConstructor()
   {
     d_ctor.reset();
   }
+}
+
+bool DatatypeConstructor::operator==(const DatatypeConstructor& cons) const
+{
+  CVC5_API_TRY_CATCH_BEGIN;
+  CVC5_API_CHECK_NOT_NULL;
+  //////// all checks before this line
+  return d_ctor == cons.d_ctor;
+  ////////
+  CVC5_API_TRY_CATCH_END;
 }
 
 std::string DatatypeConstructor::getName() const
@@ -4317,6 +4358,16 @@ Datatype::~Datatype()
   {
     d_dtype.reset();
   }
+}
+
+bool Datatype::operator==(const Datatype& dt) const
+{
+  CVC5_API_TRY_CATCH_BEGIN;
+  CVC5_API_CHECK_NOT_NULL;
+  //////// all checks before this line
+  return d_dtype == dt.d_dtype;
+  ////////
+  CVC5_API_TRY_CATCH_END;
 }
 
 DatatypeConstructor Datatype::operator[](size_t idx) const
@@ -8655,6 +8706,35 @@ size_t std::hash<cvc5::Sort>::operator()(const cvc5::Sort& s) const
 size_t std::hash<cvc5::Term>::operator()(const cvc5::Term& t) const
 {
   return std::hash<cvc5::internal::Node>()(*t.d_node);
+}
+
+size_t std::hash<cvc5::DatatypeConstructorDecl>::operator()(
+    const cvc5::DatatypeConstructorDecl& decl) const
+{
+  return std::hash<cvc5::internal::DTypeConstructor>()(*decl.d_ctor);
+}
+
+size_t std::hash<cvc5::DatatypeDecl>::operator()(
+    const cvc5::DatatypeDecl& decl) const
+{
+  return std::hash<cvc5::internal::DType>()(*decl.d_dtype);
+}
+
+size_t std::hash<cvc5::DatatypeSelector>::operator()(
+    const cvc5::DatatypeSelector& sel) const
+{
+  return std::hash<cvc5::internal::DTypeSelector>()(*sel.d_stor);
+}
+
+size_t std::hash<cvc5::DatatypeConstructor>::operator()(
+    const cvc5::DatatypeConstructor& cons) const
+{
+  return std::hash<cvc5::internal::DTypeConstructor>()(*cons.d_ctor);
+}
+
+size_t hash<cvc5::Datatype>::operator()(const cvc5::Datatype& dt) const
+{
+  return std::hash<cvc5::internal::DType>()(*dt.d_dtype);
 }
 
 }  // namespace std

--- a/src/expr/dtype.cpp
+++ b/src/expr/dtype.cpp
@@ -1005,3 +1005,11 @@ void DType::toStream(std::ostream& out) const
 }
 
 }  // namespace cvc5::internal
+
+namespace std {
+size_t hash<cvc5::internal::DType>::operator()(
+    const cvc5::internal::DType& dt) const
+{
+  return std::hash<std::string>()(dt.getName());
+}
+}  // namespace std

--- a/src/expr/dtype.h
+++ b/src/expr/dtype.h
@@ -642,24 +642,19 @@ class DType
   mutable std::map<TypeNode, CardinalityClass> d_cardClass;
 }; /* class DType */
 
-/**
- * A hash function for DTypes.  Needed to store them in hash sets
- * and hash maps.
- */
-struct DTypeHashFunction
-{
-  size_t operator()(const DType& dt) const
-  {
-    return std::hash<std::string>()(dt.getName());
-  }
-  size_t operator()(const DType* dt) const
-  {
-    return std::hash<std::string>()(dt->getName());
-  }
-}; /* struct DTypeHashFunction */
-
 std::ostream& operator<<(std::ostream& os, const DType& dt);
 
 }  // namespace cvc5::internal
+
+namespace std {
+/**
+ * A hash function for DTypes.
+ */
+template <>
+struct hash<cvc5::internal::DType>
+{
+  size_t operator()(const cvc5::internal::DType& dt) const;
+};
+}  // namespace std
 
 #endif

--- a/src/expr/dtype_cons.cpp
+++ b/src/expr/dtype_cons.cpp
@@ -731,3 +731,11 @@ std::ostream& operator<<(std::ostream& os, const DTypeConstructor& ctor)
 }
 
 }  // namespace cvc5::internal
+
+namespace std {
+size_t hash<cvc5::internal::DTypeConstructor>::operator()(
+    const cvc5::internal::DTypeConstructor& cons) const
+{
+  return std::hash<std::string>()(cons.getName());
+}
+}  // namespace std

--- a/src/expr/dtype_cons.h
+++ b/src/expr/dtype_cons.h
@@ -351,24 +351,18 @@ class DTypeConstructor
   mutable std::map<TypeNode, std::pair<CardinalityClass, bool> > d_cardInfo;
 }; /* class DTypeConstructor */
 
-/**
- * A hash function for DTypeConstructors.  Needed to store them in hash sets
- * and hash maps.
- */
-struct DTypeConstructorHashFunction
-{
-  size_t operator()(const DTypeConstructor& dtc) const
-  {
-    return std::hash<std::string>()(dtc.getName());
-  }
-  size_t operator()(const DTypeConstructor* dtc) const
-  {
-    return std::hash<std::string>()(dtc->getName());
-  }
-}; /* struct DTypeConstructorHashFunction */
-
 std::ostream& operator<<(std::ostream& os, const DTypeConstructor& ctor);
 
 }  // namespace cvc5::internal
 
+namespace std {
+/**
+ * A hash function for DTypeConstructors.
+ */
+template <>
+struct hash<cvc5::internal::DTypeConstructor>
+{
+  size_t operator()(const cvc5::internal::DTypeConstructor& cons) const;
+};
+}  // namespace std
 #endif

--- a/src/expr/dtype_selector.cpp
+++ b/src/expr/dtype_selector.cpp
@@ -90,3 +90,11 @@ std::ostream& operator<<(std::ostream& os, const DTypeSelector& arg)
 }
 
 }  // namespace cvc5::internal
+
+namespace std {
+size_t hash<cvc5::internal::DTypeSelector>::operator()(
+    const cvc5::internal::DTypeSelector& sel) const
+{
+  return std::hash<std::string>()(sel.getName());
+}
+}  // namespace std

--- a/src/expr/dtype_selector.h
+++ b/src/expr/dtype_selector.h
@@ -100,4 +100,14 @@ std::ostream& operator<<(std::ostream& os, const DTypeSelector& arg);
 
 }  // namespace cvc5::internal
 
+namespace std {
+/**
+ * A hash function for DTypeSelectors.
+ */
+template <>
+struct hash<cvc5::internal::DTypeSelector>
+{
+  size_t operator()(const cvc5::internal::DTypeSelector& cons) const;
+};
+}  // namespace std
 #endif


### PR DESCRIPTION
This is only needed for adding datatypes (and related types) to hash maps/sets. On the API level, we mainly need this for memory management in the term manager of the C API.