### PR TITLE
Separate proof status from DSL proof rule identifiers

### DIFF
--- a/src/proof/lfsc/lfsc_printer.cpp
+++ b/src/proof/lfsc/lfsc_printer.cpp
@@ -881,7 +881,7 @@ bool LfscPrinter::computeProofArgs(const ProofNode* pn,
     break;
     case ProofRule::DSL_REWRITE:
     {
-      DslProofRule di = DslProofRule::FAIL;
+      DslProofRule di = DslProofRule::NONE;
       if (!rewriter::getDslProofRule(args[0], di))
       {
         Assert(false);

--- a/src/rewriter/CMakeLists.txt
+++ b/src/rewriter/CMakeLists.txt
@@ -27,6 +27,8 @@ libcvc5_add_sources(
   rewrite_db_term_process.h
   rewrite_proof_rule.cpp
   rewrite_proof_rule.h
+  rewrite_proof_status.cpp
+  rewrite_proof_status.h
 )
 
 set(mkrewrites_script ${CMAKE_CURRENT_LIST_DIR}/mkrewrites.py)

--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -41,7 +41,7 @@ RewriteDbProofCons::RewriteDbProofCons(Env& env, RewriteDb* db)
       d_eval(nullptr),
       d_currRecLimit(0),
       d_currStepLimit(0),
-      d_currFixedPointId(DslProofRule::FAIL),
+      d_currFixedPointId(RewriteProofStatus::FAIL),
       d_statTotalInputs(
           statisticsRegistry().registerInt("RewriteDbProofCons::totalInputs")),
       d_statTotalAttempts(statisticsRegistry().registerInt(
@@ -126,7 +126,7 @@ bool RewriteDbProofCons::proveEq(CDProof* cdp,
   // initiate the getMatches routine.
   d_currRecLimit = recLimit + 1;
   d_currStepLimit = stepLimit;
-  DslProofRule id;
+  RewriteProofStatus id;
   if (!proveInternalBase(eqi, id))
   {
     Trace("rpc-debug") << "- prove internal" << std::endl;
@@ -136,7 +136,7 @@ bool RewriteDbProofCons::proveEq(CDProof* cdp,
     Trace("rpc-debug") << "- finished prove internal" << std::endl;
   }
   // if a proof was provided, fill it in
-  if (id != DslProofRule::FAIL && cdp != nullptr)
+  if (id != RewriteProofStatus::FAIL && cdp != nullptr)
   {
     ++d_statTotalInputSuccess;
     Trace("rpc-debug") << "- ensure proof" << std::endl;
@@ -153,7 +153,7 @@ bool RewriteDbProofCons::proveEq(CDProof* cdp,
   return false;
 }
 
-DslProofRule RewriteDbProofCons::proveInternal(const Node& eqi)
+RewriteProofStatus RewriteDbProofCons::proveInternal(const Node& eqi)
 {
   d_currProving.insert(eqi);
   ++d_statTotalAttempts;
@@ -166,34 +166,34 @@ DslProofRule RewriteDbProofCons::proveInternal(const Node& eqi)
   Assert(eqi.getKind() == Kind::EQUAL);
   // first, try congruence if possible, which does not count towards recursion
   // limit.
-  DslProofRule retId = proveInternalViaStrategy(eqi);
+  RewriteProofStatus retId = proveInternalViaStrategy(eqi);
   d_currProving.erase(eqi);
   return retId;
 }
 
-DslProofRule RewriteDbProofCons::proveInternalViaStrategy(const Node& eqi)
+RewriteProofStatus RewriteDbProofCons::proveInternalViaStrategy(const Node& eqi)
 {
   Assert(eqi.getKind() == Kind::EQUAL);
-  if (proveWithRule(DslProofRule::CONG, eqi, {}, {}, false, false, true))
+  if (proveWithRule(RewriteProofStatus::CONG, eqi, {}, {}, false, false, true))
   {
     Trace("rpc-debug2") << "...proved via congruence" << std::endl;
-    return DslProofRule::CONG;
+    return RewriteProofStatus::CONG;
   }
-  if (proveWithRule(DslProofRule::CONG_EVAL, eqi, {}, {}, false, false, true))
+  if (proveWithRule(RewriteProofStatus::CONG_EVAL, eqi, {}, {}, false, false, true))
   {
     Trace("rpc-debug2") << "...proved via congruence + evaluation" << std::endl;
-    return DslProofRule::CONG_EVAL;
+    return RewriteProofStatus::CONG_EVAL;
   }
   // standard normalization
-  if (proveWithRule(DslProofRule::ACI_NORM, eqi, {}, {}, false, false, true))
+  if (proveWithRule(RewriteProofStatus::ACI_NORM, eqi, {}, {}, false, false, true))
   {
-    return DslProofRule::ACI_NORM;
+    return RewriteProofStatus::ACI_NORM;
   }
   // if arithmetic, maybe holds by arithmetic normalization?
   if (proveWithRule(
-          DslProofRule::ARITH_POLY_NORM, eqi, {}, {}, false, false, true))
+          RewriteProofStatus::ARITH_POLY_NORM, eqi, {}, {}, false, false, true))
   {
-    return DslProofRule::ARITH_POLY_NORM;
+    return RewriteProofStatus::ARITH_POLY_NORM;
   }
   Trace("rpc-debug2") << "...not proved via builtin tactic" << std::endl;
   d_currRecLimit--;
@@ -207,7 +207,7 @@ DslProofRule RewriteDbProofCons::proveInternalViaStrategy(const Node& eqi)
   std::unordered_map<Node, ProvenInfo>::iterator it = d_pcache.find(eqi);
   if (it != d_pcache.end())
   {
-    if (it->second.d_id != DslProofRule::FAIL
+    if (it->second.d_id != RewriteProofStatus::FAIL
         || d_currRecLimit <= it->second.d_failMaxDepth)
     {
       return it->second.d_id;
@@ -215,8 +215,8 @@ DslProofRule RewriteDbProofCons::proveInternalViaStrategy(const Node& eqi)
   }
   // if target is (= (= t1 t2) true), maybe try showing (= t1 t2); otherwise
   // try showing (= target true)
-  DslProofRule eqTrueId =
-      eqi[1] == d_true ? DslProofRule::TRUE_INTRO : DslProofRule::TRUE_ELIM;
+  RewriteProofStatus eqTrueId =
+      eqi[1] == d_true ? RewriteProofStatus::TRUE_INTRO : RewriteProofStatus::TRUE_ELIM;
   if (proveWithRule(eqTrueId, eqi, {}, {}, false, false, true))
   {
     Trace("rpc-debug2") << "...proved via " << eqTrueId << std::endl;
@@ -226,9 +226,9 @@ DslProofRule RewriteDbProofCons::proveInternalViaStrategy(const Node& eqi)
                     << std::endl;
   // store failure, and its maximum depth
   ProvenInfo& pi = d_pcache[eqi];
-  pi.d_id = DslProofRule::FAIL;
+  pi.d_id = RewriteProofStatus::FAIL;
   pi.d_failMaxDepth = d_currRecLimit;
-  return DslProofRule::FAIL;
+  return RewriteProofStatus::FAIL;
 }
 
 bool RewriteDbProofCons::notifyMatch(const Node& s,
@@ -249,7 +249,7 @@ bool RewriteDbProofCons::notifyMatch(const Node& s,
   Assert(d_target.getKind() == Kind::EQUAL);
   Assert(s.getType().isComparableTo(n.getType()));
   Assert(vars.size() == subs.size());
-  if (d_currFixedPointId != DslProofRule::FAIL)
+  if (d_currFixedPointId != RewriteProofStatus::FAIL)
   {
     Trace("rpc-debug2") << "Part of fixed point for rule " << d_currFixedPointId
                         << std::endl;
@@ -277,10 +277,10 @@ bool RewriteDbProofCons::notifyMatch(const Node& s,
   Assert(d_target[0] == s);
   bool recurse = d_currRecLimit > 0;
   // get the rule identifiers for the conclusion
-  const std::vector<DslProofRule>& ids = d_db->getRuleIdsForHead(n);
+  const std::vector<RewriteProofStatus>& ids = d_db->getRuleIdsForHead(n);
   Assert(!ids.empty());
   // check each rule instance, succeed if one proves
-  for (DslProofRule id : ids)
+  for (RewriteProofStatus id : ids)
   {
     // try to prove target with the current rule, using inflection matching
     // and fixed point semantics
@@ -297,7 +297,7 @@ bool RewriteDbProofCons::notifyMatch(const Node& s,
   return true;
 }
 
-bool RewriteDbProofCons::proveWithRule(DslProofRule id,
+bool RewriteDbProofCons::proveWithRule(RewriteProofStatus id,
                                        const Node& target,
                                        const std::vector<Node>& vars,
                                        const std::vector<Node>& subs,
@@ -310,7 +310,7 @@ bool RewriteDbProofCons::proveWithRule(DslProofRule id,
   std::vector<Node> vcs;
   Node transEq;
   ProvenInfo pic;
-  if (id == DslProofRule::CONG)
+  if (id == RewriteProofStatus::CONG)
   {
     size_t nchild = target[0].getNumChildren();
     if (nchild == 0 || nchild != target[1].getNumChildren()
@@ -332,7 +332,7 @@ bool RewriteDbProofCons::proveWithRule(DslProofRule id,
       pic.d_vars.push_back(eq);
     }
   }
-  else if (id == DslProofRule::CONG_EVAL)
+  else if (id == RewriteProofStatus::CONG_EVAL)
   {
     size_t nchild = target[0].getNumChildren();
     // evaluate the right hand side
@@ -377,7 +377,7 @@ bool RewriteDbProofCons::proveWithRule(DslProofRule id,
       return false;
     }
   }
-  else if (id == DslProofRule::TRUE_ELIM)
+  else if (id == RewriteProofStatus::TRUE_ELIM)
   {
     if (target[1] == d_true)
     {
@@ -389,7 +389,7 @@ bool RewriteDbProofCons::proveWithRule(DslProofRule id,
     vcs.push_back(eq);
     pic.d_vars.push_back(eq);
   }
-  else if (id == DslProofRule::TRUE_INTRO)
+  else if (id == RewriteProofStatus::TRUE_INTRO)
   {
     if (target[1] != d_true || target[0].getKind() != Kind::EQUAL)
     {
@@ -401,7 +401,7 @@ bool RewriteDbProofCons::proveWithRule(DslProofRule id,
     vcs.push_back(eq);
     pic.d_vars.push_back(eq);
   }
-  else if (id == DslProofRule::ACI_NORM)
+  else if (id == RewriteProofStatus::ACI_NORM)
   {
     if (!expr::isACINorm(target[0], target[1]))
     {
@@ -409,7 +409,7 @@ bool RewriteDbProofCons::proveWithRule(DslProofRule id,
     }
     pic.d_id = id;
   }
-  else if (id == DslProofRule::ARITH_POLY_NORM)
+  else if (id == RewriteProofStatus::ARITH_POLY_NORM)
   {
     if (!theory::arith::PolyNorm::isArithPolyNorm(target[0], target[1]))
     {
@@ -425,7 +425,7 @@ bool RewriteDbProofCons::proveWithRule(DslProofRule id,
     Assert(conc.getKind() == Kind::EQUAL && target.getKind() == Kind::EQUAL);
     // get rule conclusion, which may incorporate fixed point semantics when
     // doFixedPoint is true. This stores the rule for the conclusion in pic,
-    // which is either id or DslProofRule::TRANS.
+    // which is either id or RewriteProofStatus::TRANS.
     Node stgt = getRuleConclusion(rpr, vars, subs, pic, doFixedPoint);
     Trace("rpc-debug2") << "            RHS: " << conc[1] << std::endl;
     Trace("rpc-debug2") << "Substituted RHS: " << stgt << std::endl;
@@ -478,11 +478,11 @@ bool RewriteDbProofCons::proveWithRule(DslProofRule id,
   {
     Assert(cond.getKind() == Kind::EQUAL);
     // substitute to get the condition-to-prove
-    DslProofRule cid;
+    RewriteProofStatus cid;
     // check whether condition is already known to hold or not hold
     if (proveInternalBase(cond, cid))
     {
-      if (cid == DslProofRule::FAIL)
+      if (cid == RewriteProofStatus::FAIL)
       {
         // does not hold, we fail
         Trace("rpc-debug2") << "...fail (simple condition failure for " << cond
@@ -506,8 +506,8 @@ bool RewriteDbProofCons::proveWithRule(DslProofRule id,
   {
     Trace("rpc-infer-sc") << "Check condition: " << cond << std::endl;
     // recursively check if the condition holds
-    DslProofRule cid = proveInternal(cond);
-    if (cid == DslProofRule::FAIL)
+    RewriteProofStatus cid = proveInternal(cond);
+    if (cid == RewriteProofStatus::FAIL)
     {
       // print reason for failure
       Trace("rpc-infer-debug")
@@ -528,7 +528,7 @@ bool RewriteDbProofCons::proveWithRule(DslProofRule id,
     Trace("rpc-debug2") << "..." << target << " proved by TRANS" << std::endl;
     Node transEqStart = target[0].eqNode(transEq[0]);
     // proves both
-    pi->d_id = DslProofRule::TRANS;
+    pi->d_id = RewriteProofStatus::TRANS;
     pi->d_vars.clear();
     pi->d_vars.push_back(transEqStart);
     pi->d_vars.push_back(transEq);
@@ -553,7 +553,7 @@ bool RewriteDbProofCons::proveWithRule(DslProofRule id,
   return true;
 }
 
-bool RewriteDbProofCons::proveInternalBase(const Node& eqi, DslProofRule& idb)
+bool RewriteDbProofCons::proveInternalBase(const Node& eqi, RewriteProofStatus& idb)
 {
   Trace("rpc-debug2") << "Prove internal base: " << eqi << "?" << std::endl;
   Assert(eqi.getKind() == Kind::EQUAL);
@@ -561,14 +561,14 @@ bool RewriteDbProofCons::proveInternalBase(const Node& eqi, DslProofRule& idb)
   if (d_currProving.find(eqi) != d_currProving.end())
   {
     Trace("rpc-debug2") << "...fail (already proving)" << std::endl;
-    idb = DslProofRule::FAIL;
+    idb = RewriteProofStatus::FAIL;
     return true;
   }
   // already cached?
   std::unordered_map<Node, ProvenInfo>::iterator it = d_pcache.find(eqi);
   if (it != d_pcache.end())
   {
-    if (it->second.d_id != DslProofRule::FAIL)
+    if (it->second.d_id != RewriteProofStatus::FAIL)
     {
       // proof exists, return
       idb = it->second.d_id;
@@ -591,7 +591,7 @@ bool RewriteDbProofCons::proveInternalBase(const Node& eqi, DslProofRule& idb)
   if (eqi[0] == eqi[1])
   {
     ProvenInfo& pi = d_pcache[eqi];
-    idb = DslProofRule::REFL;
+    idb = RewriteProofStatus::REFL;
     pi.d_id = idb;
     Trace("rpc-debug2") << "...success, refl" << std::endl;
     return true;
@@ -604,7 +604,7 @@ bool RewriteDbProofCons::proveInternalBase(const Node& eqi, DslProofRule& idb)
                         << (eqi[0].isVar() ? "variable" : "ill-typed") << ")"
                         << std::endl;
     ProvenInfo& pi = d_pcache[eqi];
-    idb = DslProofRule::FAIL;
+    idb = RewriteProofStatus::FAIL;
     pi.d_failMaxDepth = 0;
     pi.d_id = idb;
     return true;
@@ -626,7 +626,7 @@ bool RewriteDbProofCons::proveInternalBase(const Node& eqi, DslProofRule& idb)
       if (eq.getTypeOrNull().isNull())
       {
         ProvenInfo& pi = d_pcache[eqi];
-        idb = DslProofRule::FAIL;
+        idb = RewriteProofStatus::FAIL;
         pi.d_failMaxDepth = 0;
         pi.d_id = idb;
         Trace("rpc-debug2") << "...fail, ill-typed equality" << std::endl;
@@ -641,7 +641,7 @@ bool RewriteDbProofCons::proveInternalBase(const Node& eqi, DslProofRule& idb)
           ProvenInfo& pi = d_pcache[eqi];
           Trace("rpc-debug2") << "fail, infeasible due to rewriting: " << eqi[0]
                               << " == " << eqi[1] << std::endl;
-          idb = DslProofRule::FAIL;
+          idb = RewriteProofStatus::FAIL;
           pi.d_failMaxDepth = 0;
           pi.d_id = idb;
           return true;
@@ -660,13 +660,13 @@ bool RewriteDbProofCons::proveInternalBase(const Node& eqi, DslProofRule& idb)
     if (ev[0] == ev[1])
     {
       Trace("rpc-debug2") << "...success, eval" << std::endl;
-      idb = DslProofRule::EVAL;
+      idb = RewriteProofStatus::EVAL;
     }
     else
     {
       Trace("rpc-debug2") << "...fail (eval " << ev[0] << " and " << ev[1]
                           << ")" << std::endl;
-      idb = DslProofRule::FAIL;
+      idb = RewriteProofStatus::FAIL;
       // failure relies on nothing, depth is 0
       pi.d_failMaxDepth = 0;
     }
@@ -678,7 +678,7 @@ bool RewriteDbProofCons::proveInternalBase(const Node& eqi, DslProofRule& idb)
   {
     Trace("rpc-debug2") << "...fail (constant head)" << std::endl;
     ProvenInfo& pi = d_pcache[eqi];
-    idb = DslProofRule::FAIL;
+    idb = RewriteProofStatus::FAIL;
     pi.d_failMaxDepth = 0;
     pi.d_id = idb;
     return true;
@@ -723,16 +723,16 @@ bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
       }
       else
       {
-        Assert(pcur.d_id != DslProofRule::FAIL);
+        Assert(pcur.d_id != RewriteProofStatus::FAIL);
         Trace("rpc-debug") << "...proved via " << pcur.d_id << std::endl;
-        if (pcur.d_id == DslProofRule::REFL)
+        if (pcur.d_id == RewriteProofStatus::REFL)
         {
           it->second = true;
           // trivial proof
           Assert(cur[0] == cur[1]);
           cdp->addStep(cur, ProofRule::REFL, {}, {cur[0]});
         }
-        else if (pcur.d_id == DslProofRule::EVAL)
+        else if (pcur.d_id == RewriteProofStatus::EVAL)
         {
           it->second = true;
           // NOTE: this could just evaluate the equality itself
@@ -761,12 +761,12 @@ bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
         {
           std::vector<Node>& ps = premises[cur];
           std::vector<Node>& pfac = pfArgs[cur];
-          if (isInternalDslProofRule(pcur.d_id))
+          if (isInternalRewriteProofStatus(pcur.d_id))
           {
             // premises are the steps, stored in d_vars
             ps.insert(ps.end(), pcur.d_vars.begin(), pcur.d_vars.end());
-            if (pcur.d_id == DslProofRule::CONG
-                || pcur.d_id == DslProofRule::CONG_EVAL)
+            if (pcur.d_id == RewriteProofStatus::CONG
+                || pcur.d_id == RewriteProofStatus::CONG_EVAL)
             {
               pfac.push_back(ProofRuleChecker::mkKindNode(cur[0].getKind()));
               if (cur[0].getMetaKind() == kind::metakind::PARAMETERIZED)
@@ -816,19 +816,19 @@ bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
       std::vector<Node>& ps = premises[cur];
       // get the conclusion
       Node conc;
-      if (pcur.d_id == DslProofRule::TRANS)
+      if (pcur.d_id == RewriteProofStatus::TRANS)
       {
         conc = ps[0][0].eqNode(ps.back()[1]);
         cdp->addStep(conc, ProofRule::TRANS, ps, {});
       }
-      else if (pcur.d_id == DslProofRule::CONG)
+      else if (pcur.d_id == RewriteProofStatus::CONG)
       {
         // get the appropriate CONG rule
         std::vector<Node> cargs;
         ProofRule cr = expr::getCongRule(cur[0], cargs);
         cdp->addStep(cur, cr, ps, cargs);
       }
-      else if (pcur.d_id == DslProofRule::CONG_EVAL)
+      else if (pcur.d_id == RewriteProofStatus::CONG_EVAL)
       {
         // congruence + evaluation, given we are trying to prove
         //   (f t1 ... tn) == c
@@ -866,21 +866,21 @@ bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
         }
         cdp->addStep(cur, ProofRule::TRANS, transChildren, {});
       }
-      else if (pcur.d_id == DslProofRule::TRUE_ELIM)
+      else if (pcur.d_id == RewriteProofStatus::TRUE_ELIM)
       {
         conc = ps[0][0];
         cdp->addStep(conc, ProofRule::TRUE_ELIM, ps, {});
       }
-      else if (pcur.d_id == DslProofRule::TRUE_INTRO)
+      else if (pcur.d_id == RewriteProofStatus::TRUE_INTRO)
       {
         conc = ps[0].eqNode(d_true);
         cdp->addStep(conc, ProofRule::TRUE_INTRO, ps, {});
       }
-      else if (pcur.d_id == DslProofRule::ACI_NORM)
+      else if (pcur.d_id == RewriteProofStatus::ACI_NORM)
       {
         cdp->addStep(cur, ProofRule::ACI_NORM, {}, {cur});
       }
-      else if (pcur.d_id == DslProofRule::ARITH_POLY_NORM)
+      else if (pcur.d_id == RewriteProofStatus::ARITH_POLY_NORM)
       {
         cdp->addStep(cur, ProofRule::ARITH_POLY_NORM, {}, {cur});
       }
@@ -922,7 +922,7 @@ Node RewriteDbProofCons::getRuleConclusion(const RewriteProofRule& rpr,
   // if fixed point, we continue applying
   if (doFixedPoint && rpr.isFixedPoint())
   {
-    Assert(d_currFixedPointId == DslProofRule::FAIL);
+    Assert(d_currFixedPointId == RewriteProofStatus::FAIL);
     Assert(d_currFixedPointConc.isNull());
     d_currFixedPointId = rpr.getId();
     // check if stgt also rewrites with the same rule?
@@ -984,11 +984,11 @@ Node RewriteDbProofCons::getRuleConclusion(const RewriteProofRule& rpr,
       prev = stepConc;
     }
 
-    d_currFixedPointId = DslProofRule::FAIL;
+    d_currFixedPointId = RewriteProofStatus::FAIL;
     // add the transistivity rule here if needed
     if (transEq.size() >= 2)
     {
-      pi.d_id = DslProofRule::TRANS;
+      pi.d_id = RewriteProofStatus::TRANS;
       // store transEq in d_vars
       pi.d_vars = transEq;
       // return the end of the chain, which will be used for constrained
@@ -1046,7 +1046,7 @@ void RewriteDbProofCons::cacheProofSubPlaceholder(TNode context,
   for (const Node& cong : congs)
   {
     ProvenInfo& cpi = d_pcache[cong];
-    cpi.d_id = DslProofRule::CONG;
+    cpi.d_id = RewriteProofStatus::CONG;
     for (size_t i = 0, size = cong[0].getNumChildren(); i < size; i++)
     {
       TNode lhs = cong[0][i];
@@ -1054,7 +1054,7 @@ void RewriteDbProofCons::cacheProofSubPlaceholder(TNode context,
       if (lhs == rhs)
       {
         ProvenInfo& pi = d_pcache[lhs.eqNode(rhs)];
-        pi.d_id = DslProofRule::REFL;
+        pi.d_id = RewriteProofStatus::REFL;
       }
       cpi.d_vars.emplace_back(lhs.eqNode(rhs));
     }

--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -179,13 +179,15 @@ RewriteProofStatus RewriteDbProofCons::proveInternalViaStrategy(const Node& eqi)
     Trace("rpc-debug2") << "...proved via congruence" << std::endl;
     return RewriteProofStatus::CONG;
   }
-  if (proveWithRule(RewriteProofStatus::CONG_EVAL, eqi, {}, {}, false, false, true))
+  if (proveWithRule(
+          RewriteProofStatus::CONG_EVAL, eqi, {}, {}, false, false, true))
   {
     Trace("rpc-debug2") << "...proved via congruence + evaluation" << std::endl;
     return RewriteProofStatus::CONG_EVAL;
   }
   // standard normalization
-  if (proveWithRule(RewriteProofStatus::ACI_NORM, eqi, {}, {}, false, false, true))
+  if (proveWithRule(
+          RewriteProofStatus::ACI_NORM, eqi, {}, {}, false, false, true))
   {
     return RewriteProofStatus::ACI_NORM;
   }
@@ -215,8 +217,9 @@ RewriteProofStatus RewriteDbProofCons::proveInternalViaStrategy(const Node& eqi)
   }
   // if target is (= (= t1 t2) true), maybe try showing (= t1 t2); otherwise
   // try showing (= target true)
-  RewriteProofStatus eqTrueId =
-      eqi[1] == d_true ? RewriteProofStatus::TRUE_INTRO : RewriteProofStatus::TRUE_ELIM;
+  RewriteProofStatus eqTrueId = eqi[1] == d_true
+                                    ? RewriteProofStatus::TRUE_INTRO
+                                    : RewriteProofStatus::TRUE_ELIM;
   if (proveWithRule(eqTrueId, eqi, {}, {}, false, false, true))
   {
     Trace("rpc-debug2") << "...proved via " << eqTrueId << std::endl;
@@ -264,7 +267,13 @@ bool RewriteDbProofCons::notifyMatch(const Node& s,
     // We also don't permit inflection matching (which regardless should not
     // apply).
     if (proveWithRule(RewriteProofStatus::DSL,
-           target, vars, subs, false, false, false, d_currFixedPointId))
+                      target,
+                      vars,
+                      subs,
+                      false,
+                      false,
+                      false,
+                      d_currFixedPointId))
     {
       // successfully proved, store in temporary variable
       d_currFixedPointConc = target;
@@ -284,7 +293,14 @@ bool RewriteDbProofCons::notifyMatch(const Node& s,
   {
     // try to prove target with the current rule, using inflection matching
     // and fixed point semantics
-    if (proveWithRule(RewriteProofStatus::DSL, d_target, vars, subs, true, true, recurse, id))
+    if (proveWithRule(RewriteProofStatus::DSL,
+                      d_target,
+                      vars,
+                      subs,
+                      true,
+                      true,
+                      recurse,
+                      id))
     {
       // if successful, we do not want to be notified of further matches
       // and return false here.
@@ -555,7 +571,8 @@ bool RewriteDbProofCons::proveWithRule(RewriteProofStatus id,
   return true;
 }
 
-bool RewriteDbProofCons::proveInternalBase(const Node& eqi, RewriteProofStatus& idb)
+bool RewriteDbProofCons::proveInternalBase(const Node& eqi,
+                                           RewriteProofStatus& idb)
 {
   Trace("rpc-debug2") << "Prove internal base: " << eqi << "?" << std::endl;
   Assert(eqi.getKind() == Kind::EQUAL);
@@ -779,7 +796,7 @@ bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
           }
           else
           {
-            Assert (pcur.d_dslId!=DslProofRule::NONE);
+            Assert(pcur.d_dslId != DslProofRule::NONE);
             const RewriteProofRule& rpr = d_db->getRule(pcur.d_dslId);
             // add the DSL proof rule we used
             pfac.push_back(
@@ -890,7 +907,7 @@ bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
       else
       {
         Assert(pfArgs.find(cur) != pfArgs.end());
-        Assert (pcur.d_dslId!=DslProofRule::NONE);
+        Assert(pcur.d_dslId != DslProofRule::NONE);
         const RewriteProofRule& rpr = d_db->getRule(pcur.d_dslId);
         const std::vector<Node>& args = pfArgs[cur];
         std::vector<Node> subs(args.begin() + 1, args.end());

--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -944,7 +944,7 @@ Node RewriteDbProofCons::getRuleConclusion(const RewriteProofRule& rpr,
   // if fixed point, we continue applying
   if (doFixedPoint && rpr.isFixedPoint())
   {
-    Assert(d_currFixedPointId == RewriteProofStatus::FAIL);
+    Assert(d_currFixedPointId == DslProofRule::NONE);
     Assert(d_currFixedPointConc.isNull());
     d_currFixedPointId = rpr.getId();
     // check if stgt also rewrites with the same rule?

--- a/src/rewriter/rewrite_db_proof_cons.h
+++ b/src/rewriter/rewrite_db_proof_cons.h
@@ -95,9 +95,9 @@ class RewriteDbProofCons : protected EnvObj
   class ProvenInfo
   {
    public:
-    ProvenInfo() : d_id(DslProofRule::FAIL), d_failMaxDepth(0) {}
+    ProvenInfo() : d_id(RewriteProofStatus::FAIL), d_failMaxDepth(0) {}
     /** The identifier of the proof rule, or fail if we failed */
-    DslProofRule d_id;
+    RewriteProofStatus d_id;
     /** The substitution used, if successful */
     std::vector<Node> d_vars;
     std::vector<Node> d_subs;
@@ -109,7 +109,7 @@ class RewriteDbProofCons : protected EnvObj
     /**
      * Is internal rule? these rules store children (if any) in d_vars.
      */
-    bool isInternalRule() const { return isInternalDslProofRule(d_id); }
+    bool isInternalRule() const { return d_id!=RewriteProofStatus::DSL; }
   };
   /**
    * Prove and store the proof of eq with internal form eqi in cdp if possible,
@@ -122,7 +122,7 @@ class RewriteDbProofCons : protected EnvObj
                int64_t stepLimit);
   /**
    * Prove internal, which is the main entry point for proven an equality eqi.
-   * Returns the proof rule that was used to prove eqi, or DslProofRule::FAIL
+   * Returns the proof rule that was used to prove eqi, or RewriteProofStatus::FAIL
    * if we failed to prove.
    *
    * In detail, this runs a strategy of builtin tactics and otherwise consults
@@ -130,14 +130,14 @@ class RewriteDbProofCons : protected EnvObj
    * left hand side of eqi.
    *
    * If this call is successful (i.e. the returned rule is not
-   * DslProofRule::FAIL), the proven info for eqi is stored in d_pcache[eqi].
+   * RewriteProofStatus::FAIL), the proven info for eqi is stored in d_pcache[eqi].
    *
    * Note this method depends on the current step and recursion limits
    * d_currRecLimit/d_currStepLimit.
    */
-  DslProofRule proveInternal(const Node& eqi);
+  RewriteProofStatus proveInternal(const Node& eqi);
   /** Prove internal via strategy, a helper method for above. */
-  DslProofRule proveInternalViaStrategy(const Node& eqi);
+  RewriteProofStatus proveInternalViaStrategy(const Node& eqi);
   /**
    * Prove internal base eqi via DSL rule id.
    *
@@ -145,9 +145,9 @@ class RewriteDbProofCons : protected EnvObj
    * recursion. If so, we store the rule used for eqi in its proven info
    * (d_pcache[eqi]). Notice that this method returns true if eqi is
    * proven or *disproven*, where in the latter case proven info has d_id
-   * DslProofRule::FAIL.
+   * RewriteProofStatus::FAIL.
    */
-  bool proveInternalBase(const Node& eqi, DslProofRule& id);
+  bool proveInternalBase(const Node& eqi, RewriteProofStatus& id);
   /**
    * Ensure proof for proven fact exists in cdp. This method is called on
    * equalities eqi after they have been successfully proven by this class.
@@ -192,7 +192,7 @@ class RewriteDbProofCons : protected EnvObj
    * @param doRecurse Whether we should attempt to prove the rule when premises
    * are required, by making a recursive call to proveInternal.
    */
-  bool proveWithRule(DslProofRule id,
+  bool proveWithRule(RewriteProofStatus id,
                      const Node& target,
                      const std::vector<Node>& vars,
                      const std::vector<Node>& subs,
@@ -260,7 +260,7 @@ class RewriteDbProofCons : protected EnvObj
   /** current step recursion limit */
   uint64_t d_currStepLimit;
   /** current rule we are applying to fixed point */
-  DslProofRule d_currFixedPointId;
+  RewriteProofStatus d_currFixedPointId;
   /** current substitution from fixed point */
   std::vector<Node> d_currFixedPointSubs;
   /** current conclusion from fixed point */

--- a/src/rewriter/rewrite_db_proof_cons.h
+++ b/src/rewriter/rewrite_db_proof_cons.h
@@ -27,6 +27,7 @@
 #include "rewriter/basic_rewrite_rcons.h"
 #include "rewriter/rewrite_db.h"
 #include "rewriter/rewrite_db_term_process.h"
+#include "rewriter/rewrite_proof_status.h"
 #include "rewriter/rewrites.h"
 #include "smt/env_obj.h"
 #include "theory/evaluator.h"
@@ -95,9 +96,11 @@ class RewriteDbProofCons : protected EnvObj
   class ProvenInfo
   {
    public:
-    ProvenInfo() : d_id(RewriteProofStatus::FAIL), d_failMaxDepth(0) {}
+    ProvenInfo() : d_id(RewriteProofStatus::FAIL), d_dslId(DslProofRule::NONE), d_failMaxDepth(0) {}
     /** The identifier of the proof rule, or fail if we failed */
     RewriteProofStatus d_id;
+    /** The identifier of the DSL proof rule if d_id is DSL */
+    DslProofRule d_dslId;
     /** The substitution used, if successful */
     std::vector<Node> d_vars;
     std::vector<Node> d_subs;
@@ -180,7 +183,7 @@ class RewriteDbProofCons : protected EnvObj
    * Prove with rule, which attempts to prove the equality target using the
    * DSL proof rule id, which may be a builtin rule or a user-provided rule.
    *
-   * @param id The rule to consider
+   * @param id The rule to consider, which may be a DSL rule given by r if DSL.
    * @param target The equality to prove
    * @param vars The variables (arguments) of the proof rule
    * @param subs The substitution (instantiated arguments) of the proof rule
@@ -191,6 +194,7 @@ class RewriteDbProofCons : protected EnvObj
    * point
    * @param doRecurse Whether we should attempt to prove the rule when premises
    * are required, by making a recursive call to proveInternal.
+   * @param r The DSL rule to consider if id is DSL.
    */
   bool proveWithRule(RewriteProofStatus id,
                      const Node& target,
@@ -198,7 +202,8 @@ class RewriteDbProofCons : protected EnvObj
                      const std::vector<Node>& subs,
                      bool doTrans,
                      bool doFixedPoint,
-                     bool doRecurse);
+                     bool doRecurse,
+                     DslProofRule r = DslProofRule::NONE);
   /**
    * Get conclusion of rewrite rule rpr under the current variable and
    * substitution. Store the information in proven info pi. If doFixedPoint
@@ -260,7 +265,7 @@ class RewriteDbProofCons : protected EnvObj
   /** current step recursion limit */
   uint64_t d_currStepLimit;
   /** current rule we are applying to fixed point */
-  RewriteProofStatus d_currFixedPointId;
+  DslProofRule d_currFixedPointId;
   /** current substitution from fixed point */
   std::vector<Node> d_currFixedPointSubs;
   /** current conclusion from fixed point */

--- a/src/rewriter/rewrite_db_proof_cons.h
+++ b/src/rewriter/rewrite_db_proof_cons.h
@@ -96,7 +96,12 @@ class RewriteDbProofCons : protected EnvObj
   class ProvenInfo
   {
    public:
-    ProvenInfo() : d_id(RewriteProofStatus::FAIL), d_dslId(DslProofRule::NONE), d_failMaxDepth(0) {}
+    ProvenInfo()
+        : d_id(RewriteProofStatus::FAIL),
+          d_dslId(DslProofRule::NONE),
+          d_failMaxDepth(0)
+    {
+    }
     /** The identifier of the proof rule, or fail if we failed */
     RewriteProofStatus d_id;
     /** The identifier of the DSL proof rule if d_id is DSL */
@@ -112,7 +117,7 @@ class RewriteDbProofCons : protected EnvObj
     /**
      * Is internal rule? these rules store children (if any) in d_vars.
      */
-    bool isInternalRule() const { return d_id!=RewriteProofStatus::DSL; }
+    bool isInternalRule() const { return d_id != RewriteProofStatus::DSL; }
   };
   /**
    * Prove and store the proof of eq with internal form eqi in cdp if possible,
@@ -125,15 +130,16 @@ class RewriteDbProofCons : protected EnvObj
                int64_t stepLimit);
   /**
    * Prove internal, which is the main entry point for proven an equality eqi.
-   * Returns the proof rule that was used to prove eqi, or RewriteProofStatus::FAIL
-   * if we failed to prove.
+   * Returns the proof rule that was used to prove eqi, or
+   * RewriteProofStatus::FAIL if we failed to prove.
    *
    * In detail, this runs a strategy of builtin tactics and otherwise consults
    * the rewrite rule database for the set of rewrite rules that match the
    * left hand side of eqi.
    *
    * If this call is successful (i.e. the returned rule is not
-   * RewriteProofStatus::FAIL), the proven info for eqi is stored in d_pcache[eqi].
+   * RewriteProofStatus::FAIL), the proven info for eqi is stored in
+   * d_pcache[eqi].
    *
    * Note this method depends on the current step and recursion limits
    * d_currRecLimit/d_currStepLimit.

--- a/src/rewriter/rewrite_proof_rule.cpp
+++ b/src/rewriter/rewrite_proof_rule.cpp
@@ -26,7 +26,7 @@ using namespace cvc5::internal::kind;
 namespace cvc5::internal {
 namespace rewriter {
 
-RewriteProofRule::RewriteProofRule() : d_id(DslProofRule::FAIL) {}
+RewriteProofRule::RewriteProofRule() : d_id(DslProofRule::NONE) {}
 
 void RewriteProofRule::init(DslProofRule id,
                             const std::vector<Node>& userFvs,

--- a/src/rewriter/rewrite_proof_status.cpp
+++ b/src/rewriter/rewrite_proof_status.cpp
@@ -1,0 +1,48 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2024 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The status of a rewrite rule proof reconstruction attempt
+ */
+
+#include "rewriter/rewrite_proof_status.h"
+
+namespace cvc5::internal {
+namespace rewriter {
+
+
+const char* toString(RewriteProofStatus s)
+{
+  switch (s)
+  {
+    case RewriteProofStatus::FAIL: return "FAIL";
+    case RewriteProofStatus::REFL: return "REFL";
+    case RewriteProofStatus::EVAL: return "EVAL";
+    case RewriteProofStatus::TRANS: return "TRANS";
+    case RewriteProofStatus::CONG: return "CONG";
+    case RewriteProofStatus::CONG_EVAL: return "CONG_EVAL";
+    case RewriteProofStatus::TRUE_ELIM: return "TRUE_ELIM";
+    case RewriteProofStatus::TRUE_INTRO: return "TRUE_INTRO";
+    case RewriteProofStatus::ARITH_POLY_NORM: return "ARITH_POLY_NORM";
+    case RewriteProofStatus::ACI_NORM: return "ACI_NORM";
+    default : Unreachable();
+  }
+}
+
+std::ostream& operator<<(std::ostream& out, RewriteProofStatus s)
+{
+  out << toString(s);
+  return out;
+}
+
+}  // namespace rewriter
+}  // namespace cvc5::internal
+

--- a/src/rewriter/rewrite_proof_status.cpp
+++ b/src/rewriter/rewrite_proof_status.cpp
@@ -18,7 +18,6 @@
 namespace cvc5::internal {
 namespace rewriter {
 
-
 const char* toString(RewriteProofStatus s)
 {
   switch (s)
@@ -33,7 +32,7 @@ const char* toString(RewriteProofStatus s)
     case RewriteProofStatus::TRUE_INTRO: return "TRUE_INTRO";
     case RewriteProofStatus::ARITH_POLY_NORM: return "ARITH_POLY_NORM";
     case RewriteProofStatus::ACI_NORM: return "ACI_NORM";
-    default : Unreachable();
+    default: Unreachable();
   }
 }
 
@@ -45,4 +44,3 @@ std::ostream& operator<<(std::ostream& out, RewriteProofStatus s)
 
 }  // namespace rewriter
 }  // namespace cvc5::internal
-

--- a/src/rewriter/rewrite_proof_status.cpp
+++ b/src/rewriter/rewrite_proof_status.cpp
@@ -32,6 +32,7 @@ const char* toString(RewriteProofStatus s)
     case RewriteProofStatus::TRUE_INTRO: return "TRUE_INTRO";
     case RewriteProofStatus::ARITH_POLY_NORM: return "ARITH_POLY_NORM";
     case RewriteProofStatus::ACI_NORM: return "ACI_NORM";
+    case RewriteProofStatus::DSL: return "DSL";
     default: Unreachable();
   }
 }

--- a/src/rewriter/rewrite_proof_status.h
+++ b/src/rewriter/rewrite_proof_status.h
@@ -51,10 +51,10 @@ enum class RewriteProofStatus : uint32_t
  */
 const char* toString(RewriteProofStatus s);
 /**
- * Writes a rewrite proof status  to a stream.
+ * Writes a rewrite proof status to a stream.
  *
  * @param out The stream to write to
- * @param s The rewrite proof status  to write to the stream
+ * @param s The rewrite proof status to write to the stream
  * @return The stream
  */
 std::ostream& operator<<(std::ostream& out, RewriteProofStatus s);

--- a/src/rewriter/rewrite_proof_status.h
+++ b/src/rewriter/rewrite_proof_status.h
@@ -1,0 +1,65 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2024 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The status of a rewrite rule proof reconstruction attempt
+ */
+
+#include "cvc5_public.h"
+
+#ifndef CVC5__REWRITER__REWRITE_PROOF_STATUS__H
+#define CVC5__REWRITER__REWRITE_PROOF_STATUS__H
+
+#include "expr/node.h"
+
+namespace cvc5::internal {
+namespace rewriter {
+
+/**
+ * Identifiers for the status of a DSL proof reconstruction goal.
+ */
+enum class RewriteProofStatus : uint32_t
+{
+  FAIL = 0,
+  // The following rules can be generated temporarily during reconstruction.
+  // We convert them into ProofRule during proof finalization.
+  REFL,
+  EVAL,
+  TRANS,
+  CONG,
+  CONG_EVAL,
+  TRUE_ELIM,
+  TRUE_INTRO,
+  ARITH_POLY_NORM,
+  ACI_NORM,
+  // we have a DSL proof rule that proves this goal.
+  DSL,
+};
+
+/**
+ * Converts a rewrite proof status to a string.
+ * @param s The rewrite proof status
+ * @return The name of the rewrite proof status
+ */
+const char* toString(RewriteProofStatus s);
+/**
+ * Writes a rewrite proof status  to a stream.
+ *
+ * @param out The stream to write to
+ * @param s The rewrite proof status  to write to the stream
+ * @return The stream
+ */
+std::ostream& operator<<(std::ostream& out, RewriteProofStatus s);
+
+}  // namespace rewriter
+}  // namespace cvc5::internal
+
+#endif

--- a/src/rewriter/rewrites_template.cpp
+++ b/src/rewriter/rewrites_template.cpp
@@ -38,31 +38,10 @@ void addRules(RewriteDb& db)
   // clang-format on
 }
 
-bool isInternalDslProofRule(DslProofRule drule)
-{
-  return drule == DslProofRule::FAIL || drule == DslProofRule::REFL
-         || drule == DslProofRule::EVAL || drule == DslProofRule::TRANS
-         || drule == DslProofRule::CONG || drule == DslProofRule::CONG_EVAL
-         || drule == DslProofRule::TRUE_ELIM
-         || drule == DslProofRule::TRUE_INTRO
-         || drule == DslProofRule::ARITH_POLY_NORM
-         || drule == DslProofRule::ACI_NORM;
-}
-
 const char* toString(DslProofRule drule)
 {
   switch (drule)
   {
-    case DslProofRule::FAIL: return "FAIL";
-    case DslProofRule::REFL: return "REFL";
-    case DslProofRule::EVAL: return "EVAL";
-    case DslProofRule::TRANS: return "TRANS";
-    case DslProofRule::CONG: return "CONG";
-    case DslProofRule::CONG_EVAL: return "CONG_EVAL";
-    case DslProofRule::TRUE_ELIM: return "TRUE_ELIM";
-    case DslProofRule::TRUE_INTRO: return "TRUE_INTRO";
-    case DslProofRule::ARITH_POLY_NORM: return "ARITH_POLY_NORM";
-    case DslProofRule::ACI_NORM: return "ACI_NORM";
       // clang-format off
 ${printer}$
     default : Unreachable();

--- a/src/rewriter/rewrites_template.cpp
+++ b/src/rewriter/rewrites_template.cpp
@@ -42,6 +42,7 @@ const char* toString(DslProofRule drule)
 {
   switch (drule)
   {
+    case DslProofRule::NONE: return "NONE";
       // clang-format off
 ${printer}$
     default : Unreachable();

--- a/src/rewriter/rewrites_template.h
+++ b/src/rewriter/rewrites_template.h
@@ -15,8 +15,8 @@
 
 #include "cvc5_public.h"
 
-#ifndef CVC5__THEORY_REWRITER_REWRITES_H
-#define CVC5__THEORY_REWRITER_REWRITES_H
+#ifndef CVC5__REWRITER__REWRITES__H
+#define CVC5__REWRITER__REWRITES__H
 
 #include "expr/node.h"
 
@@ -30,25 +30,12 @@ class RewriteDb;
  */
 enum class DslProofRule : uint32_t
 {
-  FAIL = 0,
-  REFL,
-  EVAL,
-  // the following rules can be generated temporarily during reconstruction
-  TRANS,
-  CONG,
-  CONG_EVAL,
-  TRUE_ELIM,
-  TRUE_INTRO,
-  ARITH_POLY_NORM,
-  ACI_NORM,
+  NONE = 0,
   // Generated rule ids
   // clang-format off
   ${rule_ids}$
   // clang-format on
 };
-
-/** Is internal rule? */
-bool isInternalDslProofRule(DslProofRule drule);
 
 /**
  * The body of this method is auto-generated. This populates the provided


### PR DESCRIPTION
This introduces a new enum that is used internally by the DSL proof reconstruction algorithm. It separates this from DSL proof rule identifiers, since the latter will be exposed to the API and the former are internal-only.