### PR TITLE
Fix auto-generated doc for `-o block-models` and `-o portfolio`

### DIFF
--- a/src/options/base_options.toml
+++ b/src/options/base_options.toml
@@ -244,7 +244,7 @@ name   = "Base"
   name = "portfolio"
   help = "prints the option strings tried in portfolio mode."
   description = "With ``-o portfolio``, cvc5 prints the option strings tried in portfolio mode."
-  example-file = "regress0/printer/portfolio-out.smt2"
+  example-file = "regress0/printer/portfolio-out.smt2 --use-portfolio"
 [[option.mode.BLOCK_MODEL]]
   name = "block-model"
   help = "prints the formulas used when block-model is run."

--- a/src/parser/smt2/smt2_cmd_parser.cpp
+++ b/src/parser/smt2/smt2_cmd_parser.cpp
@@ -869,6 +869,11 @@ std::unique_ptr<Cmd> Smt2CmdParser::parseNextCommand()
       {
         ss = d_state.stripQuotes(ss);
       }
+      else if (key=="use-portfolio")
+      {
+        // we don't allow setting portfolio via the command line
+        d_lex.parseError("Can only enable use-portfolio via the command line");
+      }
       cmd.reset(new SetOptionCommand(key, ss));
       // Ugly that this changes the state of the parser; but
       // global-declarations affects parsing, so we can't hold off

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1250,6 +1250,7 @@ set(regress_0_tests
   regress0/printer/learned-lit-output.smt2
   regress0/printer/let_shadowing.smt2
   regress0/printer/portfolio-out.smt2
+  regress0/printer/portfolio-out-err.smt2
   regress0/printer/post-asserts-output.smt2
   regress0/printer/pre-asserts-output.smt2
   regress0/printer/print_sat_lemmas.smt2

--- a/test/regress/cli/regress0/printer/block_model_out.smt2
+++ b/test/regress/cli/regress0/printer/block_model_out.smt2
@@ -5,6 +5,7 @@
 ; EXIT: 0
 ; DISABLE-TESTER: dump
 (set-logic ALL)
+(set-option :incremental true)
 (set-option :produce-models true)
 (declare-fun x () Int)
 (declare-fun y () Int)

--- a/test/regress/cli/regress0/printer/portfolio-out-err.smt2
+++ b/test/regress/cli/regress0/printer/portfolio-out-err.smt2
@@ -1,0 +1,11 @@
+; REQUIRES: no-competition
+; COMMAND-LINE:
+; EXPECT: (error "Parse Error: ./regress0/printer/portfolio-out-err.smt2:7.28: Can only enable use-portfolio via the command line")
+; EXPECT: unsat
+; DISABLE-TESTER: dump
+(set-logic UFLIA)
+(set-option :use-portfolio true)
+(declare-fun P (Int) Bool)
+(assert (forall ((x Int)) (P x)))
+(assert (not (P 10)))
+(check-sat)

--- a/test/regress/cli/regress0/printer/portfolio-out-err.smt2
+++ b/test/regress/cli/regress0/printer/portfolio-out-err.smt2
@@ -1,8 +1,8 @@
 ; REQUIRES: no-competition
 ; COMMAND-LINE:
-; EXPECT: (error "Parse Error: ./regress0/printer/portfolio-out-err.smt2:7.28: Can only enable use-portfolio via the command line")
-; EXPECT: unsat
+; EXPECT: (error "Parse Error: portfolio-out-err.smt2:7.28: Can only enable use-portfolio via the command line")
 ; DISABLE-TESTER: dump
+; EXIT: 1
 (set-logic UFLIA)
 (set-option :use-portfolio true)
 (declare-fun P (Int) Bool)

--- a/test/regress/cli/regress0/printer/portfolio-out.smt2
+++ b/test/regress/cli/regress0/printer/portfolio-out.smt2
@@ -5,7 +5,6 @@
 ; EXIT: 0
 ; DISABLE-TESTER: dump
 (set-logic UFLIA)
-(set-option :use-portfolio true)
 (declare-fun P (Int) Bool)
 (assert (forall ((x Int)) (P x)))
 (assert (not (P 10)))


### PR DESCRIPTION
The block models benchmark did had `incremental` set in the regression preamble but not the smt2 file.

The portfolio one was quietly ignoring `use-portfolio` when set via smt2. We now throw an error.