### PR TITLE
Do not apply global negation if there are symbols that are not first class

### DIFF
--- a/src/expr/type_node.cpp
+++ b/src/expr/type_node.cpp
@@ -197,7 +197,7 @@ CardinalityClass TypeNode::getCardinalityClass()
     else
     {
       // all types we care about should be handled above
-      Assert(false);
+      Assert(false) << *this;
     }
   }
   setAttribute(TypeCardinalityClassAttr(), static_cast<uint64_t>(ret));

--- a/src/preprocessing/passes/global_negate.cpp
+++ b/src/preprocessing/passes/global_negate.cpp
@@ -43,7 +43,17 @@ Node GlobalNegate::simplify(const std::vector<Node>& assertions,
     Trace("cegqi-gn") << "  " << as << std::endl;
     expr::getSymbols(as, syms, visited);
   }
-  std::vector<Node> free_vars(syms.begin(), syms.end());
+  for (const Node& s : syms)
+  {
+    if (s.getType().isFirstClass())
+    {
+      // We have a symbol whose type is not first class. For example, a
+      // datatype selector. In such cases, this preprocessing pass cannot be
+      // applied.
+      return Node::null();
+    }
+  }
+  std::vector<Node> fvs(syms.begin(), syms.end());
 
   Node body;
   if (assertions.size() == 1)
@@ -58,17 +68,17 @@ Node GlobalNegate::simplify(const std::vector<Node>& assertions,
   // do the negation
   body = body.negate();
 
-  if (!free_vars.empty())
+  if (!fvs.empty())
   {
     std::vector<Node> bvs;
-    for (const Node& v : free_vars)
+    for (const Node& v : fvs)
     {
       Node bv = nm->mkBoundVar(v.getType());
       bvs.push_back(bv);
     }
 
     body = body.substitute(
-        free_vars.begin(), free_vars.end(), bvs.begin(), bvs.end());
+        fvs.begin(), fvs.end(), bvs.begin(), bvs.end());
 
     Node bvl = nm->mkNode(Kind::BOUND_VAR_LIST, bvs);
 
@@ -89,6 +99,11 @@ PreprocessingPassResult GlobalNegate::applyInternal(
 {
   NodeManager* nm = nodeManager();
   Node simplifiedNode = simplify(assertionsToPreprocess->ref(), nm);
+  if (simplifiedNode.isNull())
+  {
+    // failed to convert, possibly due to an unhandled symbol
+    return PreprocessingPassResult::NO_CONFLICT;
+  }
   Node trueNode = nm->mkConst(true);
   // mark as negated
   assertionsToPreprocess->markNegated();

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2753,6 +2753,7 @@ set(regress_1_tests
   regress1/quantifiers/proj-issue597.smt2
   regress1/quantifiers/proj-issue599.smt2
   regress1/quantifiers/proj-issue602.smt2
+  regress1/quantifiers/proj-issue706-gn-dt.smt2
   regress1/quantifiers/psyco-001-bv.smt2
   regress1/quantifiers/psyco-107-bv.smt2
   regress1/quantifiers/psyco-196.smt2

--- a/test/regress/cli/regress1/quantifiers/proj-issue706-gn-dt.smt2
+++ b/test/regress/cli/regress1/quantifiers/proj-issue706-gn-dt.smt2
@@ -1,0 +1,8 @@
+; EXPECT: sat
+(set-logic ALL)
+(set-option :fmf-bound true)
+(set-option :global-negate true)
+(declare-datatypes ((d 0)) (((c (s Bool)))))
+(declare-const x d)
+(assert (s x))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5-projects/issues/706.