### PR TITLE
Do not install CaDiCaL static library

### DIFF
--- a/cmake/FindCaDiCaL.cmake
+++ b/cmake/FindCaDiCaL.cmake
@@ -172,8 +172,4 @@ if(CaDiCaL_FOUND_SYSTEM)
 else()
   message(STATUS "Building CaDiCaL ${CaDiCaL_VERSION}: ${CaDiCaL_LIBRARIES}")
   add_dependencies(CaDiCaL CaDiCaL-EP)
-  install(FILES
-    ${CaDiCaL_LIBRARIES}
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  )
 endif()


### PR DESCRIPTION
We always link the CaDiCaL library statically, so there is no need to install it along cvc5.