### PR TITLE
ci: Use native build for Windows package

### DIFF
--- a/.github/actions/add-package/action.yml
+++ b/.github/actions/add-package/action.yml
@@ -9,11 +9,13 @@ inputs:
     description: token to upload package to latest
   github-token-release:
     description: token to upload package to release
+  shell:
+    default: bash
 runs:
   using: composite
   steps:
     - name: Create ZIP file
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: |
         echo "::group::Create ZIP file"
         # Run 'make install' on build directory
@@ -41,7 +43,7 @@ runs:
         echo "::endgroup::"
 
     - name: install pyGithub
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: |
         python3 -m pip install pyGithub
 

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -74,6 +74,7 @@ runs:
           mingw-w64-x86_64-cmake
           mingw-w64-x86_64-gcc
           mingw-w64-x86_64-gmp
+          zip
 
     - name: Set up num_proc variable for Linux and Windows
       if: runner.os == 'Linux' || runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
             windows-build: true
             shell: 'msys2 {0}'
             check-examples: true
+            package-name: cvc5-Win64
             exclude_regress: 1-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
@@ -78,7 +79,6 @@ jobs:
             cache-key: production-win64-cross
             strip-bin: x86_64-w64-mingw32-strip
             windows-build: true
-            package-name: cvc5-Win64
 
           - name: ubuntu:production-clang
             os: ubuntu-20.04
@@ -181,6 +181,7 @@ jobs:
         # when using GITHUB_TOKEN, no further workflows are triggered
         github-token-latest: ${{ secrets.GITHUB_TOKEN }}
         github-token-release: ${{ secrets.ACTION_USER_TOKEN }}
+        shell: ${{ matrix.shell }}
 
     - name: Create and add static package to latest and release
       if: matrix.package-name && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
@@ -191,6 +192,7 @@ jobs:
         # when using GITHUB_TOKEN, no further workflows are triggered
         github-token-latest: ${{ secrets.GITHUB_TOKEN }}
         github-token-release: ${{ secrets.ACTION_USER_TOKEN }}
+        shell: ${{ matrix.shell }}
 
   update-pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This uses the win64 native build as the source for the Win64 package instead of the cross-compiled build. The main difference lies in the location of the DLL libraries, which are situated in the 'bin' directory.