### PR TITLE
Handle case where list context occurs in condition for ALF+RARE

### DIFF
--- a/src/rewriter/rewrite_proof_rule.cpp
+++ b/src/rewriter/rewrite_proof_rule.cpp
@@ -156,6 +156,11 @@ Node RewriteProofRule::getConclusionFor(
   Node conc = getConclusion(true);
   std::unordered_map<TNode, Node> visited;
   Node ret = expr::narySubstitute(conc, d_fvs, ss, visited);
+  // also compute for the condition
+  for (const Node& c : d_cond)
+  {
+    expr::narySubstitute(c, d_fvs, ss, visited);
+  }
   std::map<Node, Node>::const_iterator itl;
   for (size_t i = 0, nfvs = ss.size(); i < nfvs; i++)
   {
@@ -177,7 +182,7 @@ Node RewriteProofRule::getConclusionFor(
         // to determine the type, we get the type of the substitution of the
         // list context of the variable.
         Node subsCtx = visited[ctx];
-        Assert(!subsCtx.isNull());
+        Assert(!subsCtx.isNull()) << "Failed to get context for " << ctx << " in " << d_id;
         Node nt = expr::getNullTerminator(ctx.getKind(), subsCtx.getType());
         wargs.push_back(nt);
       }


### PR DESCRIPTION
Ensures we can infer the required type for inputs to RARE rules defined by `define-cond-rule`.