### PR TITLE
Install CaDiCaL and Poly static libraries

### DIFF
--- a/cmake/FindCaDiCaL.cmake
+++ b/cmake/FindCaDiCaL.cmake
@@ -172,4 +172,11 @@ if(CaDiCaL_FOUND_SYSTEM)
 else()
   message(STATUS "Building CaDiCaL ${CaDiCaL_VERSION}: ${CaDiCaL_LIBRARIES}")
   add_dependencies(CaDiCaL CaDiCaL-EP)
+
+  # Install CaDiCaL static library only if it is a static build.
+  # The CaDiCaL static library is required to compile a program that
+  # uses the cvc5 static library.
+  if(NOT BUILD_SHARED_LIBS)
+    install(FILES ${CaDiCaL_LIBRARIES} TYPE ${LIB_BUILD_TYPE})
+  endif()
 endif()

--- a/cmake/FindPoly.cmake
+++ b/cmake/FindPoly.cmake
@@ -237,8 +237,9 @@ else()
 
   ExternalProject_Get_Property(Poly-EP BUILD_BYPRODUCTS INSTALL_DIR)
   string(REPLACE "<INSTALL_DIR>" "${INSTALL_DIR}" BUILD_BYPRODUCTS "${BUILD_BYPRODUCTS}")
-  # Only install shared libraries
-  if (BUILD_SHARED_LIBS)
-    install(FILES ${BUILD_BYPRODUCTS} TYPE ${LIB_BUILD_TYPE})
-  endif()
+
+  # Static builds install the Poly static libraries.
+  # These libraries are required to compile a program that
+  # uses the cvc5 static library.
+  install(FILES ${BUILD_BYPRODUCTS} TYPE ${LIB_BUILD_TYPE})
 endif()


### PR DESCRIPTION
The CaDiCaL and Poly static libraries are required to compile a program that uses the cvc5 static library.