### PR TITLE
disabling the rewriting of (^ 2 x) to (int.pow2 x)

### DIFF
--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -874,7 +874,16 @@ cdef class DatatypeSelector:
 # ----------------------------------------------------------------------------
 
 cdef class Op:
-    """Wrapper class for :cpp:class:`cvc5::api::Op`."""
+    """
+        A cvc5 operator.
+
+        An operator is a term that represents certain operators,
+        instantiated with its required parameters, e.g.,
+        a term of kind
+        :py:obj:`BITVECTOR_EXTRACT <Kind.BITVECTOR_EXTRACT>`.
+
+        Wrapper class for :cpp:class:`cvc5::Op`.
+    """
     cdef c_Op cop
     cdef TermManager tm
 
@@ -895,10 +904,10 @@ cdef class Op:
 
     def getKind(self):
         """
-            :return: the kind of this operator.
+            :return: The kind of this operator.
         """
-        return kind(<int> self.cop.getKind())
-    
+        return Kind(<int> self.cop.getKind())
+
     def isIndexed(self):
         """
             :return: True iff this operator is indexed.

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -874,16 +874,7 @@ cdef class DatatypeSelector:
 # ----------------------------------------------------------------------------
 
 cdef class Op:
-    """
-        A cvc5 operator.
-
-        An operator is a term that represents certain operators,
-        instantiated with its required parameters, e.g.,
-        a term of kind
-        :py:obj:`BITVECTOR_EXTRACT <Kind.BITVECTOR_EXTRACT>`.
-
-        Wrapper class for :cpp:class:`cvc5::Op`.
-    """
+    """Wrapper class for :cpp:class:`cvc5::api::Op`."""
     cdef c_Op cop
     cdef TermManager tm
 
@@ -904,10 +895,10 @@ cdef class Op:
 
     def getKind(self):
         """
-            :return: The kind of this operator.
+            :return: the kind of this operator.
         """
-        return Kind(<int> self.cop.getKind())
-
+        return kind(<int> self.cop.getKind())
+    
     def isIndexed(self):
         """
             :return: True iff this operator is indexed.

--- a/src/options/main_options.toml
+++ b/src/options/main_options.toml
@@ -54,6 +54,7 @@ name   = "Driver"
 
 [[option]]
   name       = "seed"
+  alias      = ["random-seed"]
   category   = "common"
   short      = "s"
   long       = "seed=N"

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -341,19 +341,6 @@ RewriteResponse ArithRewriter::postRewriteTerm(TNode t){
             }
           }
         }
-        else if (t[0].isConst()
-                 && t[0].getConst<Rational>().getNumerator().toUnsignedInt()
-                        == 2
-                 && t[1].getType().isInteger())
-        {
-          Node ret = nodeManager()->mkNode(Kind::POW2, t[1]);
-          // ensure type is preserved
-          if (t.getType().isReal())
-          {
-            ret = rewriter::ensureReal(ret);
-          }
-          return RewriteResponse(REWRITE_AGAIN, ret);
-        }
         return RewriteResponse(REWRITE_DONE, t);
       }
       case Kind::PI: return RewriteResponse(REWRITE_DONE, t);

--- a/src/theory/bags/theory_bags_type_rules.cpp
+++ b/src/theory/bags/theory_bags_type_rules.cpp
@@ -47,22 +47,27 @@ TypeNode BinaryOperatorTypeRule::computeType(NodeManager* nodeManager,
          || n.getKind() == Kind::BAG_INTER_MIN
          || n.getKind() == Kind::BAG_DIFFERENCE_SUBTRACT
          || n.getKind() == Kind::BAG_DIFFERENCE_REMOVE);
-  TypeNode bagType = n[0].getType(check);
+  TypeNode bagType = n[0].getTypeOrNull();
+  TypeNode secondBagType = n[1].getTypeOrNull();
   if (check)
   {
     if (!bagType.isBag())
     {
-      throw TypeCheckingExceptionPrivate(
-          n, "operator expects a bag, first argument is not");
+      if (errOut)
+      {
+        (*errOut) << "operator expects a bag, first argument is not";
+      }
+      return TypeNode::null();
     }
-    TypeNode secondBagType = n[1].getType(check);
     if (secondBagType != bagType)
     {
-      std::stringstream ss;
-      ss << "Operator " << n.getKind()
-         << " expects two bags of the same type. Found types '" << bagType
-         << "' and '" << secondBagType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "Operator " << n.getKind()
+                  << " expects two bags of the same type. Found types '"
+                  << bagType << "' and '" << secondBagType << "'.";
+      }
+      return TypeNode::null();
     }
   }
   return bagType;
@@ -86,18 +91,25 @@ TypeNode SubBagTypeRule::computeType(NodeManager* nodeManager,
                                      std::ostream* errOut)
 {
   Assert(n.getKind() == Kind::BAG_SUBBAG);
-  TypeNode bagType = n[0].getType(check);
+  TypeNode bagType = n[0].getTypeOrNull();
   if (check)
   {
-    if (!bagType.isBag())
+    if (!bagType.isMaybeKind(Kind::BAG_TYPE))
     {
-      throw TypeCheckingExceptionPrivate(n, "BAG_SUBBAG operating on non-bag");
+      if (errOut)
+      {
+        (*errOut) << "BAG_SUBBAG operating on non-bag";
+      }
+      return TypeNode::null();
     }
-    TypeNode secondBagType = n[1].getType(check);
-    if (secondBagType != bagType)
+    TypeNode secondBagType = n[1].getTypeOrNull();
+    if (!secondBagType.isComparableTo(bagType))
     {
-      throw TypeCheckingExceptionPrivate(
-          n, "BAG_SUBBAG operating on bags of different types");
+      if (errOut)
+      {
+        (*errOut) << "BAG_SUBBAG operating on bags of different types";
+      }
+      return TypeNode::null();
     }
   }
   return nodeManager->booleanType();
@@ -113,25 +125,30 @@ TypeNode CountTypeRule::computeType(NodeManager* nodeManager,
                                     std::ostream* errOut)
 {
   Assert(n.getKind() == Kind::BAG_COUNT);
-  TypeNode bagType = n[1].getType(check);
+  TypeNode bagType = n[1].getTypeOrNull();
   if (check)
   {
     if (!bagType.isBag())
     {
-      throw TypeCheckingExceptionPrivate(
-          n, "checking for membership in a non-bag");
+      if (errOut)
+      {
+        (*errOut) << "checking for membership in a non-bag";
+      }
+      return TypeNode::null();
     }
-    TypeNode elementType = n[0].getType(check);
+    TypeNode elementType = n[0].getTypeOrNull();
     // e.g. (bag.count 1 (bag (BagMakeOp Real) 1.0 3))) is 3 whereas
     // (bag.count 1.0 (bag (BagMakeOp Int) 1 3)) throws a typing error
     if (elementType != bagType.getBagElementType())
     {
-      std::stringstream ss;
-      ss << "member operating on bags of different types:\n"
-         << "child type:  " << elementType << "\n"
-         << "not type: " << bagType.getBagElementType() << "\n"
-         << "in term : " << n;
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "member operating on bags of different types:\n"
+                  << "child type:  " << elementType << "\n"
+                  << "not type: " << bagType.getBagElementType() << "\n"
+                  << "in term : " << n;
+      }
+      return TypeNode::null();
     }
   }
   return nodeManager->integerType();
@@ -147,25 +164,30 @@ TypeNode MemberTypeRule::computeType(NodeManager* nodeManager,
                                      std::ostream* errOut)
 {
   Assert(n.getKind() == Kind::BAG_MEMBER);
-  TypeNode bagType = n[1].getType(check);
+  TypeNode bagType = n[1].getTypeOrNull();
   if (check)
   {
     if (!bagType.isBag())
     {
-      throw TypeCheckingExceptionPrivate(
-          n, "checking for membership in a non-bag");
+      if (errOut)
+      {
+        (*errOut) << "checking for membership in a non-bag";
+      }
+      return TypeNode::null();
     }
-    TypeNode elementType = n[0].getType(check);
+    TypeNode elementType = n[0].getTypeOrNull();
     // e.g. (bag.member 1 (bag 1.0 1)) is true whereas
     // (bag.member 1.0 (bag 1 1)) throws a typing error
     if (elementType != bagType.getBagElementType())
     {
-      std::stringstream ss;
-      ss << "member operating on bags of different types:\n"
-         << "child type:  " << elementType << "\n"
-         << "not type: " << bagType.getBagElementType() << "\n"
-         << "in term : " << n;
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "member operating on bags of different types:\n"
+                  << "child type:  " << elementType << "\n"
+                  << "not type: " << bagType.getBagElementType() << "\n"
+                  << "in term : " << n;
+      }
+      return TypeNode::null();
     }
   }
   return nodeManager->booleanType();
@@ -181,14 +203,16 @@ TypeNode SetofTypeRule::computeType(NodeManager* nodeManager,
                                     std::ostream* errOut)
 {
   Assert(n.getKind() == Kind::BAG_SETOF);
-  TypeNode bagType = n[0].getType(check);
+  TypeNode bagType = n[0].getTypeOrNull();
   if (check)
   {
     if (!bagType.isBag())
     {
-      std::stringstream ss;
-      ss << "Applying BAG_SETOF on a non-bag argument in term " << n;
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "Applying BAG_SETOF on a non-bag argument in term " << n;
+      }
+      return TypeNode::null();
     }
   }
   return bagType;
@@ -204,22 +228,27 @@ TypeNode BagMakeTypeRule::computeType(NodeManager* nm,
                                       std::ostream* errOut)
 {
   Assert(n.getKind() == Kind::BAG_MAKE);
-  TypeNode actualElementType = n[0].getType(check);
+  TypeNode actualElementType = n[0].getTypeOrNull();
   if (check)
   {
     if (n.getNumChildren() != 2)
     {
-      std::stringstream ss;
-      ss << "operands in term " << n << " are " << n.getNumChildren()
-         << ", but BAG_MAKE expects 2 operands.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "operands in term " << n << " are " << n.getNumChildren()
+                  << ", but BAG_MAKE expects 2 operands.";
+      }
+      return TypeNode::null();
     }
-    TypeNode type1 = n[1].getType(check);
+    TypeNode type1 = n[1].getTypeOrNull();
     if (!type1.isInteger())
     {
-      std::stringstream ss;
-      ss << "BAG_MAKE expects an integer for " << n[1] << ". Found" << type1;
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "BAG_MAKE expects an integer for " << n[1] << ". Found"
+                  << type1;
+      }
+      return TypeNode::null();
     }
   }
 
@@ -259,13 +288,16 @@ TypeNode CardTypeRule::computeType(NodeManager* nodeManager,
                                    std::ostream* errOut)
 {
   Assert(n.getKind() == Kind::BAG_CARD);
-  TypeNode bagType = n[0].getType(check);
+  TypeNode bagType = n[0].getTypeOrNull();
   if (check)
   {
     if (!bagType.isBag())
     {
-      throw TypeCheckingExceptionPrivate(
-          n, "cardinality operates on a bag, non-bag object found");
+      if (errOut)
+      {
+        (*errOut) << "cardinality operates on a bag, non-bag object found";
+      }
+      return TypeNode::null();
     }
   }
   return nodeManager->integerType();
@@ -281,13 +313,16 @@ TypeNode ChooseTypeRule::computeType(NodeManager* nodeManager,
                                      std::ostream* errOut)
 {
   Assert(n.getKind() == Kind::BAG_CHOOSE);
-  TypeNode bagType = n[0].getType(check);
+  TypeNode bagType = n[0].getTypeOrNull();
   if (check)
   {
     if (!bagType.isBag())
     {
-      throw TypeCheckingExceptionPrivate(
-          n, "BAG_CHOOSE operator expects a bag, a non-bag is found");
+      if (errOut)
+      {
+        (*errOut) << "BAG_CHOOSE operator expects a bag, a non-bag is found";
+      }
+      return TypeNode::null();
     }
   }
   return bagType.getBagElementType();
@@ -303,39 +338,47 @@ TypeNode BagMapTypeRule::computeType(NodeManager* nodeManager,
                                      std::ostream* errOut)
 {
   Assert(n.getKind() == Kind::BAG_MAP);
-  TypeNode functionType = n[0].getType(check);
-  TypeNode bagType = n[1].getType(check);
+  TypeNode functionType = n[0].getTypeOrNull();
+  TypeNode bagType = n[1].getTypeOrNull();
   if (check)
   {
     if (!bagType.isBag())
     {
-      throw TypeCheckingExceptionPrivate(
-          n,
-          "bag.map operator expects a bag in the second argument, "
-          "a non-bag is found");
+      if (errOut)
+      {
+        (*errOut) << "bag.map operator expects a bag in the second argument, a "
+                     "non-bag is found";
+      }
+      return TypeNode::null();
     }
 
     TypeNode elementType = bagType.getBagElementType();
 
     if (!(functionType.isFunction()))
     {
-      std::stringstream ss;
-      ss << "Operator " << n.getKind() << " expects a function of type  (-> "
-         << elementType << " *) as a first argument. "
-         << "Found a term of type '" << functionType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "Operator " << n.getKind()
+                  << " expects a function of type  (-> " << elementType
+                  << " *) as a first argument. "
+                  << "Found a term of type '" << functionType << "'.";
+      }
+      return TypeNode::null();
     }
     std::vector<TypeNode> argTypes = functionType.getArgTypes();
     if (!(argTypes.size() == 1 && argTypes[0] == elementType))
     {
-      std::stringstream ss;
-      ss << "Operator " << n.getKind() << " expects a function of type  (-> "
-         << elementType << " *). "
-         << "Found a function of type '" << functionType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "Operator " << n.getKind()
+                  << " expects a function of type  (-> " << elementType
+                  << " *). "
+                  << "Found a function of type '" << functionType << "'.";
+      }
+      return TypeNode::null();
     }
   }
-  TypeNode rangeType = n[0].getType().getRangeType();
+  TypeNode rangeType = n[0].getTypeOrNull().getRangeType();
   TypeNode retType = nodeManager->mkBagType(rangeType);
   return retType;
 }
@@ -350,38 +393,46 @@ TypeNode BagFilterTypeRule::computeType(NodeManager* nodeManager,
                                         std::ostream* errOut)
 {
   Assert(n.getKind() == Kind::BAG_FILTER);
-  TypeNode functionType = n[0].getType(check);
-  TypeNode bagType = n[1].getType(check);
+  TypeNode functionType = n[0].getTypeOrNull();
+  TypeNode bagType = n[1].getTypeOrNull();
   if (check)
   {
     if (!bagType.isBag())
     {
-      throw TypeCheckingExceptionPrivate(
-          n,
-          "bag.filter operator expects a bag in the second argument, "
-          "a non-bag is found");
+      if (errOut)
+      {
+        (*errOut) << "bag.filter operator expects a bag in the second "
+                     "argument, a non-bag is found";
+      }
+      return TypeNode::null();
     }
 
     TypeNode elementType = bagType.getBagElementType();
 
     if (!(functionType.isFunction()))
     {
-      std::stringstream ss;
-      ss << "Operator " << n.getKind() << " expects a function of type  (-> "
-         << elementType << " Bool) as a first argument. "
-         << "Found a term of type '" << functionType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "Operator " << n.getKind()
+                  << " expects a function of type  (-> " << elementType
+                  << " Bool) as a first argument. "
+                  << "Found a term of type '" << functionType << "'.";
+      }
+      return TypeNode::null();
     }
     std::vector<TypeNode> argTypes = functionType.getArgTypes();
     NodeManager* nm = NodeManager::currentNM();
     if (!(argTypes.size() == 1 && argTypes[0] == elementType
           && functionType.getRangeType() == nm->booleanType()))
     {
-      std::stringstream ss;
-      ss << "Operator " << n.getKind() << " expects a function of type  (-> "
-         << elementType << " Bool). "
-         << "Found a function of type '" << functionType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "Operator " << n.getKind()
+                  << " expects a function of type  (-> " << elementType
+                  << " Bool). "
+                  << "Found a function of type '" << functionType << "'.";
+      }
+      return TypeNode::null();
     }
   }
   return bagType;
@@ -397,49 +448,60 @@ TypeNode BagFoldTypeRule::computeType(NodeManager* nodeManager,
                                       std::ostream* errOut)
 {
   Assert(n.getKind() == Kind::BAG_FOLD);
-  TypeNode functionType = n[0].getType(check);
-  TypeNode initialValueType = n[1].getType(check);
-  TypeNode bagType = n[2].getType(check);
+  TypeNode functionType = n[0].getTypeOrNull();
+  TypeNode initialValueType = n[1].getTypeOrNull();
+  TypeNode bagType = n[2].getTypeOrNull();
   if (check)
   {
     if (!bagType.isBag())
     {
-      throw TypeCheckingExceptionPrivate(
-          n,
-          "bag.fold operator expects a bag in the third argument, "
-          "a non-bag is found");
+      if (errOut)
+      {
+        (*errOut) << "bag.fold operator expects a bag in the third argument, a "
+                     "non-bag is found";
+      }
+      return TypeNode::null();
     }
 
     TypeNode elementType = bagType.getBagElementType();
 
     if (!(functionType.isFunction()))
     {
-      std::stringstream ss;
-      ss << "Operator " << n.getKind() << " expects a function of type  (-> "
-         << elementType << " T2 T2) as a first argument. "
-         << "Found a term of type '" << functionType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "Operator " << n.getKind()
+                  << " expects a function of type  (-> " << elementType
+                  << " T2 T2) as a first argument. "
+                  << "Found a term of type '" << functionType << "'.";
+      }
+      return TypeNode::null();
     }
     std::vector<TypeNode> argTypes = functionType.getArgTypes();
     TypeNode rangeType = functionType.getRangeType();
     if (!(argTypes.size() == 2 && argTypes[0] == elementType
           && argTypes[1] == rangeType))
     {
-      std::stringstream ss;
-      ss << "Operator " << n.getKind() << " expects a function of type  (-> "
-         << elementType << " T2 T2). "
-         << "Found a function of type '" << functionType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "Operator " << n.getKind()
+                  << " expects a function of type  (-> " << elementType
+                  << " T2 T2). "
+                  << "Found a function of type '" << functionType << "'.";
+      }
+      return TypeNode::null();
     }
     if (rangeType != initialValueType)
     {
-      std::stringstream ss;
-      ss << "Operator " << n.getKind() << " expects an initial value of type "
-         << rangeType << ". Found a term of type '" << initialValueType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "Operator " << n.getKind()
+                  << " expects an initial value of type " << rangeType
+                  << ". Found a term of type '" << initialValueType << "'.";
+      }
+      return TypeNode::null();
     }
   }
-  TypeNode retType = n[0].getType().getRangeType();
+  TypeNode retType = n[0].getTypeOrNull().getRangeType();
   return retType;
 }
 
@@ -453,39 +515,47 @@ TypeNode BagPartitionTypeRule::computeType(NodeManager* nodeManager,
                                            std::ostream* errOut)
 {
   Assert(n.getKind() == Kind::BAG_PARTITION);
-  TypeNode functionType = n[0].getType(check);
-  TypeNode bagType = n[1].getType(check);
+  TypeNode functionType = n[0].getTypeOrNull();
+  TypeNode bagType = n[1].getTypeOrNull();
   NodeManager* nm = NodeManager::currentNM();
   if (check)
   {
     if (!bagType.isBag())
     {
-      throw TypeCheckingExceptionPrivate(
-          n,
-          "bag.partition operator expects a bag in the second argument, "
-          "a non-bag is found");
+      if (errOut)
+      {
+        (*errOut) << "bag.partition operator expects a bag in the second "
+                     "argument, a non-bag is found";
+      }
+      return TypeNode::null();
     }
 
     TypeNode elementType = bagType.getBagElementType();
 
     if (!(functionType.isFunction()))
     {
-      std::stringstream ss;
-      ss << "Operator " << n.getKind() << " expects a function of type  (-> "
-         << elementType << " " << elementType << " Bool) as a first argument. "
-         << "Found a term of type '" << functionType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "Operator " << n.getKind()
+                  << " expects a function of type  (-> " << elementType << " "
+                  << elementType << " Bool) as a first argument. "
+                  << "Found a term of type '" << functionType << "'.";
+      }
+      return TypeNode::null();
     }
     std::vector<TypeNode> argTypes = functionType.getArgTypes();
     TypeNode rangeType = functionType.getRangeType();
     if (!(argTypes.size() == 2 && elementType == argTypes[0]
           && elementType == argTypes[1] && rangeType == nm->booleanType()))
     {
-      std::stringstream ss;
-      ss << "Operator " << n.getKind() << " expects a function of type  (-> "
-         << elementType << " " << elementType << " Bool) as a first argument. "
-         << "Found a term of type '" << functionType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "Operator " << n.getKind()
+                  << " expects a function of type  (-> " << elementType << " "
+                  << elementType << " Bool) as a first argument. "
+                  << "Found a term of type '" << functionType << "'.";
+      }
+      return TypeNode::null();
     }
   }
   TypeNode retType = nm->mkBagType(bagType);
@@ -504,16 +574,18 @@ TypeNode TableProductTypeRule::computeType(NodeManager* nodeManager,
   Assert(n.getKind() == Kind::TABLE_PRODUCT);
   Node A = n[0];
   Node B = n[1];
-  TypeNode typeA = n[0].getType(check);
-  TypeNode typeB = n[1].getType(check);
+  TypeNode typeA = n[0].getTypeOrNull();
+  TypeNode typeB = n[1].getTypeOrNull();
 
   if (check && !(typeA.isBag() && typeB.isBag()))
   {
-    std::stringstream ss;
-    ss << "Operator " << n.getKind() << " expects two bags. "
-       << "Found two terms of types '" << typeA << "' and '" << typeB
-       << "' respectively.";
-    throw TypeCheckingExceptionPrivate(n, ss.str());
+    if (errOut)
+    {
+      (*errOut) << "Operator " << n.getKind() << " expects two bags. "
+                << "Found two terms of types '" << typeA << "' and '" << typeB
+                << "' respectively.";
+    }
+    return TypeNode::null();
   }
 
   TypeNode elementAType = typeA.getBagElementType();
@@ -521,11 +593,14 @@ TypeNode TableProductTypeRule::computeType(NodeManager* nodeManager,
 
   if (check && !(elementAType.isTuple() && elementBType.isTuple()))
   {
-    std::stringstream ss;
-    ss << "Operator " << n.getKind() << " expects two tables (bags of tuples). "
-       << "Found two terms of types '" << typeA << "' and '" << typeB
-       << "' respectively.";
-    throw TypeCheckingExceptionPrivate(n, ss.str());
+    if (errOut)
+    {
+      (*errOut) << "Operator " << n.getKind()
+                << " expects two tables (bags of tuples). "
+                << "Found two terms of types '" << typeA << "' and '" << typeB
+                << "' respectively.";
+    }
+    return TypeNode::null();
   }
 
   TypeNode retTupleType =
@@ -547,32 +622,38 @@ TypeNode TableProjectTypeRule::computeType(NodeManager* nm,
          && n.getOperator().getKind() == Kind::TABLE_PROJECT_OP);
   ProjectOp op = n.getOperator().getConst<ProjectOp>();
   const std::vector<uint32_t>& indices = op.getIndices();
-  TypeNode bagType = n[0].getType(check);
+  TypeNode bagType = n[0].getTypeOrNull();
   if (check)
   {
     if (n.getNumChildren() != 1)
     {
-      std::stringstream ss;
-      ss << "operands in term " << n << " are " << n.getNumChildren()
-         << ", but TABLE_PROJECT expects 1 operand.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "operands in term " << n << " are " << n.getNumChildren()
+                  << ", but TABLE_PROJECT expects 1 operand.";
+      }
+      return TypeNode::null();
     }
 
     if (!bagType.isBag())
     {
-      std::stringstream ss;
-      ss << "TABLE_PROJECT operator expects a table. Found '" << n[0]
-         << "' of type '" << bagType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "TABLE_PROJECT operator expects a table. Found '" << n[0]
+                  << "' of type '" << bagType << "'.";
+      }
+      return TypeNode::null();
     }
 
     TypeNode tupleType = bagType.getBagElementType();
     if (!tupleType.isTuple())
     {
-      std::stringstream ss;
-      ss << "TABLE_PROJECT operator expects a table. Found '" << n[0]
-         << "' of type '" << bagType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "TABLE_PROJECT operator expects a table. Found '" << n[0]
+                  << "' of type '" << bagType << "'.";
+      }
+      return TypeNode::null();
     }
 
     // make sure all indices are less than the length of the tuple type
@@ -581,12 +662,15 @@ TypeNode TableProjectTypeRule::computeType(NodeManager* nm,
     size_t numArgs = constructor.getNumArgs();
     for (uint32_t index : indices)
     {
-      std::stringstream ss;
       if (index >= numArgs)
       {
-        ss << "Index " << index << " in term " << n << " is >= " << numArgs
-           << " which is the number of columns in " << n[0] << ".";
-        throw TypeCheckingExceptionPrivate(n, ss.str());
+        if (errOut)
+        {
+          (*errOut) << "Index " << index << " in term " << n
+                    << " is >= " << numArgs
+                    << " which is the number of columns in " << n[0] << ".";
+        }
+        return TypeNode::null();
       }
     }
   }
@@ -610,27 +694,31 @@ TypeNode TableAggregateTypeRule::computeType(NodeManager* nm,
   ProjectOp op = n.getOperator().getConst<ProjectOp>();
   const std::vector<uint32_t>& indices = op.getIndices();
 
-  TypeNode functionType = n[0].getType(check);
-  TypeNode initialValueType = n[1].getType(check);
-  TypeNode bagType = n[2].getType(check);
+  TypeNode functionType = n[0].getTypeOrNull();
+  TypeNode initialValueType = n[1].getTypeOrNull();
+  TypeNode bagType = n[2].getTypeOrNull();
 
   if (check)
   {
     if (!bagType.isBag())
     {
-      std::stringstream ss;
-      ss << "TABLE_PROJECT operator expects a table. Found '" << n[2]
-         << "' of type '" << bagType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "TABLE_PROJECT operator expects a table. Found '" << n[2]
+                  << "' of type '" << bagType << "'.";
+      }
+      return TypeNode::null();
     }
 
     TypeNode tupleType = bagType.getBagElementType();
     if (!tupleType.isTuple())
     {
-      std::stringstream ss;
-      ss << "TABLE_PROJECT operator expects a table. Found '" << n[2]
-         << "' of type '" << bagType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "TABLE_PROJECT operator expects a table. Found '" << n[2]
+                  << "' of type '" << bagType << "'.";
+      }
+      return TypeNode::null();
     }
 
     if (!TupleUtils::checkTypeIndices(tupleType, indices))
@@ -647,29 +735,38 @@ TypeNode TableAggregateTypeRule::computeType(NodeManager* nm,
 
     if (!(functionType.isFunction()))
     {
-      std::stringstream ss;
-      ss << "Operator " << n.getKind() << " expects a function of type  (-> "
-         << elementType << " T T) as a first argument. "
-         << "Found a term of type '" << functionType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "Operator " << n.getKind()
+                  << " expects a function of type  (-> " << elementType
+                  << " T T) as a first argument. "
+                  << "Found a term of type '" << functionType << "'.";
+      }
+      return TypeNode::null();
     }
     std::vector<TypeNode> argTypes = functionType.getArgTypes();
     TypeNode rangeType = functionType.getRangeType();
     if (!(argTypes.size() == 2 && argTypes[0] == elementType
           && argTypes[1] == rangeType))
     {
-      std::stringstream ss;
-      ss << "Operator " << n.getKind() << " expects a function of type  (-> "
-         << elementType << " T T). "
-         << "Found a function of type '" << functionType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "Operator " << n.getKind()
+                  << " expects a function of type  (-> " << elementType
+                  << " T T). "
+                  << "Found a function of type '" << functionType << "'.";
+      }
+      return TypeNode::null();
     }
     if (rangeType != initialValueType)
     {
-      std::stringstream ss;
-      ss << "Operator " << n.getKind() << " expects an initial value of type "
-         << rangeType << ". Found a term of type '" << initialValueType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "Operator " << n.getKind()
+                  << " expects an initial value of type " << rangeType
+                  << ". Found a term of type '" << initialValueType << "'.";
+      }
+      return TypeNode::null();
     }
   }
   return nm->mkBagType(functionType.getRangeType());
@@ -690,37 +787,44 @@ TypeNode TableJoinTypeRule::computeType(NodeManager* nm,
   const std::vector<uint32_t>& indices = op.getIndices();
   Node A = n[0];
   Node B = n[1];
-  TypeNode aType = A.getType();
-  TypeNode bType = B.getType();
+  TypeNode aType = A.getTypeOrNull();
+  TypeNode bType = B.getTypeOrNull();
 
   if (check)
   {
     if (!(aType.isBag() && bType.isBag()))
     {
-      std::stringstream ss;
-      ss << "TABLE_JOIN operator expects two tables. Found '" << n[0] << "', '"
-         << n[1] << "' of types '" << aType << "', '" << bType
-         << "' respectively. ";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "TABLE_JOIN operator expects two tables. Found '" << n[0]
+                  << "', '" << n[1] << "' of types '" << aType << "', '"
+                  << bType << "' respectively. ";
+      }
+      return TypeNode::null();
     }
 
     TypeNode aTupleType = aType.getBagElementType();
     TypeNode bTupleType = bType.getBagElementType();
     if (!(aTupleType.isTuple() && bTupleType.isTuple()))
     {
-      std::stringstream ss;
-      ss << "TABLE_JOIN operator expects two tables. Found '" << n[0] << "', '"
-         << n[1] << "' of types '" << aType << "', '" << bType
-         << "' respectively. ";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "TABLE_JOIN operator expects two tables. Found '" << n[0]
+                  << "', '" << n[1] << "' of types '" << aType << "', '"
+                  << bType << "' respectively. ";
+      }
+      return TypeNode::null();
     }
 
     if (indices.size() % 2 != 0)
     {
-      std::stringstream ss;
-      ss << "TABLE_JOIN operator expects even number of indices. Found "
-         << indices.size() << " in term " << n;
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut)
+            << "TABLE_JOIN operator expects even number of indices. Found "
+            << indices.size() << " in term " << n;
+      }
+      return TypeNode::null();
     }
     auto [aIndices, bIndices] = BagsUtils::splitTableJoinIndices(n);
     if (!TupleUtils::checkTypeIndices(aTupleType, aIndices))
@@ -749,13 +853,15 @@ TypeNode TableJoinTypeRule::computeType(NodeManager* nm,
     {
       if (aTypes[aIndices[i]] != bTypes[bIndices[i]])
       {
-        std::stringstream ss;
-        ss << "TABLE_JOIN operator expects column " << aIndices[i]
-           << " in table " << n[0] << " to match column " << bIndices[i]
-           << " in table " << n[1] << ". But their types are "
-           << aTypes[aIndices[i]] << " and " << bTypes[bIndices[i]]
-           << "' respectively. ";
-        throw TypeCheckingExceptionPrivate(n, ss.str());
+        if (errOut)
+        {
+          (*errOut) << "TABLE_JOIN operator expects column " << aIndices[i]
+                    << " in table " << n[0] << " to match column "
+                    << bIndices[i] << " in table " << n[1]
+                    << ". But their types are " << aTypes[aIndices[i]]
+                    << " and " << bTypes[bIndices[i]] << "' respectively. ";
+        }
+        return TypeNode::null();
       }
     }
   }
@@ -779,25 +885,29 @@ TypeNode TableGroupTypeRule::computeType(NodeManager* nm,
   ProjectOp op = n.getOperator().getConst<ProjectOp>();
   const std::vector<uint32_t>& indices = op.getIndices();
 
-  TypeNode bagType = n[0].getType(check);
+  TypeNode bagType = n[0].getTypeOrNull();
 
   if (check)
   {
     if (!bagType.isBag())
     {
-      std::stringstream ss;
-      ss << "TABLE_GROUP operator expects a table. Found '" << n[0]
-         << "' of type '" << bagType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "TABLE_GROUP operator expects a table. Found '" << n[0]
+                  << "' of type '" << bagType << "'.";
+      }
+      return TypeNode::null();
     }
 
     TypeNode tupleType = bagType.getBagElementType();
     if (!tupleType.isTuple())
     {
-      std::stringstream ss;
-      ss << "TABLE_GROUP operator expects a table. Found '" << n[0]
-         << "' of type '" << bagType << "'.";
-      throw TypeCheckingExceptionPrivate(n, ss.str());
+      if (errOut)
+      {
+        (*errOut) << "TABLE_GROUP operator expects a table. Found '" << n[0]
+                  << "' of type '" << bagType << "'.";
+      }
+      return TypeNode::null();
     }
 
     if (!TupleUtils::checkTypeIndices(tupleType, indices))

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -83,6 +83,7 @@ set(regress_0_tests
   regress0/arith/mod.01.smt2
   regress0/arith/mult.01.smt2
   regress0/arith/non-normal.smt2
+  regress0/arith/pow-issue-10676.smt2
   regress0/arith/projissue469-int-equality.smt2
   regress0/arith-bv-conv-ineq-rewrites.smt2
   regress0/arr1.smt2

--- a/test/regress/cli/regress0/arith/pow-issue-10676.smt2
+++ b/test/regress/cli/regress0/arith/pow-issue-10676.smt2
@@ -1,0 +1,8 @@
+; EXIT: 1
+; EXPECT: (error "The exponent of the POW(^) operator can only be a positive integral constant below 67108864. Exception occurred in:
+; EXPECT:   (^ 2 (- 2))")
+(set-logic ALL)
+(declare-fun x () Int)
+(assert (and (= (* (^ 2 x) (- 4 x)) (+ (* 2 x) 4))  (= x (- 0 2))))
+(check-sat)
+(get-model)


### PR DESCRIPTION
Fixes #10676. 
The better fix, which is planned, is to make `int.pow2` a rational operator, as discussed in https://github.com/cvc5/cvc5/pull/10237.