### PR TITLE
More aggressive techniques for reconstructing proofs of strings inferences

### DIFF
--- a/src/proof/theory_proof_step_buffer.cpp
+++ b/src/proof/theory_proof_step_buffer.cpp
@@ -171,6 +171,8 @@ bool TheoryProofStepBuffer::applyExtendedPredInfer(Node src,
   }
   else if (psrco.getKind() == Kind::AND)
   {
+    // see if src rewrites to (and ... tgt ...). In this case, we can
+    // infer tgt via AND_ELIM.
     for (size_t i = 0, nchild = psrco.getNumChildren(); i < nchild; i++)
     {
       if (psrco[i] == ptgto)
@@ -185,6 +187,8 @@ bool TheoryProofStepBuffer::applyExtendedPredInfer(Node src,
   }
   if (success)
   {
+    // If we were successful, now go back and justify the conversion to
+    // original forms, which should be trivial.
     applyPredTransform(src, srco, {});
     applyPredTransform(tgt, tgto, {});
   }

--- a/src/proof/theory_proof_step_buffer.h
+++ b/src/proof/theory_proof_step_buffer.h
@@ -106,6 +106,21 @@ class TheoryProofStepBuffer : public ProofStepBuffer
                      MethodId idr = MethodId::RW_REWRITE);
   //---------------------------- end utilities builtin proof rules
 
+  /**
+   * This method tries to infer tgt from src under substitution exp by any
+   * means available. In addition to applyPredTransform, it also may
+   * infer tgt by means of AND_ELIM on the rewritten form of src.
+   * It also explicitly converts to original form so that extended rewriting
+   * is applied to the original form (which is not done with
+   * MACRO_SR_PRED_TRANSFORM).
+   *
+   * @param src The source predicate.
+   * @param tgt The target predicate.
+   * @param exp A list of equalities corresponding to a substitution.
+   * @return true if we can successfully add proof steps to this buffer that
+   * conclude tgt from src and exp.
+   */
+  bool applyExtendedPredInfer(Node src, Node tgt, const std::vector<Node>& exp);
   //---------------------------- utility methods for normalizing clauses
   /**
    * Normalizes a non-unit clause (an OR node) according to factoring and


### PR DESCRIPTION
Introduces a new utility method for inferring whether a predicate follows from another by substitution+rewriting+AND_ELIM.

Also adds missing cases of string inferences that were not covered by proof reconstruction.

This reduces the number of unjustified THEORY_INFERENCE in our regressions from 1820 -> 1810.