### PR TITLE
Use new THEORY_REWRITE infrastructure for the theory of datatypes

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -1296,23 +1296,6 @@ enum ENUM(ProofRule) : uint32_t
   EVALUE(DT_INST),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Datatypes -- Collapse**
-   *
-   * .. math::
-   *
-   *   \inferrule{-\mid \mathit{sel}_i(C_j(t_1,\dots,t_n))}{
-   *   \mathit{sel}_i(C_j(t_1,\dots,t_n)) = r}
-   *
-   * where :math:`C_j` is a constructor, :math:`r` is :math:`t_i` if
-   * :math:`\mathit{sel}_i` is a correctly applied selector, or
-   * ``TypeNode::mkGroundTerm()`` of the proper type otherwise. Notice that the
-   * use of ``mkGroundTerm`` differs from the rewriter which uses
-   * ``mkGroundValue`` in this case.
-   * \endverbatim
-   */
-  EVALUE(DT_COLLAPSE),
-  /**
-   * \verbatim embed:rst:leading-asterisk
    * **Datatypes -- Split**
    *
    * .. math::
@@ -2313,6 +2296,53 @@ enum ENUM(ProofRewriteRule) : uint32_t
    * \endverbatim
    */
   EVALUE(EXISTS_ELIM),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Datatypes - collapse selector**
+   *
+   * .. math::
+   *   s_i(c(t_1, \ldots, t_n)) = t_i
+   *
+   * where `s_i` is the `i^th` selector for constructor `c`.
+   *
+   * \endverbatim
+   */
+  EVALUE(DT_COLLAPSE_SELECTOR),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Datatypes - collapse tester**
+   *
+   * .. math::
+   *   is-c(c(t_1, \ldots, t_n)) = true
+   *
+   * or alternatively
+   *
+   * .. math::
+   *   is-c(d(t_1, \ldots, t_n)) = true
+   *
+   * where `c` and `d` are distinct constructors.
+   *
+   * \endverbatim
+   */
+  EVALUE(DT_COLLAPSE_TESTER),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Datatypes - constructor equality**
+   *
+   * .. math::
+   *   (c(t_1, \ldots, t_n) = c(s_1, \ldots, s_n)) =
+   *   (t_1 = s_1 \wedge \ldots \wedge t_n = s_n)
+   *
+   * or alternatively
+   *
+   * .. math::
+   *   (c(t_1, \ldots, t_n) = d(s_1, \ldots, s_m)) = false
+   *
+   * where `c` and `d` are distinct constructors.
+   *
+   * \endverbatim
+   */
+  EVALUE(DT_CONS_EQ),
   /**
    * \verbatim embed:rst:leading-asterisk
    * **Strings - regular expression loop elimination**

--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -2318,7 +2318,7 @@ enum ENUM(ProofRewriteRule) : uint32_t
    * or alternatively
    *
    * .. math::
-   *   is-c(d(t_1, \ldots, t_n)) = true
+   *   is-c(d(t_1, \ldots, t_n)) = false
    *
    * where `c` and `d` are distinct constructors.
    *

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -126,7 +126,6 @@ const char* toString(ProofRule rule)
     //================================================= Datatype rules
     case ProofRule::DT_UNIF: return "DT_UNIF";
     case ProofRule::DT_INST: return "DT_INST";
-    case ProofRule::DT_COLLAPSE: return "DT_COLLAPSE";
     case ProofRule::DT_SPLIT: return "DT_SPLIT";
     case ProofRule::DT_CLASH: return "DT_CLASH";
     //================================================= Quantifiers rules
@@ -223,6 +222,9 @@ const char* toString(cvc5::ProofRewriteRule rule)
     case ProofRewriteRule::NONE: return "NONE";
     //================================================= ad-hoc rules
     case ProofRewriteRule::EXISTS_ELIM: return "exists-elim";
+    case ProofRewriteRule::DT_COLLAPSE_SELECTOR: return "dt-collapse-selector";
+    case ProofRewriteRule::DT_COLLAPSE_TESTER: return "dt-collapse-tester";
+    case ProofRewriteRule::DT_CONS_EQ: return "dt-cons-eq";
     case ProofRewriteRule::RE_LOOP_ELIM:
       return "re-loop-elim";
       //================================================= RARE rules

--- a/src/proof/proof.cpp
+++ b/src/proof/proof.cpp
@@ -18,6 +18,7 @@
 #include "proof/proof_checker.h"
 #include "proof/proof_node.h"
 #include "proof/proof_node_manager.h"
+#include "rewriter/rewrites.h"
 #include "smt/env.h"
 
 using namespace cvc5::internal::kind;
@@ -271,6 +272,22 @@ bool CDProof::addTrustedStep(Node expected,
   sargs.insert(sargs.end(), args.begin(), args.end());
   return addStep(
       expected, ProofRule::TRUST, children, sargs, ensureChildren, opolicy);
+}
+
+bool CDProof::addTheoryRewriteStep(Node expected,
+                                   ProofRewriteRule id,
+                                   bool ensureChildren,
+                                   CDPOverwrite opolicy)
+{
+  if (expected.getKind() != Kind::EQUAL)
+  {
+    return false;
+  }
+  std::vector<Node> sargs;
+  sargs.push_back(rewriter::mkRewriteRuleNode(id));
+  sargs.push_back(expected[0]);
+  return addStep(
+      expected, ProofRule::TRUST, {}, sargs, ensureChildren, opolicy);
 }
 
 bool CDProof::addStep(Node expected,

--- a/src/proof/proof.cpp
+++ b/src/proof/proof.cpp
@@ -287,7 +287,7 @@ bool CDProof::addTheoryRewriteStep(Node expected,
   sargs.push_back(rewriter::mkRewriteRuleNode(id));
   sargs.push_back(expected[0]);
   return addStep(
-      expected, ProofRule::TRUST, {}, sargs, ensureChildren, opolicy);
+      expected, ProofRule::THEORY_REWRITE, {}, sargs, ensureChildren, opolicy);
 }
 
 bool CDProof::addStep(Node expected,

--- a/src/proof/proof.h
+++ b/src/proof/proof.h
@@ -210,6 +210,14 @@ class CDProof : protected EnvObj, public ProofGenerator
                       const std::vector<Node>& args,
                       bool ensureChildren = false,
                       CDPOverwrite opolicy = CDPOverwrite::ASSUME_ONLY);
+  /**
+   * Version with ProofRewriteRule. This adds a THEORY_REWRITE step with the
+   * expected arguments.
+   */
+  bool addTheoryRewriteStep(Node expected,
+                            ProofRewriteRule id,
+                            bool ensureChildren = false,
+                            CDPOverwrite opolicy = CDPOverwrite::ASSUME_ONLY);
   /** Version with ProofStep */
   bool addStep(Node expected,
                const ProofStep& step,

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -99,6 +99,8 @@ Node DatatypesRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
         {
           nn = nodeManager()->mkAnd(rew);
         }
+        // In the "else" case above will n if this rewrite does not apply. We
+        // do not return the reflexive equality in this case.
         if (nn != n)
         {
           return nn;

--- a/src/theory/datatypes/datatypes_rewriter.h
+++ b/src/theory/datatypes/datatypes_rewriter.h
@@ -45,6 +45,15 @@ class DatatypesRewriter : public TheoryRewriter
   RewriteResponse postRewrite(TNode in) override;
   RewriteResponse preRewrite(TNode in) override;
 
+  /**
+   * Rewrite n based on the proof rewrite rule id.
+   * @param id The rewrite rule.
+   * @param n The node to rewrite.
+   * @return The rewritten version of n based on id, or Node::null() if n
+   * cannot be rewritten.
+   */
+  Node rewriteViaRule(ProofRewriteRule id, const Node& n) override;
+
   /** normalize codatatype constant
    *
    * This returns the normal form of the codatatype constant n. This runs a

--- a/src/theory/datatypes/infer_proof_cons.cpp
+++ b/src/theory/datatypes/infer_proof_cons.cpp
@@ -193,7 +193,7 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
         Node seq = sl.eqNode(sr);
         cdp->addStep(seq, ProofRule::CONG, {exp}, {asn, sop});
         Node sceq = sr.eqNode(concEq[1]);
-        cdp->addStep(sceq, ProofRule::DT_COLLAPSE, {}, {sr});
+        cdp->addTheoryRewriteStep(sceq, ProofRewriteRule::DT_COLLAPSE_SELECTOR);
         cdp->addStep(sl.eqNode(concEq[1]), ProofRule::TRANS, {seq, sceq}, {});
         if (conc.getKind() != Kind::EQUAL)
         {

--- a/src/theory/datatypes/proof_checker.cpp
+++ b/src/theory/datatypes/proof_checker.cpp
@@ -33,7 +33,6 @@ void DatatypesProofRuleChecker::registerTo(ProofChecker* pc)
 {
   pc->registerChecker(ProofRule::DT_UNIF, this);
   pc->registerChecker(ProofRule::DT_INST, this);
-  pc->registerChecker(ProofRule::DT_COLLAPSE, this);
   pc->registerChecker(ProofRule::DT_SPLIT, this);
   pc->registerChecker(ProofRule::DT_CLASH, this);
 }
@@ -82,25 +81,6 @@ Node DatatypesProofRuleChecker::checkInternal(ProofRule id,
     Node tester = utils::mkTester(t, i, dt);
     Node ticons = utils::getInstCons(t, dt, i, d_sharedSel);
     return tester.eqNode(t.eqNode(ticons));
-  }
-  else if (id == ProofRule::DT_COLLAPSE)
-  {
-    Assert(children.empty());
-    Assert(args.size() == 1);
-    Node t = args[0];
-    if (t.getKind() != Kind::APPLY_SELECTOR
-        || t[0].getKind() != Kind::APPLY_CONSTRUCTOR)
-    {
-      return Node::null();
-    }
-    Node selector = t.getOperator();
-    size_t constructorIndex = utils::indexOf(t[0].getOperator());
-    const DType& dt = utils::datatypeOf(selector);
-    const DTypeConstructor& dtc = dt[constructorIndex];
-    int selectorIndex = dtc.getSelectorIndexInternal(selector);
-    Node r =
-        selectorIndex < 0 ? nm->mkGroundTerm(t.getType()) : t[0][selectorIndex];
-    return t.eqNode(r);
   }
   else if (id == ProofRule::DT_SPLIT)
   {

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -381,17 +381,8 @@ TrustNode TheoryDatatypes::ppStaticRewrite(TNode in)
                      << endl;
   if (in.getKind() == Kind::EQUAL)
   {
-    Node nn;
-    std::vector< Node > rew;
-    if (utils::checkClash(in[0], in[1], rew))
-    {
-      nn = nodeManager()->mkConst(false);
-    }
-    else
-    {
-      nn = nodeManager()->mkAnd(rew);
-    }
-    if (in != nn)
+    Node nn = d_rewriter.rewriteViaRule(ProofRewriteRule::DT_CONS_EQ, in);
+    if (!nn.isNull() && in != nn)
     {
       return TrustNode::mkTrustRewrite(in, nn, nullptr);
     }


### PR DESCRIPTION
Reduces the unproven rewrites for datatypes from 280 -> 28.

Note this "demotes" a proof rule to be a proof rewrite rule.