### PR TITLE
Install Python bindings in interpreter default location

### DIFF
--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -226,18 +226,13 @@ else()
       ${LICENSE_FILES}
   )
 
-  # figure out if we're in a virtualenv
-  execute_process(OUTPUT_VARIABLE IN_VIRTUALENV
-    COMMAND
-    "${Python_EXECUTABLE}"
-    -c
-    "import os; print('YES' if 'VIRTUAL_ENV' in os.environ else 'NO', end='')")
-
   set(INSTALL_CMD
       "${Python_EXECUTABLE} -m pip install ${CMAKE_CURRENT_BINARY_DIR}")
-  # if we're in a virtualenv, we install it in the virtualenv lib location
-  # otherwise install in prefix
-  if ("${IN_VIRTUALENV}" STREQUAL "NO")
+
+  # If the user does not set a prefix, install the Python bindings in
+  # the default location designated by the Python interpreter used to
+  # build them. Otherwise, install them in the specified prefix.
+  if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(INSTALL_CMD "${INSTALL_CMD} --prefix ${CMAKE_INSTALL_PREFIX}")
   endif()
 


### PR DESCRIPTION
Users expect the Python bindings to be installed in the default location designated by the Python interpreter used to build them (see discussion #10255), and not the default system path set by CMake that may be not associated with any Python version. This changes the installation step to meet their expectation. Furthermore, it simplifies the installation code and ensures consistent behavior across Python environments, regardless of whether they are virtual or not.