### PR TITLE
Ensure define-fun are printed in unsat core benchmark output

### DIFF
--- a/src/smt/unsat_core_manager.cpp
+++ b/src/smt/unsat_core_manager.cpp
@@ -65,10 +65,12 @@ std::vector<Node> UnsatCoreManager::getUnsatCoreLemmas(bool isInternal)
       std::vector<Node> coreAsserts;
       std::vector<Node> coreDefs;
       partitionUnsatCore(core, coreDefs, coreAsserts);
-      coreAsserts.insert(coreAsserts.end(), coreLemmas.begin(), coreLemmas.end());
+      coreAsserts.insert(
+          coreAsserts.end(), coreLemmas.begin(), coreLemmas.end());
       std::stringstream ss;
       smt::PrintBenchmark pb(Printer::getPrinter(ss));
-      pb.printBenchmark(ss, logicInfo().getLogicString(), coreDefs, coreAsserts);
+      pb.printBenchmark(
+          ss, logicInfo().getLogicString(), coreDefs, coreAsserts);
       output(OutputTag::UNSAT_CORE_LEMMAS_BENCHMARK) << ";; unsat core + lemmas" << std::endl;
       output(OutputTag::UNSAT_CORE_LEMMAS_BENCHMARK) << ss.str();
       output(OutputTag::UNSAT_CORE_LEMMAS_BENCHMARK) << ";; end unsat core + lemmas" << std::endl;
@@ -279,13 +281,15 @@ std::vector<Node> UnsatCoreManager::reduceUnsatCore(
   return newUcAssertions;
 }
 
-void UnsatCoreManager::partitionUnsatCore(const std::vector<Node>& core, std::vector<Node>& coreDefs, std::vector<Node>& coreAsserts)
+void UnsatCoreManager::partitionUnsatCore(const std::vector<Node>& core,
+                                          std::vector<Node>& coreDefs,
+                                          std::vector<Node>& coreAsserts)
 {
   const Assertions& as = d_slv.getAssertions();
   std::unordered_set<Node> defs = as.getCurrentAssertionListDefitions();
   for (const Node& c : core)
   {
-    if (defs.find(c)!=defs.end())
+    if (defs.find(c) != defs.end())
     {
       coreDefs.push_back(c);
     }

--- a/src/smt/unsat_core_manager.cpp
+++ b/src/smt/unsat_core_manager.cpp
@@ -62,10 +62,13 @@ std::vector<Node> UnsatCoreManager::getUnsatCoreLemmas(bool isInternal)
     {
       // also must compute the unsat core of input
       std::vector<Node> core = getUnsatCore(true);
-      core.insert(core.end(), coreLemmas.begin(), coreLemmas.end());
+      std::vector<Node> coreAsserts;
+      std::vector<Node> coreDefs;
+      partitionUnsatCore(core, coreDefs, coreAsserts);
+      coreAsserts.insert(coreAsserts.end(), coreLemmas.begin(), coreLemmas.end());
       std::stringstream ss;
       smt::PrintBenchmark pb(Printer::getPrinter(ss));
-      pb.printBenchmark(ss, logicInfo().getLogicString(), {}, core);
+      pb.printBenchmark(ss, logicInfo().getLogicString(), coreDefs, coreAsserts);
       output(OutputTag::UNSAT_CORE_LEMMAS_BENCHMARK) << ";; unsat core + lemmas" << std::endl;
       output(OutputTag::UNSAT_CORE_LEMMAS_BENCHMARK) << ss.str();
       output(OutputTag::UNSAT_CORE_LEMMAS_BENCHMARK) << ";; end unsat core + lemmas" << std::endl;
@@ -119,9 +122,12 @@ void UnsatCoreManager::getUnsatCoreInternal(std::shared_ptr<ProofNode> pfn,
   // output benchmark if specified
   if (isOutputOn(OutputTag::UNSAT_CORE_BENCHMARK))
   {
+    std::vector<Node> coreAsserts;
+    std::vector<Node> coreDefs;
+    partitionUnsatCore(core, coreDefs, coreAsserts);
     std::stringstream ss;
     smt::PrintBenchmark pb(Printer::getPrinter(ss));
-    pb.printBenchmark(ss, logicInfo().getLogicString(), {}, core);
+    pb.printBenchmark(ss, logicInfo().getLogicString(), coreDefs, coreAsserts);
     output(OutputTag::UNSAT_CORE_BENCHMARK) << ";; unsat core" << std::endl;
     output(OutputTag::UNSAT_CORE_BENCHMARK) << ss.str();
     output(OutputTag::UNSAT_CORE_BENCHMARK) << ";; end unsat core" << std::endl;
@@ -271,6 +277,23 @@ std::vector<Node> UnsatCoreManager::reduceUnsatCore(
     }
   }
   return newUcAssertions;
+}
+
+void UnsatCoreManager::partitionUnsatCore(const std::vector<Node>& core, std::vector<Node>& coreDefs, std::vector<Node>& coreAsserts)
+{
+  const Assertions& as = d_slv.getAssertions();
+  std::unordered_set<Node> defs = as.getCurrentAssertionListDefitions();
+  for (const Node& c : core)
+  {
+    if (defs.find(c)!=defs.end())
+    {
+      coreDefs.push_back(c);
+    }
+    else
+    {
+      coreAsserts.push_back(c);
+    }
+  }
 }
 
 std::vector<Node> UnsatCoreManager::convertPreprocessedToInput(

--- a/src/smt/unsat_core_manager.h
+++ b/src/smt/unsat_core_manager.h
@@ -117,7 +117,9 @@ class UnsatCoreManager : protected EnvObj
    * Parition core into ordinary assertions and definitions. This method is
    * only used for printing output traces.
    */
-  void partitionUnsatCore(const std::vector<Node>& core, std::vector<Node>& coreDefs, std::vector<Node>& coreAsserts);
+  void partitionUnsatCore(const std::vector<Node>& core,
+                          std::vector<Node>& coreDefs,
+                          std::vector<Node>& coreAsserts);
   /** Reference to the SMT solver */
   SmtSolver& d_slv;
   /** Reference to the proof manager */

--- a/src/smt/unsat_core_manager.h
+++ b/src/smt/unsat_core_manager.h
@@ -113,6 +113,11 @@ class UnsatCoreManager : protected EnvObj
    */
   std::vector<Node> reduceUnsatCore(const Assertions& as,
                                     const std::vector<Node>& core);
+  /**
+   * Parition core into ordinary assertions and definitions. This method is
+   * only used for printing output traces.
+   */
+  void partitionUnsatCore(const std::vector<Node>& core, std::vector<Node>& coreDefs, std::vector<Node>& coreAsserts);
   /** Reference to the SMT solver */
   SmtSolver& d_slv;
   /** Reference to the proof manager */


### PR DESCRIPTION
Previously we would generate a higher-order benchmark with `-o unsat-core-benchmark` when define-fun are present.