### PR TITLE
Fix broken links to SMT-LIB

### DIFF
--- a/docs/binary/binary.rst
+++ b/docs/binary/binary.rst
@@ -7,7 +7,7 @@ interface.
 
 The cvc5 binary supports the following input languages:
 
-* `SMT-LIB v2 <http://smtlib.cs.uiowa.edu/language.shtml>`_
+* `SMT-LIB v2 <http://smt-lib.org/language.shtml>`_
 * `SyGuS-IF <https://sygus-org.github.io/language/>`_
 
 

--- a/docs/binary/quickstart.rst
+++ b/docs/binary/quickstart.rst
@@ -2,7 +2,7 @@ Quickstart Guide
 ================
 
 The primary input language for cvc5 is
-`SMT-LIB v2 <http://smtlib.cs.uiowa.edu/language.shtml>`_.
+`SMT-LIB v2 <http://smt-lib.org/language.shtml>`_.
 We give a short explanation of the SMT-LIB v2 quickstart
 example here.
 

--- a/docs/theories/strings.rst
+++ b/docs/theories/strings.rst
@@ -2,7 +2,7 @@ Theory Reference: Strings
 =========================
 
 cvc5 supports all operators of the `SMT-LIB standard for strings
-<https://smtlib.cs.uiowa.edu/theories-UnicodeStrings.shtml>`_. It additionally
+<https://smt-lib.org/theories-UnicodeStrings.shtml>`_. It additionally
 supports some non-standard operators that are described below.
 
 Semantics

--- a/docs/theories/theories.rst
+++ b/docs/theories/theories.rst
@@ -7,7 +7,7 @@ standardized, or that extend beyond the respective standardized theory.
 Furthermore, cvc5 supports all combinations of all implemented theories as well
 as combinations with `datatypes, quantifiers, and uninterpreted functions (as
 defined in the SMT-LIB standard)
-<https://smtlib.cs.uiowa.edu/language.shtml>`_.
+<https://smt-lib.org/language.shtml>`_.
 
 Standardized theories
 ---------------------
@@ -15,13 +15,13 @@ Standardized theories
 .. toctree::
    :maxdepth: 1
 
-   Theory of arrays <https://smtlib.cs.uiowa.edu/theories-ArraysEx.shtml>
-   Theory of bit-vectors <https://smtlib.cs.uiowa.edu/theories-FixedSizeBitVectors.shtml>
-   Theory of floating-point numbers <https://smtlib.cs.uiowa.edu/theories-FloatingPoint.shtml>
-   Theory of integer arithmetic <https://smtlib.cs.uiowa.edu/theories-Ints.shtml>
-   Theory of real arithmetic <https://smtlib.cs.uiowa.edu/theories-Reals.shtml>
-   Theory of mixed-integer arithmetic <https://smtlib.cs.uiowa.edu/theories-Reals_Ints.shtml>
-   Theory of strings <https://smtlib.cs.uiowa.edu/theories-UnicodeStrings.shtml>
+   Theory of arrays <https://smt-lib.org/theories-ArraysEx.shtml>
+   Theory of bit-vectors <https://smt-lib.org/theories-FixedSizeBitVectors.shtml>
+   Theory of floating-point numbers <https://smt-lib.org/theories-FloatingPoint.shtml>
+   Theory of integer arithmetic <https://smt-lib.org/theories-Ints.shtml>
+   Theory of real arithmetic <https://smt-lib.org/theories-Reals.shtml>
+   Theory of mixed-integer arithmetic <https://smt-lib.org/theories-Reals_Ints.shtml>
+   Theory of strings <https://smt-lib.org/theories-UnicodeStrings.shtml>
 
 Non-standard or extended theories
 ---------------------------------

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -1335,7 +1335,7 @@ void SetDefaults::widenLogic(LogicInfo& logic, const Options& opts) const
       || (logic.isTheoryEnabled(THEORY_ARITH)
           && logic.isTheoryEnabled(THEORY_BV))
       // FP requires UF since there are multiple operators that are partially
-      // defined (see http://smtlib.cs.uiowa.edu/papers/BTRW15.pdf for more
+      // defined (see http://smt-lib.org/papers/BTRW15.pdf for more
       // details).
       || logic.isTheoryEnabled(THEORY_FP))
   {

--- a/src/smt/smt_mode.h
+++ b/src/smt/smt_mode.h
@@ -25,7 +25,7 @@ namespace cvc5::internal {
 /**
  * The mode of the solver, which is an extension of Figure 4.1 on
  * page 52 of the SMT-LIB version 2.6 standard
- * http://smtlib.cs.uiowa.edu/papers/smt-lib-reference-v2.6-r2017-07-18.pdf
+ * http://smt-lib.org/papers/smt-lib-reference-v2.6-r2017-07-18.pdf
  */
 enum class SmtMode
 {


### PR DESCRIPTION
I am getting that the links to SMT-LIB in https://cvc5.github.io/docs/cvc5-1.1.2/ no longer work.

This updates the links on main to use a URL that works for me.