### PR TITLE
Disable DSL proof on a regression that times out

### DIFF
--- a/test/regress/cli/regress1/quantifiers/bug802.smt2
+++ b/test/regress/cli/regress1/quantifiers/bug802.smt2
@@ -1,3 +1,4 @@
+; DISABLE-TESTER: dsl-proof
 ; DISABLE-TESTER: lfsc
 (set-logic BV)
 (set-info :source | 


### PR DESCRIPTION
Fixes another issue in the nightlies.