### PR TITLE
ci: Fix add-package action

### DIFF
--- a/.github/actions/add-package/action.yml
+++ b/.github/actions/add-package/action.yml
@@ -45,6 +45,10 @@ runs:
     - name: install pyGithub
       shell: ${{ inputs.shell }}
       run: |
+        # Upgrading pyopenssl resolves the following error:
+        # AttributeError:
+        #   module 'lib' has no attribute 'X509_V_FLAG_NOTIFY_POLICY'
+        python3 -m pip install -U pyopenssl
         python3 -m pip install pyGithub
 
     - name: Store to latest


### PR DESCRIPTION
PR #10700 stopped installing some unnecessary Python dependencies. However, the installation of these dependencies had the side-effect of fixing an unrelated issue in the add-package action. This PR addresses directly the issue in the add-package action.