### PR TITLE
ci: Do not treat warnings as errors

### DIFF
--- a/.github/actions/configure-and-build/action.yml
+++ b/.github/actions/configure-and-build/action.yml
@@ -41,7 +41,7 @@ runs:
       run: |
         echo "::group::Shared build"
         ${{ inputs.configure-env }} ./configure.sh ${{ inputs.configure-config }} \
-          --prefix=$(pwd)/build-shared/install --werror --name=build-shared \
+          --prefix=$(pwd)/build-shared/install --name=build-shared \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
         
         cd build-shared/ && pwd=$(pwd)


### PR DESCRIPTION
The Windows build now uses GCC 14.1.0, which reports a new warning that we need to address. This temporarily removes the requirement of treating warnings as errors until we have time to address all instances of the warning.