### PR TITLE
Add callback to restrict which proofs can merge in proof node updater

### DIFF
--- a/src/proof/proof_node_updater.cpp
+++ b/src/proof/proof_node_updater.cpp
@@ -51,6 +51,12 @@ bool ProofNodeUpdaterCallback::updatePost(Node res,
   return false;
 }
 
+bool ProofNodeUpdaterCallback::canMerge(std::shared_ptr<ProofNode> pn)
+{
+  // by default, no restriction on what proofs can merge
+  return true;
+}
+
 ProofNodeUpdater::ProofNodeUpdater(Env& env,
                                    ProofNodeUpdaterCallback& cb,
                                    bool mergeSubproofs,
@@ -294,6 +300,11 @@ void ProofNodeUpdater::runFinalize(
   }
   if (d_mergeSubproofs)
   {
+    // if we cannot merge this proof, skip it
+    if (!d_cb.canMerge(cur))
+    {
+      return;
+    }
     Node res = cur->getResult();
     // cache the result if we don't contain an assumption
     if (!expr::containsAssumption(cur.get(), cfaMap, cfaAllowed))

--- a/src/proof/proof_node_updater.h
+++ b/src/proof/proof_node_updater.h
@@ -197,7 +197,6 @@ class ProofNodeUpdater : protected EnvObj
                    std::map<Node, std::shared_ptr<ProofNode>>& resCache,
                    std::map<Node, std::vector<std::shared_ptr<ProofNode>>>&
                        resCacheNcWaiting,
-                   std::map<Node, std::shared_ptr<ProofNode>>& resCachec,
                    std::unordered_map<const ProofNode*, bool>& cfaMap,
                    const std::unordered_set<Node>& cfaAllowed);
   /**

--- a/src/proof/proof_node_updater.h
+++ b/src/proof/proof_node_updater.h
@@ -87,8 +87,7 @@ class ProofNodeUpdaterCallback
    * Can we merge pn into other proofs? This method is only called if we are
    * merging subproofs with a proof node updater (mergeSubproofs=true).
    * If we return false for pn, then its contents will never be copied into
-   * another proof, although its contents may be replaced by another proof
-   * node of the same conclusion.
+   * another proof, nor will its contents be replaced.
    */
   virtual bool canMerge(std::shared_ptr<ProofNode> pn);
 };

--- a/src/proof/proof_node_updater.h
+++ b/src/proof/proof_node_updater.h
@@ -83,6 +83,14 @@ class ProofNodeUpdaterCallback
                           const std::vector<Node>& children,
                           const std::vector<Node>& args,
                           CDProof* cdp);
+  /**
+   * Can we merge pn into other proofs? This method is only called if we are
+   * merging subproofs with a proof node updater (mergeSubproofs=true).
+   * If we return false for pn, then its contents will never be copied into
+   * another proof, although its contents may be replaced by another proof
+   * node of the same conclusion.
+   */
+  virtual bool canMerge(std::shared_ptr<ProofNode> pn);
 };
 
 /**
@@ -189,6 +197,7 @@ class ProofNodeUpdater : protected EnvObj
                    std::map<Node, std::shared_ptr<ProofNode>>& resCache,
                    std::map<Node, std::vector<std::shared_ptr<ProofNode>>>&
                        resCacheNcWaiting,
+                   std::map<Node, std::shared_ptr<ProofNode>>& resCachec,
                    std::unordered_map<const ProofNode*, bool>& cfaMap,
                    const std::unordered_set<Node>& cfaAllowed);
   /**

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -175,6 +175,17 @@ bool ProofPostprocessCallback::update(Node res,
   return !ret.isNull();
 }
 
+bool ProofPostprocessCallback::canMerge(std::shared_ptr<ProofNode> pn)
+{
+  if (d_collectAllTrusted)
+  {
+    ProofRule id = pn->getRule();
+    return (id != ProofRule::TRUST_THEORY_REWRITE && id != ProofRule::TRUST);
+  }
+  // otherwise we can merge
+  return true;
+}
+
 bool ProofPostprocessCallback::updateInternal(Node res,
                                               ProofRule id,
                                               const std::vector<Node>& children,

--- a/src/smt/proof_post_processor.h
+++ b/src/smt/proof_post_processor.h
@@ -87,6 +87,13 @@ class ProofPostprocessCallback : public ProofNodeUpdaterCallback, protected EnvO
               const std::vector<Node>& args,
               CDProof* cdp,
               bool& continueUpdate) override;
+  /**
+   * Can merge. This returns false if pn is a trusted proof, since we do not
+   * want the proof node updater to merge its contents into another proof,
+   * which we otherwise would not be informed of and would lead to trusted
+   * proofs that are not recorded in d_trustedPfs.
+   */
+  bool canMerge(std::shared_ptr<ProofNode> pn) override;
 
  private:
   /** Common constants */


### PR DESCRIPTION
Corrects an issue where a trusted proof step may bypass DSL proof reconstruction by merging into another proof with the same conclusion, where that proof was not cached as a trusted proof step.