### PR TITLE
cmake: Do not search for Python development artifacts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,16 +372,10 @@ endif()
 # either to be used when the '--auto-download' option is not specified, or
 # to create a virtual environment when the '--auto-download' option is given.
 # In the latter case, it is also used to install the Python bindings (if built).
-if(BUILD_BINDINGS_PYTHON)
-  # If the component Development is requested, CMake strongly recommends to
-  # also include the component Interpreter to get expected result.
-  if(DEFINED BUILD_BINDINGS_PYTHON_VERSION)
-    find_package(Python ${BUILD_BINDINGS_PYTHON_VERSION}
-      EXACT COMPONENTS Interpreter Development REQUIRED
-    )
-  else()
-    find_package(Python COMPONENTS Interpreter Development REQUIRED)
-  endif()
+if(DEFINED BUILD_BINDINGS_PYTHON_VERSION)
+  find_package(Python ${BUILD_BINDINGS_PYTHON_VERSION}
+    EXACT COMPONENTS Interpreter REQUIRED
+  )
 else()
   find_package(Python COMPONENTS Interpreter REQUIRED)
 endif()
@@ -418,11 +412,7 @@ if(ENABLE_AUTO_DOWNLOAD AND USE_PYTHON_VENV)
   endif()
 
   # Find the Python interpreter within the virtual environment
-  if(BUILD_BINDINGS_PYTHON)
-    find_package(Python COMPONENTS Interpreter Development REQUIRED)
-  else()
-    find_package(Python COMPONENTS Interpreter REQUIRED)
-  endif()
+  find_package(Python COMPONENTS Interpreter REQUIRED)
 endif()
 
 find_package(GMP 6.3 REQUIRED)


### PR DESCRIPTION
Specifying the Development component in CMake for Python is unnecessary. Even if the search for the Development component fails, it doesn't affect the successful compilation of Python bindings. However, not finding the development artifacts might terminate the build prematurely. This situation is currently observed when building Python bindings with cibuildwheel in the PyPi packaging action. Therefore, this updates the CMakeLists file to exclude the Development component during the Python location process.