### PR TITLE
Update ProofRule::THEORY_REWRITE to take an equality

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -311,7 +311,7 @@ enum ENUM(ProofRule) : uint32_t
    * **Other theory rewrite rules**
    *
    * .. math::
-   *   \inferrule{- \mid id, t}{t = t'}
+   *   \inferrule{- \mid id, t = t'}{t = t'}
    *
    * where `id` is the :cpp:enum:`ProofRewriteRule` of the theory rewrite
    * rule which transforms :math:`t` to :math:`t'`.

--- a/proofs/alf/cvc5/rules/Strings.smt3
+++ b/proofs/alf/cvc5/rules/Strings.smt3
@@ -239,9 +239,9 @@
   :conclusion (= (str.in_re s r) b)
 )
 
-(declare-rule re-loop-elim ((l Int) (u Int) (r RegLan) (r2 RegLan))
-  :args ((= (re.loop l u r) r2))
+(declare-rule re-loop-elim ((l Int) (u Int) (r1 RegLan) (r2 RegLan))
+  :args ((= (re.loop l u r1) r2))
   :requires (((alf.is_neg (alf.add (alf.neg l) u)) false)
-             (($str_mk_re_loop_elim l (alf.add (alf.neg l) u) r) r2))
-  :conclusion (= (re.loop l u r) r2)
+             (($str_mk_re_loop_elim l (alf.add (alf.neg l) u) r1) r2))
+  :conclusion (= (re.loop l u r1) r2)
 )

--- a/proofs/alf/cvc5/rules/Strings.smt3
+++ b/proofs/alf/cvc5/rules/Strings.smt3
@@ -233,14 +233,15 @@
 
 ;;-------------------- Instances of THEORY_REWRITE
 
-(declare-rule str-in-re-eval ((s String) (r RegLan))
-  :args ((str.in_re s r))
-  :conclusion (= (str.in_re s r) ($str_eval_str_in_re s r))
+(declare-rule str-in-re-eval ((s String) (r RegLan) (b Bool))
+  :args ((= (str.in_re s r) b))
+  :requires ((($str_eval_str_in_re s r) b))
+  :conclusion (= (str.in_re s r) b)
 )
 
-(declare-rule re-loop-elim ((l Int) (u Int) (r RegLan))
-  :args ((re.loop l u r))
-  :conclusion (let ((diff (alf.add (alf.neg l) u)))
-              (alf.requires (alf.is_neg diff) false
-                 (= (re.loop l u r) ($str_mk_re_loop_elim l diff r))))
+(declare-rule re-loop-elim ((l Int) (u Int) (r RegLan) (r2 RegLan))
+  :args ((= (re.loop l u r) r2))
+  :requires (((alf.is_neg (alf.add (alf.neg l) u)) false)
+             (($str_mk_re_loop_elim l (alf.add (alf.neg l) u) r) r2))
+  :conclusion (= (re.loop l u r) r2)
 )

--- a/proofs/alf/cvc5/rules/Uf.smt3
+++ b/proofs/alf/cvc5/rules/Uf.smt3
@@ -143,8 +143,8 @@
   )
 )
 
-(declare-rule distinct-elim ((b Bool) (b2 Bool))
-  :args ((= b b2))
-  :requires ((($singleton_elim ($mk_distinct-elim b)) b2))
-  :conclusion (= b b2)
+(declare-rule distinct-elim ((b1 Bool) (b2 Bool))
+  :args ((= b1 b2))
+  :requires ((($singleton_elim ($mk_distinct-elim b1)) b2))
+  :conclusion (= b1 b2)
 )

--- a/proofs/alf/cvc5/rules/Uf.smt3
+++ b/proofs/alf/cvc5/rules/Uf.smt3
@@ -143,7 +143,8 @@
   )
 )
 
-(declare-rule distinct-elim ((b Bool))
-  :args (b)
-  :conclusion (= b ($singleton_elim ($mk_distinct-elim b)))
+(declare-rule distinct-elim ((b Bool) (b2 Bool))
+  :args ((= b b2))
+  :requires ((($singleton_elim ($mk_distinct-elim b)) b2))
+  :conclusion (= b b2)
 )

--- a/src/proof/eager_proof_generator.cpp
+++ b/src/proof/eager_proof_generator.cpp
@@ -132,7 +132,7 @@ TrustNode EagerProofGenerator::mkTrustNodeRewrite(const Node& a,
 {
   std::vector<Node> args;
   args.push_back(rewriter::mkRewriteRuleNode(id));
-  args.push_back(a);
+  args.push_back(a.eqNode(b));
   return mkTrustedRewrite(a, b, ProofRule::THEORY_REWRITE, args);
 }
 

--- a/src/proof/lfsc/lfsc_post_processor.cpp
+++ b/src/proof/lfsc/lfsc_post_processor.cpp
@@ -442,7 +442,7 @@ bool LfscProofPostprocessCallback::update(Node res,
       if (idr == ProofRewriteRule::BETA_REDUCE)
       {
         // get the term to beta-reduce
-        Node termToReduce = nm->mkNode(Kind::APPLY_UF, args[1]);
+        Node termToReduce = nm->mkNode(Kind::APPLY_UF, args[1][0]);
         addLfscRule(cdp, res, {}, LfscRule::BETA_REDUCE, {termToReduce});
       }
       else

--- a/src/proof/proof.cpp
+++ b/src/proof/proof.cpp
@@ -285,7 +285,7 @@ bool CDProof::addTheoryRewriteStep(Node expected,
   }
   std::vector<Node> sargs;
   sargs.push_back(rewriter::mkRewriteRuleNode(id));
-  sargs.push_back(expected[0]);
+  sargs.push_back(expected);
   return addStep(
       expected, ProofRule::THEORY_REWRITE, {}, sargs, ensureChildren, opolicy);
 }

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -57,7 +57,7 @@ bool BasicRewriteRCons::prove(
   if (prid != ProofRewriteRule::NONE)
   {
     if (tryRule(
-            cdp, eq, ProofRule::THEORY_REWRITE, {mkRewriteRuleNode(prid), a}))
+            cdp, eq, ProofRule::THEORY_REWRITE, {mkRewriteRuleNode(prid), eq}))
     {
       Trace("trewrite-rcons") << "Reconstruct " << eq << " (from " << prid
                               << ", " << mid << ")" << std::endl;
@@ -79,7 +79,7 @@ bool BasicRewriteRCons::postProve(
   if (prid != ProofRewriteRule::NONE)
   {
     if (tryRule(
-            cdp, eq, ProofRule::THEORY_REWRITE, {mkRewriteRuleNode(prid), a}))
+            cdp, eq, ProofRule::THEORY_REWRITE, {mkRewriteRuleNode(prid), eq}))
     {
       Trace("trewrite-rcons") << "Reconstruct (post) " << eq << " (from "
                               << prid << ", " << mid << ")" << std::endl;

--- a/src/theory/builtin/proof_checker.cpp
+++ b/src/theory/builtin/proof_checker.cpp
@@ -477,12 +477,16 @@ Node BuiltinProofRuleChecker::checkInternal(ProofRule id,
     {
       return Node::null();
     }
-    Node rhs = d_rewriter->rewriteViaRule(di, args[1]);
-    if (rhs.isNull())
+    if (args[1].getKind() != Kind::EQUAL)
     {
       return Node::null();
     }
-    return args[1].eqNode(rhs);
+    Node rhs = d_rewriter->rewriteViaRule(di, args[1][0]);
+    if (rhs.isNull() || rhs != args[1][1])
+    {
+      return Node::null();
+    }
+    return args[1];
   }
   // no rule
   return Node::null();


### PR DESCRIPTION
This is required since some rewrite rules (e.g. strings arithmetic approximations) are easy to check but hard to compute.

In particular, a forthcoming rewrite will invoke the search procedure from https://homepage.divms.uiowa.edu/~ajreynol/cav19c.pdf, but the proof checker can be configured to verify that the chosen approximation is one of the allowed ones.