### PR TITLE
Fixes several issues related to DSL/THEORY rewrites

### DIFF
--- a/src/options/proof_options.toml
+++ b/src/options/proof_options.toml
@@ -129,7 +129,7 @@ name   = "Proof"
   category   = "regular"
   long       = "proof-rewrite-rcons-step-limit=N"
   type       = "uint64_t"
-  default    = "200"
+  default    = "1000"
   help       = "the limit of steps considered for reconstructing proofs of theory rewrites"
 
 [[option]]

--- a/src/proof/proof_node_to_sexpr.cpp
+++ b/src/proof/proof_node_to_sexpr.cpp
@@ -333,6 +333,7 @@ ProofNodeToSExpr::ArgFormat ProofNodeToSExpr::getArgumentFormat(
       }
       break;
     case ProofRule::DSL_REWRITE:
+    case ProofRule::THEORY_REWRITE:
       if (i == 0)
       {
         return ArgFormat::DSL_REWRITE_ID;

--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -297,6 +297,8 @@ bool RewriteDbProofCons::notifyMatch(const Node& s,
     // for approximate types, return false in this case
     if (target.isNull())
     {
+      // note that we return false here, indicating that we don't want any
+      // more matches, since we have failed for the current fixed point rule.
       return false;
     }
     // We now prove with the given rule. this should only fail if there are
@@ -1097,6 +1099,7 @@ Node RewriteDbProofCons::getRuleConclusion(const RewriteProofRule& rpr,
 
       ProvenInfo& dpi = d_pcache[source.eqNode(target)];
       dpi.d_id = pi.d_id;
+      dpi.d_dslId = pi.d_dslId;
       dpi.d_vars = vars;
       dpi.d_subs = stepSubs;
 


### PR DESCRIPTION
Includes:
- RARE reconstruction for fixed point rules was broken in a fairly major way, since we could introduce variable aliasing for fixed point contexts. The fix is to canonize context terms at the same time as conditions/conclusions, as this will ensure all variables are unique.
- We weren't tracking the DSL rewrite id in some cases of fixed point reconstructions
- Fixes the (internal) printer for THEORY_REWRITE
- Increases the step limit of RARE reconstruction from 200 -> 1000, which is important for the industrial set of interest, and appears to lead to better performance on regressions.

The first issue would manifest as open proofs when doing RARE reconstruction. The second issue would manifest as segfaults.