### PR TITLE
Fix repeat substitutions when processing learned literals

### DIFF
--- a/src/prop/zero_level_learner.h
+++ b/src/prop/zero_level_learner.h
@@ -89,6 +89,13 @@ class ZeroLevelLearner : protected EnvObj
   bool getSolved(const Node& lit, Subs& subs);
   /** has learned literal */
   bool hasLearnedLiteralForRestart() const;
+  /** 
+   * Adds a substitution to d_tsmap. This occurs when we learn a literal at
+   * decision level zero that is equivalent to (= t s)
+   * @param t The term to substitute.
+   * @param s The value to substitute t to.
+   */
+  void addSimplification(const Node& t, const Node& s);
 
   /** The theory engine we are using */
   TheoryEngine* d_theoryEngine;

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2576,6 +2576,7 @@ set(regress_1_tests
   regress1/proj-issue619-nconst-nl-mv.smt2
   regress1/proj-issue623-bv2nat-static.smt2
   regress1/proj-issue634-diff-mc.smt2
+  regress1/proj-issue719-zll-repeat.smt2
   regress1/proof00.smt2
   regress1/proofs/add_two_base.smt2
   regress1/proofs/base-lfsc-treesize.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1420,7 +1420,6 @@ set(regress_0_tests
   regress0/quantifiers/ex6.smt2
   regress0/quantifiers/floor.smt2
   regress0/quantifiers/global_negate.smt2
-  regress1/quantifiers/ho-grammar.smt2
   regress0/quantifiers/horn-ground-pre-post.smt2
   regress0/quantifiers/is-even-pred.smt2
   regress0/quantifiers/is-int.smt2
@@ -1450,7 +1449,6 @@ set(regress_0_tests
   regress0/quantifiers/issue8923-qe-push-pop.smt2
   regress0/quantifiers/issue9602-rewrite-pow-type.smt2
   regress0/quantifiers/issue9640-vts-iff.smt2
-  regress1/quantifiers/lcl579-2-ho-mbqi.smt2
   regress0/quantifiers/lra-triv-gn.smt2
   regress0/quantifiers/macro-back-subs-sat.smt2
   regress0/quantifiers/macros-int-real.smt2
@@ -2400,6 +2398,7 @@ set(regress_1_tests
   regress1/gensys_brn001.smt2
   regress1/get-learned-literals.smt2
   regress1/get-learned-literals-types.smt2
+  regress1/quantifiers/ho-grammar.smt2
   regress1/ho/bug_freeVar_BDD_General_data_270.smt2
   regress1/ho/bound_var_bug.smt2
   regress1/ho/dd.seu-mbqi.smt2
@@ -2425,6 +2424,7 @@ set(regress_1_tests
   regress1/hole6.cvc.smt2
   regress1/interpolant-unk-570.smt2
   regress1/ite5.smt2
+  regress1/issue10750-zll-repeat.smt2
   regress1/issue3970-nl-ext-purify.smt2
   regress1/issue3990-sort-inference.smt2
   regress1/issue4273-ext-rew-cache.smt2
@@ -2773,6 +2773,7 @@ set(regress_1_tests
   regress1/quantifiers/issue9989-syqi-nwf.smt2
   regress1/quantifiers/javafe.ast.StmtVec.009.smt2
   regress1/quantifiers/lia-witness-div-pp.smt2
+  regress1/quantifiers/lcl579-2-ho-mbqi.smt2
   regress1/quantifiers/lra-vts-inf.smt2
   regress1/quantifiers/macro-geo-small-3.smt2
   regress1/quantifiers/mbqi_fast_sy_check_ic.smt2

--- a/test/regress/cli/regress1/issue10750-zll-repeat.smt2
+++ b/test/regress/cli/regress1/issue10750-zll-repeat.smt2
@@ -1,0 +1,7 @@
+; COMMAND-LINE: --produce-learned-literals
+; EXPECT: sat
+(set-logic QF_ABV)
+(declare-fun m () (_ BitVec 6))
+(assert (not (bvsle (_ bv1 32) ((_ zero_extend 26) (bvsmod (_ bv0 6) (bvadd m (bvsmod (_ bv0 6) m)))))))
+(assert (bvsge (_ bv63 6) m))
+(check-sat)

--- a/test/regress/cli/regress1/proj-issue719-zll-repeat.smt2
+++ b/test/regress/cli/regress1/proj-issue719-zll-repeat.smt2
@@ -1,4 +1,4 @@
-; EXPECT: unsat
+; EXPECT: sat
 (set-logic ALL)
 (declare-const x (_ BitVec 63))
 (set-option :lemma-inprocess full)

--- a/test/regress/cli/regress1/proj-issue719-zll-repeat.smt2
+++ b/test/regress/cli/regress1/proj-issue719-zll-repeat.smt2
@@ -1,0 +1,6 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-const x (_ BitVec 63))
+(set-option :lemma-inprocess full)
+(assert (fp.isNaN ((_ to_fp 11 53) ((_ zero_extend 1) x))))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5-projects/issues/719.
Fixes https://github.com/cvc5/cvc5/issues/10750.

This also reverts a behavior where substitutions would impact whether a learned literal was classified as an input literal.