### PR TITLE
Eliminate dependency on cardinality utility in model

### DIFF
--- a/src/theory/strings/base_solver.cpp
+++ b/src/theory/strings/base_solver.cpp
@@ -24,6 +24,7 @@
 #include "theory/strings/word.h"
 #include "util/rational.h"
 #include "util/string.h"
+#include "util/cardinality.h"
 
 using namespace std;
 using namespace cvc5::context;

--- a/src/theory/strings/base_solver.cpp
+++ b/src/theory/strings/base_solver.cpp
@@ -22,9 +22,9 @@
 #include "theory/rewriter.h"
 #include "theory/strings/theory_strings_utils.h"
 #include "theory/strings/word.h"
+#include "util/cardinality.h"
 #include "util/rational.h"
 #include "util/string.h"
-#include "util/cardinality.h"
 
 using namespace std;
 using namespace cvc5::context;

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -177,7 +177,7 @@ bool TheoryModel::isModelCoreSymbol(Node s) const
 size_t TheoryModel::getCardinality(const TypeNode& tn) const
 {
   //for now, we only handle cardinalities for uninterpreted sorts
-  Assert (tn.isUninterpretedSort());
+  Assert(tn.isUninterpretedSort());
   if (d_rep_set.hasType(tn))
   {
     Trace("model-getvalue-debug")
@@ -257,7 +257,7 @@ Node TheoryModel::getModelValue(TNode n) const
       Trace("model-getvalue-debug")
           << "get cardinality constraint " << cc.getType() << std::endl;
       size_t cval = getCardinality(cc.getType());
-      Assert (cval>0);
+      Assert(cval > 0);
       ret = nm->mkConst(Integer(cval) <= cc.getUpperBound());
     }
     // if the value was constant, we return it. If it was non-constant,

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -174,25 +174,20 @@ bool TheoryModel::isModelCoreSymbol(Node s) const
   return d_model_core.find(s) != d_model_core.end();
 }
 
-Cardinality TheoryModel::getCardinality(TypeNode tn) const
+size_t TheoryModel::getCardinality(const TypeNode& tn) const
 {
   //for now, we only handle cardinalities for uninterpreted sorts
-  if (!tn.isUninterpretedSort())
-  {
-    Trace("model-getvalue-debug")
-        << "Get cardinality other sort, unknown." << std::endl;
-    return Cardinality( CardinalityUnknown() );
-  }
+  Assert (tn.isUninterpretedSort());
   if (d_rep_set.hasType(tn))
   {
     Trace("model-getvalue-debug")
         << "Get cardinality sort, #rep : "
         << d_rep_set.getNumRepresentatives(tn) << std::endl;
-    return Cardinality(d_rep_set.getNumRepresentatives(tn));
+    return d_rep_set.getNumRepresentatives(tn);
   }
   Trace("model-getvalue-debug")
       << "Get cardinality sort, unconstrained, return 1." << std::endl;
-  return Cardinality(1);
+  return 1;
 }
 
 Node TheoryModel::getModelValue(TNode n) const
@@ -261,8 +256,9 @@ Node TheoryModel::getModelValue(TNode n) const
           ret.getOperator().getConst<CardinalityConstraint>();
       Trace("model-getvalue-debug")
           << "get cardinality constraint " << cc.getType() << std::endl;
-      ret = nm->mkConst(getCardinality(cc.getType()).getFiniteCardinality()
-                        <= cc.getUpperBound());
+      size_t cval = getCardinality(cc.getType());
+      Assert (cval>0);
+      ret = nm->mkConst(Integer(cval) <= cc.getUpperBound());
     }
     // if the value was constant, we return it. If it was non-constant,
     // we only return it if we are an evaluated kind. This can occur if the

--- a/src/theory/theory_model.h
+++ b/src/theory/theory_model.h
@@ -333,7 +333,7 @@ class TheoryModel : protected EnvObj
   bool isValue(TNode node) const;
 
  protected:
-  /** 
+  /**
    * Get cardinality for sort, where t is an uninterpreted sort.
    * @param t The sort.
    * @return the cardinality of the sort, which is the number of representatives

--- a/src/theory/theory_model.h
+++ b/src/theory/theory_model.h
@@ -27,7 +27,6 @@
 #include "theory/type_enumerator.h"
 #include "theory/type_set.h"
 #include "theory/uf/equality_engine.h"
-#include "util/cardinality.h"
 
 namespace cvc5::internal {
 

--- a/src/theory/theory_model.h
+++ b/src/theory/theory_model.h
@@ -294,9 +294,6 @@ class TheoryModel : protected EnvObj
   bool isModelCoreSymbol(Node sym) const;
   //---------------------------- end model cores
 
-  /** get cardinality for sort */
-  Cardinality getCardinality(TypeNode t) const;
-
   //---------------------------- function values
   /** Does this model have terms for the given uninterpreted function? */
   bool hasUfTerms(Node f) const;
@@ -337,6 +334,13 @@ class TheoryModel : protected EnvObj
   bool isValue(TNode node) const;
 
  protected:
+  /** 
+   * Get cardinality for sort, where t is an uninterpreted sort.
+   * @param t The sort.
+   * @return the cardinality of the sort, which is the number of representatives
+   * for that sort, or 1 if none exist.
+   */
+  size_t getCardinality(const TypeNode& t) const;
   /**
    * Assign that n is the representative of the equivalence class r.
    * @param r The equivalence class


### PR DESCRIPTION
The use of this utility was overkill, moreover we are working towards deprecating the utility.