### PR TITLE
cmake: Use a CACHE variable for Python_BASE_EXECUTABLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,8 +381,10 @@ else()
 endif()
 
 # Keep the PATH to the Python binary before setting venv.
+# Use a CACHE variable to remember the original value.
 # We use this path in the installation step of the Python bindings.
-set(Python_BASE_EXECUTABLE "${Python_EXECUTABLE}")
+set(Python_BASE_EXECUTABLE "${Python_EXECUTABLE}"
+    CACHE STRING "Base Python executable")
 
 if(ENABLE_AUTO_DOWNLOAD AND USE_PYTHON_VENV)
   # Set up Python venv if one doesn't exist already


### PR DESCRIPTION
Otherwise, subsequent runs of CMake use the updated value of Python_EXECUTABLE, which is set to the path of the interpreter in the virtual environment.