### PR TITLE
Handle concatenations with variables in regexp consume utility

### DIFF
--- a/src/theory/strings/regexp_entail.cpp
+++ b/src/theory/strings/regexp_entail.cpp
@@ -121,8 +121,7 @@ Node RegExpEntail::simpleRegexpConsume(std::vector<Node>& mchildren,
             if (remStr.isNull())
             {
               // we have fully processed the component
-              childrenc.erase(childrenc.begin() + cindex,
-                              childrenc.begin() + cindex + 1);
+              childrenc.erase(childrenc.begin() + cindex);
             }
             else
             {

--- a/src/theory/strings/regexp_entail.cpp
+++ b/src/theory/strings/regexp_entail.cpp
@@ -41,9 +41,6 @@ Node RegExpEntail::simpleRegexpConsume(std::vector<Node>& mchildren,
 {
   Trace("regexp-ext-rewrite-debug")
       << "Simple reg exp consume, dir=" << dir << ":" << std::endl;
-  Trace("regexp-ext-rewrite-debug")
-      << "  mchildren : " << mchildren << std::endl;
-  Trace("regexp-ext-rewrite-debug") << "  children : " << children << std::endl;
   NodeManager* nm = NodeManager::currentNM();
   unsigned tmin = dir < 0 ? 0 : dir;
   unsigned tmax = dir < 0 ? 1 : dir;
@@ -52,6 +49,12 @@ Node RegExpEntail::simpleRegexpConsume(std::vector<Node>& mchildren,
   {
     if (tmin <= t && t <= tmax)
     {
+      Trace("regexp-ext-rewrite-debug")
+          << "Run consume, direction is " << t << " with:" << std::endl;
+      Trace("regexp-ext-rewrite-debug")
+          << "  mchildren : " << mchildren << std::endl;
+      Trace("regexp-ext-rewrite-debug")
+          << "  children : " << children << std::endl;
       bool do_next = true;
       while (!children.empty() && !mchildren.empty() && do_next)
       {
@@ -64,30 +67,33 @@ Node RegExpEntail::simpleRegexpConsume(std::vector<Node>& mchildren,
         Assert(xc.getKind() != Kind::STRING_CONCAT);
         if (rc.getKind() == Kind::STRING_TO_REGEXP)
         {
-          if (xc == rc[0])
+          std::vector<Node> childrenc;
+          utils::getConcat(rc[0], childrenc);
+          size_t cindex = t == 1 ? 0 : childrenc.size() - 1;
+          Node rcc = childrenc[cindex];
+          Node remStr;
+          if (xc == rcc)
           {
-            children.pop_back();
             mchildren.pop_back();
             do_next = true;
             Trace("regexp-ext-rewrite-debug") << "- strip equal" << std::endl;
           }
-          else if (rc[0].isConst() && Word::isEmpty(rc[0]))
+          else if (rcc.isConst() && Word::isEmpty(rcc))
           {
             Trace("regexp-ext-rewrite-debug")
                 << "- ignore empty RE" << std::endl;
             // ignore and continue
-            children.pop_back();
             do_next = true;
           }
-          else if (xc.isConst() && rc[0].isConst())
+          else if (xc.isConst() && rcc.isConst())
           {
             // split the constant
             size_t index;
-            Node s = Word::splitConstant(xc, rc[0], index, t == 0);
+            remStr = Word::splitConstant(xc, rcc, index, t == 0);
             Trace("regexp-ext-rewrite-debug")
-                << "- CRE: Regexp const split : " << xc << " " << rc[0]
-                << " -> " << s << " " << index << " " << t << std::endl;
-            if (s.isNull())
+                << "- CRE: Regexp const split : " << xc << " " << rcc << " -> "
+                << remStr << " " << index << " " << t << std::endl;
+            if (remStr.isNull())
             {
               Trace("regexp-ext-rewrite-debug")
                   << "...return false" << std::endl;
@@ -97,19 +103,44 @@ Node RegExpEntail::simpleRegexpConsume(std::vector<Node>& mchildren,
             {
               Trace("regexp-ext-rewrite-debug")
                   << "- strip equal const" << std::endl;
-              children.pop_back();
               mchildren.pop_back();
               if (index == 0)
               {
-                mchildren.push_back(s);
+                mchildren.push_back(remStr);
+                // we've processed the remainder as leftover for the LHS
+                // string, clear it now
+                remStr = Node::null();
               }
-              else
-              {
-                children.push_back(nm->mkNode(Kind::STRING_TO_REGEXP, s));
-              }
+              // otherwise remStr is processed below
             }
             Trace("regexp-ext-rewrite-debug") << "- split const" << std::endl;
             do_next = true;
+          }
+          if (do_next)
+          {
+            if (remStr.isNull())
+            {
+              // we have fully processed the component
+              childrenc.erase(childrenc.begin() + cindex,
+                              childrenc.begin() + cindex + 1);
+            }
+            else
+            {
+              // we have a remainder
+              childrenc[cindex] = remStr;
+            }
+            if (childrenc.empty())
+            {
+              // if childrenc is empty, we are done with the current str.to_re
+              children.pop_back();
+            }
+            else
+            {
+              // otherwise we reconstruct it
+              TypeNode stype = nm->stringType();
+              children[children.size() - 1] = nm->mkNode(
+                  Kind::STRING_TO_REGEXP, utils::mkConcat(childrenc, stype));
+            }
           }
         }
         else if (xc.isConst())

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1828,6 +1828,7 @@ set(regress_0_tests
   regress0/strings/quad-138-4-2-unsat.smt2
   regress0/strings/re-consume-bi-dir.smt2
   regress0/strings/re-consume-sym.smt2
+  regress0/strings/re-consume-sym-sigma.smt2
   regress0/strings/re-include-union.smt2
   regress0/strings/re_diff.smt2
   regress0/strings/re-in-rewrite.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1826,6 +1826,8 @@ set(regress_0_tests
   regress0/strings/proj-issue595-max-model-option.smt2
   regress0/strings/quad-028-2-2-unsat.smt2
   regress0/strings/quad-138-4-2-unsat.smt2
+  regress0/strings/re-consume-bi-dir.smt2
+  regress0/strings/re-consume-sym.smt2
   regress0/strings/re-include-union.smt2
   regress0/strings/re_diff.smt2
   regress0/strings/re-in-rewrite.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1827,6 +1827,7 @@ set(regress_0_tests
   regress0/strings/quad-028-2-2-unsat.smt2
   regress0/strings/quad-138-4-2-unsat.smt2
   regress0/strings/re-consume-bi-dir.smt2
+  regress0/strings/re-consume-inter.smt2
   regress0/strings/re-consume-sym.smt2
   regress0/strings/re-consume-sym-sigma.smt2
   regress0/strings/re-include-union.smt2

--- a/test/regress/cli/regress0/strings/re-consume-bi-dir.smt2
+++ b/test/regress/cli/regress0/strings/re-consume-bi-dir.smt2
@@ -1,17 +1,8 @@
-
+; EXPECT: unsat
+(set-logic ALL)
 (declare-fun k () String)
 (assert (not (str.in_re 
 (str.++ "d.1.a" k "3") 
 (re.++ (str.to_re "d.") (re.* (re.range "0" "9")) (str.to_re ".") (re.* re.allchar))
 )))
 (check-sat)
-
-(exit)
-
-
-(alf.requires 
-
-((str.in_re ((str.++ "a") ((str.++ k) ((str.++ "3") "")))) (re.* re.allchar)) 
-((str.in_re ((str.++ "a") ((str.++ k) ""))) (re.* re.allchar)) 
-
-(Proof ((= ((str.in_re ((str.++ "d.1.a") ((str.++ k) ((str.++ "3") "")))) ((re.++ (str.to_re "d.")) ((re.++ (re.* ((re.range "0") "9"))) ((re.++ (str.to_re ".")) ((re.++ (re.* re.allchar)) (str.to_re ""))))))) ((str.in_re ((str.++ "a") ((str.++ k) ""))) (re.* re.allchar)))))

--- a/test/regress/cli/regress0/strings/re-consume-bi-dir.smt2
+++ b/test/regress/cli/regress0/strings/re-consume-bi-dir.smt2
@@ -1,0 +1,17 @@
+
+(declare-fun k () String)
+(assert (not (str.in_re 
+(str.++ "d.1.a" k "3") 
+(re.++ (str.to_re "d.") (re.* (re.range "0" "9")) (str.to_re ".") (re.* re.allchar))
+)))
+(check-sat)
+
+(exit)
+
+
+(alf.requires 
+
+((str.in_re ((str.++ "a") ((str.++ k) ((str.++ "3") "")))) (re.* re.allchar)) 
+((str.in_re ((str.++ "a") ((str.++ k) ""))) (re.* re.allchar)) 
+
+(Proof ((= ((str.in_re ((str.++ "d.1.a") ((str.++ k) ((str.++ "3") "")))) ((re.++ (str.to_re "d.")) ((re.++ (re.* ((re.range "0") "9"))) ((re.++ (str.to_re ".")) ((re.++ (re.* re.allchar)) (str.to_re ""))))))) ((str.in_re ((str.++ "a") ((str.++ k) ""))) (re.* re.allchar)))))

--- a/test/regress/cli/regress0/strings/re-consume-inter.smt2
+++ b/test/regress/cli/regress0/strings/re-consume-inter.smt2
@@ -1,0 +1,9 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-fun k () String)
+(assert (str.in_re 
+(str.++ "a.13" k ".b") 
+(re.++ (str.to_re "a.") (re.inter (re.* (re.range "0" "9")) (re.++ (re.* re.allchar) (str.to_re "3"))) (str.to_re ".b"))
+))
+(assert (or (= k "a") (= k "b")))
+(check-sat)

--- a/test/regress/cli/regress0/strings/re-consume-sym-sigma.smt2
+++ b/test/regress/cli/regress0/strings/re-consume-sym-sigma.smt2
@@ -1,0 +1,6 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-fun x () String)
+(declare-fun y () String)
+(assert (not (str.in_re (str.++ "abc" x "." y) (re.++ (str.to_re (str.++ "abc" x)) (re.* re.allchar) (str.to_re ".") (str.to_re y)))))
+(check-sat)

--- a/test/regress/cli/regress0/strings/re-consume-sym.smt2
+++ b/test/regress/cli/regress0/strings/re-consume-sym.smt2
@@ -1,6 +1,6 @@
+; EXPECT: unsat
+(set-logic ALL)
 (declare-fun x () String)
 (declare-fun y () String)
-
-
 (assert (not (str.in_re (str.++ "abc" x "." y) (re.++ (str.to_re (str.++ "abc" x)) re.allchar (str.to_re y)))))
 (check-sat)

--- a/test/regress/cli/regress0/strings/re-consume-sym.smt2
+++ b/test/regress/cli/regress0/strings/re-consume-sym.smt2
@@ -1,0 +1,6 @@
+(declare-fun x () String)
+(declare-fun y () String)
+
+
+(assert (not (str.in_re (str.++ "abc" x "." y) (re.++ (str.to_re (str.++ "abc" x)) re.allchar (str.to_re y)))))
+(check-sat)


### PR DESCRIPTION
This makes the simple regular expression consume utility handle (non-value) concatenations within `str.to_re`.

This change was uncovered when attempting to write a proof checker for this utility, where the proof checker was capable of more powerful rewrites since it did not distinguish value vs. non-value.

This is in preparation for a new theory rewrite `ProofRewriteRule::STR_IN_RE_CONSUME` which will be based on this utility.

This change leads to faster solving on a few industrial problems of interest.

Adds several regressions which excercised corner cases of this reasoning in the proof checker.