### PR TITLE
Add -o rare-db

### DIFF
--- a/src/options/base_options.toml
+++ b/src/options/base_options.toml
@@ -265,6 +265,10 @@ name   = "Base"
   help = "prints the options set during automatic configuration."
   description = "With ``-o options-auto``, cvc5 prints the options set during automatic configuration."
   example-file = "regress0/printer/print_options_auto.smt2"
+[[option.mode.RARE_DB]]
+  name = "rare-db"
+  help = "upon initialization, print the entire set of RARE rewrite rules as they are defined in the proof signature."
+  description = "With ``-o rare-db``, upon initialization, cvc5 prints the entire set of RARE rewrite rules as they are defined in the proof signature."
 
 # Stores then enabled output tags.
 [[option]]

--- a/src/proof/alf/alf_printer.h
+++ b/src/proof/alf/alf_printer.h
@@ -48,13 +48,14 @@ class AlfPrinter : protected EnvObj
    */
   void print(std::ostream& out, std::shared_ptr<ProofNode> pfn);
 
-  /** 
+  /**
    * Print proof rewrite rule name r to output stream out
    * @param out The output stream.
    * @param r The proof rewrite rule. This should be one of the proof rewrite
    * rules that corresponds to a RARE rewrite.
    */
   void printDslRule(std::ostream& out, ProofRewriteRule r);
+
  private:
   /** Return true if it is possible to trust the topmost application in pfn */
   bool isHandled(const ProofNode* pfn) const;

--- a/src/proof/alf/alf_printer.h
+++ b/src/proof/alf/alf_printer.h
@@ -43,9 +43,18 @@ class AlfPrinter : protected EnvObj
 
   /**
    * Print the full proof of assertions => false by pfn.
+   * @param out The output stream.
+   * @param pfn The proof node.
    */
   void print(std::ostream& out, std::shared_ptr<ProofNode> pfn);
 
+  /** 
+   * Print proof rewrite rule name r to output stream out
+   * @param out The output stream.
+   * @param r The proof rewrite rule. This should be one of the proof rewrite
+   * rules that corresponds to a RARE rewrite.
+   */
+  void printDslRule(std::ostream& out, ProofRewriteRule r);
  private:
   /** Return true if it is possible to trust the topmost application in pfn */
   bool isHandled(const ProofNode* pfn) const;
@@ -108,8 +117,6 @@ class AlfPrinter : protected EnvObj
    * Allocate (if necessary) the identifier for step
    */
   size_t allocateProofId(const ProofNode* pn, bool& wasAlloc);
-  /** Print DSL rule name r to output stream out */
-  void printDslRule(std::ostream& out, ProofRewriteRule r);
   /** Print let list to output stream out */
   void printLetList(std::ostream& out, LetBinding& lbind);
   /** Reference to the term processor */

--- a/src/rewriter/rewrite_db.cpp
+++ b/src/rewriter/rewrite_db.cpp
@@ -197,5 +197,10 @@ const std::unordered_set<Node>& RewriteDb::getAllFreeVariables() const
   return d_allFv;
 }
 
+std::map<ProofRewriteRule, RewriteProofRule>& RewriteDb::getAllRules() const
+{
+  return d_rewDbRule;
+}
+
 }  // namespace rewriter
 }  // namespace cvc5::internal

--- a/src/rewriter/rewrite_db.cpp
+++ b/src/rewriter/rewrite_db.cpp
@@ -197,7 +197,7 @@ const std::unordered_set<Node>& RewriteDb::getAllFreeVariables() const
   return d_allFv;
 }
 
-std::map<ProofRewriteRule, RewriteProofRule>& RewriteDb::getAllRules() const
+const std::map<ProofRewriteRule, RewriteProofRule>& RewriteDb::getAllRules() const
 {
   return d_rewDbRule;
 }

--- a/src/rewriter/rewrite_db.cpp
+++ b/src/rewriter/rewrite_db.cpp
@@ -197,7 +197,8 @@ const std::unordered_set<Node>& RewriteDb::getAllFreeVariables() const
   return d_allFv;
 }
 
-const std::map<ProofRewriteRule, RewriteProofRule>& RewriteDb::getAllRules() const
+const std::map<ProofRewriteRule, RewriteProofRule>& RewriteDb::getAllRules()
+    const
 {
   return d_rewDbRule;
 }

--- a/src/rewriter/rewrite_db.h
+++ b/src/rewriter/rewrite_db.h
@@ -91,6 +91,8 @@ class RewriteDb
   const std::vector<ProofRewriteRule>& getRuleIdsForHead(const Node& h) const;
   /** Return the union of free variables in all rules */
   const std::unordered_set<Node>& getAllFreeVariables() const;
+  /** Return the all rewrite rules */
+  std::map<ProofRewriteRule, RewriteProofRule>& getAllRules() const;
 
  private:
   /** common constants */

--- a/src/rewriter/rewrite_db.h
+++ b/src/rewriter/rewrite_db.h
@@ -91,7 +91,7 @@ class RewriteDb
   const std::vector<ProofRewriteRule>& getRuleIdsForHead(const Node& h) const;
   /** Return the union of free variables in all rules */
   const std::unordered_set<Node>& getAllFreeVariables() const;
-  /** Return the all rewrite rules */
+  /** Return all rewrite rules */
   const std::map<ProofRewriteRule, RewriteProofRule>& getAllRules() const;
 
  private:

--- a/src/rewriter/rewrite_db.h
+++ b/src/rewriter/rewrite_db.h
@@ -93,6 +93,7 @@ class RewriteDb
   const std::unordered_set<Node>& getAllFreeVariables() const;
   /** Return the all rewrite rules */
   const std::map<ProofRewriteRule, RewriteProofRule>& getAllRules() const;
+
  private:
   /** common constants */
   Node d_true;

--- a/src/rewriter/rewrite_db.h
+++ b/src/rewriter/rewrite_db.h
@@ -92,8 +92,7 @@ class RewriteDb
   /** Return the union of free variables in all rules */
   const std::unordered_set<Node>& getAllFreeVariables() const;
   /** Return the all rewrite rules */
-  std::map<ProofRewriteRule, RewriteProofRule>& getAllRules() const;
-
+  const std::map<ProofRewriteRule, RewriteProofRule>& getAllRules() const;
  private:
   /** common constants */
   Node d_true;

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -36,6 +36,7 @@
 #include "smt/proof_post_processor.h"
 #include "smt/smt_solver.h"
 
+using namespace cvc5::internal::rewriter;
 namespace cvc5::internal {
 namespace smt {
 
@@ -50,10 +51,10 @@ PfManager::PfManager(Env& env)
   if (options().proof.proofGranularityMode
       == options::ProofGranularityMode::DSL_REWRITE)
   {
-    d_rewriteDb.reset(new rewriter::RewriteDb);
+    d_rewriteDb.reset(new RewriteDb);
     if (isOutputOn(OutputTag::RARE_DB))
     {
-      if (options().proof.proofFormat != options::ProofFormatMode::ALF)
+      if (options().proof.proofFormatMode != options::ProofFormatMode::ALF)
       {
         Warning() << "Assuming --proof-format=alf when printing the RARE "
                      "database with -o rare-db"
@@ -61,10 +62,10 @@ PfManager::PfManager(Env& env)
       }
       proof::AlfNodeConverter atp(nodeManager());
       proof::AlfPrinter alfp(d_env, atp, d_rewriteDb.get());
-      std::map<ProofRewriteRule, RewriteProofRule>& rules =
+      const std::map<ProofRewriteRule, RewriteProofRule>& rules =
           d_rewriteDb->getAllRules();
       std::stringstream ss;
-      for (const std::pair<const ProofRewriteRule, RewriteProofRule> r : rules)
+      for (const std::pair<const ProofRewriteRule, RewriteProofRule>& r : rules)
       {
         alfp.printDslRule(ss, r.first);
       }

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -51,6 +51,22 @@ PfManager::PfManager(Env& env)
       == options::ProofGranularityMode::DSL_REWRITE)
   {
     d_rewriteDb.reset(new rewriter::RewriteDb);
+    if (isOutputOn(OutputTag::RARE_DB))
+    {
+      if (options().proof.proofFormat!=options::ProofFormatMode::ALF)
+      {
+        Warning() << "Assuming --proof-format=alf when printing the RARE database with -o rare-db" << std::endl;
+      }
+      proof::AlfNodeConverter atp(nodeManager());
+      proof::AlfPrinter alfp(d_env, atp, d_rewriteDb.get());
+      std::map<ProofRewriteRule, RewriteProofRule>& rules = d_rewriteDb->getAllRules();
+      std::stringstream ss;
+      for (const std::pair<const ProofRewriteRule, RewriteProofRule> r : rules)
+      {
+        alfp.printDslRule(ss, r.first);
+      }
+      output(OutputTag::RARE_DB) << ss.str();
+    }
   }
   // enable the proof checker and the proof node manager
   d_pchecker.reset(

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -56,7 +56,7 @@ PfManager::PfManager(Env& env)
     {
       if (options().proof.proofFormatMode != options::ProofFormatMode::ALF)
       {
-        Warning() << "Assuming --proof-format=alf when printing the RARE "
+        Warning() << "WARNING: Assuming --proof-format=alf when printing the RARE "
                      "database with -o rare-db"
                   << std::endl;
       }

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -53,13 +53,16 @@ PfManager::PfManager(Env& env)
     d_rewriteDb.reset(new rewriter::RewriteDb);
     if (isOutputOn(OutputTag::RARE_DB))
     {
-      if (options().proof.proofFormat!=options::ProofFormatMode::ALF)
+      if (options().proof.proofFormat != options::ProofFormatMode::ALF)
       {
-        Warning() << "Assuming --proof-format=alf when printing the RARE database with -o rare-db" << std::endl;
+        Warning() << "Assuming --proof-format=alf when printing the RARE "
+                     "database with -o rare-db"
+                  << std::endl;
       }
       proof::AlfNodeConverter atp(nodeManager());
       proof::AlfPrinter alfp(d_env, atp, d_rewriteDb.get());
-      std::map<ProofRewriteRule, RewriteProofRule>& rules = d_rewriteDb->getAllRules();
+      std::map<ProofRewriteRule, RewriteProofRule>& rules =
+          d_rewriteDb->getAllRules();
       std::stringstream ss;
       for (const std::pair<const ProofRewriteRule, RewriteProofRule> r : rules)
       {

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -56,9 +56,10 @@ PfManager::PfManager(Env& env)
     {
       if (options().proof.proofFormatMode != options::ProofFormatMode::ALF)
       {
-        Warning() << "WARNING: Assuming --proof-format=alf when printing the RARE "
-                     "database with -o rare-db"
-                  << std::endl;
+        Warning()
+            << "WARNING: Assuming --proof-format=alf when printing the RARE "
+               "database with -o rare-db"
+            << std::endl;
       }
       proof::AlfNodeConverter atp(nodeManager());
       proof::AlfPrinter alfp(d_env, atp, d_rewriteDb.get());

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -194,10 +194,12 @@ void SolverEngine::finishInit()
   }
   if (d_env->isOutputOn(OutputTag::RARE_DB))
   {
-    if (!d_env->getOptions().smt.produceProofs || options().proof.proofGranularityMode
-      != options::ProofGranularityMode::DSL_REWRITE)
+    if (!d_env->getOptions().smt.produceProofs
+        || options().proof.proofGranularityMode
+               != options::ProofGranularityMode::DSL_REWRITE)
     {
-      Warning() << "WARNING: -o rare-db requires --produce-proofs and --proof-granularity=dsl-rewrite";
+      Warning() << "WARNING: -o rare-db requires --produce-proofs and "
+                   "--proof-granularity=dsl-rewrite";
     }
   }
   // enable proof support in the environment/rewriter

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -192,6 +192,14 @@ void SolverEngine::finishInit()
         *d_env.get(), *d_smtSolver.get(), *d_pfManager.get()));
     pnm = d_pfManager->getProofNodeManager();
   }
+  if (d_env->isOutputOn(OutputTag::RARE_DB))
+  {
+    if (!d_env->getOptions().smt.produceProofs || options().proof.proofGranularityMode
+      != options::ProofGranularityMode::DSL_REWRITE)
+    {
+      Warning() << "WARNING: -o rare-db requires --produce-proofs and --proof-granularity=dsl-rewrite";
+    }
+  }
   // enable proof support in the environment/rewriter
   d_env->finishInit(pnm);
 

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -199,7 +199,7 @@ void SolverEngine::finishInit()
                != options::ProofGranularityMode::DSL_REWRITE)
     {
       Warning() << "WARNING: -o rare-db requires --produce-proofs and "
-                   "--proof-granularity=dsl-rewrite";
+                   "--proof-granularity=dsl-rewrite" << std::endl;
     }
   }
   // enable proof support in the environment/rewriter


### PR DESCRIPTION
This outputs the entire database of RARE rewrites.

This can be used to statically establish the ALF signature for RARE, instead of generating it on demand.