### PR TITLE
Add support for more arithmetic rewrites in RARE

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -13,10 +13,10 @@
  * Proof rule enumeration.
  */
 
-#if (!defined(CVC5_API_USE_C_ENUMS)                 \
-     && !defined(CVC5__API__CVC5_CPP_PROOF_RULE_H)) \
-    || (defined(CVC5_API_USE_C_ENUMS)               \
-        && !defined(CVC5__API__CVC5_C_PROOF_RULE_H))
+#if (!defined(CVC5_API_USE_C_ENUMS) &&                                         \
+     !defined(CVC5__API__CVC5_CPP_PROOF_RULE_H)) ||                            \
+    (defined(CVC5_API_USE_C_ENUMS) &&                                          \
+     !defined(CVC5__API__CVC5_C_PROOF_RULE_H))
 
 #include <cstdint>
 
@@ -2289,8 +2289,7 @@ enum ENUM(ProofRule) : uint32_t
  * proof rule.
  * \endverbatim
  */
-enum ENUM(ProofRewriteRule) : uint32_t
-{
+enum ENUM(ProofRewriteRule) : uint32_t {
   EVALUE(NONE),
   // Custom theory rewrites.
   /**
@@ -2542,8 +2541,8 @@ enum ENUM(ProofRewriteRule) : uint32_t
   EVALUE(ARITH_LEQ_NORM),
   /** Auto-generated from RARE rule arith-geq-tighten */
   EVALUE(ARITH_GEQ_TIGHTEN),
-  /** Auto-generated from RARE rule arith-geq-norm */
-  EVALUE(ARITH_GEQ_NORM),
+  /** Auto-generated from RARE rule arith-geq-norm1 */
+  EVALUE(ARITH_GEQ_NORM1),
   /** Auto-generated from RARE rule arith-geq-norm2 */
   EVALUE(ARITH_GEQ_NORM2),
   /** Auto-generated from RARE rule arith-refl-leq */
@@ -3195,7 +3194,7 @@ typedef enum ENUM(ProofRewriteRule) ENUM(ProofRewriteRule);
  * @param rule The proof rule.
  * @return The string representation.
  */
-const char* cvc5_proof_rule_to_string(Cvc5ProofRule rule);
+const char *cvc5_proof_rule_to_string(Cvc5ProofRule rule);
 
 /**
  * Hash function for Cvc5ProofRule.
@@ -3209,7 +3208,7 @@ size_t cvc5_proof_rule_hash(Cvc5ProofRule rule);
  * @param rule The proof rewrite rule.
  * @return The string representation.
  */
-const char* cvc5_proof_rewrite_rule_to_string(Cvc5ProofRewriteRule rule);
+const char *cvc5_proof_rewrite_rule_to_string(Cvc5ProofRewriteRule rule);
 
 /**
  * Hash function for Cvc5ProofRewriteRule.
@@ -3229,7 +3228,7 @@ size_t cvc5_proof_rewrite_rule_hash(Cvc5ProofRewriteRule rule);
  * @param rule The proof rule
  * @return The name of the proof rule
  */
-const char* toString(ProofRule rule);
+const char *toString(ProofRule rule);
 
 /**
  * Writes a proof rule name to a stream.
@@ -3238,7 +3237,7 @@ const char* toString(ProofRule rule);
  * @param rule The proof rule to write to the stream
  * @return The stream
  */
-CVC5_EXPORT std::ostream& operator<<(std::ostream& out, ProofRule rule);
+CVC5_EXPORT std::ostream &operator<<(std::ostream &out, ProofRule rule);
 
 /**
  * Converts a proof rewrite rule to a string. Note: This function is also
@@ -3249,7 +3248,7 @@ CVC5_EXPORT std::ostream& operator<<(std::ostream& out, ProofRule rule);
  * @param rule The proof rewrite rule
  * @return The name of the proof rewrite rule
  */
-const char* toString(ProofRewriteRule rule);
+const char *toString(ProofRewriteRule rule);
 
 /**
  * Writes a proof rewrite rule name to a stream.
@@ -3258,18 +3257,16 @@ const char* toString(ProofRewriteRule rule);
  * @param rule The proof rewrite rule to write to the stream
  * @return The stream
  */
-CVC5_EXPORT std::ostream& operator<<(std::ostream& out, ProofRewriteRule rule);
+CVC5_EXPORT std::ostream &operator<<(std::ostream &out, ProofRewriteRule rule);
 
-}  // namespace cvc5
+} // namespace cvc5
 
 namespace std {
 
 /**
  * Hash function for ProofRules.
  */
-template <>
-struct CVC5_EXPORT hash<cvc5::ProofRule>
-{
+template <> struct CVC5_EXPORT hash<cvc5::ProofRule> {
   /**
    * Hashes a ProofRule to a size_t.
    * @param rule The proof rule.
@@ -3289,9 +3286,7 @@ std::string to_string(cvc5::ProofRule rule);
 /**
  * Hash function for ProofRewriteRules.
  */
-template <>
-struct CVC5_EXPORT hash<cvc5::ProofRewriteRule>
-{
+template <> struct CVC5_EXPORT hash<cvc5::ProofRewriteRule> {
   /**
    * Hashes a ProofRewriteRule to a size_t.
    * @param rule The proof rewrite rule.
@@ -3308,7 +3303,7 @@ struct CVC5_EXPORT hash<cvc5::ProofRewriteRule>
  */
 std::string to_string(cvc5::ProofRewriteRule rule);
 
-}  // namespace std
+} // namespace std
 
 #endif
 #endif

--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -13,10 +13,10 @@
  * Proof rule enumeration.
  */
 
-#if (!defined(CVC5_API_USE_C_ENUMS) &&                                         \
-     !defined(CVC5__API__CVC5_CPP_PROOF_RULE_H)) ||                            \
-    (defined(CVC5_API_USE_C_ENUMS) &&                                          \
-     !defined(CVC5__API__CVC5_C_PROOF_RULE_H))
+#if (!defined(CVC5_API_USE_C_ENUMS)                 \
+     && !defined(CVC5__API__CVC5_CPP_PROOF_RULE_H)) \
+    || (defined(CVC5_API_USE_C_ENUMS)               \
+        && !defined(CVC5__API__CVC5_C_PROOF_RULE_H))
 
 #include <cstdint>
 
@@ -2289,7 +2289,8 @@ enum ENUM(ProofRule) : uint32_t
  * proof rule.
  * \endverbatim
  */
-enum ENUM(ProofRewriteRule) : uint32_t {
+enum ENUM(ProofRewriteRule) : uint32_t
+{
   EVALUE(NONE),
   // Custom theory rewrites.
   /**
@@ -3194,7 +3195,7 @@ typedef enum ENUM(ProofRewriteRule) ENUM(ProofRewriteRule);
  * @param rule The proof rule.
  * @return The string representation.
  */
-const char *cvc5_proof_rule_to_string(Cvc5ProofRule rule);
+const char* cvc5_proof_rule_to_string(Cvc5ProofRule rule);
 
 /**
  * Hash function for Cvc5ProofRule.
@@ -3208,7 +3209,7 @@ size_t cvc5_proof_rule_hash(Cvc5ProofRule rule);
  * @param rule The proof rewrite rule.
  * @return The string representation.
  */
-const char *cvc5_proof_rewrite_rule_to_string(Cvc5ProofRewriteRule rule);
+const char* cvc5_proof_rewrite_rule_to_string(Cvc5ProofRewriteRule rule);
 
 /**
  * Hash function for Cvc5ProofRewriteRule.
@@ -3228,7 +3229,7 @@ size_t cvc5_proof_rewrite_rule_hash(Cvc5ProofRewriteRule rule);
  * @param rule The proof rule
  * @return The name of the proof rule
  */
-const char *toString(ProofRule rule);
+const char* toString(ProofRule rule);
 
 /**
  * Writes a proof rule name to a stream.
@@ -3237,7 +3238,7 @@ const char *toString(ProofRule rule);
  * @param rule The proof rule to write to the stream
  * @return The stream
  */
-CVC5_EXPORT std::ostream &operator<<(std::ostream &out, ProofRule rule);
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, ProofRule rule);
 
 /**
  * Converts a proof rewrite rule to a string. Note: This function is also
@@ -3248,7 +3249,7 @@ CVC5_EXPORT std::ostream &operator<<(std::ostream &out, ProofRule rule);
  * @param rule The proof rewrite rule
  * @return The name of the proof rewrite rule
  */
-const char *toString(ProofRewriteRule rule);
+const char* toString(ProofRewriteRule rule);
 
 /**
  * Writes a proof rewrite rule name to a stream.
@@ -3257,16 +3258,18 @@ const char *toString(ProofRewriteRule rule);
  * @param rule The proof rewrite rule to write to the stream
  * @return The stream
  */
-CVC5_EXPORT std::ostream &operator<<(std::ostream &out, ProofRewriteRule rule);
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, ProofRewriteRule rule);
 
-} // namespace cvc5
+}  // namespace cvc5
 
 namespace std {
 
 /**
  * Hash function for ProofRules.
  */
-template <> struct CVC5_EXPORT hash<cvc5::ProofRule> {
+template <>
+struct CVC5_EXPORT hash<cvc5::ProofRule>
+{
   /**
    * Hashes a ProofRule to a size_t.
    * @param rule The proof rule.
@@ -3286,7 +3289,9 @@ std::string to_string(cvc5::ProofRule rule);
 /**
  * Hash function for ProofRewriteRules.
  */
-template <> struct CVC5_EXPORT hash<cvc5::ProofRewriteRule> {
+template <>
+struct CVC5_EXPORT hash<cvc5::ProofRewriteRule>
+{
   /**
    * Hashes a ProofRewriteRule to a size_t.
    * @param rule The proof rewrite rule.
@@ -3303,7 +3308,7 @@ template <> struct CVC5_EXPORT hash<cvc5::ProofRewriteRule> {
  */
 std::string to_string(cvc5::ProofRewriteRule rule);
 
-} // namespace std
+}  // namespace std
 
 #endif
 #endif

--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -13,10 +13,10 @@
  * Proof rule enumeration.
  */
 
-#if (!defined(CVC5_API_USE_C_ENUMS)                 \
-     && !defined(CVC5__API__CVC5_CPP_PROOF_RULE_H)) \
-    || (defined(CVC5_API_USE_C_ENUMS)               \
-        && !defined(CVC5__API__CVC5_C_PROOF_RULE_H))
+#if (!defined(CVC5_API_USE_C_ENUMS) &&                                         \
+     !defined(CVC5__API__CVC5_CPP_PROOF_RULE_H)) ||                            \
+    (defined(CVC5_API_USE_C_ENUMS) &&                                          \
+     !defined(CVC5__API__CVC5_C_PROOF_RULE_H))
 
 #include <cstdint>
 
@@ -2289,8 +2289,7 @@ enum ENUM(ProofRule) : uint32_t
  * proof rule.
  * \endverbatim
  */
-enum ENUM(ProofRewriteRule) : uint32_t
-{
+enum ENUM(ProofRewriteRule) : uint32_t {
   EVALUE(NONE),
   // Custom theory rewrites.
   /**
@@ -2440,7 +2439,8 @@ enum ENUM(ProofRewriteRule) : uint32_t
    * **Sets - empty tester evaluation**
    *
    * .. math::
-   *   \mathit{sets.is\_empty}(as \ \mathit{set.empty} \ (\mathit{Set} \ T)) = \top
+   *   \mathit{sets.is\_empty}(as \ \mathit{set.empty} \ (\mathit{Set} \ T)) =
+   * \top
    *
    * or alternatively:
    *
@@ -2460,8 +2460,20 @@ enum ENUM(ProofRewriteRule) : uint32_t
   EVALUE(ARITH_MUL_ONE),
   /** Auto-generated from RARE rule arith-mul-zero */
   EVALUE(ARITH_MUL_ZERO),
-  /** Auto-generated from RARE rule arith-int-div-one */
-  EVALUE(ARITH_INT_DIV_ONE),
+  /** Auto-generated from RARE rule arith-div-total */
+  EVALUE(ARITH_DIV_TOTAL),
+  /** Auto-generated from RARE rule arith-int-div-total */
+  EVALUE(ARITH_INT_DIV_TOTAL),
+  /** Auto-generated from RARE rule arith-int-div-total-one */
+  EVALUE(ARITH_INT_DIV_TOTAL_ONE),
+  /** Auto-generated from RARE rule arith-int-div-total-zero */
+  EVALUE(ARITH_INT_DIV_TOTAL_ZERO),
+  /** Auto-generated from RARE rule arith-int-mod-total */
+  EVALUE(ARITH_INT_MOD_TOTAL),
+  /** Auto-generated from RARE rule arith-int-mod-total-one */
+  EVALUE(ARITH_INT_MOD_TOTAL_ONE),
+  /** Auto-generated from RARE rule arith-int-mod-total-zero */
+  EVALUE(ARITH_INT_MOD_TOTAL_ZERO),
   /** Auto-generated from RARE rule arith-neg-neg-one */
   EVALUE(ARITH_NEG_NEG_ONE),
   /** Auto-generated from RARE rule arith-elim-uminus */
@@ -2480,6 +2492,8 @@ enum ENUM(ProofRewriteRule) : uint32_t
   EVALUE(ARITH_GEQ_TIGHTEN),
   /** Auto-generated from RARE rule arith-geq-norm */
   EVALUE(ARITH_GEQ_NORM),
+  /** Auto-generated from RARE rule arith-geq-norm2 */
+  EVALUE(ARITH_GEQ_NORM2),
   /** Auto-generated from RARE rule arith-refl-leq */
   EVALUE(ARITH_REFL_LEQ),
   /** Auto-generated from RARE rule arith-refl-lt */
@@ -2488,6 +2502,10 @@ enum ENUM(ProofRewriteRule) : uint32_t
   EVALUE(ARITH_REFL_GEQ),
   /** Auto-generated from RARE rule arith-refl-gt */
   EVALUE(ARITH_REFL_GT),
+  /** Auto-generated from RARE rule arith-real-eq-elim */
+  EVALUE(ARITH_REAL_EQ_ELIM),
+  /** Auto-generated from RARE rule arith-int-eq-elim */
+  EVALUE(ARITH_INT_EQ_ELIM),
   /** Auto-generated from RARE rule arith-plus-flatten */
   EVALUE(ARITH_PLUS_FLATTEN),
   /** Auto-generated from RARE rule arith-mult-flatten */
@@ -2498,6 +2516,16 @@ enum ENUM(ProofRewriteRule) : uint32_t
   EVALUE(ARITH_PLUS_CANCEL1),
   /** Auto-generated from RARE rule arith-plus-cancel2 */
   EVALUE(ARITH_PLUS_CANCEL2),
+  /** Auto-generated from RARE rule arith-abs-elim */
+  EVALUE(ARITH_ABS_ELIM),
+  /** Auto-generated from RARE rule arith-to-real-elim */
+  EVALUE(ARITH_TO_REAL_ELIM),
+  /** Auto-generated from RARE rule arith-to-int-elim-to-real */
+  EVALUE(ARITH_TO_INT_ELIM_TO_REAL),
+  /** Auto-generated from RARE rule arith-div-elim-to-real1 */
+  EVALUE(ARITH_DIV_ELIM_TO_REAL1),
+  /** Auto-generated from RARE rule arith-div-elim-to-real2 */
+  EVALUE(ARITH_DIV_ELIM_TO_REAL2),
   /** Auto-generated from RARE rule array-read-over-write */
   EVALUE(ARRAY_READ_OVER_WRITE),
   /** Auto-generated from RARE rule array-read-over-write2 */
@@ -3099,7 +3127,7 @@ typedef enum ENUM(ProofRewriteRule) ENUM(ProofRewriteRule);
  * @param rule The proof rule.
  * @return The string representation.
  */
-const char* cvc5_proof_rule_to_string(Cvc5ProofRule rule);
+const char *cvc5_proof_rule_to_string(Cvc5ProofRule rule);
 
 /**
  * Hash function for Cvc5ProofRule.
@@ -3113,7 +3141,7 @@ size_t cvc5_proof_rule_hash(Cvc5ProofRule rule);
  * @param rule The proof rewrite rule.
  * @return The string representation.
  */
-const char* cvc5_proof_rewrite_rule_to_string(Cvc5ProofRewriteRule rule);
+const char *cvc5_proof_rewrite_rule_to_string(Cvc5ProofRewriteRule rule);
 
 /**
  * Hash function for Cvc5ProofRewriteRule.
@@ -3133,7 +3161,7 @@ size_t cvc5_proof_rewrite_rule_hash(Cvc5ProofRewriteRule rule);
  * @param rule The proof rule
  * @return The name of the proof rule
  */
-const char* toString(ProofRule rule);
+const char *toString(ProofRule rule);
 
 /**
  * Writes a proof rule name to a stream.
@@ -3142,7 +3170,7 @@ const char* toString(ProofRule rule);
  * @param rule The proof rule to write to the stream
  * @return The stream
  */
-CVC5_EXPORT std::ostream& operator<<(std::ostream& out, ProofRule rule);
+CVC5_EXPORT std::ostream &operator<<(std::ostream &out, ProofRule rule);
 
 /**
  * Converts a proof rewrite rule to a string. Note: This function is also
@@ -3153,7 +3181,7 @@ CVC5_EXPORT std::ostream& operator<<(std::ostream& out, ProofRule rule);
  * @param rule The proof rewrite rule
  * @return The name of the proof rewrite rule
  */
-const char* toString(ProofRewriteRule rule);
+const char *toString(ProofRewriteRule rule);
 
 /**
  * Writes a proof rewrite rule name to a stream.
@@ -3162,18 +3190,16 @@ const char* toString(ProofRewriteRule rule);
  * @param rule The proof rewrite rule to write to the stream
  * @return The stream
  */
-CVC5_EXPORT std::ostream& operator<<(std::ostream& out, ProofRewriteRule rule);
+CVC5_EXPORT std::ostream &operator<<(std::ostream &out, ProofRewriteRule rule);
 
-}  // namespace cvc5
+} // namespace cvc5
 
 namespace std {
 
 /**
  * Hash function for ProofRules.
  */
-template <>
-struct CVC5_EXPORT hash<cvc5::ProofRule>
-{
+template <> struct CVC5_EXPORT hash<cvc5::ProofRule> {
   /**
    * Hashes a ProofRule to a size_t.
    * @param rule The proof rule.
@@ -3193,9 +3219,7 @@ std::string to_string(cvc5::ProofRule rule);
 /**
  * Hash function for ProofRewriteRules.
  */
-template <>
-struct CVC5_EXPORT hash<cvc5::ProofRewriteRule>
-{
+template <> struct CVC5_EXPORT hash<cvc5::ProofRewriteRule> {
   /**
    * Hashes a ProofRewriteRule to a size_t.
    * @param rule The proof rewrite rule.
@@ -3212,7 +3236,7 @@ struct CVC5_EXPORT hash<cvc5::ProofRewriteRule>
  */
 std::string to_string(cvc5::ProofRewriteRule rule);
 
-}  // namespace std
+} // namespace std
 
 #endif
 #endif

--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -13,10 +13,10 @@
  * Proof rule enumeration.
  */
 
-#if (!defined(CVC5_API_USE_C_ENUMS) &&                                         \
-     !defined(CVC5__API__CVC5_CPP_PROOF_RULE_H)) ||                            \
-    (defined(CVC5_API_USE_C_ENUMS) &&                                          \
-     !defined(CVC5__API__CVC5_C_PROOF_RULE_H))
+#if (!defined(CVC5_API_USE_C_ENUMS)                 \
+     && !defined(CVC5__API__CVC5_CPP_PROOF_RULE_H)) \
+    || (defined(CVC5_API_USE_C_ENUMS)               \
+        && !defined(CVC5__API__CVC5_C_PROOF_RULE_H))
 
 #include <cstdint>
 
@@ -2289,7 +2289,8 @@ enum ENUM(ProofRule) : uint32_t
  * proof rule.
  * \endverbatim
  */
-enum ENUM(ProofRewriteRule) : uint32_t {
+enum ENUM(ProofRewriteRule) : uint32_t
+{
   EVALUE(NONE),
   // Custom theory rewrites.
   /**
@@ -3127,7 +3128,7 @@ typedef enum ENUM(ProofRewriteRule) ENUM(ProofRewriteRule);
  * @param rule The proof rule.
  * @return The string representation.
  */
-const char *cvc5_proof_rule_to_string(Cvc5ProofRule rule);
+const char* cvc5_proof_rule_to_string(Cvc5ProofRule rule);
 
 /**
  * Hash function for Cvc5ProofRule.
@@ -3141,7 +3142,7 @@ size_t cvc5_proof_rule_hash(Cvc5ProofRule rule);
  * @param rule The proof rewrite rule.
  * @return The string representation.
  */
-const char *cvc5_proof_rewrite_rule_to_string(Cvc5ProofRewriteRule rule);
+const char* cvc5_proof_rewrite_rule_to_string(Cvc5ProofRewriteRule rule);
 
 /**
  * Hash function for Cvc5ProofRewriteRule.
@@ -3161,7 +3162,7 @@ size_t cvc5_proof_rewrite_rule_hash(Cvc5ProofRewriteRule rule);
  * @param rule The proof rule
  * @return The name of the proof rule
  */
-const char *toString(ProofRule rule);
+const char* toString(ProofRule rule);
 
 /**
  * Writes a proof rule name to a stream.
@@ -3170,7 +3171,7 @@ const char *toString(ProofRule rule);
  * @param rule The proof rule to write to the stream
  * @return The stream
  */
-CVC5_EXPORT std::ostream &operator<<(std::ostream &out, ProofRule rule);
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, ProofRule rule);
 
 /**
  * Converts a proof rewrite rule to a string. Note: This function is also
@@ -3181,7 +3182,7 @@ CVC5_EXPORT std::ostream &operator<<(std::ostream &out, ProofRule rule);
  * @param rule The proof rewrite rule
  * @return The name of the proof rewrite rule
  */
-const char *toString(ProofRewriteRule rule);
+const char* toString(ProofRewriteRule rule);
 
 /**
  * Writes a proof rewrite rule name to a stream.
@@ -3190,16 +3191,18 @@ const char *toString(ProofRewriteRule rule);
  * @param rule The proof rewrite rule to write to the stream
  * @return The stream
  */
-CVC5_EXPORT std::ostream &operator<<(std::ostream &out, ProofRewriteRule rule);
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, ProofRewriteRule rule);
 
-} // namespace cvc5
+}  // namespace cvc5
 
 namespace std {
 
 /**
  * Hash function for ProofRules.
  */
-template <> struct CVC5_EXPORT hash<cvc5::ProofRule> {
+template <>
+struct CVC5_EXPORT hash<cvc5::ProofRule>
+{
   /**
    * Hashes a ProofRule to a size_t.
    * @param rule The proof rule.
@@ -3219,7 +3222,9 @@ std::string to_string(cvc5::ProofRule rule);
 /**
  * Hash function for ProofRewriteRules.
  */
-template <> struct CVC5_EXPORT hash<cvc5::ProofRewriteRule> {
+template <>
+struct CVC5_EXPORT hash<cvc5::ProofRewriteRule>
+{
   /**
    * Hashes a ProofRewriteRule to a size_t.
    * @param rule The proof rewrite rule.
@@ -3236,7 +3241,7 @@ template <> struct CVC5_EXPORT hash<cvc5::ProofRewriteRule> {
  */
 std::string to_string(cvc5::ProofRewriteRule rule);
 
-} // namespace std
+}  // namespace std
 
 #endif
 #endif

--- a/src/rewriter/mkrewrites.py
+++ b/src/rewriter/mkrewrites.py
@@ -93,7 +93,7 @@ def gen_mk_node(defns, expr):
     elif isinstance(expr, App):
         args = ",".join(gen_mk_node(defns, child) for child in expr.children)
         if expr.op in {Op.EXTRACT, Op.REPEAT, Op.ZERO_EXTEND,  Op.SIGN_EXTEND,
-                       Op.ROTATE_LEFT, Op.ROTATE_RIGHT, Op.INT_TO_BV}:
+                       Op.ROTATE_LEFT, Op.ROTATE_RIGHT, Op.INT_TO_BV, Op.REGEXP_LOOP}:
           args = f'nm->mkConst(GenericOp(Kind::{gen_kind(expr.op)})),' + args
           return f'nm->mkNode(Kind::APPLY_INDEXED_SYMBOLIC, {{ {args} }})'
         return f'nm->mkNode(Kind::{gen_kind(expr.op)}, {{ {args} }})'

--- a/src/rewriter/node.py
+++ b/src/rewriter/node.py
@@ -116,14 +116,19 @@ class Op(Enum):
     SUB = ('-', 'SUB')
     MULT = ('*', 'MULT')
     INT_DIV = ('div', 'INTS_DIVISION')
+    INT_DIV_TOTAL = ('div_total', 'INTS_DIVISION_TOTAL')
     DIV = ('/', 'DIVISION')
+    DIV_TOTAL = ('/_total', 'DIVISION_TOTAL')
     MOD = ('mod', 'INTS_MODULUS')
+    MOD_TOTAL = ('mod_total', 'INTS_MODULUS_TOTAL')
     ABS = ('abs', 'ABS')
     LT = ('<', 'LT')
     GT = ('>', 'GT')
     LEQ = ('<=', 'LEQ')
     GEQ = ('>=', 'GEQ')
     POW2 = ('int.pow2', 'POW2')
+    TO_INT = ('to_int', 'TO_INTEGER')
+    TO_REAL = ('to_real', 'TO_REAL')
 
     INT_ISPOW2 = ('int.ispow2', 'INTS_ISPOW2')  # Backdoor for some bv rewrites
     INT_LENGTH = ('int.log2', 'INTS_LOG2')  # Backdoor for some bv rewrites
@@ -170,8 +175,8 @@ class Op(Enum):
     STRING_STOI = ('str.to_int', 'STRING_STOI')
     STRING_TO_CODE = ('str.to_code', 'STRING_TO_CODE')
     STRING_FROM_CODE = ('str.from_code', 'STRING_FROM_CODE')
-    STRING_TOLOWER = ('str.tolower', 'STRING_TOLOWER')
-    STRING_TOUPPER = ('str.toupper', 'STRING_TOUPPER')
+    STRING_TO_LOWER = ('str.to_lower', 'STRING_TO_LOWER')
+    STRING_TO_UPPER = ('str.to_upper', 'STRING_TO_UPPER')
     STRING_REV = ('str.rev', 'STRING_REV')
 
     SEQ_UNIT = ('seq.unit', 'SEQ_UNIT')
@@ -187,6 +192,7 @@ class Op(Enum):
     REGEXP_OPT = ('re.opt', 'REGEXP_OPT')
     REGEXP_RANGE = ('re.range', 'REGEXP_RANGE')
     REGEXP_COMPLEMENT = ('re.comp', 'REGEXP_COMPLEMENT')
+    REGEXP_LOOP = ('re.loop', 'REGEXP_LOOP')
 
     REGEXP_NONE = (None, 'REGEXP_NONE')  # Handled as constants
     REGEXP_ALL = (None, 'REGEXP_ALL')

--- a/src/rewriter/rw_parser.py
+++ b/src/rewriter/rw_parser.py
@@ -75,7 +75,7 @@ class Parser:
         return int(s[2:])
 
     def symbol(self):
-        special_chars = '=' + '_' + '+' + '-' + '<' + '>' + '*' + '.' + '@'
+        special_chars = '=' + '_' + '+' + '-' + '<' + '>' + '*' + '.' + '@' + '/'
         return pp.Word(pp.alphas + special_chars, pp.alphanums + special_chars)
 
     def app_action(self, s, l, t):

--- a/src/theory/arith/rewrites
+++ b/src/theory/arith/rewrites
@@ -15,7 +15,6 @@
 (define-rule arith-int-div-total-one ((t Int)) (div_total t 1) t)
 (define-rule arith-int-div-total-zero ((t Int)) (div_total t 0) 0)
 
-;(define-rule arith-int-mod-one ((t Int)) (mod t 1) 0)
 (define-cond-rule arith-int-mod-total ((t Int) (s Int)) (not (= s 0)) (mod t s) (mod_total t s))
 (define-rule arith-int-mod-total-one ((t Int)) (mod_total t 1) 0)
 (define-rule arith-int-mod-total-zero ((t Int)) (mod_total t 0) 0)

--- a/src/theory/arith/rewrites
+++ b/src/theory/arith/rewrites
@@ -32,7 +32,7 @@
 
 (define-rule arith-geq-tighten ((t Int) (s Int)) (not (>= t s)) (>= s (+ t 1)))
 
-(define-rule arith-geq-norm ((t ?) (s ?)) (>= t s) (>= (- t s) 0))
+(define-rule arith-geq-norm1 ((t ?) (s ?)) (>= t s) (>= (- t s) 0))
 
 (define-rule arith-geq-norm2 ((t ?) (s ?)) (>= t s) (<= (- t) (- s)))
 

--- a/src/theory/arith/rewrites
+++ b/src/theory/arith/rewrites
@@ -9,9 +9,16 @@
 (define-rule arith-mul-one ((t ? :list) (s ? :list)) (* t 1 s) (* t s))
 (define-rule arith-mul-zero ((t ? :list) (s ? :list)) (* t 0 s) 0)
 
-;(define-rule arith-div-one ((t ?)) (/ t 1) t)
+(define-cond-rule arith-div-total ((t ?) (s ?)) (not (= s 0)) (/ t s) (/_total t s))
 
-(define-rule arith-int-div-one ((t Int)) (div t 1) t)
+(define-cond-rule arith-int-div-total ((t Int) (s Int)) (not (= s 0)) (div t s) (div_total t s))
+(define-rule arith-int-div-total-one ((t Int)) (div_total t 1) t)
+(define-rule arith-int-div-total-zero ((t Int)) (div_total t 0) 0)
+
+;(define-rule arith-int-mod-one ((t Int)) (mod t 1) 0)
+(define-cond-rule arith-int-mod-total ((t Int) (s Int)) (not (= s 0)) (mod t s) (mod_total t s))
+(define-rule arith-int-mod-total-one ((t Int)) (mod_total t 1) 0)
+(define-rule arith-int-mod-total-zero ((t Int)) (mod_total t 0) 0)
 
 (define-rule arith-neg-neg-one ((t ?)) (* (- 1) (* (- 1) t)) t)
 
@@ -28,10 +35,15 @@
 
 (define-rule arith-geq-norm ((t ?) (s ?)) (>= t s) (>= (- t s) 0))
 
+(define-rule arith-geq-norm2 ((t ?) (s ?)) (>= t s) (<= (- t) (- s)))
+
 (define-rule arith-refl-leq ((t ?)) (<= t t) true)
 (define-rule arith-refl-lt ((t ?)) (< t t) false)
 (define-rule arith-refl-geq ((t ?)) (>= t t) true)
 (define-rule arith-refl-gt ((t ?)) (> t t) false)
+
+(define-rule arith-real-eq-elim ((t Real) (s Real)) (= t s) (and (>= t s) (<= t s)))
+(define-rule arith-int-eq-elim ((t Int) (s Int)) (= t s) (and (>= t s) (<= t s)))
 
 ;(define-cond-rule arith-geq-contra ((t ?) (s ?)) (not (>= (- t s) 0)) (>= t s) false)
 ;(define-cond-rule arith-eq-contra ((t ?) (s ?)) (not (= (- t s) 0)) (= t s) false)
@@ -51,3 +63,9 @@
 (define-rule* arith-plus-cancel1 ((t ? :list) (x ?) (s ? :list) (r ? :list)) (+ t x s (* (- 1) x) r) (+ t s r))
 (define-rule* arith-plus-cancel2 ((t ? :list) (x ?) (s ? :list) (r ? :list)) (+ t (* (- 1) x) s x r) (+ t s r))
 
+(define-rule arith-abs-elim ((x ?)) (abs x) (ite (< x 0) (- x) x))
+
+(define-rule arith-to-real-elim ((x Real)) (to_real x) x)
+(define-rule arith-to-int-elim-to-real ((x ?)) (to_int (to_real x)) (to_int x))
+(define-rule arith-div-elim-to-real1 ((x ?) (y ?)) (/ (to_real x) y) (/ x y))
+(define-rule arith-div-elim-to-real2 ((x ?) (y ?)) (/ x (to_real y)) (/ x y))


### PR DESCRIPTION
Note this also adds support for RARE for several new arithmetic operators, including 3 that are specific to cvc5 (`/_total`, `mod_total` and `div_total`).

It also corrects the syntax for the cvc5-specific string operators `tolower` and `toupper`, and adds parsing support for `re.loop`.