### PR TITLE
Ensure macro expansion is called in all cases for theory rewrites

### DIFF
--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -22,8 +22,12 @@
 #include "rewriter/rewrite_db_term_process.h"
 #include "rewriter/rewrites.h"
 #include "smt/env.h"
+#include "theory/arith/arith_poly_norm.h"
+#include "theory/arith/arith_proof_utilities.h"
 #include "theory/booleans/theory_bool_rewriter.h"
 #include "theory/bv/theory_bv_rewrite_rules.h"
+#include "theory/rewriter.h"
+#include "theory/strings/arith_entail.h"
 #include "util/rational.h"
 
 using namespace cvc5::internal::kind;
@@ -37,8 +41,12 @@ BasicRewriteRCons::BasicRewriteRCons(Env& env) : EnvObj(env)
                    == options::ProofGranularityMode::DSL_REWRITE_STRICT);
 }
 
-bool BasicRewriteRCons::prove(
-    CDProof* cdp, Node a, Node b, theory::TheoryId tid, MethodId mid)
+bool BasicRewriteRCons::prove(CDProof* cdp,
+                              Node a,
+                              Node b,
+                              theory::TheoryId tid,
+                              MethodId mid,
+                              std::vector<std::shared_ptr<ProofNode>>& subgoals)
 {
   Node eq = a.eqNode(b);
   Trace("trewrite-rcons") << "Reconstruct " << eq << " (from " << tid << ", "
@@ -62,7 +70,7 @@ bool BasicRewriteRCons::prove(
   // try theory rewrite (pre-rare)
   if (!d_isDslStrict)
   {
-    if (tryTheoryRewrite(cdp, eq, theory::TheoryRewriteCtx::PRE_DSL))
+    if (tryTheoryRewrite(cdp, eq, theory::TheoryRewriteCtx::PRE_DSL, subgoals))
     {
       Trace("trewrite-rcons")
           << "Reconstruct (pre) " << eq << " via theory rewrite" << std::endl;
@@ -74,7 +82,12 @@ bool BasicRewriteRCons::prove(
 }
 
 bool BasicRewriteRCons::postProve(
-    CDProof* cdp, Node a, Node b, theory::TheoryId tid, MethodId mid)
+    CDProof* cdp,
+    Node a,
+    Node b,
+    theory::TheoryId tid,
+    MethodId mid,
+    std::vector<std::shared_ptr<ProofNode>>& subgoals)
 {
   Node eq = a.eqNode(b);
   // try theory rewrite (post-rare), which may try both pre and post if
@@ -82,12 +95,14 @@ bool BasicRewriteRCons::postProve(
   bool success = false;
   if (d_isDslStrict)
   {
-    if (tryTheoryRewrite(cdp, eq, theory::TheoryRewriteCtx::PRE_DSL))
+    if (tryTheoryRewrite(cdp, eq, theory::TheoryRewriteCtx::PRE_DSL, subgoals))
     {
       success = true;
     }
   }
-  if (!success && tryTheoryRewrite(cdp, eq, theory::TheoryRewriteCtx::POST_DSL))
+  if (!success
+      && tryTheoryRewrite(
+          cdp, eq, theory::TheoryRewriteCtx::POST_DSL, subgoals))
   {
     success = true;
   }
@@ -106,7 +121,8 @@ bool BasicRewriteRCons::postProve(
 bool BasicRewriteRCons::tryRule(CDProof* cdp,
                                 Node eq,
                                 ProofRule r,
-                                const std::vector<Node>& args)
+                                const std::vector<Node>& args,
+                                bool addStep)
 {
   Trace("trewrite-rcons-debug") << "Try " << r << std::endl;
   ProofChecker* pc = d_env.getProofNodeManager()->getChecker();
@@ -115,7 +131,10 @@ bool BasicRewriteRCons::tryRule(CDProof* cdp,
   Node res = pc->checkDebug(r, {}, args, Node::null(), "trewrite-rcons");
   if (!res.isNull() && res == eq)
   {
-    cdp->addStep(eq, r, {}, args);
+    if (addStep)
+    {
+      cdp->addStep(eq, r, {}, args);
+    }
     return true;
   }
   return false;
@@ -165,17 +184,26 @@ bool BasicRewriteRCons::ensureProofMacroBoolNnfNorm(
   return true;
 }
 
-bool BasicRewriteRCons::tryTheoryRewrite(CDProof* cdp,
-                                         const Node& eq,
-                                         theory::TheoryRewriteCtx ctx)
+bool BasicRewriteRCons::tryTheoryRewrite(
+    CDProof* cdp,
+    const Node& eq,
+    theory::TheoryRewriteCtx ctx,
+    std::vector<std::shared_ptr<ProofNode>>& subgoals)
 {
   Assert(eq.getKind() == Kind::EQUAL);
   ProofRewriteRule prid = d_env.getRewriter()->findRule(eq[0], eq[1], ctx);
   if (prid != ProofRewriteRule::NONE)
   {
-    if (tryRule(
-            cdp, eq, ProofRule::THEORY_REWRITE, {mkRewriteRuleNode(prid), eq}))
+    // Do not add the step in the call to tryStep, instead we add it via
+    // ensureProofForTheoryRewrite.
+    if (tryRule(cdp,
+                eq,
+                ProofRule::THEORY_REWRITE,
+                {mkRewriteRuleNode(prid), eq},
+                false))
     {
+      // Theory rewrites may require macro expansion
+      ensureProofForTheoryRewrite(cdp, prid, eq, subgoals);
       return true;
     }
   }

--- a/src/rewriter/basic_rewrite_rcons.h
+++ b/src/rewriter/basic_rewrite_rcons.h
@@ -45,17 +45,41 @@ class BasicRewriteRCons : protected EnvObj
    * Try to prove (= a b), where a ---> b was a theory rewrite from theory
    * tid with the given method. If this method returns true, then a proof
    * of (= a b) was added to cdp.
+   * @param cdp The proof to add to.
+   * @param a The left hand side of the equality.
+   * @param b The left hand side of the equality.
+   * @param tid The theory that was the source of the rewrite (if any).
+   * @param tid The method that was the source of the rewrite (if any).
+   * @param subgoals The list of proofs introduced when proving eq that
+   * are trusted steps.
+   * @return true if we successfully added a proof of (= a b) to cdp.
    */
-  bool prove(CDProof* cdp, Node a, Node b, theory::TheoryId tid, MethodId mid);
+  bool prove(CDProof* cdp,
+             Node a,
+             Node b,
+             theory::TheoryId tid,
+             MethodId mid,
+             std::vector<std::shared_ptr<ProofNode>>& subgoals);
   /**
    * There are theory rewrites which cannot be expressed in RARE rules. In this
    * case we need to use proof rules which are not written in RARE. It is only
    * used as a last resort method so this is executed only when other rules
    * fail.
+   * @param cdp The proof to add to.
+   * @param a The left hand side of the equality.
+   * @param b The left hand side of the equality.
+   * @param tid The theory that was the source of the rewrite (if any).
+   * @param tid The method that was the source of the rewrite (if any).
+   * @param subgoals The list of proofs introduced when proving eq that
+   * are trusted steps.
+   * @return true if we successfully added a proof of (= a b) to cdp.
    */
-  bool postProve(
-      CDProof* cdp, Node a, Node b, theory::TheoryId tid, MethodId mid);
-
+  bool postProve(CDProof* cdp,
+                 Node a,
+                 Node b,
+                 theory::TheoryId tid,
+                 MethodId mid,
+                 std::vector<std::shared_ptr<ProofNode>>& subgoals);
   /**
    * Ensure we have a proof for theory rewrite id of eq in cdp. This typically
    * adds a single THEORY_REWRITE step to cdp. However, for rules with prefix
@@ -81,11 +105,14 @@ class BasicRewriteRCons : protected EnvObj
   /**
    * Try rule r, return true if eq could be proven by r with arguments args.
    * If this method returns true, a proof of eq was added to cdp.
+   * If addStep is true, we add the proof to cdp. Otherwise, the caller is
+   * responsible for adding the proof.
    */
   bool tryRule(CDProof* cdp,
                Node eq,
                ProofRule r,
-               const std::vector<Node>& args);
+               const std::vector<Node>& args,
+               bool addStep = true);
   /**
    * Elaborate a rewrite eq that was proven by
    * ProofRewriteRule::MACRO_BOOL_NNF_NORM.
@@ -106,7 +133,8 @@ class BasicRewriteRCons : protected EnvObj
    */
   bool tryTheoryRewrite(CDProof* cdp,
                         const Node& eq,
-                        theory::TheoryRewriteCtx ctx);
+                        theory::TheoryRewriteCtx ctx,
+                        std::vector<std::shared_ptr<ProofNode>>& subgoals);
 };
 
 }  // namespace rewriter

--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -95,7 +95,7 @@ bool RewriteDbProofCons::prove(
   Trace("rpc-debug") << "- prove basic" << std::endl;
   // first, try with the basic utility
   bool success = false;
-  if (d_trrc.prove(cdp, eq[0], eq[1], tid, mid))
+  if (d_trrc.prove(cdp, eq[0], eq[1], tid, mid, subgoals))
   {
     Trace("rpc") << "...success (basic)" << std::endl;
     success = true;
@@ -135,7 +135,7 @@ bool RewriteDbProofCons::prove(
   if (!success)
   {
     // now try the "post-prove" method as a last resort
-    if (d_trrc.postProve(cdp, eq[0], eq[1], tid, mid))
+    if (d_trrc.postProve(cdp, eq[0], eq[1], tid, mid, subgoals))
     {
       Trace("rpc") << "...success (post-prove basic)" << std::endl;
       success = true;


### PR DESCRIPTION
The previous PR did not account for all ways a theory rewrite could be used in RARE reconstruction.

This ensures we expand macros for theory rewrites at PRE_DSL / POST_DSL.