### PR TITLE
Disable dsl-proof on two regressions

### DIFF
--- a/test/regress/cli/regress1/quantifiers/qcft-smtlib3dbc51.smt2
+++ b/test/regress/cli/regress1/quantifiers/qcft-smtlib3dbc51.smt2
@@ -1,5 +1,6 @@
 ; COMMAND-LINE: --cbqi-tconstraint --ieval=off
 ; EXPECT: unsat
+; DISABLE-TESTER: dsl-proof
 (set-logic AUFLIRA)
 (set-info :source |http://proval.lri.fr/why-benchmarks |)
 (set-info :smt-lib-version 2.6)

--- a/test/regress/cli/regress1/quantifiers/smtlibe99bbe.smt2
+++ b/test/regress/cli/regress1/quantifiers/smtlibe99bbe.smt2
@@ -1,5 +1,6 @@
 ; COMMAND-LINE: --relevant-triggers
 ; EXPECT: unsat
+; DISABLE-TESTER: dsl-proof
 (set-logic AUFLIRA)
 (set-info :status unsat)
 (declare-sort Unit 0)


### PR DESCRIPTION
Fixes one of the issues in the nightlies.