### PR TITLE
Repair Python wheel before installing it

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -109,6 +109,14 @@ runs:
         echo "$HOME/.venv/bin" >> $GITHUB_PATH
         echo "::endgroup::"
     
+    # Required for the installation of Python bindings
+    - name: Upgrade Python pip
+      shell: ${{ inputs.shell }}
+      run: |
+        echo "::group::Upgrade Python pip"
+        python3 -m pip install --upgrade pip
+        echo "::endgroup::"
+
     - name: Install software for documentation
       if: inputs.with-documentation == 'true'
       shell: ${{ inputs.shell }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,6 +417,10 @@ if(ENABLE_AUTO_DOWNLOAD AND USE_PYTHON_VENV)
   find_package(Python COMPONENTS Interpreter REQUIRED)
 endif()
 
+if(BUILD_BINDINGS_PYTHON)
+  find_package(Pip 23.0 REQUIRED)
+endif()
+
 find_package(GMP 6.3 REQUIRED)
 
 if(ENABLE_ASAN)

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -270,7 +270,8 @@ Dependencies for Language Bindings
 
   - `Cython <https://cython.org/>`_ >= 3.0.0
   - `pytest <https://docs.pytest.org/en/6.2.x/>`_
-  - The source for the `pythonic API <(https://github.com/cvc5/cvc5_pythonic_api)>`.
+  - `repairwheel <https://github.com/jvolkman/repairwheel>`_ >= 0.2.9
+  - The source for the `pythonic API <https://github.com/cvc5/cvc5_pythonic_api>`_
 
 If ``--auto-download`` is given, the Python modules will be installed automatically in
 a virtual environment if they are missing. To install the modules globally and skip

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -267,10 +267,11 @@ Dependencies for Language Bindings
   - `JDK >= 1.8 <https://www.java.com>`_
 
 - Python
-
   - `Cython <https://cython.org/>`_ >= 3.0.0
+  - `pip <https://pip.pypa.io/>`_ >= 23.0
   - `pytest <https://docs.pytest.org/en/6.2.x/>`_
   - `repairwheel <https://github.com/jvolkman/repairwheel>`_ >= 0.2.9
+  - `setuptools <https://setuptools.pypa.io/>`_ >= 66.1.0
   - The source for the `pythonic API <https://github.com/cvc5/cvc5_pythonic_api>`_
 
 If ``--auto-download`` is given, the Python modules will be installed automatically in
@@ -279,6 +280,9 @@ the creation of the virtual environment, configure cvc5 with ``./configure.sh --
 
 If configured with ``--pythonic-path=PATH``, the build system will expect the Pythonic API's source to be at ``PATH``.
 Otherwise, if configured with ``--auto-download``, the build system will download it.
+
+Installing the Python bindings after building from source requires a Python environment with
+pip version 20.3 or higher.
 
 If you're interested in helping to develop, maintain, and test a language
 binding, please contact the cvc5 team via `our issue tracker

--- a/cmake/FindPip.cmake
+++ b/cmake/FindPip.cmake
@@ -1,0 +1,69 @@
+###############################################################################
+# Top contributors (to current version):
+#   Daniel Larraz
+#
+# This file is part of the cvc5 project.
+#
+# Copyright (c) 2009-2024 by the authors listed in the file AUTHORS
+# in the top-level source directory and their institutional affiliations.
+# All rights reserved.  See the file COPYING in the top-level source
+# directory for licensing information.
+# #############################################################################
+#
+# Find Pip
+# Pip_FOUND - found Python pip
+# Pip_VERSION - Python pip version
+##
+
+macro(get_pip_version)
+  execute_process(
+    COMMAND "${Python_EXECUTABLE}" -c "import pip; print(pip.__version__)"
+    RESULT_VARIABLE Pip_VERSION_CHECK_RESULT
+    OUTPUT_VARIABLE Pip_VERSION
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+endmacro()
+
+get_pip_version()
+
+if (Pip_FIND_REQUIRED)
+  set(Pip_FIND_MODE FATAL_ERROR)
+else()
+  set(Pip_FIND_MODE STATUS)
+endif()
+
+if(Pip_VERSION_CHECK_RESULT EQUAL 0)
+  set(Pip_FOUND TRUE)
+  if(DEFINED Pip_FIND_VERSION)
+    if(Pip_VERSION VERSION_LESS ${Pip_FIND_VERSION})
+      if(ENABLE_AUTO_DOWNLOAD)
+        execute_process (
+          COMMAND "${Python_EXECUTABLE}" -m pip install -U pip
+        )
+        get_pip_version()
+      else()
+        message(${Pip_FIND_MODE}
+          "Pip version >= ${Pip_FIND_VERSION} is required, "
+          "but found version ${Pip_VERSION}")
+      endif()
+    endif()
+  endif()
+else()
+  set(Pip_FOUND FALSE)
+  if(ENABLE_AUTO_DOWNLOAD)
+    execute_process (
+      COMMAND "${Python_EXECUTABLE}" -m ensurepip --upgrade
+      RESULT_VARIABLE ENSUREPIP_RESULT
+    )
+    if (ENSUREPIP_RESULT EQUAL 0)
+      set(Pip_FOUND TRUE)
+    else()
+      message(${Pip_FIND_MODE} "Could NOT install pip for Python version "
+        "${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
+    endif()
+  else()
+    message(${Pip_FIND_MODE} "Could NOT find pip for Python version "
+      "${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
+  endif()
+endif()

--- a/cmake/FindRepairwheel.cmake
+++ b/cmake/FindRepairwheel.cmake
@@ -1,0 +1,85 @@
+###############################################################################
+# Top contributors (to current version):
+#   Daniel Larraz
+#
+# This file is part of the cvc5 project.
+#
+# Copyright (c) 2009-2024 by the authors listed in the file AUTHORS
+# in the top-level source directory and their institutional affiliations.
+# All rights reserved.  See the file COPYING in the top-level source
+# directory for licensing information.
+# #############################################################################
+#
+# Find Repairwheel
+# Repairwheel_FOUND - system has the repairwheel executable
+# Repairwheel_EXECUTABLE - path to the repairwheel executable
+# Repairwheel_VERSION - repairwheel version
+##
+
+set(Python_SCRIPTS_Paths "")
+
+macro(add_scripts_path python_bin scheme)
+  execute_process(
+    COMMAND "${python_bin}" -c 
+      "import sysconfig; print(sysconfig.get_paths('${scheme}')['scripts'])"
+    RESULT_VARIABLE Python_SCRIPTS_RESULT
+    OUTPUT_VARIABLE Python_SCRIPTS
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if (NOT Python_SCRIPTS_RESULT AND Python_SCRIPTS)
+    list(APPEND Python_SCRIPTS_Paths ${Python_SCRIPTS})
+  endif()
+endmacro()
+
+# Look for repairwheel executable in Python "Scripts" directories
+add_scripts_path("${Python_EXECUTABLE}" "posix_prefix")
+add_scripts_path("${Python_BASE_EXECUTABLE}" "posix_user")
+add_scripts_path("${Python_BASE_EXECUTABLE}" "posix_prefix")
+if(WIN32)
+  add_scripts_path("${Python_EXECUTABLE}" "nt")
+  add_scripts_path("${Python_BASE_EXECUTABLE}" "nt_user")
+  add_scripts_path("${Python_BASE_EXECUTABLE}" "nt")
+endif()
+
+if (Repairwheel_FIND_REQUIRED)
+  set(Repairwheel_FIND_MODE FATAL_ERROR)
+else()
+  set(Repairwheel_FIND_MODE STATUS)
+endif()
+
+macro(find_repairwheel)
+  find_program(Repairwheel_EXECUTABLE repairwheel ${Python_SCRIPTS_Paths})
+  if(Repairwheel_EXECUTABLE)
+    execute_process(
+      COMMAND "${Repairwheel_EXECUTABLE}" --version
+      RESULT_VARIABLE Repairwheel_VERSION_CHECK_RESULT
+      OUTPUT_VARIABLE Repairwheel_VERSION
+    )
+    # Check we can run repairwheel successfully.
+    # Otherwise, reset path to executable.
+    if(NOT(Repairwheel_VERSION_CHECK_RESULT EQUAL 0))
+      set(Repairwheel_EXECUTABLE "")
+    endif()
+  endif()
+endmacro()
+
+find_repairwheel()
+
+if(NOT Repairwheel_EXECUTABLE AND ENABLE_AUTO_DOWNLOAD)
+  message(STATUS "Installing repairwheel")
+  # Install repairwheel from repo until v0.2.9 is released
+  execute_process(
+    COMMAND ${Python_EXECUTABLE} -m pip install 
+      git+https://github.com/jvolkman/repairwheel.git
+  )
+  find_repairwheel()
+endif()
+
+if(Repairwheel_EXECUTABLE)
+  set(Repairwheel_FOUND TRUE)
+  message(STATUS "Found repairwheel: ${Repairwheel_EXECUTABLE}")
+else()
+  set(Repairwheel_FOUND FALSE)
+  message(${Repairwheel_FIND_MODE} "Could NOT find repairwheel executable")
+endif()

--- a/cmake/FindRepairwheel.cmake
+++ b/cmake/FindRepairwheel.cmake
@@ -68,10 +68,8 @@ find_repairwheel()
 
 if(NOT Repairwheel_EXECUTABLE AND ENABLE_AUTO_DOWNLOAD)
   message(STATUS "Installing repairwheel")
-  # Install repairwheel from repo until v0.2.9 is released
   execute_process(
-    COMMAND ${Python_EXECUTABLE} -m pip install 
-      git+https://github.com/jvolkman/repairwheel.git
+    COMMAND ${Python_EXECUTABLE} -m pip install repairwheel
   )
   find_repairwheel()
 endif()

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -232,7 +232,8 @@ else()
 
   set(REPAIR_WHEEL_CMD
       "${Repairwheel_EXECUTABLE} -o ${CMAKE_BINARY_DIR}/repaired-wheel "
-      "-l ${CMAKE_BINARY_DIR}/src -l ${CMAKE_BINARY_DIR}/src/parser")
+      "-l ${CMAKE_BINARY_DIR}/src -l ${CMAKE_BINARY_DIR}/src/parser "
+      "-l ${DEPS_BASE}/bin")
 
   set(INSTALL_CMD
       "${Python_BASE_EXECUTABLE} -m pip install")

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -17,6 +17,7 @@ if(NOT ONLY_PYTHON_EXT_SRC)
   # Python modules for building and installing
   check_python_module("setuptools")
   find_package(Cython 3.0.0 REQUIRED)
+  find_package(Repairwheel 0.2.9 REQUIRED)
 endif()
 
 configure_file(genenums.py.in genenums.py)
@@ -110,6 +111,7 @@ if (WIN32)
   set(PYTHON_EXT "pyd")
   set(SETUP_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include;${CMAKE_BINARY_DIR}/include")
   set(SETUP_LIBRARY_DIRS "${CMAKE_BINARY_DIR}/src;${CMAKE_BINARY_DIR}/src/parser")
+  set(SETUP_COMPILER "[build]\ncompiler=mingw32")
 else()
   set(PYTHON_EXT "so")
   set(SETUP_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include:${CMAKE_BINARY_DIR}/include")
@@ -224,8 +226,16 @@ else()
       ${LICENSE_FILES}
   )
 
+  set(BUILD_WHEEL_CMD
+      "${Python_EXECUTABLE} -m pip wheel ${CMAKE_CURRENT_BINARY_DIR} "
+      "${BUILD_WHEEL_CMD} --wheel-dir=${CMAKE_BINARY_DIR}/unrepaired-wheel")
+
+  set(REPAIR_WHEEL_CMD
+      "${Repairwheel_EXECUTABLE} -o ${CMAKE_BINARY_DIR}/repaired-wheel "
+      "-l ${CMAKE_BINARY_DIR}/src -l ${CMAKE_BINARY_DIR}/src/parser")
+
   set(INSTALL_CMD
-      "${Python_BASE_EXECUTABLE} -m pip install ${CMAKE_CURRENT_BINARY_DIR}")
+      "${Python_BASE_EXECUTABLE} -m pip install")
 
   # If the user does not set a prefix, install the Python bindings in
   # the default location designated by the Python interpreter used to
@@ -234,9 +244,28 @@ else()
     set(INSTALL_CMD "${INSTALL_CMD} --prefix ${CMAKE_INSTALL_PREFIX}")
   endif()
 
-  message("Python bindings install command: ${INSTALL_CMD}")
+  set(UNREPAIRED_WHEEL_DIR ${CMAKE_BINARY_DIR}/unrepaired-wheel)
+  set(REPAIRED_WHEEL_DIR ${CMAKE_BINARY_DIR}/repaired-wheel)
 
-  install(CODE "execute_process(COMMAND ${INSTALL_CMD})"
+  # Remove previous wheel directories
+  install(CODE "execute_process(COMMAND \${CMAKE_COMMAND} -E remove_directory
+          ${UNREPAIRED_WHEEL_DIR} ${REPAIRED_WHEEL_DIR})"
+          FILE_PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)
+
+  # Build wheel
+  install(CODE "execute_process(COMMAND ${BUILD_WHEEL_CMD})"
+          FILE_PERMISSIONS OWNER_WRITE OWNER_READ)
+
+  # Repair wheel (include required libraries)
+  install(CODE
+          "file(GLOB WHL_FILE ${UNREPAIRED_WHEEL_DIR}/cvc5*.whl)
+           execute_process(COMMAND ${REPAIR_WHEEL_CMD} \${WHL_FILE})"
+          FILE_PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)
+
+  # Install wheel
+  install(CODE
+          "file(GLOB WHL_FILE ${REPAIRED_WHEEL_DIR}/cvc5*.whl)
+          execute_process(COMMAND ${INSTALL_CMD} \${WHL_FILE})"
           FILE_PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)
 
 endif()

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -17,6 +17,10 @@ if(NOT ONLY_PYTHON_EXT_SRC)
   # Python modules for building and installing
   check_python_module("setuptools")
   find_package(Cython 3.0.0 REQUIRED)
+  # Repairwheel copies the required shared libraries to
+  # a directory within the Python wheel package so that
+  # the package is self-contained. It works on Linux,
+  # macOS, and Windows.
   find_package(Repairwheel 0.2.9 REQUIRED)
 endif()
 

--- a/src/api/python/setup.cfg.in
+++ b/src/api/python/setup.cfg.in
@@ -2,3 +2,4 @@
 include_dirs=${SETUP_INCLUDE_DIRS}
 library_dirs=${SETUP_LIBRARY_DIRS}
 ${SETUP_RPATH}
+${SETUP_COMPILER}


### PR DESCRIPTION
It copies the necessary shared libraries to a directory within the Python package so that the libraries will be picked up at runtime.