### PR TITLE
Add implementation of proof rewrite rules for arithmetic string entailment

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -2331,6 +2331,8 @@ enum ENUM(ProofRewriteRule) : uint32_t
    * .. math::
    *   t / c = t * 1/c
    *
+   * where :math:`c` is a constant.
+   *
    * \endverbatim
    */
   EVALUE(ARITH_DIV_BY_CONST_ELIM),

--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -2326,6 +2326,48 @@ enum ENUM(ProofRewriteRule) : uint32_t
   EVALUE(MACRO_BOOL_NNF_NORM),
   /**
    * \verbatim embed:rst:leading-asterisk
+   * **Arith -- Division by constant elimination**
+   *
+   * .. math::
+   *   t / c = t * 1/c
+   *
+   * \endverbatim
+   */
+  EVALUE(ARITH_DIV_BY_CONST_ELIM),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Arithmetic - strings predicate entailment**
+   *
+   * .. math::
+   *   (>= n 0) = true
+   *
+   * Where :math:`n` can be shown to be greater than or equal to :math:`0` by
+   * reasoning about string length being positive and basic properties of
+   * addition and multiplication.
+   *
+   * \endverbatim
+   */
+  EVALUE(ARITH_STRING_PRED_ENTAIL),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Arithmetic - strings predicate entailment**
+   *
+   * .. math::
+   *   (>= n 0) = (>= m 0)
+   *
+   * Where :math:`m` is a safe under-approximation of :math:`n`, namely
+   * we have that :math:`(>= n m)` and :math:`(>= m 0)`.
+   *
+   * In detail, subterms of :math:`n` may be replaced with other terms to
+   * obtain :math:`m` based on the reasoning described in the paper
+   * Reynolds et al, CAV 2019, "High-Level Abstractions for Simplifying
+   * Extended String Constraints in SMT".
+   *
+   * \endverbatim
+   */
+  EVALUE(ARITH_STRING_PRED_SAFE_APPROX),
+  /**
+   * \verbatim embed:rst:leading-asterisk
    * **Equality -- Beta reduction**
    *
    * .. math::

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -222,6 +222,12 @@ const char* toString(cvc5::ProofRewriteRule rule)
     //================================================= ad-hoc rules
     case ProofRewriteRule::DISTINCT_ELIM: return "distinct-elim";
     case ProofRewriteRule::MACRO_BOOL_NNF_NORM: return "macro-bool-nnf-norm";
+    case ProofRewriteRule::ARITH_DIV_BY_CONST_ELIM:
+      return "arith-div-by-const-elim";
+    case ProofRewriteRule::ARITH_STRING_PRED_ENTAIL:
+      return "arith-string-pred-entail";
+    case ProofRewriteRule::ARITH_STRING_PRED_SAFE_APPROX:
+      return "arith-string-pred-safe-approx";
     case ProofRewriteRule::BETA_REDUCE: return "beta-reduce";
     case ProofRewriteRule::ARRAYS_EQ_RANGE_EXPAND:
       return "arrays-eq-range-expand";

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -34,6 +34,8 @@
 #include "theory/arith/rewriter/node_utils.h"
 #include "theory/arith/rewriter/ordering.h"
 #include "theory/arith/rewriter/rewrite_atom.h"
+#include "theory/rewriter.h"
+#include "theory/strings/arith_entail.h"
 #include "theory/theory.h"
 #include "util/bitvector.h"
 #include "util/divisible.h"
@@ -49,6 +51,66 @@ namespace arith {
 ArithRewriter::ArithRewriter(NodeManager* nm, OperatorElim& oe)
     : TheoryRewriter(nm), d_opElim(oe)
 {
+  registerProofRewriteRule(ProofRewriteRule::ARITH_DIV_BY_CONST_ELIM,
+                           TheoryRewriteCtx::PRE_DSL);
+  registerProofRewriteRule(ProofRewriteRule::MACRO_ARITH_STRING_PRED_ENTAIL,
+                           TheoryRewriteCtx::DSL_SUBCALL);
+  // we don't register ARITH_STRING_PRED_ENTAIL or ARITH_STRING_PRED_SAFE_APPROX,
+  // as these are subsumed by MACRO_ARITH_STRING_PRED_ENTAIL.
+}
+
+Node ArithRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
+{
+  switch (id)
+  {
+    case ProofRewriteRule::ARITH_DIV_BY_CONST_ELIM:
+    {
+      if (n.getKind() == Kind::DIVISION && n[1].isConst())
+      {
+        Rational r = n[1].getConst<Rational>();
+        if (r.sgn() != 0)
+        {
+          Rational rinv = Rational(1) / r;
+          NodeManager* nm = nodeManager();
+          return nm->mkNode(Kind::MULT, n[0], nm->mkConstReal(rinv));
+        }
+      }
+    }
+    break;
+    case ProofRewriteRule::ARITH_STRING_PRED_ENTAIL:
+    case ProofRewriteRule::ARITH_STRING_PRED_SAFE_APPROX:
+    {
+      if (n.getKind() != Kind::GEQ || !n[1].isConst()
+          || n[1].getConst<Rational>().sgn() != 0)
+      {
+        return Node::null();
+      }
+      if (id == ProofRewriteRule::ARITH_STRING_PRED_ENTAIL)
+      {
+        if (theory::strings::ArithEntail::checkSimple(n[0]))
+        {
+          return nodeManager()->mkConst(true);
+        }
+      }
+      else if (id == ProofRewriteRule::ARITH_STRING_PRED_SAFE_APPROX)
+      {
+        // Note that we do *not* pass a rewriter here, since the proof rule
+        // cannot depend on the rewriter.
+        theory::strings::ArithEntail ae(nullptr);
+        // must only use simple checks when computing the approximations
+        Node approx = ae.findApprox(n[0], true);
+        if (approx != n[0])
+        {
+          Trace("arith-rewriter-proof")
+              << n[0] << " --> " << approx << " by safe approx" << std::endl;
+          return nodeManager()->mkNode(Kind::GEQ, approx, n[1]);
+        }
+      }
+    }
+    break;
+    default: break;
+  }
+  return Node::null();
 }
 
 RewriteResponse ArithRewriter::preRewrite(TNode t)

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -53,8 +53,6 @@ ArithRewriter::ArithRewriter(NodeManager* nm, OperatorElim& oe)
 {
   registerProofRewriteRule(ProofRewriteRule::ARITH_DIV_BY_CONST_ELIM,
                            TheoryRewriteCtx::PRE_DSL);
-  registerProofRewriteRule(ProofRewriteRule::MACRO_ARITH_STRING_PRED_ENTAIL,
-                           TheoryRewriteCtx::DSL_SUBCALL);
   // we don't register ARITH_STRING_PRED_ENTAIL or ARITH_STRING_PRED_SAFE_APPROX,
   // as these are subsumed by MACRO_ARITH_STRING_PRED_ENTAIL.
 }

--- a/src/theory/arith/arith_rewriter.h
+++ b/src/theory/arith/arith_rewriter.h
@@ -48,6 +48,15 @@ class ArithRewriter : public TheoryRewriter
    */
   Node rewriteIneqToBv(const Node& ineq);
 
+  /**
+   * Rewrite n based on the proof rewrite rule id.
+   * @param id The rewrite rule.
+   * @param n The node to rewrite.
+   * @return The rewritten version of n based on id, or Node::null() if n
+   * cannot be rewritten.
+   */
+  Node rewriteViaRule(ProofRewriteRule id, const Node& n) override;
+
  private:
   /** preRewrite for atoms */
   RewriteResponse preRewriteAtom(TNode t);


### PR DESCRIPTION
This adds one simple theory rewrite (division by constant) and two key rewrites involving arithmetic entailment for strings.

Notice that we must register these rewrites with the arithmetic rewriter, since arithmetic owns `>=`, despite the reasoning being primarily strings. 

The latter 2 rules will be used to elaborate a forthcoming `MACRO_ARITH_STRING_PRED_ENTAIL` theory rewrite, which will be the central tactic for proving arithmetic entailments involving strings.