### PR TITLE
Refactor strings entailment utility in preparation for new proof rewrite rule

### DIFF
--- a/src/theory/strings/sequences_rewriter.cpp
+++ b/src/theory/strings/sequences_rewriter.cpp
@@ -44,7 +44,7 @@ SequencesRewriter::SequencesRewriter(NodeManager* nm,
       d_statistics(statistics),
       d_rr(r),
       d_arithEntail(r),
-      d_stringsEntail(r, d_arithEntail, *this)
+      d_stringsEntail(r, d_arithEntail, this)
 {
   d_sigmaStar = nm->mkNode(Kind::REGEXP_STAR, nm->mkNode(Kind::REGEXP_ALLCHAR));
   d_true = nm->mkConst(true);

--- a/src/theory/strings/strings_entail.h
+++ b/src/theory/strings/strings_entail.h
@@ -315,6 +315,7 @@ class StringsEntail
    * infer that any of the yi must be empty.
    */
   Node inferEqsFromContains(Node x, Node y);
+
  private:
   /** component contains base
    *

--- a/src/theory/strings/strings_entail.h
+++ b/src/theory/strings/strings_entail.h
@@ -22,6 +22,7 @@
 
 #include "expr/node.h"
 #include "theory/strings/arith_entail.h"
+#include "theory/strings/rewrites.h"
 
 namespace cvc5::internal {
 namespace theory {
@@ -40,7 +41,7 @@ class SequencesRewriter;
 class StringsEntail
 {
  public:
-  StringsEntail(Rewriter* r, ArithEntail& aent, SequencesRewriter& rewriter);
+  StringsEntail(Rewriter* r, ArithEntail& aent, SequencesRewriter* rewriter);
 
   /** can constant contain list
    * return true if constant c can contain the list l in order
@@ -314,7 +315,6 @@ class StringsEntail
    * infer that any of the yi must be empty.
    */
   Node inferEqsFromContains(Node x, Node y);
-
  private:
   /** component contains base
    *
@@ -394,7 +394,7 @@ class StringsEntail
    * Reference to the sequences rewriter that owns this `StringsEntail`
    * instance.
    */
-  SequencesRewriter& d_rewriter;
+  SequencesRewriter* d_rewriter;
 };
 
 }  // namespace strings


### PR DESCRIPTION
Analogous to the arithmetic utility, we need a version of this utility which does not use the rewriter as a subroutine.