### PR TITLE
Update string util for regexp concatenation

### DIFF
--- a/src/theory/strings/theory_strings_utils.cpp
+++ b/src/theory/strings/theory_strings_utils.cpp
@@ -129,17 +129,23 @@ void getConcat(Node n, std::vector<Node>& c)
 Node mkConcat(const std::vector<Node>& c, TypeNode tn)
 {
   Assert(tn.isStringLike() || tn.isRegExp());
-  if (c.empty())
-  {
-    Assert(tn.isStringLike());
-    return Word::mkEmptyWord(tn);
-  }
-  else if (c.size() == 1)
+  if (c.size() == 1)
   {
     return c[0];
   }
+  NodeManager* nm = NodeManager::currentNM();
+  if (c.empty())
+  {
+    if (tn.isRegExp())
+    {
+      TypeNode stn = nm->stringType();
+      Node emp = Word::mkEmptyWord(stn);
+      return nm->mkNode(Kind::STRING_TO_REGEXP, emp);
+    }
+    return Word::mkEmptyWord(tn);
+  }
   Kind k = tn.isStringLike() ? Kind::STRING_CONCAT : Kind::REGEXP_CONCAT;
-  return NodeManager::currentNM()->mkNode(k, c);
+  return nm->mkNode(k, c);
 }
 
 Node mkPrefix(Node t, Node n)

--- a/src/theory/strings/theory_strings_utils.h
+++ b/src/theory/strings/theory_strings_utils.h
@@ -49,6 +49,7 @@ void flattenOp(Kind k, Node n, std::vector<Node>& conj);
  * when n = str.++( x, y ), c is { x, y }
  * when n = str.++( x, str.++( y, z ), w ), c is { x, str.++( y, z ), w )
  * when n = x, c is { x }
+ * when n = "", c is { "" }
  *
  * Also applies to regular expressions (re.++ above).
  */


### PR DESCRIPTION
When the proof rewrite rule corresponding to STR_IN_RE_CONSUME is added, it will require update to the `mkConcat` utility to ensure we handle regular expression concatenation as well. 