### PR TITLE
Use SET_CHOOSE operator for bounded set instantiation

### DIFF
--- a/src/theory/quantifiers/fmf/bounded_integers.cpp
+++ b/src/theory/quantifiers/fmf/bounded_integers.cpp
@@ -727,18 +727,8 @@ Node BoundedIntegers::getSetRangeValue( Node q, Node v, RepSetIterator * rsi ) {
   {
     if (i == d_setm_choice[sro].size())
     {
-      choice_i = nm->mkBoundVar(tne);
-      choices.push_back(choice_i);
-      Node cBody = nm->mkNode(Kind::SET_MEMBER, choice_i, sro);
-      if (choices.size() > 1)
-      {
-        cBody =
-            nm->mkNode(Kind::AND, cBody, nm->mkNode(Kind::DISTINCT, choices));
-      }
-      choices.pop_back();
-      Node bvl = nm->mkNode(Kind::BOUND_VAR_LIST, choice_i);
-      choice_i = nm->mkNode(
-          Kind::WITNESS, bvl, nm->mkNode(Kind::OR, sro.eqNode(nsr), cBody));
+      Node stgt = nsr.getKind() == Kind::SET_EMPTY ? sro : nm->mkNode(Kind::SET_MINUS, sro, nsr);
+      choice_i = nm->mkNode(Kind::SET_CHOOSE, stgt);
       d_setm_choice[sro].push_back(choice_i);
     }
     Assert(i < d_setm_choice[sro].size());
@@ -758,8 +748,8 @@ Node BoundedIntegers::getSetRangeValue( Node q, Node v, RepSetIterator * rsi ) {
   //   e.g.
   // singleton(0) union singleton(1)
   //   becomes
-  // C1 union (witness y. S =(set.singleton C1) OR (y in S AND distinct(y, C1)))
-  // where C1 = (witness x. S=empty OR x in S).
+  // C1 union (set.singleton (set.choose (set.minus S C1)))
+  // where C1 = (set.singleton (set.choose S)).
   Trace("bound-int-rsi") << "...reconstructed " << nsr << std::endl;
   return nsr;
 }

--- a/src/theory/quantifiers/fmf/bounded_integers.cpp
+++ b/src/theory/quantifiers/fmf/bounded_integers.cpp
@@ -719,9 +719,6 @@ Node BoundedIntegers::getSetRangeValue( Node q, Node v, RepSetIterator * rsi ) {
   }
   Assert(sr.getKind() == Kind::SET_SINGLETON);
   srCard++;
-  // choices[i] stores the canonical symbolic representation of the (i+1)^th
-  // element of sro
-  std::vector<Node> choices;
   Node choice_i;
   for (unsigned i = 0; i < srCard; i++)
   {
@@ -733,7 +730,6 @@ Node BoundedIntegers::getSetRangeValue( Node q, Node v, RepSetIterator * rsi ) {
     }
     Assert(i < d_setm_choice[sro].size());
     choice_i = d_setm_choice[sro][i];
-    choices.push_back(choice_i);
     Node sChoiceI = nm->mkNode(Kind::SET_SINGLETON, choice_i);
     if (nsr.getKind() == Kind::SET_EMPTY)
     {

--- a/src/theory/quantifiers/fmf/bounded_integers.cpp
+++ b/src/theory/quantifiers/fmf/bounded_integers.cpp
@@ -724,7 +724,9 @@ Node BoundedIntegers::getSetRangeValue( Node q, Node v, RepSetIterator * rsi ) {
   {
     if (i == d_setm_choice[sro].size())
     {
-      Node stgt = nsr.getKind() == Kind::SET_EMPTY ? sro : nm->mkNode(Kind::SET_MINUS, sro, nsr);
+      Node stgt = nsr.getKind() == Kind::SET_EMPTY
+                      ? sro
+                      : nm->mkNode(Kind::SET_MINUS, sro, nsr);
       choice_i = nm->mkNode(Kind::SET_CHOOSE, stgt);
       d_setm_choice[sro].push_back(choice_i);
     }

--- a/src/theory/quantifiers/fmf/bounded_integers.h
+++ b/src/theory/quantifiers/fmf/bounded_integers.h
@@ -250,7 +250,7 @@ private:
    * on the current iterator rsi.
    */
   Node getSetRange( Node q, Node v, RepSetIterator * rsi );
-  /** 
+  /**
    * Get the current value for set variable v of quantified formula q based
    * on the current iterator rsi. Additionally transforms the model value for
    * v based on the set_choose operator for the purposes of instantiating with

--- a/src/theory/quantifiers/fmf/bounded_integers.h
+++ b/src/theory/quantifiers/fmf/bounded_integers.h
@@ -245,8 +245,17 @@ private:
   void getBounds( Node f, Node v, RepSetIterator * rsi, Node & l, Node & u );
   void getBoundValues( Node f, Node v, RepSetIterator * rsi, Node & l, Node & u );
   bool isGroundRange(Node f, Node v);
-  //for set range
+  /**
+   * Get the current value for set variable v of quantified formula q based
+   * on the current iterator rsi.
+   */
   Node getSetRange( Node q, Node v, RepSetIterator * rsi );
+  /** 
+   * Get the current value for set variable v of quantified formula q based
+   * on the current iterator rsi. Additionally transforms the model value for
+   * v based on the set_choose operator for the purposes of instantiating with
+   * symbolic elements of the model of v.
+   */
   Node getSetRangeValue( Node q, Node v, RepSetIterator * rsi );
   Node matchBoundVar( Node v, Node t, Node e );
   


### PR DESCRIPTION
This eliminates the use of `WITNESS` for bounded set instantiation.

Towards further simplification of skolem manager and term formula removal passes.

Eliminates 6 trusted proofs steps in our regressions of id WITNESS_AXIOM.