### PR TITLE
Update syntax for list operators in ALF

### DIFF
--- a/contrib/get-alf-checker
+++ b/contrib/get-alf-checker
@@ -24,7 +24,7 @@ ALFC_DIR="$BASE_DIR/alf-checker"
 mkdir -p $ALFC_DIR
 
 # download and unpack ALFC
-ALF_VERSION="32f19e225a8bd560ead65ad0edb48144ecdbc168"
+ALF_VERSION="6f041dbdcbffe1e79a9c9d65bd6a2757ec51f7b7"
 download "https://github.com/cvc5/alfc/archive/$ALF_VERSION.tar.gz" $BASE_DIR/tmp/alfc.tgz
 tar --strip 1 -xzf $BASE_DIR/tmp/alfc.tgz -C $ALFC_DIR
 

--- a/proofs/alf/cvc5/programs/Nary.smt3
+++ b/proofs/alf/cvc5/programs/Nary.smt3
@@ -31,7 +31,7 @@
     ((L Type) (cons (-> L L L)) (nil L) (c L) (t L) (xs L :list))
     ((-> L L L) L L L) Bool
     (
-        ((nary.is_subset cons nil (cons c xs) t) (alf.ite (alf.is_neg (alf.find cons t c)) false (nary.is_subset cons nil xs t)))
+        ((nary.is_subset cons nil (cons c xs) t) (alf.ite (alf.is_neg (alf.list_find cons t c)) false (nary.is_subset cons nil xs t)))
         ((nary.is_subset cons nil nil t)         true)
     )
 )

--- a/proofs/alf/cvc5/programs/Strings.smt3
+++ b/proofs/alf/cvc5/programs/Strings.smt3
@@ -25,7 +25,7 @@
 
 ; Return the concatenation of strings x and y, treated as lists.
 (define $str_concat ((T Type :implicit) (x (Seq T)) (y (Seq T)))
-  (alf.concat str.++ x y)
+  (alf.list_concat str.++ x y)
 )
 
 ; Return the result of prepending of string x to string y where the latter is

--- a/proofs/alf/cvc5/programs/Utils.smt3
+++ b/proofs/alf/cvc5/programs/Utils.smt3
@@ -128,7 +128,7 @@
   ((-> T U S) S S) S
   (
     ((get_a_norm_rec f id (f id x2))  (get_a_norm_rec f id x2))
-    ((get_a_norm_rec f id (f x1 x2))  (alf.concat f (get_a_norm_rec f id x1) (get_a_norm_rec f id x2)))
+    ((get_a_norm_rec f id (f x1 x2))  (alf.list_concat f (get_a_norm_rec f id x1) (get_a_norm_rec f id x2)))
     ((get_a_norm_rec f id id)         id)
     ((get_a_norm_rec f id x)          (alf.cons f x id))
   )

--- a/proofs/alf/cvc5/rules/Booleans.smt3
+++ b/proofs/alf/cvc5/rules/Booleans.smt3
@@ -42,7 +42,7 @@
       ((resolve C1 C2 pol L)
         (let ((lp (alf.ite pol L (not L))))
         (let ((ln (alf.ite pol (not L) L)))
-            (from_clause (alf.concat or
+            (from_clause (alf.list_concat or
                     (removeSelf lp (to_clause C1))
                     (removeSelf ln (to_clause C2)))))))
     )
@@ -64,7 +64,7 @@
             (chainResolveRec
                 (let ((lp (alf.ite pol L (not L))))
                 (let ((ln (alf.ite pol (not L) L)))
-                    (alf.concat or
+                    (alf.list_concat or
                             (removeSelf lp C1)
                             (removeSelf ln (to_clause C2))))) Cs pols lits))
     )
@@ -90,7 +90,7 @@
 (program factorLiterals ((xs Bool :list) (l Bool) (ls Bool :list))
     (Bool Bool) Bool
     (
-        ((factorLiterals xs (or l ls)) (let ((cond (alf.is_neg (alf.find or xs l))))
+        ((factorLiterals xs (or l ls)) (let ((cond (alf.is_neg (alf.list_find or xs l))))
                                        (let ((ret (factorLiterals
                                                     (alf.ite cond (alf.cons or l xs) xs)
                                                     ls)))
@@ -139,7 +139,7 @@
 (declare-rule and_elim ((Fs Bool) (i Int))
     :premises (Fs)
     :args (i)
-    :conclusion (alf.extract and Fs i)
+    :conclusion (alf.list_nth and Fs i)
 )
 
 ; AND_INTRO
@@ -152,7 +152,7 @@
 (declare-rule not_or_elim ((Fs Bool) (i Int))
     :premises ((not Fs))
     :args (i)
-    :conclusion (not (alf.extract or Fs i))
+    :conclusion (not (alf.list_nth or Fs i))
 )
 
 ; IMPLIES_ELIM
@@ -266,7 +266,7 @@
 ; CNF_AND_POS
 (declare-rule cnf_and_pos ((Fs Bool) (i Int))
     :args (Fs i)
-    :conclusion (or (not Fs) (alf.extract and Fs i))
+    :conclusion (or (not Fs) (alf.list_nth and Fs i))
 )
 
 ; CNF_AND_NEG
@@ -284,7 +284,7 @@
 ; CNF_OR_NEG
 (declare-rule cnf_or_neg ((Fs Bool) (i Int))
     :args (Fs i)
-    :conclusion (or Fs (not (alf.extract or Fs i)))
+    :conclusion (or Fs (not (alf.list_nth or Fs i)))
 )
 
 ; CNF_IMPLIES_POS

--- a/proofs/alf/cvc5/theories/Bags.smt3
+++ b/proofs/alf/cvc5/theories/Bags.smt3
@@ -24,7 +24,7 @@
 (declare-const bag.filter (-> (! Type :var T :implicit) (-> T Bool) (Bag T) (Bag T)))
 (declare-const bag.map (-> (! Type :var T :implicit) (! Type :var U :implicit) (-> T U) (Bag T) (Bag U)))
 (declare-const bag.fold (-> (! Type :var T :implicit) (! Type :var U :implicit) (-> T U U) U (Bag T) U))
-(declare-const table.product (-> (! Type :var T :implicit) (! Type :var U :implicit) (Bag T) (Bag U) (Bag (alf.concat Tuple U T))))
+(declare-const table.product (-> (! Type :var T :implicit) (! Type :var U :implicit) (Bag T) (Bag U) (Bag (alf.list_concat Tuple U T))))
 (declare-const table.group (-> (! Type :var T :implicit) @List (Bag T) (Bag (Bag T))))
 
 ; Skolems for the theory of bags.

--- a/proofs/alf/cvc5/theories/Datatypes.smt3
+++ b/proofs/alf/cvc5/theories/Datatypes.smt3
@@ -8,7 +8,7 @@
                          T U (alf.cons Tuple T U)) :right-assoc-nil tuple.unit)
 (declare-const tuple.select
     (-> (! Type :var T :implicit)
-        (! Int :var i) T (alf.extract Tuple T i)))
+        (! Int :var i) T (alf.list_nth Tuple T i)))
 (declare-const tuple.update
     (-> (! Type :var T :implicit) (! Type :var S :implicit)
         Int T S T))

--- a/proofs/alf/cvc5/theories/Sets.smt3
+++ b/proofs/alf/cvc5/theories/Sets.smt3
@@ -36,7 +36,7 @@
 ; Relation operators.
 (declare-const rel.tclosure (-> (! Type :var T :implicit) (Set (Tuple T T)) (Set (Tuple T T))))
 (declare-const rel.transpose (-> (! Type :var T :implicit) (Set T) (Set (nary.reverse T))))
-(declare-const rel.product (-> (! Type :var T :implicit) (! Type :var U :implicit) (Set T) (Set U) (Set (alf.concat Tuple T U))))
+(declare-const rel.product (-> (! Type :var T :implicit) (! Type :var U :implicit) (Set T) (Set U) (Set (alf.list_concat Tuple T U))))
 (declare-const rel.join (-> (! Type :var T :implicit) (! Type :var U :implicit) (Set T) (Set U) (Set (nary.join Tuple UnitTuple T U))))
 (declare-const rel.group (-> (! Type :var T :implicit) @List (Set T) (Set (Set T))))
 


### PR DESCRIPTION
This updates the syntax of list operators in ALF to one that has no ambiguity in terms of arity, using the updated operator names.