### PR TITLE
Accurately print total arithmetic operators

### DIFF
--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1170,12 +1170,12 @@ std::string Smt2Printer::smtKindString(Kind k)
     case Kind::LEQ: return "<=";
     case Kind::GT: return ">";
     case Kind::GEQ: return ">=";
-    case Kind::DIVISION:
-    case Kind::DIVISION_TOTAL: return "/";
-    case Kind::INTS_DIVISION_TOTAL:
+    case Kind::DIVISION: return "/";
+    case Kind::DIVISION_TOTAL: return "/_total";
     case Kind::INTS_DIVISION: return "div";
-    case Kind::INTS_MODULUS_TOTAL:
+    case Kind::INTS_DIVISION_TOTAL: return "div_total";
     case Kind::INTS_MODULUS: return "mod";
+    case Kind::INTS_MODULUS_TOTAL: return "mod_total";
     case Kind::INTS_LOG2: return "int.log2";
     case Kind::INTS_ISPOW2: return "int.ispow2";
     case Kind::ABS: return "abs";

--- a/src/proof/alf/alf_node_converter.cpp
+++ b/src/proof/alf/alf_node_converter.cpp
@@ -607,11 +607,6 @@ Node AlfNodeConverter::getOperatorOfTerm(Node n, bool reqCast)
     else
     {
       opName << printer::smt2::Smt2Printer::smtKindString(k);
-      if (k == Kind::DIVISION_TOTAL || k == Kind::INTS_DIVISION_TOTAL
-          || k == Kind::INTS_MODULUS_TOTAL)
-      {
-        opName << "_total";
-      }
     }
   }
   std::vector<Node> args(n.begin(), n.end());


### PR DESCRIPTION
These functions are now first-class kinds and should be printed with an appropriate syntax.

The syntax coincides with the ALF / RARE signatures.

Note that we do not *parse* these operators by default yet, although this issue similar to re-parsing skolem functions.

Nevertheless, this makes our printer more transparent and *not* silently assume that the total versions of these operators are the same as the original ones.