### PR TITLE
Eliminate handling of WITNESS in assertions

### DIFF
--- a/proofs/alf/cvc5/rules/Quantifiers.smt3
+++ b/proofs/alf/cvc5/rules/Quantifiers.smt3
@@ -27,17 +27,9 @@
         ))
 )
 
-(declare-rule skolem_intro ((T Type) (t T))
-  :args (t)
-  :conclusion 
-    (alf.match ((T Type) (x T) (F Bool))
-      t
-      (
-        ; special case for witness
-        ((@quantifiers_skolemize (exists (@list x) F) x) (= t (witness (@list x) F)))
-        ((@purify x)                                     (= t x))
-      )
-   )
+(declare-rule skolem_intro ((T Type) (x T))
+  :args ((@purify x))
+  :conclusion (= (@purify x) x)
 )
 
 ; B is the formula to apply to

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -66,33 +66,10 @@ std::ostream& operator<<(std::ostream& out, InternalSkolemId id)
 
 SkolemManager::SkolemManager() : d_skolemCounter(0) {}
 
-Node SkolemManager::mkPurifySkolem(Node t,
-                                   ProofGenerator* pg)
+Node SkolemManager::mkPurifySkolem(Node t)
 {
   // We do not recursively compute the original form of t here
-  Node k;
-  if (t.getKind() == Kind::WITNESS)
-  {
-    // The purification skolem for (witness ((x T)) P) is the same as
-    // the skolem function (QUANTIFIERS_SKOLEMIZE (exists ((x T)) P) x).
-    NodeManager* nm = NodeManager::currentNM();
-    Node exists =
-        nm->mkNode(Kind::EXISTS, std::vector<Node>(t.begin(), t.end()));
-    k = mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE, {exists, t[0][0]});
-    // store the proof generator if it exists
-    if (pg != nullptr)
-    {
-      d_gens[exists] = pg;
-    }
-    UnpurifiedFormAttribute ufa;
-    k.setAttribute(ufa, t);
-  }
-  else
-  {
-    k = mkSkolemFunction(SkolemId::PURIFY, {t});
-    // shouldn't provide proof generators for other terms
-    Assert(pg == nullptr);
-  }
+  Node k = mkSkolemFunction(SkolemId::PURIFY, {t});
   Trace("sk-manager-skolem") << "skolem: " << k << " purify " << t << std::endl;
   return k;
 }
@@ -271,16 +248,6 @@ Node SkolemManager::mkDummySkolem(const std::string& prefix,
                                   int flags)
 {
   return mkSkolemNode(Kind::DUMMY_SKOLEM, prefix, type, flags);
-}
-
-ProofGenerator* SkolemManager::getProofGenerator(Node t) const
-{
-  std::map<Node, ProofGenerator*>::const_iterator it = d_gens.find(t);
-  if (it != d_gens.end())
-  {
-    return it->second;
-  }
-  return nullptr;
 }
 
 bool SkolemManager::isAbstractValue(TNode n) const

--- a/src/expr/skolem_manager.h
+++ b/src/expr/skolem_manager.h
@@ -143,14 +143,9 @@ class SkolemManager
    * will return two different Skolems.
    *
    * @param t The term to purify
-   * @param pg The proof generator for the skolemization of t. This should
-   * only be provided if t is a witness term (witness ((x T)) P). If non-null,
-   * this proof generator must respond to a call to getProofFor on
-   * (exists ((x T)) P) during the lifetime of the current node manager.
    * @return The purification skolem for t
    */
-  Node mkPurifySkolem(Node t,
-                      ProofGenerator* pg = nullptr);
+  Node mkPurifySkolem(Node t);
   /**
    * Make skolem function. This method should be used for creating fixed
    * skolem functions of the forms described in SkolemId. The user of this
@@ -231,11 +226,6 @@ class SkolemManager
                      const TypeNode& type,
                      const std::string& comment = "",
                      int flags = SKOLEM_DEFAULT);
-  /**
-   * Get proof generator for existentially quantified formula q. This returns
-   * the proof generator that was provided in a call to `mkSkolemize` above.
-   */
-  ProofGenerator* getProofGenerator(Node q) const;
   /** Returns true if n is a skolem that stands for an abstract value */
   bool isAbstractValue(TNode n) const;
   /**
@@ -263,10 +253,6 @@ class SkolemManager
   std::map<std::tuple<SkolemId, TypeNode, Node>, Node> d_skolemFuns;
   /** Backwards mapping of above */
   std::map<Node, std::tuple<SkolemId, TypeNode, Node>> d_skolemFunMap;
-  /**
-   * Mapping from witness terms to proof generators.
-   */
-  std::map<Node, ProofGenerator*> d_gens;
 
   /**
    * A counter used to produce unique skolem names.

--- a/src/proof/trust_id.cpp
+++ b/src/proof/trust_id.cpp
@@ -36,7 +36,6 @@ const char* toString(TrustId id)
     case TrustId::THEORY_PREPROCESS_LEMMA: return "THEORY_PREPROCESS_LEMMA";
     case TrustId::THEORY_EXPAND_DEF: return "THEORY_EXPAND_DEF";
     case TrustId::EXT_THEORY_REWRITE: return "EXT_THEORY_REWRITE";
-    case TrustId::WITNESS_AXIOM: return "WITNESS_AXIOM";
     case TrustId::REWRITE_NO_ELABORATE: return "REWRITE_NO_ELABORATE";
     case TrustId::FLATTENING_REWRITE: return "FLATTENING_REWRITE";
     case TrustId::SUBS_NO_ELABORATE: return "SUBS_NO_ELABORATE";

--- a/src/proof/trust_id.h
+++ b/src/proof/trust_id.h
@@ -47,8 +47,6 @@ enum class TrustId : uint32_t
   THEORY_EXPAND_DEF,
   /** An extended theory rewrite */
   EXT_THEORY_REWRITE,
-  /** An axiom for an introduced witness term without a corresponding proof */
-  WITNESS_AXIOM,
   /** A rewrite whose proof could not be elaborated */
   REWRITE_NO_ELABORATE,
   /** A flattening rewrite in an equality engine proof */

--- a/src/smt/term_formula_removal.cpp
+++ b/src/smt/term_formula_removal.cpp
@@ -270,6 +270,7 @@ Node RemoveTermFormulas::runCurrentInternal(TNode node,
                                             uint32_t cval,
                                             TConvProofGenerator* pg)
 {
+  AlwaysAssert (node.getKind()!=Kind::WITNESS) << "WITNESS should never appear in asserted terms";
   NodeManager *nodeManager = NodeManager::currentNM();
   SkolemManager* sm = nodeManager->getSkolemManager();
 
@@ -336,60 +337,6 @@ Node RemoveTermFormulas::runCurrentInternal(TNode node,
                       {axiom, eq},
                       {newAssertion});
         newAssertionPg = d_lp.get();
-      }
-    }
-  }
-  else if (node.getKind() == Kind::WITNESS)
-  {
-    // If a witness choice
-    //   For details on this operator, see
-    //   http://planetmath.org/hilbertsvarepsilonoperator.
-    if (!expr::hasFreeVar(node))
-    {
-      // NOTE: we can replace by t if body is of the form (and (= z t) ...)
-      skolem = getSkolemForNode(node);
-      if (skolem.isNull())
-      {
-        Trace("rtf-proof-debug")
-            << "RemoveTermFormulas::run: make WITNESS skolem" << std::endl;
-        // Make the skolem to witness the choice, which notice is handled
-        // as a special case within SkolemManager::mkPurifySkolem.
-        skolem = sm->mkPurifySkolem(node);
-        d_skolem_cache.insert(node, skolem);
-        if (nodeType.isBoolean() && inTerm)
-        {
-          // must treat as a Boolean term skolem
-          d_env.registerBooleanTermSkolem(skolem);
-        }
-
-        Assert(node[0].getNumChildren() == 1);
-
-        // The new assertion is the assumption that the body
-        // of the witness operator holds for the Skolem
-        newAssertion = node[1].substitute(node[0][0], skolem);
-
-        // Get the proof generator, if one exists, which was responsible for
-        // constructing this witness term. This may not exist, in which case
-        // the witness term was trivial to justify. This is the case e.g. for
-        // purification witness terms.
-        if (isProofEnabled())
-        {
-          Node existsAssertion =
-              nodeManager->mkNode(Kind::EXISTS, node[0], node[1]);
-          // -------------------- from skolem manager
-          // (exists x. node[1])
-          // -------------------- SKOLEMIZE
-          // node[1] * { x -> skolem }
-          ProofGenerator* expg = sm->getProofGenerator(existsAssertion);
-          d_lp->addLazyStep(existsAssertion,
-                            expg,
-                            TrustId::WITNESS_AXIOM,
-                            true,
-                            "RemoveTermFormulas::run:skolem_pf");
-          d_lp->addStep(
-              newAssertion, ProofRule::SKOLEMIZE, {existsAssertion}, {});
-          newAssertionPg = d_lp.get();
-        }
       }
     }
   }


### PR DESCRIPTION
This eliminates the dependency on proofs from the skolem manager, which could lead to issues where skolems are created in the same skolem manager in different solvers (with/without proofs).

This dependency was to support a deprecated feature where proofs could be attached to witness terms.  This functionality was never used and moreover complicated some of our proof rules and the term formula removal preprocessing pass.  This can be simplified now.

This is work towards stabilizing the ALF signature as well as supporting more advanced usages of skolems in distributed/parallel cvc5 instances.