### PR TITLE
Update UF signature to standard documentation in ALF

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -1134,6 +1134,10 @@ enum ENUM(ProofRule) : uint32_t
    *
    * For example, this rule concludes :math:`f(x,y) = @(@(f,x),y)`, where
    * :math:`@` isthe ``HO_APPLY`` kind.
+   *
+   * Note this rule can be treated as a
+   * :cpp:enumerator:`REFL <cvc5::ProofRule::REFL>` when appropriate in
+   * external proof formats.
    *  \endverbatim
    */
   EVALUE(HO_APP_ENCODE),

--- a/proofs/alf/cvc5/rules/Uf.smt3
+++ b/proofs/alf/cvc5/rules/Uf.smt3
@@ -3,7 +3,7 @@
 ; rule: refl
 ; implements: ProofRule::REFL
 ; args:
-; - t : T. The term to apply reflexivity to.
+; - t T: The term to apply reflexivity to.
 ; conclusion: The equality between t and itself.
 (declare-rule refl ((T Type) (t T))
     :args (t)
@@ -28,8 +28,8 @@
 
 ; program: $mk_trans
 ; args:
-; - t1 : U. The current left hand side of the equality we have proven.
-; - t2 : U. The current right hand side of the equality we have proven.
+; - t1 U: The current left hand side of the equality we have proven.
+; - t2 U: The current right hand side of the equality we have proven.
 ; - E Bool: A conjunction of the remaining equalities we have left to process.
 ; return: >
 ;   An equality between the original left hand side and the final right
@@ -47,7 +47,7 @@
 ; rule: trans
 ; implements: ProofRule::TRANS
 ; premises:
-; - E: A conjunction of equalities to apply transitivity to.
+; - E [:list]: A conjunction of equalities to apply transitivity to.
 ; conclusion: >
 ;   An equality between the left hand side of the first equality
 ;   and the right hand side of the last equality, assuming that the right hand
@@ -63,8 +63,8 @@
 
 ; program: $mk_cong
 ; args:
-; - t1 : U. The current left hand side of the equality we have proven.
-; - t2 : U. The current right hand side of the equality we have proven.
+; - t1 U: The current left hand side of the equality we have proven.
+; - t2 U: The current right hand side of the equality we have proven.
 ; - E Bool: A conjunction of the remaining equalities we have left to process.
 ; return: >
 ;   An equality where the original terms are applied to the left and

--- a/proofs/alf/cvc5/rules/Uf.smt3
+++ b/proofs/alf/cvc5/rules/Uf.smt3
@@ -163,6 +163,12 @@
     :conclusion (not F)
 )
 
+; @rule cong implements ProofRule::HO_CONG
+; @premises E. A conjunction of equalities to apply congruence to.
+; @conclusion An equality between a function application that is given by
+; the premises E. Note that the first equality in E should be an equality
+; between function that are respectively applied to the arguments given by
+; the remaining equalities.
 (declare-rule ho_cong ((T Type) (U Type) (E Bool) (f (-> T U)))
     :premise-list E and
     :args ()

--- a/proofs/alf/cvc5/rules/Uf.smt3
+++ b/proofs/alf/cvc5/rules/Uf.smt3
@@ -1,17 +1,18 @@
 (include "../theories/Builtin.smt3")
 
-; REFL
+; @rule refl implements ProofRule::REFL
+; @arg t : T. The term to apply reflexivity to.
+; @conclusion The equality between t and itself.
 (declare-rule refl ((T Type) (t T))
-    :premises ()
     :args (t)
     :conclusion (= t t)
 )
 
-; SYMM
-; Either t1 = t2 ==> t2 = t1 or t1 != t2 ==> t2 != t1
+; @rule symm implements ProofRule::SYMM
+; @arg F : Bool. The (dis)equality to apply symmetry to.
+; @conclusion The symmetric version of the (dis)equality F.
 (declare-rule symm ((F Bool))
     :premises (F)
-    :args ()
     :conclusion
         (alf.match ((T Type) (t1 T) (t2 T))
             F
@@ -21,23 +22,34 @@
             ))
 )
 
-; TRANS
-; note that we assume that there is never exactly one premise
-(program mk_trans ((U Type) (t1 U) (t2 U) (t3 U) (t4 U) (tail Bool :list))
+; @program $mk_trans
+; @arg t1 : U. The current left hand side of the equality we have proven.
+; @arg t2 : U. The current right hand side of the equality we have proven.
+; @arg F : Bool. A conjunction of the remaining equalities we have left to
+; process.
+; @returns an equality between the original left hand side and the final right
+; hand side. Each additional equality checks that its left hand side matches
+; the current right hand side.
+(program $mk_trans ((U Type) (t1 U) (t2 U) (t3 U) (t4 U) (tail Bool :list))
     (U U Bool) Bool
     (
-        ((mk_trans t1 t2 (and (= t3 t4) tail))
-            (alf.requires t2 t3 (mk_trans t1 t4 tail)))
-        ((mk_trans t1 t2 true)              (= t1 t2))
+        (($mk_trans t1 t2 (and (= t3 t4) tail))
+            (alf.requires t2 t3 ($mk_trans t1 t4 tail)))
+        (($mk_trans t1 t2 true)              (= t1 t2))
     )
 )
 
+; @rule trans implements ProofRule::TRANS
+; @premises E. A conjunction of equalities to apply transitivity to.
+; @conclusion An equality between the left hand side of the first equality
+; and the right hand side of the last equality, assuming that the right hand
+; side of each equality matches the left hand side of the one that follows it.
 (declare-rule trans ((T Type) (U Type) (E Bool) (f (-> T U)))
     :premise-list E and
     :conclusion
         (alf.match ((t1 U) (t2 U) (tail Bool :list))
         E
-        (((and (= t1 t2) tail) (mk_trans t1 t2 tail))))
+        (((and (= t1 t2) tail) ($mk_trans t1 t2 tail))))
 )
 
 ; CONG

--- a/proofs/alf/cvc5/rules/Uf.smt3
+++ b/proofs/alf/cvc5/rules/Uf.smt3
@@ -163,22 +163,13 @@
     :conclusion (not F)
 )
 
-; HO_CONG
-(program mk_ho_cong ((T Type) (U Type) (f1 (-> T U)) (f2 (-> T U)) (t1 U) (t2 U) (tail Bool :list))
-    (U U Bool) Bool
-    (
-        ((mk_ho_cong f1 f2 (and (= t1 t2) tail)) (mk_ho_cong (f1 t1) (f2 t2) tail))
-        ((mk_ho_cong t1 t2 true)                 (= t1 t2))
-    )
-)
-
 (declare-rule ho_cong ((T Type) (U Type) (E Bool) (f (-> T U)))
     :premise-list E and
     :args ()
     :conclusion
         (alf.match ((t1 U) (t2 U) (tail Bool :list))
         E
-        (((and (= t1 t2) tail) (mk_ho_cong t1 t2 tail))))
+        (((and (= t1 t2) tail) ($mk_cong t1 t2 tail))))
 )
 
 ; HO_APP_ENCODE

--- a/proofs/alf/cvc5/rules/Uf.smt3
+++ b/proofs/alf/cvc5/rules/Uf.smt3
@@ -128,25 +128,36 @@
     :conclusion (= ($mk_nary_cong_lhs f E) ($mk_nary_cong_rhs f E))
 )
 
-; TRUE_INTRO
+; @rule true_intro implements ProofRule::TRUE_INTRO
+; @premise F. The formula to process.
+; @conclusion The equality between F and true.
 (declare-rule true_intro ((F Bool))
     :premises (F)
     :conclusion (= F true)
 )
 
-; TRUE_ELIM
+; @rule true_elim implements ProofRule::TRUE_ELIM
+; @premise F1. The formula to process, which is an equality whose right hand
+; side is true.
+; @conclusion The left hand side of the premise.
 (declare-rule true_elim ((F Bool))
     :premises ((= F true))
     :conclusion F
 )
 
-; FALSE_INTRO
+; @rule false_intro implements ProofRule::FALSE_INTRO
+; @premise F1. The formula to process, which is a negation.
+; @conclusion The equality between the formula the premise negates and false.
 (declare-rule false_intro ((F Bool))
     :premises ((not F))
     :conclusion (= F false)
 )
 
-; FALSE_ELIM
+
+; @rule true_elim implements ProofRule::TRUE_ELIM
+; @premise F1. The formula to process, which is an equality whose right hand
+; side is false.
+; @conclusion The negation of the left hand side of the premise.
 (declare-rule false_elim ((F Bool))
     :premises ((= F false))
     :conclusion (not F)

--- a/proofs/alf/cvc5/rules/Uf.smt3
+++ b/proofs/alf/cvc5/rules/Uf.smt3
@@ -1,16 +1,20 @@
 (include "../theories/Builtin.smt3")
 
-; @rule refl implements ProofRule::REFL
-; @arg t : T. The term to apply reflexivity to.
-; @conclusion The equality between t and itself.
+; rule: refl
+; implements: ProofRule::REFL
+; args:
+; - t : T. The term to apply reflexivity to.
+; conclusion: The equality between t and itself.
 (declare-rule refl ((T Type) (t T))
     :args (t)
     :conclusion (= t t)
 )
 
-; @rule symm implements ProofRule::SYMM
-; @arg F : Bool. The (dis)equality to apply symmetry to.
-; @conclusion The symmetric version of the (dis)equality F.
+; rule: symm
+; implements: ProofRule::SYMM
+; args:
+; - F Bool: The (dis)equality to apply symmetry to.
+; conclusion: The symmetric version of the (dis)equality F.
 (declare-rule symm ((F Bool))
     :premises (F)
     :conclusion
@@ -22,14 +26,15 @@
             ))
 )
 
-; @program $mk_trans
-; @arg t1 : U. The current left hand side of the equality we have proven.
-; @arg t2 : U. The current right hand side of the equality we have proven.
-; @arg E : Bool. A conjunction of the remaining equalities we have left to
-; process.
-; @returns an equality between the original left hand side and the final right
-; hand side. Each additional equality checks that its left hand side matches
-; the current right hand side.
+; program: $mk_trans
+; args:
+; - t1 : U. The current left hand side of the equality we have proven.
+; - t2 : U. The current right hand side of the equality we have proven.
+; - E Bool: A conjunction of the remaining equalities we have left to process.
+; return: >
+;   An equality between the original left hand side and the final right
+;   hand side. Each additional equality checks that its left hand side matches
+;   the current right hand side.
 (program $mk_trans ((U Type) (t1 U) (t2 U) (t3 U) (t4 U) (tail Bool :list))
     (U U Bool) Bool
     (
@@ -39,11 +44,14 @@
     )
 )
 
-; @rule trans implements ProofRule::TRANS
-; @premises E. A conjunction of equalities to apply transitivity to.
-; @conclusion An equality between the left hand side of the first equality
-; and the right hand side of the last equality, assuming that the right hand
-; side of each equality matches the left hand side of the one that follows it.
+; rule: trans
+; implements: ProofRule::TRANS
+; premises:
+; - E: A conjunction of equalities to apply transitivity to.
+; conclusion: >
+;   An equality between the left hand side of the first equality
+;   and the right hand side of the last equality, assuming that the right hand
+;   side of each equality matches the left hand side of the one that follows it.
 (declare-rule trans ((T Type) (U Type) (E Bool) (f (-> T U)))
     :premise-list E and
     :conclusion
@@ -53,13 +61,14 @@
 )
 
 
-; @program $mk_cong
-; @arg t1 : U. The current left hand side of the equality we have proven.
-; @arg t2 : U. The current right hand side of the equality we have proven.
-; @arg E : Bool. A conjunction of the remaining equalities we have left to
-; process.
-; @returns an equality where the original terms are applied to the left and 
-; right hand sides of the equalities given by E.
+; program: $mk_cong
+; args:
+; - t1 : U. The current left hand side of the equality we have proven.
+; - t2 : U. The current right hand side of the equality we have proven.
+; - E Bool: A conjunction of the remaining equalities we have left to process.
+; return: >
+;   An equality where the original terms are applied to the left and
+;   right hand sides of the equalities given by E.
 (program $mk_cong ((T Type) (U Type) (f1 (-> T U)) (f2 (-> T U)) (t1 U) (t2 U) (tail Bool :list))
     (U U Bool) Bool
     (
@@ -69,29 +78,37 @@
     )
 )
 
-; @rule cong implements ProofRule::CONG
-; @premises E. A conjunction of equalities to apply congruence to.
-; @arg f : (-> T U). The function to apply congruence to. This is assumed to be
-; a function that is not n-ary, e.g. it is not marked :right-assoc-nil.
-; Congruence for n-ary operators requires a different rule (nary_cong) below.
-; @conclusion An equality between applications of f whose arguments are given
-; by the equalities in E.
+; rule: cong
+; implements: ProofRule::CONG
+; premises:
+; - E [:list]: A conjunction of equalities to apply congruence to.
+; args:
+; - f (-> T U): >
+;   The function to apply congruence to. This is assumed to be
+;   a function that is not n-ary, e.g. it is not marked :right-assoc-nil.
+;   Congruence for n-ary operators requires a different rule (nary_cong) below.
+; conclusion: >
+;   An equality between applications of f whose arguments are given
+;   by the equalities in E.
 (declare-rule cong ((T Type) (U Type) (E Bool) (f (-> T U)))
     :premise-list E and
     :args (f)
     :conclusion ($mk_cong f f E)
 )
 
-; @program $mk_nary_cong_lhs
-; @arg f : (-> U U U). The function we are applying congruence over. This is
-; assumed to be a right-associative n-ary operator with nil terminator, i.e.
-; marked with :right-assoc-nil.
-; @arg E : Bool. A conjunction of the remaining equalities we have left to
-; process.
-; @returns the left hand side of the equality proven by nary_cong for f and
-; the given premises E.
-; @note We use two side conditions for computing each side of the returned
-; equality. This avoids constructing equalities between intermediate terms.
+; program: $mk_nary_cong_lhs
+; args:
+; - f (-> U U U): >
+;   The function we are applying congruence over. This is
+;   assumed to be a right-associative n-ary operator with nil terminator, i.e.
+;   marked with :right-assoc-nil.
+; - E Bool: A conjunction of the remaining equalities we have left to process.
+; return: >
+;   The left hand side of the equality proven by nary_cong for f and
+;   the given premises E.
+; note: >
+;   We use two side conditions for computing each side of the returned
+;   equality. This avoids constructing equalities between intermediate terms.
 (program $mk_nary_cong_lhs ((U Type) (f (-> U U U)) (s1 U) (s2 U) (tail Bool :list))
     ((-> U U U) Bool) Bool
     (
@@ -100,13 +117,14 @@
     )
 )
 
-; @program $mk_nary_cong_rhs
-; @arg f : (-> U U U). The function we are applying congruence over.
-; @arg E : Bool. A conjunction of the remaining equalities we have left to
+; program: $mk_nary_cong_rhs
+; args:
+; - f (-> U U U): The function we are applying congruence over.
+; - E Bool: A conjunction of the remaining equalities we have left to
 ; process.
-; @returns the right hand side of the equality proven by nary_cong for f and
+; return: the right hand side of the equality proven by nary_cong for f and
 ; the given premises E.
-; @note This program is analogous to $mk_nary_cong_lhs.
+; note: This program is analogous to $mk_nary_cong_lhs.
 (program $mk_nary_cong_rhs ((U Type) (f (-> U U U)) (s1 U) (s2 U) (tail Bool :list))
     ((-> U U U) Bool) Bool
     (
@@ -115,60 +133,74 @@
     )
 )
 
-; @rule nary_cong implements ProofRule::NARY_CONG
-; @premises E. A conjunction of equalities to apply nary-congruence to.
-; @arg f : (-> T U). The function to apply congruence to. This is assumed to be
-; a function that is right-associative n-ary operator with nil terminator, e.g.
-; it is marked :right-assoc-nil.
-; @conclusion An equality between applications of f whose arguments are given
-; by the equalities in E.
+; rule: nary_cong
+; implements: ProofRule::NARY_CONG
+; premises:
+; - E [:list]: A conjunction of equalities to apply nary-congruence to.
+; args:
+; - f (-> T U): >
+;   The function to apply congruence to. This is assumed to be
+;   a function that is right-associative n-ary operator with nil terminator, e.g.
+;   it is marked :right-assoc-nil.
+; conclusion: >
+;   An equality between applications of f whose arguments are given
+;   by the equalities in E.
 (declare-rule nary_cong ((U Type) (E Bool) (f (-> U U)) (nil U))
     :premise-list E and
     :args (f)
     :conclusion (= ($mk_nary_cong_lhs f E) ($mk_nary_cong_rhs f E))
 )
 
-; @rule true_intro implements ProofRule::TRUE_INTRO
-; @premise F. The formula to process.
-; @conclusion The equality between F and true.
+; rule: true_intro
+; implements: ProofRule::TRUE_INTRO
+; premises:
+; - F: The formula to process.
+; conclusion: The equality between F and true.
 (declare-rule true_intro ((F Bool))
     :premises (F)
     :conclusion (= F true)
 )
 
-; @rule true_elim implements ProofRule::TRUE_ELIM
-; @premise F1. The formula to process, which is an equality whose right hand
-; side is true.
-; @conclusion The left hand side of the premise.
+; rule: true_elim
+; implements: ProofRule::TRUE_ELIM
+; premises:
+; - F1: The formula to process, which is an equality whose right hand side is true.
+; conclusion: The left hand side of the premise.
 (declare-rule true_elim ((F Bool))
     :premises ((= F true))
     :conclusion F
 )
 
-; @rule false_intro implements ProofRule::FALSE_INTRO
-; @premise F1. The formula to process, which is a negation.
-; @conclusion The equality between the formula the premise negates and false.
+; rule: false_intro
+; implements: ProofRule::FALSE_INTRO
+; premises:
+; - F1: The formula to process, which is a negation.
+; conclusion: The equality between the formula the premise negates and false.
 (declare-rule false_intro ((F Bool))
     :premises ((not F))
     :conclusion (= F false)
 )
 
 
-; @rule false_elim implements ProofRule::FALSE_ELIM
-; @premise F1. The formula to process, which is an equality whose right hand
-; side is false.
-; @conclusion The negation of the left hand side of the premise.
+; rule: false_elim
+; implements: ProofRule::FALSE_ELIM
+; premises:
+; - F1: The formula to process, which is an equality whose right hand side is false.
+; conclusion: The negation of the left hand side of the premise.
 (declare-rule false_elim ((F Bool))
     :premises ((= F false))
     :conclusion (not F)
 )
 
-; @rule ho_cong implements ProofRule::HO_CONG
-; @premises E. A conjunction of equalities to apply congruence to.
-; @conclusion An equality between a function application that is given by
-; the premises E. Note that the first equality in E should be an equality
-; between function that are respectively applied to the arguments given by
-; the remaining equalities.
+; rule: ho_cong
+; implements: ProofRule::HO_CONG
+; premises:
+; - E [:list]: A conjunction of equalities to apply congruence to.
+; conclusion: >
+;   An equality between a function application that is given by
+;   the premises E. Note that the first equality in E should be an equality
+;   between function that are respectively applied to the arguments given by
+;   the remaining equalities.
 (declare-rule ho_cong ((T Type) (U Type) (E Bool) (f (-> T U)))
     :premise-list E and
     :args ()
@@ -180,8 +212,13 @@
 
 ;;-------------------- Instances of THEORY_REWRITE
 
-; Note that distinct is already treated as pairwise, thus we only need to convert from
-; binary distinct to disequalities.
+; program: $mk_distinct-elim
+; args:
+; - F Bool: The application of distinct to eliminate.
+; return: The result of converting distinct in F to negated equalities.
+; note: >
+;   The distinct function is already treated as pairwise, thus we only need to convert from
+;   binary distinct to disequalities.
 (program $mk_distinct-elim ((T Type) (x T) (y T) (b Bool :list))
   (Bool) Bool
   (
@@ -191,10 +228,12 @@
   )
 )
 
-; @rule distinct-elim implements ProofRewriteRule::DISTINCT_ELIM.
-; @arg eq : Bool. The equality between formulas b1 and b2 to prove.
-; @requires showing that eliminating distinct from b1 results in b2.
-; @conclusion The given equality.
+; rule: distinct-elim
+; implements: ProofRewriteRule::DISTINCT_ELIM.
+; args:
+; - eq Bool: The equality between formulas b1 and b2 to prove.
+; requires: Showing that eliminating distinct from b1 results in b2.
+; conclusion: The given equality.
 (declare-rule distinct-elim ((b1 Bool) (b2 Bool))
   :args ((= b1 b2))
   :requires ((($singleton_elim ($mk_distinct-elim b1)) b2))

--- a/proofs/alf/cvc5/rules/Uf.smt3
+++ b/proofs/alf/cvc5/rules/Uf.smt3
@@ -25,7 +25,7 @@
 ; @program $mk_trans
 ; @arg t1 : U. The current left hand side of the equality we have proven.
 ; @arg t2 : U. The current right hand side of the equality we have proven.
-; @arg F : Bool. A conjunction of the remaining equalities we have left to
+; @arg E : Bool. A conjunction of the remaining equalities we have left to
 ; process.
 ; @returns an equality between the original left hand side and the final right
 ; hand side. Each additional equality checks that its left hand side matches
@@ -52,20 +52,34 @@
         (((and (= t1 t2) tail) ($mk_trans t1 t2 tail))))
 )
 
-; CONG
-(program mk_cong ((T Type) (U Type) (f1 (-> T U)) (f2 (-> T U)) (t1 U) (t2 U) (tail Bool :list))
+
+; @program $mk_cong
+; @arg t1 : U. The current left hand side of the equality we have proven.
+; @arg t2 : U. The current right hand side of the equality we have proven.
+; @arg E : Bool. A conjunction of the remaining equalities we have left to
+; process.
+; @returns an equality where the original terms are applied to the left and 
+; right hand sides of the equalities given by E.
+(program $mk_cong ((T Type) (U Type) (f1 (-> T U)) (f2 (-> T U)) (t1 U) (t2 U) (tail Bool :list))
     (U U Bool) Bool
     (
-        ((mk_cong f1 f2 (and (= t1 t2) tail)) (mk_cong (f1 t1) (f2 t2) tail))
-        ((mk_cong t1 t2 true)                 (= t1 t2))
-        ((mk_cong f1 f2 (= t1 t2))            (= (f1 t1) (f2 t2)))
+        (($mk_cong f1 f2 (and (= t1 t2) tail)) ($mk_cong (f1 t1) (f2 t2) tail))
+        (($mk_cong t1 t2 true)                 (= t1 t2))
+        (($mk_cong f1 f2 (= t1 t2))            (= (f1 t1) (f2 t2)))
     )
 )
 
+; @rule cong implements ProofRule::CONG
+; @premises E. A conjunction of equalities to apply congruence to.
+; @arg f : (-> T U). The function to apply congruence to. This is assumed to be
+; a function that is not n-ary, e.g. it is not marked :right-assoc-nil.
+; Congruence for n-ary operators requires a different rule (nary_cong) below.
+; @conclusion An equality between applications of f whose arguments are given
+; by the equalities in E.
 (declare-rule cong ((T Type) (U Type) (E Bool) (f (-> T U)))
     :premise-list E and
     :args (f)
-    :conclusion (mk_cong f f E)
+    :conclusion ($mk_cong f f E)
 )
 
 ; N-ary congruence
@@ -95,28 +109,24 @@
 ; TRUE_INTRO
 (declare-rule true_intro ((F Bool))
     :premises (F)
-    :args ()
     :conclusion (= F true)
 )
 
 ; TRUE_ELIM
 (declare-rule true_elim ((F Bool))
     :premises ((= F true))
-    :args ()
     :conclusion F
 )
 
 ; FALSE_INTRO
 (declare-rule false_intro ((F Bool))
     :premises ((not F))
-    :args ()
     :conclusion (= F false)
 )
 
 ; FALSE_ELIM
 (declare-rule false_elim ((F Bool))
     :premises ((= F false))
-    :args ()
     :conclusion (not F)
 )
 
@@ -155,6 +165,10 @@
   )
 )
 
+; @rule distinct-elim implements ProofRewriteRule::DISTINCT_ELIM.
+; @arg eq : Bool. The equality between formulas b1 and b2 to prove.
+; @requires showing that eliminating distinct from b1 results in b2.
+; @conclusion The given equality.
 (declare-rule distinct-elim ((b1 Bool) (b2 Bool))
   :args ((= b1 b2))
   :requires ((($singleton_elim ($mk_distinct-elim b1)) b2))

--- a/proofs/alf/cvc5/rules/Uf.smt3
+++ b/proofs/alf/cvc5/rules/Uf.smt3
@@ -154,7 +154,7 @@
 )
 
 
-; @rule true_elim implements ProofRule::TRUE_ELIM
+; @rule false_elim implements ProofRule::FALSE_ELIM
 ; @premise F1. The formula to process, which is an equality whose right hand
 ; side is false.
 ; @conclusion The negation of the left hand side of the premise.
@@ -163,7 +163,7 @@
     :conclusion (not F)
 )
 
-; @rule cong implements ProofRule::HO_CONG
+; @rule ho_cong implements ProofRule::HO_CONG
 ; @premises E. A conjunction of equalities to apply congruence to.
 ; @conclusion An equality between a function application that is given by
 ; the premises E. Note that the first equality in E should be an equality
@@ -177,10 +177,6 @@
         E
         (((and (= t1 t2) tail) ($mk_cong t1 t2 tail))))
 )
-
-; HO_APP_ENCODE
-
-; BETA_REDUCE
 
 ;;-------------------- Instances of THEORY_REWRITE
 

--- a/proofs/alf/cvc5/rules/Uf.smt3
+++ b/proofs/alf/cvc5/rules/Uf.smt3
@@ -82,28 +82,50 @@
     :conclusion ($mk_cong f f E)
 )
 
-; N-ary congruence
-; We use two side conditions for computing each side of the returned equality.
-; This avoids intermediate node construction.
-(program mk_nary_cong_lhs ((U Type) (f (-> U U)) (s1 U) (s2 U) (tail Bool :list))
-    ((-> U U) Bool) Bool
+; @program $mk_nary_cong_lhs
+; @arg f : (-> U U U). The function we are applying congruence over. This is
+; assumed to be a right-associative n-ary operator with nil terminator, i.e.
+; marked with :right-assoc-nil.
+; @arg E : Bool. A conjunction of the remaining equalities we have left to
+; process.
+; @returns the left hand side of the equality proven by nary_cong for f and
+; the given premises E.
+; @note We use two side conditions for computing each side of the returned
+; equality. This avoids constructing equalities between intermediate terms.
+(program $mk_nary_cong_lhs ((U Type) (f (-> U U U)) (s1 U) (s2 U) (tail Bool :list))
+    ((-> U U U) Bool) Bool
     (
-        ((mk_nary_cong_lhs f (and (= s1 s2) tail)) (alf.cons f s1 (mk_nary_cong_lhs f tail)))
-        ((mk_nary_cong_lhs f true)                 (alf.nil f))
-    )
-)
-(program mk_nary_cong_rhs ((U Type) (f (-> U U)) (s1 U) (s2 U) (tail Bool :list))
-    ((-> U U) Bool) Bool
-    (
-        ((mk_nary_cong_rhs f (and (= s1 s2) tail)) (alf.cons f s2 (mk_nary_cong_rhs f tail)))
-        ((mk_nary_cong_rhs f true)                 (alf.nil f))
+        (($mk_nary_cong_lhs f (and (= s1 s2) tail)) (alf.cons f s1 ($mk_nary_cong_lhs f tail)))
+        (($mk_nary_cong_lhs f true)                 (alf.nil f))
     )
 )
 
+; @program $mk_nary_cong_rhs
+; @arg f : (-> U U U). The function we are applying congruence over.
+; @arg E : Bool. A conjunction of the remaining equalities we have left to
+; process.
+; @returns the right hand side of the equality proven by nary_cong for f and
+; the given premises E.
+; @note This program is analogous to $mk_nary_cong_lhs.
+(program $mk_nary_cong_rhs ((U Type) (f (-> U U U)) (s1 U) (s2 U) (tail Bool :list))
+    ((-> U U U) Bool) Bool
+    (
+        (($mk_nary_cong_rhs f (and (= s1 s2) tail)) (alf.cons f s2 ($mk_nary_cong_rhs f tail)))
+        (($mk_nary_cong_rhs f true)                 (alf.nil f))
+    )
+)
+
+; @rule nary_cong implements ProofRule::NARY_CONG
+; @premises E. A conjunction of equalities to apply nary-congruence to.
+; @arg f : (-> T U). The function to apply congruence to. This is assumed to be
+; a function that is right-associative n-ary operator with nil terminator, e.g.
+; it is marked :right-assoc-nil.
+; @conclusion An equality between applications of f whose arguments are given
+; by the equalities in E.
 (declare-rule nary_cong ((U Type) (E Bool) (f (-> U U)) (nil U))
     :premise-list E and
     :args (f)
-    :conclusion (= (mk_nary_cong_lhs f E) (mk_nary_cong_rhs f E))
+    :conclusion (= ($mk_nary_cong_lhs f E) ($mk_nary_cong_rhs f E))
 )
 
 ; TRUE_INTRO

--- a/proofs/alf/cvc5/rules/Uf.smt3
+++ b/proofs/alf/cvc5/rules/Uf.smt3
@@ -154,7 +154,7 @@
 ; rule: true_intro
 ; implements: ProofRule::TRUE_INTRO
 ; premises:
-; - F: The formula to process.
+; - F: A formula.
 ; conclusion: The equality between F and true.
 (declare-rule true_intro ((F Bool))
     :premises (F)
@@ -164,7 +164,7 @@
 ; rule: true_elim
 ; implements: ProofRule::TRUE_ELIM
 ; premises:
-; - F1: The formula to process, which is an equality whose right hand side is true.
+; - F1: The formula, which is an equality whose right hand side is true.
 ; conclusion: The left hand side of the premise.
 (declare-rule true_elim ((F Bool))
     :premises ((= F true))
@@ -174,7 +174,7 @@
 ; rule: false_intro
 ; implements: ProofRule::FALSE_INTRO
 ; premises:
-; - F1: The formula to process, which is a negation.
+; - F1: The formula, which is a negation.
 ; conclusion: The equality between the formula the premise negates and false.
 (declare-rule false_intro ((F Bool))
     :premises ((not F))
@@ -185,7 +185,7 @@
 ; rule: false_elim
 ; implements: ProofRule::FALSE_ELIM
 ; premises:
-; - F1: The formula to process, which is an equality whose right hand side is false.
+; - F1: The formula, which is an equality whose right hand side is false.
 ; conclusion: The negation of the left hand side of the premise.
 (declare-rule false_elim ((F Bool))
     :premises ((= F false))

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -380,6 +380,8 @@ std::string AlfPrinter::getRuleName(const ProofNode* pfn) const
   {
     // ENCODE_EQ_INTRO proves (= t (convert t)) from argument t,
     // where (convert t) is indistinguishable from t according to the proof.
+    // Similarly, HO_APP_ENCODE proves an equality between a term of kind
+    // Kind::HO_APPLY and Kind::APPLY_UF, which denotes the same term in ALF.
     return "refl";
   }
   std::string name = toString(r);

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -144,6 +144,7 @@ bool AlfPrinter::isHandled(const ProofNode* pfn) const
     case ProofRule::SKOLEMIZE:
     case ProofRule::ALPHA_EQUIV:
     case ProofRule::ENCODE_EQ_INTRO:
+    case ProofRule::HO_APP_ENCODE:
     case ProofRule::ACI_NORM:
     case ProofRule::DSL_REWRITE: return true;
     case ProofRule::THEORY_REWRITE:
@@ -375,7 +376,7 @@ std::string AlfPrinter::getRuleName(const ProofNode* pfn) const
     ss << id;
     return ss.str();
   }
-  else if (r == ProofRule::ENCODE_EQ_INTRO)
+  else if (r == ProofRule::ENCODE_EQ_INTRO || r == ProofRule::HO_APP_ENCODE)
   {
     // ENCODE_EQ_INTRO proves (= t (convert t)) from argument t,
     // where (convert t) is indistinguishable from t according to the proof.


### PR DESCRIPTION
This furthermore makes a simplification to use a common utility in `ho_cong`. It also adds support for `HO_APP_ENCODE`, which is a no-op in ALF.