### PR TITLE
Add simple infrequently used string proof rules to ALF signature

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -1592,8 +1592,8 @@ enum ENUM(ProofRule) : uint32_t
    *   \inferrule{\mathit{len}(t) \geq n\mid \top}{t = w_1\cdot w_2 \wedge
    *   \mathit{len}(w_2) = n}
    *
-   * where :math:`w_1` is :math:`\mathit{skolem}(\mathit{pre}(t,n)` and
-   * :math:`w_2` is :math:`\mathit{skolem}(\mathit{suf}(t,n)`.
+   * where :math:`w_1` is the purification skolem for :math:`\mathit{pre}(t,n)` and
+   * :math:`w_2` is the purification skolem for :math:`\mathit{suf}(t,n)`.
    * \endverbatim
    */
   EVALUE(STRING_DECOMPOSE),
@@ -1721,7 +1721,7 @@ enum ENUM(ProofRule) : uint32_t
    * .. math::
    *
    *   \inferrule{-\mid t,s}{\mathit{to\_code}(t) = -1 \vee \mathit{to\_code}(t) \neq
-   *   \mathit{to\_code}(s) \vee t\neq s}
+   *   \mathit{to\_code}(s) \vee t = s}
    * \endverbatim
    */
   EVALUE(STRING_CODE_INJ),

--- a/proofs/alf/cvc5/rules/Strings.smt3
+++ b/proofs/alf/cvc5/rules/Strings.smt3
@@ -188,6 +188,24 @@
               false)))))
 )
 
+; rule: string_decompose
+; implements: ProofRule::STRING_DECOMPOSE
+;(declare-rule string_decompose
+
+; rule: string_code_inj
+; implements: ProofRule::STRING_CODE_INJ:
+(declare-rule string_code_inj ((t String) (s String))
+  :args (t s)
+  :conclusion (or (= (str.to_code t) -1) (not (= (str.to_code t) (str.to_code s)) (not (= t s))))
+)
+
+; rule: string_seq_unit_inj
+; implements: ProofRule::STRING_SEQ_UNIT_INJ:
+(declare-rule string_seq_unit_inj ((U Type) (s U) (t U))
+  :premises ((= (seq.unit s) (str.unit t)))
+  :conclusion (= s t)
+)
+
 ;;-------------------- Regular expressions
 
 ; ProofRule::RE_INTER

--- a/proofs/alf/cvc5/rules/Strings.smt3
+++ b/proofs/alf/cvc5/rules/Strings.smt3
@@ -190,10 +190,20 @@
 
 ; rule: string_decompose
 ; implements: ProofRule::STRING_DECOMPOSE
+; premises:
+; - a: An inequality between the length of some string term s and integer n.
+; args:
+; - b Bool: Whether we are the reverse variant of this inference.
+; conclusion: >
+;   A conjunction stating that s is equal to two purification skolems
+;   corresponding to decomposing s at position n, and that the decomposed term
+;   has length n.
 (declare-rule string_decompose ((U Type) (s (Seq U)) (n Int) (b Bool))
   :premises ((>= (str.len s) n))
   :args (b)
-  :conclusion false
+  :conclusion (let ((kp (@purify (skolem_prefix s n)))
+                    (ks (@purify (skolem_suffix_rem s n))))
+              (and (= s (str.++ kp ks)) (= (str.len (alf.ite b ks kp)) n)))
 )
 
 

--- a/proofs/alf/cvc5/rules/Strings.smt3
+++ b/proofs/alf/cvc5/rules/Strings.smt3
@@ -188,25 +188,6 @@
               false)))))
 )
 
-; rule: string_decompose
-; implements: ProofRule::STRING_DECOMPOSE
-; premises:
-; - a: An inequality between the length of some string term s and integer n.
-; args:
-; - b Bool: Whether we are the reverse variant of this inference.
-; conclusion: >
-;   A conjunction stating that s is equal to two purification skolems
-;   corresponding to decomposing s at position n, and that the decomposed term
-;   has length n.
-(declare-rule string_decompose ((U Type) (s (Seq U)) (n Int) (b Bool))
-  :premises ((>= (str.len s) n))
-  :args (b)
-  :conclusion (let ((kp (@purify (skolem_prefix s n)))
-                    (ks (@purify (skolem_suffix_rem s n))))
-              (and (= s (str.++ kp ks)) (= (str.len (alf.ite b ks kp)) n)))
-)
-
-
 ; rule: string_code_inj
 ; implements: ProofRule::STRING_CODE_INJ
 ; args:

--- a/proofs/alf/cvc5/rules/Strings.smt3
+++ b/proofs/alf/cvc5/rules/Strings.smt3
@@ -190,20 +190,34 @@
 
 ; rule: string_decompose
 ; implements: ProofRule::STRING_DECOMPOSE
-;(declare-rule string_decompose
+(declare-rule string_decompose ((U Type) (s (Seq U)) (n Int) (b Bool))
+  :premises ((>= (str.len s) n))
+  :args (b)
+  :conclusion false
+)
+
 
 ; rule: string_code_inj
-; implements: ProofRule::STRING_CODE_INJ:
+; implements: ProofRule::STRING_CODE_INJ
+; args:
+; - t String: The first string.
+; - s String: The second string.
+; conclusion: >
+;   A disjunction of three cases, indicating that t is not a string of length
+;   one, its code point is different from that of s, or t and s are equal.
 (declare-rule string_code_inj ((t String) (s String))
   :args (t s)
-  :conclusion (or (= (str.to_code t) -1) (not (= (str.to_code t) (str.to_code s)) (not (= t s))))
+  :conclusion (or (= (str.to_code t) -1) (not (= (str.to_code t) (str.to_code s))) (= t s))
 )
 
 ; rule: string_seq_unit_inj
-; implements: ProofRule::STRING_SEQ_UNIT_INJ:
-(declare-rule string_seq_unit_inj ((U Type) (s U) (t U))
-  :premises ((= (seq.unit s) (str.unit t)))
-  :conclusion (= s t)
+; implements: ProofRule::STRING_SEQ_UNIT_INJ
+; premises:
+; - eq: An equality stating that the unit sequences of elements a and b are equal.
+; conclusion: That a and b are equal.
+(declare-rule string_seq_unit_inj ((U Type) (a U) (b U))
+  :premises ((= (seq.unit a) (seq.unit b)))
+  :conclusion (= a b)
 )
 
 ;;-------------------- Regular expressions

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -139,6 +139,7 @@ bool AlfPrinter::isHandled(const ProofNode* pfn) const
     case ProofRule::RE_UNFOLD_POS:
     case ProofRule::RE_UNFOLD_NEG_CONCAT_FIXED:
     case ProofRule::RE_UNFOLD_NEG:
+    case ProofRule::STRING_DECOMPOSE:
     case ProofRule::STRING_CODE_INJ:
     case ProofRule::STRING_SEQ_UNIT_INJ:
     case ProofRule::ITE_EQ:

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -139,6 +139,8 @@ bool AlfPrinter::isHandled(const ProofNode* pfn) const
     case ProofRule::RE_UNFOLD_POS:
     case ProofRule::RE_UNFOLD_NEG_CONCAT_FIXED:
     case ProofRule::RE_UNFOLD_NEG:
+    case ProofRule::STRING_CODE_INJ:
+    case ProofRule::STRING_SEQ_UNIT_INJ:
     case ProofRule::ITE_EQ:
     case ProofRule::INSTANTIATE:
     case ProofRule::SKOLEMIZE:

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -139,7 +139,6 @@ bool AlfPrinter::isHandled(const ProofNode* pfn) const
     case ProofRule::RE_UNFOLD_POS:
     case ProofRule::RE_UNFOLD_NEG_CONCAT_FIXED:
     case ProofRule::RE_UNFOLD_NEG:
-    case ProofRule::STRING_DECOMPOSE:
     case ProofRule::STRING_CODE_INJ:
     case ProofRule::STRING_SEQ_UNIT_INJ:
     case ProofRule::ITE_EQ:


### PR DESCRIPTION
Adds 2 of the remaining 3 rules to the string signature.