### PR TITLE
Make `safe-options` itself an expert option

### DIFF
--- a/src/options/base_options.toml
+++ b/src/options/base_options.toml
@@ -334,7 +334,7 @@ name   = "Base"
 
 [[option]]
   name       = "safeOptions"
-  category   = "common"
+  category   = "expert"
   long       = "safe-options"
   type       = "bool"
   default    = "false"


### PR DESCRIPTION
This eliminates the possibility that a user could later disable `safe-options`, as it is itself a common option.

Now, if `safe-options` is set to true, it cannot be later disabled or else an options exception will occur.