### PR TITLE
Simplify ProofRule::SKOLEMIZE

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -1303,12 +1303,6 @@ enum ENUM(ProofRule) : uint32_t
    *
    * .. math::
    *
-   *   \inferrule{\exists x_1\dots x_n.\> F\mid -}{F\sigma}
-   *
-   * or
-   *
-   * .. math::
-   *
    *   \inferrule{\neg (\forall x_1\dots x_n.\> F)\mid -}{\neg F\sigma}
    *
    * where :math:`\sigma` maps :math:`x_1,\dots,x_n` to their representative

--- a/include/cvc5/cvc5_skolem_id.h
+++ b/include/cvc5/cvc5_skolem_id.h
@@ -175,7 +175,8 @@ enum ENUM(SkolemId) : uint32_t
    */
   EVALUE(SHARED_SELECTOR),
   /**
-   * The n^th skolem for quantified formula Q.
+   * The n^th skolem for quantified formula Q, where Q is a universally quantified
+   * formula.
    *
    * - Number of skolem indices: ``2``
    *   - ``1:`` The quantified formula Q.

--- a/proofs/alf/cvc5/rules/Quantifiers.smt3
+++ b/proofs/alf/cvc5/rules/Quantifiers.smt3
@@ -16,15 +16,9 @@
   )
 )
 
-(declare-rule skolemize ((F Bool))
-  :premises (F)
-  :conclusion
-    (alf.match ((T Type) (x @List) (G Bool))
-        F
-        (
-          ((exists x G)       (substitute_list x (mk_skolems x F) G))
-          ((not (forall x G)) (substitute_list x (mk_skolems x (exists x (not G))) (not G)))
-        ))
+(declare-rule skolemize ((x @List) (G Bool))
+  :premises ((not (forall x G)))
+  :conclusion (substitute_list x (mk_skolems x (forall x G)) (not G))
 )
 
 (declare-rule skolem_intro ((T Type) (x T))

--- a/src/expr/elim_witness_converter.cpp
+++ b/src/expr/elim_witness_converter.cpp
@@ -32,10 +32,11 @@ Node ElimWitnessNodeConverter::postConvert(Node n)
     NodeManager* nm = nodeManager();
     SkolemManager* skm = nm->getSkolemManager();
     std::vector<Node> nchildren(n.begin(), n.end());
-    Node exists = nm->mkNode(Kind::EXISTS, nchildren);
+    nchildren[1] = nchildren[1].notNode();
+    Node q = nm->mkNode(Kind::FORALL, nchildren);
     Node k = skm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE,
-                                   {exists, n[0][0]});
-    d_exists.push_back(exists);
+                                   {q, n[0][0]});
+    d_exists.push_back(q.notNode());
     return k;
   }
   return n;

--- a/src/expr/elim_witness_converter.cpp
+++ b/src/expr/elim_witness_converter.cpp
@@ -34,13 +34,20 @@ Node ElimWitnessNodeConverter::postConvert(Node n)
     std::vector<Node> nchildren(n.begin(), n.end());
     nchildren[1] = nchildren[1].notNode();
     Node q = nm->mkNode(Kind::FORALL, nchildren);
+    Node qn = getNormalFormFor(q);
     Node k = skm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE,
-                                   {q, n[0][0]});
-    d_exists.push_back(q.notNode());
+                                   {qn, n[0][0]});
+    d_exists.push_back(qn.notNode());
     return k;
   }
   return n;
 }
+
+Node ElimWitnessNodeConverter::getNormalFormFor(const Node& q)
+{
+  return q;
+}
+
 const std::vector<Node>& ElimWitnessNodeConverter::getExistentials() const
 {
   return d_exists;

--- a/src/expr/elim_witness_converter.cpp
+++ b/src/expr/elim_witness_converter.cpp
@@ -35,18 +35,15 @@ Node ElimWitnessNodeConverter::postConvert(Node n)
     nchildren[1] = nchildren[1].notNode();
     Node q = nm->mkNode(Kind::FORALL, nchildren);
     Node qn = getNormalFormFor(q);
-    Node k = skm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE,
-                                   {qn, n[0][0]});
+    Node k =
+        skm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE, {qn, n[0][0]});
     d_exists.push_back(qn.notNode());
     return k;
   }
   return n;
 }
 
-Node ElimWitnessNodeConverter::getNormalFormFor(const Node& q)
-{
-  return q;
-}
+Node ElimWitnessNodeConverter::getNormalFormFor(const Node& q) { return q; }
 
 const std::vector<Node>& ElimWitnessNodeConverter::getExistentials() const
 {

--- a/src/expr/elim_witness_converter.h
+++ b/src/expr/elim_witness_converter.h
@@ -50,6 +50,7 @@ class ElimWitnessNodeConverter : protected EnvObj, public NodeConverter
    * a skolem variable for based on eliminating a witness term.
    */
   virtual Node getNormalFormFor(const Node& q);
+
  private:
   /** The list of existentials introduced by eliminating witness */
   std::vector<Node> d_exists;

--- a/src/expr/elim_witness_converter.h
+++ b/src/expr/elim_witness_converter.h
@@ -45,6 +45,11 @@ class ElimWitnessNodeConverter : protected EnvObj, public NodeConverter
    */
   const std::vector<Node>& getExistentials() const;
 
+  /**
+   * Get the normal form of a quantified formula for which we are introducing
+   * a skolem variable for based on eliminating a witness term.
+   */
+  virtual Node getNormalFormFor(const Node& q);
  private:
   /** The list of existentials introduced by eliminating witness */
   std::vector<Node> d_exists;

--- a/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
@@ -941,6 +941,28 @@ bool CegInstantiator::constructInstantiationInc(Node pv,
   }
 }
 
+/**
+ * A class for eliminating witness terms. We require overriding the methd of
+ * the base class to ensure that quantified formulas have been run through
+ * theory preprocessing.
+ */
+class PreprocessElimWitnessNodeConverter : public ElimWitnessNodeConverter 
+{
+public:
+  PreprocessElimWitnessNodeConverter(Env& env, Valuation& val) : ElimWitnessNodeConverter(env), d_val(val){}
+  /** 
+   * Get the normal form for quantified formula q, which must perform theory
+   * preprocessing.
+   */
+  Node getNormalFormFor(const Node& q) override
+  {
+    return d_val.getPreprocessedTerm(q);
+  }
+private:
+  /** Reference to a valuation */
+  Valuation& d_val;
+};
+
 bool CegInstantiator::doAddInstantiation(std::vector<Node>& vars,
                                          std::vector<Node>& subs)
 {
@@ -983,7 +1005,7 @@ bool CegInstantiator::doAddInstantiation(std::vector<Node>& vars,
   {
     if (expr::hasSubtermKind(Kind::WITNESS, s))
     {
-      ElimWitnessNodeConverter ewc(d_env);
+      PreprocessElimWitnessNodeConverter ewc(d_env, d_qstate.getValuation());
       Node sc = ewc.convert(s);
       const std::vector<Node>& wexists = ewc.getExistentials();
       exists.insert(exists.end(), wexists.begin(), wexists.end());

--- a/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
@@ -946,11 +946,14 @@ bool CegInstantiator::constructInstantiationInc(Node pv,
  * the base class to ensure that quantified formulas have been run through
  * theory preprocessing.
  */
-class PreprocessElimWitnessNodeConverter : public ElimWitnessNodeConverter 
+class PreprocessElimWitnessNodeConverter : public ElimWitnessNodeConverter
 {
-public:
-  PreprocessElimWitnessNodeConverter(Env& env, Valuation& val) : ElimWitnessNodeConverter(env), d_val(val){}
-  /** 
+ public:
+  PreprocessElimWitnessNodeConverter(Env& env, Valuation& val)
+      : ElimWitnessNodeConverter(env), d_val(val)
+  {
+  }
+  /**
    * Get the normal form for quantified formula q, which must perform theory
    * preprocessing.
    */
@@ -958,7 +961,8 @@ public:
   {
     return d_val.getPreprocessedTerm(q);
   }
-private:
+
+ private:
   /** Reference to a valuation */
   Valuation& d_val;
 };

--- a/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
@@ -942,9 +942,11 @@ bool CegInstantiator::constructInstantiationInc(Node pv,
 }
 
 /**
- * A class for eliminating witness terms. We require overriding the methd of
+ * A class for eliminating witness terms. We require overriding the metohd of
  * the base class to ensure that quantified formulas have been run through
- * theory preprocessing.
+ * theory preprocessing. This ensures that the skolem variables introduced
+ * align exactly with the quantified formula we will assert in the corresponding
+ * QUANTIFIERS_CEGQI_WITNESS lemma.
  */
 class PreprocessElimWitnessNodeConverter : public ElimWitnessNodeConverter
 {

--- a/src/theory/quantifiers/proof_checker.cpp
+++ b/src/theory/quantifiers/proof_checker.cpp
@@ -45,7 +45,6 @@ Node QuantifiersProofRuleChecker::checkInternal(
     const std::vector<Node>& children,
     const std::vector<Node>& args)
 {
-  NodeManager* nm = nodeManager();
   if (id == ProofRule::SKOLEM_INTRO)
   {
     Assert(children.empty());
@@ -57,28 +56,18 @@ Node QuantifiersProofRuleChecker::checkInternal(
   {
     Assert(children.size() == 1);
     Assert(args.empty());
-    // can use either negated FORALL or EXISTS
-    if (children[0].getKind() != Kind::EXISTS
-        && (children[0].getKind() != Kind::NOT
-            || children[0][0].getKind() != Kind::FORALL))
+    // must use negated FORALL
+    if (children[0].getKind() != Kind::NOT
+            || children[0][0].getKind() != Kind::FORALL)
     {
       return Node::null();
     }
-    Node exists;
-    if (children[0].getKind() == Kind::EXISTS)
-    {
-      exists = children[0];
-    }
-    else
-    {
-      std::vector<Node> echildren(children[0][0].begin(), children[0][0].end());
-      echildren[1] = echildren[1].notNode();
-      exists = nm->mkNode(Kind::EXISTS, echildren);
-    }
-    std::vector<Node> vars(exists[0].begin(), exists[0].end());
-    std::vector<Node> skolems = Skolemize::getSkolemConstants(exists);
-    Node res = exists[1].substitute(
+    Node q = children[0][0];
+    std::vector<Node> vars(q[0].begin(), q[0].end());
+    std::vector<Node> skolems = Skolemize::getSkolemConstants(q);
+    Node res = q[1].substitute(
         vars.begin(), vars.end(), skolems.begin(), skolems.end());
+    res = res.notNode();
     return res;
   }
   else if (id == ProofRule::INSTANTIATE)

--- a/src/theory/quantifiers/proof_checker.cpp
+++ b/src/theory/quantifiers/proof_checker.cpp
@@ -58,7 +58,7 @@ Node QuantifiersProofRuleChecker::checkInternal(
     Assert(args.empty());
     // must use negated FORALL
     if (children[0].getKind() != Kind::NOT
-            || children[0][0].getKind() != Kind::FORALL)
+        || children[0][0].getKind() != Kind::FORALL)
     {
       return Node::null();
     }

--- a/src/theory/quantifiers/skolemize.cpp
+++ b/src/theory/quantifiers/skolemize.cpp
@@ -66,12 +66,11 @@ TrustNode Skolemize::process(Node q)
     NodeManager* nm = NodeManager::currentNM();
     std::vector<Node> echildren(q.begin(), q.end());
     echildren[1] = echildren[1].notNode();
-    Node existsq = nm->mkNode(Kind::EXISTS, echildren);
-    std::vector<Node> vars(existsq[0].begin(), existsq[0].end());
     // cache the skolems in d_skolem_constants[q]
     std::vector<Node>& skolems = d_skolem_constants[q];
-    skolems = getSkolemConstants(existsq);
-    Node res = existsq[1].substitute(
+    skolems = getSkolemConstants(q);
+    std::vector<Node> vars(q[0].begin(), q[0].end());
+    Node res = q[1].substitute(
         vars.begin(), vars.end(), skolems.begin(), skolems.end());
     Node qnot = q.notNode();
     CDProof cdp(d_env);
@@ -106,15 +105,7 @@ TrustNode Skolemize::process(Node q)
 
 std::vector<Node> Skolemize::getSkolemConstants(const Node& q)
 {
-  if (q.getKind()==Kind::FORALL)
-  {
-    std::vector<Node> echildren(q.begin(), q.end());
-    echildren[1] = echildren[1].notNode();
-    NodeManager* nm = NodeManager::currentNM();
-    Node existsq = nm->mkNode(Kind::EXISTS, echildren);
-    return getSkolemConstants(existsq);
-  }
-  Assert(q.getKind() == Kind::EXISTS);
+  Assert (q.getKind()==Kind::FORALL);
   std::vector<Node> skolems;
   for (size_t i = 0, nvars = q[0].getNumChildren(); i < nvars; i++)
   {
@@ -125,7 +116,7 @@ std::vector<Node> Skolemize::getSkolemConstants(const Node& q)
 
 Node Skolemize::getSkolemConstant(const Node& q, size_t i)
 {
-  Assert(q.getKind() == Kind::EXISTS);
+  Assert(q.getKind() == Kind::FORALL);
   Assert(i < q[0].getNumChildren());
   NodeManager* nm = NodeManager::currentNM();
   SkolemManager* sm = nm->getSkolemManager();

--- a/src/theory/quantifiers/skolemize.cpp
+++ b/src/theory/quantifiers/skolemize.cpp
@@ -74,6 +74,7 @@ TrustNode Skolemize::process(Node q)
         vars.begin(), vars.end(), skolems.begin(), skolems.end());
     Node qnot = q.notNode();
     CDProof cdp(d_env);
+    res = res.notNode();
     cdp.addStep(res, ProofRule::SKOLEMIZE, {qnot}, {});
     std::shared_ptr<ProofNode> pf = cdp.getProofFor(res);
     std::vector<Node> assumps;

--- a/src/theory/quantifiers/skolemize.cpp
+++ b/src/theory/quantifiers/skolemize.cpp
@@ -106,7 +106,7 @@ TrustNode Skolemize::process(Node q)
 
 std::vector<Node> Skolemize::getSkolemConstants(const Node& q)
 {
-  Assert (q.getKind()==Kind::FORALL);
+  Assert(q.getKind() == Kind::FORALL);
   std::vector<Node> skolems;
   for (size_t i = 0, nvars = q[0].getNumChildren(); i < nvars; i++)
   {


### PR DESCRIPTION
Changes:
- ProofRule::SKOLEMIZE only expects negated universals as premises.
- Skolems of id `QUANTIFIERS_SKOLEMIZE` take a universal instead of an existential.

After doing this change, several BV invertibility condition benchmarks became "unknown", since the witness term elimination introduced in https://github.com/cvc5/cvc5/pull/10848 was not quite optimal: in particular, the skolems introduced when eliminating witness for BV invertibility condition instantiations would not align with the quantified formulas since we did not run theory preprocessing on them.  This fixes the issue by making the witness elimination take this into account via a new callback in this utility.