### PR TITLE
ci: Update update-pr action to fix issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
       group: update-pr
     steps:
       - name: Automatically update PR
-        uses: adRise/update-pr-branch@v0.8.0
+        uses: adRise/update-pr-branch@v0.8.1
         with:
           token: ${{ secrets.ACTION_USER_TOKEN }}
           base: 'main'


### PR DESCRIPTION
We recently updated the update-pr action to v0.8.0 to address a warning. Unfortunately, this release includes a bug that was fixed in a later release (v0.8.1). This PR updates the update-pr action to the latest version.