### PR TITLE
ci: Remove update-pr action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,18 +192,3 @@ jobs:
         github-token-latest: ${{ secrets.GITHUB_TOKEN }}
         github-token-release: ${{ secrets.ACTION_USER_TOKEN }}
         shell: ${{ matrix.shell }}
-
-  update-pr:
-    runs-on: ubuntu-latest
-    if: github.repository == 'cvc5/cvc5' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-    concurrency:
-      group: update-pr
-    steps:
-      - name: Automatically update PR
-        uses: adRise/update-pr-branch@v0.7.2
-        with:
-          token: ${{ secrets.ACTION_USER_TOKEN }}
-          base: 'main'
-          sort: 'created'
-          direction: 'asc'
-          required_approval_count: 1


### PR DESCRIPTION
We are replacing the update-pr action with GitHub merge queues.