### PR TITLE
Use value- (not default-) initialization for RealAlgebraicNumber

### DIFF
--- a/src/theory/arith/rewriter/rewrite_atom.cpp
+++ b/src/theory/arith/rewriter/rewrite_atom.cpp
@@ -161,7 +161,7 @@ std::pair<Node, RealAlgebraicNumber> removeMinAbsCoeff(Sum& sum)
 
 RealAlgebraicNumber removeConstant(Sum& sum)
 {
-  RealAlgebraicNumber res;
+  RealAlgebraicNumber res{};
   if (!sum.empty())
   {
     auto constantit = sum.begin();


### PR DESCRIPTION
Ensure RealAlgebraicNumber::removeConstant returns a fully initialized value.

If merged this will resolve #10918