### PR TITLE
cmake: Check repairwheel version

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -267,6 +267,7 @@ Dependencies for Language Bindings
   - `JDK >= 1.8 <https://www.java.com>`_
 
 - Python
+
   - `Cython <https://cython.org/>`_ >= 3.0.0
   - `pip <https://pip.pypa.io/>`_ >= 23.0
   - `pytest <https://docs.pytest.org/en/6.2.x/>`_

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -270,7 +270,7 @@ Dependencies for Language Bindings
   - `Cython <https://cython.org/>`_ >= 3.0.0
   - `pip <https://pip.pypa.io/>`_ >= 23.0
   - `pytest <https://docs.pytest.org/en/6.2.x/>`_
-  - `repairwheel <https://github.com/jvolkman/repairwheel>`_ >= 0.2.9
+  - `repairwheel <https://github.com/jvolkman/repairwheel>`_ >= 0.3.1
   - `setuptools <https://setuptools.pypa.io/>`_ >= 66.1.0
   - The source for the `pythonic API <https://github.com/cvc5/cvc5_pythonic_api>`_
 

--- a/cmake/FindRepairwheel.cmake
+++ b/cmake/FindRepairwheel.cmake
@@ -55,6 +55,7 @@ macro(get_repairwheel_version)
       COMMAND "${Repairwheel_EXECUTABLE}" --version
       RESULT_VARIABLE Repairwheel_VERSION_CHECK_RESULT
       OUTPUT_VARIABLE Repairwheel_VERSION
+      ERROR_QUIET
     )
   else()
     set(Repairwheel_VERSION_CHECK_RESULT 127) # Not-found exit code
@@ -78,7 +79,7 @@ if (Repairwheel_VERSION_CHECK_RESULT EQUAL 0)
     else()
       if (Repairwheel_VERSION VERSION_LESS ${Repairwheel_FIND_VERSION})
         set(INSTALL_REQUIREWHEEL TRUE)
-        set(INSTALL_REQUIREWHEEL_OPTION " -U")
+        set(INSTALL_REQUIREWHEEL_OPTION ";-U")
         set(INSTALL_REQUIREWHEEL_MESSAGE ">=${Repairwheel_FIND_VERSION}")
       endif()
     endif()
@@ -99,7 +100,7 @@ else()
       "Use --auto-download to let us install it for you.")
   else()
     set(INSTALL_REQUIREWHEEL TRUE)
-    set(INSTALL_REQUIREWHEEL_OPTION " -U")
+    set(INSTALL_REQUIREWHEEL_OPTION ";-U")
     set(INSTALL_REQUIREWHEEL_MESSAGE "")
   endif()
 endif()

--- a/cmake/FindRepairwheel.cmake
+++ b/cmake/FindRepairwheel.cmake
@@ -61,78 +61,62 @@ macro(get_repairwheel_version)
   endif()
 endmacro()
 
+set(INSTALL_REQUIREWHEEL FALSE)
+
 get_repairwheel_version()
 
 if (Repairwheel_VERSION_CHECK_RESULT EQUAL 0)
   set(Repairwheel_FOUND TRUE)
   message(STATUS "Found repairwheel version: ${Repairwheel_VERSION}")
   if (DEFINED Repairwheel_FIND_VERSION)
-    if(Repairwheel_FIND_VERSION_EXACT)
+    if (Repairwheel_FIND_VERSION_EXACT)
       if (NOT (Repairwheel_VERSION VERSION_EQUAL ${Repairwheel_FIND_VERSION}))
-        if(ENABLE_AUTO_DOWNLOAD)
-          message(STATUS
-            "Installing repairwheel==${Repairwheel_FIND_VERSION}"
-          )
-          execute_process(
-            COMMAND
-              ${Python_EXECUTABLE} -m pip install repairwheel==${Repairwheel_FIND_VERSION}
-              RESULT_VARIABLE REPAIRWHEEL_INSTALL_CMD_EXIT_CODE
-          )
-          if(REPAIRWHEEL_INSTALL_CMD_EXIT_CODE)
-            message(${Repairwheel_FIND_MODE}
-              "Could NOT install repairwheel==${Repairwheel_FIND_VERSION}"
-            )
-          else()
-            get_repairwheel_version()
-          endif()
-        else()
-          message(${Repairwheel_FIND_MODE}
-            "Repairwheel version ${Repairwheel_FIND_VERSION} is required, "
-            "but found version ${Repairwheel_VERSION}"
-          )
-        endif()
+        set(INSTALL_REQUIREWHEEL TRUE)
+        set(INSTALL_REQUIREWHEEL_OPTION "==${Repairwheel_FIND_VERSION}")
+        set(INSTALL_REQUIREWHEEL_MESSAGE "==${Repairwheel_FIND_VERSION}")
       endif()
     else()
       if (Repairwheel_VERSION VERSION_LESS ${Repairwheel_FIND_VERSION})
-        if(ENABLE_AUTO_DOWNLOAD)
-          message(STATUS "Upgrading repairwheel")
-          execute_process(COMMAND
-            ${Python_EXECUTABLE} -m pip install repairwheel -U
-            RESULT_VARIABLE REPAIRWHEEL_INSTALL_CMD_EXIT_CODE
-          )
-          if(REPAIRWHEEL_INSTALL_CMD_EXIT_CODE)
-            message(${Repairwheel_FIND_MODE}
-              "Could NOT install repairwheel >= ${Repairwheel_FIND_VERSION}"
-            )
-          else()
-            get_repairwheel_version()
-          endif()
-        else()
-          message(${Repairwheel_FIND_MODE}
-            "Repairwheel version >= ${Repairwheel_FIND_VERSION} is required, "
-            "but found version ${Repairwheel_VERSION}"
-          )
-        endif()
+        set(INSTALL_REQUIREWHEEL TRUE)
+        set(INSTALL_REQUIREWHEEL_OPTION " -U")
+        set(INSTALL_REQUIREWHEEL_MESSAGE ">=${Repairwheel_FIND_VERSION}")
       endif()
+    endif()
+    if (INSTALL_REQUIREWHEEL AND NOT ENABLE_AUTO_DOWNLOAD)
+      set(INSTALL_REQUIREWHEEL FALSE)
+      message(${Repairwheel_FIND_MODE}
+        "Repairwheel version ${Repairwheel_FIND_VERSION} is required, "
+        "but found version ${Repairwheel_VERSION}.\n"
+        "Use --auto-download to let us install it for you."
+      )
     endif()
   endif()
 else()
   set(Repairwheel_FOUND FALSE)
-  if(ENABLE_AUTO_DOWNLOAD)
-    message(STATUS "Installing repairwheel")
-    execute_process(
-      COMMAND ${Python_EXECUTABLE} -m pip install repairwheel
-      RESULT_VARIABLE REPAIRWHEEL_INSTALL_CMD_EXIT_CODE
-    )
-    if(REPAIRWHEEL_INSTALL_CMD_EXIT_CODE)
-      message(${Repairwheel_FIND_MODE} "Could NOT install repairwheel")
-    else()
-      set(Repairwheel_FOUND TRUE)
-      get_repairwheel_version()
-    endif()
-  else()
+  if (NOT ENABLE_AUTO_DOWNLOAD)
     message(${Repairwheel_FIND_MODE}
-      "Could NOT find repairwheel executable"
+      "Could NOT find repairwheel executable. "
+      "Use --auto-download to let us install it for you.")
+  else()
+    set(INSTALL_REQUIREWHEEL TRUE)
+    set(INSTALL_REQUIREWHEEL_OPTION " -U")
+    set(INSTALL_REQUIREWHEEL_MESSAGE "")
+  endif()
+endif()
+
+if(INSTALL_REQUIREWHEEL)
+  message(STATUS "Installing repairwheel${INSTALL_REQUIREWHEEL_MESSAGE}")
+  execute_process(
+    COMMAND
+    ${Python_EXECUTABLE} -m pip install repairwheel${INSTALL_REQUIREWHEEL_OPTION}
+    RESULT_VARIABLE REPAIRWHEEL_INSTALL_CMD_EXIT_CODE
+  )
+  if(REPAIRWHEEL_INSTALL_CMD_EXIT_CODE)
+    message(${Repairwheel_FIND_MODE}
+      "Could NOT install repairwheel${INSTALL_REQUIREWHEEL_MESSAGE}"
     )
+  else()
+    set(Repairwheel_FOUND TRUE)
+    get_repairwheel_version()
   endif()
 endif()

--- a/cmake/FindRepairwheel.cmake
+++ b/cmake/FindRepairwheel.cmake
@@ -86,7 +86,7 @@ if (Repairwheel_VERSION_CHECK_RESULT EQUAL 0)
     if (INSTALL_REQUIREWHEEL AND NOT ENABLE_AUTO_DOWNLOAD)
       set(INSTALL_REQUIREWHEEL FALSE)
       message(${Repairwheel_FIND_MODE}
-        "Repairwheel version ${Repairwheel_FIND_VERSION} is required, "
+        "Repairwheel version${INSTALL_REQUIREWHEEL_MESSAGE} is required, "
         "but found version ${Repairwheel_VERSION}.\n"
         "Use --auto-download to let us install it for you."
       )

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -21,7 +21,7 @@ if(NOT ONLY_PYTHON_EXT_SRC)
   # a directory within the Python wheel package so that
   # the package is self-contained. It works on Linux,
   # macOS, and Windows.
-  find_package(Repairwheel 0.2.9 REQUIRED)
+  find_package(Repairwheel 0.3.1 REQUIRED)
 endif()
 
 configure_file(genenums.py.in genenums.py)


### PR DESCRIPTION
This PR extends `FindRequirewheel` to check a version (if one is provided) and support the `EXACT` and `REQUIRED` keywords.