### PR TITLE
Replace declare-sort with declare-type, remove define-fun

### DIFF
--- a/proofs/alf/cvc5/Cvc5.smt3
+++ b/proofs/alf/cvc5/Cvc5.smt3
@@ -18,7 +18,7 @@
 
 ; extensions
 (declare-const fmf.card (-> Type Int Bool))
-(declare-sort @ho-elim-sort 1)
+(declare-type @ho-elim-sort (Type))
 (declare-const @fmf-fun-sort (-> (! Type :var T :implicit) T Type))
 
 ; evaluate, for all theories

--- a/proofs/alf/cvc5/programs/Arith.smt3
+++ b/proofs/alf/cvc5/programs/Arith.smt3
@@ -54,10 +54,10 @@
 ; Definitions of monomials and polynomials.
 ; A monomial is a list of terms that are ordered by `$compare_var` and a rational coefficient.
 ; A polynomial is a list of monomials whose monomials are ordered by `$compare_var`.
-(declare-sort @Monomial 0)
+(declare-type @Monomial ())
 (declare-const @mon (-> (! Type :var T :implicit) T Real @Monomial))
 
-(declare-sort @Polynomial 0)
+(declare-type @Polynomial ())
 (declare-const @poly.zero @Polynomial)
 (declare-const @poly (-> @Monomial @Polynomial @Polynomial) :right-assoc-nil @poly.zero)
 

--- a/proofs/alf/cvc5/programs/Strings.smt3
+++ b/proofs/alf/cvc5/programs/Strings.smt3
@@ -325,7 +325,7 @@
 )
 
 ; Compute the eager reduction predicate for (str.code s)
-(define-fun string_eager_reduction_to_code ((s String)) Bool
+(define string_eager_reduction_to_code ((s String))
   (let ((t (str.to_code s)))
   (ite
     (= (str.len s) 1)
@@ -397,7 +397,7 @@
   )
 )
 
-(define-fun re_unfold_pos_concat ((t String) (r RegLan)) (@Pair String Bool)
+(define re_unfold_pos_concat ((t String) (r RegLan))
   (re_unfold_pos_concat_rec t r r 0)
 )
 

--- a/proofs/alf/cvc5/programs/Utils.smt3
+++ b/proofs/alf/cvc5/programs/Utils.smt3
@@ -53,7 +53,7 @@
 (declare-const @pair (-> (! Type :var U :implicit) (! Type :var T :implicit) U T (@Pair U T)))
 
 ; untyped list
-(declare-sort @List 0)
+(declare-type @List ())
 (declare-const @list.nil @List)
 (declare-const @list (-> (! Type :var T :implicit) T @List @List) :right-assoc-nil @list.nil)
 

--- a/proofs/alf/cvc5/theories/Arith.smt3
+++ b/proofs/alf/cvc5/theories/Arith.smt3
@@ -1,7 +1,7 @@
 (include "../theories/Builtin.smt3")
 
-(declare-sort Int 0)
-(declare-sort Real 0)
+(declare-type Int ())
+(declare-type Real ())
 
 (declare-consts <numeral> Int)
 (declare-consts <rational> Real)

--- a/proofs/alf/cvc5/theories/Arrays.smt3
+++ b/proofs/alf/cvc5/theories/Arrays.smt3
@@ -1,6 +1,6 @@
 (include "../theories/Builtin.smt3")
 
-(declare-sort Array 2)
+(declare-type Array (Type Type))
 
 ; Core operators.
 (declare-const select (-> (! Type :var U :implicit) (! Type :var T :implicit)

--- a/proofs/alf/cvc5/theories/Bags.smt3
+++ b/proofs/alf/cvc5/theories/Bags.smt3
@@ -2,7 +2,7 @@
 (include "../theories/Builtin.smt3")
 (include "../theories/Arith.smt3")
 
-(declare-sort Bag 1)
+(declare-type Bag (Type))
 
 ; NOTE: permits non-set types
 (declare-const bag.empty (-> (! Type :var T) T))

--- a/proofs/alf/cvc5/theories/FloatingPoints.smt3
+++ b/proofs/alf/cvc5/theories/FloatingPoints.smt3
@@ -6,7 +6,7 @@
   ;(-> (! Int :var e) (! Int :var s) Type)
   (-> Int Int Type)
 )
-(declare-sort RoundingMode 0)
+(declare-type RoundingMode ())
 
 ; A floating point constant is a term having 3 bitvector children.
 ; Note this is used for both FLOATINGPOINT_FP and CONST_FLOATINGPOINT

--- a/proofs/alf/cvc5/theories/Sets.smt3
+++ b/proofs/alf/cvc5/theories/Sets.smt3
@@ -4,7 +4,7 @@
 (include "../theories/Datatypes.smt3")
 
 ; The set type
-(declare-sort Set 1)
+(declare-type Set (Type))
 
 ; Constants for the theory of sets.
 ; NOTE: empty and universe permits non-set types

--- a/proofs/alf/cvc5/theories/Strings.smt3
+++ b/proofs/alf/cvc5/theories/Strings.smt3
@@ -8,7 +8,7 @@
 ; Note that this is only for the purposes of simplifying the type rules below.
 ; Internally, cvc5 will never generate any proofs involving the Char type.
 (declare-type Char ())
-(define-fun String () Type (Seq Char))
+(define String () (Seq Char))
 
 ; The regular expression type.
 (declare-type RegLan ())

--- a/proofs/alf/cvc5/theories/Strings.smt3
+++ b/proofs/alf/cvc5/theories/Strings.smt3
@@ -7,11 +7,11 @@
 ; String is treated as a sequence of characters in the ALF signature.
 ; Note that this is only for the purposes of simplifying the type rules below.
 ; Internally, cvc5 will never generate any proofs involving the Char type.
-(declare-sort Char 0)
+(declare-type Char ())
 (define-fun String () Type (Seq Char))
 
 ; The regular expression type.
-(declare-sort RegLan 0)
+(declare-type RegLan ())
 
 ; String literals are strings.
 (declare-consts <string> String)


### PR DESCRIPTION
Technically, `declare-sort` is expected to be deprecated syntax in SMT-LIB version 3. This updates our use of `declare-sort` to `declare-type`.
Also removes `define-fun` which technically is syntax sugar for `declare-fun` and `assert` and thus should only be accepted in reference files.