### PR TITLE
cmake: Require pip before creating venv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,6 +387,7 @@ set(Python_BASE_EXECUTABLE "${Python_EXECUTABLE}"
     CACHE STRING "Base Python executable")
 
 if(ENABLE_AUTO_DOWNLOAD AND USE_PYTHON_VENV)
+  find_package(Pip REQUIRED)
   # Set up Python venv if one doesn't exist already
   set(VENV_PATH "${CMAKE_BINARY_DIR}/venv-${Python_VERSION}")
   if(NOT EXISTS ${VENV_PATH})


### PR DESCRIPTION
This PR prevents the build system from getting stuck when pip is not initially present on the system. Previously, if the build system created a virtual environment without pip and the user installed pip later, the build system would still look for pip in the already created virtual environment.