### PR TITLE
c++ api: Add hashing for grammars.

### DIFF
--- a/include/cvc5/cvc5.h
+++ b/include/cvc5/cvc5.h
@@ -3064,8 +3064,25 @@ class CVC5_EXPORT Grammar
 {
   friend class parser::Cmd;
   friend class Solver;
+  friend struct std::hash<Grammar>;
 
  public:
+  /**
+   * Nullary constructor. Needed for the Cython API.
+   */
+  Grammar();
+
+  /**
+   * Destructor for bookeeping.
+   */
+  ~Grammar();
+
+  /**
+   * Determine if this is the null grammar (Grammar::Grammar()).
+   * @return True if this grammar is the null grammar.
+   */
+  bool isNull() const;
+
   /**
    * Add `rule` to the set of rules corresponding to `ntSymbol`.
    * @param ntSymbol The non-terminal to which the rule is added.
@@ -3098,16 +3115,6 @@ class CVC5_EXPORT Grammar
    */
   std::string toString() const;
 
-  /**
-   * Nullary constructor. Needed for the Cython API.
-   */
-  Grammar();
-
-  /**
-   * Destructor for bookeeping.
-   */
-  ~Grammar();
-
  private:
   /**
    * Constructor.
@@ -3131,7 +3138,7 @@ class CVC5_EXPORT Grammar
    */
   TermManager* d_tm;
   /** The internal representation of this grammar. */
-  std::shared_ptr<internal::SygusGrammar> d_sg;
+  std::shared_ptr<internal::SygusGrammar> d_grammar;
 };
 
 /**
@@ -3141,6 +3148,21 @@ class CVC5_EXPORT Grammar
  * @return The output stream.
  */
 CVC5_EXPORT std::ostream& operator<<(std::ostream& out, const Grammar& g);
+
+}  // namespace cvc5
+
+namespace std {
+/**
+ * Hash function for grammar.
+ */
+template <>
+struct CVC5_EXPORT hash<cvc5::Grammar>
+{
+  size_t operator()(const cvc5::Grammar& grammar) const;
+};
+}  // namespace std
+
+namespace cvc5 {
 
 /* -------------------------------------------------------------------------- */
 /* Options                                                                    */
@@ -3572,6 +3594,12 @@ class CVC5_EXPORT Proof
    * Destructor.
    */
   ~Proof();
+
+  /**
+   * Determine if this is the null proof (Proof::Proof()).
+   * @return True if this grammar is the null proof.
+   */
+  bool isNull() const;
 
   /** @return The proof rule used by the root step of the proof. */
   ProofRule getRule() const;

--- a/src/expr/sygus_grammar.cpp
+++ b/src/expr/sygus_grammar.cpp
@@ -23,6 +23,7 @@
 #include "printer/printer.h"
 #include "printer/smt2/smt2_printer.h"
 #include "theory/datatypes/sygus_datatype_utils.h"
+#include "util/hash.h"
 
 namespace cvc5::internal {
 
@@ -358,3 +359,35 @@ std::string SygusGrammar::toString() const
 }
 
 }  // namespace cvc5::internal
+
+namespace std {
+size_t hash<cvc5::internal::SygusGrammar>::operator()(
+    const cvc5::internal::SygusGrammar& grammar) const
+{
+  uint64_t ret = cvc5::internal::fnv1a::offsetBasis;
+  for (const auto& v : grammar.d_sygusVars)
+  {
+    ret = cvc5::internal::fnv1a::fnv1a_64(ret,
+                                          std::hash<cvc5::internal::Node>{}(v));
+  }
+  for (const auto& nts : grammar.d_ntSyms)
+  {
+    ret = cvc5::internal::fnv1a::fnv1a_64(
+        ret, std::hash<cvc5::internal::Node>{}(nts));
+  }
+  for (const auto& r : grammar.d_rules)
+  {
+    uint64_t rhash = cvc5::internal::fnv1a::offsetBasis;
+    for (const auto& n : r.second)
+    {
+      rhash = cvc5::internal::fnv1a::fnv1a_64(
+          rhash, std::hash<cvc5::internal::Node>{}(n));
+    }
+    rhash = cvc5::internal::fnv1a::fnv1a_64(
+        rhash, std::hash<cvc5::internal::Node>{}(r.first));
+    ret = cvc5::internal::fnv1a::fnv1a_64(ret, rhash);
+  }
+  return cvc5::internal::fnv1a::fnv1a_64(
+      ret, std::hash<cvc5::internal::TypeNode>{}(grammar.d_datatype));
+}
+}  // namespace std

--- a/src/expr/sygus_grammar.h
+++ b/src/expr/sygus_grammar.h
@@ -30,6 +30,8 @@ namespace cvc5::internal {
  */
 class SygusGrammar
 {
+  friend struct std::hash<SygusGrammar>;
+
  public:
   /**
    * Constructor.
@@ -133,4 +135,11 @@ class SygusGrammar
 
 }  // namespace cvc5::internal
 
+namespace std {
+template <>
+struct hash<cvc5::internal::SygusGrammar>
+{
+  size_t operator()(const cvc5::internal::SygusGrammar& grammar) const;
+};
+}  // namespace std
 #endif

--- a/test/unit/api/c/capi_op_black.cpp
+++ b/test/unit/api/c/capi_op_black.cpp
@@ -46,8 +46,13 @@ TEST_F(TestCApiBlackOp, hash)
 {
   ASSERT_DEATH(cvc5_op_hash(nullptr), "invalid operator");
   std::vector<uint32_t> idxs = {4, 0};
-  (void)cvc5_op_hash(
-      cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_EXTRACT, idxs.size(), idxs.data()));
+  Cvc5Op op1 =
+      cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_EXTRACT, idxs.size(), idxs.data());
+  idxs = {4, 1};
+  Cvc5Op op2 =
+      cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_EXTRACT, idxs.size(), idxs.data());
+  ASSERT_EQ(cvc5_op_hash(op1), cvc5_op_hash(op1));
+  ASSERT_NE(cvc5_op_hash(op1), cvc5_op_hash(op2));
 }
 
 TEST_F(TestCApiBlackOp, get_kind)

--- a/test/unit/api/c/capi_sort_black.cpp
+++ b/test/unit/api/c/capi_sort_black.cpp
@@ -69,6 +69,8 @@ TEST_F(TestCApiBlackSort, hash)
 {
   ASSERT_DEATH(cvc5_sort_hash(nullptr), "invalid sort");
   (void)cvc5_sort_hash(d_int);
+  ASSERT_EQ(cvc5_sort_hash(d_int), cvc5_sort_hash(d_int));
+  ASSERT_NE(cvc5_sort_hash(d_int), cvc5_sort_hash(d_bool));
 }
 
 TEST_F(TestCApiBlackSort, compare)

--- a/test/unit/api/c/capi_term_black.cpp
+++ b/test/unit/api/c/capi_term_black.cpp
@@ -46,6 +46,10 @@ TEST_F(TestCApiBlackTerm, hash)
 {
   ASSERT_DEATH(cvc5_term_hash(nullptr), "invalid term");
   (void)cvc5_term_hash(cvc5_mk_integer_int64(d_tm, 2));
+  Cvc5Term x = cvc5_mk_var(d_tm, d_int, "x");
+  Cvc5Term y = cvc5_mk_var(d_tm, d_int, "y");
+  ASSERT_EQ(cvc5_term_hash(x), cvc5_term_hash(x));
+  ASSERT_NE(cvc5_term_hash(x), cvc5_term_hash(y));
 }
 
 TEST_F(TestCApiBlackTerm, compare)

--- a/test/unit/api/cpp/api_op_black.cpp
+++ b/test/unit/api/cpp/api_op_black.cpp
@@ -25,8 +25,12 @@ class TestApiBlackOp : public TestApi
 
 TEST_F(TestApiBlackOp, hash)
 {
-  std::hash<cvc5::Op> h;
-  ASSERT_NO_THROW(h(d_tm.mkOp(Kind::BITVECTOR_EXTRACT, {31, 1})));
+  std::hash<Op> h;
+  ASSERT_EQ(h(d_tm.mkOp(Kind::BITVECTOR_EXTRACT, {31, 1})),
+            h(d_tm.mkOp(Kind::BITVECTOR_EXTRACT, {31, 1})));
+  ASSERT_NE(h(d_tm.mkOp(Kind::BITVECTOR_EXTRACT, {31, 1})),
+            h(d_tm.mkOp(Kind::BITVECTOR_EXTRACT, {31, 2})));
+  (void)std::hash<Op>{}(Op());
 }
 
 TEST_F(TestApiBlackOp, getKind)

--- a/test/unit/api/cpp/api_sort_black.cpp
+++ b/test/unit/api/cpp/api_sort_black.cpp
@@ -49,8 +49,10 @@ class TestApiBlackSort : public TestApi
 
 TEST_F(TestApiBlackSort, hash)
 {
-  std::hash<cvc5::Sort> h;
-  ASSERT_NO_THROW(h(d_tm.getIntegerSort()));
+  std::hash<Sort> h;
+  ASSERT_EQ(h(d_tm.getIntegerSort()), h(d_tm.getIntegerSort()));
+  ASSERT_NE(h(d_tm.getIntegerSort()), h(d_tm.getStringSort()));
+  (void)std::hash<Sort>{}(Sort());
 }
 
 TEST_F(TestApiBlackSort, operators_comparison)

--- a/test/unit/api/cpp/api_term_black.cpp
+++ b/test/unit/api/cpp/api_term_black.cpp
@@ -23,7 +23,7 @@ class TestApiBlackTerm : public TestApi
 {
 };
 
-TEST_F(TestApiBlackTerm, eq)
+TEST_F(TestApiBlackTerm, equalHash)
 {
   Sort uSort = d_tm.mkUninterpretedSort("u");
   Term x = d_tm.mkVar(uSort, "x");
@@ -36,6 +36,10 @@ TEST_F(TestApiBlackTerm, eq)
   ASSERT_TRUE(x != y);
   ASSERT_FALSE((x == z));
   ASSERT_TRUE(x != z);
+
+  ASSERT_EQ(std::hash<Term>{}(x), std::hash<Term>{}(x));
+  ASSERT_NE(std::hash<Term>{}(x), std::hash<Term>{}(y));
+  (void)std::hash<Term>{}(Term());
 }
 
 TEST_F(TestApiBlackTerm, getId)

--- a/test/unit/api/cpp/datatype_api_black.cpp
+++ b/test/unit/api/cpp/datatype_api_black.cpp
@@ -189,6 +189,12 @@ TEST_F(TestApiBlackDatatype, equalHash)
             std::hash<DatatypeSelector>{}(head2));
   ASSERT_EQ(std::hash<Datatype>{}(dt1), std::hash<Datatype>{}(dt1));
   ASSERT_EQ(std::hash<Datatype>{}(dt1), std::hash<Datatype>{}(dt2));
+
+  (void)std::hash<DatatypeDecl>{}(DatatypeDecl());
+  (void)std::hash<DatatypeConstructorDecl>{}(DatatypeConstructorDecl());
+  (void)std::hash<DatatypeConstructor>{}(DatatypeConstructor());
+  //(void)std::hash<DatatypeSelector>{}(DatatypeSelector());
+  //(void)std::hash<Datatype>{}(Datatype());
 }
 
 TEST_F(TestApiBlackDatatype, mkDatatypeSorts)

--- a/test/unit/api/cpp/proof_black.cpp
+++ b/test/unit/api/cpp/proof_black.cpp
@@ -125,7 +125,7 @@ TEST_F(TestApiBlackProof, getArguments)
   ASSERT_NO_THROW(proof.getArguments());
 }
 
-TEST_F(TestApiBlackProof, eq)
+TEST_F(TestApiBlackProof, equalhash)
 {
   Proof x = createProof();
   Proof y = x.getChildren()[0];
@@ -139,6 +139,7 @@ TEST_F(TestApiBlackProof, eq)
   ASSERT_TRUE(x != z);
 
   ASSERT_TRUE(std::hash<Proof>()(x) == std::hash<Proof>()(x));
+  (void)std::hash<Proof>{}(Proof());
 }
 
 }  // namespace test


### PR DESCRIPTION
This also adds guards for `std::hash` over API types when the functions are called on null objects.