### PR TITLE
c api: Add missing tests in capi_solver_black.

### DIFF
--- a/src/api/c/cvc5.cpp
+++ b/src/api/c/cvc5.cpp
@@ -5401,6 +5401,27 @@ void cvc5_print_stats_safe(Cvc5* cvc5, int fd)
   CVC5_CAPI_TRY_CATCH_END;
 }
 
+bool cvc5_is_output_on(Cvc5* cvc5, const char* tag)
+{
+  bool res = false;
+  CVC5_CAPI_TRY_CATCH_BEGIN;
+  CVC5_CAPI_CHECK_NOT_NULL(cvc5);
+  CVC5_CAPI_CHECK_NOT_NULL(tag);
+  res = cvc5->d_solver.isOutputOn(tag);
+  CVC5_CAPI_TRY_CATCH_END;
+  return res;
+}
+
+const char* cvc5_get_version(Cvc5* cvc5)
+{
+  static thread_local std::string str;
+  CVC5_CAPI_TRY_CATCH_BEGIN;
+  CVC5_CAPI_CHECK_NOT_NULL(cvc5);
+  str = cvc5->d_solver.getVersion();
+  CVC5_CAPI_TRY_CATCH_END;
+  return str.c_str();
+}
+
 /* .................................................................... */
 /* SMT-LIB-style Term/Sort Creation                                     */
 /* .................................................................... */

--- a/test/unit/api/cpp/api_solver_black.cpp
+++ b/test/unit/api/cpp/api_solver_black.cpp
@@ -2378,7 +2378,7 @@ TEST_F(TestApiBlackSolver, tupleProject)
       projection.toString());
 }
 
-TEST_F(TestApiBlackSolver, Output)
+TEST_F(TestApiBlackSolver, output)
 {
   ASSERT_THROW(d_solver->isOutputOn("foo-invalid"), CVC5ApiException);
   ASSERT_THROW(d_solver->getOutput("foo-invalid"), CVC5ApiException);
@@ -2689,7 +2689,6 @@ TEST_F(TestApiBlackSolver, basicFiniteField)
 
 TEST_F(TestApiBlackSolver, basicFiniteFieldBase)
 {
-  Solver slv(d_tm);
   d_solver->setOption("produce-models", "true");
 
   Sort F = d_tm.mkFiniteFieldSort("101", 2);


### PR DESCRIPTION
Support for function cvc5::Solver::getOutput() is still missing as it is
currently unclear how to change its C++ interface to allow support in
other language bindings.