### PR TITLE
ff: bugfix: CoCoA tracer

### DIFF
--- a/src/theory/ff/cocoa_encoder.cpp
+++ b/src/theory/ff/cocoa_encoder.cpp
@@ -319,6 +319,8 @@ void CocoaEncoder::encodeFact(const Node& f)
     Poly diff = d_cache.at(f[0][0]) - d_cache.at(f[0][1]);
     p = diff * symPoly(d_diseqSyms.at(f)) - 1;
   }
+  // normalize; if we don't do it, CoCoA will in GB input, confusing our tracer.
+  p = p / CoCoA::LC(p);
   d_cache.insert({f, p});
   d_polyFacts.insert({extractStr(p), f});
 }

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -797,6 +797,7 @@ set(regress_0_tests
   regress0/ff/field_poly.smt2
   regress0/ff/multicheck.smt2
   regress0/ff/negneg.smt2
+  regress0/ff/issue10937.smt2
   regress0/ff/proj-issue705.smt2
   regress0/ff/randcompile-sound-3i-5t-circ.smt2
   regress0/ff/randcompile-sound-3i-5t-zokcirc.smt2

--- a/test/regress/cli/regress0/ff/issue10937.smt2
+++ b/test/regress/cli/regress0/ff/issue10937.smt2
@@ -1,0 +1,33 @@
+; REQUIRES: cocoa
+; EXPECT: unsat
+; COMMAND-LINE: --ff-solver gb
+; COMMAND-LINE: --ff-solver split
+
+; original:
+; ### start
+; s = Solver()
+;
+; mac1,mac2,m1,m2,k1,k2,d = FiniteFieldElems('mac1 mac2 m1 m2 k1 k2 d', 7)
+;
+; s.add(mac1 == k1 + (d * m1))
+; s.add(mac2 == k2 + (d * m2))
+; s.add(mac1 + mac2 != (k1 + k2) + (d * (m1 + m2)))
+; s.check()
+; ### end
+
+; translated into SMT2:
+(set-logic QF_FF)
+(define-sort F () (_ FiniteField 7))
+(declare-const mac1 F)
+(declare-const mac2 F)
+(declare-const m1 F)
+(declare-const m2 F)
+(declare-const k1 F)
+(declare-const k2 F)
+(declare-const d F)
+
+(assert (= mac1 (ff.add k1 (ff.mul d m1))))
+(assert (= mac2 (ff.add k2 (ff.mul d m2))))
+(assert (not (= (ff.add mac1 mac2) (ff.add k1 k2 (ff.mul d (ff.add m1 m2))))))
+(check-sat)
+


### PR DESCRIPTION
We give CoCoA polynomials P = {p1, ..., pN} and ask for a GB. We record poly ops that it does to get the GB.
If the GB has 1, we trace the ops to find a subset Q of P that gives 1. If we miss a poly op, then the trace fails.
The bug is a missing poly op: normalizing the elements of P to be monic. However, it's not clear how to trace CoCoA's normalizations. So now, we normalize ourselves, before calling GB.

fixes #10937