### PR TITLE
Replace unsafe call to IllegalArgument macro

### DIFF
--- a/src/theory/logic_info.cpp
+++ b/src/theory/logic_info.cpp
@@ -553,7 +553,10 @@ void LogicInfo::setLogicString(std::string logicString)
     } else {
       err << "junk (\"" << p << "\") at end of logic string: " << logicString;
     }
-    IllegalArgument(logicString, err.str().c_str());
+    // The strings logicString and p are user-provided and
+    // may include format specifiers (e.g. "QF_LIA%s").
+    // Do not use unsafe macros/functions such as IllegalArgument.
+    throw cvc5::internal::Exception(err.str().c_str());
   }
 
   // ensure a getLogic() returns the same thing as was set

--- a/test/regress/cli/regress0/issue10813-set-logic.smt2
+++ b/test/regress/cli/regress0/issue10813-set-logic.smt2
@@ -1,0 +1,2 @@
+; EXIT: 1
+(set-logic QF_LIA%s)


### PR DESCRIPTION
Fixes the last issue reported in #10813