### PR TITLE
Bump pythonic version

### DIFF
--- a/cmake/FindCVC5PythonicAPI.cmake
+++ b/cmake/FindCVC5PythonicAPI.cmake
@@ -39,7 +39,7 @@ else()
     CVC5PythonicAPI
     ${COMMON_EP_CONFIG}
     URL https://github.com/cvc5/cvc5_pythonic_api/archive/${CVC5PythonicAPI_VERSION}.zip
-    URL_HASH SHA256=a8c02f60d5a387dbd5e85cb6751a0ebcdfc5cc51
+    URL_HASH SHA256=2bbee4592f7e01869a1512d11d57dcd88453f44076306c0d294877e81e2c0ca9
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""

--- a/cmake/FindCVC5PythonicAPI.cmake
+++ b/cmake/FindCVC5PythonicAPI.cmake
@@ -10,7 +10,7 @@
 # directory for licensing information.
 # #############################################################################
 #
-# Find cvc5 pythonic api. 
+# Find cvc5 pythonic api.
 # CVC5PythonicAPI_FOUND - found cvc5 pythonic api
 # CVC5PythonicAPI_BASEDIR - the base directory of the cvc5 pythonic api
 ##
@@ -34,12 +34,12 @@ else()
     check_auto_download("CVC5PythonicAPI" "--no-python-bindings")
   endif()
 
-  set(CVC5PythonicAPI_VERSION "1582d36944310a96cc8e2dfc01e3682745866812")
+  set(CVC5PythonicAPI_VERSION "be54c2388b3271f657cad41cf5e3d6bc97cd51a1")
   ExternalProject_Add(
     CVC5PythonicAPI
     ${COMMON_EP_CONFIG}
     URL https://github.com/cvc5/cvc5_pythonic_api/archive/${CVC5PythonicAPI_VERSION}.zip
-    URL_HASH SHA1=4380d6bd58ef3e82acc51d4aaf6fd62ba38e6070
+    URL_HASH SHA256=a8c02f60d5a387dbd5e85cb6751a0ebcdfc5cc51
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""


### PR DESCRIPTION
This new version has support for unsat cores and proofs.

Marking as "major" because this is important for a deadline.