### PR TITLE
cmake: Set minimum version for system-wide Poly to 0.1.13.

### DIFF
--- a/cmake/FindPoly.cmake
+++ b/cmake/FindPoly.cmake
@@ -39,6 +39,7 @@ if(Poly_INCLUDE_DIR
   )
   string(REGEX MATCH "[0-9.]+" Poly_VERSION "${Poly_VERSION}")
 
+  set(Poly_FIND_VERSION "0.1.13")
   check_system_version("Poly")
 endif()
 


### PR DESCRIPTION
This will ensure that we build Poly if the system version is too old (0.1.11 is too old and causes build errors).