### PR TITLE
Detect EOF when parsing s-expressions in parser

### DIFF
--- a/src/parser/smt2/smt2_term_parser.cpp
+++ b/src/parser/smt2/smt2_term_parser.cpp
@@ -698,6 +698,11 @@ Term Smt2TermParser::parseSymbolicExpr()
         sstack.pop_back();
       }
       break;
+      case Token::EOF_TOK:
+      {
+        d_lex.parseError("Expected SMT-LIBv2 s-expression");
+      }
+      break;
       // ------------------- base case
       default:
       {

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1154,6 +1154,7 @@ set(regress_0_tests
   regress0/parser/issue10723-divisible0.smt2
   regress0/parser/issue10813-1.smt2
   regress0/parser/issue10813-2.smt2
+  regress0/parser/issue10889-sexpr-eof.smt2
   regress0/parser/issue5163.smt2
   regress0/parser/issue6908-get-value-uc.smt2
   regress0/parser/issue7274.smt2

--- a/test/regress/cli/regress0/parser/issue10889-sexpr-eof.smt2
+++ b/test/regress/cli/regress0/parser/issue10889-sexpr-eof.smt2
@@ -1,0 +1,11 @@
+; DISABLE-TESTER: dump
+; REQUIRES: no-competition
+; SCRUBBER: grep -o "Expected SMT-LIBv2 s-expression"
+; EXPECT: Expected SMT-LIBv2 s-expression
+; EXIT: 1
+(set-logic ALL)
+(set-option :incremental (true
+(declare-const i2 Int)
+(push 1)
+(assert (>= i2 -1))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/10889.