### PR TITLE
regress: Disable dsl-proof tester for regression.

### DIFF
--- a/test/regress/cli/regress0/ff/tlimit_per.smt2
+++ b/test/regress/cli/regress0/ff/tlimit_per.smt2
@@ -1,5 +1,6 @@
 ; REQUIRES: cocoa
 ; COMMAND-LINE: --tlimit-per 500 --incremental
+; DISABLE-TESTER: dsl-proof
 ; EXPECT: unknown
 ; EXPECT: unsat
 (set-info :smt-lib-version 2.6)


### PR DESCRIPTION
Regression tlimit_per.smt2 times out with dsl-proof tester in nightlies.