### PR TITLE
cmake: Fix for unit tests on Windows

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -38,7 +38,7 @@ add_custom_target(units
   DEPENDS build-units)
 
 set(CVC5_UNIT_TEST_FLAGS_BLACK
-  -D__BUILDING_CVC5LIB_UNIT_TEST -D__BUILDING_CVC5PARSERLIB_UNIT_TEST)
+  -D__BUILDING_CVC5LIB_UNIT_TEST -D__BUILDING_CVC5PARSERLIB_UNIT_TEST -Dcvc5_obj_EXPORTS)
 
 # Generate and add unit test.
 macro(cvc5_add_unit_test is_white name output_dir)
@@ -82,7 +82,7 @@ macro(cvc5_add_unit_test is_white name output_dir)
     else()
       set(test_name unit/${output_dir}/${name})
     endif()
-    add_test(${test_name} ${test_bin_dir}/${name})
+    add_test(${test_name} ${ENV_PATH_CMD} ${test_bin_dir}/${name})
     set_tests_properties(${test_name} PROPERTIES LABELS "unit")
     # set_tests_properties(${test_name} PROPERTIES FIXTURES_REQUIRED build_units_fixture)
   endif()


### PR DESCRIPTION
This change is enough to run unit tests on Windows with a static build. Running unit tests with a shared build requires further investigation.