### PR TITLE
cmake: Fix the installation of the static CoCoA library

### DIFF
--- a/cmake/FindCoCoA.cmake
+++ b/cmake/FindCoCoA.cmake
@@ -115,6 +115,10 @@ else()
   add_dependencies(CoCoA CoCoA-EP)
   # Install static library only if it is a static build.
   if(NOT BUILD_SHARED_LIBS)
-    install(FILES ${CoCoA_LIBRARIES} TYPE ${LIB_BUILD_TYPE})
+    set(CoCoA_INSTALLED_LIBRARY
+      "${DEPS_BASE}/lib/libcocoa-${CoCoA_VERSION}.a"
+    )
+    install(FILES ${CoCoA_INSTALLED_LIBRARY} TYPE ${LIB_BUILD_TYPE}
+            RENAME "libcocoa.a")
   endif()
 endif()


### PR DESCRIPTION
The `libcocoa.a` file installed in `${DEPS_BASE}/lib/` is a symbolic link, not the actual library file. This installs the actual CoCoA static library.