### PR TITLE
Retire competition scripts from 2024 and remove usage of --arrays-weak-equiv

### DIFF
--- a/contrib/competitions/smt-comp/run-script-smtcomp-current
+++ b/contrib/competitions/smt-comp/run-script-smtcomp-current
@@ -144,9 +144,9 @@ QF_AUFBV)
   finishwith --decision=stoponly
   ;;
 QF_ABV)
-  trywith 50 --ite-simp --simp-with-care --repeat-simp --arrays-weak-equiv
-  trywith 500 --arrays-weak-equiv
-  finishwith --ite-simp --simp-with-care --repeat-simp --arrays-weak-equiv
+  trywith 50 --ite-simp --simp-with-care --repeat-simp
+  trywith 500
+  finishwith --ite-simp --simp-with-care --repeat-simp
   ;;
 QF_BV|QF_UFBV)
   finishwith --bitblast=eager --bv-assert-input
@@ -161,7 +161,7 @@ QF_AUFNIA)
   finishwith --decision=justification --no-arrays-eager-index --arrays-eager-lemmas
   ;;
 QF_ALIA)
-  trywith 140 --decision=justification --arrays-weak-equiv
+  trywith 140 --decision=justification
   finishwith --decision=stoponly --no-arrays-eager-index --arrays-eager-lemmas
   ;;
 QF_S|QF_SLIA)

--- a/contrib/competitions/smt-comp/run-script-smtcomp-current-unsat-cores
+++ b/contrib/competitions/smt-comp/run-script-smtcomp-current-unsat-cores
@@ -42,7 +42,7 @@ QF_AUFBV)
   finishwith --decision=stoponly
   ;;
 QF_ABV)
-  finishwith --arrays-weak-equiv
+  finishwith
   ;;
 QF_UFBV)
   finishwith

--- a/contrib/competitions/smt-comp/run-script-smtcomp2024
+++ b/contrib/competitions/smt-comp/run-script-smtcomp2024
@@ -1,0 +1,177 @@
+#!/bin/bash
+
+cvc5=$(dirname "$(readlink -f "$0")")/cvc5
+bench="$1"
+
+# Output other than "sat"/"unsat" is either written to stderr or to "err.log"
+# in the directory specified by $2 if it has been set (e.g. when running on
+# StarExec).
+out_file=/dev/stderr
+
+if [ -n "$STAREXEC_WALLCLOCK_LIMIT" ]; then
+  # If we are running on StarExec, don't print to `/dev/stderr/` even when $2
+  # is not provided.
+  out_file="/dev/null"
+fi
+
+if [ -n "$2" ]; then
+  out_file="$2/err.log"
+fi
+
+logic=$(expr "$(grep -m1 '^[^;]*set-logic' "$bench")" : ' *(set-logic  *\([A-Z_]*\) *) *$')
+
+# use: trywith [params..]
+# to attempt a run.  Only thing printed on stdout is "sat" or "unsat", in which
+# case this run script terminates immediately.  Otherwise, this function
+# returns normally and prints the output of the solver to $out_file.
+function trywith {
+  limit=$1; shift;
+  result="$({ ulimit -S -t "$limit"; $cvc5 -L smt2.6 --no-incremental --no-type-checking --no-interactive --fp-exp "$@" $bench; } 2>&1)"
+  case "$result" in
+    sat|unsat) echo "$result"; exit 0;;
+    *)         echo "$result" &> "$out_file";;
+  esac
+}
+
+# use: finishwith [params..]
+# to run cvc5. Only "sat" or "unsat" are output. Other outputs are written to
+# $out_file.
+function finishwith {
+  result="$({ $cvc5 -L smt2.6 --no-incremental --no-type-checking --no-interactive "$@" $bench; } 2>&1)"
+  case "$result" in
+    sat|unsat) echo "$result"; exit 0;;
+    *)         echo "$result" &> "$out_file";;
+  esac
+}
+
+# the following is designed for a run time of 20 min.
+case "$logic" in
+
+QF_LRA)
+  trywith 200 --miplib-trick --miplib-trick-subs=4 --use-approx --lemmas-on-replay-failure --replay-early-close-depth=4 --replay-lemma-reject-cut=128 --replay-reject-cut=512 --unconstrained-simp --use-soi
+  finishwith --no-restrict-pivots --use-soi --new-prop --unconstrained-simp
+  ;;
+QF_LIA)
+  # same as QF_LRA but add --pb-rewrites
+  finishwith --miplib-trick --miplib-trick-subs=4 --use-approx --lemmas-on-replay-failure --replay-early-close-depth=4 --replay-lemma-reject-cut=128 --replay-reject-cut=512 --unconstrained-simp --use-soi --pb-rewrites --ite-simp --simp-ite-compress
+  ;;
+QF_NIA)
+  trywith 420 --nl-ext-tplanes --decision=justification
+  trywith 60 --nl-ext-tplanes --decision=internal
+  trywith 60 --no-nl-ext-tplanes --decision=internal
+  trywith 60 --no-arith-brab --nl-ext-tplanes --decision=internal
+  # this totals up to more than 20 minutes, although notice that smaller bit-widths may quickly fail
+  trywith 300 --solve-int-as-bv=2 --bitblast=eager
+  trywith 300 --solve-int-as-bv=4 --bitblast=eager
+  trywith 300 --solve-int-as-bv=8 --bitblast=eager
+  trywith 300 --solve-int-as-bv=16 --bitblast=eager
+  trywith 600 --solve-int-as-bv=32 --bitblast=eager
+  finishwith --nl-ext-tplanes --decision=internal
+  ;;
+QF_NRA)
+  trywith 600 --decision=justification
+  trywith 300 --decision=internal --no-nl-cov --nl-ext=full --nl-ext-tplanes
+  finishwith --decision=internal --nl-ext=none
+  ;;
+# all logics with UF + quantifiers should either fall under this or special cases below
+ALIA|AUFLIA|AUFLIRA|AUFNIRA|UF|UFBVLIA|UFBVFP|UFIDL|UFLIA|UFLRA|UFNIA|UFDT|UFDTLIA|UFDTLIRA|AUFDTLIA|AUFDTLIRA|AUFBV|AUFBVDTLIA|AUFBVFP|AUFNIA|UFFPDTLIRA|UFFPDTNIRA)
+  # initial runs 1 min
+  trywith 30 --simplification=none --enum-inst
+  trywith 30 --no-e-matching --enum-inst
+  trywith 30 --no-e-matching --enum-inst --enum-inst-sum
+  # trigger selections 3 min
+  trywith 30 --relevant-triggers --enum-inst
+  trywith 30 --trigger-sel=max --enum-inst
+  trywith 30 --multi-trigger-when-single --enum-inst
+  trywith 30 --multi-trigger-when-single --multi-trigger-priority --enum-inst
+  trywith 30 --multi-trigger-cache --enum-inst
+  trywith 30 --no-multi-trigger-linear --enum-inst
+  # other 4 min 30 sec
+  trywith 30 --pre-skolem-quant=on --enum-inst
+  trywith 30 --inst-when=full --enum-inst
+  trywith 30 --no-e-matching --no-cbqi --enum-inst
+  trywith 30 --enum-inst --quant-ind
+  trywith 30 --decision=internal --simplification=none --no-inst-no-entail --no-cbqi --enum-inst
+  trywith 30 --decision=internal --enum-inst --enum-inst-sum
+  trywith 30 --term-db-mode=relevant --enum-inst
+  trywith 30 --enum-inst-interleave --enum-inst
+  trywith 30 --preregister-mode=lazy --enum-inst
+  # finite model find and mbqi 3 min 30 sec
+  trywith 30 --finite-model-find --fmf-mbqi=none
+  trywith 30 --finite-model-find --decision=internal
+  trywith 30 --finite-model-find --macros-quant --macros-quant-mode=all
+  trywith 60 --finite-model-find --e-matching
+  trywith 60 --mbqi
+  # long runs 3 min
+  trywith 180 --finite-model-find --decision=internal
+  finishwith --enum-inst
+  ;;
+UFBV)
+  # most problems in UFBV are essentially BV
+  trywith 150 --sygus-inst
+  trywith 150 --mbqi --no-cegqi --no-sygus-inst
+  trywith 300 --enum-inst --cegqi-nested-qe --decision=internal
+  trywith 300 --mbqi-fast-sygus --no-cegqi --no-sygus-inst
+  trywith 30 --enum-inst --no-cegqi-innermost --global-negate
+  finishwith --finite-model-find
+  ;;
+ABV|BV)
+  trywith 80 --enum-inst
+  trywith 80 --sygus-inst
+  trywith 80 --mbqi --no-cegqi --no-sygus-inst
+  trywith 300 --mbqi-fast-sygus --no-cegqi --no-sygus-inst
+  trywith 300 --enum-inst --cegqi-nested-qe --decision=internal
+  trywith 30 --enum-inst --no-cegqi-bv
+  trywith 30 --enum-inst --cegqi-bv-ineq=eq-slack
+  # finish 10min
+  finishwith --enum-inst --no-cegqi-innermost --global-negate
+  ;;
+ABVFP|ABVFPLRA|BVFP|FP|NIA|NRA|BVFPLRA)
+  trywith 300 --mbqi-fast-sygus --no-cegqi --no-sygus-inst
+  trywith 300 --enum-inst --nl-ext-tplanes
+  trywith 60 --mbqi --no-cegqi --no-sygus-inst
+  finishwith --sygus-inst
+  ;;
+LIA|LRA)
+  trywith 30 --enum-inst
+  trywith 300 --enum-inst --cegqi-nested-qe
+  trywith 30 --mbqi --no-cegqi --no-sygus-inst
+  trywith 30 --mbqi-fast-sygus --no-cegqi --no-sygus-inst
+  finishwith --enum-inst --cegqi-nested-qe --decision=internal
+  ;;
+QF_AUFBV)
+  trywith 600
+  finishwith --decision=stoponly
+  ;;
+QF_ABV)
+  trywith 50 --ite-simp --simp-with-care --repeat-simp
+  trywith 500
+  finishwith --ite-simp --simp-with-care --repeat-simp
+  ;;
+QF_BV|QF_UFBV)
+  finishwith --bitblast=eager --bv-assert-input
+  ;;
+QF_AUFLIA)
+  finishwith --no-arrays-eager-index --arrays-eager-lemmas --decision=justification
+  ;;
+QF_AX)
+  finishwith --no-arrays-eager-index --arrays-eager-lemmas --decision=internal
+  ;;
+QF_AUFNIA)
+  finishwith --decision=justification --no-arrays-eager-index --arrays-eager-lemmas
+  ;;
+QF_ALIA)
+  trywith 140 --decision=justification
+  finishwith --decision=stoponly --no-arrays-eager-index --arrays-eager-lemmas
+  ;;
+QF_S|QF_SLIA)
+  trywith 300 --strings-exp --strings-fmf --no-jh-rlv-order
+  finishwith --strings-exp --no-jh-rlv-order
+  ;;
+*)
+  # just run the default
+  finishwith
+  ;;
+
+esac
+

--- a/contrib/competitions/smt-comp/run-script-smtcomp2024-incremental
+++ b/contrib/competitions/smt-comp/run-script-smtcomp2024-incremental
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+cvc5=$(dirname "$(readlink -f "$0")")/cvc5
+
+line=""
+while [[ -z "$line" ]]; do
+  read line
+done
+if [ "$line" != '(set-option :print-success true)' ]; then
+  echo 'ERROR: first line supposed to be set-option :print-success, but got: "'"$line"'"' >&2
+  exit 1
+fi
+echo success
+line=""
+while [[ -z "$line" ]]; do
+  read line
+done
+logic=$(expr "$line" : ' *(set-logic  *\([A-Z_]*\) *) *$')
+if [ -z "$logic" ]; then
+  echo 'ERROR: second line supposed to be set-logic, but got: "'"$line"'"' >&2
+  exit 1
+fi
+echo success
+
+function runcvc5 {
+  # we run in this way for line-buffered input, otherwise memory's a
+  # concern (plus it mimics what we'll end up getting from an
+  # application-track trace runner?)
+  $cvc5 --incremental --force-logic="$logic" -L smt2.6 --print-success --no-type-checking --no-interactive --fp-exp "$@" <&0-
+}
+
+case "$logic" in
+
+QF_AUFLIA)
+  runcvc5 --no-arrays-eager-index --arrays-eager-lemmas
+  ;;
+QF_BV)
+  runcvc5 --bitblast=eager
+  ;;
+*)
+  # just run the default
+  runcvc5
+  ;;
+
+esac

--- a/contrib/competitions/smt-comp/run-script-smtcomp2024-model-validation
+++ b/contrib/competitions/smt-comp/run-script-smtcomp2024-model-validation
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+cvc5=$(dirname "$(readlink -f "$0")")/cvc5
+bench="$1"
+
+logic=$(expr "$(grep -m1 '^[^;]*set-logic' "$bench")" : ' *(set-logic  *\([A-Z_]*\) *) *$')
+
+# use: finishwith [params..]
+# to run cvc5 and let it output whatever it will to stdout.
+function finishwith {
+  $cvc5 -L smt2.6 --no-incremental --no-type-checking --no-interactive --fp-exp "$@" $bench
+}
+
+case "$logic" in
+
+QF_LRA)
+  finishwith --no-restrict-pivots --use-soi --new-prop
+  ;;
+QF_LIA)
+  finishwith --miplib-trick --miplib-trick-subs=4 --use-approx --lemmas-on-replay-failure --replay-early-close-depth=4 --replay-lemma-reject-cut=128 --replay-reject-cut=512 --use-soi --pb-rewrites --ite-simp --simp-ite-compress
+  ;;
+QF_BV)
+  finishwith --bv-assert-input
+  ;;
+*)
+  # just run the default
+  finishwith
+  ;;
+
+esac

--- a/contrib/competitions/smt-comp/run-script-smtcomp2024-unsat-cores
+++ b/contrib/competitions/smt-comp/run-script-smtcomp2024-unsat-cores
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+cvc5=$(dirname "$(readlink -f "$0")")/cvc5
+bench="$1"
+
+logic=$(expr "$(grep -m1 '^[^;]*set-logic' "$bench")" : ' *(set-logic  *\([A-Z_]*\) *) *$')
+
+# use: finishwith [params..]
+# to run cvc5 and let it output whatever it will to stdout.
+function finishwith {
+  $cvc5 -L smt2.6 --no-incremental --no-type-checking --no-interactive --fp-exp "$@" $bench
+}
+
+case "$logic" in
+
+QF_LRA)
+  finishwith --no-restrict-pivots --use-soi --new-prop
+  ;;
+QF_LIA)
+  finishwith --miplib-trick --miplib-trick-subs=4 --use-approx --lemmas-on-replay-failure --replay-early-close-depth=4 --replay-lemma-reject-cut=128 --replay-reject-cut=512 --use-soi
+  ;;
+QF_NIA)
+  finishwith --nl-ext-tplanes
+  ;;
+# all logics with UF + quantifiers should either fall under this or special cases below
+ALIA|AUFLIA|AUFLIRA|AUFNIRA|UF|UFBVLIA|UFIDL|UFLIA|UFLRA|UFNIA|UFDT|UFDTLIA|UFDTLIRA|AUFDTLIA|AUFDTLIRA|AUFBV|AUFBVDTLIA|AUFBVFP|AUFNIA|UFFPDTLIRA|UFFPDTNIRA|ABVFP|BVFP|FP)
+  finishwith --full-saturate-quant
+  ;;
+UFBV)
+  finishwith --finite-model-find
+  ;;
+BV)
+  finishwith --full-saturate-quant --decision=internal
+  ;;
+LIA|LRA)
+  finishwith --full-saturate-quant --cegqi-nested-qe --decision=internal
+  ;;
+NIA|NRA)
+  finishwith --full-saturate-quant --cegqi-nested-qe --decision=internal
+  ;;
+QF_AUFBV)
+  finishwith --decision=stoponly
+  ;;
+QF_ABV)
+  finishwith --arrays-weak-equiv
+  ;;
+QF_UFBV)
+  finishwith
+  ;;
+QF_BV)
+  finishwith
+  ;;
+QF_AUFLIA)
+  finishwith --no-arrays-eager-index --arrays-eager-lemmas --decision=justification
+  ;;
+QF_AX)
+  finishwith --no-arrays-eager-index --arrays-eager-lemmas --decision=internal
+  ;;
+QF_AUFNIA)
+  finishwith --decision=justification --no-arrays-eager-index --arrays-eager-lemmas
+  ;;
+QF_ALIA)
+  finishwith --decision=stoponly --no-arrays-eager-index --arrays-eager-lemmas
+  ;;
+QF_S|QF_SLIA)
+  finishwith --strings-exp
+  ;;
+*)
+  # just run the default
+  finishwith
+  ;;
+
+esac
+


### PR DESCRIPTION
This pull request creates a copy of the competition scripts to document the state of the scripts as they were used for the 2024 competition.

It also removes all uses of the experimental option `--arrays-weak-equiv`.  This is done in two commits. The first commit removes it from the single query script, and the second commit removes it from the unsat-cores script after the 2024 copies are created.
The problem with `--arrays-weak-equiv` is documented here.