### PR TITLE
docs: Add Google Analytics

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -148,5 +148,5 @@ runs:
         python3 -m pip install \
           sphinx==7.1.2 \
           sphinxcontrib-bibtex==2.5.0 sphinx-tabs==3.4.1 sphinx-rtd-theme==1.3.0 breathe==4.35.0 \
-          sphinxcontrib-programoutput==0.17
+          sphinxcontrib-programoutput==0.17 sphinxcontrib-googleanalytics==0.4
         echo "::endgroup::"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         build:
           - name: ubuntu:production
             os: ubuntu-20.04
-            config: production --auto-download --all-bindings --editline --docs
+            config: production --auto-download --all-bindings --editline --docs --docs-ga
             cache-key: production
             strip-bin: strip
             python-bindings: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ option(BUILD_BINDINGS_JAVA "Build Java bindings based on new C++ API ")
 
 # Api documentation
 option(BUILD_DOCS "Build Api documentation")
+option(BUILD_DOCS_GA "Build API documentation with Google Analytics")
 
 option(BUILD_GMP "Build GMP from sources")
 

--- a/configure.sh
+++ b/configure.sh
@@ -27,6 +27,7 @@ General options;
   --win64-native           natively compile for Windows 64 bit
   --ninja                  use Ninja build system
   --docs                   build Api documentation
+  --docs-ga                build API documentation with Google Analytics
 
 
 Features:
@@ -115,6 +116,7 @@ cryptominisat=default
 debug_context_mm=default
 debug_symbols=default
 docs=default
+docs_ga=default
 glpk=default
 gpl=default
 kissat=default
@@ -243,6 +245,9 @@ do
 
     --docs) docs=ON;;
     --no-docs) docs=OFF;;
+
+    --docs-ga) docs_ga=ON;;
+    --no-docs-ga) docs_ga=OFF;;
 
     --glpk) glpk=ON;;
     --no-glpk) glpk=OFF;;
@@ -394,6 +399,8 @@ fi
   && cmake_opts="$cmake_opts -DENABLE_UNIT_TESTING=$unit_testing"
 [ $docs != default ] \
   && cmake_opts="$cmake_opts -DBUILD_DOCS=$docs"
+[ $docs_ga != default ] \
+  && cmake_opts="$cmake_opts -DBUILD_DOCS_GA=$docs_ga"
 [ $python_bindings != default ] \
   && cmake_opts="$cmake_opts -DBUILD_BINDINGS_PYTHON=$python_bindings"
 [ $python_only_src != default ] \

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -23,6 +23,12 @@ add_subdirectory(api)
 
 set(SPHINX_INPUT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(SPHINX_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/sphinx)
+if(BUILD_DOCS_GA)
+  check_python_module(sphinxcontrib.googleanalytics sphinxcontrib.googleanalytics)
+  set(GOOGLE_ANALYTICS_ENABLE "True")
+else()
+  set(GOOGLE_ANALYTICS_ENABLE "False")
+endif()
 
 configure_file(conf.py.in ${CMAKE_CURRENT_BINARY_DIR}/conf.py)
 
@@ -30,7 +36,7 @@ add_custom_target(
   docs
   DEPENDS docs-cpp docs-java docs-python gen-options cvc5-bin
   COMMAND
-    ${SPHINX_EXECUTABLE} -v -b html -c ${CMAKE_CURRENT_BINARY_DIR}
+    ${Python_EXECUTABLE} ${SPHINX_EXECUTABLE} -v -b html -c ${CMAKE_CURRENT_BINARY_DIR}
     # Tell Breathe where to find the Doxygen output
     -Dbreathe_projects.cvc5=${CPP_DOXYGEN_XML_DIR}
     -Dbreathe_projects.std=${CPP_DOXYGEN_XML_DIR} ${SPHINX_INPUT_DIR}

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -57,6 +57,10 @@ extensions = [
         'run_command',
 ]
 
+# Google analytics
+if ${GOOGLE_ANALYTICS_ENABLE}:
+  extensions += ['sphinxcontrib.googleanalytics']
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
@@ -140,6 +144,10 @@ cpp_index_common_prefix = ["cvc5::"]
 
 bibtex_bibfiles = ['references.bib']
 
+# -- extension:: sphinxcontrib.googleanalytics -------------------------------
+
+googleanalytics_id = 'G-ML12X2V35B'
+googleanalytics_enabled = ${GOOGLE_ANALYTICS_ENABLE}
 
 # -- custom extension:: examples ---------------------------------------------
 


### PR DESCRIPTION
This adds the bits in the docs build system to add the Google Analytics tags. This will be enabled for the documentation uploaded via CI. By default documentation is not built with GA. This needs to be explicitly enabled via `--docs-ga`.