### PR TITLE
bags: Disable proof testers for regression.

### DIFF
--- a/test/regress/cli/regress2/bags/reduce_constants_dup.smt2
+++ b/test/regress/cli/regress2/bags/reduce_constants_dup.smt2
@@ -1,3 +1,6 @@
+; DISABLE-TESTER: unsat-core
+; DISABLE-TESTER: proof
+; DISABLE-TESTER: dsl-proof
 ; DISABLE-TESTER: alf
 ; DISABLE-TESTER: lfsc
 ; test name: testReduceConstantsDup2


### PR DESCRIPTION
Regression regress2/bags/reduce_constants_dup.smt2 times out in the nightlies asan builds with proof testers.