### PR TITLE
ci: Add missing libraries to Win64 packages

### DIFF
--- a/.github/actions/add-package/action.yml
+++ b/.github/actions/add-package/action.yml
@@ -27,6 +27,17 @@ runs:
         # They are built for testing purposes, but
         # only work for the specific CI Python version.
         rm -rf ${{ inputs.build-dir }}/install/lib/python*
+        rm -rf ${{ inputs.build-dir }}/install/lib/site-packages
+
+        if [[ "$RUNNER_OS" == "Windows" ]]; then
+          if [ -f ${{ inputs.build-dir }}/install/bin/libcvc5.dll ]; then
+            cp /mingw64/bin/libgcc_s_seh-1.dll ${{ inputs.build-dir }}/install/bin/
+            cp /mingw64/bin/libstdc++-6.dll ${{ inputs.build-dir }}/install/bin/
+            cp /mingw64/bin/libwinpthread-1.dll ${{ inputs.build-dir }}/install/bin/
+          else
+            cp /mingw64/lib/libgmp.a ${{ inputs.build-dir }}/install/lib/
+          fi
+        fi
 
         # Copy COPYING file and licenses directory to install directory
         cp COPYING ${{ inputs.build-dir }}/install/


### PR DESCRIPTION
It also removes the Python bindings built for testing purposes.