### PR TITLE
ci: Build GMP and CLN from source for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         build:
           - name: ubuntu:production
             os: ubuntu-20.04
-            config: production --auto-download --all-bindings --editline --docs
+            config: production --auto-download --all-bindings --editline --docs -DBUILD_GMP=1
             cache-key: production
             strip-bin: strip
             python-bindings: true
@@ -119,7 +119,7 @@ jobs:
           # GPL versions
           - name: ubuntu:production-gpl
             os: ubuntu-20.04
-            config: production --auto-download --editline --gpl --cln --glpk --cocoa
+            config: production --auto-download --editline --gpl --cln --glpk --cocoa -DBUILD_GMP=1 -DBUILD_CLN=1
             cache-key: production-gpl
             strip-bin: strip
             package-name: cvc5-Linux-x86_64
@@ -127,7 +127,7 @@ jobs:
 
           - name: macos:production-gpl
             os: macos-13
-            config: production --auto-download --editline --gpl --cln --glpk --cocoa -DBUILD_GMP=1
+            config: production --auto-download --editline --gpl --cln --glpk --cocoa -DBUILD_GMP=1 -DBUILD_CLN=1
             cache-key: production-gpl
             strip-bin: strip
             package-name: cvc5-macOS-x86_64
@@ -136,7 +136,7 @@ jobs:
 
           - name: macos:production-arm64-gpl
             os: macos-14
-            config: production --auto-download --editline --gpl --cln --glpk --cocoa -DBUILD_GMP=1
+            config: production --auto-download --editline --gpl --cln --glpk --cocoa -DBUILD_GMP=1 -DBUILD_CLN=1
             cache-key: production-arm64-gpl
             strip-bin: strip
             package-name: cvc5-macOS-arm64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,8 @@ option(BUILD_BINDINGS_JAVA "Build Java bindings based on new C++ API ")
 # Api documentation
 option(BUILD_DOCS "Build Api documentation")
 
-option(BUILD_GMP "Build GMP from sources")
+option(BUILD_GMP "Build GMP from source")
+option(BUILD_CLN "Build CLN from source")
 
 # Link against static system libraries
 cvc5_option(STATIC_BINARY "Link against static system libraries \

--- a/cmake/FindCLN.cmake
+++ b/cmake/FindCLN.cmake
@@ -18,8 +18,10 @@
 
 include(deps-helper)
 
-find_path(CLN_INCLUDE_DIR NAMES cln/cln.h)
-find_library(CLN_LIBRARIES NAMES cln)
+if (NOT BUILD_CLN)
+  find_path(CLN_INCLUDE_DIR NAMES cln/cln.h)
+  find_library(CLN_LIBRARIES NAMES cln)
+endif()
 
 set(CLN_FOUND_SYSTEM FALSE)
 if(CLN_INCLUDE_DIR AND CLN_LIBRARIES)

--- a/contrib/arm64-gpl.Dockerfile
+++ b/contrib/arm64-gpl.Dockerfile
@@ -8,8 +8,6 @@ RUN apt-get update && apt-get install -y \
   automake \
   cmake \
   g++ \
-  libcln-dev \
-  libgmp-dev \
   libtool \
   openjdk-11-jdk \
   python3 \


### PR DESCRIPTION
This ensures that the GMP and CLN libraries are included in the release packages.