### PR TITLE
cmake: Specify installation component names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,9 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 # plugins.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Default component used in install() commands
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME cvc5)
+
 #-----------------------------------------------------------------------------#
 # Policies
 

--- a/docs/api/python/python.rst
+++ b/docs/api/python/python.rst
@@ -61,10 +61,18 @@ these steps:
   make # add -jN for parallel build using N threads
   make install
 
-For Windows, the steps above must be executed on a MINGW64 environment
-(see the `installation instructions <../../installation/installation>`).
+The last step installs both the cvc5 binary and the Python bindings.
+If you want to install only the Python bindings, run the following
+command instead of ``make install``:
 
-And to make sure that it works:
+.. code:: bash
+
+  cmake --install . --component python-api
+
+For Windows, the steps above must be executed on a MINGW64 environment
+(see the :doc:`installation instructions <../../installation/installation>`).
+
+Finally, you can make sure that it works by running:
 
 .. code:: bash
 

--- a/src/api/java/CMakeLists.txt
+++ b/src/api/java/CMakeLists.txt
@@ -262,13 +262,17 @@ add_dependencies(cvc5jar generate-java-kinds cvc5jni cvc5 cvc5parser)
 # Install in the same directory of cvc5-targets.
 # On Windows, CMake's default install action places
 # DLLs into the runtime path (by default "bin")
-install(TARGETS cvc5jni)
+install(TARGETS cvc5jni COMPONENT java-api)
 
-install_jar(cvc5jar DESTINATION share/java)
+install_jar(cvc5jar
+  DESTINATION share/java
+  COMPONENT java-api
+)
 
 install_jar_exports(
   TARGETS cvc5jar
   NAMESPACE cvc5::
   FILE cvc5JavaTargets.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cvc5
+  COMPONENT java-api
 )

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -243,7 +243,12 @@ else()
   # the default location designated by the Python interpreter used to
   # build them. Otherwise, install them in the specified prefix.
   if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    set(INSTALL_CMD "${INSTALL_CMD} --prefix ${CMAKE_INSTALL_PREFIX}")
+    # We escape the CMAKE_INSTALL_PREFIX variable so that
+    # it is evaluated at installation time.
+    # This is important for component-specific installations
+    # where the prefix may change (e.g., using
+    # 'cmake --install build --component python-api --prefix ./new-prefix').
+    set(INSTALL_CMD "${INSTALL_CMD} --prefix \${CMAKE_INSTALL_PREFIX}")
   endif()
 
   install(CODE "execute_process(COMMAND \${CMAKE_COMMAND}
@@ -252,6 +257,7 @@ else()
     -DBUILD_DIR=${CMAKE_BINARY_DIR}
     -DDEPS_BASE=${DEPS_BASE}
     -DINSTALL_CMD=\"${INSTALL_CMD}\"
-    -P ${CMAKE_SOURCE_DIR}/cmake/install_python_wheel.cmake)")
+    -P ${CMAKE_SOURCE_DIR}/cmake/install_python_wheel.cmake)"
+    COMPONENT python-api)
 
 endif()


### PR DESCRIPTION
This allows users to install the Python or Java bindings independently from the rest of the components.