### PR TITLE
ci: Disable link checker for docs upload.

### DIFF
--- a/.github/workflows/docs_upload.yml
+++ b/.github/workflows/docs_upload.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           git config --global user.email "docbot@cvc5"
           git config --global user.name "DocBot"
-      
+
       - name: Download artifact
         uses: actions/github-script@v7
         with:
@@ -41,12 +41,14 @@ jobs:
 
       - name: Unpack artifact
         run: unzip download.zip -d docs-new/
-      
-      - name: Check for broken links
-        continue-on-error: true
-        run: |
-          python3 -m pip install linkchecker
-          linkchecker --check-extern docs-new/index.html
+
+      # disabled, causes websites like gmplib.org to trigger their anti-dos
+      # measure, which causes the action to time out
+      #- name: Check for broken links
+      #  continue-on-error: true
+      #  run: |
+      #    python3 -m pip install linkchecker
+      #    linkchecker --check-extern docs-new/index.html
 
 # This workflow is run for commits in PRs (from branches in forks), commits
 # (from branches in main repo, usually main branch) and tags. Unfortunately,


### PR DESCRIPTION
The link checker triggers anti-dos measures of websites like
gmplib.org, which causes the docs upload action to timeout and fail.