### PR TITLE
Minor improvement for ARITH_POLY_NORM for bitvector terms

### DIFF
--- a/src/theory/arith/arith_poly_norm.cpp
+++ b/src/theory/arith/arith_poly_norm.cpp
@@ -443,7 +443,9 @@ bool PolyNorm::isArithPolyNorm(TNode a, TNode b)
   return areEqualPolyNormTyped(at, pa, pb);
 }
 
-bool PolyNorm::areEqualPolyNormTyped(const TypeNode& t, PolyNorm& pa, PolyNorm& pb)
+bool PolyNorm::areEqualPolyNormTyped(const TypeNode& t,
+                                     PolyNorm& pa,
+                                     PolyNorm& pb)
 {
   // do modulus by 2^bitwidth if bitvectors
   if (t.isBitVector())

--- a/src/theory/arith/arith_poly_norm.cpp
+++ b/src/theory/arith/arith_poly_norm.cpp
@@ -440,10 +440,15 @@ bool PolyNorm::isArithPolyNorm(TNode a, TNode b)
   // We impose no type requirements here.
   PolyNorm pa = PolyNorm::mkPolyNorm(a);
   PolyNorm pb = PolyNorm::mkPolyNorm(b);
+  return areEqualPolyNormTyped(at, pa, pb);
+}
+
+bool PolyNorm::areEqualPolyNormTyped(const TypeNode& t, PolyNorm& pa, PolyNorm& pb)
+{
   // do modulus by 2^bitwidth if bitvectors
-  if (at.isBitVector())
+  if (t.isBitVector())
   {
-    Rational w = Rational(Integer(2).pow(at.getBitVectorSize()));
+    Rational w = Rational(Integer(2).pow(t.getBitVectorSize()));
     pa.modCoeffs(w);
     pb.modCoeffs(w);
   }
@@ -494,15 +499,8 @@ bool PolyNorm::isArithPolyNormAtom(TNode a, TNode b)
   // if a non-arithmetic equality
   if (k == Kind::EQUAL && !eqtn.isRealOrInt())
   {
-    if (eqtn.isBitVector())
-    {
-      // for bitvectors, take modulo 2^w on coefficients
-      Rational w = Rational(Integer(2).pow(eqtn.getBitVectorSize()));
-      pa.modCoeffs(w);
-      pb.modCoeffs(w);
-    }
-    // Check for equality. notice that we don't insist on any type here.
-    return pa.isEqual(pb);
+    // Check for equality, taking modulo 2^w on coefficients.
+    return areEqualPolyNormTyped(eqtn, pa, pb);
   }
   // check if the two polynomials are equal modulo a constant coefficient
   // in other words, x ~ y is equivalent to z ~ w if

--- a/src/theory/arith/arith_poly_norm.cpp
+++ b/src/theory/arith/arith_poly_norm.cpp
@@ -440,6 +440,13 @@ bool PolyNorm::isArithPolyNorm(TNode a, TNode b)
   // We impose no type requirements here.
   PolyNorm pa = PolyNorm::mkPolyNorm(a);
   PolyNorm pb = PolyNorm::mkPolyNorm(b);
+  // do modulus by 2^bitwidth if bitvectors
+  if (at.isBitVector())
+  {
+    Rational w = Rational(Integer(2).pow(at.getBitVectorSize()));
+    pa.modCoeffs(w);
+    pb.modCoeffs(w);
+  }
   return pa.isEqual(pb);
 }
 

--- a/src/theory/arith/arith_poly_norm.h
+++ b/src/theory/arith/arith_poly_norm.h
@@ -111,7 +111,9 @@ class PolyNorm
    * is a bitvector type, then the coefficients of pa and pb are taken
    * modulo 2 to the bitwidth.
    */
-  static bool areEqualPolyNormTyped(const TypeNode& t, PolyNorm& pa, PolyNorm& pb);
+  static bool areEqualPolyNormTyped(const TypeNode& t,
+                                    PolyNorm& pa,
+                                    PolyNorm& pb);
   /**
    * Given two terms that are variables in monomials, return the
    * variable for the monomial when they are multiplied.

--- a/src/theory/arith/arith_poly_norm.h
+++ b/src/theory/arith/arith_poly_norm.h
@@ -107,6 +107,12 @@ class PolyNorm
    */
   static PolyNorm mkDiff(TNode a, TNode b);
   /**
+   * Are pa and pb equal polynomial normalizations of terms of type t? If t
+   * is a bitvector type, then the coefficients of pa and pb are taken
+   * modulo 2 to the bitwidth.
+   */
+  static bool areEqualPolyNormTyped(const TypeNode& t, PolyNorm& pa, PolyNorm& pb);
+  /**
    * Given two terms that are variables in monomials, return the
    * variable for the monomial when they are multiplied.
    */


### PR DESCRIPTION
Leads to 3 of the remaining 72 BV rewrites being successfully elaborated.

Required for making https://github.com/cvc5/cvc5/pull/10911 work.