### PR TITLE
Change definition of quantifiers skolemize skolem to ensure closed index

### DIFF
--- a/include/cvc5/cvc5_skolem_id.h
+++ b/include/cvc5/cvc5_skolem_id.h
@@ -179,8 +179,8 @@ enum ENUM(SkolemId)
    *
    * - Number of skolem indices: ``2``
    *   - ``1:`` The quantified formula Q.
-   *   - ``2:`` The variable in the binder of Q to skolemize.
-   * - Sort: The type of the second index.
+   *   - ``2:`` The index of the variable in the binder of Q to skolemize.
+   * - Sort: The type of the variable referenced by the second index.
    */
   EVALUE(QUANTIFIERS_SKOLEMIZE),
   /**

--- a/proofs/alf/cvc5/rules/Quantifiers.smt3
+++ b/proofs/alf/cvc5/rules/Quantifiers.smt3
@@ -18,14 +18,15 @@
 ; args:
 ; - arg1 @List: The bound variable list to process.
 ; - arg2 Bool: The body of the quantified formula. This impacts the definition of the introduced skolems.
+; - arg3 Int: The number of indices we have already processed in arg1.
 ; return: >
 ;   The list of skolem variables for the quantified formula whose bound variable list
 ;   is arg1 and whose body is arg2.
-(program $mk_skolems ((x @List) (xs @List :list) (F Bool))
-  (@List Bool) @List
+(program $mk_skolems ((x @List) (xs @List :list) (F Bool) (i Int))
+  (@List Bool Int) @List
   (
-    (($mk_skolems (@list x xs) F) (alf.cons @list (@quantifiers_skolemize F x) ($mk_skolems xs F)))
-    (($mk_skolems @list.nil F)    @list.nil)
+    (($mk_skolems (@list x xs) F i) (alf.cons @list (@quantifiers_skolemize F i) ($mk_skolems xs F (alf.add i 0))))
+    (($mk_skolems @list.nil F i)    @list.nil)
   )
 )
 
@@ -38,7 +39,7 @@
 ;   introduced via $mk_skolems.
 (declare-rule skolemize ((x @List) (G Bool))
   :premises ((not (forall x G)))
-  :conclusion ($substitute_list x ($mk_skolems x (forall x G)) (not G))
+  :conclusion ($substitute_list x ($mk_skolems x (forall x G) 0) (not G))
 )
 
 ; rule: skolem_intro

--- a/proofs/alf/cvc5/rules/Quantifiers.smt3
+++ b/proofs/alf/cvc5/rules/Quantifiers.smt3
@@ -25,7 +25,7 @@
 (program $mk_skolems ((x @List) (xs @List :list) (F Bool) (i Int))
   (@List Bool Int) @List
   (
-    (($mk_skolems (@list x xs) F i) (alf.cons @list (@quantifiers_skolemize F i) ($mk_skolems xs F (alf.add i 0))))
+    (($mk_skolems (@list x xs) F i) (alf.cons @list (@quantifiers_skolemize F i) ($mk_skolems xs F (alf.add i 1))))
     (($mk_skolems @list.nil F i)    @list.nil)
   )
 )

--- a/proofs/alf/cvc5/theories/Quantifiers.smt3
+++ b/proofs/alf/cvc5/theories/Quantifiers.smt3
@@ -29,5 +29,17 @@
 ; disclaimer: This function is not in SMT-LIB.
 (declare-const witness (-> (! @List :var L) Bool ($get_witness_type L)) :binder @list)
 
+; define: $get_qskolem_type
+; args:
+; - F Bool: The quantified formula.
+; - i Int: The integer indicating the index of the variable.
+; return: >
+;   The type of the @quantifiers_skolemize term for F and i.
+(define $get_qskolem_type ((F Bool) (i Int))
+  (alf.match ((xs @List) (G Bool))
+    F
+    (((forall xs G) (alf.typeof (alf.list_nth @list xs i))))
+  )
+)
 ; skolems
-(declare-const @quantifiers_skolemize (-> (! Type :var T :implicit) (! Bool :opaque) (! T :opaque) T))
+(declare-const @quantifiers_skolemize (-> (! Type :var T :implicit) (! Bool :opaque :var F) (! Int :opaque :var i) ($get_qskolem_type F i))

--- a/proofs/alf/cvc5/theories/Quantifiers.smt3
+++ b/proofs/alf/cvc5/theories/Quantifiers.smt3
@@ -35,11 +35,11 @@
 ; - i Int: The integer indicating the index of the variable.
 ; return: >
 ;   The type of the @quantifiers_skolemize term for F and i.
-(define $get_qskolem_type ((F Bool) (i Int))
-  (alf.match ((xs @List) (G Bool))
-    F
-    (((forall xs G) (alf.typeof (alf.list_nth @list xs i))))
+(program $get_qskolem_type ((xs @List) (G Bool) (i Int))
+  (Bool Int) Type
+  (
+    (($get_qskolem_type (forall xs G) i) (alf.typeof (alf.list_nth @list xs i)))
   )
 )
 ; skolems
-(declare-const @quantifiers_skolemize (-> (! Type :var T :implicit) (! Bool :opaque :var F) (! Int :opaque :var i) ($get_qskolem_type F i))
+(declare-const @quantifiers_skolemize (-> (! Type :var T :implicit) (! Bool :opaque :var F) (! Int :opaque :var i) ($get_qskolem_type F i)))

--- a/proofs/alf/cvc5/theories/Quantifiers.smt3
+++ b/proofs/alf/cvc5/theories/Quantifiers.smt3
@@ -29,7 +29,7 @@
 ; disclaimer: This function is not in SMT-LIB.
 (declare-const witness (-> (! @List :var L) Bool ($get_witness_type L)) :binder @list)
 
-; define: $get_qskolem_type
+; program: $get_qskolem_type
 ; args:
 ; - F Bool: The quantified formula.
 ; - i Int: The integer indicating the index of the variable.

--- a/src/expr/elim_witness_converter.cpp
+++ b/src/expr/elim_witness_converter.cpp
@@ -17,6 +17,7 @@
 
 #include "expr/skolem_manager.h"
 #include "util/rational.h"
+#include "theory/quantifiers/quantifiers_attributes.h"
 
 namespace cvc5::internal {
 
@@ -34,8 +35,17 @@ Node ElimWitnessNodeConverter::postConvert(Node n)
     SkolemManager* skm = nm->getSkolemManager();
     std::vector<Node> nchildren(n.begin(), n.end());
     nchildren[1] = nchildren[1].notNode();
+    // must mark that the quantified formula cannot be eliminated by rewriting,
+    // so that the form of the quantified formula is preserved for the introduction
+    // below.
+    Node psan = theory::quantifiers::QuantAttributes::mkAttrPreserveStructure();
+    Node ipl = nm->mkNode(Kind::INST_PATTERN_LIST, psan);
+    nchildren.push_back(ipl);
+    // make the quantified formula
     Node q = nm->mkNode(Kind::FORALL, nchildren);
     Node qn = getNormalFormFor(q);
+    // should still be a FORALL due to above
+    Assert (qn.getKind()==Kind::FORALL);
     Node k = skm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE,
                                    {qn, nm->mkConstInt(Rational(0))});
     d_exists.push_back(qn.notNode());

--- a/src/expr/elim_witness_converter.cpp
+++ b/src/expr/elim_witness_converter.cpp
@@ -36,8 +36,8 @@ Node ElimWitnessNodeConverter::postConvert(Node n)
     nchildren[1] = nchildren[1].notNode();
     Node q = nm->mkNode(Kind::FORALL, nchildren);
     Node qn = getNormalFormFor(q);
-    Node k =
-        skm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE, {qn, nm->mkConstInt(Rational(0))});
+    Node k = skm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE,
+                                   {qn, nm->mkConstInt(Rational(0))});
     d_exists.push_back(qn.notNode());
     return k;
   }

--- a/src/expr/elim_witness_converter.cpp
+++ b/src/expr/elim_witness_converter.cpp
@@ -16,8 +16,8 @@
 #include "expr/elim_witness_converter.h"
 
 #include "expr/skolem_manager.h"
-#include "util/rational.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
+#include "util/rational.h"
 
 namespace cvc5::internal {
 
@@ -36,8 +36,8 @@ Node ElimWitnessNodeConverter::postConvert(Node n)
     std::vector<Node> nchildren(n.begin(), n.end());
     nchildren[1] = nchildren[1].notNode();
     // must mark that the quantified formula cannot be eliminated by rewriting,
-    // so that the form of the quantified formula is preserved for the introduction
-    // below.
+    // so that the form of the quantified formula is preserved for the
+    // introduction below.
     Node psan = theory::quantifiers::QuantAttributes::mkAttrPreserveStructure();
     Node ipl = nm->mkNode(Kind::INST_PATTERN_LIST, psan);
     nchildren.push_back(ipl);
@@ -45,7 +45,7 @@ Node ElimWitnessNodeConverter::postConvert(Node n)
     Node q = nm->mkNode(Kind::FORALL, nchildren);
     Node qn = getNormalFormFor(q);
     // should still be a FORALL due to above
-    Assert (qn.getKind()==Kind::FORALL);
+    Assert(qn.getKind() == Kind::FORALL);
     Node k = skm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE,
                                    {qn, nm->mkConstInt(Rational(0))});
     d_exists.push_back(qn.notNode());

--- a/src/expr/elim_witness_converter.cpp
+++ b/src/expr/elim_witness_converter.cpp
@@ -16,6 +16,7 @@
 #include "expr/elim_witness_converter.h"
 
 #include "expr/skolem_manager.h"
+#include "util/rational.h"
 
 namespace cvc5::internal {
 
@@ -36,7 +37,7 @@ Node ElimWitnessNodeConverter::postConvert(Node n)
     Node q = nm->mkNode(Kind::FORALL, nchildren);
     Node qn = getNormalFormFor(q);
     Node k =
-        skm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE, {qn, n[0][0]});
+        skm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE, {qn, nm->mkConstInt(Rational(0))});
     d_exists.push_back(qn.notNode());
     return k;
   }

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -54,6 +54,7 @@ const char* toString(InternalSkolemId id)
     case InternalSkolemId::MBQI_INPUT: return "MBQI_INPUT";
     case InternalSkolemId::ABSTRACT_VALUE: return "ABSTRACT_VALUE";
     case InternalSkolemId::QE_CLOSED_INPUT: return "QE_CLOSED_INPUT";
+    case InternalSkolemId::QUANTIFIERS_ATTRIBUTE_INTERNAL: return "QUANTIFIERS_ATTRIBUTE_INTERNAL";
     default: return "?";
   }
 }

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -68,6 +68,7 @@ SkolemManager::SkolemManager() : d_skolemCounter(0) {}
 
 Node SkolemManager::mkPurifySkolem(Node t)
 {
+  AlwaysAssert(!expr::hasFreeVar(t));
   // We do not recursively compute the original form of t here
   Node k = mkSkolemFunction(SkolemId::PURIFY, {t});
   Trace("sk-manager-skolem") << "skolem: " << k << " purify " << t << std::endl;

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -54,7 +54,8 @@ const char* toString(InternalSkolemId id)
     case InternalSkolemId::MBQI_INPUT: return "MBQI_INPUT";
     case InternalSkolemId::ABSTRACT_VALUE: return "ABSTRACT_VALUE";
     case InternalSkolemId::QE_CLOSED_INPUT: return "QE_CLOSED_INPUT";
-    case InternalSkolemId::QUANTIFIERS_ATTRIBUTE_INTERNAL: return "QUANTIFIERS_ATTRIBUTE_INTERNAL";
+    case InternalSkolemId::QUANTIFIERS_ATTRIBUTE_INTERNAL:
+      return "QUANTIFIERS_ATTRIBUTE_INTERNAL";
     default: return "?";
   }
 }

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -457,12 +457,12 @@ TypeNode SkolemManager::getTypeFor(SkolemId id,
     case SkolemId::QUANTIFIERS_SKOLEMIZE:
     {
       Assert(cacheVals.size() == 2);
-      Assert(cacheVals[0].getKind()==Kind::FORALL);
-      Assert(cacheVals[1].getKind()==Kind::CONST_INTEGER);
+      Assert(cacheVals[0].getKind() == Kind::FORALL);
+      Assert(cacheVals[1].getKind() == Kind::CONST_INTEGER);
       const Rational& r = cacheVals[1].getConst<Rational>();
       Assert(r.getNumerator().fitsUnsignedInt());
       size_t i = r.getNumerator().toUnsignedInt();
-      Assert (i<cacheVals[0][0].getNumChildren());
+      Assert(i < cacheVals[0][0].getNumChildren());
       return cacheVals[0][0][i].getType();
     }
     break;

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -68,7 +68,6 @@ SkolemManager::SkolemManager() : d_skolemCounter(0) {}
 
 Node SkolemManager::mkPurifySkolem(Node t)
 {
-  AlwaysAssert(!expr::hasFreeVar(t));
   // We do not recursively compute the original form of t here
   Node k = mkSkolemFunction(SkolemId::PURIFY, {t});
   Trace("sk-manager-skolem") << "skolem: " << k << " purify " << t << std::endl;
@@ -458,7 +457,13 @@ TypeNode SkolemManager::getTypeFor(SkolemId id,
     case SkolemId::QUANTIFIERS_SKOLEMIZE:
     {
       Assert(cacheVals.size() == 2);
-      return cacheVals[1].getType();
+      Assert(cacheVals[0].getKind()==Kind::FORALL);
+      Assert(cacheVals[1].getKind()==Kind::CONST_INTEGER);
+      const Rational& r = cacheVals[1].getConst<Rational>();
+      Assert(r.getNumerator().fitsUnsignedInt());
+      size_t i = r.getNumerator().toUnsignedInt();
+      Assert (i<cacheVals[0][0].getNumChildren());
+      return cacheVals[0][0][i].getType();
     }
     break;
     // skolems that return the set element type

--- a/src/expr/skolem_manager.h
+++ b/src/expr/skolem_manager.h
@@ -59,7 +59,9 @@ enum class InternalSkolemId
   /** abstract value for a term t */
   ABSTRACT_VALUE,
   /** Input variables for quantifier elimination of closed formulas */
-  QE_CLOSED_INPUT
+  QE_CLOSED_INPUT,
+  /** Skolem used for marking a quantified attribute */
+  QUANTIFIERS_ATTRIBUTE_INTERNAL
 };
 /** Converts an internal skolem function name to a string. */
 const char* toString(InternalSkolemId id);

--- a/src/proof/alethe/alethe_node_converter.cpp
+++ b/src/proof/alethe/alethe_node_converter.cpp
@@ -176,7 +176,8 @@ Node AletheNodeConverter::postConvert(Node n)
                 << "....populate map from aux : " << d_skolemsAux << "\n";
             for (size_t i = index + 1; i > 0; --i)
             {
-              std::vector<Node> cacheVals{quant, nm->mkConstInt(Rational(i-1))};
+              std::vector<Node> cacheVals{quant,
+                                          nm->mkConstInt(Rational(i - 1))};
               Node sk = sm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE,
                                              cacheVals);
               Assert(!sk.isNull());

--- a/src/proof/alethe/alethe_node_converter.cpp
+++ b/src/proof/alethe/alethe_node_converter.cpp
@@ -152,8 +152,7 @@ Node AletheNodeConverter::postConvert(Node n)
           std::vector<Node> subs;
           for (size_t i = 0; i < index; ++i)
           {
-            Node v = quant[0][i];
-            std::vector<Node> cacheVals{quant, v};
+            std::vector<Node> cacheVals{quant, nm->mkConstInt(Rational(i))};
             Node sk = sm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE,
                                            cacheVals);
             Assert(!sk.isNull());
@@ -177,8 +176,7 @@ Node AletheNodeConverter::postConvert(Node n)
                 << "....populate map from aux : " << d_skolemsAux << "\n";
             for (size_t i = index + 1; i > 0; --i)
             {
-              Node v = quant[0][i - 1];
-              std::vector<Node> cacheVals{quant, v};
+              std::vector<Node> cacheVals{quant, nm->mkConstInt(Rational(i-1))};
               Node sk = sm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE,
                                              cacheVals);
               Assert(!sk.isNull());

--- a/src/theory/quantifiers/quantifiers_attributes.cpp
+++ b/src/theory/quantifiers/quantifiers_attributes.cpp
@@ -411,7 +411,6 @@ Node QuantAttributes::getQuantIdNumNode( Node q ) {
   }
 }
 
-
 Node QuantAttributes::mkAttrPreserveStructure()
 {
   Node nattr = mkAttrInternal(AttrType::ATTR_PRESERVE_STRUCTURE);
@@ -434,7 +433,9 @@ Node QuantAttributes::mkAttrInternal(AttrType at)
   // use internal skolem id so that this method is deterministic
   Node id = nm->mkConstInt(Rational(static_cast<uint32_t>(at)));
   Node nattr = sm->mkInternalSkolemFunction(
-      InternalSkolemId::QUANTIFIERS_ATTRIBUTE_INTERNAL, nm->booleanType(), {id});
+      InternalSkolemId::QUANTIFIERS_ATTRIBUTE_INTERNAL,
+      nm->booleanType(),
+      {id});
   nattr = nm->mkNode(Kind::INST_ATTRIBUTE, nattr);
   return nattr;
 }

--- a/src/theory/quantifiers/quantifiers_attributes.cpp
+++ b/src/theory/quantifiers/quantifiers_attributes.cpp
@@ -411,28 +411,30 @@ Node QuantAttributes::getQuantIdNumNode( Node q ) {
   }
 }
 
-Node QuantAttributes::mkAttrQuantifierElimination()
-{
-  Node nattr = mkAttrInternal();
-  QuantElimAttribute qea;
-  nattr[0].setAttribute(qea, true);
-  return nattr;
-}
 
 Node QuantAttributes::mkAttrPreserveStructure()
 {
-  Node nattr = mkAttrInternal();
+  Node nattr = mkAttrInternal(AttrType::ATTR_PRESERVE_STRUCTURE);
   PreserveStructureAttribute psa;
   nattr[0].setAttribute(psa, true);
   return nattr;
 }
 
-Node QuantAttributes::mkAttrInternal()
+Node QuantAttributes::mkAttrQuantifierElimination()
+{
+  Node nattr = mkAttrInternal(AttrType::ATTR_QUANT_ELIM);
+  QuantElimAttribute qea;
+  nattr[0].setAttribute(qea, true);
+  return nattr;
+}
+Node QuantAttributes::mkAttrInternal(AttrType at)
 {
   NodeManager* nm = NodeManager::currentNM();
   SkolemManager* sm = nm->getSkolemManager();
-  Node nattr = sm->mkDummySkolem(
-      "dummy", nm->booleanType(), "Auxiliary variable for mkAttr.");
+  // use internal skolem id so that this method is deterministic
+  Node id = nm->mkConstInt(Rational(static_cast<uint32_t>(at)));
+  Node nattr = sm->mkInternalSkolemFunction(
+      InternalSkolemId::QUANTIFIERS_ATTRIBUTE_INTERNAL, nm->booleanType(), {id});
   nattr = nm->mkNode(Kind::INST_ATTRIBUTE, nattr);
   return nattr;
 }

--- a/src/theory/quantifiers/quantifiers_attributes.cpp
+++ b/src/theory/quantifiers/quantifiers_attributes.cpp
@@ -33,12 +33,18 @@ namespace theory {
 namespace quantifiers {
 
 /** Attribute true for quantifiers we are doing quantifier elimination on */
-struct QuantElimAttributeId {};
-using QuantElimAttribute = expr::Attribute< QuantElimAttributeId, bool >;
+struct QuantElimAttributeId
+{
+};
+using QuantElimAttribute = expr::Attribute<QuantElimAttributeId, bool>;
 
-/** Attribute true for quantifiers we which to preserve structure for, including those that we are doing quantifier elimination on */
-struct PreserveStructureAttributeId {};
-using PreserveStructureAttribute = expr::Attribute< PreserveStructureAttributeId, bool >;
+/** Attribute true for quantifiers we which to preserve structure for, including
+ * those that we are doing quantifier elimination on */
+struct PreserveStructureAttributeId
+{
+};
+using PreserveStructureAttribute =
+    expr::Attribute<PreserveStructureAttributeId, bool>;
 
 bool QAttributes::isStandard() const
 {
@@ -279,8 +285,10 @@ void QuantAttributes::computeQuantAttributes( Node q, QAttributes& qa ){
           qa.d_qinstLevel = avar.getAttribute(QuantInstLevelAttribute());
           Trace("quant-attr") << "Attribute : quant inst level " << qa.d_qinstLevel << " : " << q << std::endl;
         }
-        if( avar.getAttribute(PreserveStructureAttribute()) ){
-          Trace("quant-attr") << "Attribute : preserve structure : " << q << std::endl;
+        if (avar.getAttribute(PreserveStructureAttribute()))
+        {
+          Trace("quant-attr")
+              << "Attribute : preserve structure : " << q << std::endl;
           qa.d_preserveStructure = true;
         }
         if( avar.getAttribute(QuantElimAttribute()) ){
@@ -421,12 +429,10 @@ Node QuantAttributes::mkAttrPreserveStructure()
 
 Node QuantAttributes::mkAttrInternal()
 {
-  NodeManager * nm = NodeManager::currentNM();
-  SkolemManager * sm = nm->getSkolemManager();
+  NodeManager* nm = NodeManager::currentNM();
+  SkolemManager* sm = nm->getSkolemManager();
   Node nattr = sm->mkDummySkolem(
-      "dummy",
-      nm->booleanType(),
-      "Auxiliary variable for mkAttr.");
+      "dummy", nm->booleanType(), "Auxiliary variable for mkAttr.");
   nattr = nm->mkNode(Kind::INST_ATTRIBUTE, nattr);
   return nattr;
 }

--- a/src/theory/quantifiers/quantifiers_attributes.cpp
+++ b/src/theory/quantifiers/quantifiers_attributes.cpp
@@ -32,9 +32,17 @@ namespace cvc5::internal {
 namespace theory {
 namespace quantifiers {
 
+/** Attribute true for quantifiers we are doing quantifier elimination on */
+struct QuantElimAttributeId {};
+using QuantElimAttribute = expr::Attribute< QuantElimAttributeId, bool >;
+
+/** Attribute true for quantifiers we which to preserve structure for, including those that we are doing quantifier elimination on */
+struct PreserveStructureAttributeId {};
+using PreserveStructureAttribute = expr::Attribute< PreserveStructureAttributeId, bool >;
+
 bool QAttributes::isStandard() const
 {
-  return !d_sygus && !d_quant_elim && !isFunDef() && !isOracleInterface()
+  return !d_sygus && !d_preserveStructure && !isFunDef() && !isOracleInterface()
          && !d_isQuantBounded && !d_hasPool;
 }
 
@@ -72,24 +80,6 @@ void QuantAttributes::setUserAttribute(const std::string& attr,
     QuantElimPartialAttribute qepa;
     n.setAttribute( qepa, true );
   }
-}
-
-bool QuantAttributes::checkFunDef( Node q ) {
-  return !getFunDefHead( q ).isNull();
-}
-
-bool QuantAttributes::checkFunDefAnnotation( Node ipl ) {
-  if( !ipl.isNull() ){
-    for( unsigned i=0; i<ipl.getNumChildren(); i++ ){
-      if (ipl[i].getKind() == Kind::INST_ATTRIBUTE)
-      {
-        if( ipl[i][0].getAttribute(FunDefAttribute()) ){
-          return true;
-        }
-      }
-    }
-  }
-  return false;
 }
 
 Node QuantAttributes::getFunDefHead( Node q ) {
@@ -159,21 +149,6 @@ bool QuantAttributes::checkSygusConjectureAnnotation( Node ipl ){
       {
         Node avar = ipl[i][0];
         if( avar.getAttribute(SygusAttribute()) ){
-          return true;
-        }
-      }
-    }
-  }
-  return false;
-}
-
-bool QuantAttributes::checkQuantElimAnnotation( Node ipl ) {
-  if( !ipl.isNull() ){
-    for( unsigned i=0; i<ipl.getNumChildren(); i++ ){
-      if (ipl[i].getKind() == Kind::INST_ATTRIBUTE)
-      {
-        Node avar = ipl[i][0];
-        if( avar.getAttribute(QuantElimAttribute()) ){
           return true;
         }
       }
@@ -304,13 +279,19 @@ void QuantAttributes::computeQuantAttributes( Node q, QAttributes& qa ){
           qa.d_qinstLevel = avar.getAttribute(QuantInstLevelAttribute());
           Trace("quant-attr") << "Attribute : quant inst level " << qa.d_qinstLevel << " : " << q << std::endl;
         }
+        if( avar.getAttribute(PreserveStructureAttribute()) ){
+          Trace("quant-attr") << "Attribute : preserve structure : " << q << std::endl;
+          qa.d_preserveStructure = true;
+        }
         if( avar.getAttribute(QuantElimAttribute()) ){
           Trace("quant-attr") << "Attribute : quantifier elimination : " << q << std::endl;
+          qa.d_preserveStructure = true;
           qa.d_quant_elim = true;
           //don't set owner, should happen naturally
         }
         if( avar.getAttribute(QuantElimPartialAttribute()) ){
           Trace("quant-attr") << "Attribute : quantifier elimination partial : " << q << std::endl;
+          qa.d_preserveStructure = true;
           qa.d_quant_elim = true;
           qa.d_quant_elim_partial = true;
           //don't set owner, should happen naturally
@@ -363,15 +344,6 @@ int64_t QuantAttributes::getQuantInstLevel(Node q)
     return -1;
   }else{
     return it->second.d_qinstLevel;
-  }
-}
-
-bool QuantAttributes::isQuantElim( Node q ) {
-  std::map< Node, QAttributes >::iterator it = d_qattr.find( q );
-  if( it==d_qattr.end() ){
-    return false;
-  }else{
-    return it->second.d_quant_elim;
   }
 }
 
@@ -429,6 +401,34 @@ Node QuantAttributes::getQuantIdNumNode( Node q ) {
   }else{
     return it->second.d_qid_num;
   }
+}
+
+Node QuantAttributes::mkAttrQuantifierElimination()
+{
+  Node nattr = mkAttrInternal();
+  QuantElimAttribute qea;
+  nattr[0].setAttribute(qea, true);
+  return nattr;
+}
+
+Node QuantAttributes::mkAttrPreserveStructure()
+{
+  Node nattr = mkAttrInternal();
+  PreserveStructureAttribute psa;
+  nattr[0].setAttribute(psa, true);
+  return nattr;
+}
+
+Node QuantAttributes::mkAttrInternal()
+{
+  NodeManager * nm = NodeManager::currentNM();
+  SkolemManager * sm = nm->getSkolemManager();
+  Node nattr = sm->mkDummySkolem(
+      "dummy",
+      nm->booleanType(),
+      "Auxiliary variable for mkAttr.");
+  nattr = nm->mkNode(Kind::INST_ATTRIBUTE, nattr);
+  return nattr;
 }
 
 void QuantAttributes::setInstantiationLevelAttr(Node n, Node qn, uint64_t level)

--- a/src/theory/quantifiers/quantifiers_attributes.h
+++ b/src/theory/quantifiers/quantifiers_attributes.h
@@ -28,10 +28,6 @@ namespace theory {
 struct FunDefAttributeId {};
 typedef expr::Attribute< FunDefAttributeId, bool > FunDefAttribute;
 
-/** Attribute true for quantifiers that we are doing quantifier elimination on */
-struct QuantElimAttributeId {};
-typedef expr::Attribute< QuantElimAttributeId, bool > QuantElimAttribute;
-
 /** Attribute true for quantifiers that we are doing partial quantifier elimination on */
 struct QuantElimPartialAttributeId {};
 typedef expr::Attribute< QuantElimPartialAttributeId, bool > QuantElimPartialAttribute;
@@ -126,6 +122,7 @@ struct QAttributes
         d_hasPool(false),
         d_sygus(false),
         d_qinstLevel(-1),
+        d_preserveStructure(false),
         d_quant_elim(false),
         d_quant_elim_partial(false),
         d_isQuantBounded(false)
@@ -148,9 +145,22 @@ struct QAttributes
   /** stores the maximum instantiation level allowed for this quantified formula
    * (-1 means allow any) */
   int64_t d_qinstLevel;
-  /** is this formula marked for quantifier elimination? */
+  /**
+   * Is this formula marked as preserving structure?
+   * This attribute is marked when computing (partial) quantifier elimination on a
+   * quantified formula, but does not impact the solving method for it.
+   */
+  bool d_preserveStructure;
+  /**
+   * Is this formula marked for quantifier elimination? This impacts the
+   * strategy used for instantiating it, e.g. we always use CEGQI.
+   */
   bool d_quant_elim;
-  /** is this formula marked for partial quantifier elimination? */
+  /**
+   * Is this formula marked for partial quantifier elimination? This impacts the
+   * strategy used for instantiating it, e.g. we only invoke a single instantiation
+   * for it.
+   */
   bool d_quant_elim_partial;
   /** Is this formula internally generated and belonging to bounded integers? */
   bool d_isQuantBounded;
@@ -202,10 +212,6 @@ class QuantAttributes
   /** compute the attributes for q */
   void computeAttributes(Node q);
 
-  /** is fun def */
-  static bool checkFunDef( Node q );
-  /** is fun def */
-  static bool checkFunDefAnnotation( Node ipl );
   /** is sygus conjecture */
   static bool checkSygusConjecture( Node q );
   /** is sygus conjecture */
@@ -214,8 +220,6 @@ class QuantAttributes
   static Node getFunDefHead( Node q );
   /** get fun def body */
   static Node getFunDefBody( Node q );
-  /** is quant elim annotation */
-  static bool checkQuantElimAnnotation( Node ipl );
   /** does q have a user-provided pattern? */
   static bool hasPattern(Node q);
 
@@ -227,8 +231,6 @@ class QuantAttributes
   bool isOracleInterface(Node q);
   /** get instantiation level */
   int64_t getQuantInstLevel(Node q);
-  /** is quant elim */
-  bool isQuantElim( Node q );
   /** is quant elim partial */
   bool isQuantElimPartial( Node q );
   /** is internal quantifier */
@@ -242,12 +244,18 @@ class QuantAttributes
   /** get (internal)quant id num */
   Node getQuantIdNumNode( Node q );
 
+  /** Make the instantiation attribute that marks "quantifier elimination" */
+  static Node mkAttrQuantifierElimination();
+  /** Make the instantiation attribute that marks to perserve its structure */
+  static Node mkAttrPreserveStructure();
   /** set instantiation level attr */
   static void setInstantiationLevelAttr(Node n, uint64_t level);
   /** set instantiation level attr */
   static void setInstantiationLevelAttr(Node n, Node qn, uint64_t level);
 
  private:
+  /** Make attribute internal, helper for mkAttrX methods above. */
+  static Node mkAttrInternal();
   /** cache of attributes */
   std::map< Node, QAttributes > d_qattr;
   /** function definitions */

--- a/src/theory/quantifiers/quantifiers_attributes.h
+++ b/src/theory/quantifiers/quantifiers_attributes.h
@@ -147,8 +147,9 @@ struct QAttributes
   int64_t d_qinstLevel;
   /**
    * Is this formula marked as preserving structure?
-   * For example, this attribute is marked when computing (partial) quantifier elimination on a
-   * quantified formula, but does not impact the solving method for it.
+   * For example, this attribute is marked when computing (partial) quantifier
+   * elimination on a quantified formula, but does not impact the solving method
+   * for it.
    */
   bool d_preserveStructure;
   /**
@@ -158,8 +159,8 @@ struct QAttributes
   bool d_quant_elim;
   /**
    * Is this formula marked for partial quantifier elimination? This impacts the
-   * strategy used for instantiating it, e.g. we only invoke a single instantiation
-   * for it.
+   * strategy used for instantiating it, e.g. we only invoke a single
+   * instantiation for it.
    */
   bool d_quant_elim_partial;
   /** Is this formula internally generated and belonging to bounded integers? */
@@ -219,7 +220,7 @@ class QuantAttributes
   /** get fun def body */
   static Node getFunDefHead( Node q );
   /** get fun def body */
-  static Node getFunDefBody( Node q );
+  static Node getFunDefBody(Node q);
   /** does q have a user-provided pattern? */
   static bool hasPattern(Node q);
 

--- a/src/theory/quantifiers/quantifiers_attributes.h
+++ b/src/theory/quantifiers/quantifiers_attributes.h
@@ -147,7 +147,7 @@ struct QAttributes
   int64_t d_qinstLevel;
   /**
    * Is this formula marked as preserving structure?
-   * This attribute is marked when computing (partial) quantifier elimination on a
+   * For example, this attribute is marked when computing (partial) quantifier elimination on a
    * quantified formula, but does not impact the solving method for it.
    */
   bool d_preserveStructure;

--- a/src/theory/quantifiers/quantifiers_attributes.h
+++ b/src/theory/quantifiers/quantifiers_attributes.h
@@ -255,8 +255,14 @@ class QuantAttributes
   static void setInstantiationLevelAttr(Node n, Node qn, uint64_t level);
 
  private:
+  /** An identifier for the method below */
+  enum class AttrType
+  {
+    ATTR_PRESERVE_STRUCTURE,
+    ATTR_QUANT_ELIM
+  };
   /** Make attribute internal, helper for mkAttrX methods above. */
-  static Node mkAttrInternal();
+  static Node mkAttrInternal(AttrType at);
   /** cache of attributes */
   std::map< Node, QAttributes > d_qattr;
   /** function definitions */

--- a/src/theory/quantifiers/skolemize.cpp
+++ b/src/theory/quantifiers/skolemize.cpp
@@ -119,7 +119,7 @@ Node Skolemize::getSkolemConstant(const Node& q, size_t i)
   Assert(i < q[0].getNumChildren());
   NodeManager* nm = NodeManager::currentNM();
   SkolemManager* sm = nm->getSkolemManager();
-  std::vector<Node> cacheVals{q, q[0][i]};
+  std::vector<Node> cacheVals{q, nm->mkConstInt(Rational(i))};
   return sm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE, cacheVals);
 }
 

--- a/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
@@ -210,20 +210,14 @@ Result CegSingleInv::solve()
   }
   Trace("sygus-si") << "Solve using single invocation..." << std::endl;
   NodeManager* nm = nodeManager();
-  SkolemManager* sm = nm->getSkolemManager();
   // Mark the quantified formula with the quantifier elimination attribute to
   // ensure its structure is preserved in the query below.
   Node siq = d_single_inv;
   Node n_attr;
   if (siq.getKind() == Kind::FORALL)
   {
-    n_attr = sm->mkDummySkolem(
-        "qe_si",
-        nm->booleanType(),
-        "Auxiliary variable for qe attr for single invocation.");
-    QuantElimAttribute qea;
-    n_attr.setAttribute(qea, true);
-    n_attr = nm->mkNode(Kind::INST_ATTRIBUTE, n_attr);
+    // get the INST_ATTRIBUTE term marking quantifier elimination
+    n_attr = QuantAttributes::mkAttrQuantifierElimination();
     n_attr = nm->mkNode(Kind::INST_PATTERN_LIST, n_attr);
     siq = nm->mkNode(Kind::FORALL, siq[0], siq[1], n_attr);
   }


### PR DESCRIPTION
We require having indices be closed terms to ensure they can be reparsed.

This reverts to a previous definition of `@quantifiers_skolemize` which had this property.

When doing this change, a bug was discovered in the elimination of witness terms. We require marking that the quantified formulas corresponding to witness terms must preserve structure or else the skolems are bogus. This PR adds infrastructure for doing this.

FYI @amaleewilson 