### PR TITLE
Update alfc version

### DIFF
--- a/contrib/get-alf-checker
+++ b/contrib/get-alf-checker
@@ -24,7 +24,7 @@ ALFC_DIR="$BASE_DIR/alf-checker"
 mkdir -p $ALFC_DIR
 
 # download and unpack ALFC
-ALF_VERSION="a15cd9ef2dc591573c43469ab749b925fa01602d"
+ALF_VERSION="1657714832b3c3dcf98fe26c4bd9d18c9741d9bc"
 download "https://github.com/cvc5/alfc/archive/$ALF_VERSION.tar.gz" $BASE_DIR/tmp/alfc.tgz
 tar --strip 1 -xzf $BASE_DIR/tmp/alfc.tgz -C $ALFC_DIR
 

--- a/proofs/alf/cvc5/Cvc5.smt3
+++ b/proofs/alf/cvc5/Cvc5.smt3
@@ -91,9 +91,9 @@
     (S) S
     (
       ; core
-      ((run_evaluate (= x y))             (let ((ex (run_evaluate x)))
-                                          (let ((ey (run_evaluate y)))
-                                          (let ((res (alf.is_eq ex ey)))
+      ((run_evaluate (= x y))             (alf.define ((ex (run_evaluate x)))
+                                          (alf.define ((ey (run_evaluate y)))
+                                          (alf.define ((res (alf.is_eq ex ey)))
                                           (alf.ite (alf.and (alf.is_q ex) (alf.is_q ey)) res
                                           (alf.ite (alf.and (alf.is_z ex) (alf.is_z ey)) res
                                           (alf.ite (alf.and (alf.is_bin ex) (alf.is_bin ey)) res
@@ -108,23 +108,23 @@
   
       ; arithmetic
       ((run_evaluate (< x z))             (alf.is_neg ($arith_eval_qsub (run_evaluate x) (run_evaluate z))))
-      ((run_evaluate (<= x z))            (let ((d ($arith_eval_qsub (run_evaluate x) (run_evaluate z))))
+      ((run_evaluate (<= x z))            (alf.define ((d ($arith_eval_qsub (run_evaluate x) (run_evaluate z))))
                                             (alf.or (alf.is_neg d) (alf.is_eq d 0/1))))
       ((run_evaluate (> x z))             (alf.is_neg ($arith_eval_qsub (run_evaluate z) (run_evaluate x))))
-      ((run_evaluate (>= x z))            (let ((d ($arith_eval_qsub (run_evaluate z) (run_evaluate x))))
+      ((run_evaluate (>= x z))            (alf.define ((d ($arith_eval_qsub (run_evaluate z) (run_evaluate x))))
                                             (alf.or (alf.is_neg d) (alf.is_eq d 0/1))))
       ((run_evaluate (+ x ys))            ($arith_eval_add (run_evaluate x) (run_evaluate ys)))
       ((run_evaluate (- x z))             ($arith_eval_sub (run_evaluate x) (run_evaluate z)))
       ((run_evaluate (* x ys))            ($arith_eval_mul (run_evaluate x) (run_evaluate ys)))
       ((run_evaluate (- x))               (alf.neg (run_evaluate x)))
       ((run_evaluate (/ x y))             (alf.qdiv (alf.to_q (run_evaluate x)) (alf.to_q (run_evaluate y))))
-      ((run_evaluate (/_total x y))       (let ((d (alf.to_q (run_evaluate y))))
+      ((run_evaluate (/_total x y))       (alf.define ((d (alf.to_q (run_evaluate y))))
                                             (alf.ite (alf.is_eq d 0/1) 0/1 (alf.qdiv (alf.to_q (run_evaluate x)) d))))
       ((run_evaluate (div x y))           (alf.zdiv (run_evaluate x) (run_evaluate y)))
-      ((run_evaluate (div_total x y))     (let ((d (run_evaluate y)))
+      ((run_evaluate (div_total x y))     (alf.define ((d (run_evaluate y)))
                                             (alf.ite (alf.is_eq d 0) 0 (alf.zdiv (run_evaluate x) d))))
       ((run_evaluate (mod x y))           (alf.zmod (run_evaluate x) (run_evaluate y)))
-      ((run_evaluate (mod_total x y))     (let ((d (run_evaluate y)))
+      ((run_evaluate (mod_total x y))     (alf.define ((d (run_evaluate y)))
                                             (alf.ite (alf.is_eq d 0) 0 (alf.zmod (run_evaluate x) d))))
       ((run_evaluate (to_real x))         (alf.to_q (run_evaluate x)))
       ((run_evaluate (to_int x))          (alf.to_z (run_evaluate x)))
@@ -134,12 +134,12 @@
       ; strings
       ((run_evaluate (str.++ xs yss))     (alf.concat (run_evaluate xs) (run_evaluate yss)))
       ((run_evaluate (str.len x))         (alf.len (run_evaluate x)))
-      ((run_evaluate (str.substr x n m))  (let ((r (run_evaluate n)))
+      ((run_evaluate (str.substr x n m))  (alf.define ((r (run_evaluate n)))
                                             (alf.extract (run_evaluate x) r (alf.add r (run_evaluate m) -1))))
       ((run_evaluate (str.contains x y))  (alf.not (alf.is_neg (alf.find (run_evaluate x) (run_evaluate y)))))
-      ((run_evaluate (str.replace x y z)) (let ((ex (run_evaluate x)))
-                                          (let ((ey (run_evaluate y)))
-                                          (let ((r (alf.find (alf.to_str ex) (alf.to_str ey)))) ; ensure string literals
+      ((run_evaluate (str.replace x y z)) (alf.define ((ex (run_evaluate x)))
+                                          (alf.define ((ey (run_evaluate y)))
+                                          (alf.define ((r (alf.find (alf.to_str ex) (alf.to_str ey)))) ; ensure string literals
                                             (alf.ite (alf.is_neg r)
                                               ex
                                               (alf.concat 
@@ -148,18 +148,18 @@
                                                 (alf.extract ex (alf.add r (alf.len ey)) (alf.len ex)))
                                             )
                                           ))))
-      ((run_evaluate (str.indexof x y n)) (let ((en (run_evaluate n)))
+      ((run_evaluate (str.indexof x y n)) (alf.define ((en (run_evaluate n)))
                                           (alf.ite (alf.is_neg en) -1
-                                            (let ((ex (run_evaluate x)))
-                                            (let ((exl (alf.len ex)))
+                                            (alf.define ((ex (run_evaluate x)))
+                                            (alf.define ((exl (alf.len ex)))
                                             (alf.ite (alf.gt en exl) -1
-                                              (let ((exs (alf.extract ex n exl)))
-                                              (let ((ey (run_evaluate y)))
-                                              (let ((r (alf.find (alf.to_str exs) (alf.to_str ey))))
+                                              (alf.define ((exs (alf.extract ex n exl)))
+                                              (alf.define ((ey (run_evaluate y)))
+                                              (alf.define ((r (alf.find (alf.to_str exs) (alf.to_str ey))))
                                               (alf.ite (alf.is_neg r) r (alf.add n r)))))))))))
-      ((run_evaluate (str.to_code x))     (let ((ex (run_evaluate x)))
+      ((run_evaluate (str.to_code x))     (alf.define ((ex (run_evaluate x)))
                                           (alf.ite (alf.is_eq (alf.len ex) 1) (alf.to_z ex) -1)))
-      ((run_evaluate (str.from_code x))   (let ((ex (run_evaluate x)))
+      ((run_evaluate (str.from_code x))   (alf.define ((ex (run_evaluate x)))
                                           (alf.ite ($str_is_code_point ex) (alf.to_str x) "")))
 
       ; bitvectors
@@ -260,7 +260,7 @@
 ; conclusion: The given equality.
 (declare-rule aci_norm ((U Type) (a U) (b U))
   :args ((= a b))
-  :requires (((let ((an ($get_aci_normal_form a)) (bn ($get_aci_normal_form b)))
+  :requires (((alf.define ((an ($get_aci_normal_form a)) (bn ($get_aci_normal_form b)))
               (alf.ite (alf.is_eq an b) true
               (alf.ite (alf.is_eq a bn) true
                 (alf.is_eq an bn)))) true))

--- a/proofs/alf/cvc5/programs/Arith.smt3
+++ b/proofs/alf/cvc5/programs/Arith.smt3
@@ -11,8 +11,8 @@
 ;   can each be integer or real. This method returns an integer value if x and y
 ;   are both integer, or a rational value otherwise.
 (define $arith_eval_add ((T Type :implicit) (U Type :implicit) (x T) (y U))
-  (let ((xq (alf.to_q x)))
-  (let ((yq (alf.to_q y)))
+  (alf.define ((xq (alf.to_q x)))
+  (alf.define ((yq (alf.to_q y)))
     (alf.ite (alf.is_eq x xq)
       (alf.add xq yq)
       (alf.ite (alf.is_eq y yq)
@@ -41,8 +41,8 @@
 ;   can each be integer or real. This method returns an integer value if x and y
 ;   are both integer, or a rational value otherwise.
 (define $arith_eval_mul ((T Type :implicit) (U Type :implicit) (x T) (y U))
-  (let ((xq (alf.to_q x)))
-  (let ((yq (alf.to_q y)))
+  (alf.define ((xq (alf.to_q x)))
+  (alf.define ((yq (alf.to_q y)))
     (alf.ite (alf.is_eq x xq)
       (alf.mul xq yq)
       (alf.ite (alf.is_eq y yq)
@@ -115,7 +115,7 @@
   (@Polynomial @Polynomial) @Polynomial
   (
     (($poly_add (@poly (@mon a1 c1) p1) (@poly (@mon a2 c2) p2)) (alf.ite (alf.is_eq a1 a2)
-                                                                  (let ((ca (alf.add c1 c2)) (pa ($poly_add p1 p2)))
+                                                                  (alf.define ((ca (alf.add c1 c2)) (pa ($poly_add p1 p2)))
                                                                   ; check if cancels
                                                                   (alf.ite (alf.is_eq ca 0.0) pa (alf.cons @poly (@mon a1 ca) pa)))
                                                                 (alf.ite ($compare_var a1 a2)
@@ -194,7 +194,7 @@
     (($get_poly_norm (- a1 a2))    ($poly_add ($get_poly_norm a1) ($poly_neg ($get_poly_norm a2))))
     (($get_poly_norm (* a1 a2))    ($poly_mul ($get_poly_norm a1) ($get_poly_norm a2)))
     (($get_poly_norm (to_real a1)) ($get_poly_norm a1))
-    (($get_poly_norm a)            (let ((aq (alf.to_q a)))
+    (($get_poly_norm a)            (alf.define ((aq (alf.to_q a)))
                                   ; if it is a constant, which can be tested if to_q is idempotent after the first
                                   (alf.ite (alf.is_eq aq (alf.to_q aq))
                                     ; if it is zero, it cancels, otherwise it is 1 with itself as coefficient
@@ -240,7 +240,7 @@
   (@Polynomial @Polynomial Bool) Bool
   (
     (($poly_is_equal_mod_c @poly.zero @poly.zero reqPos)                         true)
-    (($poly_is_equal_mod_c (@poly (@mon a c1) p1) (@poly (@mon a c2) p2) reqPos) (let ((c (alf.qdiv c2 c1))) 
+    (($poly_is_equal_mod_c (@poly (@mon a c1) p1) (@poly (@mon a c2) p2) reqPos) (alf.define ((c (alf.qdiv c2 c1))) 
                                                                                 (alf.requires (alf.and reqPos (alf.is_neg c)) false
                                                                                 ($poly_is_equal_mod_c_rec c p1 p2))))
   )

--- a/proofs/alf/cvc5/programs/Nary.smt3
+++ b/proofs/alf/cvc5/programs/Nary.smt3
@@ -48,7 +48,7 @@
     ((L Type) (cons (-> L L L)) (x L) (xs L :list))
     (L) L
     (
-        ((nary.reverse (cons x xs)) (let ((nil (alf.nil cons x xs))) (nary.reverseRec cons nil (cons x xs) nil)))
+        ((nary.reverse (cons x xs)) (alf.define ((nil (alf.nil cons x xs))) (nary.reverseRec cons nil (cons x xs) nil)))
         ((nary.reverse x)           x)
     )
 )

--- a/proofs/alf/cvc5/programs/Strings.smt3
+++ b/proofs/alf/cvc5/programs/Strings.smt3
@@ -56,11 +56,11 @@
   (($str_fixed_len_re re.allchar)       1)
   (($str_fixed_len_re (re.range s1 s2)) 1)
   (($str_fixed_len_re (str.to_re s1))   (alf.len s1))
-  (($str_fixed_len_re (re.union r r1))  (let ((n ($str_fixed_len_re r)))
+  (($str_fixed_len_re (re.union r r1))  (alf.define ((n ($str_fixed_len_re r)))
                                           (alf.ite (alf.is_eq r1 re.none)
                                             n
                                             (alf.requires ($str_fixed_len_re r1) n n))))
-  (($str_fixed_len_re (re.inter r r1))  (let ((n ($str_fixed_len_re r)))
+  (($str_fixed_len_re (re.inter r r1))  (alf.define ((n ($str_fixed_len_re r)))
                                           (alf.ite (alf.is_eq r1 re.all)
                                             n
                                             (alf.requires ($str_fixed_len_re r1) n n))))
@@ -99,7 +99,7 @@
                                                               ; to make progress, first component must be non-empty
                                                               ($str_eval_str_in_re_rec s 1 r1 (re.* r1))))
   (($str_eval_str_in_re_rec s 0 (str.to_re sr) @re.null)    (alf.is_eq s sr))
-  (($str_eval_str_in_re_rec s 0 (re.range s1 s2) @re.null)  (let ((cs (alf.to_z s)))
+  (($str_eval_str_in_re_rec s 0 (re.range s1 s2) @re.null)  (alf.define ((cs (alf.to_z s)))
                                                             (alf.requires (alf.len s1) 1
                                                             (alf.requires (alf.len s2) 1
                                                             (alf.ite (alf.is_eq (alf.len s) 1)
@@ -110,10 +110,10 @@
   (($str_eval_str_in_re_rec s 0 re.all @re.null)            true)
   (($str_eval_str_in_re_rec s 0 re.none @re.null)           false)
   (($str_eval_str_in_re_rec s 0 (re.comp r1) @re.null)      (alf.not ($str_eval_str_in_re_rec s 0 r1 @re.null)))
-  (($str_eval_str_in_re_rec s n r1 r2)                      (let ((ls (alf.len s)))
-                                                            (let ((ss1 (alf.extract s 0 (alf.add n -1))))
-                                                            (let ((ss2 (alf.extract s n ls)))
-                                                            (let ((res (alf.ite ($str_eval_str_in_re_rec ss1 0 r1 @re.null)
+  (($str_eval_str_in_re_rec s n r1 r2)                      (alf.define ((ls (alf.len s)))
+                                                            (alf.define ((ss1 (alf.extract s 0 (alf.add n -1))))
+                                                            (alf.define ((ss2 (alf.extract s n ls)))
+                                                            (alf.define ((res (alf.ite ($str_eval_str_in_re_rec ss1 0 r1 @re.null)
                                                                        (alf.ite ($str_eval_str_in_re_rec ss2 0 r2 @re.null)
                                                                          true false)
                                                                        false)))
@@ -198,7 +198,7 @@
     ((Seq T)) (Seq T)
     (
         (($str_nary_intro (str.++ t ss)) (str.++ t ss))
-        (($str_nary_intro t)             (let ((nil (mk_emptystr (alf.typeof t))))
+        (($str_nary_intro t)             (alf.define ((nil (mk_emptystr (alf.typeof t))))
                                             (alf.ite (alf.is_eq t nil) t ($str_cons t nil))))
     )
 )
@@ -222,7 +222,7 @@
     ((T Type) (t (Seq T)) (ss (Seq T) :list))
     ((Seq T)) (Seq T)
     (
-        (($str_nary_elim (str.++ t ss)) (let ((nil (mk_emptystr (alf.typeof t))))
+        (($str_nary_elim (str.++ t ss)) (alf.define ((nil (mk_emptystr (alf.typeof t))))
                                            (alf.ite (alf.is_eq ss nil) t (str.++ t ss))))
         (($str_nary_elim t)             ($str_self_if_empty t))
     )
@@ -249,10 +249,10 @@
   ((Seq U) Int Int) Bool
   (
     ((string_reduction_substr x n m)
-      (let ((k (@purify (str.substr x n m))))
-      (let ((npm (+ n m)))
-      (let ((k1 (@purify (skolem_prefix x n))))
-      (let ((k2 (@purify (skolem_suffix_rem x npm))))
+      (alf.define ((k (@purify (str.substr x n m))))
+      (alf.define ((npm (+ n m)))
+      (alf.define ((k1 (@purify (skolem_prefix x n))))
+      (alf.define ((k2 (@purify (skolem_suffix_rem x npm))))
       (ite
         ; condition
         (and (>= n 0)(> (str.len x) n) (> m 0))
@@ -273,10 +273,10 @@
   ((Seq U) (Seq U) Int) Bool
   (
     ((string_reduction_indexof x y n)
-      (let ((k (@purify (str.indexof x y n))))
-      (let ((xn (str.substr x n (- (str.len x) n))))
-      (let ((k1 (@purify (skolem_first_ctn_pre xn y))))
-      (let ((k2 (@purify (skolem_first_ctn_post xn y))))
+      (alf.define ((k (@purify (str.indexof x y n))))
+      (alf.define ((xn (str.substr x n (- (str.len x) n))))
+      (alf.define ((k1 (@purify (skolem_first_ctn_pre xn y))))
+      (alf.define ((k2 (@purify (skolem_first_ctn_post xn y))))
       (ite
         (or (not (str.contains xn y)) (> n (str.len x)) (> 0 n))
         (= k (alf.neg 1))
@@ -319,8 +319,8 @@
   ((Seq U) (Seq U)) Bool
   (
     ((string_eager_reduction_contains t r)
-        (let ((k1 (@purify (skolem_first_ctn_pre t r))))
-        (let ((k2 (@purify (skolem_first_ctn_post t r))))
+        (alf.define ((k1 (@purify (skolem_first_ctn_pre t r))))
+        (alf.define ((k2 (@purify (skolem_first_ctn_post t r))))
         (ite
           (str.contains t r)
           (= t (str.++ k1 r k2))
@@ -331,7 +331,7 @@
 
 ; Compute the eager reduction predicate for (str.code s)
 (define string_eager_reduction_to_code ((s String))
-  (let ((t (str.to_code s)))
+  (alf.define ((t (str.to_code s)))
   (ite
     (= (str.len s) 1)
     (and (>= t 0) (< t 196608))
@@ -343,7 +343,7 @@
   (U U Int) Bool
   (
     ((string_eager_reduction_indexof x y n)
-        (let ((t (str.indexof x y n)))
+        (alf.define ((t (str.indexof x y n)))
         (and (or (= t (alf.neg 1)) (>= t n))
              (<= t (str.len x)))))
   )
@@ -392,7 +392,7 @@
               ; a constant regular expression, append s
               ((str.to_re s) (@pair (str.++ s c) M))
               ; otherwise, make the skolem and append with constraint
-              (r            (let ((k (@re_unfold_pos_component t ro i)))
+              (r            (alf.define ((k (@re_unfold_pos_component t ro i)))
                             (@pair (str.++ k c) (and (str.in_re k r) M))))
             )
           )
@@ -787,7 +787,7 @@
     (($str_re_consume_rec s1 (re.++ @re.empty r2) @result.null rev)
       ($str_re_consume_rec s1 r2 @result.null rev)) ; finished current component
     ; Intersection reports conflicts eagerly, and otherwise combines the results
-    (($str_re_consume_rec s1 (re.inter r1 r2) b rev)   (let ((r1r ($re_to_flat_form r1 rev)))
+    (($str_re_consume_rec s1 (re.inter r1 r2) b rev)   (alf.define ((r1r ($re_to_flat_form r1 rev)))
                                                        (alf.match ((bb Bool))
                                                           ($str_re_consume_rec s1 r1r @result.null rev)
                                                           (
@@ -798,7 +798,7 @@
     (($str_re_consume_rec s1 re.all @result.null rev)  (str.in_re "" @re.empty)) ; only used if re.all appears in unexpected position
     (($str_re_consume_rec s1 re.all b rev)             b)                        ; end of re.inter
     ; Union ignores conflicts, and otherwise combines the results. We report a conflict if all children give conflicts.
-    (($str_re_consume_rec s1 (re.union r1 r2) b rev)   (let ((r1r ($re_to_flat_form r1 rev)))
+    (($str_re_consume_rec s1 (re.union r1 r2) b rev)   (alf.define ((r1r ($re_to_flat_form r1 rev)))
                                                        (alf.match ((bb Bool))
                                                           ($str_re_consume_rec s1 r1r @result.null rev)
                                                           (
@@ -824,13 +824,13 @@
 ;   them again and consume from the beginning of the remainder. Finally, we convert
 ;   back from flat form when applicable.
 (define $str_re_consume ((s String) (r RegLan))
-  (let ((ss (string_to_flat_form s true)))  
-  (let ((rr ($re_to_flat_form r true)))
+  (alf.define ((ss (string_to_flat_form s true)))  
+  (alf.define ((rr ($re_to_flat_form r true)))
   (alf.match ((s1 String) (r1 RegLan))
       ($str_re_consume_rec ss rr @result.null true)
       (
         (false              false)
-        ((str.in_re s1 r1)  (let ((s1r ($str_rev true s1)) (r1r ($re_to_flat_form r1 true)))
+        ((str.in_re s1 r1)  (alf.define ((s1r ($str_rev true s1)) (r1r ($re_to_flat_form r1 true)))
                             (alf.match ((s2 String) (r2 RegLan))
                               ($str_re_consume_rec s1r r1r @result.null false)
                               (

--- a/proofs/alf/cvc5/programs/Utils.smt3
+++ b/proofs/alf/cvc5/programs/Utils.smt3
@@ -121,7 +121,7 @@
 (define $get_aci_norm ((T Type :implicit) (t T))
   (alf.match ((S Type) (U Type) (V Type) (f (-> S U V)) (x S) (y U :list))
     t
-    (((f x y) (let ((id (alf.nil f x y))) ($singleton_elim_aci f id ($get_aci_norm_rec f id t))))))
+    (((f x y) (alf.define ((id (alf.nil f x y))) ($singleton_elim_aci f id ($get_aci_norm_rec f id t))))))
 )
 
 ;; =============== for ACI_NORM associative
@@ -149,7 +149,7 @@
 (define $get_a_norm ((T Type :implicit) (t T))
   (alf.match ((S Type) (U Type) (V Type) (f (-> S U V)) (x S) (y U :list))
     t
-    (((f x y) (let ((id (alf.nil f x y))) ($singleton_elim_aci f id ($get_a_norm_rec f id t))))))
+    (((f x y) (alf.define ((id (alf.nil f x y))) ($singleton_elim_aci f id ($get_a_norm_rec f id t))))))
 )
 
 

--- a/proofs/alf/cvc5/rules/Arith.smt3
+++ b/proofs/alf/cvc5/rules/Arith.smt3
@@ -214,7 +214,7 @@
 (program $greatest_int_lt ((R Type) (c R))
   (R) Int
   (
-    (($greatest_int_lt c) (let ((ci (alf.to_z c)))
+    (($greatest_int_lt c) (alf.define ((ci (alf.to_z c)))
                                (alf.ite (alf.is_eq (alf.to_q c) (alf.to_q ci))
                                  (alf.add -1 ci)
                                  ci)))

--- a/proofs/alf/cvc5/rules/Booleans.smt3
+++ b/proofs/alf/cvc5/rules/Booleans.smt3
@@ -67,8 +67,8 @@
 ;   that L is removed with the appropriate polarity in both clauses. We then
 ;   concatentate the results, converting back to a unit formula if necessary.
 (define $resolve ((C1 Bool) (C2 Bool) (pol Bool) (L Bool))
-    (let ((lp (alf.ite pol L (not L))))
-    (let ((ln (alf.ite pol (not L) L)))
+    (alf.define ((lp (alf.ite pol L (not L))))
+    (alf.define ((ln (alf.ite pol (not L) L)))
         ($from_clause (alf.list_concat or
             ($remove_maybe_self lp ($to_clause C1))
             ($remove_maybe_self ln ($to_clause C2))))))
@@ -112,8 +112,8 @@
         (($chain_resolve_rec C1 true @list.nil @list.nil)         ($from_clause C1))
         (($chain_resolve_rec C1 (and C2 Cs) (@list pol pols) (@list L lits))
             ($chain_resolve_rec
-                (let ((lp (alf.ite pol L (not L))))
-                (let ((ln (alf.ite pol (not L) L)))
+                (alf.define ((lp (alf.ite pol L (not L))))
+                (alf.define ((ln (alf.ite pol (not L) L)))
                     (alf.list_concat or
                         ($remove_maybe_self lp C1)
                         ($remove_maybe_self ln ($to_clause C2))))) Cs pols lits))
@@ -158,8 +158,8 @@
 (program $factor_literals ((xs Bool :list) (l Bool) (ls Bool :list))
     (Bool Bool) Bool
     (
-        (($factor_literals xs (or l ls)) (let ((cond (alf.is_neg (alf.list_find or xs l))))
-                                         (let ((ret ($factor_literals
+        (($factor_literals xs (or l ls)) (alf.define ((cond (alf.is_neg (alf.list_find or xs l))))
+                                         (alf.define ((ret ($factor_literals
                                                     (alf.ite cond (alf.cons or l xs) xs)
                                                     ls)))
                                             (alf.ite cond (alf.cons or l ret) ret))))

--- a/proofs/alf/cvc5/rules/Builtin.smt3
+++ b/proofs/alf/cvc5/rules/Builtin.smt3
@@ -103,6 +103,6 @@
 (declare-rule ite_eq ((T Type) (b Bool) (t1 T) (t2 T))
   :args ((ite b t1 t2))
   :conclusion
-    (let ((k (ite b t1 t2))) (ite b (= k t1) (= k t2)))
+    (alf.define ((k (ite b t1 t2))) (ite b (= k t1) (= k t2)))
 )
 

--- a/proofs/alf/cvc5/rules/Strings.smt3
+++ b/proofs/alf/cvc5/rules/Strings.smt3
@@ -33,9 +33,9 @@
 
 ; returns true if s1 is a prefix of s, taking into account flattening
 (define string_is_prefix ((U Type :implicit) (s U) (s1 U) (rev Bool))
-  (let ((sf (string_to_flat_form s rev)))
-  (let ((sf1 (string_to_flat_form s1 rev)))
-  (let ((U (alf.typeof s)))
+  (alf.define ((sf (string_to_flat_form s rev)))
+  (alf.define ((sf1 (string_to_flat_form s1 rev)))
+  (alf.define ((U (alf.typeof s)))
   (nary.is_prefix str.++ (mk_emptystr U) sf1 sf))))
 )
 
@@ -79,7 +79,7 @@
             (string_to_flat_form s rev)
             (((str.++ s1 s2)
               (alf.requires s1 sc
-                (let ((k (@purify (skolem_unify_split t1 s1 rev))))
+                (alf.define ((k (@purify (skolem_unify_split t1 s1 rev))))
                 (and 
                   (or 
                     (= t1
@@ -108,7 +108,7 @@
             (string_to_flat_form s rev)
             (((str.++ s1 s2)
               (alf.requires s1 sc
-                (let ((k (@purify (skolem_unify_split t1 s1 rev))))
+                (alf.define ((k (@purify (skolem_unify_split t1 s1 rev))))
                   (and
                     (= t1
                       (alf.ite rev
@@ -131,13 +131,13 @@
           (alf.match ((s1 (Seq U)) (s2 (Seq U) :list))
             ($str_rev rev ($str_nary_intro s))  ; must do nary intro when s is just a constant
             (((str.++ s1 s2)
-                (let ((sc (string_to_flat_form s1 rev)))
-                (let ((v (alf.add 1 ($str_overlap ($tail sc) (string_to_flat_form t2 rev)))))
+                (alf.define ((sc (string_to_flat_form s1 rev)))
+                (alf.define ((v (alf.add 1 ($str_overlap ($tail sc) (string_to_flat_form t2 rev)))))
                   (= tc
                     (alf.ite rev
-                      (let ((oc ($str_suffix_w_len s1 v)))
+                      (alf.define ((oc ($str_suffix_w_len s1 v)))
                       (str.++ (@purify (skolem_prefix tc (- (str.len tc) (str.len oc)))) oc))
-                      (let ((oc (skolem_prefix s1 v)))
+                      (alf.define ((oc (skolem_prefix s1 v)))
                       (str.++ oc (@purify (skolem_suffix_rem tc (str.len oc)))))))
                 )))))))))
 )
@@ -153,8 +153,8 @@
            (string_to_flat_form s rev)
            (string_to_flat_form t rev))
       (((@pair ss ts)
-          (let ((cs (string_head_or_empty ss)))
-          (let ((ct (string_head_or_empty ts)))
+          (alf.define ((cs (string_head_or_empty ss)))
+          (alf.define ((ct (string_head_or_empty ts)))
             ; ensure they are disequal, return false
             (alf.requires
               (alf.ite ($str_is_empty cs)
@@ -202,10 +202,10 @@
   :premises ((>= (str.len s) n))
   :args (b)
   :conclusion (alf.ite b
-                (let ((kp (@purify (skolem_prefix s n)))
+                (alf.define ((kp (@purify (skolem_prefix s n)))
                       (ks (@purify (skolem_suffix_rem s n))))
                 (and (= s (str.++ kp ks)) (= (str.len kp) n)))
-                (let ((kp (@purify ($str_prefix_wo_len s n)))
+                (alf.define ((kp (@purify ($str_prefix_wo_len s n)))
                       (ks (@purify ($str_suffix_w_len s n))))
                 (and (= s (str.++ kp ks)) (= (str.len ks) n)))))
 
@@ -262,7 +262,7 @@
             (alf.match ((tk String) (M Bool :list))
             (re_unfold_pos_concat t r)
             (((@pair tk M)
-                (let ((teq (= t tk))) (alf.ite (alf.is_eq M true) teq (and teq M)))))))
+                (alf.define ((teq (= t tk))) (alf.ite (alf.is_eq M true) teq (and teq M)))))))
     ))
 )
 
@@ -274,7 +274,7 @@
     (alf.match ((r1 RegLan) (r2 RegLan :list))
       ($str_rev rev r)
       (
-        ((re.++ r1 r2) (let ((n ($str_fixed_len_re r1)))
+        ((re.++ r1 r2) (alf.define ((n ($str_fixed_len_re r1)))
                        (alf.ite rev
                        (or (not (str.in_re ($str_suffix_w_len s n) r1))
                            (not (str.in_re (skolem_prefix s (- (str.len s) n)) ($singleton_elim ($str_rev rev r2)))))


### PR DESCRIPTION
Also removes deprecated `let` syntax in favor of `alf.define`. 