### PR TITLE
cmake: Fixes for setuptools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,10 +394,22 @@ set(Python_BASE_EXECUTABLE "${Python_EXECUTABLE}"
 
 macro(create_venv)
   message(STATUS "Creating Python virtual environment")
-  # Use packages installed in the base installation if they're already present
+  # Use packages installed in the base installation if they're already present...
+  if(BUILD_BINDINGS_PYTHON AND NOT ONLY_PYTHON_EXT_SRC)
+    #... unless we are building the Python bindings.
+    # Building the Python bindings currently requires a recent version of
+    # setuptools. On old systems with Python 3.8 or 3.9, upgrading to the latest
+    # version of setuptools without manually upgrading its dependencies
+    # can cause problems (see https://github.com/pypa/setuptools/issues/4478).
+    # Therefore, we start with a clean virtual environment so that
+    # all the latest dependencies of setuptools are installed.
+    set(VENV_SYSTEM_PACKAGES_FLAG "")
+  else()
+    set(VENV_SYSTEM_PACKAGES_FLAG "--system-site-packages")
+  endif()
   execute_process (
     COMMAND
-      "${Python_EXECUTABLE}" -m venv --system-site-packages "${VENV_PATH}"
+      "${Python_EXECUTABLE}" -m venv ${VENV_SYSTEM_PACKAGES_FLAG} "${VENV_PATH}"
     RESULT_VARIABLE VENV_CMD_EXIT_CODE
   )
   if(VENV_CMD_EXIT_CODE)

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -146,7 +146,7 @@ versions; more recent versions should be compatible.
 - `CMake >= 3.16 <https://cmake.org>`_
 - `GNU Make <https://www.gnu.org/software/make/>`_
   or `Ninja <https://ninja-build.org/>`_
-- `Python >= 3.6 <https://www.python.org>`_
+- `Python >= 3.7 <https://www.python.org>`_
   + module `tomli <https://pypi.org/project/tomli/>`_ (Python < 3.11)
   + module `pyparsing <https://pypi.org/project/pyparsing/>`_
 - `GMP v6.3 (GNU Multi-Precision arithmetic library) <https://gmplib.org>`_

--- a/cmake/FindSetuptools.cmake
+++ b/cmake/FindSetuptools.cmake
@@ -46,7 +46,11 @@ if (Setuptools_VERSION_CHECK_RESULT EQUAL 0)
         set(INSTALL_SETUPTOOLS_MESSAGE "==${Setuptools_FIND_VERSION}")
       endif()
     else()
-      if (Setuptools_VERSION VERSION_LESS ${Setuptools_FIND_VERSION})
+      # Setuptools v70.2.0 is broken on Windows.
+      #   See https://github.com/pypa/distutils/issues/268
+      # If v70.2.0 is installed, upgrade it to a newer version.
+      if (Setuptools_VERSION VERSION_LESS ${Setuptools_FIND_VERSION} OR
+          (WIN32 AND Setuptools_VERSION VERSION_EQUAL 70.2.0))
         set(INSTALL_SETUPTOOLS TRUE)
         set(INSTALL_SETUPTOOLS_OPTION ";-U")
         set(INSTALL_SETUPTOOLS_MESSAGE ">=${Setuptools_FIND_VERSION}")

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -15,11 +15,9 @@
 
 if(NOT ONLY_PYTHON_EXT_SRC)
   # Python modules for building:
-  # Version 70.2.0 is broken on Windows.
-  #   See https://github.com/pypa/distutils/issues/268
-  # Version 71.0.1 is broken on all platforms.
-  # Install exact version 70.3.0 as a workaround.
-  find_package(Setuptools 70.3.0 EXACT REQUIRED)
+  # v68.0.0 is the last version of setuptools that is
+  # compatible with Python 3.7
+  find_package(Setuptools 66.1.0 REQUIRED)
   find_package(Cython 3.0.0 REQUIRED)
   # Python modules for installing:
   find_package(Pip 23.0 REQUIRED)


### PR DESCRIPTION
This replaces a workaround introduced to address issues caused by setuptools v71.0.0 with a more flexible solution. It also updates INSTALL to reflect that the minimum required version of Python is 3.7. For instance, `mkrewrites.py` uses `dataclasses`, a feature added in Python 3.7, and setuptools 66.1.0 requires Python 3.7 or later.