### PR TITLE
Revert to fresh binder semantics in parser

### DIFF
--- a/src/options/parser_options.toml
+++ b/src/options/parser_options.toml
@@ -33,6 +33,14 @@ name   = "Parser"
   default    = "true"
   help       = "use API interface for fresh constants when parsing declarations and definitions"
 
+[[option]]
+  name       = "freshBinders"
+  category   = "expert"
+  long       = "fresh-binders"
+  type       = "bool"
+  default    = "true"
+  help       = "construct fresh variables always when parsing binders"
+
 # this is to support security in the online version, and in other similar
 # contexts (--no-include-file disables filesystem access in TPTP and SMT2
 # parsers) the name --no-include-file is legacy: it also now limits any

--- a/src/parser/parser_state.h
+++ b/src/parser/parser_state.h
@@ -215,7 +215,7 @@ class CVC5_EXPORT ParserState
    * @param name The name of the variable
    * @param type The type of the variable
    * @param fresh If true, the variable is always new. If false, we lookup the
-   * variable in a cache and return a
+   * variable in a cache and return a.
    */
   Term bindBoundVar(const std::string& name,
                     const Sort& type,

--- a/src/parser/smt2/smt2_cmd_parser.cpp
+++ b/src/parser/smt2/smt2_cmd_parser.cpp
@@ -402,10 +402,12 @@ std::unique_ptr<Cmd> Smt2CmdParser::parseNextCommand()
       {
         d_state.pushScope();
       }
+      bool freshBinders = d_state.usingFreshBinders();
+      // If d_freshBinders is false,
       // Must use fresh=false here to ensure that variables introduced by
       // define-fun are accurate with respect to proofs, i.e. variables of
       // the same name and type are indeed the same variable.
-      std::vector<Term> terms = d_state.bindBoundVars(sortedVarNames, false);
+      std::vector<Term> terms = d_state.bindBoundVars(sortedVarNames, freshBinders);
       Term expr = d_tparser.parseTerm();
       if (!flattenVars.empty())
       {

--- a/src/parser/smt2/smt2_cmd_parser.cpp
+++ b/src/parser/smt2/smt2_cmd_parser.cpp
@@ -407,7 +407,8 @@ std::unique_ptr<Cmd> Smt2CmdParser::parseNextCommand()
       // Must use fresh=false here to ensure that variables introduced by
       // define-fun are accurate with respect to proofs, i.e. variables of
       // the same name and type are indeed the same variable.
-      std::vector<Term> terms = d_state.bindBoundVars(sortedVarNames, freshBinders);
+      std::vector<Term> terms =
+          d_state.bindBoundVars(sortedVarNames, freshBinders);
       Term expr = d_tparser.parseTerm();
       if (!flattenVars.empty())
       {

--- a/src/parser/smt2/smt2_cmd_parser.cpp
+++ b/src/parser/smt2/smt2_cmd_parser.cpp
@@ -403,9 +403,9 @@ std::unique_ptr<Cmd> Smt2CmdParser::parseNextCommand()
         d_state.pushScope();
       }
       bool freshBinders = d_state.usingFreshBinders();
-      // If freshBinders is false, we use fresh=false here to ensure that variables introduced by
-      // define-fun are accurate with respect to proofs, i.e. variables of
-      // the same name and type are indeed the same variable.
+      // If freshBinders is false, we use fresh=false here to ensure that
+      // variables introduced by define-fun are accurate with respect to proofs,
+      // i.e. variables of the same name and type are indeed the same variable.
       std::vector<Term> terms =
           d_state.bindBoundVars(sortedVarNames, freshBinders);
       Term expr = d_tparser.parseTerm();

--- a/src/parser/smt2/smt2_cmd_parser.cpp
+++ b/src/parser/smt2/smt2_cmd_parser.cpp
@@ -403,8 +403,7 @@ std::unique_ptr<Cmd> Smt2CmdParser::parseNextCommand()
         d_state.pushScope();
       }
       bool freshBinders = d_state.usingFreshBinders();
-      // If d_freshBinders is false,
-      // Must use fresh=false here to ensure that variables introduced by
+      // If freshBinders is false, we use fresh=false here to ensure that variables introduced by
       // define-fun are accurate with respect to proofs, i.e. variables of
       // the same name and type are indeed the same variable.
       std::vector<Term> terms =

--- a/src/parser/smt2/smt2_cmd_parser.h
+++ b/src/parser/smt2/smt2_cmd_parser.h
@@ -52,10 +52,6 @@ class Smt2CmdParser
   Smt2TermParser& d_tparser;
   /** Map strings to tokens */
   std::map<std::string, Token> d_table;
-  /** is strict */
-  bool d_isStrict;
-  /** is sygus */
-  bool d_isSygus;
 };
 
 }  // namespace parser

--- a/src/parser/smt2/smt2_state.cpp
+++ b/src/parser/smt2/smt2_state.cpp
@@ -34,7 +34,7 @@ Smt2State::Smt2State(ParserStateCallback* psc,
       d_logicSet(false),
       d_seenSetLogic(false)
 {
-  d_solver->getOption("fresh-binders") == "true";
+  d_freshBinders = (d_solver->getOption("fresh-binders") == "true");
 }
 
 Smt2State::~Smt2State() {}

--- a/src/parser/smt2/smt2_state.cpp
+++ b/src/parser/smt2/smt2_state.cpp
@@ -1034,10 +1034,7 @@ bool Smt2State::hasGrammars() const
          || d_solver->getOption("produce-interpolants") == "true";
 }
 
-bool Smt2State::usingFreshBinders() const
-{
-  return d_freshBinders;
-}
+bool Smt2State::usingFreshBinders() const { return d_freshBinders; }
 
 void Smt2State::checkThatLogicIsSet()
 {

--- a/src/parser/smt2/smt2_state.cpp
+++ b/src/parser/smt2/smt2_state.cpp
@@ -34,6 +34,7 @@ Smt2State::Smt2State(ParserStateCallback* psc,
       d_logicSet(false),
       d_seenSetLogic(false)
 {
+  d_solver->getOption("fresh-binders") == "true";
 }
 
 Smt2State::~Smt2State() {}
@@ -1031,6 +1032,11 @@ bool Smt2State::hasGrammars() const
 {
   return sygus() || d_solver->getOption("produce-abducts") == "true"
          || d_solver->getOption("produce-interpolants") == "true";
+}
+
+bool Smt2State::usingFreshBinders() const
+{
+  return d_freshBinders;
 }
 
 void Smt2State::checkThatLogicIsSet()

--- a/src/parser/smt2/smt2_state.h
+++ b/src/parser/smt2/smt2_state.h
@@ -256,6 +256,12 @@ class Smt2State : public ParserState
    * grammar-specific token `Constant`.
    */
   bool hasGrammars() const;
+  /**
+   * Are we using fresh binders? If this returns true, then every binder
+   * is assumed to refer to fresh variables. If this returns false, then
+   * variables are assumed to be globally unique up to their name and type.
+   */
+  bool usingFreshBinders() const;
 
   void checkThatLogicIsSet();
 
@@ -469,6 +475,8 @@ class Smt2State : public ParserState
 
   /** Are we parsing a sygus file? */
   bool d_isSygus;
+  /** are we using fresh binders? */
+  bool d_freshBinders;
   /** Has the logic been set (either by forcing it or a set-logic command)? */
   bool d_logicSet;
   /** Have we seen a set-logic command yet? */

--- a/src/parser/smt2/smt2_term_parser.cpp
+++ b/src/parser/smt2/smt2_term_parser.cpp
@@ -214,8 +214,9 @@ Term Smt2TermParser::parseTerm()
                 d_lex.parseError("Expected non-empty sorted variable list");
               }
               bool freshBinders = d_state.usingFreshBinders();
-              // If freshBinders is false, we set fresh to false here. This means that (x Int) appearing
-              // in a quantified formula always constructs the same variable.
+              // If freshBinders is false, we set fresh to false here. This
+              // means that (x Int) appearing in a quantified formula always
+              // constructs the same variable.
               std::vector<Term> vs =
                   d_state.bindBoundVars(sortedVarNames, freshBinders);
               Term vl = tm.mkTerm(Kind::VARIABLE_LIST, vs);

--- a/src/parser/smt2/smt2_term_parser.cpp
+++ b/src/parser/smt2/smt2_term_parser.cpp
@@ -213,10 +213,11 @@ Term Smt2TermParser::parseTerm()
               {
                 d_lex.parseError("Expected non-empty sorted variable list");
               }
-              // We set fresh to false here. This means that (x Int) appearing
+              bool freshBinders = d_state.usingFreshBinders();
+              // If freshBinders is false, we set fresh to false here. This means that (x Int) appearing
               // in a quantified formula always constructs the same variable.
               std::vector<Term> vs =
-                  d_state.bindBoundVars(sortedVarNames, false);
+                  d_state.bindBoundVars(sortedVarNames, freshBinders);
               Term vl = tm.mkTerm(Kind::VARIABLE_LIST, vs);
               args.push_back(vl);
               xstack.emplace_back(ParseCtx::CLOSURE_NEXT_ARG);

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -24,7 +24,6 @@
 #include "expr/node_algorithm.h"
 #include "expr/subs.h"
 #include "options/main_options.h"
-#include "options/parser_options.h"
 #include "printer/printer.h"
 #include "printer/smt2/smt2_printer.h"
 #include "proof/alf/alf_dependent_type_converter.h"
@@ -153,6 +152,7 @@ bool AlfPrinter::isHandled(const ProofNode* pfn) const
     case ProofRule::ITE_EQ:
     case ProofRule::INSTANTIATE:
     case ProofRule::SKOLEMIZE:
+    case ProofRule::ALPHA_EQUIV:
     case ProofRule::ENCODE_EQ_INTRO:
     case ProofRule::HO_APP_ENCODE:
     case ProofRule::ACI_NORM:
@@ -200,12 +200,6 @@ bool AlfPrinter::isHandled(const ProofNode* pfn) const
       Kind k = pargs[0].getKind();
       return k == Kind::STRING_CONTAINS || k == Kind::STRING_TO_CODE
              || k == Kind::STRING_INDEXOF || k == Kind::STRING_IN_REGEXP;
-    }
-    break;
-    case ProofRule::ALPHA_EQUIV:
-    {
-      // only works in general if not using fresh binders
-      return !options().parser.freshBinders;
     }
     break;
     //

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -24,6 +24,7 @@
 #include "expr/node_algorithm.h"
 #include "expr/subs.h"
 #include "options/main_options.h"
+#include "options/parser_options.h"
 #include "printer/printer.h"
 #include "printer/smt2/smt2_printer.h"
 #include "proof/alf/alf_dependent_type_converter.h"
@@ -152,7 +153,6 @@ bool AlfPrinter::isHandled(const ProofNode* pfn) const
     case ProofRule::ITE_EQ:
     case ProofRule::INSTANTIATE:
     case ProofRule::SKOLEMIZE:
-    case ProofRule::ALPHA_EQUIV:
     case ProofRule::ENCODE_EQ_INTRO:
     case ProofRule::HO_APP_ENCODE:
     case ProofRule::ACI_NORM:
@@ -200,6 +200,12 @@ bool AlfPrinter::isHandled(const ProofNode* pfn) const
       Kind k = pargs[0].getKind();
       return k == Kind::STRING_CONTAINS || k == Kind::STRING_TO_CODE
              || k == Kind::STRING_INDEXOF || k == Kind::STRING_IN_REGEXP;
+    }
+    break;
+    case ProofRule::ALPHA_EQUIV:
+    {
+      // only works in general if not using fresh binders
+      return !options().parser.freshBinders;
     }
     break;
     //

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1431,6 +1431,7 @@ set(regress_0_tests
   regress0/quantifiers/is-even-pred.smt2
   regress0/quantifiers/is-int.smt2
   regress0/quantifiers/issue1805.smt2
+  regress0/quantifiers/issue11066-fresh-binders.smt2
   regress0/quantifiers/issue2031-bv-var-elim.smt2
   regress0/quantifiers/issue2033-macro-arith.smt2
   regress0/quantifiers/issue2035.smt2

--- a/test/regress/cli/regress0/quantifiers/issue11066-fresh-binders.smt2
+++ b/test/regress/cli/regress0/quantifiers/issue11066-fresh-binders.smt2
@@ -1,4 +1,5 @@
 ; EXPECT: unsat
+; DISABLE-TESTER: alf
 (set-logic ALL)
 (assert (exists ((x Real))
           (let ((?y x))

--- a/test/regress/cli/regress0/quantifiers/issue11066-fresh-binders.smt2
+++ b/test/regress/cli/regress0/quantifiers/issue11066-fresh-binders.smt2
@@ -1,0 +1,6 @@
+; EXPECT: unsat
+(set-logic ALL)
+(assert (exists ((x Real))
+          (let ((?y x))
+          (and (<= 0 x) (exists ((x Real)) (forall ((v Real)) (> 0 ?y)))))))
+(check-sat)

--- a/test/regress/cli/run_regression.py
+++ b/test/regress/cli/run_regression.py
@@ -281,6 +281,7 @@ class AlfTester(Tester):
                 "--proof-format=alf",
                 "--proof-granularity=dsl-rewrite",
                 "--proof-print-conclusion",
+                "--no-fresh-binders",  #FIXME
             ] + benchmark_info.command_line_args
             output, error, exit_status = run_process(
                 [benchmark_info.cvc5_binary]

--- a/test/regress/cli/run_regression.py
+++ b/test/regress/cli/run_regression.py
@@ -281,7 +281,7 @@ class AlfTester(Tester):
                 "--proof-format=alf",
                 "--proof-granularity=dsl-rewrite",
                 "--proof-print-conclusion",
-                "--no-fresh-binders",  #FIXME
+                "--no-fresh-binders",  #FIXME cvc5 wishue 156
             ] + benchmark_info.command_line_args
             output, error, exit_status = run_process(
                 [benchmark_info.cvc5_binary]


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/11066.

This reverts a change to how variables are parsed as introduced in https://github.com/cvc5/cvc5/pull/10556.

After this PR, the reverted behavior is available with `--no-fresh-binders`, but still suffers from potential unsoundness demonstrated on https://github.com/cvc5/cvc5/issues/11066.

In particular, with non-fresh binders, it is possible to use SMT-LIB `let` to generate a term that is not properly interpreted by our parser, as demonstrated by the minimal example on that issue. In particular, since we do not interpret `let` as object syntax, the minimized benchmark on that issue leads to a substitution that is not capture avoiding.

The option `--no-fresh-binders` should be considered moving forward for proofs / distributed solving but will need a workaround to address the above issue, either by making `let` object syntax or further restricting which inputs we allow in the parser.