### PR TITLE
Disable ALF in regression

### DIFF
--- a/test/regress/cli/regress0/use_approx/bug812_approx.smt2
+++ b/test/regress/cli/regress0/use_approx/bug812_approx.smt2
@@ -1,5 +1,6 @@
 ; REQUIRES: glpk
 ; COMMAND-LINE: --use-approx
+; DISABLE-TESTER: alf
 (set-logic UFNIA)
 (set-info :source "Reduced from regression 'bug812.smt2' using ddSMT to exercise GLPK")
 (set-info :smt-lib-version 2.6)


### PR DESCRIPTION
This fails due to a mismatch in policies for handling overloading between alfc and cvc5.

Fixes an issue in the nightles.