### PR TITLE
Fix policy for whether a term is unsharable

### DIFF
--- a/src/smt/env.cpp
+++ b/src/smt/env.cpp
@@ -317,6 +317,7 @@ Node Env::getSharableFormula(const Node& n) const
     // note we only remove purify skolems if the above option is disabled
     on = SkolemManager::getOriginalForm(n);
   }
+  SkolemManager * skm = d_nm->getSkolemManager();
   std::vector<Node> toProcess;
   toProcess.push_back(on);
   size_t index = 0;
@@ -345,7 +346,7 @@ Node Env::getSharableFormula(const Node& n) const
         // must ensure that the indices of the skolem are also legal
         SkolemId id;
         Node cacheVal;
-        if (!SkoleManager::isSkolemFunction(s, id, cacheVal))
+        if (!skm->isSkolemFunction(s, id, cacheVal))
         {
           // kind SKOLEM should imply that it is a skolem function
           Assert(false);

--- a/src/smt/env.cpp
+++ b/src/smt/env.cpp
@@ -311,7 +311,7 @@ bool Env::isBooleanTermSkolem(const Node& k) const
 
 Node Env::getSharableFormula(const Node& n) const
 {
-  Node on = n; 
+  Node on = n;
   if (!d_options.base.pluginShareSkolems)
   {
     // note we only remove purify skolems if the above option is disabled
@@ -330,12 +330,12 @@ Node Env::getSharableFormula(const Node& n) const
     for (const Node& s : syms)
     {
       Kind sk = s.getKind();
-      if (sk==Kind::INST_CONSTANT || sk==Kind::DUMMY_SKOLEM)
+      if (sk == Kind::INST_CONSTANT || sk == Kind::DUMMY_SKOLEM)
       {
         // these kinds are never sharable
         return Node::null();
       }
-      if (sk==Kind::SKOLEM)
+      if (sk == Kind::SKOLEM)
       {
         if (!d_options.base.pluginShareSkolems)
         {
@@ -347,17 +347,19 @@ Node Env::getSharableFormula(const Node& n) const
         Node cacheVal;
         if (!SkoleManager::isSkolemFunction(sk, id, cacheVal))
         {
-          Assert (false);
+          Assert(false);
           return Node::null();
         }
-        if (!cacheVal.isNull() && std::find(toProcess.begin(), toProcess.end(), cacheVal)==toProcess.end())
+        if (!cacheVal.isNull()
+            && std::find(toProcess.begin(), toProcess.end(), cacheVal)
+                   == toProcess.end())
         {
           // add to process vector
           toProcess.push_back(cacheVal);
         }
       }
     }
-  }while (index<toProcess.size());
+  } while (index < toProcess.size());
   // If we didn't encounter an illegal term, we now eliminate subtyping
   SubtypeElimNodeConverter senc(d_nm);
   on = senc.convert(on);

--- a/src/smt/env.cpp
+++ b/src/smt/env.cpp
@@ -347,6 +347,7 @@ Node Env::getSharableFormula(const Node& n) const
         Node cacheVal;
         if (!SkoleManager::isSkolemFunction(sk, id, cacheVal))
         {
+          // kind SKOLEM should imply that it is a skolem function
           Assert(false);
           return Node::null();
         }
@@ -354,7 +355,7 @@ Node Env::getSharableFormula(const Node& n) const
             && std::find(toProcess.begin(), toProcess.end(), cacheVal)
                    == toProcess.end())
         {
-          // add to process vector
+          // if we have a cache value, add it to process vector
           toProcess.push_back(cacheVal);
         }
       }

--- a/src/smt/env.cpp
+++ b/src/smt/env.cpp
@@ -326,7 +326,7 @@ Node Env::getSharableFormula(const Node& n) const
     index++;
     // get the symbols contained in n
     std::unordered_set<Node> syms;
-    expr::getSymbols(on, syms);
+    expr::getSymbols(nn, syms);
     for (const Node& s : syms)
     {
       Kind sk = s.getKind();

--- a/src/smt/env.cpp
+++ b/src/smt/env.cpp
@@ -324,7 +324,7 @@ Node Env::getSharableFormula(const Node& n) const
   {
     Node nn = toProcess[index];
     index++;
-    // get the symbols contained in n
+    // get the symbols contained in nn
     std::unordered_set<Node> syms;
     expr::getSymbols(nn, syms);
     for (const Node& s : syms)

--- a/src/smt/env.cpp
+++ b/src/smt/env.cpp
@@ -345,7 +345,7 @@ Node Env::getSharableFormula(const Node& n) const
         // must ensure that the indices of the skolem are also legal
         SkolemId id;
         Node cacheVal;
-        if (!SkoleManager::isSkolemFunction(sk, id, cacheVal))
+        if (!SkoleManager::isSkolemFunction(s, id, cacheVal))
         {
           // kind SKOLEM should imply that it is a skolem function
           Assert(false);

--- a/src/smt/env.cpp
+++ b/src/smt/env.cpp
@@ -311,24 +311,54 @@ bool Env::isBooleanTermSkolem(const Node& k) const
 
 Node Env::getSharableFormula(const Node& n) const
 {
-  Node on = n;
-  // these kinds are never sharable
-  std::unordered_set<Kind, kind::KindHashFunction> ks = {Kind::INST_CONSTANT,
-                                                         Kind::DUMMY_SKOLEM};
+  Node on = n; 
   if (!d_options.base.pluginShareSkolems)
   {
     // note we only remove purify skolems if the above option is disabled
     on = SkolemManager::getOriginalForm(n);
-    // SKOLEM is additionally unsharable if option is set.
-    ks.insert(Kind::SKOLEM);
   }
-  if (expr::hasSubtermKinds(ks, on))
+  std::vector<Node> toProcess;
+  toProcess.push_back(on);
+  size_t index = 0;
+  do
   {
-    // We cannot share formulas with skolems currently.
-    // We should never share formulas with instantiation constants.
-    return Node::null();
-  }
-  // also eliminate subtyping
+    Node nn = toProcess[index];
+    index++;
+    // get the symbols contained in n
+    std::unordered_set<Node> syms;
+    expr::getSymbols(on, syms);
+    for (const Node& s : syms)
+    {
+      Kind sk = s.getKind();
+      if (sk==Kind::INST_CONSTANT || sk==Kind::DUMMY_SKOLEM)
+      {
+        // these kinds are never sharable
+        return Node::null();
+      }
+      if (sk==Kind::SKOLEM)
+      {
+        if (!d_options.base.pluginShareSkolems)
+        {
+          // not shared if option is false
+          return Node::null();
+        }
+        // must ensure that the indices of the skolem are also legal
+        SkolemId id;
+        Node cacheVal;
+        if (!SkoleManager::isSkolemFunction(sk, id, cacheVal))
+        {
+          Assert (false);
+          return Node::null();
+        }
+        if (!cacheVal.isNull() && std::find(toProcess.begin(), toProcess.end(), cacheVal)==toProcess.end())
+        {
+          // add to process vector
+          toProcess.push_back(cacheVal);
+        }
+      }
+    }
+  }while (index<toProcess.size());
+  // If we didn't encounter an illegal term, we now eliminate subtyping
   SubtypeElimNodeConverter senc(d_nm);
   on = senc.convert(on);
   return on;


### PR DESCRIPTION
The *indices* of skolems could also contain illegal symbols, this traverses indices of skolems until fixed point.