### PR TITLE
Change default proof granularity to theory rewrite

### DIFF
--- a/src/options/proof_options.toml
+++ b/src/options/proof_options.toml
@@ -100,7 +100,7 @@ name   = "Proof"
   category   = "regular"
   long       = "proof-granularity=MODE"
   type       = "ProofGranularityMode"
-  default    = "THEORY_REWRITE"
+  default    = "MACRO"
   help       = "modes for proof granularity"
   help_mode  = "Modes for proof granularity."
 [[option.mode.MACRO]]

--- a/src/options/proof_options.toml
+++ b/src/options/proof_options.toml
@@ -100,7 +100,7 @@ name   = "Proof"
   category   = "regular"
   long       = "proof-granularity=MODE"
   type       = "ProofGranularityMode"
-  default    = "MACRO"
+  default    = "THEORY_REWRITE"
   help       = "modes for proof granularity"
   help_mode  = "Modes for proof granularity."
 [[option.mode.MACRO]]

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -173,6 +173,15 @@ void SetDefaults::setDefaultsPre(Options& opts)
   {
     // if the user requested proofs, proof mode is full
     SET_AND_NOTIFY(smt, proofMode, options::ProofMode::FULL, "enabling proofs");
+    // Default granularity is theory rewrite if we are intentionally using
+    // proofs, otherwise it is MACRO (e.g. if produce unsat cores is true)
+    if (opts.proof.proofGranularityMode
+        < options::ProofGranularityMode::THEORY_REWRITE)
+    {
+      SET_AND_NOTIFY(proof, proofGranularityMode,
+                        options::ProofGranularityMode::THEORY_REWRITE,
+                        "enabling proofs");
+    }
     // unsat cores are available due to proofs being enabled
     if (opts.smt.unsatCoresMode != options::UnsatCoresMode::SAT_PROOF)
     {

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -178,9 +178,10 @@ void SetDefaults::setDefaultsPre(Options& opts)
     if (opts.proof.proofGranularityMode
         < options::ProofGranularityMode::THEORY_REWRITE)
     {
-      SET_AND_NOTIFY(proof, proofGranularityMode,
-                        options::ProofGranularityMode::THEORY_REWRITE,
-                        "enabling proofs");
+      SET_AND_NOTIFY(proof,
+                     proofGranularityMode,
+                     options::ProofGranularityMode::THEORY_REWRITE,
+                     "enabling proofs");
     }
     // unsat cores are available due to proofs being enabled
     if (opts.smt.unsatCoresMode != options::UnsatCoresMode::SAT_PROOF)


### PR DESCRIPTION
Macro rewrite is likely not a good default.

We could even consider `dsl-rewrite` as the new default.