### PR TITLE
Minor fixes and updates for strings infer proof cons

### DIFF
--- a/proofs/alf/cvc5/rules/Strings.smt3
+++ b/proofs/alf/cvc5/rules/Strings.smt3
@@ -279,12 +279,12 @@
   :premises ((>= (str.len s) n))
   :args (b)
   :conclusion (alf.ite b
-                (alf.define ((kp (@purify ($str_prefix s n)))
-                      (ks (@purify ($str_suffix_rem s n))))
-                (and (= s (str.++ kp ks)) (= (str.len kp) n)))
                 (alf.define ((kp (@purify ($str_prefix_rem s n)))
                       (ks (@purify ($str_suffix s n))))
-                (and (= s (str.++ kp ks)) (= (str.len ks) n)))))
+                (and (= s (str.++ kp ks)) (= (str.len ks) n)))
+                (alf.define ((kp (@purify ($str_prefix s n)))
+                      (ks (@purify ($str_suffix_rem s n))))
+                (and (= s (str.++ kp ks)) (= (str.len kp) n)))))
 
 ; rule: string_code_inj
 ; implements: ProofRule::STRING_CODE_INJ

--- a/src/theory/strings/infer_proof_cons.cpp
+++ b/src/theory/strings/infer_proof_cons.cpp
@@ -922,6 +922,8 @@ void InferProofCons::convert(InferenceId infer,
         if (curr.isNull())
         {
           curr = prev;
+          // This is an equality between a variable and a concatention or
+          // constant term (for example see below).
           // orient the substitution properly
           if (!eqs[i][1].isConst()
               && eqs[i][1].getKind() != Kind::STRING_CONCAT)

--- a/src/theory/strings/infer_proof_cons.cpp
+++ b/src/theory/strings/infer_proof_cons.cpp
@@ -940,8 +940,13 @@ void InferProofCons::convert(InferenceId infer,
       {
         break;
       }
-      // substitution is applied in reverse order
-      AlwaysAssert(false);
+      // Substitution is applied in reverse order
+      // An example of this inference that uses a substituion is the conflict:
+      //  (str.in_re w (re.++ (re.* re.allchar) (str.to_re "ABC")))
+      //  (= w (str.++ z y x))
+      //  (= x "D")
+      // where we apply w -> (str.++ z y x), then x -> "D" to the first
+      // predicate to obtain a conflict by rewriting (predicate elim).
       std::reverse(subs.begin(), subs.end());
       Trace("strings-ipc-prefix")
           << "- Possible conflicting equality : " << curr << std::endl;

--- a/src/theory/strings/infer_proof_cons.cpp
+++ b/src/theory/strings/infer_proof_cons.cpp
@@ -1179,7 +1179,7 @@ Node InferProofCons::convertTrans(Node eqa,
     Node eqaSym = i == 0 ? eqa[1].eqNode(eqa[0]) : eqa;
     for (uint32_t j = 0; j < 2; j++)
     {
-      Node eqbSym = j == 0 ? eqb : eqb[1].eqNode(eqb[1]);
+      Node eqbSym = j == 0 ? eqb : eqb[1].eqNode(eqb[0]);
       if (eqa[i] == eqb[j])
       {
         std::vector<Node> children;


### PR DESCRIPTION
Also fixes the definition of STRING_DECOMPOSE which had not been tested due to reconstruction failures.