### PR TITLE
Fix HO extensionality for finite range types

### DIFF
--- a/include/cvc5/cvc5_skolem_id.h
+++ b/include/cvc5/cvc5_skolem_id.h
@@ -186,6 +186,17 @@ enum ENUM(SkolemId)
    */
   EVALUE(SHARED_SELECTOR),
   /**
+   * The higher-roder diff skolem, which is the witness k for the inference
+   * ``(=> (not (= A B)) (not (= (A k1 ... kn) (B k1 ... kn))))``.
+   *
+   * - Number of skolem indices: ``2``
+   *   - ``1:`` The first function of sort ``(-> T1 ... Tn T)``.
+   *   - ``2:`` The second function of sort ``(-> T1 ... Tn T)``.
+   *   - ``3:`` The argument index i.
+   * - Sort: ``Ti``
+   */
+  EVALUE(HO_DEQ_DIFF),
+  /**
    * The n^th skolem for the negation of universally quantified formula Q.
    *
    * - Number of skolem indices: ``2``

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -562,7 +562,7 @@ TypeNode SkolemManager::getTypeFor(SkolemId id,
       Assert(r.getNumerator().fitsUnsignedInt());
       size_t i = r.getNumerator().toUnsignedInt();
       std::vector<TypeNode> argTypes = cacheVals[0].getType().getArgTypes();
-      Assert (i<argTypes.size());
+      Assert(i < argTypes.size());
       return argTypes[i];
     }
     // fp skolems

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -125,7 +125,6 @@ bool SkolemManager::isCommutativeSkolemId(SkolemId id)
   switch (id)
   {
     case cvc5::SkolemId::ARRAY_DEQ_DIFF:
-    case cvc5::SkolemId::HO_DEQ_DIFF:
     case cvc5::SkolemId::BAGS_DEQ_DIFF:
     case cvc5::SkolemId::SETS_DEQ_DIFF:
     case cvc5::SkolemId::STRINGS_DEQ_DIFF: return true;
@@ -561,6 +560,7 @@ TypeNode SkolemManager::getTypeFor(SkolemId id,
       const Rational& r = cacheVals[2].getConst<Rational>();
       Assert(r.getNumerator().fitsUnsignedInt());
       size_t i = r.getNumerator().toUnsignedInt();
+      Assert(cacheVals[0].getType().isFunction());
       std::vector<TypeNode> argTypes = cacheVals[0].getType().getArgTypes();
       Assert(i < argTypes.size());
       return argTypes[i];

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -125,6 +125,7 @@ bool SkolemManager::isCommutativeSkolemId(SkolemId id)
   switch (id)
   {
     case cvc5::SkolemId::ARRAY_DEQ_DIFF:
+    case cvc5::SkolemId::HO_DEQ_DIFF:
     case cvc5::SkolemId::BAGS_DEQ_DIFF:
     case cvc5::SkolemId::SETS_DEQ_DIFF:
     case cvc5::SkolemId::STRINGS_DEQ_DIFF: return true;
@@ -554,6 +555,15 @@ TypeNode SkolemManager::getTypeFor(SkolemId id,
       TypeNode dtt = cacheVals[0].getConst<SortToTerm>().getType();
       TypeNode t = cacheVals[1].getConst<SortToTerm>().getType();
       return nm->mkSelectorType(dtt, t);
+    }
+    case SkolemId::HO_DEQ_DIFF:
+    {
+      const Rational& r = cacheVals[2].getConst<Rational>();
+      Assert(r.getNumerator().fitsUnsignedInt());
+      size_t i = r.getNumerator().toUnsignedInt();
+      std::vector<TypeNode> argTypes = cacheVals[0].getType().getArgTypes();
+      Assert (i<argTypes.size());
+      return argTypes[i];
     }
     // fp skolems
     case SkolemId::FP_MIN_ZERO:

--- a/src/printer/enum_to_string.cpp
+++ b/src/printer/enum_to_string.cpp
@@ -41,6 +41,7 @@ const char* toString(cvc5::SkolemId id)
     case cvc5::SkolemId::TRANSCENDENTAL_SINE_PHASE_SHIFT:
       return "transcendental_sine_phase_shift";
     case cvc5::SkolemId::SHARED_SELECTOR: return "shared_selector";
+    case cvc5::SkolemId::HO_DEQ_DIFF: return "ho_deq_diff";
     case cvc5::SkolemId::QUANTIFIERS_SKOLEMIZE:
       return "quantifiers_skolemize";
     case cvc5::SkolemId::STRINGS_NUM_OCCUR: return "strings_num_occur";

--- a/src/theory/uf/ho_extension.cpp
+++ b/src/theory/uf/ho_extension.cpp
@@ -343,8 +343,6 @@ unsigned HoExtension::checkExtensionality(TheoryModel* m)
                 return 1;
               }
             }
-            // Enumerate the first two values for this sort, there must be
-            // at least two values since this is an infinite sort.
             bool success = false;
             TypeNode tn = edeq[0][0].getType();
             Trace("uf-ho-debug")
@@ -352,6 +350,14 @@ unsigned HoExtension::checkExtensionality(TheoryModel* m)
                 << std::endl;
             if (d_env.isFiniteType(tn))
             {
+              // We are an infinite function type with a finite range sort.
+              // Model construction assigns the first value for all
+              // unconstrained variables for such sorts, which does not
+              // suffice in this context since we are trying to make the
+              // functions disequal. Thus, for such case we enumerate the first
+              // two values for this sort and set the extensionality index to
+              // be equal to these two distinct values.  There must be at least
+              // two values since this is an infinite function sort.
               TypeEnumerator te(tn);
               Node v1 = *te;
               te++;

--- a/src/theory/uf/ho_extension.cpp
+++ b/src/theory/uf/ho_extension.cpp
@@ -343,15 +343,17 @@ unsigned HoExtension::checkExtensionality(TheoryModel* m)
             bool success = false;
             TypeNode tn = edeq[0][0].getType();
             Trace("uf-ho-debug")
-                  << "Add extensionality deq to model for : " << edeq << std::endl;
+                << "Add extensionality deq to model for : " << edeq
+                << std::endl;
             if (d_env.isFiniteType(tn))
             {
               TypeEnumerator te(tn);
               Node v1 = *te;
               te++;
               Node v2 = *te;
-              Assert (!v2.isNull() && v2!=v1);
-              success = m->assertEquality(edeq[0][0], v1, true) && m->assertEquality(edeq[0][1], v2, true);
+              Assert(!v2.isNull() && v2 != v1);
+              success = m->assertEquality(edeq[0][0], v1, true)
+                        && m->assertEquality(edeq[0][1], v2, true);
             }
             else
             {

--- a/src/theory/uf/ho_extension.cpp
+++ b/src/theory/uf/ho_extension.cpp
@@ -338,13 +338,26 @@ unsigned HoExtension::checkExtensionality(TheoryModel* m)
                 return 1;
               }
             }
-            TypeEnumerator te(edeq[0][0].getType());
-            Node v1 = *te;
-            te++;
-            Node v2 = *te;
+            // Enumerate the first two values for this sort, there must be
+            // at least two values since this is an infinite sort.
+            bool success = false;
+            TypeNode tn = edeq[0][0].getType();
             Trace("uf-ho-debug")
-                << "Add extensionality deq to model : " << edeq << std::endl;
-            if (!m->assertEquality(edeq[0][0], v1, true) || !m->assertEquality(edeq[0][1], v2, true))
+                  << "Add extensionality deq to model for : " << edeq << std::endl;
+            if (d_env.isFiniteType(tn))
+            {
+              TypeEnumerator te(tn);
+              Node v1 = *te;
+              te++;
+              Node v2 = *te;
+              Assert (!v2.isNull() && v2!=v1);
+              success = m->assertEquality(edeq[0][0], v1, true) && m->assertEquality(edeq[0][1], v2, true);
+            }
+            else
+            {
+              success = m->assertEquality(edeq[0][0], edeq[0][1], false);
+            }
+            if (!success)
             {
               Node eq = edeq[0][0].eqNode(edeq[0][1]);
               Node lem = nm->mkNode(Kind::OR, deq.negate(), eq);

--- a/src/theory/uf/ho_extension.cpp
+++ b/src/theory/uf/ho_extension.cpp
@@ -282,7 +282,7 @@ unsigned HoExtension::checkExtensionality(TheoryModel* m)
       // if not during collect model, must have a finite type
       // we consider the cardinality of tn's range type (as opposed to tn)
       // since the model construction will enumerate values of this type.
-      if (d_env.isFiniteType(tn.getRangeType()) != isCollectModel)
+      if (d_env.isFiniteType(tn) != isCollectModel)
       {
         func_eqcs[tn].push_back(eqc);
         Trace("uf-ho-debug")
@@ -338,9 +338,13 @@ unsigned HoExtension::checkExtensionality(TheoryModel* m)
                 return 1;
               }
             }
+            TypeEnumerator te(edeq[0][0].getType());
+            Node v1 = *te;
+            te++;
+            Node v2 = *te;
             Trace("uf-ho-debug")
                 << "Add extensionality deq to model : " << edeq << std::endl;
-            if (!m->assertEquality(edeq[0][0], edeq[0][1], false))
+            if (!m->assertEquality(edeq[0][0], v1, true) || !m->assertEquality(edeq[0][1], v2, true))
             {
               Node eq = edeq[0][0].eqNode(edeq[0][1]);
               Node lem = nm->mkNode(Kind::OR, deq.negate(), eq);

--- a/src/theory/uf/ho_extension.cpp
+++ b/src/theory/uf/ho_extension.cpp
@@ -18,11 +18,11 @@
 #include "expr/node_algorithm.h"
 #include "expr/skolem_manager.h"
 #include "options/uf_options.h"
+#include "theory/smt_engine_subsolver.h"
 #include "theory/theory_model.h"
 #include "theory/uf/function_const.h"
 #include "theory/uf/lambda_lift.h"
 #include "theory/uf/theory_uf_rewriter.h"
-#include "theory/smt_engine_subsolver.h"
 #include "util/rational.h"
 
 using namespace std;

--- a/src/theory/uf/ho_extension.cpp
+++ b/src/theory/uf/ho_extension.cpp
@@ -283,10 +283,10 @@ unsigned HoExtension::checkExtensionality(TheoryModel* m)
     if (tn.isFunction() && d_lambdaEqc.find(eqc) == d_lambdaEqc.end())
     {
       hasFunctions = true;
-      // if during collect model, must have an infinite type
-      // if not during collect model, must have a finite type
-      // we consider the cardinality of tn's range type (as opposed to tn)
-      // since the model construction will enumerate values of this type.
+      // If during collect model, must have an infinite function type, since
+      // such function are not necessary to be handled during solving.
+      // If not during collect model, must have a finite function type, since
+      // such function symbols must be handled during solving.
       if (d_env.isFiniteType(tn) != isCollectModel)
       {
         func_eqcs[tn].push_back(eqc);

--- a/test/regress/cli/regress1/ho/sev428-mbqi.smt2
+++ b/test/regress/cli/regress1/ho/sev428-mbqi.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --mbqi --ho-elim
+; COMMAND-LINE: --mbqi
 ; EXPECT: unsat
 (set-logic HO_ALL)
 (declare-sort $$unsorted 0)


### PR DESCRIPTION
This change avoids adding many extensionality lemmas for functions with infinite function type but finite range type.

This does not apply extensionality for function types with finite range types. Instead, we use a model construction that sets their index equal to two distinct values of their range type.

This furthermore introduces the skolem HO_DEQ_DIFF which was missing previously.