### PR TITLE
Enable term-db-mode=relevant by default

### DIFF
--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -223,7 +223,7 @@ name   = "Quantifiers"
   category   = "regular"
   long       = "term-db-mode=MODE"
   type       = "TermDbMode"
-  default    = "ALL"
+  default    = "RELEVANT"
   help       = "which ground terms to consider for instantiation"
   help_mode  = "Modes for terms included in the quantifiers term database."
 [[option.mode.ALL]]

--- a/test/regress/cli/regress0/quantifiers/dd.ricart-ieval.smt2
+++ b/test/regress/cli/regress0/quantifiers/dd.ricart-ieval.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --ieval=use
+; COMMAND-LINE: --ieval=use --term-db-mode=all
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-const x9 Bool)

--- a/test/regress/cli/regress1/quantifiers/quaternion_ds1_symm_0428.fof.smt2
+++ b/test/regress/cli/regress1/quantifiers/quaternion_ds1_symm_0428.fof.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --full-saturate-quant --multi-trigger-cache
+; COMMAND-LINE: --full-saturate-quant --multi-trigger-cache --term-db-mode=all
 ; EXPECT: unsat
 (set-logic AUFLIRA)
 (set-info :status unsat)


### PR DESCRIPTION
This option makes it so that only terms that appear in assertions are considered e.g. for E-matching.  This is in contrast to the default behavior where additionally "preregistered" terms are considered.

This gives convincing results on SMT-LIB quantified logics:
+293-167 over 86550 benchmarks in logics with UF and quantifiers.
it is 9.7% faster on average on commonly solved instances 16820s vs 18467s.