### PR TITLE
[alethe] Optimize printer

### DIFF
--- a/src/proof/alethe/alethe_let_binding.cpp
+++ b/src/proof/alethe/alethe_let_binding.cpp
@@ -113,6 +113,8 @@ Node AletheLetBinding::convert(Node n, const std::string& prefix)
         // We print terms non-flattened and with lambda applications in
         // non-curried manner
         options::ioutils::applyDagThresh(ss, 0);
+        // Guarantee we print reals as expected
+        options::ioutils::applyPrintArithLitToken(ss, true);
         options::ioutils::applyFlattenHOChains(ss, true);
         cur.toStream(ss);
         ss << " :named " << prefix << id << ")";
@@ -204,6 +206,8 @@ Node AletheLetBinding::convert(Node n, const std::string& prefix)
         // We print terms non-flattened and with lambda applications in
         // non-curried manner
         options::ioutils::applyDagThresh(ss, 0);
+        // Guarantee we print reals as expected
+        options::ioutils::applyPrintArithLitToken(ss, true);
         options::ioutils::applyFlattenHOChains(ss, true);
         ret.toStream(ss);
         ssVar << prefix << id;

--- a/src/proof/alethe/alethe_printer.cpp
+++ b/src/proof/alethe/alethe_printer.cpp
@@ -19,8 +19,8 @@
 #include <sstream>
 #include <unordered_map>
 
-#include "options/proof_options.h"
 #include "options/printer_options.h"
+#include "options/proof_options.h"
 #include "proof/alethe/alethe_proof_rule.h"
 #include "util/smt2_quote_string.h"
 
@@ -78,6 +78,9 @@ bool LetUpdaterPfCallback::shouldUpdate(std::shared_ptr<ProofNode> pn,
 
 AletheProofPrinter::AletheProofPrinter(Env& env, AletheNodeConverter& anc)
     : EnvObj(env),
+      d_context(),
+      d_assumptionsMap(&d_context),
+      d_pfMap(&d_context),
       d_lbind(options().printer.dagThresh ? options().printer.dagThresh + 1
                                           : 0),
       d_anc(anc),
@@ -85,29 +88,59 @@ AletheProofPrinter::AletheProofPrinter(Env& env, AletheNodeConverter& anc)
 {
 }
 
-void AletheProofPrinter::printStepId(
+void AletheProofPrinter::printStep(
     std::ostream& out,
-    std::shared_ptr<ProofNode> pfn,
-    std::unordered_map<Node, std::string>& assumptionsMap,
-    std::unordered_map<std::shared_ptr<ProofNode>, std::string>& pfMap)
+    const std::string& stepId,
+    AletheRule arule,
+    const std::vector<Node>& pfArgs,
+    const std::vector<std::shared_ptr<ProofNode>>& pfChildren)
+{
+  out << "(step " << stepId << " ";
+  // print the conclusion and the rule
+  printTerm(out, pfArgs[2]);
+  out << " :rule " << arule;
+  if (!pfChildren.empty())
+  {
+    out << " :premises (";
+    bool first = true;
+    for (const std::shared_ptr<ProofNode>& pfChild : pfChildren)
+    {
+      out << (first ? "" : " ");
+      first = false;
+      printStepId(out, pfChild);
+    }
+    out << ")";
+  }
+  if (pfArgs.size() > 3)
+  {
+    out << " :args (";
+    for (size_t i = 3, size = pfArgs.size(); i < size; i++)
+    {
+      printTerm(out, pfArgs[i]);
+      out << (i < pfArgs.size() - 1 ? " " : "");
+    }
+    out << ")";
+  }
+  out << ")" << std::endl;
+}
+
+void AletheProofPrinter::printStepId(std::ostream& out,
+                                     std::shared_ptr<ProofNode> pfn)
 {
   if (pfn->getRule() == ProofRule::ASSUME)
   {
     Node res = d_anc.convert(pfn->getResult());
     Assert(!res.isNull());
     Trace("alethe-printer") << "... reached assumption " << res << std::endl;
-    auto it = assumptionsMap.find(res);
-    Assert(it != assumptionsMap.end())
-        << "Assumption has not been printed yet! " << res << "/"
-        << assumptionsMap << std::endl;
-    Trace("alethe-printer") << "... found assumption in list " << it->second
-                            << ": " << res << "/" << assumptionsMap << std::endl;
+    auto it = d_assumptionsMap.find(res);
+    Assert(it != d_assumptionsMap.end())
+        << "Assumption has not been printed yet! " << res << std::endl;
     out << it->second;
     return;
   }
-  Assert(pfMap.find(pfn) != pfMap.end())
-      << "Cannot find proof of " << pfn->getResult() << std::endl;
-  out << pfMap.find(pfn)->second;
+  Assert(d_pfMap.find(pfn.get()) != d_pfMap.end())
+      << "Cannot find pf of " << pfn->getResult() << std::endl;
+  out << d_pfMap.find(pfn.get())->second;
 }
 
 void AletheProofPrinter::printTerm(std::ostream& out, TNode n)
@@ -119,6 +152,8 @@ void AletheProofPrinter::printTerm(std::ostream& out, TNode n)
   // Make sure we do not introduce "let" for sharing, since names will not have
   // been introduced under binders.
   options::ioutils::applyDagThresh(ss, 0);
+  // Guarantee we print reals as expected
+  options::ioutils::applyPrintArithLitToken(ss, true);
   ss << d_lbind.convert(n, "@p_");
   out << ss.str();
 }
@@ -167,7 +202,6 @@ void AletheProofPrinter::print(
     }
   }
   Trace("alethe-printer") << "- Print assumptions." << std::endl;
-  std::unordered_map<Node, std::string> assumptionsMap;
   const std::vector<Node>& args = pfn->getArguments();
   // Special handling for the first scope. Print assumptions and add them to the
   // list but do not print anchor.
@@ -184,29 +218,25 @@ void AletheProofPrinter::print(
       // the quotes need to be added back.
       std::string quotedName = quoteSymbol(it->second);
       out << "(assume " << quotedName << " ";
-      assumptionsMap[args[i]] = quotedName;
+      d_assumptionsMap[args[i]] = quotedName;
     }
     else
     {
       out << "(assume a" << i << " ";
-      assumptionsMap[args[i]] = "a" + std::to_string(i);
+      d_assumptionsMap[args[i]] = "a" + std::to_string(i);
     }
     printTerm(out, args[i]);
     out << ")" << std::endl;
   }
   // Then, print the rest of the proof node
-  std::unordered_map<std::shared_ptr<ProofNode>, std::string> pfMap;
   size_t id = 0;
-  printInternal(out, "", id, pfn->getChildren()[0], assumptionsMap, pfMap);
+  printInternal(out, "", id, pfn->getChildren()[0]);
 }
 
-void AletheProofPrinter::printInternal(
-    std::ostream& out,
-    const std::string& prefix,
-    size_t& id,
-    std::shared_ptr<ProofNode> pfn,
-    std::unordered_map<Node, std::string>& assumptionsMap,
-    std::unordered_map<std::shared_ptr<ProofNode>, std::string>& pfMap)
+void AletheProofPrinter::printInternal(std::ostream& out,
+                                       const std::string& prefix,
+                                       size_t& id,
+                                       std::shared_ptr<ProofNode> pfn)
 {
   // assumptions are not printed when reached here because in Alethe they are
   // always printed beforehand, i.e., from the scope introducing them, or being
@@ -215,17 +245,18 @@ void AletheProofPrinter::printInternal(
   {
     return;
   }
-  std::unordered_map<std::shared_ptr<ProofNode>, std::string>::const_iterator pfIt =
-      pfMap.find(pfn);
-  if (pfIt != pfMap.end())
+  context::CDHashMap<ProofNode*, std::string>::const_iterator pfIt =
+      d_pfMap.find(pfn.get());
+  if (pfIt != d_pfMap.end())
   {
     Trace("alethe-printer") << "... step is already printed t" << pfIt->second
                             << " " << pfn->getResult() << " "
-                            << getAletheRule(pfn->getArguments()[0]) << std::endl;
+                            << getAletheRule(pfn->getArguments()[0]) << "\n";
     return;
   }
   const std::vector<Node>& args = pfn->getArguments();
-  const std::vector<std::shared_ptr<ProofNode>>& pfChildren = pfn->getChildren();
+  const std::vector<std::shared_ptr<ProofNode>>& pfChildren =
+      pfn->getChildren();
   // Get the alethe proof rule
   AletheRule arule = getAletheRule(args[0]);
   Trace("alethe-printer") << "... print step " << arule << " : " << args[2]
@@ -238,18 +269,9 @@ void AletheProofPrinter::printInternal(
     Assert(pfChildren.size() == 1);
     out << "(anchor :step " << prefix << "t" << id;
     std::string subproofPrefix = prefix + "t" + std::to_string(id) + ".";
-    // create maps to be used when printing the subproof, which will be discarded once we finish
-    std::unordered_map<Node, std::string> subproofAssumptionsMap{assumptionsMap.begin(), assumptionsMap.end()};
-    std::unordered_map<std::shared_ptr<ProofNode>, std::string> subproofPfMap{pfMap.begin(), pfMap.end()};
+    // create a new context for the subproof
+    d_context.push();
     std::vector<std::string> dischargeIds;
-    // since the subproof shape relies on having at least one step inside it, if
-    // the step relative to children[0] is already pfMap, we remove it from
-    // subproofPfMap
-    auto it = subproofPfMap.find(pfChildren[0]);
-    if (it != subproofPfMap.end())
-    {
-      subproofPfMap.erase(it);
-    }
     // if subproof, print assumptions, otherwise print arguments
     if (arule == AletheRule::ANCHOR_SUBPROOF)
     {
@@ -263,13 +285,14 @@ void AletheProofPrinter::printInternal(
         out << "(assume " << assumptionId << " ";
         printTerm(out, args[i]);
         out << ")" << std::endl;
-        subproofAssumptionsMap[args[i]] = assumptionId;
+        d_assumptionsMap[args[i]] = assumptionId;
         dischargeIds.push_back(assumptionId);
       }
     }
     else
     {
-      Assert(arule >= AletheRule::ANCHOR_BIND && arule <= AletheRule::ANCHOR_SKO_EX);
+      Assert(arule >= AletheRule::ANCHOR_BIND
+             && arule <= AletheRule::ANCHOR_SKO_EX);
       out << " :args (";
       for (size_t i = 3, size = args.size(); i < size; ++i)
       {
@@ -286,8 +309,25 @@ void AletheProofPrinter::printInternal(
       }
       out << "))" << std::endl;
     }
-    size_t subproofId = 0;
-    printInternal(out, subproofPrefix, subproofId, pfChildren[0], subproofAssumptionsMap, subproofPfMap);
+    // since the subproof shape relies on having at least one step inside it, if
+    // the step relative to children[0] is already d_pfMap, we should just print
+    // the step and be done
+    auto it = d_pfMap.find(pfChildren[0].get());
+    if (it != d_pfMap.end())
+    {
+      std::string childStepId = prefix + "t" + std::to_string(id) + ".t0";
+      const std::vector<Node>& childArgs = pfChildren[0]->getArguments();
+      const std::vector<std::shared_ptr<ProofNode>>& childPfChildren =
+          pfChildren[0]->getChildren();
+      AletheRule childArule = getAletheRule(childArgs[0]);
+      printStep(out, childStepId, childArule, childArgs, childPfChildren);
+    }
+    else
+    {
+      size_t subproofId = 0;
+      printInternal(out, subproofPrefix, subproofId, pfChildren[0]);
+    }
+    d_context.pop();
     Trace("alethe-printer") << pop;
     std::string stepId = prefix + "t" + std::to_string(id++);
     out << "(step " << stepId << " ";
@@ -304,45 +344,21 @@ void AletheProofPrinter::printInternal(
       out << ")";
     }
     out << ")" << std::endl;
-    pfMap[pfn] = stepId;
+    d_pfMap[pfn.get()] = stepId;
     return;
   }
   // Print the steps for children to guarantee we will have ids for them in the
   // premises of this step
   for (const std::shared_ptr<ProofNode>& pfChild : pfChildren)
   {
-    printInternal(out, prefix, id, pfChild, assumptionsMap, pfMap);
+    Trace("alethe-printer") << push;
+    printInternal(out, prefix, id, pfChild);
+    Trace("alethe-printer") << pop;
   }
   // Print this step
   std::string stepId = prefix + "t" + std::to_string(id++);
-  out << "(step " << stepId << " ";
-  // print the conclusion and the rule
-  printTerm(out, args[2]);
-  out << " :rule " << arule;
-  if (!pfChildren.empty())
-  {
-    out << " :premises (";
-    bool first = true;
-    for (const std::shared_ptr<ProofNode>& pfChild : pfChildren)
-    {
-      out << (first ? "" : " ");
-      first = false;
-      printStepId(out, pfChild, assumptionsMap, pfMap);
-    }
-    out << ")";
-  }
-  if (args.size() > 3)
-  {
-    out << " :args (";
-    for (size_t i = 3, size = args.size(); i < size; i++)
-    {
-      printTerm(out, args[i]);
-      out << (i < args.size() - 1 ? " " : "");
-    }
-    out << ")";
-  }
-  out << ")" << std::endl;
-  pfMap[pfn] = stepId;
+  printStep(out, stepId, arule, args, pfChildren);
+  d_pfMap[pfn.get()] = stepId;
 }
 
 }  // namespace proof

--- a/src/proof/alethe/alethe_printer.h
+++ b/src/proof/alethe/alethe_printer.h
@@ -18,8 +18,10 @@
 #ifndef CVC5__PROOF__ALETHE__ALETHE_PROOF_PRINTER_H
 #define CVC5__PROOF__ALETHE__ALETHE_PROOF_PRINTER_H
 
-#include "proof/alethe/alethe_node_converter.h"
+#include "context/cdhashset.h"
 #include "proof/alethe/alethe_let_binding.h"
+#include "proof/alethe/alethe_node_converter.h"
+#include "proof/alethe/alethe_proof_rule.h"
 #include "proof/proof_node.h"
 #include "proof/proof_node_updater.h"
 #include "smt/env_obj.h"
@@ -77,6 +79,13 @@ class AletheProofPrinter : protected EnvObj
              const std::map<Node, std::string>& assertionNames);
 
  private:
+  /** The printing context */
+  context::Context d_context;
+  /** Assumptions in context */
+  context::CDHashMap<Node, std::string> d_assumptionsMap;
+  /** Printed steps in context */
+  context::CDHashMap<ProofNode*, std::string> d_pfMap;
+
   /** Prints an Alethe proof node
    *
    * The printing is parameterized by a prefix to be used in the step ids, as
@@ -88,19 +97,11 @@ class AletheProofPrinter : protected EnvObj
    * @param prefix The prefix to be used in step ids.
    * @param id The current id being used for printing step ids
    * @param pfn The proof node to be printed
-   * @param assumptionsMap Map from assumptions to their ids. Since these ids
-   * are arbitrary symbols for assumptions (which could be defined using user
-   * names), the map ranges over strings
-   * @param pfMap Map from proof nodes to their ids
    */
-  void printInternal(
-      std::ostream& out,
-      const std::string& prefix,
-      size_t& id,
-      std::shared_ptr<ProofNode> pfn,
-      std::unordered_map<Node, std::string>& assumptionsMap,
-      std::unordered_map<std::shared_ptr<ProofNode>, std::string>& pfMap);
-
+  void printInternal(std::ostream& out,
+                     const std::string& prefix,
+                     size_t& id,
+                     std::shared_ptr<ProofNode> pfn);
 
   /** Print term into stream
    *
@@ -120,11 +121,21 @@ class AletheProofPrinter : protected EnvObj
    * @param assumptionsMap Map from assumptions to their ids
    * @param pfMap Map from proof nodes to their ids
    */
-  void printStepId(
-      std::ostream& out,
-      std::shared_ptr<ProofNode> pfn,
-      std::unordered_map<Node, std::string>& assumptionsMap,
-      std::unordered_map<std::shared_ptr<ProofNode>, std::string>& pfMap);
+  void printStepId(std::ostream& out, std::shared_ptr<ProofNode> pfn);
+
+  /** Print the step with respective id, rule, premises and arguments.
+   *
+   * @param out The stream to write to
+   * @param stepId The id of the step
+   * @param rule The Alethe rule of the step
+   * @param pfArgs The arguments of this step
+   * @param pfChildren The premises of this step
+   */
+  void printStep(std::ostream& out,
+                 const std::string& stepId,
+                 AletheRule arule,
+                 const std::vector<Node>& pfArgs,
+                 const std::vector<std::shared_ptr<ProofNode>>& pfChildren);
 
   /** The let binder for printing with sharing. */
   AletheLetBinding d_lbind;


### PR DESCRIPTION
Previously the printer was copying caches when going into new scopes, which could be a performance bottleneck for very large proofs. This addresses the issue by using context-dependent caches.

This commit also updates the printing of terms to use the GMP notation for rational values.