### PR TITLE
[alethe] Updates to resolution post-processing

### DIFF
--- a/src/proof/alethe/alethe_post_processor.cpp
+++ b/src/proof/alethe/alethe_post_processor.cpp
@@ -576,11 +576,7 @@ bool AletheProofPostprocessCallback::update(Node res,
       else if (id == ProofRule::MACRO_RESOLUTION
                || id == ProofRule::MACRO_RESOLUTION_TRUST)
       {
-        for (size_t i = 1, nargs = args.size(); i < nargs; i = i + 2)
-        {
-          cargs.push_back(args[i]);
-          cargs.push_back(args[i + 1]);
-        }
+        cargs.insert(cargs.end(), args.begin() + 1, args.end());
       }
       else
       {

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -113,8 +113,12 @@ PfManager::PfManager(Env& env)
     d_pfpp->setEliminateRule(ProofRule::MACRO_SR_PRED_INTRO);
     d_pfpp->setEliminateRule(ProofRule::MACRO_SR_PRED_ELIM);
     d_pfpp->setEliminateRule(ProofRule::MACRO_SR_PRED_TRANSFORM);
-    d_pfpp->setEliminateRule(ProofRule::MACRO_RESOLUTION_TRUST);
-    d_pfpp->setEliminateRule(ProofRule::MACRO_RESOLUTION);
+    // Alethe does not require macro resolution to be expanded
+    if (options().proof.proofFormatMode != options::ProofFormatMode::ALETHE)
+    {
+      d_pfpp->setEliminateRule(ProofRule::MACRO_RESOLUTION_TRUST);
+      d_pfpp->setEliminateRule(ProofRule::MACRO_RESOLUTION);
+    }
     d_pfpp->setEliminateRule(ProofRule::MACRO_ARITH_SCALE_SUM_UB);
     if (options().proof.proofGranularityMode
         != options::ProofGranularityMode::REWRITE)


### PR DESCRIPTION
This commit also disables the expansion of "MACRO_RESOLUTION" when printing Alethe proofs, since the `resolution` rule in Alethe coincides with that rule. 