### PR TITLE
Refactor `CnfStream`

### DIFF
--- a/src/prop/cadical.cpp
+++ b/src/prop/cadical.cpp
@@ -1069,7 +1069,7 @@ SatValue CadicalSolver::_solve(const std::vector<SatLiteral>& assumptions)
 
 /* SatSolver Interface ------------------------------------------------------ */
 
-ClauseId CadicalSolver::addClause(SatClause& clause, bool removable)
+ClauseId CadicalSolver::addClause(const SatClause& clause, bool removable)
 {
   if (d_propagator && TraceIsOn("cadical::propagator"))
   {
@@ -1102,7 +1102,7 @@ ClauseId CadicalSolver::addClause(SatClause& clause, bool removable)
   return ClauseIdError;
 }
 
-ClauseId CadicalSolver::addXorClause(SatClause& clause,
+ClauseId CadicalSolver::addXorClause(const SatClause& clause,
                                      bool rhs,
                                      bool removable)
 {

--- a/src/prop/cadical.h
+++ b/src/prop/cadical.h
@@ -40,9 +40,9 @@ class CadicalSolver : public CDCLTSatSolver, protected EnvObj
 
   /* SatSolver interface -------------------------------------------------- */
 
-  ClauseId addClause(SatClause& clause, bool removable) override;
+  ClauseId addClause(const SatClause& clause, bool removable) override;
 
-  ClauseId addXorClause(SatClause& clause, bool rhs, bool removable) override;
+  ClauseId addXorClause(const SatClause& clause, bool rhs, bool removable) override;
 
   SatVariable newVar(bool isTheoryAtom = false, bool canErase = true) override;
 

--- a/src/prop/cnf_stream.h
+++ b/src/prop/cnf_stream.h
@@ -108,6 +108,13 @@ class CnfStream : protected EnvObj
    * @param negated whether we are asserting the node negated
    */
   void convertAndAssert(TNode node, bool removable, bool negated);
+
+  /**
+   * Returns true iff the literal is assigned to a node
+   * @param literal the literal
+   */
+  bool hasNode(const SatLiteral& literal) const;
+
   /**
    * Get the node that is represented by the given SatLiteral.
    * @param literal the literal from the sat solver
@@ -153,12 +160,6 @@ class CnfStream : protected EnvObj
    */
   bool isNotifyFormula(TNode node) const;
 
-  /** Retrieves map from nodes to literals. */
-  const CnfStream::NodeToLiteralMap& getTranslationCache() const;
-
-  /** Retrieves map from literals to nodes. */
-  const CnfStream::LiteralToNodeMap& getNodeCache() const;
-
   /**
    * Dump dimacs of the given clauses to the given output stream.
    * We use the identifiers for literals computed by this class. All literals
@@ -200,6 +201,9 @@ class CnfStream : protected EnvObj
   void dumpDimacs(std::ostream& out,
                   const std::vector<Node>& clauses,
                   const std::vector<Node>& auxUnits);
+
+  /** Used to debug a satisfying assignment */
+  void traceSatisfyingAssignment(std::string trace) const;
 
  protected:
   /** Helper function */
@@ -258,34 +262,7 @@ class CnfStream : protected EnvObj
    * @param clause the clause to assert
    * @return whether the clause was asserted in the SAT solver.
    */
-  bool assertClause(TNode node, SatClause& clause);
-
-  /**
-   * Asserts the unit clause to the sat solver.
-   * @param node the node giving rise to this clause
-   * @param a the unit literal of the clause
-   * @return whether the clause was asserted in the SAT solver.
-   */
-  bool assertClause(TNode node, SatLiteral a);
-
-  /**
-   * Asserts the binary clause to the sat solver.
-   * @param node the node giving rise to this clause
-   * @param a the first literal in the clause
-   * @param b the second literal in the clause
-   * @return whether the clause was asserted in the SAT solver.
-   */
-  bool assertClause(TNode node, SatLiteral a, SatLiteral b);
-
-  /**
-   * Asserts the ternary clause to the sat solver.
-   * @param node the node giving rise to this clause
-   * @param a the first literal in the clause
-   * @param b the second literal in the clause
-   * @param c the thirs literal in the clause
-   * @return whether the clause was asserted in the SAT solver.
-   */
-  bool assertClause(TNode node, SatLiteral a, SatLiteral b, SatLiteral c);
+  bool assertClause(TNode node, const SatClause& clause);
 
   /**
    * Acquires a new variable from the SAT solver to represent the node

--- a/src/prop/cryptominisat.cpp
+++ b/src/prop/cryptominisat.cpp
@@ -59,7 +59,7 @@ SatValue toSatLiteralValue(CMSat::lbool res)
   return SAT_VALUE_FALSE;
 }
 
-void toInternalClause(SatClause& clause,
+void toInternalClause(const SatClause& clause,
                       std::vector<CMSat::Lit>& internal_clause)
 {
   for (unsigned i = 0; i < clause.size(); ++i)
@@ -110,7 +110,7 @@ void CryptoMinisatSolver::setMaxTime()
   }
 }
 
-ClauseId CryptoMinisatSolver::addXorClause(SatClause& clause,
+ClauseId CryptoMinisatSolver::addXorClause(const SatClause& clause,
                                            bool rhs,
                                            bool removable)
 {
@@ -135,7 +135,8 @@ ClauseId CryptoMinisatSolver::addXorClause(SatClause& clause,
   return ClauseIdError;
 }
 
-ClauseId CryptoMinisatSolver::addClause(SatClause& clause, bool removable){
+ClauseId CryptoMinisatSolver::addClause(const SatClause& clause, bool removable)
+{
   Trace("sat::cryptominisat") << "Add clause " << clause <<"\n";
 
   if (!d_okay) {

--- a/src/prop/cryptominisat.h
+++ b/src/prop/cryptominisat.h
@@ -43,8 +43,10 @@ class CryptoMinisatSolver : public SatSolver
  public:
   ~CryptoMinisatSolver() override;
 
-  ClauseId addClause(SatClause& clause, bool removable) override;
-  ClauseId addXorClause(SatClause& clause, bool rhs, bool removable) override;
+  ClauseId addClause(const SatClause& clause, bool removable) override;
+  ClauseId addXorClause(const SatClause& clause,
+                        bool rhs,
+                        bool removable) override;
 
   bool nativeXor() override { return true; }
 

--- a/src/prop/kissat.cpp
+++ b/src/prop/kissat.cpp
@@ -84,7 +84,7 @@ void KissatSolver::init()
 
 KissatSolver::~KissatSolver() { kissat_release(d_solver); }
 
-ClauseId KissatSolver::addClause(SatClause& clause, bool removable)
+ClauseId KissatSolver::addClause(const SatClause& clause, bool removable)
 {
   for (const SatLiteral& lit : clause)
   {
@@ -95,7 +95,7 @@ ClauseId KissatSolver::addClause(SatClause& clause, bool removable)
   return ClauseIdError;
 }
 
-ClauseId KissatSolver::addXorClause(SatClause& clause, bool rhs, bool removable)
+ClauseId KissatSolver::addXorClause(const SatClause& clause, bool rhs, bool removable)
 {
   Unreachable() << "Kissat does not support adding XOR clauses.";
 }

--- a/src/prop/kissat.h
+++ b/src/prop/kissat.h
@@ -38,9 +38,11 @@ class KissatSolver : public SatSolver
  public:
   ~KissatSolver() override;
 
-  ClauseId addClause(SatClause& clause, bool removable) override;
+  ClauseId addClause(const SatClause& clause, bool removable) override;
 
-  ClauseId addXorClause(SatClause& clause, bool rhs, bool removable) override;
+  ClauseId addXorClause(const SatClause& clause,
+                        bool rhs,
+                        bool removable) override;
 
   SatVariable newVar(bool isTheoryAtom = false, bool canErase = true) override;
 

--- a/src/prop/minisat/minisat.cpp
+++ b/src/prop/minisat/minisat.cpp
@@ -90,8 +90,8 @@ Minisat::lbool MinisatSatSolver::toMinisatlbool(SatValue val)
   return false;
   }*/
 
-void MinisatSatSolver::toMinisatClause(SatClause& clause,
-                                           Minisat::vec<Minisat::Lit>& minisat_clause) {
+void MinisatSatSolver::toMinisatClause(const SatClause& clause,
+                                       Minisat::vec<Minisat::Lit>& minisat_clause) {
   for (unsigned i = 0; i < clause.size(); ++i) {
     minisat_clause.push(toMinisatLit(clause[i]));
   }
@@ -170,7 +170,7 @@ void MinisatSatSolver::setupOptions() {
   d_minisat->restart_inc = options().prop.satRestartInc;
 }
 
-ClauseId MinisatSatSolver::addClause(SatClause& clause, bool removable)
+ClauseId MinisatSatSolver::addClause(const SatClause& clause, bool removable)
 {
   Minisat::vec<Minisat::Lit> minisat_clause;
   toMinisatClause(clause, minisat_clause);

--- a/src/prop/minisat/minisat.h
+++ b/src/prop/minisat/minisat.h
@@ -46,15 +46,15 @@ class MinisatSatSolver : public CDCLTSatSolver, protected EnvObj
   static Minisat::lbool  toMinisatlbool(SatValue val);
   //(Commented because not in use) static bool            tobool(SatValue val);
 
-  static void  toMinisatClause(SatClause& clause, Minisat::vec<Minisat::Lit>& minisat_clause);
+  static void  toMinisatClause(const SatClause& clause, Minisat::vec<Minisat::Lit>& minisat_clause);
   static void  toSatClause    (const Minisat::Clause& clause, SatClause& sat_clause);
   void initialize(context::Context* context,
                   TheoryProxy* theoryProxy,
                   context::UserContext* userContext,
                   PropPfManager* ppm) override;
 
-  ClauseId addClause(SatClause& clause, bool removable) override;
-  ClauseId addXorClause(SatClause& clause, bool rhs, bool removable) override
+  ClauseId addClause(const SatClause& clause, bool removable) override;
+  ClauseId addXorClause(const SatClause& clause, bool rhs, bool removable) override
   {
     Unreachable() << "Minisat does not support native XOR reasoning";
   }

--- a/src/prop/prop_engine.cpp
+++ b/src/prop/prop_engine.cpp
@@ -394,25 +394,6 @@ bool PropEngine::isFixed(TNode lit) const
   return false;
 }
 
-void PropEngine::printSatisfyingAssignment(){
-  const CnfStream::NodeToLiteralMap& transCache =
-    d_cnfStream->getTranslationCache();
-  Trace("prop-value") << "Literal | Value | Expr" << std::endl
-                      << "----------------------------------------"
-                      << "-----------------" << std::endl;
-  for(CnfStream::NodeToLiteralMap::const_iterator i = transCache.begin(),
-      end = transCache.end();
-      i != end;
-      ++i) {
-    std::pair<Node, SatLiteral> curr = *i;
-    SatLiteral l = curr.second;
-    if(!l.isNegated()) {
-      Node n = curr.first;
-      SatValue value = d_satSolver->modelValue(l);
-      Trace("prop-value") << "'" << l << "' " << value << " " << n << std::endl;
-    }
-  }
-}
 void PropEngine::outputIncompleteReason(UnknownExplanation uexp,
                                         theory::IncompleteId iid)
 {
@@ -428,7 +409,8 @@ void PropEngine::outputIncompleteReason(UnknownExplanation uexp,
   }
 }
 
-Result PropEngine::checkSat() {
+Result PropEngine::checkSat()
+{
   Assert(!d_inCheckSat) << "Sat solver in solve()!";
   Trace("prop") << "PropEngine::checkSat()" << std::endl;
 
@@ -466,23 +448,19 @@ Result PropEngine::checkSat() {
 
   d_theoryProxy->postsolve(result);
 
-  if( result == SAT_VALUE_UNKNOWN ) {
+  if (result == SAT_VALUE_UNKNOWN)
+  {
     ResourceManager* rm = resourceManager();
     UnknownExplanation why = UnknownExplanation::INTERRUPTED;
-    if (rm->outOfTime())
-    {
-      why = UnknownExplanation::TIMEOUT;
-    }
-    if (rm->outOfResources())
-    {
-      why = UnknownExplanation::RESOURCEOUT;
-    }
+    if (rm->outOfTime()) why = UnknownExplanation::TIMEOUT;
+    if (rm->outOfResources()) why = UnknownExplanation::RESOURCEOUT;
     outputIncompleteReason(why);
     return Result(Result::UNKNOWN, why);
   }
 
-  if( result == SAT_VALUE_TRUE && TraceIsOn("prop") ) {
-    printSatisfyingAssignment();
+  if (result == SAT_VALUE_TRUE && TraceIsOn("prop-value"))
+  {
+    d_cnfStream->traceSatisfyingAssignment("prop-value");
   }
 
   Trace("prop") << "PropEngine::checkSat() => " << result << std::endl;

--- a/src/prop/prop_engine.h
+++ b/src/prop/prop_engine.h
@@ -362,8 +362,6 @@ class PropEngine : protected EnvObj
   modes::LearnedLitType getLiteralType(const Node& lit) const;
 
  private:
-  /** Dump out the satisfying assignment (after SAT result) */
-  void printSatisfyingAssignment();
   /** Print reason for answering unknown on output when applicable */
   void outputIncompleteReason(
       UnknownExplanation uexp,

--- a/src/prop/sat_solver.h
+++ b/src/prop/sat_solver.h
@@ -43,14 +43,16 @@ public:
   virtual ~SatSolver() { }
 
   /** Assert a clause in the solver. */
-  virtual ClauseId addClause(SatClause& clause,
+  virtual ClauseId addClause(const SatClause& clause,
                              bool removable) = 0;
 
   /** Return true if the solver supports native xor resoning */
   virtual bool nativeXor() { return false; }
 
   /** Add a clause corresponding to rhs = l1 xor .. xor ln  */
-  virtual ClauseId addXorClause(SatClause& clause, bool rhs, bool removable) = 0;
+  virtual ClauseId addXorClause(const SatClause& clause,
+                                bool rhs,
+                                bool removable) = 0;
 
   /**
    * Create a new boolean variable in the solver.

--- a/test/unit/prop/cnf_stream_white.cpp
+++ b/test/unit/prop/cnf_stream_white.cpp
@@ -51,13 +51,15 @@ class FakeSatSolver : public SatSolver
 
   SatVariable falseVar() override { return d_nextVar++; }
 
-  ClauseId addClause(SatClause& c, bool lemma) override
+  ClauseId addClause(const SatClause& c, bool lemma) override
   {
     d_addClauseCalled = true;
     return ClauseIdUndef;
   }
 
-  ClauseId addXorClause(SatClause& clause, bool rhs, bool removable) override
+  ClauseId addXorClause(const SatClause& clause,
+                        bool rhs,
+                        bool removable) override
   {
     d_addClauseCalled = true;
     return ClauseIdUndef;


### PR DESCRIPTION
I've been working with @HanielB  on implementing a proof manager for the generation of DRAT proofs. To simplify the review process, we will split the changes into self-contained PRs. This first PR focuses on cleaning up the `CnfStream` code, which we identified as appropriate when developing the DRAT proof manager.

- **Removed `assertClause` functions with multiple parameter lists**:
  - Replaced with a single `assertClause` function that takes constant references instead of references.
  - This change keeps the code cleaner and avoids the overhead of additional function calls, as the removed functions simply created new vectors of literals and called the principal `assertClause` function.

- **Updated `addClause` method in `SatSolver` class**:
  - The update integrates seamlessly with the existing codebase, without considerable changes.

- **Removed `getTranslationCache` and `getNodeCache` functions**:
  - Returning constant references to the `CnfStream` caches was deemed unsafe and unnecessary.
  - Updated methods to use `hasNode`, `getNode`, `hasLiteral`, and `getLiteral` calls instead, aligning with existing practices.