### PR TITLE
Remove option `strings-code-elim`

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -13,10 +13,10 @@
  * Proof rule enumeration.
  */
 
-#if (!defined(CVC5_API_USE_C_ENUMS)                 \
-     && !defined(CVC5__API__CVC5_CPP_PROOF_RULE_H)) \
-    || (defined(CVC5_API_USE_C_ENUMS)               \
-        && !defined(CVC5__API__CVC5_C_PROOF_RULE_H))
+#if (!defined(CVC5_API_USE_C_ENUMS) &&                                         \
+     !defined(CVC5__API__CVC5_CPP_PROOF_RULE_H)) ||                            \
+    (defined(CVC5_API_USE_C_ENUMS) &&                                          \
+     !defined(CVC5__API__CVC5_C_PROOF_RULE_H))
 
 #include <stdint.h>
 
@@ -2269,8 +2269,7 @@ enum ENUM(ProofRule)
  * proof rule.
  * \endverbatim
  */
-enum ENUM(ProofRewriteRule)
-{
+enum ENUM(ProofRewriteRule) {
   EVALUE(NONE),
   // Custom theory rewrites.
   /**
@@ -2320,11 +2319,14 @@ enum ENUM(ProofRewriteRule)
    *   (>= s t) = c
    *
    * where :math:`c` is a Boolean constant.
-   * This macro is elaborated by applications of :cpp:enumerator:`EVALUATE <cvc5::ProofRule::EVALUATE>`,
-   * :cpp:enumerator:`ARITH_POLY_NORM <cvc5::ProofRule::ARITH_POLY_NORM>`,
-   * :cpp:enumerator:`ARITH_STRING_PRED_ENTAIL <cvc5::ProofRewriteRule::ARITH_STRING_PRED_ENTAIL>`,
-   * :cpp:enumerator:`ARITH_STRING_PRED_SAFE_APPROX <cvc5::ProofRewriteRule::ARITH_STRING_PRED_SAFE_APPROX>`,
-   * as well as other rewrites for normalizing arithmetic predicates.
+   * This macro is elaborated by applications of :cpp:enumerator:`EVALUATE
+   * <cvc5::ProofRule::EVALUATE>`, :cpp:enumerator:`ARITH_POLY_NORM
+   * <cvc5::ProofRule::ARITH_POLY_NORM>`,
+   * :cpp:enumerator:`ARITH_STRING_PRED_ENTAIL
+   * <cvc5::ProofRewriteRule::ARITH_STRING_PRED_ENTAIL>`,
+   * :cpp:enumerator:`ARITH_STRING_PRED_SAFE_APPROX
+   * <cvc5::ProofRewriteRule::ARITH_STRING_PRED_SAFE_APPROX>`, as well as other
+   * rewrites for normalizing arithmetic predicates.
    *
    * \endverbatim
    */
@@ -2559,7 +2561,8 @@ enum ENUM(ProofRewriteRule)
    * **Bitvectors - Extract continuous substrings of bitvectors**
    *
    * .. math::
-   *    bvand(a,\ c) = concat(bvand(a[i_0:j_0],\ c_0) ... bvand(a[i_n:j_n],\ c_n))
+   *    bvand(a,\ c) = concat(bvand(a[i_0:j_0],\ c_0) ...
+   * bvand(a[i_n:j_n],\ c_n))
    *
    * where c0,..., cn are maximally continuous substrings of 0 or 1 in the
    * constant c \endverbatim
@@ -2591,7 +2594,8 @@ enum ENUM(ProofRewriteRule)
    * or alternatively:
    *
    * .. math::
-   *   \mathit{re.union}(R) = \mathit{re.union}(\mathit{re}.\text{*}(\mathit{re.allchar}),\ R_0)
+   *   \mathit{re.union}(R) =
+   * \mathit{re.union}(\mathit{re}.\text{*}(\mathit{re.allchar}),\ R_0)
    *
    * where :math:`R` is a list of regular expressions containing `r_1`,
    * `re.comp(r_2)` and the list :math:`R_0`, where `r_1` is a superset of
@@ -2631,7 +2635,10 @@ enum ENUM(ProofRewriteRule)
    * **Strings - string in regular expression concatenation star character**
    *
    * .. math::
-   *   \mathit{str.in\_re}(\mathit{str}.\text{++}(s_1, \ldots, s_n), \mathit{re}.\text{*}(R)) =\\ \mathit{str.in\_re}(s_1, \mathit{re}.\text{*}(R)) \wedge \ldots \wedge \mathit{str.in\_re}(s_n, \mathit{re}.\text{*}(R))
+   *   \mathit{str.in\_re}(\mathit{str}.\text{++}(s_1, \ldots, s_n),
+   * \mathit{re}.\text{*}(R)) =\\ \mathit{str.in\_re}(s_1,
+   * \mathit{re}.\text{*}(R)) \wedge \ldots \wedge \mathit{str.in\_re}(s_n,
+   * \mathit{re}.\text{*}(R))
    *
    * where all strings in :math:`R` have length one.
    *
@@ -2643,12 +2650,15 @@ enum ENUM(ProofRewriteRule)
    * **Strings - string in regular expression sigma**
    *
    * .. math::
-   *   \mathit{str.in\_re}(s, \mathit{re}.\text{++}(\mathit{re.allchar}, \ldots, \mathit{re.allchar})) = (\mathit{str.len}(s) = n)
+   *   \mathit{str.in\_re}(s, \mathit{re}.\text{++}(\mathit{re.allchar}, \ldots,
+   * \mathit{re.allchar})) = (\mathit{str.len}(s) = n)
    *
    * or alternatively:
    *
    * .. math::
-   *   \mathit{str.in\_re}(s, \mathit{re}.\text{++}(\mathit{re.allchar}, \ldots, \mathit{re.allchar}, \mathit{re}.\text{*}(\mathit{re.allchar}))) = (\mathit{str.len}(s) \ge n)
+   *   \mathit{str.in\_re}(s, \mathit{re}.\text{++}(\mathit{re.allchar}, \ldots,
+   * \mathit{re.allchar}, \mathit{re}.\text{*}(\mathit{re.allchar}))) =
+   * (\mathit{str.len}(s) \ge n)
    *
    * \endverbatim
    */
@@ -2658,7 +2668,9 @@ enum ENUM(ProofRewriteRule)
    * **Strings - string in regular expression sigma star**
    *
    * .. math::
-   *   \mathit{str.in\_re}(s, \mathit{re}.\text{*}(\mathit{re}.\text{++}(\mathit{re.allchar}, \ldots, \mathit{re.allchar}))) = (\mathit{str.len}(s) \ \% \ n = 0)
+   *   \mathit{str.in\_re}(s,
+   * \mathit{re}.\text{*}(\mathit{re}.\text{++}(\mathit{re.allchar}, \ldots,
+   * \mathit{re.allchar}))) = (\mathit{str.len}(s) \ \% \ n = 0)
    *
    * where :math:`n` is the number of :math:`\mathit{re.allchar}` arguments to
    * :math:`\mathit{re}.\text{++}`.
@@ -3396,8 +3408,6 @@ enum ENUM(ProofRewriteRule)
   EVALUE(RE_INTER_CSTRING),
   /** Auto-generated from RARE rule re-inter-cstring-neg */
   EVALUE(RE_INTER_CSTRING_NEG),
-  /** Auto-generated from RARE rule str-nth-elim-code */
-  EVALUE(STR_NTH_ELIM_CODE),
   /** Auto-generated from RARE rule str-substr-len-include */
   EVALUE(STR_SUBSTR_LEN_INCLUDE),
   /** Auto-generated from RARE rule str-substr-len-include-pre */
@@ -3528,7 +3538,7 @@ typedef enum ENUM(ProofRewriteRule) ENUM(ProofRewriteRule);
  * @param rule The proof rule.
  * @return The string representation.
  */
-CVC5_EXPORT const char* cvc5_proof_rule_to_string(Cvc5ProofRule rule);
+CVC5_EXPORT const char *cvc5_proof_rule_to_string(Cvc5ProofRule rule);
 
 /**
  * Hash function for Cvc5ProofRule.
@@ -3542,8 +3552,8 @@ CVC5_EXPORT size_t cvc5_proof_rule_hash(Cvc5ProofRule rule);
  * @param rule The proof rewrite rule.
  * @return The string representation.
  */
-CVC5_EXPORT const char* cvc5_proof_rewrite_rule_to_string(
-    Cvc5ProofRewriteRule rule);
+CVC5_EXPORT const char *
+cvc5_proof_rewrite_rule_to_string(Cvc5ProofRewriteRule rule);
 
 /**
  * Hash function for Cvc5ProofRewriteRule.
@@ -3563,7 +3573,7 @@ CVC5_EXPORT size_t cvc5_proof_rewrite_rule_hash(Cvc5ProofRewriteRule rule);
  * @param rule The proof rule
  * @return The name of the proof rule
  */
-CVC5_EXPORT const char* toString(ProofRule rule);
+CVC5_EXPORT const char *toString(ProofRule rule);
 
 /**
  * Writes a proof rule name to a stream.
@@ -3572,7 +3582,7 @@ CVC5_EXPORT const char* toString(ProofRule rule);
  * @param rule The proof rule to write to the stream
  * @return The stream
  */
-CVC5_EXPORT std::ostream& operator<<(std::ostream& out, ProofRule rule);
+CVC5_EXPORT std::ostream &operator<<(std::ostream &out, ProofRule rule);
 
 /**
  * Converts a proof rewrite rule to a string. Note: This function is also
@@ -3583,7 +3593,7 @@ CVC5_EXPORT std::ostream& operator<<(std::ostream& out, ProofRule rule);
  * @param rule The proof rewrite rule
  * @return The name of the proof rewrite rule
  */
-CVC5_EXPORT const char* toString(ProofRewriteRule rule);
+CVC5_EXPORT const char *toString(ProofRewriteRule rule);
 
 /**
  * Writes a proof rewrite rule name to a stream.
@@ -3592,18 +3602,16 @@ CVC5_EXPORT const char* toString(ProofRewriteRule rule);
  * @param rule The proof rewrite rule to write to the stream
  * @return The stream
  */
-CVC5_EXPORT std::ostream& operator<<(std::ostream& out, ProofRewriteRule rule);
+CVC5_EXPORT std::ostream &operator<<(std::ostream &out, ProofRewriteRule rule);
 
-}  // namespace cvc5
+} // namespace cvc5
 
 namespace std {
 
 /**
  * Hash function for ProofRules.
  */
-template <>
-struct CVC5_EXPORT hash<cvc5::ProofRule>
-{
+template <> struct CVC5_EXPORT hash<cvc5::ProofRule> {
   /**
    * Hashes a ProofRule to a size_t.
    * @param rule The proof rule.
@@ -3623,9 +3631,7 @@ CVC5_EXPORT std::string to_string(cvc5::ProofRule rule);
 /**
  * Hash function for ProofRewriteRules.
  */
-template <>
-struct CVC5_EXPORT hash<cvc5::ProofRewriteRule>
-{
+template <> struct CVC5_EXPORT hash<cvc5::ProofRewriteRule> {
   /**
    * Hashes a ProofRewriteRule to a size_t.
    * @param rule The proof rewrite rule.
@@ -3642,7 +3648,7 @@ struct CVC5_EXPORT hash<cvc5::ProofRewriteRule>
  */
 CVC5_EXPORT std::string to_string(cvc5::ProofRewriteRule rule);
 
-}  // namespace std
+} // namespace std
 
 #endif
 #endif

--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -2320,14 +2320,11 @@ enum ENUM(ProofRewriteRule)
    *   (>= s t) = c
    *
    * where :math:`c` is a Boolean constant.
-   * This macro is elaborated by applications of :cpp:enumerator:`EVALUATE
-   * <cvc5::ProofRule::EVALUATE>`, :cpp:enumerator:`ARITH_POLY_NORM
-   * <cvc5::ProofRule::ARITH_POLY_NORM>`,
-   * :cpp:enumerator:`ARITH_STRING_PRED_ENTAIL
-   * <cvc5::ProofRewriteRule::ARITH_STRING_PRED_ENTAIL>`,
-   * :cpp:enumerator:`ARITH_STRING_PRED_SAFE_APPROX
-   * <cvc5::ProofRewriteRule::ARITH_STRING_PRED_SAFE_APPROX>`, as well as other
-   * rewrites for normalizing arithmetic predicates.
+   * This macro is elaborated by applications of :cpp:enumerator:`EVALUATE <cvc5::ProofRule::EVALUATE>`,
+   * :cpp:enumerator:`ARITH_POLY_NORM <cvc5::ProofRule::ARITH_POLY_NORM>`,
+   * :cpp:enumerator:`ARITH_STRING_PRED_ENTAIL <cvc5::ProofRewriteRule::ARITH_STRING_PRED_ENTAIL>`,
+   * :cpp:enumerator:`ARITH_STRING_PRED_SAFE_APPROX <cvc5::ProofRewriteRule::ARITH_STRING_PRED_SAFE_APPROX>`,
+   * as well as other rewrites for normalizing arithmetic predicates.
    *
    * \endverbatim
    */
@@ -2562,8 +2559,7 @@ enum ENUM(ProofRewriteRule)
    * **Bitvectors - Extract continuous substrings of bitvectors**
    *
    * .. math::
-   *    bvand(a,\ c) = concat(bvand(a[i_0:j_0],\ c_0) ...
-   * bvand(a[i_n:j_n],\ c_n))
+   *    bvand(a,\ c) = concat(bvand(a[i_0:j_0],\ c_0) ... bvand(a[i_n:j_n],\ c_n))
    *
    * where c0,..., cn are maximally continuous substrings of 0 or 1 in the
    * constant c \endverbatim
@@ -2595,8 +2591,7 @@ enum ENUM(ProofRewriteRule)
    * or alternatively:
    *
    * .. math::
-   *   \mathit{re.union}(R) =
-   * \mathit{re.union}(\mathit{re}.\text{*}(\mathit{re.allchar}),\ R_0)
+   *   \mathit{re.union}(R) = \mathit{re.union}(\mathit{re}.\text{*}(\mathit{re.allchar}),\ R_0)
    *
    * where :math:`R` is a list of regular expressions containing `r_1`,
    * `re.comp(r_2)` and the list :math:`R_0`, where `r_1` is a superset of
@@ -2636,10 +2631,7 @@ enum ENUM(ProofRewriteRule)
    * **Strings - string in regular expression concatenation star character**
    *
    * .. math::
-   *   \mathit{str.in\_re}(\mathit{str}.\text{++}(s_1, \ldots, s_n),
-   * \mathit{re}.\text{*}(R)) =\\ \mathit{str.in\_re}(s_1,
-   * \mathit{re}.\text{*}(R)) \wedge \ldots \wedge \mathit{str.in\_re}(s_n,
-   * \mathit{re}.\text{*}(R))
+   *   \mathit{str.in\_re}(\mathit{str}.\text{++}(s_1, \ldots, s_n), \mathit{re}.\text{*}(R)) =\\ \mathit{str.in\_re}(s_1, \mathit{re}.\text{*}(R)) \wedge \ldots \wedge \mathit{str.in\_re}(s_n, \mathit{re}.\text{*}(R))
    *
    * where all strings in :math:`R` have length one.
    *
@@ -2651,15 +2643,12 @@ enum ENUM(ProofRewriteRule)
    * **Strings - string in regular expression sigma**
    *
    * .. math::
-   *   \mathit{str.in\_re}(s, \mathit{re}.\text{++}(\mathit{re.allchar}, \ldots,
-   * \mathit{re.allchar})) = (\mathit{str.len}(s) = n)
+   *   \mathit{str.in\_re}(s, \mathit{re}.\text{++}(\mathit{re.allchar}, \ldots, \mathit{re.allchar})) = (\mathit{str.len}(s) = n)
    *
    * or alternatively:
    *
    * .. math::
-   *   \mathit{str.in\_re}(s, \mathit{re}.\text{++}(\mathit{re.allchar}, \ldots,
-   * \mathit{re.allchar}, \mathit{re}.\text{*}(\mathit{re.allchar}))) =
-   * (\mathit{str.len}(s) \ge n)
+   *   \mathit{str.in\_re}(s, \mathit{re}.\text{++}(\mathit{re.allchar}, \ldots, \mathit{re.allchar}, \mathit{re}.\text{*}(\mathit{re.allchar}))) = (\mathit{str.len}(s) \ge n)
    *
    * \endverbatim
    */
@@ -2669,9 +2658,7 @@ enum ENUM(ProofRewriteRule)
    * **Strings - string in regular expression sigma star**
    *
    * .. math::
-   *   \mathit{str.in\_re}(s,
-   * \mathit{re}.\text{*}(\mathit{re}.\text{++}(\mathit{re.allchar}, \ldots,
-   * \mathit{re.allchar}))) = (\mathit{str.len}(s) \ \% \ n = 0)
+   *   \mathit{str.in\_re}(s, \mathit{re}.\text{*}(\mathit{re}.\text{++}(\mathit{re.allchar}, \ldots, \mathit{re.allchar}))) = (\mathit{str.len}(s) \ \% \ n = 0)
    *
    * where :math:`n` is the number of :math:`\mathit{re.allchar}` arguments to
    * :math:`\mathit{re}.\text{++}`.

--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -13,10 +13,10 @@
  * Proof rule enumeration.
  */
 
-#if (!defined(CVC5_API_USE_C_ENUMS) &&                                         \
-     !defined(CVC5__API__CVC5_CPP_PROOF_RULE_H)) ||                            \
-    (defined(CVC5_API_USE_C_ENUMS) &&                                          \
-     !defined(CVC5__API__CVC5_C_PROOF_RULE_H))
+#if (!defined(CVC5_API_USE_C_ENUMS)                 \
+     && !defined(CVC5__API__CVC5_CPP_PROOF_RULE_H)) \
+    || (defined(CVC5_API_USE_C_ENUMS)               \
+        && !defined(CVC5__API__CVC5_C_PROOF_RULE_H))
 
 #include <stdint.h>
 
@@ -2269,7 +2269,8 @@ enum ENUM(ProofRule)
  * proof rule.
  * \endverbatim
  */
-enum ENUM(ProofRewriteRule) {
+enum ENUM(ProofRewriteRule)
+{
   EVALUE(NONE),
   // Custom theory rewrites.
   /**
@@ -3538,7 +3539,7 @@ typedef enum ENUM(ProofRewriteRule) ENUM(ProofRewriteRule);
  * @param rule The proof rule.
  * @return The string representation.
  */
-CVC5_EXPORT const char *cvc5_proof_rule_to_string(Cvc5ProofRule rule);
+CVC5_EXPORT const char* cvc5_proof_rule_to_string(Cvc5ProofRule rule);
 
 /**
  * Hash function for Cvc5ProofRule.
@@ -3552,8 +3553,8 @@ CVC5_EXPORT size_t cvc5_proof_rule_hash(Cvc5ProofRule rule);
  * @param rule The proof rewrite rule.
  * @return The string representation.
  */
-CVC5_EXPORT const char *
-cvc5_proof_rewrite_rule_to_string(Cvc5ProofRewriteRule rule);
+CVC5_EXPORT const char* cvc5_proof_rewrite_rule_to_string(
+    Cvc5ProofRewriteRule rule);
 
 /**
  * Hash function for Cvc5ProofRewriteRule.
@@ -3573,7 +3574,7 @@ CVC5_EXPORT size_t cvc5_proof_rewrite_rule_hash(Cvc5ProofRewriteRule rule);
  * @param rule The proof rule
  * @return The name of the proof rule
  */
-CVC5_EXPORT const char *toString(ProofRule rule);
+CVC5_EXPORT const char* toString(ProofRule rule);
 
 /**
  * Writes a proof rule name to a stream.
@@ -3582,7 +3583,7 @@ CVC5_EXPORT const char *toString(ProofRule rule);
  * @param rule The proof rule to write to the stream
  * @return The stream
  */
-CVC5_EXPORT std::ostream &operator<<(std::ostream &out, ProofRule rule);
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, ProofRule rule);
 
 /**
  * Converts a proof rewrite rule to a string. Note: This function is also
@@ -3593,7 +3594,7 @@ CVC5_EXPORT std::ostream &operator<<(std::ostream &out, ProofRule rule);
  * @param rule The proof rewrite rule
  * @return The name of the proof rewrite rule
  */
-CVC5_EXPORT const char *toString(ProofRewriteRule rule);
+CVC5_EXPORT const char* toString(ProofRewriteRule rule);
 
 /**
  * Writes a proof rewrite rule name to a stream.
@@ -3602,16 +3603,18 @@ CVC5_EXPORT const char *toString(ProofRewriteRule rule);
  * @param rule The proof rewrite rule to write to the stream
  * @return The stream
  */
-CVC5_EXPORT std::ostream &operator<<(std::ostream &out, ProofRewriteRule rule);
+CVC5_EXPORT std::ostream& operator<<(std::ostream& out, ProofRewriteRule rule);
 
-} // namespace cvc5
+}  // namespace cvc5
 
 namespace std {
 
 /**
  * Hash function for ProofRules.
  */
-template <> struct CVC5_EXPORT hash<cvc5::ProofRule> {
+template <>
+struct CVC5_EXPORT hash<cvc5::ProofRule>
+{
   /**
    * Hashes a ProofRule to a size_t.
    * @param rule The proof rule.
@@ -3631,7 +3634,9 @@ CVC5_EXPORT std::string to_string(cvc5::ProofRule rule);
 /**
  * Hash function for ProofRewriteRules.
  */
-template <> struct CVC5_EXPORT hash<cvc5::ProofRewriteRule> {
+template <>
+struct CVC5_EXPORT hash<cvc5::ProofRewriteRule>
+{
   /**
    * Hashes a ProofRewriteRule to a size_t.
    * @param rule The proof rewrite rule.
@@ -3648,7 +3653,7 @@ template <> struct CVC5_EXPORT hash<cvc5::ProofRewriteRule> {
  */
 CVC5_EXPORT std::string to_string(cvc5::ProofRewriteRule rule);
 
-} // namespace std
+}  // namespace std
 
 #endif
 #endif

--- a/src/options/strings_options.toml
+++ b/src/options/strings_options.toml
@@ -229,14 +229,6 @@ name   = "Strings Theory"
   help       = "The maximum size of string values in models"
 
 [[option]]
-  name       = "stringsCodeElim"
-  category   = "expert"
-  long       = "strings-code-elim"
-  type       = "bool"
-  default    = "false"
-  help       = "eliminate code points during preprocessing"
-
-[[option]]
   name       = "stringRegexpPosConcatEager"
   category   = "expert"
   long       = "strings-re-posc-eager"

--- a/src/theory/strings/rewrites
+++ b/src/theory/strings/rewrites
@@ -305,10 +305,6 @@
   (re.inter xs (str.to_re s) ys) 
   re.none)
 
-(define-rule str-nth-elim-code ((s String) (n Int))
-  (seq.nth s n)
-  (str.to_code (str.substr s n 1)))
-
 (define-cond-rule str-substr-len-include ((s1 ?Seq) (s2 ?Seq :list) (n Int))
   (= n (str.len s1))
   (str.substr (str.++ s1 s2) 0 n)

--- a/src/theory/strings/sequences_rewriter.cpp
+++ b/src/theory/strings/sequences_rewriter.cpp
@@ -2059,12 +2059,6 @@ Node SequencesRewriter::rewriteSeqNth(Node node)
         return returnRewrite(node, ret, Rewrite::SEQ_NTH_EVAL);
       }
     }
-    if (s.getType().isString())
-    {
-      NodeManager* nm = nodeManager();
-      Node ret = nm->mkConstInt(Rational(-1));
-      return returnRewrite(node, ret, Rewrite::SEQ_NTH_EVAL_OOB);
-    }
   }
 
   std::vector<Node> prefix, suffix;

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -1141,35 +1141,7 @@ TrustNode TheoryStrings::ppRewrite(TNode atom, std::vector<SkolemLemma>& lems)
     lems.push_back(SkolemLemma(tnk, k));
     return TrustNode::mkTrustRewrite(atom, k, nullptr);
   }
-  if (options().strings.stringsCodeElim)
-  {
-    if (ak == Kind::STRING_TO_CODE)
-    {
-      // If we are eliminating code, convert it to nth.
-      // str.to_code(t) ---> ite(str.len(t) = 1, str.nth(t,0), -1)
-      NodeManager* nm = nodeManager();
-      Node t = atom[0];
-      Node cond =
-          nm->mkNode(Kind::EQUAL, nm->mkNode(Kind::STRING_LENGTH, t), d_one);
-      Node ret = nm->mkNode(
-          Kind::ITE, cond, nm->mkNode(Kind::SEQ_NTH, t, d_zero), d_neg_one);
-      return TrustNode::mkTrustRewrite(atom, ret, nullptr);
-    }
-  }
-  else if (ak == Kind::SEQ_NTH && atom[0].getType().isString())
-  {
-    // If we are not eliminating code, we are eliminating nth (over strings);
-    // convert it to code.
-    // (seq.nth x n) ---> (str.to_code (str.substr x n 1))
-    NodeManager* nm = nodeManager();
-    Node ret = nm->mkNode(Kind::STRING_TO_CODE,
-                          nm->mkNode(Kind::STRING_SUBSTR,
-                                     atom[0],
-                                     atom[1],
-                                     nm->mkConstInt(Rational(1))));
-    return TrustNode::mkTrustRewrite(atom, ret, nullptr);
-  }
-  else if (ak == Kind::REGEXP_RANGE)
+  if (ak == Kind::REGEXP_RANGE)
   {
     for (const Node& nc : atom)
     {

--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -1128,7 +1128,8 @@ Node StringsPreprocess::mkCodePointAtIndex(Node x, Node i)
   if (x.getType().isString())
   {
     Node one = nm->mkConstInt(Rational(1));
-    return nm->mkNode(Kind::STRING_TO_CODE, nm->mkNode(Kind::STRING_SUBSTR, {x, i, one}));
+    return nm->mkNode(Kind::STRING_TO_CODE,
+                      nm->mkNode(Kind::STRING_SUBSTR, {x, i, one}));
   }
   return nm->mkNode(Kind::SEQ_NTH, x, i);
 }

--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -1125,6 +1125,11 @@ Node StringsPreprocess::mkCodePointAtIndex(Node x, Node i)
   // (STRING_TO_CODE, (STRING_SUBSTR, x, i, 1)) here. The former may be
   // converted to the latter during preprocessing based on our options.
   NodeManager* nm = NodeManager::currentNM();
+  if (x.getType().isString())
+  {
+    Node one = nm->mkConstInt(Rational(1));
+    return nm->mkNode(Kind::STRING_TO_CODE, nm->mkNode(Kind::STRING_SUBSTR, {x, i, one}));
+  }
   return nm->mkNode(Kind::SEQ_NTH, x, i);
 }
 

--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -1121,9 +1121,10 @@ Node StringsPreprocess::simplifyRec(Node t, std::vector<Node>& asserts)
 }
 Node StringsPreprocess::mkCodePointAtIndex(Node x, Node i)
 {
-  // We use (SEQ_NTH, x, i) instead of
-  // (STRING_TO_CODE, (STRING_SUBSTR, x, i, 1)) here. The former may be
-  // converted to the latter during preprocessing based on our options.
+  // If x is a string, we use (STRING_TO_CODE, (STRING_SUBSTR, x, i, 1)).
+  // It is possible to have an extension where (STRING_NTH x i) is generated
+  // here for a new STRING_NTH kind, if there was a native way of handling nth
+  // for strings, but this is not explored here.
   NodeManager* nm = NodeManager::currentNM();
   if (x.getType().isString())
   {

--- a/src/theory/strings/theory_strings_type_rules.cpp
+++ b/src/theory/strings/theory_strings_type_rules.cpp
@@ -536,9 +536,9 @@ TypeNode SeqNthTypeRule::computeType(NodeManager* nodeManager,
     // if selecting from abstract, we don't know the type
     return nodeManager->mkAbstractType(Kind::ABSTRACT_TYPE);
   }
+  // must check sequence here to ensure not a string
   if (!t.isSequence())
   {
-    AlwaysAssert(false);
     if (errOut)
     {
       (*errOut) << "expecting a sequence term in nth";

--- a/src/theory/strings/theory_strings_type_rules.cpp
+++ b/src/theory/strings/theory_strings_type_rules.cpp
@@ -511,7 +511,7 @@ TypeNode SeqNthTypeRule::computeType(NodeManager* nodeManager,
 {
   Assert(n.getKind() == Kind::SEQ_NTH);
   TypeNode t = n[0].getTypeOrNull();
-  if (check && !isMaybeStringLike(t))
+  if (check && !t.isMaybeKind(Kind::SEQUENCE_TYPE))
   {
     if (errOut)
     {
@@ -536,12 +536,16 @@ TypeNode SeqNthTypeRule::computeType(NodeManager* nodeManager,
     // if selecting from abstract, we don't know the type
     return nodeManager->mkAbstractType(Kind::ABSTRACT_TYPE);
   }
-  if (t.isSequence())
+  if (!t.isSequence())
   {
-    return t.getSequenceElementType();
+    AlwaysAssert(false);
+    if (errOut)
+    {
+      (*errOut) << "expecting a sequence term in nth";
+    }
+    return TypeNode::null();
   }
-  Assert(t.isString());
-  return nodeManager->integerType();
+  return t.getSequenceElementType();
 }
 
 Cardinality SequenceProperties::computeCardinality(TypeNode type)

--- a/test/regress/cli/regress0/strings/issue5816-re-kind.smt2
+++ b/test/regress/cli/regress0/strings/issue5816-re-kind.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE: --no-strings-code-elim
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress0/strings/model-code-point.smt2
+++ b/test/regress/cli/regress0/strings/model-code-point.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --lang=smt2.6 --produce-models --no-strings-code-elim
+; COMMAND-LINE: --lang=smt2.6 --produce-models
 ; EXPECT: sat
 ; EXPECT: ((x "\u{a}"))
 ; EXPECT: ((y "\u{7f}"))

--- a/test/regress/cli/regress0/strings/simple-nth-fail.smt2
+++ b/test/regress/cli/regress0/strings/simple-nth-fail.smt2
@@ -1,5 +1,3 @@
-; COMMAND-LINE: --no-strings-code-elim
-; COMMAND-LINE: --strings-code-elim
 (set-logic QF_SLIA)
 (set-info :status sat)
 (declare-const i Int)

--- a/test/regress/cli/regress1/decision/jh-test1.smt2
+++ b/test/regress/cli/regress1/decision/jh-test1.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --decision=justification --no-strings-code-elim
+; COMMAND-LINE: --decision=justification
 ; EXPECT: sat
 (set-logic ALL)
 (declare-const size4 String)

--- a/test/regress/cli/regress1/strings/str-code-sat.smt2
+++ b/test/regress/cli/regress1/strings/str-code-sat.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE: --no-strings-code-elim
 ; EXPECT: sat
 (set-logic QF_SLIA)
 (set-info :status sat)

--- a/test/regress/cli/regress1/strings/strings-code-elim-min.smt2
+++ b/test/regress/cli/regress1/strings/strings-code-elim-min.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --decision=internal --strings-code-elim
+; COMMAND-LINE: --decision=internal
 ; EXPECT: sat
 (set-logic QF_SLIA)
 (declare-fun s () String)

--- a/test/regress/cli/regress1/strings/to_upper_12.smt2
+++ b/test/regress/cli/regress1/strings/to_upper_12.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy --strings-code-elim
+; COMMAND-LINE: --strings-exp --seq-array=lazy
 ; EXPECT: sat
 (set-logic QF_SLIA)
 (declare-const X String)

--- a/test/regress/cli/regress1/strings/to_upper_over_concat.smt2
+++ b/test/regress/cli/regress1/strings/to_upper_over_concat.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy --strings-code-elim
+; COMMAND-LINE: --strings-exp --seq-array=lazy
 ; EXPECT: sat
 (set-logic QF_SLIA)
 (declare-const x String)


### PR DESCRIPTION
Makes `seq.nth` only apply to sequences.  Deletes a now irrelevant RARE rewrite.