### PR TITLE
Add missing support for the assertionNames field of proofToString to Python and Java API and add unit test for all bindings

### DIFF
--- a/include/cvc5/cvc5.h
+++ b/include/cvc5/cvc5.h
@@ -6113,7 +6113,7 @@ class CVC5_EXPORT Solver
    * `modes::ProofFormat::NONE` if the proof is from a component other than
    * `modes::ProofComponent::FULL`.
    * @param assertionNames Mapping between assertions and names, if they were
-   * given by the user.
+   * given by the user.  This is used by the Alethe proof format.
    * @return The string representation of the proof in the given format.
    */
   std::string proofToString(

--- a/src/api/java/io/github/cvc5/Solver.java
+++ b/src/api/java/io/github/cvc5/Solver.java
@@ -2766,6 +2766,27 @@ public class Solver extends AbstractPointer
   private native String proofToString(long pointer, long proofs, int format);
 
   /**
+   * Prints a proof into a string with a slected proof format mode.
+   * Other aspects of printing are taken from the solver options.
+   *
+   * @api.note This method is experimental and may change in future versions.
+   *
+   * @param proof A proof.
+   * @param format The proof format used to print the proof. Must be
+   * `PROOF_FORMAT_NONE` if the proof is from a component other than
+   * `PROOF_COMPONENT_FULL`.
+   * @param assertionNames Mapping between assertions and names, if they were
+   * given by the user.  This is used by the Alethe proof format.
+   * @return The proof printed in the current format.
+   */
+  public String proofToString(Proof proof, ProofFormat format, Map assertionNames)
+  {
+    return proofToString(pointer, proof.getPointer(), format.getValue(), assertionNames);
+  }
+
+  private native String proofToString(long pointer, long proofs, int format, Map assertionNames);
+
+  /**
    * Get the value of the given term in the current model.
    *
    * SMT-LIB:

--- a/src/api/python/cvc5.pxd
+++ b/src/api/python/cvc5.pxd
@@ -454,7 +454,7 @@ cdef extern from "<cvc5/cvc5.h>" namespace "cvc5":
         Term defineFunsRec(vector[Term]& funs, vector[vector[Term]]& bound_vars,
                            vector[Term]& terms, bint glbl) except +
         vector[Proof] getProof(ProofComponent c) except +
-        string proofToString(Proof proof, ProofFormat format) except +
+        string proofToString(Proof proof, ProofFormat format, const map[Term, string]& assertionNames) except +
         vector[Term] getLearnedLiterals(LearnedLitType type) except +
         vector[Term] getAssertions() except +
         string getInfo(const string& flag) except +

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -14,6 +14,7 @@ from libcpp.pair cimport pair
 from libcpp.set cimport set as c_set
 from libcpp.string cimport string
 from libcpp.vector cimport vector
+from libcpp.map cimport map
 
 from cvc5 cimport cout
 from cvc5 cimport stringstream
@@ -3591,7 +3592,8 @@ cdef class Solver:
         return proofs
 
     def proofToString(self, proof,
-                      format = ProofFormat.DEFAULT):
+                      format = ProofFormat.DEFAULT,
+                      assertionNames = {}):
         """
             Prints proof into a string with a selected proof format mode.
             Other aspects of printing are taken from the solver options.
@@ -3603,11 +3605,19 @@ cdef class Solver:
                           :py:meth:`getProof()`.
             :param format: The proof format used to print the proof.  Must be
                           "None" if the proof is not a full proof.
+            :param assertionNames: Mapping between assertions and names, if
+                                   they were  given by the user.  This is used
+                                   by the Alethe proof format.
 
             :return: The proof printed in the current format.
         """
+        #    assertionMap[(<Term?> k).cterm] = assertionNames[k]
+        cdef map[c_Term, string] assertionMap
+        for k in assertionNames:
+            assertionMap[(<Term> k).cterm] = assertionNames[k].encode('utf-8')
         return self.csolver.proofToString((<Proof?> proof).cproof,
-                                         <c_ProofFormat> format.value)
+                                         <c_ProofFormat> format.value,
+                                         assertionMap)
 
     def getLearnedLiterals(self, type = LearnedLitType.INPUT):
         """

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -3611,7 +3611,6 @@ cdef class Solver:
 
             :return: The proof printed in the current format.
         """
-        #    assertionMap[(<Term?> k).cterm] = assertionNames[k]
         cdef map[c_Term, string] assertionMap
         for k in assertionNames:
             assertionMap[(<Term> k).cterm] = assertionNames[k].encode('utf-8')

--- a/test/unit/api/cpp/api_solver_black.cpp
+++ b/test/unit/api/cpp/api_solver_black.cpp
@@ -1250,6 +1250,37 @@ TEST_F(TestApiBlackSolver, getProofAndProofToString)
   ASSERT_FALSE(printedProof.empty());
 }
 
+TEST_F(TestApiBlackSolver, proofToStringAssertionNames)
+{
+  d_solver->setOption("produce-proofs", "true");
+
+  std::vector<Proof> proofs;
+
+  Term x = d_tm.mkConst(d_uninterpreted, "x");
+  Term y = d_tm.mkConst(d_uninterpreted, "y");
+
+  Term x_eq_y = d_tm.mkTerm(Kind::EQUAL, {x, y});
+  Term not_x_eq_y = d_tm.mkTerm(Kind::NOT, {x_eq_y});
+
+  std::map<cvc5::Term, std::string> assertionNames;
+  assertionNames.emplace(x_eq_y, "as1");
+  assertionNames.emplace(not_x_eq_y, "as2");
+
+  d_solver->assertFormula(x_eq_y);
+  d_solver->assertFormula(not_x_eq_y);
+
+  ASSERT_TRUE(d_solver->checkSat().isUnsat());
+
+  std::string printedProof;
+  ASSERT_NO_THROW(proofs = d_solver->getProof());
+  ASSERT_FALSE(proofs.empty());
+  ASSERT_NO_THROW(printedProof = d_solver->proofToString(
+                      proofs[0], modes::ProofFormat::ALETHE, assertionNames));
+  ASSERT_FALSE(printedProof.empty());
+  ASSERT_LT(printedProof.find("as1"), std::string::npos);
+  ASSERT_LT(printedProof.find("as2"), std::string::npos);
+}
+
 TEST_F(TestApiBlackSolver, getDifficulty)
 {
   d_solver->setOption("produce-difficulty", "true");

--- a/test/unit/api/java/SolverTest.java
+++ b/test/unit/api/java/SolverTest.java
@@ -944,6 +944,35 @@ class SolverTest
   }
 
   @Test
+  void proofToStringAssertionNames()
+  {
+    d_solver.setOption("produce-proofs", "true");
+
+    Sort uSort = d_solver.mkUninterpretedSort("u");
+
+    Term x = d_solver.mkConst(uSort, "x");
+    Term y = d_solver.mkConst(uSort, "y");
+
+    Term x_eq_y = d_solver.mkTerm(Kind.EQUAL, x, y);
+    Term not_x_eq_y = d_solver.mkTerm(Kind.NOT, x_eq_y);
+
+    Map<Term, String> assertionNames = new HashMap();
+    assertionNames.put(x_eq_y, "as1");
+    assertionNames.put(not_x_eq_y, "as2");
+
+    d_solver.assertFormula(x_eq_y);
+    d_solver.assertFormula(not_x_eq_y);
+    assertTrue(d_solver.checkSat().isUnsat());
+
+    Proof[] proofs = d_solver.getProof();
+    assertNotEquals(0, proofs.length);
+    String printedProof = d_solver.proofToString(proofs[0], ProofFormat.ALETHE, assertionNames);
+    assertFalse(printedProof.isEmpty());
+    assertTrue(printedProof.contains("as1"));
+    assertTrue(printedProof.contains("as2"));
+  }
+
+  @Test
   void getUnsatCoreLemmas1()
   {
     d_solver.assertFormula(d_solver.mkFalse());

--- a/test/unit/api/python/test_solver.py
+++ b/test/unit/api/python/test_solver.py
@@ -584,7 +584,7 @@ def test_get_unsat_core_and_proof(tm, solver):
 
 
 def test_get_unsat_core_and_proof_to_string(tm, solver):
-    solver.setOption("produce-proofs", "true");
+    solver.setOption("produce-proofs", "true")
 
     uSort = tm.mkUninterpretedSort("u")
     intSort = tm.getIntegerSort()
@@ -620,6 +620,31 @@ def test_get_unsat_core_and_proof_to_string(tm, solver):
     proofs = solver.getProof(ProofComponent.SAT)
     printedProof = solver.proofToString(proofs[0], ProofFormat.NONE)
     assert len(printedProof) > 0
+
+
+def test_proof_to_string_assertion_names(tm, solver):
+    solver.setOption("produce-proofs", "true")
+    uSort = tm.mkUninterpretedSort("u")
+    x = tm.mkConst(uSort, "x")
+    y = tm.mkConst(uSort, "y")
+
+    x_eq_y = tm.mkTerm(Kind.EQUAL, x, y)
+    not_x_eq_y = tm.mkTerm(Kind.NOT, x_eq_y)
+
+    names = {x_eq_y: "as1", not_x_eq_y: "as2"}
+
+    solver.assertFormula(x_eq_y)
+    solver.assertFormula(not_x_eq_y)
+
+    assert solver.checkSat().isUnsat()
+
+    proofs = solver.getProof()
+    assert len(proofs) > 0
+    printedProof = solver.proofToString(proofs[0], ProofFormat.ALETHE, names)
+    assert len(printedProof) > 0
+    assert b"as1" in printedProof
+    assert b"as2" in printedProof
+
 
 def test_learned_literals(solver):
     solver.setOption("produce-learned-literals", "true")


### PR DESCRIPTION
@aniemetz Sorry, this took me longer than I hoped.