### PR TITLE
Fix issue with non-standard RE ranges in regular expression consume

### DIFF
--- a/src/theory/strings/regexp_entail.cpp
+++ b/src/theory/strings/regexp_entail.cpp
@@ -159,7 +159,7 @@ Node RegExpEntail::simpleRegexpConsume(std::vector<Node>& mchildren,
             if (!isConstRegExp(rc))
             {
               // if a non-standard re.range term, abort
-              return Node::null();
+              break;
             }
             std::vector<unsigned> ssVec;
             ssVec.push_back(t == 0 ? s.back() : s.front());

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1788,6 +1788,7 @@ set(regress_0_tests
   regress0/strings/instance13131.smt2
   regress0/strings/instance15449.smt2
   regress0/strings/is_digit_simple.smt2
+  regress0/strings/issue11168.smt2
   regress0/strings/issue1189.smt2
   regress0/strings/issue2958.smt2
   regress0/strings/issue3440.smt2

--- a/test/regress/cli/regress0/strings/issue11168.smt2
+++ b/test/regress/cli/regress0/strings/issue11168.smt2
@@ -1,0 +1,7 @@
+; EXPECT: (error "expecting a constant string term in regexp range")
+; EXIT: 1
+(set-logic ALL)
+(declare-const a String)
+(declare-const b String)
+(assert (not (str.in_re "a" (re.+ (re.range a b))))) 
+(check-sat)


### PR DESCRIPTION
This bug accidentally reverses the contents of a regular expression concatentation in certain range cases, which would lead to unsoundess if we supported non-standard RE ranges.

This bug was introduced in the refactor here: https://github.com/cvc5/cvc5/commit/20ffeae01dc565547015590e06efc4db0092734f, which made the rewriter call the re consume utility in a new way is sensitive to the order of the vector.

Fixes https://github.com/cvc5/cvc5/issues/11168.