### PR TITLE
Minor change to explanation in strings

### DIFF
--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -254,6 +254,12 @@ void InferenceManager::addToExplanation(Node a,
 {
   if (a != b)
   {
+    // prefer having constants on the RHS, which helps proof reconstruction
+    if (a.isConst() && !b.isConst())
+    {
+      addToExplanation(b, a, exp);
+      return;
+    }
     Trace("strings-explain")
         << "Add to explanation : " << a << " == " << b << std::endl;
     Assert(d_state.areEqual(a, b));

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -257,8 +257,9 @@ void InferenceManager::addToExplanation(Node a,
     // prefer having constants on the RHS, which helps proof reconstruction
     if (a.isConst() && !b.isConst())
     {
-      addToExplanation(b, a, exp);
-      return;
+      Node tmp = a;
+      a = b;
+      b = tmp;
     }
     Trace("strings-explain")
         << "Add to explanation : " << a << " == " << b << std::endl;


### PR DESCRIPTION
This reorients equalities `(= c x)` to `(= x c)` where `c` is a constant string.

This is helpful in rare cases for proof elaboration in strings inferences.