### PR TITLE
Pin setuptools to versions below 72.2.0 for PyPy

### DIFF
--- a/src/api/python/pyproject.toml
+++ b/src/api/python/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     # Avoid issue #268: https://github.com/pypa/distutils/issues/268
     "setuptools!=70.2.0; os_name == 'nt'",
     # Avoid issue #283: https://github.com/pypa/distutils/issues/283
-    "setuptools<72.2.0; implementation_name == pypy",
+    "setuptools<72.2.0; implementation_name == 'pypy'",
     "Cython>=3"
 ]
 build-backend = "setuptools.build_meta"

--- a/src/api/python/pyproject.toml
+++ b/src/api/python/pyproject.toml
@@ -1,7 +1,10 @@
 [build-system]
 requires = [
     "setuptools>=66.1.0",
+    # Avoid issue #268: https://github.com/pypa/distutils/issues/268
     "setuptools!=70.2.0; os_name == 'nt'",
+    # Avoid issue #283: https://github.com/pypa/distutils/issues/283
+    "setuptools<72.2.0; implementation_name == pypy",
     "Cython>=3"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
It avoids issue https://github.com/pypa/distutils/issues/283, which currently breaks the PyPI workflow.