### PR TITLE
Handle rare case of aliased purification variables in string infer proof cons

### DIFF
--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -685,6 +685,7 @@ Node ProofPostprocessCallback::expandMacros(ProofRule id,
     {
       getMethodId(args[2], ida);
     }
+    Trace("smt-proof-pp-debug") << "Expand SUBS " << ids << " " << ida << std::endl;
     std::vector<std::shared_ptr<CDProof>> pfs;
     std::vector<TNode> vsList;
     std::vector<TNode> ssList;

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -685,7 +685,8 @@ Node ProofPostprocessCallback::expandMacros(ProofRule id,
     {
       getMethodId(args[2], ida);
     }
-    Trace("smt-proof-pp-debug") << "Expand SUBS " << ids << " " << ida << std::endl;
+    Trace("smt-proof-pp-debug")
+        << "Expand SUBS " << ids << " " << ida << std::endl;
     std::vector<std::shared_ptr<CDProof>> pfs;
     std::vector<TNode> vsList;
     std::vector<TNode> ssList;

--- a/src/theory/strings/infer_proof_cons.cpp
+++ b/src/theory/strings/infer_proof_cons.cpp
@@ -1282,10 +1282,11 @@ bool InferProofCons::purifyCoreSubstitution(
     TheoryProofStepBuffer& psb,
     std::unordered_set<Node>& termsToPurify)
 {
+  SkolemManager* sm = NodeManager::currentNM()->getSkolemManager();
   for (const Node& nc : children)
   {
     Assert(nc.getKind() == Kind::EQUAL);
-    if (!nc[0].isVar())
+    if (!nc[0].isVar() || sm->getId(nc[0])==SkolemId::PURIFY)
     {
       termsToPurify.insert(nc[0]);
     }

--- a/src/theory/strings/infer_proof_cons.cpp
+++ b/src/theory/strings/infer_proof_cons.cpp
@@ -1282,7 +1282,6 @@ bool InferProofCons::purifyCoreSubstitution(
     TheoryProofStepBuffer& psb,
     std::unordered_set<Node>& termsToPurify)
 {
-  SkolemManager* sm = NodeManager::currentNM()->getSkolemManager();
   for (const Node& nc : children)
   {
     Assert(nc.getKind() == Kind::EQUAL);
@@ -1292,7 +1291,8 @@ bool InferProofCons::purifyCoreSubstitution(
     }
   }
   // To avoid rare issues where purification variables introduced by this method
-  // already appear in the conflict, we also purify them here.
+  // already appear in the inference, we also purify them here.
+  SkolemManager* sm = NodeManager::currentNM()->getSkolemManager();
   SkolemId id;
   Node cval;
   for (const Node& nc : children)

--- a/src/theory/strings/infer_proof_cons.cpp
+++ b/src/theory/strings/infer_proof_cons.cpp
@@ -1299,7 +1299,8 @@ bool InferProofCons::purifyCoreSubstitution(
   {
     // if this is a purification skolem of a term that is being purified,
     // we purify this.
-    if (sm->isSkolemFunction(nc[0], id, cval) && id == SkolemId::PURIFY && termsToPurify.find(cval)!=termsToPurify.end())
+    if (sm->isSkolemFunction(nc[0], id, cval) && id == SkolemId::PURIFY
+        && termsToPurify.find(cval) != termsToPurify.end())
     {
       termsToPurify.insert(nc[0]);
     }
@@ -1327,11 +1328,12 @@ bool InferProofCons::purifyCoreSubstitution(
   return true;
 }
 
-Node InferProofCons::purifyPredicate(PurifyType pt,
-                                     Node lit,
-                                     bool concludeNew,
-                                     TheoryProofStepBuffer& psb,
-                                     const std::unordered_set<Node>& termsToPurify)
+Node InferProofCons::purifyPredicate(
+    PurifyType pt,
+    Node lit,
+    bool concludeNew,
+    TheoryProofStepBuffer& psb,
+    const std::unordered_set<Node>& termsToPurify)
 {
   bool pol = lit.getKind() != Kind::NOT;
   Node atom = pol ? lit : lit[0];
@@ -1401,8 +1403,8 @@ Node InferProofCons::purifyPredicate(PurifyType pt,
   return newLit;
 }
 
-Node InferProofCons::purifyCoreTerm(Node n,
-                                    const std::unordered_set<Node>& termsToPurify)
+Node InferProofCons::purifyCoreTerm(
+    Node n, const std::unordered_set<Node>& termsToPurify)
 {
   if (n.getKind() == Kind::STRING_CONCAT)
   {
@@ -1416,7 +1418,8 @@ Node InferProofCons::purifyCoreTerm(Node n,
   return maybePurifyTerm(n, termsToPurify);
 }
 
-Node InferProofCons::purifyApp(Node n, const std::unordered_set<Node>& termsToPurify)
+Node InferProofCons::purifyApp(Node n,
+                               const std::unordered_set<Node>& termsToPurify)
 {
   if (n.getNumChildren() == 0)
   {
@@ -1430,8 +1433,8 @@ Node InferProofCons::purifyApp(Node n, const std::unordered_set<Node>& termsToPu
   return NodeManager::currentNM()->mkNode(n.getKind(), pcs);
 }
 
-Node InferProofCons::maybePurifyTerm(Node n,
-                                     const std::unordered_set<Node>& termsToPurify)
+Node InferProofCons::maybePurifyTerm(
+    Node n, const std::unordered_set<Node>& termsToPurify)
 {
   if (termsToPurify.find(n) == termsToPurify.end())
   {

--- a/src/theory/strings/infer_proof_cons.cpp
+++ b/src/theory/strings/infer_proof_cons.cpp
@@ -1286,6 +1286,8 @@ bool InferProofCons::purifyCoreSubstitution(
   for (const Node& nc : children)
   {
     Assert(nc.getKind() == Kind::EQUAL);
+    // to avoid issues where purification variables introduced by this method
+    // already appear in the conflict, we also purify them here.
     if (!nc[0].isVar() || sm->getId(nc[0]) == SkolemId::PURIFY)
     {
       termsToPurify.insert(nc[0]);

--- a/src/theory/strings/infer_proof_cons.cpp
+++ b/src/theory/strings/infer_proof_cons.cpp
@@ -1286,7 +1286,7 @@ bool InferProofCons::purifyCoreSubstitution(
   for (const Node& nc : children)
   {
     Assert(nc.getKind() == Kind::EQUAL);
-    if (!nc[0].isVar() || sm->getId(nc[0])==SkolemId::PURIFY)
+    if (!nc[0].isVar() || sm->getId(nc[0]) == SkolemId::PURIFY)
     {
       termsToPurify.insert(nc[0]);
     }

--- a/src/theory/strings/infer_proof_cons.cpp
+++ b/src/theory/strings/infer_proof_cons.cpp
@@ -1291,7 +1291,7 @@ bool InferProofCons::purifyCoreSubstitution(
       termsToPurify.insert(nc[0]);
     }
   }
-  // To avoid issues where purification variables introduced by this method
+  // To avoid rare issues where purification variables introduced by this method
   // already appear in the conflict, we also purify them here.
   SkolemId id;
   Node cval;

--- a/src/theory/strings/infer_proof_cons.h
+++ b/src/theory/strings/infer_proof_cons.h
@@ -252,24 +252,24 @@ class InferProofCons : protected EnvObj, public ProofGenerator
                               Node lit,
                               bool concludeNew,
                               TheoryProofStepBuffer& psb,
-                              std::unordered_set<Node>& termsToPurify);
+                              const std::unordered_set<Node>& termsToPurify);
   /**
    * Purify term with respect to a set of terms to purify. This replaces
    * all terms to purify with their purification variables that occur in
    * positions that are relevant for the core calculus of strings (direct
    * children of concat or equal).
    */
-  static Node purifyCoreTerm(Node n, std::unordered_set<Node>& termsToPurify);
+  static Node purifyCoreTerm(Node n, const std::unordered_set<Node>& termsToPurify);
   /**
    * Purify application, which replaces each direct child nc of n with
    * maybePurifyTerm(nc, termsToPurify).
    */
-  static Node purifyApp(Node n, std::unordered_set<Node>& termsToPurify);
+  static Node purifyApp(Node n, const std::unordered_set<Node>& termsToPurify);
   /**
    * Maybe purify term, which returns the skolem variable for n if it occurs
    * in termsToPurify.
    */
-  static Node maybePurifyTerm(Node n, std::unordered_set<Node>& termsToPurify);
+  static Node maybePurifyTerm(Node n, const std::unordered_set<Node>& termsToPurify);
   /** The lazy fact map */
   NodeInferInfoMap d_lazyFactMap;
   /** Reference to the statistics for the theory of strings/sequences. */

--- a/src/theory/strings/infer_proof_cons.h
+++ b/src/theory/strings/infer_proof_cons.h
@@ -259,7 +259,8 @@ class InferProofCons : protected EnvObj, public ProofGenerator
    * positions that are relevant for the core calculus of strings (direct
    * children of concat or equal).
    */
-  static Node purifyCoreTerm(Node n, const std::unordered_set<Node>& termsToPurify);
+  static Node purifyCoreTerm(Node n,
+                             const std::unordered_set<Node>& termsToPurify);
   /**
    * Purify application, which replaces each direct child nc of n with
    * maybePurifyTerm(nc, termsToPurify).
@@ -269,7 +270,8 @@ class InferProofCons : protected EnvObj, public ProofGenerator
    * Maybe purify term, which returns the skolem variable for n if it occurs
    * in termsToPurify.
    */
-  static Node maybePurifyTerm(Node n, const std::unordered_set<Node>& termsToPurify);
+  static Node maybePurifyTerm(Node n,
+                              const std::unordered_set<Node>& termsToPurify);
   /** The lazy fact map */
   NodeInferInfoMap d_lazyFactMap;
   /** Reference to the statistics for the theory of strings/sequences. */

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1790,6 +1790,7 @@ set(regress_0_tests
   regress0/strings/instance13131.smt2
   regress0/strings/instance15449.smt2
   regress0/strings/is_digit_simple.smt2
+  regress0/strings/issue11164-double-purify.smt2
   regress0/strings/issue11168.smt2
   regress0/strings/issue1189.smt2
   regress0/strings/issue2958.smt2

--- a/test/regress/cli/regress0/strings/issue11164-double-purify.smt2
+++ b/test/regress/cli/regress0/strings/issue11164-double-purify.smt2
@@ -1,0 +1,6 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-const a String)  
+(declare-const b Int)  
+(assert (not (str.contains (str.replace_all a "a" a) (str.at a b)))) 
+(check-sat)


### PR DESCRIPTION
We use a step that introduces purification skolems to ensure that substitutions are applied properly to reason about string inferences. However, this could lead to issues in very rare cases where the purification skolem was already a part of the inference we are processing.

This PR solves the issue by additionally purifying the purification variables in the rare case this occurs. This occurs on 2 existing regressions and in the regression added for the resolved issue.

Fixes https://github.com/cvc5/cvc5/issues/11164.