### PR TITLE
Extend set.all & set.some to accepts multiple sets

### DIFF
--- a/src/theory/sets/kinds
+++ b/src/theory/sets/kinds
@@ -85,11 +85,11 @@ operator SET_FILTER        2  "set filter operator"
 
 # set.all operator is a predicate that holds iff all elements in a given set satisfy the the given predicate.
 # (set.all p A) receives a predicate p of type (-> T Bool) and a set of type (Set T) and returns Bool
-operator SET_ALL           2  "set all operator"
+operator SET_ALL           2:  "set all operator"
 
 # set.some operator is a predicate that holds iff at least one element in a given set satisfies the the given predicate.
 # (set.some p A) receives a predicate p of type (-> T Bool) and a set of type (Set T) and returns Bool
-operator SET_SOME           2  "set some operator"
+operator SET_SOME          2:  "set some operator"
 
 # set.fold operator combines elements of a set into a single value.
 # (set.fold f t A) folds the elements of set A starting with term t and using

--- a/src/theory/sets/theory_sets_rewriter.cpp
+++ b/src/theory/sets/theory_sets_rewriter.cpp
@@ -734,13 +734,11 @@ RewriteResponse TheorySetsRewriter::preRewrite(TNode node) {
           Node x = nm->mkBoundVar("x" + std::to_string(i), argTypes[i]);
           boundVariables.push_back(x);
         }
-
-        std::cout << "Bound variables: " << boundVariables << std::endl;
+        
         std::vector<Node> terms;
         terms.push_back(p);
         terms.insert(terms.end(), boundVariables.begin(), boundVariables.end());
-        Node application = nm->mkNode(Kind::APPLY_UF, terms);
-        std::cout << "application: " << application << std::endl;
+        Node application = nm->mkNode(Kind::APPLY_UF, terms);        
         Node boundVariable = nm->mkNode(Kind::BOUND_VAR_LIST,
                                         boundVariables[argumentsCount - 1]);
         Node lambda = nm->mkNode(Kind::LAMBDA, boundVariable, application);
@@ -750,8 +748,7 @@ RewriteResponse TheorySetsRewriter::preRewrite(TNode node) {
           boundVariable = nm->mkNode(Kind::BOUND_VAR_LIST, boundVariables[i]);
           lambda = nm->mkNode(Kind::LAMBDA, boundVariable, setQuantifier);
           setQuantifier = nm->mkNode(k, lambda, node[i + 1]);
-        }
-        std::cout << "setQuantifier: " << setQuantifier << std::endl;
+        }        
         return RewriteResponse(REWRITE_AGAIN, setQuantifier);
       }
     }

--- a/src/theory/sets/theory_sets_rewriter.cpp
+++ b/src/theory/sets/theory_sets_rewriter.cpp
@@ -712,6 +712,7 @@ RewriteResponse TheorySetsRewriter::preRewrite(TNode node) {
 
 RewriteResponse TheorySetsRewriter::preRewriteSetQuantifier(TNode node)
 {
+  Assert(node.getKind() == Kind::SET_ALL || node.getKind() == Kind::SET_SOME);
   NodeManager* nm = nodeManager();
   Kind k = node.getKind();
   Node p = node[0];

--- a/src/theory/sets/theory_sets_rewriter.cpp
+++ b/src/theory/sets/theory_sets_rewriter.cpp
@@ -703,59 +703,66 @@ RewriteResponse TheorySetsRewriter::preRewrite(TNode node) {
   }
   else if (k == Kind::SET_ALL || k == Kind::SET_SOME)
   {
-    Node p = node[0];
-    std::vector<TypeNode> argTypes = p.getType().getArgTypes();
-    size_t argumentsCount = argTypes.size();
-    if (argumentsCount > 1)
-    {
-      // rewrite the set quantifier as nested terms
-      if (p.getKind() == Kind::LAMBDA)
-      {
-        // for lambda functions, reuse the declared bound variables
-        Node body = p[1];
-        Node boundVariable =
-            nm->mkNode(Kind::BOUND_VAR_LIST, p[0][argumentsCount - 1]);
-        Node lambda = nm->mkNode(Kind::LAMBDA, boundVariable, body);
-        Node setQuantifier = nm->mkNode(k, lambda, node[argumentsCount]);
-        for (int i = argumentsCount - 2; i >= 0; i--)
-        {
-          boundVariable = nm->mkNode(Kind::BOUND_VAR_LIST, p[0][i]);
-          lambda = nm->mkNode(Kind::LAMBDA, boundVariable, setQuantifier);
-          setQuantifier = nm->mkNode(k, lambda, node[i + 1]);
-        }
-        return RewriteResponse(REWRITE_AGAIN, setQuantifier);
-      }
-      else
-      {
-        // for other functions, use fresh bound variables
-        std::vector<Node> boundVariables;
-        for (size_t i = 0; i < argumentsCount; i++)
-        {
-          Node x = nm->mkBoundVar("x" + std::to_string(i), argTypes[i]);
-          boundVariables.push_back(x);
-        }
-        
-        std::vector<Node> terms;
-        terms.push_back(p);
-        terms.insert(terms.end(), boundVariables.begin(), boundVariables.end());
-        Node application = nm->mkNode(Kind::APPLY_UF, terms);        
-        Node boundVariable = nm->mkNode(Kind::BOUND_VAR_LIST,
-                                        boundVariables[argumentsCount - 1]);
-        Node lambda = nm->mkNode(Kind::LAMBDA, boundVariable, application);
-        Node setQuantifier = nm->mkNode(k, lambda, node[argumentsCount]);
-        for (int i = argumentsCount - 2; i >= 0; i--)
-        {
-          boundVariable = nm->mkNode(Kind::BOUND_VAR_LIST, boundVariables[i]);
-          lambda = nm->mkNode(Kind::LAMBDA, boundVariable, setQuantifier);
-          setQuantifier = nm->mkNode(k, lambda, node[i + 1]);
-        }        
-        return RewriteResponse(REWRITE_AGAIN, setQuantifier);
-      }
-    }
-
-    return RewriteResponse(REWRITE_DONE, node);
+    return preRewriteSetQuantifier(node);
   }
   // could have an efficient normalizer for union here
+
+  return RewriteResponse(REWRITE_DONE, node);
+}
+
+RewriteResponse TheorySetsRewriter::preRewriteSetQuantifier(TNode node)
+{
+  NodeManager* nm = nodeManager();
+  Kind k = node.getKind();
+  Node p = node[0];
+  std::vector<TypeNode> argTypes = p.getType().getArgTypes();
+  size_t argumentsCount = argTypes.size();
+  if (argumentsCount > 1)
+  {
+    // rewrite the set quantifier as nested terms
+    if (p.getKind() == Kind::LAMBDA)
+    {
+      // for lambda functions, reuse the declared bound variables
+      Node body = p[1];
+      Node boundVariable =
+          nm->mkNode(Kind::BOUND_VAR_LIST, p[0][argumentsCount - 1]);
+      Node lambda = nm->mkNode(Kind::LAMBDA, boundVariable, body);
+      Node setQuantifier = nm->mkNode(k, lambda, node[argumentsCount]);
+      for (int i = argumentsCount - 2; i >= 0; i--)
+      {
+        boundVariable = nm->mkNode(Kind::BOUND_VAR_LIST, p[0][i]);
+        lambda = nm->mkNode(Kind::LAMBDA, boundVariable, setQuantifier);
+        setQuantifier = nm->mkNode(k, lambda, node[i + 1]);
+      }
+      return RewriteResponse(REWRITE_AGAIN, setQuantifier);
+    }
+    else
+    {
+      // for other functions, use fresh bound variables
+      std::vector<Node> boundVariables;
+      for (size_t i = 0; i < argumentsCount; i++)
+      {
+        Node x = nm->mkBoundVar("x" + std::to_string(i + 1), argTypes[i]);
+        boundVariables.push_back(x);
+      }
+
+      std::vector<Node> terms;
+      terms.push_back(p);
+      terms.insert(terms.end(), boundVariables.begin(), boundVariables.end());
+      Node application = nm->mkNode(Kind::APPLY_UF, terms);
+      Node boundVariable =
+          nm->mkNode(Kind::BOUND_VAR_LIST, boundVariables[argumentsCount - 1]);
+      Node lambda = nm->mkNode(Kind::LAMBDA, boundVariable, application);
+      Node setQuantifier = nm->mkNode(k, lambda, node[argumentsCount]);
+      for (int i = argumentsCount - 2; i >= 0; i--)
+      {
+        boundVariable = nm->mkNode(Kind::BOUND_VAR_LIST, boundVariables[i]);
+        lambda = nm->mkNode(Kind::LAMBDA, boundVariable, setQuantifier);
+        setQuantifier = nm->mkNode(k, lambda, node[i + 1]);
+      }
+      return RewriteResponse(REWRITE_AGAIN, setQuantifier);
+    }
+  }
 
   return RewriteResponse(REWRITE_DONE, node);
 }

--- a/src/theory/sets/theory_sets_rewriter.h
+++ b/src/theory/sets/theory_sets_rewriter.h
@@ -73,6 +73,25 @@ class TheorySetsRewriter : public TheoryRewriter
   RewriteResponse preRewrite(TNode node) override;
 
   /**
+   * Rewrite set quantifier nodes with at least 2 sets into
+   * nested of set quantified nodes.
+   * For lambda predicates it reuses the declared bound variables.
+   * For other predicates it uses fresh bound variables.
+   * Examples:
+   * - (set.all (lambda ((x Int) (y Int)) (> x y)) A B)
+   *   is rewritten as
+   *   (set.all (lambda ((x Int)) (set.all (lambda ((y Int)) (> x y)) B)) A)
+   *
+   * - (set.all p A B)
+   *   is rewritten as
+   *   (set.all (lambda ((x1 Int)) (set.all (lambda ((x2 Int)) (p x1 x2)) B)) A)
+   *
+   * where A, B are sets of type (Set Int),
+   * and p is a predicate of type (-> Int Int Bool).
+   */
+  RewriteResponse preRewriteSetQuantifier(TNode node);
+
+  /**
    * Rewrite an equality, in case special handling is required.
    */
   Node rewriteEquality(TNode equality)

--- a/src/theory/sets/theory_sets_type_rules.cpp
+++ b/src/theory/sets/theory_sets_type_rules.cpp
@@ -572,23 +572,17 @@ TypeNode SetAllSomeTypeRule::computeType(NodeManager* nodeManager,
                                          std::ostream* errOut)
 {
   Assert(n.getKind() == Kind::SET_ALL || n.getKind() == Kind::SET_SOME);
-  std::string op = n.getKind() == Kind::SET_ALL ? "set.all" : "set.some";
   TypeNode functionType = n[0].getTypeOrNull();
-  TypeNode setType = n[1].getTypeOrNull();
   if (check)
   {
-    if (!setType.isMaybeKind(Kind::SET_TYPE))
+    if (!functionType.isMaybeKind(Kind::FUNCTION_TYPE))
     {
       if (errOut)
       {
-        (*errOut) << op
-                  << " operator expects a set in the second "
-                     "argument, a non-set is found";
+        (*errOut) << "Operator " << n.getKind()
+                  << " expects a predicate as a first argument. "
+                  << "Found a term of type '" << functionType << "'.";
       }
-      return TypeNode::null();
-    }
-    if (!checkFunctionTypeFor(n, functionType, setType, errOut))
-    {
       return TypeNode::null();
     }
     if (functionType.isFunction())
@@ -598,10 +592,69 @@ TypeNode SetAllSomeTypeRule::computeType(NodeManager* nodeManager,
       {
         if (errOut)
         {
-          (*errOut) << "Operator " << op
+          (*errOut) << "Operator " << n.getKind()
                     << " expects a function returning Bool.";
         }
         return TypeNode::null();
+      }
+      std::vector<TypeNode> argTypes = functionType.getArgTypes();
+      if (argTypes.size() == 0)
+      {
+        if (errOut)
+        {
+          (*errOut)
+              << "Operator " << n.getKind()
+              << " expects a function that receives at least one argument. "
+              << "Found a function of type '" << functionType << "'.";
+        }
+        return TypeNode::null();
+      }
+      // the number of passed sets should match the number of arguments
+      size_t setsCount = n.getNumChildren() - 1;
+      if (argTypes.size() != setsCount)
+      {
+        if (errOut)
+        {
+          (*errOut) << "Operator " << n.getKind()
+                    << " expects the number of sets to match the number of "
+                    << "arguments to the predicate. "
+                    << "Found a predicate with " << argTypes.size()
+                    << " arguments and " << setsCount << " in term '" << n
+                    << "'.";
+        }
+        return TypeNode::null();
+      }
+
+      // each predicate argument should match the element type of the
+      // corresponding set
+      for (size_t i = 0; i < argTypes.size(); i++)
+      {
+        TypeNode setType = n[i + 1].getType();
+        if (!setType.isMaybeKind(Kind::SET_TYPE))
+        {
+          if (errOut)
+          {
+            (*errOut) << " expect term '" << n[i + 1] << "' to have a set type'"
+                      << ", found type '" << setType << "'.";
+          }
+          return TypeNode::null();
+        }
+
+        if (setType.isSet())
+        {
+          TypeNode elementType = setType.getSetElementType();
+          if (!(elementType.isNull()
+                || argTypes[i].isComparableTo(elementType)))
+          {
+            if (errOut)
+            {
+              (*errOut) << "The type of input " << i << " '" << argTypes[i]
+                        << "' is not comparable to the element type of the "
+                        << "corresponding set which is " << elementType;
+            }
+            return TypeNode::null();
+          }
+        }
       }
     }
   }

--- a/src/theory/sets/theory_sets_type_rules.cpp
+++ b/src/theory/sets/theory_sets_type_rules.cpp
@@ -617,10 +617,9 @@ TypeNode SetAllSomeTypeRule::computeType(NodeManager* nodeManager,
         {
           (*errOut) << "Operator " << n.getKind()
                     << " expects the number of sets to match the number of "
-                    << "arguments to the predicate. "
-                    << "Found a predicate with " << argTypes.size()
-                    << " arguments and " << setsCount << " in term '" << n
-                    << "'.";
+                    << "inputs in the predicate. "
+                    << "Found " << setsCount << " sets and a predicate with "
+                    << argTypes.size() << " inputs in term '" << n << "'";
         }
         return TypeNode::null();
       }

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2972,6 +2972,7 @@ set(regress_1_tests
   regress1/seq/issue8148-2-const-mv.smt2
   regress1/seq/issue8148-const-mv.smt2
   regress1/seq/issue8936-nth-eager-red.smt2
+  regress1/sets/all_nested.smt2
   regress1/sets/all1.smt2
   regress1/sets/all2.smt2
   regress1/sets/all3.smt2  

--- a/test/regress/cli/regress1/sets/all3.smt2
+++ b/test/regress/cli/regress1/sets/all3.smt2
@@ -1,3 +1,4 @@
+; DISABLE-TESTER: proof
 (set-logic HO_ALL)
 (set-info :status unsat)
 

--- a/test/regress/cli/regress1/sets/all_nested.smt2
+++ b/test/regress/cli/regress1/sets/all_nested.smt2
@@ -1,0 +1,13 @@
+; EXPECT: sat
+; EXPECT: (((set.all (lambda ((x Int)) (> x 0)) (set.singleton 4)) true))
+; EXPECT: (((set.all gt (set.singleton 4) (set.singleton 5)) false))
+; EXPECT: (((set.all (lambda ((x Int) (y Int)) (> x y)) (set.singleton 4) (set.singleton 5)) false))
+; EXPECT: (((set.some (lambda ((x Int) (y Int) (z Int)) (> z (+ x y))) (set.singleton 4) (set.singleton 5) (set.singleton 10)) true))
+(set-logic HO_ALL)
+(set-option :produce-models true)
+(define-fun gt ((x Int) (y Int)) Bool (> x y))
+(check-sat)
+(get-value ((set.all (lambda ((x Int)) (> x 0)) (set.singleton 4))))
+(get-value ((set.all gt (set.singleton 4)(set.singleton 5))))
+(get-value ((set.all (lambda ((x Int) (y Int)) (> x y)) (set.singleton 4) (set.singleton 5))))
+(get-value ((set.some (lambda ((x Int) (y Int) (z Int)) (> z (+ x y))) (set.singleton 4)(set.singleton 5)(set.singleton 10))))


### PR DESCRIPTION
Applications like Alloy use quantified expressions which allow multiple bound variables. 
It is tedious to translate them using operators set.all and set.some with unary predicates and single sets. 
This PR extends these operators to allow multiple sets to be passed as arguments and rewrite these terms internally as nested set terms. 