### PR TITLE
Fix print benchmark utility when :qid is present

### DIFF
--- a/src/smt/print_benchmark.cpp
+++ b/src/smt/print_benchmark.cpp
@@ -15,25 +15,26 @@
 
 #include "smt/print_benchmark.h"
 
+#include "expr/attribute.h"
 #include "expr/dtype.h"
 #include "expr/node_algorithm.h"
 #include "expr/node_converter.h"
 #include "printer/printer.h"
-#include "expr/attribute.h"
 
 using namespace cvc5::internal::kind;
 
 namespace cvc5::internal {
 namespace smt {
-  
+
 /**
- * Attribute true for symbols that should be excluded from the output of this utility.
+ * Attribute true for symbols that should be excluded from the output of this
+ * utility.
  */
 struct BenchmarkNoPrintAttributeId
 {
 };
-using BenchmarkNoPrintAttribute = expr::Attribute<BenchmarkNoPrintAttributeId, bool>;
-
+using BenchmarkNoPrintAttribute =
+    expr::Attribute<BenchmarkNoPrintAttributeId, bool>;
 
 void PrintBenchmark::printDeclarationsFrom(std::ostream& outDecl,
                                            std::ostream& outDef,

--- a/src/smt/print_benchmark.h
+++ b/src/smt/print_benchmark.h
@@ -86,11 +86,12 @@ class PrintBenchmark
                       const std::string& logic,
                       const std::vector<Node>& defs,
                       const std::vector<Node>& assertions);
-    
-   /** 
-    * Mark that the given symbol should not be printed in benchmark outputs.
-    */
-   static void markNoPrint(Node& sym);
+
+  /**
+   * Mark that the given symbol should not be printed in benchmark outputs.
+   */
+  static void markNoPrint(Node& sym);
+
  private:
   /**
    * print declared symbols in funs but not processed; updates processed to

--- a/src/smt/print_benchmark.h
+++ b/src/smt/print_benchmark.h
@@ -86,7 +86,11 @@ class PrintBenchmark
                       const std::string& logic,
                       const std::vector<Node>& defs,
                       const std::vector<Node>& assertions);
-
+    
+   /** 
+    * Mark that the given symbol should not be printed in benchmark outputs.
+    */
+   static void markNoPrint(Node& sym);
  private:
   /**
    * print declared symbols in funs but not processed; updates processed to

--- a/src/theory/quantifiers/quantifiers_attributes.cpp
+++ b/src/theory/quantifiers/quantifiers_attributes.cpp
@@ -17,13 +17,13 @@
 
 #include "expr/skolem_manager.h"
 #include "options/quantifiers_options.h"
+#include "smt/print_benchmark.h"
 #include "theory/arith/arith_msum.h"
 #include "theory/quantifiers/fmf/bounded_integers.h"
 #include "theory/quantifiers/sygus/synth_engine.h"
 #include "theory/quantifiers/term_util.h"
 #include "util/rational.h"
 #include "util/string.h"
-#include "smt/print_benchmark.h"
 
 using namespace std;
 using namespace cvc5::internal::kind;

--- a/src/theory/quantifiers/quantifiers_attributes.cpp
+++ b/src/theory/quantifiers/quantifiers_attributes.cpp
@@ -23,6 +23,7 @@
 #include "theory/quantifiers/term_util.h"
 #include "util/rational.h"
 #include "util/string.h"
+#include "smt/print_benchmark.h"
 
 using namespace std;
 using namespace cvc5::internal::kind;
@@ -270,6 +271,10 @@ void QuantAttributes::computeQuantAttributes( Node q, QAttributes& qa ){
           if (q[2][i].getNumChildren() > 1)
           {
             std::string name = q[2][i][1].getName();
+            // mark that this symbol should not be printed with the print
+            // benchmark utility
+            Node sym = q[2][i][1];
+            smt::PrintBenchmark::markNoPrint(sym);
             Trace("quant-attr") << "Attribute : quantifier name : " << name
                                 << " for " << q << std::endl;
             // assign the name to a variable with the given name (to avoid


### PR DESCRIPTION
Currently `:qid` makes print benchmark print spurious declarations corresponding to quantifier ids.