### PR TITLE
A few minor changes to how proofs are configured

### DIFF
--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -136,9 +136,9 @@ PfManager::PfManager(Env& env)
     // theory-specific lazy proof reconstruction
     d_pfpp->setEliminateRule(ProofRule::MACRO_STRING_INFERENCE);
     d_pfpp->setEliminateRule(ProofRule::MACRO_BV_BITBLAST);
+    // we only try to eliminate TRUST if not macro level
+    d_pfpp->setEliminateRule(ProofRule::TRUST);
   }
-  // always try to eliminate TRUST
-  d_pfpp->setEliminateRule(ProofRule::TRUST);
   d_false = nodeManager()->mkConst(false);
 }
 

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -175,7 +175,7 @@ void SetDefaults::setDefaultsPre(Options& opts)
     // if the user requested proofs, proof mode is (at least) full
     if (opts.smt.proofMode < options::ProofMode::FULL)
     {
-      SET_AND_NOTIFY(
+      SET_AND_NOTIFY_IF_NOT_USER(
           smt, proofMode, options::ProofMode::FULL, "enabling proofs");
     }
     // Default granularity is theory rewrite if we are intentionally using

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1667,7 +1667,8 @@ std::vector<std::shared_ptr<ProofNode>> SolverEngine::getProof(
 {
   Trace("smt") << "SMT getProof()\n";
   const Options& opts = d_env->getOptions();
-  if (!opts.smt.produceProofs)
+  // must be at least SAT proof producing
+  if (!opts.smt.produceProofs || !d_env->isSatProofProducing())
   {
     throw ModalException("Cannot get a proof when proof option is off.");
   }

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1667,7 +1667,7 @@ std::vector<std::shared_ptr<ProofNode>> SolverEngine::getProof(
 {
   Trace("smt") << "SMT getProof()\n";
   const Options& opts = d_env->getOptions();
-  if (!opts.smt.produceProofs || !d_env->isTheoryProofProducing())
+  if (!opts.smt.produceProofs)
   {
     throw ModalException("Cannot get a proof when proof option is off.");
   }


### PR DESCRIPTION
Makes the following changes:
- `--proof-mode` is not overridden if set by user.
- `TRUST` is not eliminated when granularity is set to `MACRO`.
- Allows the user to ask for a proof when theory proofs are disabled.