### PR TITLE
Fix a few options classification

### DIFF
--- a/src/options/theory_options.toml
+++ b/src/options/theory_options.toml
@@ -26,7 +26,7 @@ name   = "Theory Layer"
 
 [[option]]
   name       = "condenseFunctionValues"
-  category   = "expert"
+  category   = "common"
   long       = "condense-function-values"
   type       = "bool"
   default    = "true"
@@ -34,7 +34,7 @@ name   = "Theory Layer"
 
 [[option]]
   name       = "defaultFunctionValueMode"
-  category   = "expert"
+  category   = "common"
   long       = "default-function-value-mode=MODE"
   type       = "DefaultFunctionValueMode"
   default    = "FIRST"


### PR DESCRIPTION
These options shouldn't impact the behavior of the solver in any significant way, moreover we need them to be common for use in combination with `--safe-options`.