### PR TITLE
[proofs] [alethe] Enable Alethe tester in CI

### DIFF
--- a/.github/actions/setup-cache/action.yml
+++ b/.github/actions/setup-cache/action.yml
@@ -60,8 +60,9 @@ runs:
     - name: Install contrib dependencies
       if: steps.contrib-cache.outputs.cache-hit != 'true'
       shell: ${{ inputs.shell }}
-      run: ./contrib/get-carcara-checker
-      run: ./contrib/get-ethos-checker
+      run: |
+        ./contrib/get-carcara-checker
+        ./contrib/get-ethos-checker
 
     - name: Setup dependencies cache
       uses: actions/cache@v4

--- a/.github/actions/setup-cache/action.yml
+++ b/.github/actions/setup-cache/action.yml
@@ -60,6 +60,7 @@ runs:
     - name: Install contrib dependencies
       if: steps.contrib-cache.outputs.cache-hit != 'true'
       shell: ${{ inputs.shell }}
+      run: ./contrib/get-carcara-checker
       run: ./contrib/get-ethos-checker
 
     - name: Setup dependencies cache
@@ -69,4 +70,3 @@ runs:
           build-shared/deps
           build-static/deps
         key: ${{ inputs.cache-key }}-${{ runner.os }}-deps-${{ hashFiles('cmake/**') }}-${{ hashFiles('.github/**') }}
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
             macos-target: 10.13
             exclude_regress: 3-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
- 
+
           - name: macos:production-arm64
             os: macos-14
             config: production --auto-download --all-bindings --editline -DBUILD_GMP=1
@@ -114,7 +114,7 @@ jobs:
             config: production --auto-download --assertions --tracing --cln --gpl
             cache-key: dbgclang
             exclude_regress: 3-4
-            run_regression_args: --tester cpc --tester base --tester model --tester synth --tester abduct --tester unsat-core --tester dump
+            run_regression_args: --tester cpc --tester alethe --tester base --tester model --tester synth --tester abduct --tester unsat-core --tester dump
 
           # GPL versions
           - name: ubuntu:production-gpl
@@ -203,7 +203,7 @@ jobs:
         regressions-args: ${{ matrix.build.run_regression_args }}
         regressions-exclude: ${{ matrix.build.exclude_regress }}
         shell: ${{ matrix.build.shell }}
-  
+
     - name: Run tests
       if: matrix.build.run_regression_args
       uses: ./.github/actions/run-tests


### PR DESCRIPTION
This makes it so that we run the the checking of Alethe proofs in CI. This is fundamental so that we do not inadvertently break the Alethe proofs.