### PR TITLE
Provide histogram of statistics for unsat core lemmas

### DIFF
--- a/src/prop/prop_proof_manager.cpp
+++ b/src/prop/prop_proof_manager.cpp
@@ -72,7 +72,8 @@ PropPfManager::PropPfManager(Env& env,
       d_satPm(nullptr),
       d_uclIds(statisticsRegistry().registerHistogram<theory::InferenceId>(
           "ppm::unsatCoreLemmaIds")),
-      d_uclSize(statisticsRegistry().registerInt("ppm::unsatCoreLemmaSize"))
+      d_uclSize(statisticsRegistry().registerInt("ppm::unsatCoreLemmaSize")),
+      d_numUcl(statisticsRegistry().registerInt("ppm::unsatCoreLemmaCalls"))
 {
   // Add trivial assumption. This is so that we can check that the prop engine's
   // proof is closed, as the SAT solver's refutation proof may use True as an
@@ -150,6 +151,7 @@ std::vector<Node> PropPfManager::getUnsatCoreLemmas()
   }
   if (d_trackLemmaClauseIds)
   {
+    ++d_numUcl;
     uint64_t timestamp;
     for (const Node& lemma : usedLemmas)
     {

--- a/src/prop/prop_proof_manager.cpp
+++ b/src/prop/prop_proof_manager.cpp
@@ -69,7 +69,10 @@ PropPfManager::PropPfManager(Env& env,
       d_lemmaClauseIds(userContext()),
       d_lemmaClauseTimestamp(userContext()),
       d_currLemmaId(theory::InferenceId::NONE),
-      d_satPm(nullptr)
+      d_satPm(nullptr),
+      d_uclIds(statisticsRegistry().registerHistogram<theory::InferenceId>(
+          "ppm::unsatCoreLemmaIds")),
+      d_uclSize(statisticsRegistry().registerInt("ppm::unsatCoreLemmaSize"))
 {
   // Add trivial assumption. This is so that we can check that the prop engine's
   // proof is closed, as the SAT solver's refutation proof may use True as an
@@ -143,6 +146,15 @@ std::vector<Node> PropPfManager::getUnsatCoreLemmas()
     if (std::find(ucc.begin(), ucc.end(), lemma) != ucc.end())
     {
       usedLemmas.push_back(lemma);
+    }
+  }
+  if (d_trackLemmaClauseIds)
+  {
+    uint64_t timestamp;
+    for (const Node& lemma : usedLemmas)
+    {
+      d_uclIds << getInferenceIdFor(lemma, timestamp);
+      ++d_uclSize;
     }
   }
   return usedLemmas;

--- a/src/prop/prop_proof_manager.h
+++ b/src/prop/prop_proof_manager.h
@@ -294,6 +294,13 @@ class PropPfManager : protected EnvObj
   Node d_currPropagationProcessed;
   /** Temporary, pointer to SAT proof manager */
   SatProofManager* d_satPm;
+  /**
+   * Counts number of inference ids in requested unsat core lemmas. Note this is
+   * tracked only if -o unsat-core-lemmas is on.
+   */
+  HistogramStat<theory::InferenceId> d_uclIds;
+  /** Total number of unsat core lemmas */
+  IntStat d_uclSize;
 }; /* class PropPfManager */
 
 }  // namespace prop

--- a/src/prop/prop_proof_manager.h
+++ b/src/prop/prop_proof_manager.h
@@ -301,6 +301,8 @@ class PropPfManager : protected EnvObj
   HistogramStat<theory::InferenceId> d_uclIds;
   /** Total number of unsat core lemmas */
   IntStat d_uclSize;
+  /** Total number of times we asked for unsat core lemmas */
+  IntStat d_numUcl;
 }; /* class PropPfManager */
 
 }  // namespace prop

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -160,9 +160,10 @@ void SetDefaults::setDefaultsPre(Options& opts)
         options::ProofGranularityMode::DSL_REWRITE,
         "check-proof-steps");
   }
-  // if check-proofs, dump-proofs, or proof-mode=full, then proofs being fully
-  // enabled is implied
+  // if check-proofs, dump-proofs, dump-unsat-cores-lemmas, or proof-mode=full,
+  // then proofs being fully enabled is implied
   if (opts.smt.checkProofs || opts.driver.dumpProofs
+      || opts.driver.dumpUnsatCoresLemmas
       || opts.smt.proofMode == options::ProofMode::FULL
       || opts.smt.proofMode == options::ProofMode::FULL_STRICT)
   {


### PR DESCRIPTION
We now get information on what kinds of lemmas were in the unsat core when `-o unsat-core-lemmas` is used, e.g.:
```
ppm::unsatCoreLemmaIds = { DATATYPES_CLASH_CONFLICT: 14, DATATYPES_COLLAPSE_SEL: 24, DATATYPES_INST: 29, DATATYPES_PURIFY: 12, DATATYPES_SPLIT: 8, DATATYPES_TESTER_CONFLICT: 37, EQ_CONSTANT_MERGE: 17, NONE: 126, QUANTIFIERS_INST_E_MATCHING: 84, QUANTIFIERS_INST_E_MATCHING_SIMPLE: 378, THEORY_PP_SKOLEM_LEM: 173 }
ppm::unsatCoreLemmaSize = 902
```

Also makes proofs enabled when `--dump-unsat-cores-lemmas` is used.
