### PR TITLE
Fix bug in proof CNF stream

### DIFF
--- a/src/prop/proof_cnf_stream.cpp
+++ b/src/prop/proof_cnf_stream.cpp
@@ -39,10 +39,14 @@ void ProofCnfStream::convertAndAssert(TNode node,
                                       bool input,
                                       ProofGenerator* pg)
 {
+  // this method is re-entrant due to lemmas sent during preregistration of new
+  // lemmas, thus we must remember and revert d_input below.
+  bool backupInput = d_input;
   Trace("cnf") << "ProofCnfStream::convertAndAssert(" << node
                << ", negated = " << (negated ? "true" : "false")
                << ", removable = " << (removable ? "true" : "false")
-               << "), level " << userContext()->getLevel() << "\n";
+               << ", input = " << (input ? "true" : "false") << "), level "
+               << userContext()->getLevel() << "\n";
   d_cnfStream.d_removable = removable;
   d_input = input;
   if (pg)
@@ -57,7 +61,7 @@ void ProofCnfStream::convertAndAssert(TNode node,
                          "ProofCnfStream::convertAndAssert:cnf");
   }
   convertAndAssert(node, negated);
-  d_input = false;
+  d_input = backupInput;
 }
 
 void ProofCnfStream::convertAndAssert(TNode node, bool negated)


### PR DESCRIPTION
This could cause us to mislabel an input clause as a theory lemma, due to CNF stream being reentrant.

The fix follows a style used in the CNF stream already https://github.com/cvc5/cvc5/blob/main/src/prop/cnf_stream.cpp#L210

This could potentially cause us to give unsound unsat cores when we are proof producing, although we have never observed this.