### PR TITLE
Add option --full-sygus-verify and warn when SyGuS solver is incomplete

### DIFF
--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -1325,7 +1325,7 @@ name   = "Quantifiers"
   long       = "sygus-verify-timeout=N"
   type       = "uint64_t"
   default    = "0"
-  help       = "timeout (in milliseconds) for verifying satisfiability of synthesized terms"
+  help       = "timeout (in milliseconds) for verifying satisfiability of synthesized terms (0 == no limit)"
 
 [[option]]
   name       = "fullSygusVerify"

--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -1327,6 +1327,14 @@ name   = "Quantifiers"
   default    = "0"
   help       = "timeout (in milliseconds) for verifying satisfiability of synthesized terms"
 
+[[option]]
+  name       = "fullSygusVerify"
+  category   = "expert"
+  long       = "full-sygus-verify"
+  type       = "bool"
+  default    = "false"
+  help       = "resort to full effort techniques instead of answering unknown when checking sygus candidates"
+
 # Internal uses of sygus
 
 [[option]]

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -1640,7 +1640,8 @@ void SetDefaults::setDefaultsSygus(Options& opts) const
   // full verify mode enables options to ensure full effort on candidates
   if (opts.quantifiers.fullSygusVerify)
   {
-    SET_AND_NOTIFY(quantifiers, sygusVerifyInstMaxRounds, -1, "full sygus verify");
+    SET_AND_NOTIFY(
+        quantifiers, sygusVerifyInstMaxRounds, -1, "full sygus verify");
     SET_AND_NOTIFY(quantifiers, fullSaturateQuant, true, "full sygus verify");
   }
   // must use Ferrante/Rackoff for real arithmetic

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -1637,6 +1637,12 @@ void SetDefaults::setDefaultsQuantifiers(const LogicInfo& logic,
 void SetDefaults::setDefaultsSygus(Options& opts) const
 {
   SET_AND_NOTIFY(quantifiers, sygus, true, "enabling sygus");
+  // full verify mode enables options to ensure full effort on candidates
+  if (opts.quantifiers.fullSygusVerify)
+  {
+    SET_AND_NOTIFY(quantifiers, sygusVerifyInstMaxRounds, -1, "full sygus verify");
+    SET_AND_NOTIFY(quantifiers, fullSaturateQuant, true, "full sygus verify");
+  }
   // must use Ferrante/Rackoff for real arithmetic
   SET_AND_NOTIFY(quantifiers, cegqiMidpoint, true, "sygus");
   // must disable cegqi-bv since it may introduce witness terms, which

--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -612,11 +612,12 @@ bool SynthConjecture::doCheck()
     {
       d_verifyWarned = true;
       std::stringstream ss;
-      ss << "The SyGuS solver failed to verify a canidate solution.";
-      if (options().quantifiers.fullSygusVerify)
+      ss << "Warning: The SyGuS solver failed to verify a canidate solution, likely due to the base logic being undecidable.";
+      if (!options().quantifiers.fullSygusVerify)
       {
-        ss << " The option --full-sygus-verify can be used to put more effort into verifying individual candidate solutions."
+        ss << " The option --full-sygus-verify can be used to put more effort into verifying individual candidate solutions.";
       }
+      ss << " Use -q to silence this warning.";
       Warning() << ss.str() << std::endl;
     }
     // In the rare case that the subcall is unknown, we simply exclude the

--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -612,10 +612,12 @@ bool SynthConjecture::doCheck()
     {
       d_verifyWarned = true;
       std::stringstream ss;
-      ss << "Warning: The SyGuS solver failed to verify a canidate solution, likely due to the base logic being undecidable.";
+      ss << "Warning: The SyGuS solver failed to verify a canidate solution, "
+            "likely due to the base logic being undecidable.";
       if (!options().quantifiers.fullSygusVerify)
       {
-        ss << " The option --full-sygus-verify can be used to put more effort into verifying individual candidate solutions.";
+        ss << " The option --full-sygus-verify can be used to put more effort "
+              "into verifying individual candidate solutions.";
       }
       ss << " Use -q to silence this warning.";
       Warning() << ss.str() << std::endl;

--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -74,7 +74,8 @@ SynthConjecture::SynthConjecture(Env& env,
       d_ceg_cegisUnif(new CegisUnif(env, qs, qim, d_tds, this)),
       d_sygus_ccore(new CegisCoreConnective(env, qs, qim, d_tds, this)),
       d_master(nullptr),
-      d_repair_index(0)
+      d_repair_index(0),
+      d_verifyWarned(false)
 {
   if (options().datatypes.sygusSymBreakPbe
       || options().quantifiers.sygusUnifPbe)
@@ -607,6 +608,17 @@ bool SynthConjecture::doCheck()
   }
   else if (r.getStatus() != Result::UNSAT)
   {
+    if (!d_verifyWarned)
+    {
+      d_verifyWarned = true;
+      std::stringstream ss;
+      ss << "The SyGuS solver failed to verify a canidate solution.";
+      if (options().quantifiers.fullSygusVerify)
+      {
+        ss << " The option --full-sygus-verify can be used to put more effort into verifying individual candidate solutions."
+      }
+      Warning() << ss.str() << std::endl;
+    }
     // In the rare case that the subcall is unknown, we simply exclude the
     // solution, without adding a counterexample point. This should only
     // happen if the quantifier free logic is undecidable.

--- a/src/theory/quantifiers/sygus/synth_conjecture.h
+++ b/src/theory/quantifiers/sygus/synth_conjecture.h
@@ -341,6 +341,8 @@ class SynthConjecture : protected EnvObj
    * rewrite rules.
    */
   std::map<Node, std::unique_ptr<ExpressionMinerManager>> d_exprm;
+  /** Have we given a warning for a candidate that failed verification? */
+  bool d_verifyWarned;
 };
 
 }  // namespace quantifiers

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -505,6 +505,7 @@ void TermDbSygus::registerEnumerator(Node e,
     Assert(d_qim != nullptr);
     d_qim->setRefutationUnsound(
         IncompleteId::QUANTIFIERS_SYGUS_SMART_BLOCK_ANY_CONSTANT);
+    Warning() << "Warning: The SyGuS solver is incomplete when symbolic constants are used in grammars and --sygus-repair-const is disabled" << std::endl;
   }
   d_enum_active_gen[e] = isActiveGen;
   d_enum_basic[e] = isActiveGen && !isVarAgnostic;

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -507,7 +507,7 @@ void TermDbSygus::registerEnumerator(Node e,
         IncompleteId::QUANTIFIERS_SYGUS_SMART_BLOCK_ANY_CONSTANT);
     Warning()
         << "Warning: The SyGuS solver is incomplete when symbolic constants "
-           "are used in grammars and --sygus-repair-const is disabled"
+           "are used in grammars and --sygus-repair-const is disabled."
         << std::endl;
   }
   d_enum_active_gen[e] = isActiveGen;

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -505,7 +505,10 @@ void TermDbSygus::registerEnumerator(Node e,
     Assert(d_qim != nullptr);
     d_qim->setRefutationUnsound(
         IncompleteId::QUANTIFIERS_SYGUS_SMART_BLOCK_ANY_CONSTANT);
-    Warning() << "Warning: The SyGuS solver is incomplete when symbolic constants are used in grammars and --sygus-repair-const is disabled" << std::endl;
+    Warning()
+        << "Warning: The SyGuS solver is incomplete when symbolic constants "
+           "are used in grammars and --sygus-repair-const is disabled"
+        << std::endl;
   }
   d_enum_active_gen[e] = isActiveGen;
   d_enum_basic[e] = isActiveGen && !isVarAgnostic;

--- a/test/regress/cli/regress1/sygus/proj-issue222-any-const.sy
+++ b/test/regress/cli/regress1/sygus/proj-issue222-any-const.sy
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --sygus-out=status --sygus-enum=smart --no-sygus-repair-const
+; COMMAND-LINE: --sygus-out=status --sygus-enum=smart --no-sygus-repair-const -q
 ; EXPECT: fail
 (set-logic ALL)
 (define-fun clamp-int((x Int)) Int (ite (< 5 x) 5 (ite (< x 0) 0 x)))

--- a/test/regress/cli/regress1/sygus/rec-fun-while-1.sy
+++ b/test/regress/cli/regress1/sygus/rec-fun-while-1.sy
@@ -1,5 +1,5 @@
 ; EXPECT: feasible
-; COMMAND-LINE: --sygus-out=status --lang=sygus2 --no-check-synth-sol
+; COMMAND-LINE: --sygus-out=status --lang=sygus2 --no-check-synth-sol -q
 
 (set-logic ALL)
 

--- a/test/regress/cli/regress1/sygus/rec-fun-while-infinite.sy
+++ b/test/regress/cli/regress1/sygus/rec-fun-while-infinite.sy
@@ -1,5 +1,5 @@
 ; EXPECT: fail
-; COMMAND-LINE: --sygus-out=status --lang=sygus2 --no-check-synth-sol
+; COMMAND-LINE: --sygus-out=status --lang=sygus2 --no-check-synth-sol -q
 
 (set-logic ALL)
 

--- a/test/regress/cli/regress1/sygus/sum-sq-unknown.sy
+++ b/test/regress/cli/regress1/sygus/sum-sq-unknown.sy
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --sygus-verify-timeout=100 --sygus-enum=smart
+; COMMAND-LINE: --sygus-verify-timeout=100 --sygus-enum=smart -q
 ; EXPECT: fail
 (set-logic ALL)
 (synth-fun f ((x Int) (y Int)) Bool

--- a/test/regress/cli/regress2/sygus/sumn_recur_synth.sy
+++ b/test/regress/cli/regress2/sygus/sumn_recur_synth.sy
@@ -1,5 +1,5 @@
 ; EXPECT: feasible
-; COMMAND-LINE: --lang=sygus2 --sygus-out=status
+; COMMAND-LINE: --lang=sygus2 --sygus-out=status -q
 (set-logic UFLIA)
 
 (declare-var x Int)


### PR DESCRIPTION
This updates the default behavior of the SyGuS solver to warn the user if a candidate solution failed to verify, and suggests a new option `--full-sygus-verify` to fix the issue.