### PR TITLE
Improve support for non-closed kinds in mbqi

### DIFF
--- a/src/theory/quantifiers/inst_strategy_mbqi.cpp
+++ b/src/theory/quantifiers/inst_strategy_mbqi.cpp
@@ -177,6 +177,10 @@ void InstStrategyMbqi::process(Node q)
   for (const Node& k : skolems.d_subs)
   {
     TypeNode tn = k.getType();
+    if (!tn.isSort())
+    {
+      continue;
+    }
     itk = freshVarType.find(tn);
     if (itk == freshVarType.end())
     {

--- a/src/theory/quantifiers/inst_strategy_mbqi.cpp
+++ b/src/theory/quantifiers/inst_strategy_mbqi.cpp
@@ -396,11 +396,18 @@ Node InstStrategyMbqi::convertToQuery(
       }
       else if (d_nonClosedKinds.find(ck) != d_nonClosedKinds.end())
       {
-        // return the fresh variable for this term
-        Node k = sm->mkPurifySkolem(cur);
-        freshVarType[cur.getType()].insert(k);
-        cmap[cur] = k;
-        continue;
+        // if its a constant, we can continue, we will assume it is distinct
+        // from all others of its type
+        if (cur.isConst())
+        {
+          // return the fresh variable for this term
+          Node k = sm->mkPurifySkolem(cur);
+          freshVarType[cur.getType()].insert(k);
+          cmap[cur] = k;
+          continue;
+        }
+        // if this is a bad kind, fail immediately
+        return Node::null();
       }
       else if (cur.getNumChildren() == 0)
       {

--- a/src/theory/quantifiers/inst_strategy_mbqi.cpp
+++ b/src/theory/quantifiers/inst_strategy_mbqi.cpp
@@ -346,14 +346,6 @@ Node InstStrategyMbqi::convertToQuery(
       {
         cmap[cur] = cur;
       }
-      else if (ck == Kind::UNINTERPRETED_SORT_VALUE)
-      {
-        // return the fresh variable for this term
-        Node k = sm->mkPurifySkolem(cur);
-        freshVarType[cur.getType()].insert(k);
-        cmap[cur] = k;
-        continue;
-      }
       else if (ck == Kind::CONST_SEQUENCE || ck == Kind::FUNCTION_ARRAY_CONST
                || cur.isVar())
       {
@@ -404,8 +396,11 @@ Node InstStrategyMbqi::convertToQuery(
       }
       else if (d_nonClosedKinds.find(ck) != d_nonClosedKinds.end())
       {
-        // if this is a bad kind, fail immediately
-        return Node::null();
+        // return the fresh variable for this term
+        Node k = sm->mkPurifySkolem(cur);
+        freshVarType[cur.getType()].insert(k);
+        cmap[cur] = k;
+        continue;
       }
       else if (cur.getNumChildren() == 0)
       {

--- a/src/theory/quantifiers/inst_strategy_mbqi.cpp
+++ b/src/theory/quantifiers/inst_strategy_mbqi.cpp
@@ -177,17 +177,13 @@ void InstStrategyMbqi::process(Node q)
   for (const Node& k : skolems.d_subs)
   {
     TypeNode tn = k.getType();
-    if (!tn.isSort())
-    {
-      continue;
-    }
-    itk = freshVarType.find(tn);
-    if (itk == freshVarType.end())
+    if (!tn.isUninterpretedSort())
     {
       // not an uninterpreted sort, continue
       continue;
     }
-    if (itk->second.empty())
+    itk = freshVarType.find(tn);
+    if (itk == freshVarType.end() || itk->second.empty())
     {
       Trace("mbqi") << "warning: failed to get vars for type " << tn
                     << std::endl;


### PR DESCRIPTION
This limitation would cause MBQI to be highly incomplete on any quantified array logics since array values would not be handled in subsolver queries. 

The workaround is to treat array constants in the same way we treat uninterpreted constants.

This change leads to MBQI being very effective on certain SMT-LIB logics e.g. ABV, results to come.