### PR TITLE
Do not check for shadowed variables with --wf-checking

### DIFF
--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -6879,7 +6879,8 @@ void Solver::ensureWellFormedTerm(const Term& t) const
     if (!d_slv->isWellFormedTerm(*t.d_node))
     {
       std::stringstream se;
-      se << "cannot process term " << *t.d_node << " with free variables" << std::endl;
+      se << "cannot process term " << *t.d_node << " with free variables"
+         << std::endl;
       throw CVC5ApiException(se.str().c_str());
     }
   }

--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -6873,18 +6873,13 @@ void Solver::ensureWellFormedTerm(const Term& t) const
   // only check if option is set
   if (d_slv->getOptions().expr.wellFormedChecking)
   {
-    // We check if we have free variables; we do not check for shadowed
-    // variables as this is handled by our rewriter internally.
-    // To call expr::hasFreeVar, we must rewrite (simplify) to avoid shadowed
-    // variables.
-    internal::Node snode = d_slv->simplify(*t.d_node, false);
-    if (internal::expr::hasFreeVar(snode))
+    // Call isWellFormedTerm of the underlying solver, which checks if the
+    // given node has free variables. We do not check for variable shadowing,
+    // since this can be handled by our rewriter.
+    if (!d_slv->isWellFormedTerm(*t.d_node))
     {
       std::stringstream se;
-      se << "cannot process term " << *t.d_node << " with ";
-      std::unordered_set<internal::Node> fvs;
-      internal::expr::getFreeVariables(snode, fvs);
-      se << "free variables: " << fvs << std::endl;
+      se << "cannot process term " << *t.d_node << " with free variables" << std::endl;
       throw CVC5ApiException(se.str().c_str());
     }
   }

--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -6873,11 +6873,17 @@ void Solver::ensureWellFormedTerm(const Term& t) const
   // only check if option is set
   if (d_slv->getOptions().expr.wellFormedChecking)
   {
-    if (internal::expr::hasFreeVar(*t.d_node))
+    // We check if we have free variables; we do not check for shadowed
+    // variables as this is handled by our rewriter internally.
+    // To call expr::hasFreeVar, we must rewrite (simplify) to avoid shadowed
+    // variables.
+    internal::Node snode = d_slv->simplify(*t.d_node, false);
+    if (internal::expr::hasFreeVar(snode))
     {
       std::stringstream se;
       se << "cannot process term " << *t.d_node << " with ";
-      internal::expr::getFreeVariables(*t.d_node, fvs);
+      std::unordered_set<internal::Node> fvs;
+      internal::expr::getFreeVariables(snode, fvs);
       se << "free variables: " << fvs << std::endl;
       throw CVC5ApiException(se.str().c_str());
     }

--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -6873,21 +6873,12 @@ void Solver::ensureWellFormedTerm(const Term& t) const
   // only check if option is set
   if (d_slv->getOptions().expr.wellFormedChecking)
   {
-    bool wasShadow = false;
-    if (internal::expr::hasFreeOrShadowedVar(*t.d_node, wasShadow))
+    if (internal::expr::hasFreeVar(*t.d_node))
     {
       std::stringstream se;
       se << "cannot process term " << *t.d_node << " with ";
-      if (wasShadow)
-      {
-        se << "shadowed variables " << std::endl;
-      }
-      else
-      {
-        std::unordered_set<internal::Node> fvs;
-        internal::expr::getFreeVariables(*t.d_node, fvs);
-        se << "free variables: " << fvs << std::endl;
-      }
+      internal::expr::getFreeVariables(*t.d_node, fvs);
+      se << "free variables: " << fvs << std::endl;
       throw CVC5ApiException(se.str().c_str());
     }
   }

--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -348,11 +348,12 @@ bool checkVariablesInternal(TNode n,
       else if (cur.isClosure())
       {
         // add to scope
+        std::vector<TNode> boundvars;
         for (const TNode& cn : cur[0])
         {
-          if (checkShadow)
+          if (scope.find(cn) != scope.end())
           {
-            if (scope.find(cn) != scope.end())
+            if (checkShadow)
             {
               wasShadow = true;
               return true;
@@ -360,11 +361,10 @@ bool checkVariablesInternal(TNode n,
           }
           else
           {
-            // should not shadow
-            Assert(scope.find(cn) == scope.end())
-                << "Shadowed variable " << cn << " in " << cur << "\n";
+            // add to scope if it is not shadowing
+            boundvars.push_back(cn);
+            scope.insert(cn);
           }
-          scope.insert(cn);
         }
         // must make recursive call to use separate cache
         if (checkVariablesInternal(
@@ -374,7 +374,7 @@ bool checkVariablesInternal(TNode n,
           return true;
         }
         // cleanup
-        for (const TNode& cn : cur[0])
+        for (const TNode& cn : boundvars)
         {
           scope.erase(cn);
         }

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1396,10 +1396,11 @@ const Options& SolverEngine::options() const { return d_env->getOptions(); }
 
 bool SolverEngine::isWellFormedTerm(const Node& n) const
 {
+  // FIXME
   // Must rewrite before checking for free variables
-  Node nr = d_env->getRewriter()->rewrite(n);
+  //Node nr = d_env->getRewriter()->rewrite(n);
   // Well formed if it does not have free variables.
-  return !expr::hasFreeVar(nr);
+  return !expr::hasFreeVar(n);
 }
 
 void SolverEngine::ensureWellFormedTerm(const Node& n,

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1340,10 +1340,7 @@ void SolverEngine::blockModel(modes::BlockModelsMode mode)
 void SolverEngine::blockModelValues(const std::vector<Node>& exprs)
 {
   Trace("smt") << "SMT blockModelValues()" << endl;
-  for (const Node& e : exprs)
-  {
-    ensureWellFormedTerm(e, "block model values");
-  }
+  ensureWellFormedTerms(exprs, "block model values");
 
   TheoryModel* m = getAvailableModel("block model values");
 
@@ -1397,6 +1394,14 @@ std::vector<Node> SolverEngine::getAssertionsInternal() const
 
 const Options& SolverEngine::options() const { return d_env->getOptions(); }
 
+bool SolverEngine::isWellFormedTerm(const Node& n) const
+{
+  // Must rewrite before checking for free variables
+  Node nr = d_env->getRewriter()->rewrite(n);
+  // Well formed if it does not have free variables.
+  return !expr::hasFreeVar(nr);
+}
+  
 void SolverEngine::ensureWellFormedTerm(const Node& n,
                                         const std::string& src) const
 {

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1401,7 +1401,7 @@ bool SolverEngine::isWellFormedTerm(const Node& n) const
   // Well formed if it does not have free variables.
   return !expr::hasFreeVar(nr);
 }
-  
+
 void SolverEngine::ensureWellFormedTerm(const Node& n,
                                         const std::string& src) const
 {

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1396,10 +1396,8 @@ const Options& SolverEngine::options() const { return d_env->getOptions(); }
 
 bool SolverEngine::isWellFormedTerm(const Node& n) const
 {
-  // FIXME
-  // Must rewrite before checking for free variables
-  //Node nr = d_env->getRewriter()->rewrite(n);
-  // Well formed if it does not have free variables.
+  // Well formed if it does not have free variables. Note that n may have
+  // variable shadowing.
   return !expr::hasFreeVar(n);
 }
 
@@ -1408,10 +1406,9 @@ void SolverEngine::ensureWellFormedTerm(const Node& n,
 {
   if (Configuration::isAssertionBuild())
   {
-    // Must rewrite before checking for free variables
-    Node nr = d_env->getRewriter()->rewrite(n);
     // Don't check for shadowing here, since shadowing may occur from API
-    // users, including the smt2 parser.
+    // users, including the smt2 parser. We don't need to rewrite since
+    // getFreeVariables is robust to variable shadowing.
     std::unordered_set<internal::Node> fvs;
     expr::getFreeVariables(nr, fvs);
     if (!fvs.empty())

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1410,11 +1410,11 @@ void SolverEngine::ensureWellFormedTerm(const Node& n,
     // users, including the smt2 parser. We don't need to rewrite since
     // getFreeVariables is robust to variable shadowing.
     std::unordered_set<internal::Node> fvs;
-    expr::getFreeVariables(nr, fvs);
+    expr::getFreeVariables(n, fvs);
     if (!fvs.empty())
     {
       std::stringstream se;
-      se << "Cannot process term " << nr << " with ";
+      se << "Cannot process term " << n << " with ";
       se << "free variables: " << fvs << std::endl;
       throw ModalException(se.str().c_str());
     }

--- a/src/smt/solver_engine.h
+++ b/src/smt/solver_engine.h
@@ -1033,6 +1033,14 @@ class CVC5_EXPORT SolverEngine
   const Options& options() const;
 
   /**
+   * Return true if the given term is a valid closed term, which can be used as an
+   * argument to, e.g., assert, get-value, block-model-values, etc.
+   *
+   * @param n The node to check
+   * @return true if n is a well formed term.
+   */
+  bool isWellFormedTerm(const Node& n) const;
+  /**
    * Check that the given term is a valid closed term, which can be used as an
    * argument to, e.g., assert, get-value, block-model-values, etc.
    *

--- a/src/smt/solver_engine.h
+++ b/src/smt/solver_engine.h
@@ -1033,8 +1033,8 @@ class CVC5_EXPORT SolverEngine
   const Options& options() const;
 
   /**
-   * Return true if the given term is a valid closed term, which can be used as an
-   * argument to, e.g., assert, get-value, block-model-values, etc.
+   * Return true if the given term is a valid closed term, which can be used as
+   * an argument to, e.g., assert, get-value, block-model-values, etc.
    *
    * @param n The node to check
    * @return true if n is a well formed term.


### PR DESCRIPTION
Shadowed variables are now always allowed in our API.

This relaxes an API check for shadowed variables with `--wf-checking` which is inconsistent with other behaviors of cvc5.

A similar relaxation was done to our assertions utility on https://github.com/cvc5/cvc5/pull/10556. The same change should have been applied for the code changed in this PR.

This also makes our implementation of `expr::hasFreeVar` robust to variable shadowing.