### PR TITLE
Minor fixes for print benchmark utility

### DIFF
--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -384,6 +384,7 @@ bool AlfPrinter::canEvaluateRegExp(Node r) const
     visit.pop_back();
     if (visited.find(cur) == visited.end())
     {
+      visited.insert(cur);
       switch (cur.getKind())
       {
         case Kind::REGEXP_ALL:

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -384,7 +384,6 @@ bool AlfPrinter::canEvaluateRegExp(Node r) const
     visit.pop_back();
     if (visited.find(cur) == visited.end())
     {
-      visited.insert(cur);
       switch (cur.getKind())
       {
         case Kind::REGEXP_ALL:
@@ -644,7 +643,7 @@ void AlfPrinter::print(AlfPrintChannelOut& aout,
         // [1] print the declarations
         printer::smt2::Smt2Printer alfp(printer::smt2::Variant::alf_variant);
         // we do not print declarations in a sorted manner to reduce overhead
-        smt::PrintBenchmark pb(&alfp, false, &d_tproc);
+        smt::PrintBenchmark pb(nodeManager(), &alfp, false, &d_tproc);
         std::stringstream outDecl;
         std::stringstream outDef;
         pb.printDeclarationsFrom(outDecl, outDef, definitions, assertions);

--- a/src/smt/print_benchmark.cpp
+++ b/src/smt/print_benchmark.cpp
@@ -154,9 +154,11 @@ void PrintBenchmark::printDeclarationsFrom(std::ostream& outDecl,
     printDeclaredFuns(outDecl, syms, alreadyPrintedDecl);
     if (d_sorted)
     {
-      // Sort ordinary and recursive definitions for deterministic order.
+      // Sort recursive definitions for deterministic order.
       std::sort(recDefs.begin(), recDefs.end());
-      std::sort(ordinaryDefs.begin(), ordinaryDefs.end());
+      // In general, we cannot sort the ordinary definitions since they were
+      // added to the vector in an order which ensures the functions they
+      // depend on are defined first.
     }
     // print the ordinary definitions
     for (const Node& f : ordinaryDefs)
@@ -348,6 +350,7 @@ void PrintBenchmark::getConnectedDefinitions(
     getConnectedDefinitions(
         s, recDefs, ordinaryDefs, syms, defMap, processedDefs, visited);
   }
+  // add the symbol after we add the definitions
   if (!it->second.first)
   {
     // an ordinary define-fun symbol

--- a/src/smt/print_benchmark.cpp
+++ b/src/smt/print_benchmark.cpp
@@ -262,7 +262,7 @@ void PrintBenchmark::printDeclaredFuns(std::ostream& out,
     // (exported) skolems, as they are printed as parsable terms.
     if (printSkolemDefs && f.getKind() == Kind::SKOLEM)
     {
-      if (sm->SkolemId(n)!= SkolemId::INTERNAL)
+      if (sm->getId(f)!= SkolemId::INTERNAL)
       {
         continue;
       }

--- a/src/smt/print_benchmark.cpp
+++ b/src/smt/print_benchmark.cpp
@@ -20,6 +20,7 @@
 #include "expr/node_algorithm.h"
 #include "expr/node_converter.h"
 #include "printer/printer.h"
+#include "expr/skolem_manager.h"
 
 using namespace cvc5::internal::kind;
 
@@ -200,6 +201,7 @@ void PrintBenchmark::printDeclaredFuns(std::ostream& out,
                                        std::unordered_set<Node>& alreadyPrinted)
 {
   bool printSkolemDefs = options::ioutils::getPrintSkolemDefinitions(out);
+  SkolemManager* sm = d_nm->getSkolemManager();
   BenchmarkNoPrintAttribute bnpa;
   for (const Node& f : funs)
   {
@@ -215,10 +217,13 @@ void PrintBenchmark::printDeclaredFuns(std::ostream& out,
       continue;
     }
     // if print skolem definitions is true, we shouldn't print declarations for
-    // skolems
+    // (exported) skolems, as they are printed as parsable terms.
     if (printSkolemDefs && f.getKind() == Kind::SKOLEM)
     {
-      continue;
+      if (sm->SkolemId(n)!= SkolemId::INTERNAL)
+      {
+        continue;
+      }
     }
     if (alreadyPrinted.find(f) == alreadyPrinted.end())
     {

--- a/src/smt/print_benchmark.cpp
+++ b/src/smt/print_benchmark.cpp
@@ -216,7 +216,7 @@ void PrintBenchmark::printDeclaredFuns(std::ostream& out,
     }
     // if print skolem definitions is true, we shouldn't print declarations for
     // skolems
-    if (printSkolemDefs && f.getKind()==Kind::SKOLEM)
+    if (printSkolemDefs && f.getKind() == Kind::SKOLEM)
     {
       continue;
     }

--- a/src/smt/print_benchmark.h
+++ b/src/smt/print_benchmark.h
@@ -41,7 +41,7 @@ class PrintBenchmark
  public:
   /**
    * Constructor.
-   * @param nm     Pointer to the node manager.
+   * @param nm     The associated node manager.
    * @param p      The associated printer.
    * @param sorted True if declarations should be sorted wrt node id.
    * @param c      The associated node converter.

--- a/src/smt/print_benchmark.h
+++ b/src/smt/print_benchmark.h
@@ -41,14 +41,16 @@ class PrintBenchmark
  public:
   /**
    * Constructor.
+   * @param nm     Pointer to the node manager.
    * @param p      The associated printer.
    * @param sorted True if declarations should be sorted wrt node id.
    * @param c      The associated node converter.
    */
-  PrintBenchmark(const Printer* p,
+  PrintBenchmark(NodeManager * nm,
+                 const Printer* p,
                  bool sorted = true,
                  NodeConverter* c = nullptr)
-      : d_printer(p), d_sorted(sorted), d_converter(c)
+      : d_nm(nm), d_printer(p), d_sorted(sorted), d_converter(c)
   {
   }
   /**
@@ -153,6 +155,8 @@ class PrintBenchmark
    * @return true if the definition was successfully inferred
    */
   bool decomposeDefinition(Node a, bool& isRecDef, Node& sym, Node& body);
+  /** Pointer to the node manager */
+  NodeManager * d_nm;
   /**
    * Pointer to the printer we are using, which is responsible for printing
    * individual commands.

--- a/src/smt/process_assertions.cpp
+++ b/src/smt/process_assertions.cpp
@@ -471,7 +471,7 @@ void ProcessAssertions::dumpAssertions(const std::string& key,
 void ProcessAssertions::dumpAssertionsToStream(std::ostream& os,
                                                const AssertionPipeline& ap)
 {
-  PrintBenchmark pb(Printer::getPrinter(os));
+  PrintBenchmark pb(nodeManager(), Printer::getPrinter(os));
   std::vector<Node> assertions;
   // Notice that users may define ordinary and recursive functions. The latter
   // get added to the list of assertions as quantified formulas. Since we are

--- a/src/smt/timeout_core_manager.cpp
+++ b/src/smt/timeout_core_manager.cpp
@@ -267,7 +267,7 @@ Result TimeoutCoreManager::checkSatNext(const std::vector<Node>& nextAssertions,
     {
       std::vector<Node> bench(nextAssertions.begin(), nextAssertions.end());
       std::stringstream ss;
-      smt::PrintBenchmark pb(Printer::getPrinter(ss));
+      smt::PrintBenchmark pb(nodeManager(), Printer::getPrinter(ss));
       pb.printBenchmark(ss, d_env.getLogicInfo().getLogicString(), {}, bench);
       output(OutputTag::TIMEOUT_CORE_BENCHMARK)
           << ";; timeout core" << std::endl;

--- a/src/smt/unsat_core_manager.cpp
+++ b/src/smt/unsat_core_manager.cpp
@@ -68,7 +68,7 @@ std::vector<Node> UnsatCoreManager::getUnsatCoreLemmas(bool isInternal)
       coreAsserts.insert(
           coreAsserts.end(), coreLemmas.begin(), coreLemmas.end());
       std::stringstream ss;
-      smt::PrintBenchmark pb(Printer::getPrinter(ss));
+      smt::PrintBenchmark pb(nodeManager(), Printer::getPrinter(ss));
       pb.printBenchmark(
           ss, logicInfo().getLogicString(), coreDefs, coreAsserts);
       output(OutputTag::UNSAT_CORE_LEMMAS_BENCHMARK) << ";; unsat core + lemmas" << std::endl;
@@ -128,7 +128,7 @@ void UnsatCoreManager::getUnsatCoreInternal(std::shared_ptr<ProofNode> pfn,
     std::vector<Node> coreDefs;
     partitionUnsatCore(core, coreDefs, coreAsserts);
     std::stringstream ss;
-    smt::PrintBenchmark pb(Printer::getPrinter(ss));
+    smt::PrintBenchmark pb(nodeManager(), Printer::getPrinter(ss));
     pb.printBenchmark(ss, logicInfo().getLogicString(), coreDefs, coreAsserts);
     output(OutputTag::UNSAT_CORE_BENCHMARK) << ";; unsat core" << std::endl;
     output(OutputTag::UNSAT_CORE_BENCHMARK) << ss.str();

--- a/src/theory/quantifiers/query_generator.cpp
+++ b/src/theory/quantifiers/query_generator.cpp
@@ -71,7 +71,7 @@ void QueryGenerator::dumpQuery(Node qy,
   std::stringstream fname;
   fname << "query" << d_queryCount << ".smt2";
   std::ofstream fs(fname.str(), std::ofstream::out);
-  smt::PrintBenchmark pb(Printer::getPrinter(fs));
+  smt::PrintBenchmark pb(nodeManager(), Printer::getPrinter(fs));
   pb.printBenchmark(fs, d_env.getLogicInfo().getLogicString(), {}, {kqy});
   fs.close();
 }


### PR DESCRIPTION
Includes two fixes:
First, declarations for skolems are not printing if `--print-skolem-definitions` is enabled.
Second, definitions are considered in the proper order of dependencies (and can't be sorted).