### PR TITLE
Fix proofs + cadical in set defaults

### DIFF
--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -1059,7 +1059,12 @@ bool SetDefaults::incompatibleWithProofs(Options& opts,
   {
     if (opts.proof.propProofMode == options::PropProofMode::PROOF)
     {
-      reason << "(resolution) proofs not supported in cadical";
+      reason << "(resolution) proofs in CaDiCaL";
+      return true;
+    }
+    if (opts.smt.proofMode!=options::ProofMode::PP_ONLY)
+    {
+      reason << "CaDiCaL";
       return true;
     }
   }

--- a/test/regress/cli/regress0/prop/cadical_bug1.smt2
+++ b/test/regress/cli/regress0/prop/cadical_bug1.smt2
@@ -1,4 +1,5 @@
 ; COMMAND-LINE: -i --sat-solver=cadical
+; DISABLE-TESTER: proof
 (set-logic BV)
 (declare-const c (_ BitVec 1))
 (assert (forall ((m (_ BitVec 32))) (distinct (_ bv0 32) (bvadd ((_ zero_extend 31) c) (bvmul m (_ bv2 32))))))

--- a/test/regress/cli/regress0/prop/cadical_bug2.smt2
+++ b/test/regress/cli/regress0/prop/cadical_bug2.smt2
@@ -1,4 +1,5 @@
 ; COMMAND-LINE: -i --sat-solver=cadical
+; DISABLE-TESTER: proof
 (set-logic QF_BV)
 (declare-const x Bool)
 (declare-fun p () Bool)

--- a/test/regress/cli/regress0/prop/cadical_bug4.smt2
+++ b/test/regress/cli/regress0/prop/cadical_bug4.smt2
@@ -1,6 +1,5 @@
 ; COMMAND-LINE: -i --sat-solver=cadical
-; DISABLE-TESTER: cpc
-; DISABLE-TESTER: alethe
+; DISABLE-TESTER: proof
 (set-logic QF_LIA)
 (declare-fun s () Int)
 (push)

--- a/test/regress/cli/regress0/prop/cadical_bug5.smt2
+++ b/test/regress/cli/regress0/prop/cadical_bug5.smt2
@@ -1,4 +1,5 @@
 ; COMMAND-LINE: -i --sat-solver=cadical
+; DISABLE-TESTER: proof
 (set-logic ALL)
 (declare-fun a () Real)
 (assert (= 1.0 (/ 0.0 a)))

--- a/test/regress/cli/regress0/prop/cadical_bug6.smt2
+++ b/test/regress/cli/regress0/prop/cadical_bug6.smt2
@@ -1,4 +1,5 @@
 ; COMMAND-LINE: -i --sat-solver=cadical
+; DISABLE-TESTER: proof
 ; EXPECT: unsat
 ; EXPECT: unsat
 ; EXPECT: unsat


### PR DESCRIPTION
Currently we are not properly guarding when the user tries to use cadical + proofs.