### PR TITLE
[proofs] [alethe] Fix translations of CONTRA rule

### DIFF
--- a/src/proof/alethe/alethe_post_processor.cpp
+++ b/src/proof/alethe/alethe_post_processor.cpp
@@ -771,12 +771,11 @@ bool AletheProofPostprocessCallback::update(Node res,
     // * the corresponding proof node is false
     case ProofRule::CONTRA:
     {
-      return addAletheStep(AletheRule::RESOLUTION,
+      return addAletheStep(AletheRule::RESOLUTION_OR,
                            res,
                            nm->mkNode(Kind::SEXPR, d_cl),
                            children,
-                           d_resPivots ? std::vector<Node>{children[0], d_true}
-                                       : std::vector<Node>(),
+                           {children[0], d_true},
                            *cdp);
     }
     // ======== And elimination


### PR DESCRIPTION
Rules translated via resolution of unprocessed premises need to be post-processed to reason about whether the premises are singleton clauses or not. This is marked by the use of the AletheRule::RESOLUTION_OR rule in the Alethe post-processor. The translation of ProofRule::CONTRA was not using the proper resolution, which could lead to invalid `resolution` steps in the final Alethe proof. This commit fixes this.