### PR TITLE
More changes for safe-options

### DIFF
--- a/src/options/base_options.toml
+++ b/src/options/base_options.toml
@@ -92,7 +92,7 @@ name   = "Base"
 [[option]]
   name       = "statisticsAll"
   long       = "stats-all"
-  category   = "expert"
+  category   = "common"
   type       = "bool"
   default    = "false"
   predicates = ["setStatsDetail"]
@@ -101,7 +101,7 @@ name   = "Base"
 [[option]]
   name       = "statisticsInternal"
   long       = "stats-internal"
-  category   = "expert"
+  category   = "common"
   type       = "bool"
   default    = "false"
   predicates = ["setStatsDetail"]

--- a/src/options/printer_options.toml
+++ b/src/options/printer_options.toml
@@ -14,7 +14,7 @@ name   = "Printing"
 
 [[option]]
   name       = "nodeDepth"
-  category   = "expert"
+  category   = "common"
   long       = "expr-depth=N"
   type       = "int64_t"
   default    = "-1"

--- a/src/options/proof_options.toml
+++ b/src/options/proof_options.toml
@@ -89,7 +89,7 @@ name   = "Proof"
 
 [[option]]
   name       = "proofGranularityMode"
-  category   = "regular"
+  category   = "common"
   long       = "proof-granularity=MODE"
   type       = "ProofGranularityMode"
   default    = "MACRO"

--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -644,7 +644,7 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "fmfFunWellDefined"
-  category   = "regular"
+  category   = "expert"
   long       = "fmf-fun"
   type       = "bool"
   default    = "false"
@@ -652,7 +652,7 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "fmfFunWellDefinedRelevant"
-  category   = "regular"
+  category   = "expert"
   long       = "fmf-fun-rlv"
   type       = "bool"
   default    = "false"

--- a/src/options/sets_options.toml
+++ b/src/options/sets_options.toml
@@ -24,3 +24,11 @@ name   = "Sets Theory"
   type       = "bool"
   default    = "true"
   help       = "enable the relations extension of the theory of sets"
+
+[[option]]
+  name       = "setsCardExp"
+  category   = "expert"
+  long       = "sets-card-exp"
+  type       = "bool"
+  default    = "true"
+  help       = "enable the cardinality extension of the theory of sets"

--- a/src/options/sets_options.toml
+++ b/src/options/sets_options.toml
@@ -16,3 +16,11 @@ name   = "Sets Theory"
   type       = "bool"
   default    = "false"
   help       = "enable extended symbols such as complement and universe in theory of sets"
+
+[[option]]
+  name       = "relsExp"
+  category   = "expert"
+  long       = "rels-exp"
+  type       = "bool"
+  default    = "true"
+  help       = "enable the relations extension of the theory of sets"

--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -110,7 +110,7 @@ name   = "SMT Layer"
 
 [[option]]
   name       = "produceProofs"
-  category   = "regular"
+  category   = "common"
   long       = "produce-proofs"
   type       = "bool"
   default    = "false"
@@ -142,7 +142,7 @@ name   = "SMT Layer"
 
 [[option]]
   name       = "checkProofs"
-  category   = "regular"
+  category   = "common"
   long       = "check-proofs"
   type       = "bool"
   default    = "false"

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -138,6 +138,7 @@ void SetDefaults::setDefaultsPre(Options& opts)
     SET_AND_NOTIFY_IF_NOT_USER(fp, fpExp, false, "safe options");
     SET_AND_NOTIFY_IF_NOT_USER(sets, setsExp, false, "safe options");
     SET_AND_NOTIFY_IF_NOT_USER(sets, relsExp, false, "safe options");
+    SET_AND_NOTIFY_IF_NOT_USER(sets, setsCardExp, false, "safe options");
   }
   // implied options
   if (opts.smt.debugCheckModels)

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -137,6 +137,7 @@ void SetDefaults::setDefaultsPre(Options& opts)
     // enabled by default later
     SET_AND_NOTIFY_IF_NOT_USER(fp, fpExp, false, "safe options");
     SET_AND_NOTIFY_IF_NOT_USER(sets, setsExp, false, "safe options");
+    SET_AND_NOTIFY_IF_NOT_USER(sets, relsExp, false, "safe options");
   }
   // implied options
   if (opts.smt.debugCheckModels)

--- a/src/theory/sets/theory_sets_private.cpp
+++ b/src/theory/sets/theory_sets_private.cpp
@@ -59,6 +59,7 @@ TheorySetsPrivate::TheorySetsPrivate(Env& env,
       d_cardSolver(new CardinalityExtension(d_env, state, im, d_treg)),
       d_hasEnabledRels(false),
       d_rels_enabled(false),
+      d_hasEnabledCard(false),
       d_card_enabled(false),
       d_higher_order_kinds_enabled(false),
       d_cpacb(cpacb)
@@ -196,7 +197,25 @@ TheorySetsPrivate::EqcInfo* TheorySetsPrivate::getOrMakeEqcInfo(TNode n,
     return eqc_i->second;
   }
 }
-
+void TheorySetsPrivate::ensureCardinalityEnabled()
+{
+  if (d_card_enabled)
+  {
+    return;
+  }
+  d_card_enabled = true;
+  if (!d_hasEnabledCard)
+  {
+    if (!options().sets.setsCardExp)
+    {
+      std::stringstream ss;
+      ss << "Set cardinality is not supported in this configuration, try "
+            "--sets-card-exp.";
+      throw LogicException(ss.str());
+    }
+    d_hasEnabledCard = true;
+  }
+}
 void TheorySetsPrivate::ensureRelationsEnabled()
 {
   if (d_rels_enabled)
@@ -283,7 +302,7 @@ void TheorySetsPrivate::fullEffortCheck()
         }
         else if (nk == Kind::SET_CARD)
         {
-          d_card_enabled = true;
+          ensureCardinalityEnabled();
           // register it with the cardinality solver
           d_cardSolver->registerTerm(n);
           if (d_im.hasSent())

--- a/src/theory/sets/theory_sets_private.cpp
+++ b/src/theory/sets/theory_sets_private.cpp
@@ -57,6 +57,7 @@ TheorySetsPrivate::TheorySetsPrivate(Env& env,
       d_treg(d_env, state, im, skc),
       d_rels(new TheorySetsRels(d_env, state, im, skc, d_treg)),
       d_cardSolver(new CardinalityExtension(d_env, state, im, d_treg)),
+      d_hasEnabledRels(false),
       d_rels_enabled(false),
       d_card_enabled(false),
       d_higher_order_kinds_enabled(false),
@@ -196,6 +197,26 @@ TheorySetsPrivate::EqcInfo* TheorySetsPrivate::getOrMakeEqcInfo(TNode n,
   }
 }
 
+void TheorySetsPrivate::ensureRelationsEnabled()
+{
+  if (d_rels_enabled)
+  {
+    return;
+  }
+  d_rels_enabled = true;
+  if (!d_hasEnabledRels)
+  {
+    if (!options().sets.relsExp)
+    {
+      std::stringstream ss;
+      ss << "Relations are not supported in this configuration, try "
+            "--rels-exp.";
+      throw LogicException(ss.str());
+    }
+    d_hasEnabledRels = true;
+  }
+}
+
 void TheorySetsPrivate::fullEffortReset()
 {
   Assert(d_equalityEngine->consistent());
@@ -291,7 +312,7 @@ void TheorySetsPrivate::fullEffortCheck()
         }
         else if (d_rels->isRelationKind(nk))
         {
-          d_rels_enabled = true;
+          ensureRelationsEnabled();
         }
         else if(isHigherOrderKind(nk))
         {

--- a/src/theory/sets/theory_sets_private.h
+++ b/src/theory/sets/theory_sets_private.h
@@ -388,6 +388,11 @@ class TheorySetsPrivate : protected EnvObj
    * if not */
   void ensureFirstClassSetType(TypeNode tn) const;
   /**
+   * Ensure cardinality is enabled, which may throw a logic exception if
+   * setCardExp is false.
+   */
+  void ensureCardinalityEnabled();
+  /**
    * Ensure relations are enabled, which may throw a logic exception if
    * relsExp is false.
    */
@@ -396,7 +401,7 @@ class TheorySetsPrivate : protected EnvObj
   std::unique_ptr<TheorySetsRels> d_rels;
   /** subtheory solver for the theory of sets with cardinality */
   std::unique_ptr<CardinalityExtension> d_cardSolver;
-  /** Have we ever see relations? */
+  /** Have we ever seen relations? */
   bool d_hasEnabledRels;
   /** are relations enabled?
    *
@@ -404,6 +409,8 @@ class TheorySetsPrivate : protected EnvObj
    * involving relational constraints is asserted to this theory.
    */
   bool d_rels_enabled;
+  /** Have we ever seen cardinality? */
+  bool d_hasEnabledCard;
   /** is cardinality enabled?
    *
    * This flag is set to true during a full effort check if any constraint

--- a/src/theory/sets/theory_sets_private.h
+++ b/src/theory/sets/theory_sets_private.h
@@ -387,10 +387,17 @@ class TheorySetsPrivate : protected EnvObj
   /** ensure that the set type is over first class type, throw logic exception
    * if not */
   void ensureFirstClassSetType(TypeNode tn) const;
+  /**
+   * Ensure relations are enabled, which may throw a logic exception if
+   * relsExp is false.
+   */
+  void ensureRelationsEnabled();
   /** subtheory solver for the theory of relations */
   std::unique_ptr<TheorySetsRels> d_rels;
   /** subtheory solver for the theory of sets with cardinality */
   std::unique_ptr<CardinalityExtension> d_cardSolver;
+  /** Have we ever see relations? */
+  bool d_hasEnabledRels;
   /** are relations enabled?
    *
    * This flag is set to true during a full effort check if any constraint


### PR DESCRIPTION
This is work towards having 100% proof coverage when safe-options is enabled.

This PR makes the following changes:
(1) several options related to proofs are now common options, as they should be considered part of our core infrastructure,
(2) a few components (sets+cardinality, relations and fmf-fun) are demoted to expert,
(3) a few miscellaneous debugging options (stats and printing) are changed to common.  This is to support testing setups where these can be used for testing cvc5 when safe-options is enabled.