### PR TITLE
Add missing proofs for conflicts in sets

### DIFF
--- a/src/theory/sets/inference_manager.cpp
+++ b/src/theory/sets/inference_manager.cpp
@@ -111,7 +111,12 @@ bool InferenceManager::assertFactRec(Node fact, InferenceId id, Node exp, int in
 
 void InferenceManager::assertSetsConflict(const Node& conf, InferenceId id)
 {
-  conflict(conf, id);
+  if (d_ipc)
+  {
+    d_ipc->notifyConflict(conf, id);
+  }
+  TrustNode trn = TrustNode::mkTrustConflict(conf, d_ipc.get());
+  trustedConflict(trn, id);
 }
 
 bool InferenceManager::assertSetsFact(Node atom,


### PR DESCRIPTION
Fills in missing proofs for 27 lemmas in our regressions.