### PR TITLE
Do not use strings-exp in regressions

### DIFF
--- a/test/regress/cli/regress0/arith/projissue469-int-equality.smt2
+++ b/test/regress/cli/regress0/arith/projissue469-int-equality.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-option :nl-ext-ent-conf true)

--- a/test/regress/cli/regress0/deep-restart/dd.wrong-sat-020322.smt2
+++ b/test/regress/cli/regress0/deep-restart/dd.wrong-sat-020322.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --deep-restart=input-and-prop --strings-exp
+; COMMAND-LINE: --deep-restart=input-and-prop
 ; EXPECT: unsat
 ; DISABLE-TESTER: unsat-core
 ; DISABLE-TESTER: proof

--- a/test/regress/cli/regress0/fp/proj-issue477-fp-set-comprehension.smt2
+++ b/test/regress/cli/regress0/fp/proj-issue477-fp-set-comprehension.smt2
@@ -1,6 +1,6 @@
 ; EXPECT: unknown
 (set-logic ALL)
-(set-option :strings-exp true)
+
 (set-option :sets-exp true)
 (assert (= (seq.nth (seq.unit false) (bag.count (_ NaN 11 53) (bag (_ +zero 11 53) 1))) (seq.nth (seq.extract (seq.unit false) (bag.count (_ NaN 11 53) (bag (_ +zero 11 53) 1)) (bag.count (set.choose (set.comprehension ((_x14 Float64)) false _x14)) (bag (_ +zero 11 53) 1))) 0)))
 (check-sat)

--- a/test/regress/cli/regress0/ho/issue5371.smt2
+++ b/test/regress/cli/regress0/ho/issue5371.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic HO_ALL)
 (declare-fun a (Bool) Bool)

--- a/test/regress/cli/regress0/ho/issue6536.smt2
+++ b/test/regress/cli/regress0/ho/issue6536.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --mbqi
+; COMMAND-LINE: --mbqi
 ; EXPECT: sat
 (set-logic HO_ALL)
 (declare-datatypes ((a 0) (b 0)) (((c) (d)) ((h (j b)) (e))))

--- a/test/regress/cli/regress0/issue5187-div-justification.smt2
+++ b/test/regress/cli/regress0/issue5187-div-justification.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp -i
+; COMMAND-LINE: -i
 ; EXPECT: unsat
 ; EXPECT: unsat
 ; EXPECT: unsat

--- a/test/regress/cli/regress0/preprocess/issue5943-non-clausal-simp.smt2
+++ b/test/regress/cli/regress0/preprocess/issue5943-non-clausal-simp.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic QF_SLIA)
 (declare-fun s () String)

--- a/test/regress/cli/regress0/proofs/dsl-rule-comp-types.smt2
+++ b/test/regress/cli/regress0/proofs/dsl-rule-comp-types.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress0/proofs/issue9156-doublePropProof.smt2
+++ b/test/regress/cli/regress0/proofs/issue9156-doublePropProof.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --check-proofs --check-unsat-cores
+; COMMAND-LINE: --check-proofs --check-unsat-cores
 ; EXPECT: unsat
 (set-logic QF_SLIA)
 (declare-fun a () String)

--- a/test/regress/cli/regress0/proofs/issue9172-doublePropProof.smt2
+++ b/test/regress/cli/regress0/proofs/issue9172-doublePropProof.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --check-proofs --check-unsat-cores
+; COMMAND-LINE: --check-proofs --check-unsat-cores
 ; EXPECT: unsat
 (set-logic QF_SLIA)
 (declare-fun b () String)

--- a/test/regress/cli/regress0/proofs/proj-issue462-sat-proof-option.smt2
+++ b/test/regress/cli/regress0/proofs/proj-issue462-sat-proof-option.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress0/push-pop/bug654-dd.smt2
+++ b/test/regress/cli/regress0/push-pop/bug654-dd.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --incremental --fmf-fun --strings-exp
+; COMMAND-LINE: --incremental --fmf-fun
 ; DISABLE-TESTER: model
 (set-logic ALL)
 (declare-datatypes ((List_T_C 0) (T_CustomerType 0)) (

--- a/test/regress/cli/regress0/seq/array/array1.smt2
+++ b/test/regress/cli/regress0/seq/array/array1.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --incremental --strings-exp --seq-array=eager
+; COMMAND-LINE: --incremental --seq-array=eager
 ; EXPECT: unsat
 
 (set-logic ALL)

--- a/test/regress/cli/regress0/seq/array/array2.smt2
+++ b/test/regress/cli/regress0/seq/array/array2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --incremental --strings-exp --seq-array=eager
+; COMMAND-LINE: --incremental --seq-array=eager
 ; EXPECT: unsat
 
 (set-logic ALL)

--- a/test/regress/cli/regress0/seq/array/array3.smt2
+++ b/test/regress/cli/regress0/seq/array/array3.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --incremental --strings-exp --seq-array=lazy
+; COMMAND-LINE: --incremental --seq-array=lazy
 ; EXPECT: sat
 
 (set-logic ALL)

--- a/test/regress/cli/regress0/seq/array/array4.smt2
+++ b/test/regress/cli/regress0/seq/array/array4.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --incremental --strings-exp --seq-array=eager
+; COMMAND-LINE: --incremental --seq-array=eager
 ; EXPECT: unsat
 
 (set-info :smt-lib-version 2.6)

--- a/test/regress/cli/regress0/seq/array/distinct-update.smt2
+++ b/test/regress/cli/regress0/seq/array/distinct-update.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=eager
+; COMMAND-LINE: --seq-array=eager
 (set-logic QF_SLIA)
 (set-info :status unsat)
 

--- a/test/regress/cli/regress0/seq/array/model-dd-1220.smt2
+++ b/test/regress/cli/regress0/seq/array/model-dd-1220.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --seq-array=lazy --strings-exp
+; COMMAND-LINE: --seq-array=lazy
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress0/seq/array/nth-concat.smt2
+++ b/test/regress/cli/regress0/seq/array/nth-concat.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --incremental --strings-exp --seq-array=eager
+; COMMAND-LINE: --incremental --seq-array=eager
 ; EXPECT: unsat
 
 (set-logic QF_SLIA)

--- a/test/regress/cli/regress0/seq/array/update-fallback.smt2
+++ b/test/regress/cli/regress0/seq/array/update-fallback.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy
+; COMMAND-LINE: --seq-array=lazy
 ; EXPECT: unsat
 
 (set-logic QF_SLIA)

--- a/test/regress/cli/regress0/seq/array/update-word-eq.smt2
+++ b/test/regress/cli/regress0/seq/array/update-word-eq.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=eager
+; COMMAND-LINE: --seq-array=eager
 (set-logic QF_SLIA)
 (set-info :status unsat)
 

--- a/test/regress/cli/regress0/seq/err1.smt2
+++ b/test/regress/cli/regress0/seq/err1.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy
+; COMMAND-LINE: --seq-array=lazy
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-sort E 0)

--- a/test/regress/cli/regress0/seq/intseq.smt2
+++ b/test/regress/cli/regress0/seq/intseq.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ;EXPECT: unsat
 (set-logic ALL)
 (declare-fun tickleBool (Bool) Bool)

--- a/test/regress/cli/regress0/seq/intseq_dt.smt2
+++ b/test/regress/cli/regress0/seq/intseq_dt.smt2
@@ -1,4 +1,4 @@
-;COMMAND-LINE: --dt-nested-rec --strings-exp
+;COMMAND-LINE: --dt-nested-rec
 ;EXPECT: unsat
 (set-logic ALL)
 (declare-fun tickleBool (Bool) Bool)

--- a/test/regress/cli/regress0/seq/issue4370-bool-terms.smt2
+++ b/test/regress/cli/regress0/seq/issue4370-bool-terms.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp -q
+; COMMAND-LINE: -q
 (set-logic ALL)
 (set-info :status sat)
 (declare-datatypes ((a 0)) (((b))))

--- a/test/regress/cli/regress0/seq/issue5543-unit-cmv.smt2
+++ b/test/regress/cli/regress0/seq/issue5543-unit-cmv.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun a () (Seq (Seq Int)))

--- a/test/regress/cli/regress0/seq/issue5547-seq-len-unit.smt2
+++ b/test/regress/cli/regress0/seq/issue5547-seq-len-unit.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_SLIA)
 (declare-fun seq3 () (Seq Int))

--- a/test/regress/cli/regress0/seq/issue5547-small-seq-len-unit.smt2
+++ b/test/regress/cli/regress0/seq/issue5547-small-seq-len-unit.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --simplification=none --strings-exp
+; COMMAND-LINE: --simplification=none
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun a () (Seq Int))

--- a/test/regress/cli/regress0/seq/nth-oob.smt2
+++ b/test/regress/cli/regress0/seq/nth-oob.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy
+; COMMAND-LINE: --seq-array=lazy
 ; EXPECT: unsat
 
 (set-logic QF_SLIA)

--- a/test/regress/cli/regress0/seq/nth-update.smt2
+++ b/test/regress/cli/regress0/seq/nth-update.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy
+; COMMAND-LINE: --seq-array=lazy
 ; EXPECT: sat
 (set-logic QF_SLIA)
 (declare-const x (Seq Int))

--- a/test/regress/cli/regress0/seq/proj-issue384-subtypes.smt2
+++ b/test/regress/cli/regress0/seq/proj-issue384-subtypes.smt2
@@ -1,7 +1,7 @@
 (set-logic ALL)
 (set-info :status unsat)
 (set-option :global-declarations true)
-(set-option :strings-exp true)
+
 (assert (let ((_let0 (seq.unit real.pi)))(seq.suffixof _let0 (seq.update _let0 (seq.len _let0) _let0))))
 (assert (let ((_let0 real.pi))(let ((_let1 (- _let0)))(let ((_let2 (+ _let1 _let0)))(>= _let1 (* _let2 _let2) _let1)))))
 (check-sat)

--- a/test/regress/cli/regress0/seq/quant_len_trigger.smt2
+++ b/test/regress/cli/regress0/seq/quant_len_trigger.smt2
@@ -1,6 +1,6 @@
 ; EXPECT: unsat
 
-(set-option :strings-exp true)
+
 (set-logic ALL)
 
 (assert (forall ((x (Seq Int)) (xx (Seq Int)) ) (=> (and (= (seq.len x) (seq.len xx)) (forall ((i Int) )   (=> (and (<= 0 i) (< i (seq.len x))) (= (seq.nth x i) (seq.nth xx i))))) (= x xx))))

--- a/test/regress/cli/regress0/seq/query0-subtype-skel.smt2
+++ b/test/regress/cli/regress0/seq/query0-subtype-skel.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress0/seq/query1-subtype.smt2
+++ b/test/regress/cli/regress0/seq/query1-subtype.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --simplification=none
+; COMMAND-LINE: --simplification=none
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun x () (Seq Real))

--- a/test/regress/cli/regress0/seq/query2-subtype.smt2
+++ b/test/regress/cli/regress0/seq/query2-subtype.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --simplification=none --strings-fmf
+; COMMAND-LINE: --simplification=none --strings-fmf
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun x () (Seq Real))

--- a/test/regress/cli/regress0/seq/seq-ex3.smt2
+++ b/test/regress/cli/regress0/seq/seq-ex3.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (set-info :status unsat)
 (declare-fun x () (Seq (Seq Int)))

--- a/test/regress/cli/regress0/seq/seq-ex4.smt2
+++ b/test/regress/cli/regress0/seq/seq-ex4.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (set-info :status unsat)
 (declare-fun z () (Seq Int))

--- a/test/regress/cli/regress0/seq/seq-ex5-dd.smt2
+++ b/test/regress/cli/regress0/seq/seq-ex5-dd.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (set-info :status sat)
 (declare-fun z () (Seq Int))

--- a/test/regress/cli/regress0/seq/seq-ex5.smt2
+++ b/test/regress/cli/regress0/seq/seq-ex5.smt2
@@ -1,5 +1,5 @@
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-fun z () (Seq Int))
 (declare-fun w () (Seq Int))

--- a/test/regress/cli/regress0/seq/seq-expand-defs.smt2
+++ b/test/regress/cli/regress0/seq/seq-expand-defs.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 ; EXPECT: (((seq.nth y 7) 404))
 ; EXPECT: (((str.from_code x) "?"))

--- a/test/regress/cli/regress0/seq/seq-nth-uf-z.smt2
+++ b/test/regress/cli/regress0/seq/seq-nth-uf-z.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ;EXPECT: unsat
 (set-logic ALL)
 (declare-fun a () (Seq Int))

--- a/test/regress/cli/regress0/seq/seq-nth-uf.smt2
+++ b/test/regress/cli/regress0/seq/seq-nth-uf.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_UFSLIA)
 (set-info :status unsat)
 (declare-fun a () (Seq Int))

--- a/test/regress/cli/regress0/seq/seq-nth-undef-unsat.smt2
+++ b/test/regress/cli/regress0/seq/seq-nth-undef-unsat.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ;EXPECT: unsat
 (set-logic ALL)
 (declare-fun s () (Seq Int))

--- a/test/regress/cli/regress0/seq/seq-nth.smt2
+++ b/test/regress/cli/regress0/seq/seq-nth.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ;EXPECT: sat
 (set-logic ALL)
 (declare-fun s () (Seq Int))

--- a/test/regress/cli/regress0/seq/seq-types.smt2
+++ b/test/regress/cli/regress0/seq/seq-types.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ;EXPECT: unsat
 (set-logic ALL)
 (declare-fun s () (Seq Int))

--- a/test/regress/cli/regress0/seq/seqa-model-unsound-dd.smt2
+++ b/test/regress/cli/regress0/seq/seqa-model-unsound-dd.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=eager
+; COMMAND-LINE: --seq-array=eager
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-sort T 0)

--- a/test/regress/cli/regress0/seq/shared-term-registration.smt2
+++ b/test/regress/cli/regress0/seq/shared-term-registration.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy
+; COMMAND-LINE: --seq-array=lazy
 ; EXPECT: unknown
 (set-logic ALL)
 (declare-sort T@$ 0)

--- a/test/regress/cli/regress0/seq/update-concat-non-atomic.smt2
+++ b/test/regress/cli/regress0/seq/update-concat-non-atomic.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy
+; COMMAND-LINE: --seq-array=lazy
 ; EXPECT: sat
 (set-logic ALL)
 (declare-sort S 0)

--- a/test/regress/cli/regress0/seq/update-concat-non-atomic2.smt2
+++ b/test/regress/cli/regress0/seq/update-concat-non-atomic2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy
+; COMMAND-LINE: --seq-array=lazy
 ; EXPECT: sat
 (set-logic ALL)
 (declare-sort S 0)

--- a/test/regress/cli/regress0/seq/update-eq-unsat.smt2
+++ b/test/regress/cli/regress0/seq/update-eq-unsat.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=eager
+; COMMAND-LINE: --seq-array=eager
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun x () (Seq Int))

--- a/test/regress/cli/regress0/seq/update-eq.smt2
+++ b/test/regress/cli/regress0/seq/update-eq.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy
+; COMMAND-LINE: --seq-array=lazy
 (set-logic QF_UFSLIA)
 (declare-sort E 0)
 (declare-fun x () (Seq E))

--- a/test/regress/cli/regress0/seq/wrong-model-020322.smt2
+++ b/test/regress/cli/regress0/seq/wrong-model-020322.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy
+; COMMAND-LINE: --seq-array=lazy
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress0/seq/wrong-sat-020322.smt2
+++ b/test/regress/cli/regress0/seq/wrong-sat-020322.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy
+; COMMAND-LINE: --seq-array=lazy
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress0/strings/bug002.smt2
+++ b/test/regress/cli/regress0/strings/bug002.smt2
@@ -1,6 +1,6 @@
 (set-info :smt-lib-version 2.6)
 (set-logic ASLIA)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 
 ; regex = [\*-,\t\*-\|](.{6,}()?)+

--- a/test/regress/cli/regress0/strings/bug612.smt2
+++ b/test/regress/cli/regress0/strings/bug612.smt2
@@ -1,5 +1,5 @@
 (set-logic QF_S)
-(set-option :strings-exp true)
+
 (set-info :status unsat)
 
 (declare-fun s () String)

--- a/test/regress/cli/regress0/strings/bug613.smt2
+++ b/test/regress/cli/regress0/strings/bug613.smt2
@@ -1,6 +1,6 @@
 (set-logic QF_SLIA)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 
 (declare-fun s () String)
 (assert (= s "<a></a>"))

--- a/test/regress/cli/regress0/strings/code-perf.smt2
+++ b/test/regress/cli/regress0/strings/code-perf.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-info :smt-lib-version 2.6)
 (set-logic QF_SLIA)

--- a/test/regress/cli/regress0/strings/delta-trust-subs.smt2
+++ b/test/regress/cli/regress0/strings/delta-trust-subs.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress0/strings/idof-rewrites.smt2
+++ b/test/regress/cli/regress0/strings/idof-rewrites.smt2
@@ -1,6 +1,6 @@
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (declare-fun s () String)
 (declare-fun t () String)
 

--- a/test/regress/cli/regress0/strings/idof-sem.smt2
+++ b/test/regress/cli/regress0/strings/idof-sem.smt2
@@ -1,5 +1,5 @@
 (set-logic SLIA)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-fun x () String)
 (assert (not (= (str.indexof x "" 0) (- 1))))

--- a/test/regress/cli/regress0/strings/ilc-like.smt2
+++ b/test/regress/cli/regress0/strings/ilc-like.smt2
@@ -1,6 +1,6 @@
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
  
 (declare-fun s () String)
 (assert (= s "I like cookies."))

--- a/test/regress/cli/regress0/strings/indexof-sym-simp.smt2
+++ b/test/regress/cli/regress0/strings/indexof-sym-simp.smt2
@@ -1,6 +1,6 @@
 (set-logic ALL)
 (set-info :status unsat)
-(set-option :strings-exp true)
+
 (declare-fun s () String)
 (declare-fun t () String)
 (declare-fun r () String)

--- a/test/regress/cli/regress0/strings/indexof_re-start-index.smt2
+++ b/test/regress/cli/regress0/strings/indexof_re-start-index.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (declare-fun i () Int)
 (declare-fun a () String)

--- a/test/regress/cli/regress0/strings/indexof_re.smt2
+++ b/test/regress/cli/regress0/strings/indexof_re.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (declare-const x String)
 (assert (or

--- a/test/regress/cli/regress0/strings/issue1189.smt2
+++ b/test/regress/cli/regress0/strings/issue1189.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)
 (set-info :status unsat)
-(set-option :strings-exp true)
+
 (declare-const x Int)
 (assert (str.contains (str.++ "some text" (str.from_int x) "tor") "vector"))
 (check-sat)

--- a/test/regress/cli/regress0/strings/issue2958.smt2
+++ b/test/regress/cli/regress0/strings/issue2958.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; COMMAND-LINE: --conflict-process=min
 (set-info :smt-lib-version 2.6)
 (set-logic QF_SLIA)

--- a/test/regress/cli/regress0/strings/issue3497.smt2
+++ b/test/regress/cli/regress0/strings/issue3497.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_SLIA)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (declare-fun x () String)
 (declare-fun y () String)
 (assert (= (str.indexof x y 1) (str.len x)))

--- a/test/regress/cli/regress0/strings/issue4376.smt2
+++ b/test/regress/cli/regress0/strings/issue4376.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-info :status sat)
 (set-logic QF_SLIA)
 (declare-const i0 Int)

--- a/test/regress/cli/regress0/strings/issue4915.smt2
+++ b/test/regress/cli/regress0/strings/issue4915.smt2
@@ -1,5 +1,5 @@
 ; EXPECT: unsat
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (declare-const Str4 String)
 (declare-const Str18 String)

--- a/test/regress/cli/regress0/strings/issue5090.smt2
+++ b/test/regress/cli/regress0/strings/issue5090.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --incremental
+; COMMAND-LINE: --incremental
 (set-logic QF_S)
 (declare-const Str0 String)
 (declare-const Str1 String)

--- a/test/regress/cli/regress0/strings/issue5384-double-conflict.smt2
+++ b/test/regress/cli/regress0/strings/issue5384-double-conflict.smt2
@@ -1,5 +1,5 @@
 (set-logic QF_S)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-fun _substvar_130_ () Bool)
 (declare-fun _substvar_156_ () Bool)

--- a/test/regress/cli/regress0/strings/issue5542-strings-seq-mix.smt2
+++ b/test/regress/cli/regress0/strings/issue5542-strings-seq-mix.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress0/strings/issue5771-eager-pp.smt2
+++ b/test/regress/cli/regress0/strings/issue5771-eager-pp.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --no-strings-lazy-pp --strings-exp
+; COMMAND-LINE: --no-strings-lazy-pp
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun a () Int)

--- a/test/regress/cli/regress0/strings/issue5915-repl-ctn-rewrite.smt2
+++ b/test/regress/cli/regress0/strings/issue5915-repl-ctn-rewrite.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress0/strings/issue6203-3-unfold-trivial-true.smt2
+++ b/test/regress/cli/regress0/strings/issue6203-3-unfold-trivial-true.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun s () String)

--- a/test/regress/cli/regress0/strings/issue6510-seq-bool.smt2
+++ b/test/regress/cli/regress0/strings/issue6510-seq-bool.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp -q
+; COMMAND-LINE: -q
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun e () (Seq Bool))

--- a/test/regress/cli/regress0/strings/issue6560-indexof-reduction.smt2
+++ b/test/regress/cli/regress0/strings/issue6560-indexof-reduction.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress0/strings/issue6604-re-elim.smt2
+++ b/test/regress/cli/regress0/strings/issue6604-re-elim.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --re-elim=on --strings-exp
+; COMMAND-LINE: --re-elim=on
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun a () String)

--- a/test/regress/cli/regress0/strings/issue6643-ctn-decompose-conflict.smt2
+++ b/test/regress/cli/regress0/strings/issue6643-ctn-decompose-conflict.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (declare-fun y () String)
 (declare-fun z () String)

--- a/test/regress/cli/regress0/strings/issue7974-incomplete-neg-member.smt2
+++ b/test/regress/cli/regress0/strings/issue7974-incomplete-neg-member.smt2
@@ -1,5 +1,5 @@
 ; COMMAND-LINE: --incremental
-; EXPECT: (error "Strings Incomplete (due to Negative Membership) by default, try --strings-exp option.")
+; EXPECT: (error "Strings Incomplete (due to Negative Membership) by default, try option.")
 ; EXIT: 1
 (set-logic ALL)
 (declare-fun v () String)

--- a/test/regress/cli/regress0/strings/issue7974-incomplete-neg-member.smt2
+++ b/test/regress/cli/regress0/strings/issue7974-incomplete-neg-member.smt2
@@ -1,5 +1,5 @@
 ; COMMAND-LINE: --incremental
-; EXPECT: (error "Strings Incomplete (due to Negative Membership) by default, try option.")
+; EXPECT: (error "Strings Incomplete (due to Negative Membership) by default, try --strings-exp option.")
 ; EXIT: 1
 (set-logic ALL)
 (declare-fun v () String)

--- a/test/regress/cli/regress0/strings/issue8346-idof-max.smt2
+++ b/test/regress/cli/regress0/strings/issue8346-idof-max.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp -q
+; COMMAND-LINE: -q
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress0/strings/issue8722-learned-rew.smt2
+++ b/test/regress/cli/regress0/strings/issue8722-learned-rew.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --learned-rewrite --strings-exp
+; COMMAND-LINE: --learned-rewrite
 ; EXPECT: sat
 (set-logic ALL)
 (declare-const a String) 

--- a/test/regress/cli/regress0/strings/itos-entail.smt2
+++ b/test/regress/cli/regress0/strings/itos-entail.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (declare-fun x () Int)
 (declare-fun y () String)
 (declare-fun z () String)

--- a/test/regress/cli/regress0/strings/leadingzero001.smt2
+++ b/test/regress/cli/regress0/strings/leadingzero001.smt2
@@ -1,6 +1,6 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_S)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 
 (declare-fun Y () String)

--- a/test/regress/cli/regress0/strings/leq.smt2
+++ b/test/regress/cli/regress0/strings/leq.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (declare-const x String)
 (declare-const y String)

--- a/test/regress/cli/regress0/strings/norn-31.smt2
+++ b/test/regress/cli/regress0/strings/norn-31.smt2
@@ -1,6 +1,6 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-info :status unsat)
 
 (declare-fun var_0 () String)

--- a/test/regress/cli/regress0/strings/norn-simp-rew.smt2
+++ b/test/regress/cli/regress0/strings/norn-simp-rew.smt2
@@ -1,6 +1,6 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-info :status unsat)
 
 (declare-fun var_0 () String)

--- a/test/regress/cli/regress0/strings/re.all.smt2
+++ b/test/regress/cli/regress0/strings/re.all.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (set-info :status unsat)
 (declare-const x String)

--- a/test/regress/cli/regress0/strings/regexp_inclusion.smt2
+++ b/test/regress/cli/regress0/strings/regexp_inclusion.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-info :status unsat)
 (set-logic ALL)
 (declare-const actionName String)

--- a/test/regress/cli/regress0/strings/regexp_inclusion_reduction.smt2
+++ b/test/regress/cli/regress0/strings/regexp_inclusion_reduction.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-info :status sat)
 (set-logic QF_SLIA)
 (declare-const x String)

--- a/test/regress/cli/regress0/strings/repl-rewrites2.smt2
+++ b/test/regress/cli/regress0/strings/repl-rewrites2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress0/strings/rewrites-v2.smt2
+++ b/test/regress/cli/regress0/strings/rewrites-v2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-info :smt-lib-version 2.6)
 (set-logic SLIA)

--- a/test/regress/cli/regress0/strings/std2.6.1.smt2
+++ b/test/regress/cli/regress0/strings/std2.6.1.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --lang=smt2.6
+; COMMAND-LINE: --lang=smt2.6
 ; EXPECT: sat
 (set-logic QF_UFSLIA)
 (set-info :status sat)

--- a/test/regress/cli/regress0/strings/strings-charat.cvc.smt2
+++ b/test/regress/cli/regress0/strings/strings-charat.cvc.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (set-option :incremental false)

--- a/test/regress/cli/regress0/strings/strip-endpoint-itos.smt2
+++ b/test/regress/cli/regress0/strings/strip-endpoint-itos.smt2
@@ -1,6 +1,6 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-fun x () Int)
 (assert (str.contains "Ducati100" (str.from_int x)))

--- a/test/regress/cli/regress0/strings/substr-rewrites.smt2
+++ b/test/regress/cli/regress0/strings/substr-rewrites.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic SLIA)
 (set-info :status unsat)

--- a/test/regress/cli/regress0/strings/tolower-rrs.smt2
+++ b/test/regress/cli/regress0/strings/tolower-rrs.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)

--- a/test/regress/cli/regress0/strings/tolower-simple.smt2
+++ b/test/regress/cli/regress0/strings/tolower-simple.smt2
@@ -1,5 +1,5 @@
 (set-logic ALL)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-const x String)
 (declare-const y String)

--- a/test/regress/cli/regress0/strings/type001.smt2
+++ b/test/regress/cli/regress0/strings/type001.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_SLIA)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 
 (declare-fun x () String)
 (declare-fun y () String)

--- a/test/regress/cli/regress0/strings/unicode-esc.smt2
+++ b/test/regress/cli/regress0/strings/unicode-esc.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --lang=smt2.6
+; COMMAND-LINE: --lang=smt2.6
 ; EXPECT: sat
 (set-logic ALL)
 

--- a/test/regress/cli/regress0/strings/unsound-0908.smt2
+++ b/test/regress/cli/regress0/strings/unsound-0908.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_SLIA)
 (set-info :status sat)

--- a/test/regress/cli/regress0/strings/unsound-repl-rewrite.smt2
+++ b/test/regress/cli/regress0/strings/unsound-repl-rewrite.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_S)
 (declare-fun x () String)

--- a/test/regress/cli/regress1/bags/fold2.smt2
+++ b/test/regress/cli/regress1/bags/fold2.smt2
@@ -2,7 +2,7 @@
 (set-info :status sat)
 (set-option :fmf-bound true)
 (set-option :uf-lazy-ll true)
-(set-option :strings-exp true)
+
 (define-fun min ((x String) (y String)) String (ite (str.< x y) x y))
 (declare-fun A () (Bag String))
 (declare-fun x () String)

--- a/test/regress/cli/regress1/bags/fold3.smt2
+++ b/test/regress/cli/regress1/bags/fold3.smt2
@@ -2,7 +2,7 @@
 (set-info :status sat)
 (set-option :fmf-bound true)
 (set-option :uf-lazy-ll true)
-(set-option :strings-exp true)
+
 (define-fun min ((x String) (y String)) String (ite (str.< x y) x y))
 (declare-fun A () (Bag String))
 (declare-fun minimum () String)

--- a/test/regress/cli/regress1/bags/map4.smt2
+++ b/test/regress/cli/regress1/bags/map4.smt2
@@ -2,7 +2,7 @@
 (set-info :status sat)
 (set-option :fmf-bound true)
 (set-option :uf-lazy-ll true)
-(set-option :strings-exp true)
+
 (set-option :simplification none)
 (declare-const A (Bag (Tuple Int)))
 (declare-const B (Bag (Tuple Int)))

--- a/test/regress/cli/regress1/bags/murxla2.smt2
+++ b/test/regress/cli/regress1/bags/murxla2.smt2
@@ -1,6 +1,6 @@
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (declare-const x Int)
 (assert (seq.contains (seq.at (seq.unit (bag false x)) x) (seq.unit (bag false x))))
 (check-sat)

--- a/test/regress/cli/regress1/bug590.smt2
+++ b/test/regress/cli/regress1/bug590.smt2
@@ -3,7 +3,7 @@
 ; EXPECT: ((charlst2 (
 
 (set-logic ALL)
-(set-option :strings-exp true)
+
 (set-option :produce-models true)
 (set-info :smt-lib-version 2.6)
 (set-info :status unknown)

--- a/test/regress/cli/regress1/cores/issue5604.smt2
+++ b/test/regress/cli/regress1/cores/issue5604.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun a () String)

--- a/test/regress/cli/regress1/fmf/issue8096-non-const-rep.smt2
+++ b/test/regress/cli/regress1/fmf/issue8096-non-const-rep.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp -q
+; COMMAND-LINE: -q
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress1/nl/issue9183-3.smt2
+++ b/test/regress/cli/regress1/nl/issue9183-3.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --decision=stoponly --strings-exp
+; COMMAND-LINE: --decision=stoponly
 ; EXPECT: sat
 (set-logic QF_NRA) 
 (declare-const a Real) 

--- a/test/regress/cli/regress1/quantifiers/issue2970-string-var-elim.smt2
+++ b/test/regress/cli/regress1/quantifiers/issue2970-string-var-elim.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic ALL)
 (set-info :status unsat)
 (declare-fun s () String)

--- a/test/regress/cli/regress1/quantifiers/issue3537.smt2
+++ b/test/regress/cli/regress1/quantifiers/issue3537.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --finite-model-find --fmf-bound
+; COMMAND-LINE: --finite-model-find --fmf-bound
 ; EXPECT: sat
 (set-logic ALL)
 (declare-datatypes ((UNIT 0)) (((Unit))

--- a/test/regress/cli/regress1/quantifiers/issue5288-vts-real-int.smt2
+++ b/test/regress/cli/regress1/quantifiers/issue5288-vts-real-int.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress1/quantifiers/issue5378-witness.smt2
+++ b/test/regress/cli/regress1/quantifiers/issue5378-witness.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --sygus-inst --strings-exp
+; COMMAND-LINE: --sygus-inst
 ; EXPECT: unsat
 (set-logic ALL)
 (assert (forall ((a Int) (b Int)) (or (> (to_real a) (/ 0.0 (to_real b))) (exists ((c Int)) (< a c b)))))

--- a/test/regress/cli/regress1/quantifiers/issue5469-aext.smt2
+++ b/test/regress/cli/regress1/quantifiers/issue5469-aext.smt2
@@ -1,8 +1,8 @@
-; COMMAND-LINE: --sygus-inst --strings-exp -q
+; COMMAND-LINE: --sygus-inst -q
 ; EXPECT: sat
 (set-logic NIA)
 (set-option :sygus-inst true)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-fun d () Int)
 (assert (forall ((g Int)) (or (> 1 g) (> g (div 1 d)))))

--- a/test/regress/cli/regress1/quantifiers/issue5470-aext.smt2
+++ b/test/regress/cli/regress1/quantifiers/issue5470-aext.smt2
@@ -1,7 +1,7 @@
 ; EXPECT: sat
 ; DISABLE-TESTER: model
 (set-logic NIA)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-fun b () Int)
 (assert (exists ((c Int)) (< 0 c (div 0 b))))

--- a/test/regress/cli/regress1/quantifiers/issue5471-aext.smt2
+++ b/test/regress/cli/regress1/quantifiers/issue5471-aext.smt2
@@ -1,6 +1,6 @@
 (set-logic NRA)
 (set-option :sygus-inst true)
-(set-option :strings-exp true)
+
 (set-info :status unsat)
 (declare-fun a () Real)
 (declare-fun b () Real)

--- a/test/regress/cli/regress1/quantifiers/issue8572-sygus-inst-ic-purify.smt2
+++ b/test/regress/cli/regress1/quantifiers/issue8572-sygus-inst-ic-purify.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --sygus-inst
+; COMMAND-LINE: --sygus-inst
 ; EXPECT: unsat
 (set-logic ALL)
 (assert (forall ((e String)) (= 0 (ite (str.contains (str.substr e 0 (- (str.len e) 1)) "/") 1 0))))

--- a/test/regress/cli/regress1/quantifiers/proj-issue295.smt2
+++ b/test/regress/cli/regress1/quantifiers/proj-issue295.smt2
@@ -1,7 +1,7 @@
 ; COMMAND-LINE: -q --sygus-inst
 ; EXPECT: sat
 (set-logic ALL)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (assert (forall ((x Int)) (not (= (str.++ "V" "s") (str.++ "V" (str.substr (str.substr "VZ" 0 x) 0 1))))))
 (check-sat)

--- a/test/regress/cli/regress1/quantifiers/seq-solved-enum.smt2
+++ b/test/regress/cli/regress1/quantifiers/seq-solved-enum.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --full-saturate-quant
+; COMMAND-LINE: --full-saturate-quant
 ; EXPECT: unsat
 (set-logic ALL)
 

--- a/test/regress/cli/regress1/quantifiers/seq-unsolved-ematch.smt2
+++ b/test/regress/cli/regress1/quantifiers/seq-unsolved-ematch.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --full-saturate-quant
+; COMMAND-LINE: --full-saturate-quant
 ; EXPECT: unsat
 (set-logic ALL)
 

--- a/test/regress/cli/regress1/quantifiers/seqa-unsat-unknown-110921.smt2
+++ b/test/regress/cli/regress1/quantifiers/seqa-unsat-unknown-110921.smt2
@@ -1,6 +1,6 @@
 ; DISABLE-TESTER: lfsc
 ; DISABLE-TESTER: cpc
-; COMMAND-LINE: --strings-exp --seq-array=eager
+; COMMAND-LINE: --seq-array=eager
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-sort T 0)

--- a/test/regress/cli/regress1/seq/issue8148-2-const-mv.smt2
+++ b/test/regress/cli/regress1/seq/issue8148-2-const-mv.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/seq/issue8148-const-mv.smt2
+++ b/test/regress/cli/regress1/seq/issue8148-const-mv.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/seq/issue8936-nth-eager-red.smt2
+++ b/test/regress/cli/regress1/seq/issue8936-nth-eager-red.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --no-strings-lazy-pp
+; COMMAND-LINE: --no-strings-lazy-pp
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun a () (Seq Int))

--- a/test/regress/cli/regress1/sets/issue5942-witness.smt2
+++ b/test/regress/cli/regress1/sets/issue5942-witness.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/sets/issue8987-ho-exception.smt2
+++ b/test/regress/cli/regress1/sets/issue8987-ho-exception.smt2
@@ -1,7 +1,7 @@
 ; EXPECT: (error "Term of kind rel.project are only supported with higher-order logic. Try adding the logic prefix HO_.")
 ; EXIT: 1
 (set-logic ALL)
-(set-option :strings-exp true)
+
 (declare-fun e () (Relation String))
 (declare-fun v () Int)
 (assert (and (= (str.from_int v) (str.from_int 0)) (= (rel.project e) (rel.project (set.singleton (tuple ""))))))

--- a/test/regress/cli/regress1/sets/issue8987-ho.smt2
+++ b/test/regress/cli/regress1/sets/issue8987-ho.smt2
@@ -1,7 +1,7 @@
 ; COMMAND-LINE: --uf-lazy-ll
 ; EXPECT: sat
 (set-logic HO_ALL)
-(set-option :strings-exp true)
+
 (declare-fun e () (Relation String))
 (declare-fun v () Int)
 (assert (and (= (str.from_int v) (str.from_int 0)) (= (rel.project e) (rel.project (set.singleton (tuple ""))))))

--- a/test/regress/cli/regress1/sets/proj-issue494-finite-leafof.smt2
+++ b/test/regress/cli/regress1/sets/proj-issue494-finite-leafof.smt2
@@ -1,6 +1,6 @@
 (set-logic ALL)
 (set-info :status unsat)
-(set-option :strings-exp true)
+
 (set-option :sets-exp true)
 (declare-const x (Array (Set RoundingMode) (Set RoundingMode)))
 (check-sat-assuming (

--- a/test/regress/cli/regress1/sets/set_fold3.smt2
+++ b/test/regress/cli/regress1/sets/set_fold3.smt2
@@ -2,7 +2,7 @@
 (set-info :status sat)
 (set-option :fmf-bound true)
 (set-option :uf-lazy-ll true)
-(set-option :strings-exp true)
+
 (define-fun min ((x String) (y String)) String (ite (str.< x y) x y))
 (declare-fun A () (Set String))
 (declare-fun x () String)

--- a/test/regress/cli/regress1/strings/artemis-0512-nonterm.smt2
+++ b/test/regress/cli/regress1/strings/artemis-0512-nonterm.smt2
@@ -1,6 +1,6 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-info :status unsat)
 
 (declare-const Y String)

--- a/test/regress/cli/regress1/strings/at001.smt2
+++ b/test/regress/cli/regress1/strings/at001.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (set-info :status sat)
 

--- a/test/regress/cli/regress1/strings/bug615.smt2
+++ b/test/regress/cli/regress1/strings/bug615.smt2
@@ -1,6 +1,6 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_S)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 
 (declare-fun s () String)

--- a/test/regress/cli/regress1/strings/bug682.smt2
+++ b/test/regress/cli/regress1/strings/bug682.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --incremental --strings-exp
+; COMMAND-LINE: --incremental
 (set-logic QF_S)
 
 (declare-fun a () String)

--- a/test/regress/cli/regress1/strings/bug799-min.smt2
+++ b/test/regress/cli/regress1/strings/bug799-min.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --incremental --strings-exp
+; COMMAND-LINE: --incremental
 ; EXPECT: sat
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)

--- a/test/regress/cli/regress1/strings/cee-norn-aes-trivially.smt2
+++ b/test/regress/cli/regress1/strings/cee-norn-aes-trivially.smt2
@@ -1,5 +1,5 @@
-; COMMAND-LINE: --arith-eq-solver --ee-mode=distributed --strings-exp
-; COMMAND-LINE: --arith-eq-solver --ee-mode=central --strings-exp
+; COMMAND-LINE: --arith-eq-solver --ee-mode=distributed
+; COMMAND-LINE: --arith-eq-solver --ee-mode=central
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun v () String)

--- a/test/regress/cli/regress1/strings/chapman150408.smt2
+++ b/test/regress/cli/regress1/strings/chapman150408.smt2
@@ -1,6 +1,6 @@
 (set-logic SLIA)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (declare-fun string () String)
 (assert (and
      (and (not (not (not (= (ite (> (str.indexof string ";" 0) 0) 1 0)

--- a/test/regress/cli/regress1/strings/cmu-2db2-extf-reg.smt2
+++ b/test/regress/cli/regress1/strings/cmu-2db2-extf-reg.smt2
@@ -1,6 +1,6 @@
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 
 (declare-fun s () String)
 

--- a/test/regress/cli/regress1/strings/cmu-5042-0707-2.smt2
+++ b/test/regress/cli/regress1/strings/cmu-5042-0707-2.smt2
@@ -1,6 +1,6 @@
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 
 (declare-fun key2 () String)
 (declare-fun key1 () String)

--- a/test/regress/cli/regress1/strings/cmu-inc-nlpp-071516.smt2
+++ b/test/regress/cli/regress1/strings/cmu-inc-nlpp-071516.smt2
@@ -1,6 +1,6 @@
 (set-logic ALL)
 (set-info :status unsat)
-(set-option :strings-exp true)
+
 
 (declare-fun url () String)
 

--- a/test/regress/cli/regress1/strings/cmu-substr-rw.smt2
+++ b/test/regress/cli/regress1/strings/cmu-substr-rw.smt2
@@ -1,6 +1,6 @@
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 
 (declare-fun uri () String)
 

--- a/test/regress/cli/regress1/strings/code-sequence.smt2
+++ b/test/regress/cli/regress1/strings/code-sequence.smt2
@@ -1,5 +1,5 @@
 (set-logic SLIA)
-(set-option :strings-exp true)
+
 (set-option :strings-fmf true)
 (set-option :fmf-bound true)
 (set-info :status sat)

--- a/test/regress/cli/regress1/strings/complement-test.smt2
+++ b/test/regress/cli/regress1/strings/complement-test.smt2
@@ -1,5 +1,5 @@
 (set-logic SLIA)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-fun x () String)
 (declare-fun y () String)

--- a/test/regress/cli/regress1/strings/crash-1019.smt2
+++ b/test/regress/cli/regress1/strings/crash-1019.smt2
@@ -1,5 +1,5 @@
 (set-logic ALL)
-(set-option :strings-exp true)
+
 (set-info :status unsat)
  
 (declare-fun s () String)

--- a/test/regress/cli/regress1/strings/double-replace.smt2
+++ b/test/regress/cli/regress1/strings/double-replace.smt2
@@ -1,6 +1,6 @@
 (set-logic SLIA)
 (set-option :strings-fmf true)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-fun x () String)
 (declare-fun y () String)

--- a/test/regress/cli/regress1/strings/fmf001.smt2
+++ b/test/regress/cli/regress1/strings/fmf001.smt2
@@ -1,6 +1,6 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_S)
-(set-option :strings-exp true)
+
 (set-option :strings-fmf true)
 (set-info :status sat)
 

--- a/test/regress/cli/regress1/strings/fmf002.smt2
+++ b/test/regress/cli/regress1/strings/fmf002.smt2
@@ -1,6 +1,6 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-option :strings-fmf true)
 (set-info :status sat)
 

--- a/test/regress/cli/regress1/strings/gm-inc-071516-2.smt2
+++ b/test/regress/cli/regress1/strings/gm-inc-071516-2.smt2
@@ -1,6 +1,6 @@
 (set-logic ALL)
 (set-info :status unsat)
-(set-option :strings-exp true)
+
 
 (declare-fun value2 () String)
 (declare-fun key2 () String)

--- a/test/regress/cli/regress1/strings/goodAI.smt2
+++ b/test/regress/cli/regress1/strings/goodAI.smt2
@@ -1,5 +1,5 @@
 (set-logic QF_S)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-const input_0_1000 String)
 (assert (= (str.substr input_0_1000 0 4) "good"))

--- a/test/regress/cli/regress1/strings/idof-handg.smt2
+++ b/test/regress/cli/regress1/strings/idof-handg.smt2
@@ -1,5 +1,5 @@
 (set-logic ALL)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-fun s () String)
 (assert (str.contains s "Hello and goodbye!"))

--- a/test/regress/cli/regress1/strings/idof-nconst-index.smt2
+++ b/test/regress/cli/regress1/strings/idof-nconst-index.smt2
@@ -1,5 +1,5 @@
 (set-logic ALL)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-fun s () String)
 (assert (str.contains s "Hello and goodbye!"))

--- a/test/regress/cli/regress1/strings/idof-neg-index.smt2
+++ b/test/regress/cli/regress1/strings/idof-neg-index.smt2
@@ -1,5 +1,5 @@
 (set-logic ALL)
-(set-option :strings-exp true)
+
 (set-info :status unsat)
 (declare-fun s () String)
 (declare-fun x () Int)

--- a/test/regress/cli/regress1/strings/idof-triv.smt2
+++ b/test/regress/cli/regress1/strings/idof-triv.smt2
@@ -1,6 +1,6 @@
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (declare-fun string () String)
 ;(assert (= string "::")) 
 (assert (> (str.indexof string ":" 0) 0))

--- a/test/regress/cli/regress1/strings/ilc-l-nt.smt2
+++ b/test/regress/cli/regress1/strings/ilc-l-nt.smt2
@@ -1,6 +1,6 @@
 (set-logic ALL)
 (set-info :status unsat)
-(set-option :strings-exp true)
+
  
 (declare-fun s () String)
 (assert (or (= s "Id like cookies.") (= s "Id not like cookies.")))

--- a/test/regress/cli/regress1/strings/indexof_re_red.smt2
+++ b/test/regress/cli/regress1/strings/indexof_re_red.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --incremental
+; COMMAND-LINE: --incremental
 (set-logic QF_SLIA)
 (declare-const x String)
 (declare-const i Int)

--- a/test/regress/cli/regress1/strings/instance1079-re-loop-cong.smt2
+++ b/test/regress/cli/regress1/strings/instance1079-re-loop-cong.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic QF_S)
 (set-info :status unsat)

--- a/test/regress/cli/regress1/strings/instance6561-dd-concat-unify-char.smt2
+++ b/test/regress/cli/regress1/strings/instance6561-dd-concat-unify-char.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress1/strings/issue1105.smt2
+++ b/test/regress/cli/regress1/strings/issue1105.smt2
@@ -1,6 +1,6 @@
 ; EXPECT: sat
 (set-logic ALL)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-datatype Val
     ((Str (str String))

--- a/test/regress/cli/regress1/strings/issue1684-regex.smt2
+++ b/test/regress/cli/regress1/strings/issue1684-regex.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_S)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (declare-const s String)
 (assert (str.in_re s (re.* (re.range "\u{0}" "\u{ff}"))))
 (assert (str.in_re s (re.range "\u{0}" "\u{ff}")))

--- a/test/regress/cli/regress1/strings/issue2429-code.smt2
+++ b/test/regress/cli/regress1/strings/issue2429-code.smt2
@@ -1,6 +1,6 @@
 ; COMMAND-LINE: -q
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-option :produce-models true)
 (set-info :status sat)
 

--- a/test/regress/cli/regress1/strings/issue2981.smt2
+++ b/test/regress/cli/regress1/strings/issue2981.smt2
@@ -1,6 +1,6 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-const x String)
 (declare-const y String)

--- a/test/regress/cli/regress1/strings/issue2982.smt2
+++ b/test/regress/cli/regress1/strings/issue2982.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --re-elim=agg
+; COMMAND-LINE: --re-elim=agg
 ; EXPECT: unsat
 (set-logic QF_SLIA)
 

--- a/test/regress/cli/regress1/strings/issue3090.smt2
+++ b/test/regress/cli/regress1/strings/issue3090.smt2
@@ -1,5 +1,5 @@
 (set-logic ALL)
-(set-option :strings-exp true)
+
 (set-info :status unsat)
 (declare-const id String)
 (assert (and (str.in_re id (re.+ (re.range "0" "9"))) (str.contains id "value")))

--- a/test/regress/cli/regress1/strings/issue3217.smt2
+++ b/test/regress/cli/regress1/strings/issue3217.smt2
@@ -1,5 +1,5 @@
 (set-logic ALL)
-(set-option :strings-exp true)
+
 (set-info :status unsat)
 (declare-fun a () String)
 (declare-fun b () String)

--- a/test/regress/cli/regress1/strings/issue3272.smt2
+++ b/test/regress/cli/regress1/strings/issue3272.smt2
@@ -1,6 +1,6 @@
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-fun a () String) 
 (declare-fun b () String) 

--- a/test/regress/cli/regress1/strings/issue3357.smt2
+++ b/test/regress/cli/regress1/strings/issue3357.smt2
@@ -1,5 +1,5 @@
 (set-logic ALL)
-(set-option :strings-exp true)
+
 (set-info :status unsat)
 (declare-fun a () String)
 (declare-fun b () String)

--- a/test/regress/cli/regress1/strings/issue3657-unexpectedUnsatCVC4.smt2
+++ b/test/regress/cli/regress1/strings/issue3657-unexpectedUnsatCVC4.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --fmf-fun-rlv -i
+; COMMAND-LINE: --fmf-fun-rlv -i
 ; EXPECT: sat
 ; EXPECT: sat
 ; EXPECT: sat

--- a/test/regress/cli/regress1/strings/issue4379.smt2
+++ b/test/regress/cli/regress1/strings/issue4379.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_SLIA)
 (set-info :status sat)

--- a/test/regress/cli/regress1/strings/issue4701_substr_splice.smt2
+++ b/test/regress/cli/regress1/strings/issue4701_substr_splice.smt2
@@ -1,6 +1,6 @@
 (set-logic QF_SLIA)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (declare-fun a () String)
 (declare-fun b () String)
 (declare-fun c () String)

--- a/test/regress/cli/regress1/strings/issue5330.smt2
+++ b/test/regress/cli/regress1/strings/issue5330.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_SLIA)
 (declare-fun str1 () String)

--- a/test/regress/cli/regress1/strings/issue5330_2.smt2
+++ b/test/regress/cli/regress1/strings/issue5330_2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_SLIA)
 (declare-fun seq11 () (Seq Int))

--- a/test/regress/cli/regress1/strings/issue5510-re-consume.smt2
+++ b/test/regress/cli/regress1/strings/issue5510-re-consume.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_S)
 (set-info :status sat)

--- a/test/regress/cli/regress1/strings/issue5520-re-consume.smt2
+++ b/test/regress/cli/regress1/strings/issue5520-re-consume.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_S)
 (set-info :status sat)

--- a/test/regress/cli/regress1/strings/issue5610-2-infer-proxy.smt2
+++ b/test/regress/cli/regress1/strings/issue5610-2-infer-proxy.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun r () String)

--- a/test/regress/cli/regress1/strings/issue5610-infer-proxy.smt2
+++ b/test/regress/cli/regress1/strings/issue5610-infer-proxy.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun str5 () String)

--- a/test/regress/cli/regress1/strings/issue5611-deq-norm-emp.smt2
+++ b/test/regress/cli/regress1/strings/issue5611-deq-norm-emp.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -i --strings-exp -q
+; COMMAND-LINE: -i -q
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun str7 () String)

--- a/test/regress/cli/regress1/strings/issue5692-infer-proxy.smt2
+++ b/test/regress/cli/regress1/strings/issue5692-infer-proxy.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/strings/issue5940-2-skc-len-conc.smt2
+++ b/test/regress/cli/regress1/strings/issue5940-2-skc-len-conc.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun x () String)

--- a/test/regress/cli/regress1/strings/issue5940-skc-len-conc.smt2
+++ b/test/regress/cli/regress1/strings/issue5940-skc-len-conc.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (define-fun z () Int 0)                                                            

--- a/test/regress/cli/regress1/strings/issue6057-replace-re-all-jiwonparc.smt2
+++ b/test/regress/cli/regress1/strings/issue6057-replace-re-all-jiwonparc.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (declare-fun a () String)
 ; A complicated way of saying a = "b"

--- a/test/regress/cli/regress1/strings/issue6072-inc-no-const-reg.smt2
+++ b/test/regress/cli/regress1/strings/issue6072-inc-no-const-reg.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: -i --strings-exp
+; COMMAND-LINE: -i
 ; EXPECT: sat
 ; EXPECT: sat
 (set-logic ALL)

--- a/test/regress/cli/regress1/strings/issue6075-repl-len-one-rr.smt2
+++ b/test/regress/cli/regress1/strings/issue6075-repl-len-one-rr.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun x () String)

--- a/test/regress/cli/regress1/strings/issue6101-2.smt2
+++ b/test/regress/cli/regress1/strings/issue6101-2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun x () String)

--- a/test/regress/cli/regress1/strings/issue6101.smt2
+++ b/test/regress/cli/regress1/strings/issue6101.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun x () String)

--- a/test/regress/cli/regress1/strings/issue6132-non-unique-skolem.smt2
+++ b/test/regress/cli/regress1/strings/issue6132-non-unique-skolem.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun str () String)                                                        

--- a/test/regress/cli/regress1/strings/issue6142-repl-inv-rew.smt2
+++ b/test/regress/cli/regress1/strings/issue6142-repl-inv-rew.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun x () String)

--- a/test/regress/cli/regress1/strings/issue6180-2-proxy-vars.smt2
+++ b/test/regress/cli/regress1/strings/issue6180-2-proxy-vars.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress1/strings/issue6180-proxy-vars.smt2
+++ b/test/regress/cli/regress1/strings/issue6180-proxy-vars.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress1/strings/issue6184-unsat-core.smt2
+++ b/test/regress/cli/regress1/strings/issue6184-unsat-core.smt2
@@ -1,6 +1,6 @@
 ; EXPECT: unsat
-; COMMAND-LINE: --strings-exp
-; COMMAND-LINE: --strings-exp --produce-proofs
+; COMMAND-LINE:
+; COMMAND-LINE: --produce-proofs
 ;; The second command line option is to test unsat core checking with
 ;; proofs, which at one point had issues for this benchmark due to
 ;; cycle detection in LazyCDProofChain

--- a/test/regress/cli/regress1/strings/issue6191-replace-all.smt2
+++ b/test/regress/cli/regress1/strings/issue6191-replace-all.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --no-strings-lazy-pp
+; COMMAND-LINE: --no-strings-lazy-pp
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun x_9 () String)                                                        

--- a/test/regress/cli/regress1/strings/issue6203-1-substr-ctn-strip.smt2
+++ b/test/regress/cli/regress1/strings/issue6203-1-substr-ctn-strip.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun a () String)

--- a/test/regress/cli/regress1/strings/issue6203-2-re-ccache.smt2
+++ b/test/regress/cli/regress1/strings/issue6203-2-re-ccache.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun a () String)

--- a/test/regress/cli/regress1/strings/issue6203-6-replace-re.smt2
+++ b/test/regress/cli/regress1/strings/issue6203-6-replace-re.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (declare-fun a () String)
 (assert (not (str.in_re (str.replace_re a (re.++ (re.* (re.union (str.to_re "a") (str.to_re ""))) (str.to_re "b")) "") (str.to_re ""))))

--- a/test/regress/cli/regress1/strings/issue6214-2-sym-re-inc.smt2
+++ b/test/regress/cli/regress1/strings/issue6214-2-sym-re-inc.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun a () String)

--- a/test/regress/cli/regress1/strings/issue6214-3-sym-re-inc.smt2
+++ b/test/regress/cli/regress1/strings/issue6214-3-sym-re-inc.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun a () String)

--- a/test/regress/cli/regress1/strings/issue6214-4-sym-re-inc.smt2
+++ b/test/regress/cli/regress1/strings/issue6214-4-sym-re-inc.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun a () String)

--- a/test/regress/cli/regress1/strings/issue6270.smt2
+++ b/test/regress/cli/regress1/strings/issue6270.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --nl-ext-tplanes
+; COMMAND-LINE: --nl-ext-tplanes
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun i9 () Int)

--- a/test/regress/cli/regress1/strings/issue6271-2-rnf.smt2
+++ b/test/regress/cli/regress1/strings/issue6271-2-rnf.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun str4 () String)

--- a/test/regress/cli/regress1/strings/issue6271-rnf.smt2
+++ b/test/regress/cli/regress1/strings/issue6271-rnf.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --strings-fmf
+; COMMAND-LINE: --strings-fmf
 ; EXPECT: sat
 (set-logic ALL)
 (set-option :strings-fmf true)

--- a/test/regress/cli/regress1/strings/issue6337-replace-re-all.smt2
+++ b/test/regress/cli/regress1/strings/issue6337-replace-re-all.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (declare-fun str3 () String)
 (declare-fun str8 () String)

--- a/test/regress/cli/regress1/strings/issue6337-replace-re.smt2
+++ b/test/regress/cli/regress1/strings/issue6337-replace-re.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (declare-fun a () String)
 (declare-fun b () String)

--- a/test/regress/cli/regress1/strings/issue6604-2.smt2
+++ b/test/regress/cli/regress1/strings/issue6604-2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --re-elim=on
+; COMMAND-LINE: --re-elim=on
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-const a String)

--- a/test/regress/cli/regress1/strings/issue6635-rre.smt2
+++ b/test/regress/cli/regress1/strings/issue6635-rre.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --re-elim=agg
+; COMMAND-LINE: --re-elim=agg
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun a () String)

--- a/test/regress/cli/regress1/strings/issue6653-4-rre.smt2
+++ b/test/regress/cli/regress1/strings/issue6653-4-rre.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --re-elim=agg
+; COMMAND-LINE: --re-elim=agg
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun x () String)

--- a/test/regress/cli/regress1/strings/issue6653-rre-small.smt2
+++ b/test/regress/cli/regress1/strings/issue6653-rre-small.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --strings-fmf --re-elim=agg
+; COMMAND-LINE: --strings-fmf --re-elim=agg
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun a () String)

--- a/test/regress/cli/regress1/strings/issue6653-rre.smt2
+++ b/test/regress/cli/regress1/strings/issue6653-rre.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --re-elim=agg
+; COMMAND-LINE: --re-elim=agg
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun a () String)

--- a/test/regress/cli/regress1/strings/issue6654-indexof_re_red.smt2
+++ b/test/regress/cli/regress1/strings/issue6654-indexof_re_red.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun a () String)

--- a/test/regress/cli/regress1/strings/issue6766-re-elim-bv.smt2
+++ b/test/regress/cli/regress1/strings/issue6766-re-elim-bv.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --re-elim=agg
+; COMMAND-LINE: --re-elim=agg
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun a () String)

--- a/test/regress/cli/regress1/strings/issue6777-seq-nth-eval-cm.smt2
+++ b/test/regress/cli/regress1/strings/issue6777-seq-nth-eval-cm.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/strings/issue6913.smt2
+++ b/test/regress/cli/regress1/strings/issue6913.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 ;; repeated assumption in local proof lead to confusion with
 ;; discharge. Disabling for now while the use of "discharge" is not

--- a/test/regress/cli/regress1/strings/issue6973-dup-lemma-conc.smt2
+++ b/test/regress/cli/regress1/strings/issue6973-dup-lemma-conc.smt2
@@ -1,5 +1,5 @@
-; COMMAND-LINE: --strings-exp
-; COMMAND-LINE: --strings-exp --re-elim=agg
+; COMMAND-LINE:
+; COMMAND-LINE: --re-elim=agg
 (set-logic QF_SLIA)
 (set-info :status unsat)
 (declare-fun a () String)

--- a/test/regress/cli/regress1/strings/issue8094-witness-model.smt2
+++ b/test/regress/cli/regress1/strings/issue8094-witness-model.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp -q
+; COMMAND-LINE: -q
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/strings/issue8347-has-skolem.smt2
+++ b/test/regress/cli/regress1/strings/issue8347-has-skolem.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp -i
+; COMMAND-LINE: -i
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun uf6_2 (Bool Bool Bool Bool Bool Bool) Bool)

--- a/test/regress/cli/regress1/strings/issue8434-nterm-str-rw.smt2
+++ b/test/regress/cli/regress1/strings/issue8434-nterm-str-rw.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun T_7 () String)                                                     

--- a/test/regress/cli/regress1/strings/issue8890-inj-oob.smt2
+++ b/test/regress/cli/regress1/strings/issue8890-inj-oob.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --mbqi --strings-fmf
+; COMMAND-LINE: --mbqi --strings-fmf
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun b (Int) Bool)

--- a/test/regress/cli/regress1/strings/issue8906-oob-exp.smt2
+++ b/test/regress/cli/regress1/strings/issue8906-oob-exp.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unknown
 (set-logic ALL)
 (declare-const x1 Bool)

--- a/test/regress/cli/regress1/strings/issue8915-str-unit-model.smt2
+++ b/test/regress/cli/regress1/strings/issue8915-str-unit-model.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun a () String)

--- a/test/regress/cli/regress1/strings/issue8916-str-unit-pairs.smt2
+++ b/test/regress/cli/regress1/strings/issue8916-str-unit-pairs.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --no-strings-lazy-pp
+; COMMAND-LINE: --no-strings-lazy-pp
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun v () String)

--- a/test/regress/cli/regress1/strings/issue8918-str-nth-crange-red.smt2
+++ b/test/regress/cli/regress1/strings/issue8918-str-nth-crange-red.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --no-strings-lazy-pp
+; COMMAND-LINE: --no-strings-lazy-pp
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun a () String)

--- a/test/regress/cli/regress1/strings/issue9040-re-inter-comp.smt2
+++ b/test/regress/cli/regress1/strings/issue9040-re-inter-comp.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --re-inter=all --strings-exp
+; COMMAND-LINE: --re-inter=all
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun e () String)

--- a/test/regress/cli/regress1/strings/loop007.smt2
+++ b/test/regress/cli/regress1/strings/loop007.smt2
@@ -1,5 +1,5 @@
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 
 (declare-fun x () String)

--- a/test/regress/cli/regress1/strings/loop008.smt2
+++ b/test/regress/cli/regress1/strings/loop008.smt2
@@ -1,5 +1,5 @@
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 
 (declare-fun x () String)

--- a/test/regress/cli/regress1/strings/loop009.smt2
+++ b/test/regress/cli/regress1/strings/loop009.smt2
@@ -1,5 +1,5 @@
 (set-logic QF_S)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 
 (declare-fun x () String)

--- a/test/regress/cli/regress1/strings/no-lazy-pp-quant.smt2
+++ b/test/regress/cli/regress1/strings/no-lazy-pp-quant.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --no-strings-lazy-pp
+; COMMAND-LINE: --no-strings-lazy-pp
 ; EXPECT: sat
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)

--- a/test/regress/cli/regress1/strings/non-terminating-rewrite-aent.smt2
+++ b/test/regress/cli/regress1/strings/non-terminating-rewrite-aent.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/strings/non_termination_regular_expression4.smt2
+++ b/test/regress/cli/regress1/strings/non_termination_regular_expression4.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)
 (set-info :status unsat)
-(set-option :strings-exp true)
+
 (set-option :re-elim on)
 (declare-const actionName String)
 (declare-const actionNamespace String)

--- a/test/regress/cli/regress1/strings/norn-13.smt2
+++ b/test/regress/cli/regress1/strings/norn-13.smt2
@@ -1,5 +1,5 @@
 (set-logic QF_S)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 
 (declare-fun var_0 () String)

--- a/test/regress/cli/regress1/strings/norn-360.smt2
+++ b/test/regress/cli/regress1/strings/norn-360.smt2
@@ -1,6 +1,6 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 
 (declare-fun var_0 () String)

--- a/test/regress/cli/regress1/strings/norn-ab.smt2
+++ b/test/regress/cli/regress1/strings/norn-ab.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic SLIA)
 (set-info :status unsat)
-(set-option :strings-exp true)
+
 
 (declare-fun var_0 () String)
 (declare-fun var_1 () String)

--- a/test/regress/cli/regress1/strings/norn-nel-bug-052116.smt2
+++ b/test/regress/cli/regress1/strings/norn-nel-bug-052116.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_S)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 
 (declare-fun var_0 () String)
 (declare-fun var_1 () String)

--- a/test/regress/cli/regress1/strings/norn-simp-rew-sat.smt2
+++ b/test/regress/cli/regress1/strings/norn-simp-rew-sat.smt2
@@ -1,6 +1,6 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 
 (declare-fun var_0 () String)

--- a/test/regress/cli/regress1/strings/nt6-dd.smt2
+++ b/test/regress/cli/regress1/strings/nt6-dd.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --re-elim=on
+; COMMAND-LINE: --re-elim=on
 ; EXPECT: sat
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)

--- a/test/regress/cli/regress1/strings/nterm-re-inter-sigma.smt2
+++ b/test/regress/cli/regress1/strings/nterm-re-inter-sigma.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (declare-fun x () String)
 
 (assert

--- a/test/regress/cli/regress1/strings/pierre150331.smt2
+++ b/test/regress/cli/regress1/strings/pierre150331.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic SLIA)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (define-fun stringEval ((?s String)) Bool (str.in_re ?s 
 (re.union 
 (str.to_re "H")

--- a/test/regress/cli/regress1/strings/policy_variable.smt2
+++ b/test/regress/cli/regress1/strings/policy_variable.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)
 (set-info :status unsat)
-(set-option :strings-exp true)
+
 (set-option :re-elim on)
 (declare-const actionName String)
 (declare-const actionNamespace String)

--- a/test/regress/cli/regress1/strings/pre_ctn_no_skolem_share.smt2
+++ b/test/regress/cli/regress1/strings/pre_ctn_no_skolem_share.smt2
@@ -1,6 +1,6 @@
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)
-(set-option :strings-exp true)
+
 (set-option :strings-fmf true)
 (set-info :status sat)
 (declare-fun z () String)

--- a/test/regress/cli/regress1/strings/proj-issue281.smt2
+++ b/test/regress/cli/regress1/strings/proj-issue281.smt2
@@ -1,6 +1,6 @@
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (declare-const x Bool)
 (declare-fun c () Int)
 (declare-fun c_ () Int)

--- a/test/regress/cli/regress1/strings/proj-issue331.smt2
+++ b/test/regress/cli/regress1/strings/proj-issue331.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress1/strings/proj-issue502-merge-type.smt2
+++ b/test/regress/cli/regress1/strings/proj-issue502-merge-type.smt2
@@ -2,5 +2,5 @@
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (check-sat-assuming ((seq.nth (seq.unit (is_int (seq.nth (seq.unit real.pi) 1))) (to_int (seq.nth (seq.unit real.pi) 1)))))

--- a/test/regress/cli/regress1/strings/proj254-re-elim-agg.smt2
+++ b/test/regress/cli/regress1/strings/proj254-re-elim-agg.smt2
@@ -1,7 +1,7 @@
 (set-logic ALL)
 (set-info :status sat)
 (set-option :produce-models true)
-(set-option :strings-exp true)
+
 (set-option :re-elim agg)
 (declare-fun a () String)
 (assert (str.in_re a (re.++ (re.+ (str.to_re "AB")) (str.to_re "B"))))

--- a/test/regress/cli/regress1/strings/prop-engine-order.smt2
+++ b/test/regress/cli/regress1/strings/prop-engine-order.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (declare-const x3 Bool)

--- a/test/regress/cli/regress1/strings/query4674.smt2
+++ b/test/regress/cli/regress1/strings/query4674.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (set-option :re-elim off)
 (declare-fun x () String)
 (assert (let ((_let_0 (re.* re.allchar ))) (and (not (= (str.in_re x (re.++ _let_0 re.allchar  _let_0 (str.to_re (str.++ "A" (str.++ "B" (str.++ "C" "A")))) _let_0 re.allchar  _let_0)) (str.in_re x (re.++ _let_0 re.allchar  _let_0 re.allchar  _let_0 (str.to_re (str.++ "B" (str.++ "C" (str.++ "B" "B")))) _let_0)))) (not (= (str.in_re x (re.++ _let_0 re.allchar  _let_0 (str.to_re (str.++ "C" (str.++ "B" "C"))) _let_0 (str.to_re "B") _let_0)) (str.in_re x (re.++ _let_0 re.allchar  _let_0 (str.to_re "C") _let_0 (str.to_re (str.++ "B" (str.++ "C" "B"))) _let_0)))))))

--- a/test/regress/cli/regress1/strings/query8485.smt2
+++ b/test/regress/cli/regress1/strings/query8485.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (set-option :re-elim off)
 (declare-fun x () String)
 (assert (let ((_let_0 (re.* re.allchar ))) (and (not (= (str.in_re x (re.++ _let_0 re.allchar  _let_0 (str.to_re (str.++ "B" (str.++ "A" (str.++ "C" "B")))) _let_0 re.allchar  _let_0)) (str.in_re x (re.++ _let_0 re.allchar  _let_0 (str.to_re (str.++ "A" (str.++ "B" (str.++ "C" "C")))) _let_0 re.allchar  _let_0)))) (not (= (str.in_re x (re.++ _let_0 re.allchar  _let_0 (str.to_re (str.++ "C" (str.++ "B" (str.++ "A" "B")))) _let_0 re.allchar  _let_0)) (str.in_re x (re.++ _let_0 re.allchar  _let_0 (str.to_re (str.++ "C" (str.++ "B" "A"))) _let_0 (str.to_re "B") _let_0)))))))

--- a/test/regress/cli/regress1/strings/re-agg-total1.smt2
+++ b/test/regress/cli/regress1/strings/re-agg-total1.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_SLIA)
 (set-info :status unsat)
-(set-option :strings-exp true)
+
 (set-option :re-elim agg)
 (declare-const x String)
 (declare-const y String)

--- a/test/regress/cli/regress1/strings/re-agg-total2.smt2
+++ b/test/regress/cli/regress1/strings/re-agg-total2.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)
 (set-info :status unsat)
-(set-option :strings-exp true)
+
 (set-option :re-elim agg)
 (declare-const x String)
 (declare-const y String)

--- a/test/regress/cli/regress1/strings/re-elim-exact.smt2
+++ b/test/regress/cli/regress1/strings/re-elim-exact.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (set-option :re-elim on)
 (declare-fun x () String)
 

--- a/test/regress/cli/regress1/strings/re-mod-eq.smt2
+++ b/test/regress/cli/regress1/strings/re-mod-eq.smt2
@@ -1,6 +1,6 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-info :status unsat)
 (declare-fun x () String)
 (declare-fun y () String)

--- a/test/regress/cli/regress1/strings/re-neg-concat-reduct.smt2
+++ b/test/regress/cli/regress1/strings/re-neg-concat-reduct.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_S)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 
 (declare-fun x () String)
 

--- a/test/regress/cli/regress1/strings/re-neg-unfold-rev-a.smt2
+++ b/test/regress/cli/regress1/strings/re-neg-unfold-rev-a.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_S)
 (set-info :status unsat)
-(set-option :strings-exp true)
+
 
 (declare-const x String)
 (declare-const y String)

--- a/test/regress/cli/regress1/strings/re-unsound-080718.smt2
+++ b/test/regress/cli/regress1/strings/re-unsound-080718.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)

--- a/test/regress/cli/regress1/strings/regexp-050-multiply-graft-fuzz-dd.smt2
+++ b/test/regress/cli/regress1/strings/regexp-050-multiply-graft-fuzz-dd.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress1/strings/regexp-strat-fix.smt2
+++ b/test/regress/cli/regress1/strings/regexp-strat-fix.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_S)
 (set-info :status unsat)
-(set-option :strings-exp true)
+
 (declare-fun var0 () String)
 (assert (str.in_re var0 (re.* (re.* (str.to_re "0")))))
 (assert (not (str.in_re var0 (re.union (re.+ (str.to_re "0")) (re.* (str.to_re "1"))))))

--- a/test/regress/cli/regress1/strings/regexp001.smt2
+++ b/test/regress/cli/regress1/strings/regexp001.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_S)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 
 (declare-fun x () String)
 

--- a/test/regress/cli/regress1/strings/regexp002.smt2
+++ b/test/regress/cli/regress1/strings/regexp002.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_S)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 
 (declare-fun x () String)
 (declare-fun y () String)

--- a/test/regress/cli/regress1/strings/regexp003.smt2
+++ b/test/regress/cli/regress1/strings/regexp003.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_S)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 
 (declare-const s String)
 

--- a/test/regress/cli/regress1/strings/reloop.smt2
+++ b/test/regress/cli/regress1/strings/reloop.smt2
@@ -1,6 +1,6 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 
 (declare-fun x () String)

--- a/test/regress/cli/regress1/strings/repl-empty-sem.smt2
+++ b/test/regress/cli/regress1/strings/repl-empty-sem.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/strings/repl-soundness-sem.smt2
+++ b/test/regress/cli/regress1/strings/repl-soundness-sem.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress1/strings/replaceall-len.smt2
+++ b/test/regress/cli/regress1/strings/replaceall-len.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (set-option :strings-fmf true)
 (set-option :produce-models true)
 (declare-fun x () String)

--- a/test/regress/cli/regress1/strings/replaceall-replace.smt2
+++ b/test/regress/cli/regress1/strings/replaceall-replace.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (set-option :strings-fmf true)
 (set-option :produce-models true)
 (declare-fun x () String)

--- a/test/regress/cli/regress1/strings/rev-conv1.smt2
+++ b/test/regress/cli/regress1/strings/rev-conv1.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/strings/rev-ex1.smt2
+++ b/test/regress/cli/regress1/strings/rev-ex1.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/strings/rev-ex2.smt2
+++ b/test/regress/cli/regress1/strings/rev-ex2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress1/strings/rev-ex3.smt2
+++ b/test/regress/cli/regress1/strings/rev-ex3.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress1/strings/rev-ex4.smt2
+++ b/test/regress/cli/regress1/strings/rev-ex4.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --strings-fmf
+; COMMAND-LINE: --strings-fmf
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress1/strings/rev-ex5.smt2
+++ b/test/regress/cli/regress1/strings/rev-ex5.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/strings/rew-020618.smt2
+++ b/test/regress/cli/regress1/strings/rew-020618.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress1/strings/seq-quant-infinite-branch.smt2
+++ b/test/regress/cli/regress1/strings/seq-quant-infinite-branch.smt2
@@ -1,7 +1,7 @@
 (set-logic ALL)
 (set-info :status unsat)
 (declare-const x8 Bool)
-(set-option :strings-exp true)
+
 (declare-fun s () (Seq Int))
 (declare-fun x () Int)
 (declare-fun i () Int)

--- a/test/regress/cli/regress1/strings/seq-skeleton-gap.smt2
+++ b/test/regress/cli/regress1/strings/seq-skeleton-gap.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy
+; COMMAND-LINE: --seq-array=lazy
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun a () (Seq Int))

--- a/test/regress/cli/regress1/strings/stoi-400million.smt2
+++ b/test/regress/cli/regress1/strings/stoi-400million.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --no-jh-rlv-order
+; COMMAND-LINE: --no-jh-rlv-order
 ; EXPECT: sat
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)

--- a/test/regress/cli/regress1/strings/stoi-solve.smt2
+++ b/test/regress/cli/regress1/strings/stoi-solve.smt2
@@ -1,6 +1,6 @@
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (declare-fun x () String)
 (assert (= (str.to_int x) 12345)) 
 (check-sat)

--- a/test/regress/cli/regress1/strings/str-rev-simple-s.smt2
+++ b/test/regress/cli/regress1/strings/str-rev-simple-s.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/strings/string-unsound-sem.smt2
+++ b/test/regress/cli/regress1/strings/string-unsound-sem.smt2
@@ -1,6 +1,6 @@
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-fun x () String)
 (declare-fun y () String)

--- a/test/regress/cli/regress1/strings/strings-index-empty.smt2
+++ b/test/regress/cli/regress1/strings/strings-index-empty.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --simplification=none --strings-exp --no-strings-lazy-pp
+; COMMAND-LINE: --simplification=none --no-strings-lazy-pp
 ; EXPECT: sat
 (set-logic SLIA)
 (set-info :status sat)

--- a/test/regress/cli/regress1/strings/strings-leq-trans-unsat.smt2
+++ b/test/regress/cli/regress1/strings/strings-leq-trans-unsat.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 ; DISABLE-TESTER: unsat-core
 ; timeout with unsat cores

--- a/test/regress/cli/regress1/strings/strings-lt-len5.smt2
+++ b/test/regress/cli/regress1/strings/strings-lt-len5.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_SLIA)
 (set-info :status sat)

--- a/test/regress/cli/regress1/strings/strings-lt-simple.smt2
+++ b/test/regress/cli/regress1/strings/strings-lt-simple.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_SLIA)
 (set-info :status sat)

--- a/test/regress/cli/regress1/strings/strip-endpt-sound.smt2
+++ b/test/regress/cli/regress1/strings/strip-endpt-sound.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_S)
 (declare-fun x () String)

--- a/test/regress/cli/regress1/strings/substr001.smt2
+++ b/test/regress/cli/regress1/strings/substr001.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (set-info :status sat)
 

--- a/test/regress/cli/regress1/strings/timeout-no-resp.smt2
+++ b/test/regress/cli/regress1/strings/timeout-no-resp.smt2
@@ -1,6 +1,6 @@
 (set-logic SLIA)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (declare-const x String)
 (declare-const y String)
 (assert (not (= (str.replace "A" (str.replace x "A" y) x) (str.replace "A" x (str.replace x y x)))))

--- a/test/regress/cli/regress1/strings/to_upper_12.smt2
+++ b/test/regress/cli/regress1/strings/to_upper_12.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy
+; COMMAND-LINE: --seq-array=lazy
 ; EXPECT: sat
 (set-logic QF_SLIA)
 (declare-const X String)

--- a/test/regress/cli/regress1/strings/to_upper_over_concat.smt2
+++ b/test/regress/cli/regress1/strings/to_upper_over_concat.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --seq-array=lazy
+; COMMAND-LINE: --seq-array=lazy
 ; EXPECT: sat
 (set-logic QF_SLIA)
 (declare-const x String)

--- a/test/regress/cli/regress1/strings/tolower-find.smt2
+++ b/test/regress/cli/regress1/strings/tolower-find.smt2
@@ -1,5 +1,5 @@
 (set-logic ALL)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-const x String)
 (declare-const y String)

--- a/test/regress/cli/regress1/strings/type002.smt2
+++ b/test/regress/cli/regress1/strings/type002.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_SLIA)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 
 (declare-fun x () String)
 (declare-fun y () String)

--- a/test/regress/cli/regress1/strings/type003.smt2
+++ b/test/regress/cli/regress1/strings/type003.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_SLIA)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 
 (declare-fun i () Int)
 (declare-fun s () String)

--- a/test/regress/cli/regress1/strings/update-ex1.smt2
+++ b/test/regress/cli/regress1/strings/update-ex1.smt2
@@ -1,5 +1,5 @@
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-fun s () String)
 

--- a/test/regress/cli/regress1/strings/update-ex2.smt2
+++ b/test/regress/cli/regress1/strings/update-ex2.smt2
@@ -1,5 +1,5 @@
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-info :status unsat)
 (declare-fun s () String)
 

--- a/test/regress/cli/regress1/strings/username_checker_min.smt2
+++ b/test/regress/cli/regress1/strings/username_checker_min.smt2
@@ -1,6 +1,6 @@
 (set-info :smt-lib-version 2.6)
 (set-logic QF_S)
-(set-option :strings-exp true)
+
 (set-info :status unsat)
 
 (declare-const buff String)

--- a/test/regress/cli/regress1/strings/witness-model.smt2
+++ b/test/regress/cli/regress1/strings/witness-model.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp -q
+; COMMAND-LINE: -q
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/sygus/issue3247.smt2
+++ b/test/regress/cli/regress1/sygus/issue3247.smt2
@@ -1,5 +1,5 @@
 ; EXPECT: unsat
-; COMMAND-LINE: --sygus-inference=try --strings-exp -q
+; COMMAND-LINE: --sygus-inference=try -q
 ; DISABLE-TESTER: unsat-core
 ; DISABLE-TESTER: proof
 (set-logic ALL)

--- a/test/regress/cli/regress1/sygus/issue8976-interp-check.smt2
+++ b/test/regress/cli/regress1/sygus/issue8976-interp-check.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --produce-interpolants -q --strings-exp --check-models
+; COMMAND-LINE: --produce-interpolants -q --check-models
 ; EXPECT: fail
 (set-logic ALL)
 (declare-fun a () String)                                                       

--- a/test/regress/cli/regress1/sygus/proj-issue183.smt2
+++ b/test/regress/cli/regress1/sygus/proj-issue183.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-option :sygus-inference try)

--- a/test/regress/cli/regress1/sygus/rex-strings-alarm.sy
+++ b/test/regress/cli/regress1/sygus/rex-strings-alarm.sy
@@ -1,5 +1,5 @@
 ; EXPECT: feasible
-; COMMAND-LINE: --sygus-out=status --lang=sygus2 --strings-exp
+; COMMAND-LINE: --sygus-out=status --lang=sygus2
 
 (set-logic S)
 

--- a/test/regress/cli/regress2/seq/err-model-soundness.smt2
+++ b/test/regress/cli/regress2/seq/err-model-soundness.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic ALL)
 (declare-sort E 0)
 (declare-fun x () (Seq E))

--- a/test/regress/cli/regress2/strings/bidir_star.smt2
+++ b/test/regress/cli/regress2/strings/bidir_star.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic SLIA)
 (declare-fun a () String)
 (assert (>= (str.len a) 2))

--- a/test/regress/cli/regress2/strings/cmi-split-cm-fail.smt2
+++ b/test/regress/cli/regress2/strings/cmi-split-cm-fail.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-info :smt-lib-version 2.6)
 (set-logic QF_SLIA)

--- a/test/regress/cli/regress2/strings/cmu-dis-0707-3.smt2
+++ b/test/regress/cli/regress2/strings/cmu-dis-0707-3.smt2
@@ -2,7 +2,7 @@
 (set-logic ALL)
 (set-info :status sat)
 (set-info :smt-lib-version 2.6)
-(set-option :strings-exp true)
+
 (declare-fun value () String)
 (declare-fun name () String)
 (assert (not (not (not (= (ite (str.contains value "?") 1 0) 0))))) 

--- a/test/regress/cli/regress2/strings/cmu-disagree-0707-dd.smt2
+++ b/test/regress/cli/regress2/strings/cmu-disagree-0707-dd.smt2
@@ -1,6 +1,6 @@
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (set-option :strings-fmf true)
 
 

--- a/test/regress/cli/regress2/strings/cmu-prereg-fmf.smt2
+++ b/test/regress/cli/regress2/strings/cmu-prereg-fmf.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --strings-fmf
+; COMMAND-LINE: --strings-fmf
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress2/strings/cmu-repl-len-nterm.smt2
+++ b/test/regress/cli/regress2/strings/cmu-repl-len-nterm.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress2/strings/dd.trust-subs.smt2
+++ b/test/regress/cli/regress2/strings/dd.trust-subs.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun x () String)

--- a/test/regress/cli/regress2/strings/issue3203.smt2
+++ b/test/regress/cli/regress2/strings/issue3203.smt2
@@ -1,7 +1,7 @@
 ; Temporarily disable checking of unsat cores (see issue #3606)
 ; DISABLE-TESTER: unsat-core
 (set-logic ALL)
-(set-option :strings-exp true)
+
 (set-info :status unsat)
 (declare-fun a () String)
 (declare-fun b () String)

--- a/test/regress/cli/regress2/strings/issue5381.smt2
+++ b/test/regress/cli/regress2/strings/issue5381.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-fmf --strings-exp
+; COMMAND-LINE: --strings-fmf
 ; EXPECT: sat
 (set-logic QF_SLIA)
 (set-info :status sat)

--- a/test/regress/cli/regress2/strings/issue6057-replace-re-all-simplified.smt2
+++ b/test/regress/cli/regress2/strings/issue6057-replace-re-all-simplified.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (declare-fun literal_5 () String)                                               
 (assert (not (=

--- a/test/regress/cli/regress2/strings/issue6057-replace-re-all.smt2
+++ b/test/regress/cli/regress2/strings/issue6057-replace-re-all.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --no-jh-rlv-order
+; COMMAND-LINE: --no-jh-rlv-order
 (set-logic QF_SLIA)
 (declare-fun literal_0 () String)
 (assert (and (str.<= (str.++ literal_0 "\u{2f}\u{71}\u{75}\u{65}\u{73}\u{74}\u{69}\u{6f}\u{6e}\u{2f}\u{74}\u{79}\u{70}\u{65}\u{2f}\u{6e}\u{75}\u{6d}\u{65}\u{72}\u{69}\u{63}\u{61}\u{6c}\u{2f}\u{65}\u{64}\u{69}\u{74}\u{71}\u{75}\u{65}\u{73}\u{74}\u{69}\u{6f}\u{6e}\u{2e}\u{68}\u{74}\u{6d}\u{6c}") 

--- a/test/regress/cli/regress2/strings/issue6636-replace-re-all.smt2
+++ b/test/regress/cli/regress2/strings/issue6636-replace-re-all.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (declare-fun a () String)
 (assert (not (= a (str.replace_re_all a (re.++ (re.* re.allchar) (str.to_re a) (re.* re.allchar)) a))))

--- a/test/regress/cli/regress2/strings/issue6637-replace-re-all.smt2
+++ b/test/regress/cli/regress2/strings/issue6637-replace-re-all.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (declare-fun a () String)
 (assert (= (str.len a) 2))

--- a/test/regress/cli/regress2/strings/issue918.smt2
+++ b/test/regress/cli/regress2/strings/issue918.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --re-elim=on
+; COMMAND-LINE: --re-elim=on
 ; EXPECT: sat
 (set-info :smt-lib-version 2.6)
 (set-option :produce-models true)

--- a/test/regress/cli/regress2/strings/non_termination_regular_expression6.smt2
+++ b/test/regress/cli/regress2/strings/non_termination_regular_expression6.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --re-elim=on
+; COMMAND-LINE: --re-elim=on
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress2/strings/range-perf.smt2
+++ b/test/regress/cli/regress2/strings/range-perf.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: sat
 (set-logic QF_SLIA)
 (declare-const x String)

--- a/test/regress/cli/regress2/strings/repl-repl-i-no-push.smt2
+++ b/test/regress/cli/regress2/strings/repl-repl-i-no-push.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --strings-fmf --incremental
+; COMMAND-LINE: --strings-fmf --incremental
 ; EXPECT: sat
 ; EXPECT: unsat
 ; EXPECT: sat

--- a/test/regress/cli/regress2/strings/repl-repl.smt2
+++ b/test/regress/cli/regress2/strings/repl-repl.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --strings-fmf --incremental
+; COMMAND-LINE: --strings-fmf --incremental
 ; EXPECT: sat
 ; EXPECT: unsat
 ; EXPECT: sat

--- a/test/regress/cli/regress2/strings/replace_re.smt2
+++ b/test/regress/cli/regress2/strings/replace_re.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-option :incremental true)
 (set-logic SLIA)
 (declare-const x String)

--- a/test/regress/cli/regress2/strings/replaceall-diffrange.smt2
+++ b/test/regress/cli/regress2/strings/replaceall-diffrange.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (set-option :strings-fmf true)
 (declare-fun x () String)
 (declare-fun y () String)

--- a/test/regress/cli/regress2/strings/replaceall-len-c.smt2
+++ b/test/regress/cli/regress2/strings/replaceall-len-c.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (set-option :strings-fmf true)
 (declare-fun x () String)
 (assert (= (str.len (str.replace_all "ABBABAAB" x "C")) 5))

--- a/test/regress/cli/regress2/strings/small-1.smt2
+++ b/test/regress/cli/regress2/strings/small-1.smt2
@@ -1,7 +1,7 @@
 (set-info :smt-lib-version 2.6)
 (set-logic ALL)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (set-option :re-elim on)
 (declare-const x String)
 (assert (str.in_re x (re.++ (str.to_re "example-bucket/") (re.* re.allchar) (str.to_re "/") re.allchar re.allchar re.allchar re.allchar re.allchar re.allchar re.allchar re.allchar (str.to_re "-") re.allchar re.allchar re.allchar re.allchar (str.to_re "-") re.allchar re.allchar re.allchar re.allchar (str.to_re "-") re.allchar re.allchar re.allchar re.allchar (str.to_re "-") re.allchar re.allchar re.allchar re.allchar re.allchar re.allchar re.allchar re.allchar re.allchar re.allchar re.allchar re.allchar (str.to_re "/foo"))))

--- a/test/regress/cli/regress2/strings/update-ex3.smt2
+++ b/test/regress/cli/regress2/strings/update-ex3.smt2
@@ -1,5 +1,5 @@
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-fun s () String)
 (declare-fun x () Int)

--- a/test/regress/cli/regress2/strings/update-ex4-seq.smt2
+++ b/test/regress/cli/regress2/strings/update-ex4-seq.smt2
@@ -1,5 +1,5 @@
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-info :status sat)
 (declare-fun s () (Seq Int))
 (declare-fun x () Int)

--- a/test/regress/cli/regress3/bags/reduce_constants_dup.smt2
+++ b/test/regress/cli/regress3/bags/reduce_constants_dup.smt2
@@ -12,7 +12,7 @@
 (set-option :uf-lazy-ll true)
 (set-option :fmf-bound true)
 (set-option :tlimit-per 10000)
-(set-option :strings-exp true)
+
 
 (declare-const EMP (Bag (Tuple (Nullable Int) (Nullable String) (Nullable String) (Nullable Int) (Nullable Int) (Nullable Int) (Nullable Int) (Nullable Int) (Nullable Int))))
 (declare-const q1 (Bag (Tuple (Nullable Int) (Nullable String) (Nullable String) (Nullable Int) (Nullable Int) (Nullable Int) (Nullable Int) (Nullable Int) (Nullable Int))))

--- a/test/regress/cli/regress3/strings/extf_d_perf.smt2
+++ b/test/regress/cli/regress3/strings/extf_d_perf.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --strings-fmf
+; COMMAND-LINE: --strings-fmf
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun _substvar_140_ () String)

--- a/test/regress/cli/regress3/strings/indexof_re_red.smt2
+++ b/test/regress/cli/regress3/strings/indexof_re_red.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-logic QF_SLIA)
 (declare-const x String)
 (declare-const i Int)

--- a/test/regress/cli/regress3/strings/norn-dis-0707-3.smt2
+++ b/test/regress/cli/regress3/strings/norn-dis-0707-3.smt2
@@ -1,6 +1,6 @@
 (set-logic QF_S)
 (set-info :status sat)
-(set-option :strings-exp true)
+
 (set-option :strings-fmf true)
 
 (declare-fun var_0 () String)

--- a/test/regress/cli/regress3/strings/replace_re_all.smt2
+++ b/test/regress/cli/regress3/strings/replace_re_all.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 (set-option :incremental true)
 (set-logic SLIA)
 (declare-const x String)

--- a/test/regress/cli/regress4/issue2429.smt2
+++ b/test/regress/cli/regress4/issue2429.smt2
@@ -1,5 +1,5 @@
 (set-logic QF_SLIA)
-(set-option :strings-exp true)
+
 (set-option :produce-models true)
 (set-info :status sat)
 

--- a/test/regress/cli/regress4/unsat-circ-reduce.smt2
+++ b/test/regress/cli/regress4/unsat-circ-reduce.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp
+; COMMAND-LINE:
 ; EXPECT: unsat
 (set-logic QF_SLIA)
 (set-info :status unsat)


### PR DESCRIPTION
This is a deprecated option that is enabled by default in applicable logics. It is classified as "regular" meaning that it impacts `--safe-options`.

This removes `--strings-exp` from our regressions, thus making more regressions legal for safe options.  The motivation is to increase our testing coverage for safe-options.