### PR TITLE
Add Eunoia definition of ARITH_REDUCTION

### DIFF
--- a/proofs/eo/cpc/rules/Arith.eo
+++ b/proofs/eo/cpc/rules/Arith.eo
@@ -259,7 +259,7 @@
 ; - r Real: The argument to to_int.
 ; return: the reduction predicate for (to_int r).
 (define $arith_to_int_reduction ((r Real))
-  (eo::define ((k (to_real (@purify (to_int r)))))
+  (eo::define ((k (@purify (to_int r))))
     (and (<= 0/1 (- r k)) (< (- r k) 1/1))))
 
 ; define: $arith_int_div_total_reduction
@@ -288,7 +288,7 @@
   (eo::match ((r Real) (U Type) (u U) (V Type) (v V))
     t
     (
-    ((is_int r)       (eo::define ((k (to_real (@purify (to_int r)))))
+    ((is_int r)       (eo::define ((k (@purify (to_int r))))
                         (and (= t (= (- r k) 0/1)) ($arith_to_int_reduction r))))
     ((to_int r)       (eo::define ((k (@purify (to_int r))))
                         (and (= t k) ($arith_to_int_reduction r))))

--- a/proofs/eo/cpc/rules/Arith.eo
+++ b/proofs/eo/cpc/rules/Arith.eo
@@ -259,7 +259,7 @@
 ; - r Real: The argument to to_int.
 ; return: the reduction predicate for (to_int r).
 (define $arith_to_int_reduction ((r Real))
-  (eo::define ((k (@purify (to_int r))))
+  (eo::define ((k (to_real (@purify (to_int r)))))
     (and (<= 0/1 (- r k)) (< (- r k) 1/1))))
 
 ; define: $arith_int_div_total_reduction
@@ -288,7 +288,7 @@
   (eo::match ((r Real) (U Type) (u U) (V Type) (v V))
     t
     (
-    ((is_int r)       (eo::define ((k (@purify (to_int r))))
+    ((is_int r)       (eo::define ((k (to_real (@purify (to_int r)))))
                         (and (= t (= (- r k) 0/1)) ($arith_to_int_reduction r))))
     ((to_int r)       (eo::define ((k (@purify (to_int r))))
                         (and (= t k) ($arith_to_int_reduction r))))

--- a/proofs/eo/cpc/rules/Arith.eo
+++ b/proofs/eo/cpc/rules/Arith.eo
@@ -292,7 +292,7 @@
                         (and (= t (= (- r k) 0/1)) ($arith_to_int_reduction r))))
     ((to_int r)       (eo::define ((k (@purify (to_int r))))
                         (and (= t k) ($arith_to_int_reduction r))))
-    ((/ u v)          (= (/ u v) (ite (= v ($arith_mk_zero (eo::typeof v))) (@div_by_zero u) (/_total u v))))
+    ((/ u v)          (= t (ite (= v ($arith_mk_zero (eo::typeof v))) (@div_by_zero u) (/_total u v))))
     ((div u v)        (= t (ite (= v 0) (@int_div_by_zero u) (div_total u v))))
     ((mod u v)        (= t (ite (= v 0) (@mod_by_zero u) (mod_total u v))))
     ((/_total u v)    (eo::define ((k (@purify (/_total u v))))

--- a/proofs/eo/cpc/rules/Arith.eo
+++ b/proofs/eo/cpc/rules/Arith.eo
@@ -254,21 +254,33 @@
 
 ;;;;; ProofRule::ARITH_REDUCTION
 
+; define: $arith_to_int_reduction
+; args:
+; - r Real: The argument to to_int.
+; return: the reduction predicate for (to_int r).
 (define $arith_to_int_reduction ((r Real))
   (eo::define ((k (@purify (to_int r))))
     (and (<= 0/1 (- r k)) (< (- r k) 1/1))))
 
+; define: $arith_int_div_total_reduction
+; args:
+; - u Int: The first argument to div_total.
+; - v Int: The second argument to div_total.
+; return: the reduction predicate for (div_total u v).
+; note: >
+;   We use an optimized form of the lemma when v is a non-zero constant.
+;   This method does not evaluate if v is the constant zero.
 (define $arith_int_div_total_reduction ((u Int) (v Int))
   (eo::define ((k (@purify (div_total u v))))
   (eo::define ((lb (<= (* v k) u)))
   (eo::ite (eo::is_z v)
     (eo::requires (eo::is_eq v 0) false
-    (and lb (< u (* v (+ k (eo::ite (eo::is_neg v) -1 1))))))
+      (and lb (< u (* v (+ k (eo::ite (eo::is_neg v) -1 1))))))
     (and
       (=> (> v 0) (and lb (< u (* v (+ k 1)))))
       (=> (< v 0) (and lb (< u (* v (+ k -1))))))))))
 
-; program: $arith_reduction_pred
+; define: $arith_reduction_pred
 ; args:
 ; - t T: The term we are considering, which is expected to be an application of an extended arithmetic operator.
 ; return: the reduction predicate for term t.

--- a/proofs/eo/cpc/rules/Arith.eo
+++ b/proofs/eo/cpc/rules/Arith.eo
@@ -260,13 +260,13 @@
 
 (define $arith_int_div_total_reduction ((u Int) (v Int))
   (eo::define ((k (@purify (div_total u v))))
-  (eo::define ((leq (<= (* v k) u)))
+  (eo::define ((lb (<= (* v k) u)))
   (eo::ite (eo::is_z v)
     (eo::requires (eo::is_eq v 0) false
-    (and leq (< u (* v (+ k (eo::ite (eo::is_neg v) -1 1))))))
+    (and lb (< u (* v (+ k (eo::ite (eo::is_neg v) -1 1))))))
     (and
-      (=> (> v 0) (and leq (< u (* v (+ k 1)))))
-      (=> (< v 0) (and leq (< u (* v (+ k -1))))))))))
+      (=> (> v 0) (and lb (< u (* v (+ k 1)))))
+      (=> (< v 0) (and lb (< u (* v (+ k -1))))))))))
 
 ; program: $arith_reduction_pred
 ; args:
@@ -277,10 +277,10 @@
     t
     (
     ((is_int r)       (eo::define ((k (@purify (to_int r))))
-                        (and (= t (= r k)) ($arith_to_int_reduction r))))
+                        (and (= t (= (- r k) 0/1)) ($arith_to_int_reduction r))))
     ((to_int r)       (eo::define ((k (@purify (to_int r))))
                         (and (= t k) ($arith_to_int_reduction r))))
-    ((/ u v)          (= t (ite (= v ($arith_mk_zero (eo::typeof v))) (@div_by_zero u) (/_total u v))))
+    ((/ u v)          (= (/ u v) (ite (= v ($arith_mk_zero (eo::typeof v))) (@div_by_zero u) (/_total u v))))
     ((div u v)        (= t (ite (= v 0) (@int_div_by_zero u) (div_total u v))))
     ((mod u v)        (= t (ite (= v 0) (@mod_by_zero u) (mod_total u v))))
     ((/_total u v)    (eo::define ((k (@purify (/_total u v))))
@@ -289,7 +289,7 @@
                         (and (= t k) ($arith_int_div_total_reduction u v))))
     ((mod_total u v)  (eo::define ((k (@purify (div_total u v))))
                         (and (= t (- u (* v k))) ($arith_int_div_total_reduction u v))))
-    ((abs u)          (= t (ite (< ($arith_mk_zero (eo::typeof u)) u) u (- u))))
+    ((abs u)          (= t (ite (< u ($arith_mk_zero (eo::typeof u))) (- u) u)))
     )
   )
 )

--- a/proofs/eo/cpc/rules/Arith.eo
+++ b/proofs/eo/cpc/rules/Arith.eo
@@ -251,3 +251,55 @@
   :premises ((> s t))
   :conclusion (>= s ($least_int_gt t))
 )
+
+;;;;; ProofRule::ARITH_REDUCTION
+
+(define $arith_to_int_reduction ((r Real))
+  (eo::define ((k (@purify (to_int r))))
+    (and (<= 0/1 (- r k)) (< (- r k) 1/1))))
+
+(define $arith_int_div_total_reduction ((u Int) (v Int))
+  (eo::define ((k (@purify (div_total u v))))
+  (eo::define ((leq (<= (* v k) u)))
+  (eo::ite (eo::is_z v)
+    (eo::requires (eo::is_eq v 0) false
+    (and leq (< u (* v (+ k (eo::ite (eo::is_neg v) -1 1))))))
+    (and
+      (=> (> v 0) (and leq (< u (* v (+ k 1)))))
+      (=> (< v 0) (and leq (< u (* v (+ k -1))))))))))
+
+; program: $arith_reduction_pred
+; args:
+; - t T: The term we are considering, which is expected to be an application of an extended arithmetic operator.
+; return: the reduction predicate for term t.
+(define $arith_reduction_pred ((T Type :implicit) (t T))
+  (eo::match ((r Real) (U Type) (u U) (V Type) (v V))
+    t
+    (
+    ((is_int r)       (eo::define ((k (@purify (to_int r))))
+                        (and (= t (= r k)) ($arith_to_int_reduction r))))
+    ((to_int r)       (eo::define ((k (@purify (to_int r))))
+                        (and (= t k) ($arith_to_int_reduction r))))
+    ((/ u v)          (= t (ite (= v ($arith_mk_zero (eo::typeof v))) (@div_by_zero u) (/_total u v))))
+    ((div u v)        (= t (ite (= v 0) (@int_div_by_zero u) (div_total u v))))
+    ((mod u v)        (= t (ite (= v 0) (@mod_by_zero u) (mod_total u v))))
+    ((/_total u v)    (eo::define ((k (@purify (/_total u v))))
+                        (and (= t k) (=> (not (= v ($arith_mk_zero (eo::typeof v)))) (= (* v k) u)))))
+    ((div_total u v)  (eo::define ((k (@purify (div_total u v))))
+                        (and (= t k) ($arith_int_div_total_reduction u v))))
+    ((mod_total u v)  (eo::define ((k (@purify (div_total u v))))
+                        (and (= t (- u (* v k))) ($arith_int_div_total_reduction u v))))
+    ((abs u)          (= t (ite (< ($arith_mk_zero (eo::typeof u)) u) u (- u))))
+    )
+  )
+)
+
+; rule: arith_reduction
+; implements: ProofRule::ARITH_REDUCTION
+; args:
+; - t T: The term we are considering, which is expected to be an application of an extended arithmetic operator.
+; conclusion: The reduction predicate for t.
+(declare-rule arith_reduction ((T Type) (t T))
+  :args (t)
+  :conclusion ($arith_reduction_pred t)
+)

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -207,8 +207,8 @@ bool AlfPrinter::isHandled(const ProofNode* pfn) const
     break;
     case ProofRule::ARITH_REDUCTION:
     {
-      // FIXME
-      return true;
+      Kind k = pargs[0].getKind();
+      return k==Kind::TO_INTEGER || k==Kind::IS_INTEGER || k==Kind::DIVISION || k==Kind::DIVISION_TOTAL || k==Kind::INTS_DIVISION || k==Kind::INTS_DIVISION_TOTAL || k==Kind::INTS_MODULUS || k==Kind::INTS_MODULUS_TOTAL || k==Kind::ABS;
     }
     break;
     case ProofRule::STRING_REDUCTION:

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -205,6 +205,12 @@ bool AlfPrinter::isHandled(const ProofNode* pfn) const
       return res[0][0].getType().isRealOrInt();
     }
     break;
+    case ProofRule::ARITH_REDUCTION:
+    {
+      // FIXME
+      return true;
+    }
+    break;
     case ProofRule::STRING_REDUCTION:
     {
       // depends on the operator

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -208,7 +208,11 @@ bool AlfPrinter::isHandled(const ProofNode* pfn) const
     case ProofRule::ARITH_REDUCTION:
     {
       Kind k = pargs[0].getKind();
-      return k==Kind::TO_INTEGER || k==Kind::IS_INTEGER || k==Kind::DIVISION || k==Kind::DIVISION_TOTAL || k==Kind::INTS_DIVISION || k==Kind::INTS_DIVISION_TOTAL || k==Kind::INTS_MODULUS || k==Kind::INTS_MODULUS_TOTAL || k==Kind::ABS;
+      return k == Kind::TO_INTEGER || k == Kind::IS_INTEGER
+             || k == Kind::DIVISION || k == Kind::DIVISION_TOTAL
+             || k == Kind::INTS_DIVISION || k == Kind::INTS_DIVISION_TOTAL
+             || k == Kind::INTS_MODULUS || k == Kind::INTS_MODULUS_TOTAL
+             || k == Kind::ABS;
     }
     break;
     case ProofRule::STRING_REDUCTION:

--- a/src/theory/arith/operator_elim.cpp
+++ b/src/theory/arith/operator_elim.cpp
@@ -149,32 +149,16 @@ Node OperatorElim::eliminateOperators(NodeManager* nm,
       {
         const Rational& rat = den.getConst<Rational>();
         Assert(!num.isConst() && rat.sgn() != 0);
-        if (rat > 0)
-        {
-          lem = nm->mkNode(
-              Kind::AND,
-              leqNum,
-              nm->mkNode(
-                  Kind::LT,
-                  num,
-                  nm->mkNode(
-                      Kind::MULT,
-                      den,
-                      nm->mkNode(Kind::ADD, v, nm->mkConstInt(Rational(1))))));
-        }
-        else
-        {
-          lem = nm->mkNode(
-              Kind::AND,
-              leqNum,
-              nm->mkNode(
-                  Kind::LT,
-                  num,
-                  nm->mkNode(
-                      Kind::MULT,
-                      den,
-                      nm->mkNode(Kind::ADD, v, nm->mkConstInt(Rational(-1))))));
-        }
+        lem = nm->mkNode(
+            Kind::AND,
+            leqNum,
+            nm->mkNode(
+                Kind::LT,
+                num,
+                nm->mkNode(
+                    Kind::MULT,
+                    den,
+                    nm->mkNode(Kind::ADD, v, nm->mkConstInt(Rational( rat > 0 ? 1 : -1))))));
       }
       else
       {

--- a/src/theory/arith/operator_elim.cpp
+++ b/src/theory/arith/operator_elim.cpp
@@ -158,7 +158,9 @@ Node OperatorElim::eliminateOperators(NodeManager* nm,
                 nm->mkNode(
                     Kind::MULT,
                     den,
-                    nm->mkNode(Kind::ADD, v, nm->mkConstInt(Rational( rat > 0 ? 1 : -1))))));
+                    nm->mkNode(Kind::ADD,
+                               v,
+                               nm->mkConstInt(Rational(rat > 0 ? 1 : -1))))));
       }
       else
       {

--- a/src/theory/arith/operator_elim.cpp
+++ b/src/theory/arith/operator_elim.cpp
@@ -118,7 +118,7 @@ Node OperatorElim::eliminateOperators(NodeManager* nm,
       Node v = sm->mkPurifySkolem(pterm);
       Node one = nm->mkConstReal(Rational(1));
       Node zero = nm->mkConstReal(Rational(0));
-      Node diff = nm->mkNode(Kind::SUB, node[0], nm->mkNode(Kind::TO_REAL, v));
+      Node diff = nm->mkNode(Kind::SUB, node[0], v);
       Node lem = mkInRange(diff, zero, one);
       lems.emplace_back(lem, v);
       if (k == Kind::IS_INTEGER)

--- a/src/theory/arith/operator_elim.cpp
+++ b/src/theory/arith/operator_elim.cpp
@@ -118,7 +118,7 @@ Node OperatorElim::eliminateOperators(NodeManager* nm,
       Node v = sm->mkPurifySkolem(pterm);
       Node one = nm->mkConstReal(Rational(1));
       Node zero = nm->mkConstReal(Rational(0));
-      Node diff = nm->mkNode(Kind::SUB, node[0], v);
+      Node diff = nm->mkNode(Kind::SUB, node[0], nm->mkNode(Kind::TO_REAL, v));
       Node lem = mkInRange(diff, zero, one);
       lems.emplace_back(lem, v);
       if (k == Kind::IS_INTEGER)


### PR DESCRIPTION
The transdental functions are not yet covered for now.

Also makes a minor simplification to the code for operator elim.

A followup PR will modify this rule to avoid introducing mixed arithmetic.