### PR TITLE
Adding an official skolem to int-blasting

### DIFF
--- a/include/cvc5/cvc5_skolem_id.h
+++ b/include/cvc5/cvc5_skolem_id.h
@@ -741,6 +741,12 @@ enum ENUM(SkolemId)
    * For example, if the original function is from
    * BV and Strings to Strings, the resulting
    * function is from Ints and Strings to Strings.
+   * - Number of skolem indices: ``1``
+   *   - ``1:`` the original function f, with BV sorts.
+   * - Sort: `(-> T1' ... ( -> Tn' T')...)` Where
+   *   f has sort (->T1 ... (-> Tn T)...) and Ti' (T') is 
+   *   `Int` if Ti (T) is `BV` and Ti' (T') is just Ti (T)
+   *   otherwise.
    */
   EVALUE(BV_TO_INT_UF),
 

--- a/include/cvc5/cvc5_skolem_id.h
+++ b/include/cvc5/cvc5_skolem_id.h
@@ -732,6 +732,18 @@ enum ENUM(SkolemId)
    * - Sort: ``(-> FP Real)``
    */
   EVALUE(FP_TO_REAL),
+
+  /**
+   * A skolem function introduced by the int-blaster.
+   * Given a function f with argument and/or return types
+   * that include bit-vectors, we get a function
+   * that replaces them by integer types.
+   * For example, if the original function is from
+   * BV and Strings to Strings, the resulting
+   * function is from Ints and Strings to Strings.
+   */
+  EVALUE(BV_TO_INT_UF),
+
   //================================================= Unknown rule
   /** Indicates this is not a skolem. */
   EVALUE(NONE),

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -897,16 +897,7 @@ cdef class DatatypeSelector:
 # ----------------------------------------------------------------------------
 
 cdef class Op:
-    """
-        A cvc5 operator.
-
-        An operator is a term that represents certain operators,
-        instantiated with its required parameters, e.g.,
-        a term of kind
-        :py:obj:`BITVECTOR_EXTRACT <Kind.BITVECTOR_EXTRACT>`.
-
-        Wrapper class for :cpp:class:`cvc5::Op`.
-    """
+    """Wrapper class for :cpp:class:`cvc5::api::Op`."""
     cdef c_Op cop
     cdef TermManager tm
 
@@ -927,10 +918,10 @@ cdef class Op:
 
     def getKind(self):
         """
-            :return: The kind of this operator.
+            :return: the kind of this operator.
         """
-        return Kind(<int> self.cop.getKind())
-
+        return kind(<int> self.cop.getKind())
+    
     def isIndexed(self):
         """
             :return: True iff this operator is indexed.

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -897,7 +897,16 @@ cdef class DatatypeSelector:
 # ----------------------------------------------------------------------------
 
 cdef class Op:
-    """Wrapper class for :cpp:class:`cvc5::api::Op`."""
+    """
+        A cvc5 operator.
+
+        An operator is a term that represents certain operators,
+        instantiated with its required parameters, e.g.,
+        a term of kind
+        :py:obj:`BITVECTOR_EXTRACT <Kind.BITVECTOR_EXTRACT>`.
+
+        Wrapper class for :cpp:class:`cvc5::Op`.
+    """
     cdef c_Op cop
     cdef TermManager tm
 
@@ -918,10 +927,10 @@ cdef class Op:
 
     def getKind(self):
         """
-            :return: the kind of this operator.
+            :return: The kind of this operator.
         """
-        return kind(<int> self.cop.getKind())
-    
+        return Kind(<int> self.cop.getKind())
+
     def isIndexed(self):
         """
             :return: True iff this operator is indexed.

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -584,8 +584,9 @@ TypeNode SkolemManager::getTypeFor(SkolemId id,
     case SkolemId::BV_TO_INT_UF:
     {
       Assert(cacheVals.size() == 1);
-      Assert(cacheVals[0].getType().isFunction());
+      // fetch the original function
       Node bvUF = cacheVals[0];
+      Assert(cacheVals[0].getType().isFunction());
       // old and new types of domain and result
       TypeNode tn = bvUF.getType();
       TypeNode bvRange = tn.getRangeType();

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -581,6 +581,28 @@ TypeNode SkolemManager::getTypeFor(SkolemId id,
       Assert(type.isFloatingPoint());
       return nm->mkFunctionType({type}, nm->realType());
     }
+    case SkolemId::BV_TO_INT_UF:
+    {
+      Assert(cacheVals.size() == 1);
+      Assert(cacheVals[0].getType().isFunction());
+      Node bvUF = cacheVals[0];
+      // old and new types of domain and result
+      TypeNode tn = bvUF.getType();
+      TypeNode bvRange = tn.getRangeType();
+      std::vector<TypeNode> bvDomain = tn.getArgTypes();
+      std::vector<TypeNode> intDomain;
+
+      // if the original range is a bit-vector sort,
+      // the new range should be an integer sort.
+      // Otherwise, we keep the original range.
+      // Similarly for the domain sorts.
+      TypeNode intRange = bvRange.isBitVector() ? nm->integerType() : bvRange;
+      for (const TypeNode& d : bvDomain)
+      {
+        intDomain.push_back(d.isBitVector() ? nm->integerType() : d);
+      }
+      return nm->mkFunctionType(intDomain, intRange);
+    }
     //
     default: break;
   }
@@ -623,6 +645,7 @@ size_t SkolemManager::getNumIndicesForSkolemId(SkolemId id) const
     case SkolemId::SETS_FOLD_UNION:
     case SkolemId::FP_MIN_ZERO:
     case SkolemId::FP_MAX_ZERO:
+    case SkolemId::BV_TO_INT_UF:
     case SkolemId::FP_TO_REAL: return 1;
 
     // Number of skolem indices: 2

--- a/src/expr/skolem_manager.h
+++ b/src/expr/skolem_manager.h
@@ -152,7 +152,10 @@ class SkolemManager
    * Make skolem function. This method should be used for creating fixed
    * skolem functions of the forms described in SkolemId. The user of this
    * method is responsible for providing a proper type for the identifier that
-   * matches the description of id. Skolem functions are useful for modelling
+   * matches the description of id. 
+   * This is done from the function
+   * `SkolemManager::getTypeFor`.
+   * Skolem functions are useful for modelling
    * the behavior of partial functions, or for theory-specific inferences that
    * introduce fresh variables.
    *

--- a/src/expr/skolem_manager.h
+++ b/src/expr/skolem_manager.h
@@ -152,7 +152,7 @@ class SkolemManager
    * Make skolem function. This method should be used for creating fixed
    * skolem functions of the forms described in SkolemId. The user of this
    * method is responsible for providing a proper type for the identifier that
-   * matches the description of id. 
+   * matches the description of id.
    * This is done from the function
    * `SkolemManager::getTypeFor`.
    * Skolem functions are useful for modelling

--- a/src/expr/skolem_manager.h
+++ b/src/expr/skolem_manager.h
@@ -153,7 +153,7 @@ class SkolemManager
    * skolem functions of the forms described in SkolemId. The user of this
    * method is responsible for providing a proper type for the identifier that
    * matches the description of id.
-   * This is done from the function
+   * This can be done from the function
    * `SkolemManager::getTypeFor`.
    * Skolem functions are useful for modelling
    * the behavior of partial functions, or for theory-specific inferences that

--- a/src/printer/enum_to_string.cpp
+++ b/src/printer/enum_to_string.cpp
@@ -93,6 +93,7 @@ const char* toString(cvc5::SkolemId id)
     case cvc5::SkolemId::SETS_FOLD_ELEMENTS: return "sets_fold_elements";
     case cvc5::SkolemId::SETS_FOLD_UNION: return "sets_fold_union";
     case cvc5::SkolemId::SETS_MAP_DOWN_ELEMENT: return "sets_map_down_element";
+    case cvc5::SkolemId::BV_TO_INT_UF: return "bv_to_int_uf";
     case cvc5::SkolemId::NONE: return "none";
     default: return "?";
   }

--- a/src/theory/bv/int_blaster.cpp
+++ b/src/theory/bv/int_blaster.cpp
@@ -824,6 +824,9 @@ Node IntBlaster::translateFunctionSymbol(Node bvUF,
 
   // iterate the arguments, cast BV arguments to integers
   int i = 0;
+  TypeNode tn = bvUF.getType();
+  TypeNode bvRange = tn.getRangeType();
+  std::vector<TypeNode> bvDomain = tn.getArgTypes();
   for (const TypeNode& d : bvDomain)
   {
     // Each bit-vector argument is casted to a natural number

--- a/src/theory/bv/int_blaster.cpp
+++ b/src/theory/bv/int_blaster.cpp
@@ -811,32 +811,9 @@ Node IntBlaster::translateNoChildren(Node original,
 Node IntBlaster::translateFunctionSymbol(Node bvUF,
                                          std::map<Node, Node>& skolems)
 {
-  // construct the new function symbol.
-  Node intUF;
-  // old and new types of domain and result
-  TypeNode tn = bvUF.getType();
-  TypeNode bvRange = tn.getRangeType();
-  std::vector<TypeNode> bvDomain = tn.getArgTypes();
-  std::vector<TypeNode> intDomain;
-
-  // if the original range is a bit-vector sort,
-  // the new range should be an integer sort.
-  // Otherwise, we keep the original range.
-  // Similarly for the domain sorts.
-  TypeNode intRange = bvRange.isBitVector() ? d_nm->integerType() : bvRange;
-  for (const TypeNode& d : bvDomain)
-  {
-    intDomain.push_back(d.isBitVector() ? d_nm->integerType() : d);
-  }
-
   // create the new function symbol as a skolem
-  std::ostringstream os;
-  os << "__intblast_fun_" << bvUF << "_int";
   SkolemManager* sm = d_nm->getSkolemManager();
-  intUF = sm->mkDummySkolem(
-      os.str(), d_nm->mkFunctionType(intDomain, intRange), "bv2int function");
-
-  // add definition of old function symbol to skolems.
+  Node intUF = sm->mkSkolemFunction(SkolemId::BV_TO_INT_UF, bvUF);
 
   // formal arguments of the lambda expression.
   std::vector<Node> args;


### PR DESCRIPTION
This PR eliminates the single usage of `mkDummySkolem` from the int-blaster.