### PR TITLE
Add proof support for several simple elimination theory rewrites

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -2329,7 +2329,31 @@ enum ENUM(ProofRewriteRule)
    * \endverbatim
    */
   EVALUE(DISTINCT_ELIM),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **UF -- Bitvector to natural elimination**
+   *
+   * .. math::
+   *   \texttt{bv2nat}(t) = t_1 + \ldots + t_n
+   *
+   * where for :math:`i=1, \ldots, n`, :math:`t_i` is
+   * :math:`\texttt{ite}(x[i-1, i-1] = 1, 2^i, 0)`.
+   *
+   * \endverbatim
+   */
   EVALUE(BV_TO_NAT_ELIM),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **UF -- Integer to bitvector elimination**
+   *
+   * .. math::
+   *   \texttt{int2bv}_n(t) = (bvconcat t_1 \ldots t_n)
+   *
+   * where for :math:`i=1, \ldots, n`, :math:`t_i` is
+   * :math:`\texttt{ite}(\texttt{mod}(t,2^n) \geq 2^{n-1}, 1, 0)`.
+   *
+   * \endverbatim
+   */
   EVALUE(INT_TO_BV_ELIM),
   /**
    * \verbatim embed:rst:leading-asterisk
@@ -2359,7 +2383,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(ARITH_DIV_BY_CONST_ELIM),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Arithmetic - strings predicate entailment**
+   * **Arithmetic -- strings predicate entailment**
    *
    * .. math::
    *   (= s t) = c
@@ -2379,7 +2403,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(MACRO_ARITH_STRING_PRED_ENTAIL),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Arithmetic - strings predicate entailment**
+   * **Arithmetic -- strings predicate entailment**
    *
    * .. math::
    *   (>= n 0) = true
@@ -2393,7 +2417,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(ARITH_STRING_PRED_ENTAIL),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Arithmetic - strings predicate entailment**
+   * **Arithmetic -- strings predicate entailment**
    *
    * .. math::
    *   (>= n 0) = (>= m 0)
@@ -2409,6 +2433,17 @@ enum ENUM(ProofRewriteRule)
    * \endverbatim
    */
   EVALUE(ARITH_STRING_PRED_SAFE_APPROX),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Arithmetic -- power elimination**
+   *
+   * .. math::
+   *   (^ x c) = (x \cdot \ldots \cdot x)
+   *
+   * where :math:`c` is a non-negative integer.
+   *
+   * \endverbatim
+   */
   EVALUE(ARITH_POW_ELIM),
   /**
    * \verbatim embed:rst:leading-asterisk
@@ -2523,7 +2558,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(DT_INST),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Datatypes - collapse selector**
+   * **Datatypes -- collapse selector**
    *
    * .. math::
    *   s_i(c(t_1, \ldots, t_n)) = t_i
@@ -2535,7 +2570,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(DT_COLLAPSE_SELECTOR),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Datatypes - collapse tester**
+   * **Datatypes -- collapse tester**
    *
    * .. math::
    *   \mathit{is}_c(c(t_1, \ldots, t_n)) = true
@@ -2552,7 +2587,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(DT_COLLAPSE_TESTER),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Datatypes - collapse tester**
+   * **Datatypes -- collapse tester**
    *
    * .. math::
    *   \mathit{is}_c(t) = true
@@ -2564,7 +2599,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(DT_COLLAPSE_TESTER_SINGLETON),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Datatypes - constructor equality**
+   * **Datatypes -- constructor equality**
    *
    * .. math::
    *   (c(t_1, \ldots, t_n) = c(s_1, \ldots, s_n)) =
@@ -2580,10 +2615,23 @@ enum ENUM(ProofRewriteRule)
    * \endverbatim
    */
   EVALUE(DT_CONS_EQ),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Datatypes -- match elimination**
+   *
+   * .. math::
+   *   \texttt{match}(t ((p_1 c_1) \ldots (p_n c_n))) = \texttt{ite}(F_1, r_1, \texttt{ite}( \ldots, r_n))
+   * 
+   * where for :math:`i=1, \ldots, n`, :math:`F_1` is a formula that holds iff
+   * :math:`t` matches :math:`p_i` and :math:`r_i` is the result of a
+   * substitution on :math:`c_i` based on this match.
+   *
+   * \endverbatim
+   */
   EVALUE(DT_MATCH_ELIM),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Bitvectors - Unsigned multiplication overflow detection elimination**
+   * **Bitvectors -- Unsigned multiplication overflow detection elimination**
    *
    * See M.Gok, M.J. Schulte, P.I. Balzola, "Efficient integer multiplication
    * overflow detection circuits", 2001.
@@ -2593,7 +2641,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(BV_UMULO_ELIMINATE),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Bitvectors - Unsigned multiplication overflow detection elimination**
+   * **Bitvectors -- Unsigned multiplication overflow detection elimination**
    *
    * See M.Gok, M.J. Schulte, P.I. Balzola, "Efficient integer multiplication
    * overflow detection circuits", 2001.
@@ -2603,13 +2651,13 @@ enum ENUM(ProofRewriteRule)
   EVALUE(BV_SMULO_ELIMINATE),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Bitvectors - Combine like terms during addition by counting terms**
+   * **Bitvectors -- Combine like terms during addition by counting terms**
    * \endverbatim
    */
   EVALUE(BV_ADD_COMBINE_LIKE_TERMS),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Bitvectors - Extract negations from multiplicands**
+   * **Bitvectors -- Extract negations from multiplicands**
    *
    * .. math::
    *    bvmul(bvneg(a),\ b,\ c) = bvneg(bvmul(a,\ b,\ c))
@@ -2619,7 +2667,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(BV_MULT_SIMPLIFY),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Bitvectors - Extract continuous substrings of bitvectors**
+   * **Bitvectors -- Extract continuous substrings of bitvectors**
    *
    * .. math::
    *    bvand(a,\ c) = concat(bvand(a[i_0:j_0],\ c_0) ... bvand(a[i_n:j_n],\ c_n))
@@ -2630,7 +2678,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(BV_BITWISE_SLICING),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Strings - regular expression loop elimination**
+   * **Strings -- regular expression loop elimination**
    *
    * .. math::
    *   re.loop_{l,u}(R) = re.union(R^l, \ldots, R^u)
@@ -2642,7 +2690,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(RE_LOOP_ELIM),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Strings - regular expression intersection/union inclusion**
+   * **Strings -- regular expression intersection/union inclusion**
    *
    * .. math::
    *   (re.inter\ R) = \mathit{re.inter}(\mathit{re.none}, R_0)
@@ -2665,7 +2713,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(RE_INTER_UNION_INCLUSION),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Strings - regular expression membership evaluation**
+   * **Strings -- regular expression membership evaluation**
    *
    * .. math::
    *   \mathit{str.in\_re}(s, R) = c
@@ -2678,7 +2726,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(STR_IN_RE_EVAL),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Strings - regular expression membership consume**
+   * **Strings -- regular expression membership consume**
    *
    * .. math::
    *   \mathit{str.in_re}(s, R) = b
@@ -2691,7 +2739,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(STR_IN_RE_CONSUME),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Strings - string in regular expression concatenation star character**
+   * **Strings -- string in regular expression concatenation star character**
    *
    * .. math::
    *   \mathit{str.in\_re}(\mathit{str}.\text{++}(s_1, \ldots, s_n), \mathit{re}.\text{*}(R)) =\\ \mathit{str.in\_re}(s_1, \mathit{re}.\text{*}(R)) \wedge \ldots \wedge \mathit{str.in\_re}(s_n, \mathit{re}.\text{*}(R))
@@ -2703,7 +2751,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(STR_IN_RE_CONCAT_STAR_CHAR),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Strings - string in regular expression sigma**
+   * **Strings -- string in regular expression sigma**
    *
    * .. math::
    *   \mathit{str.in\_re}(s, \mathit{re}.\text{++}(\mathit{re.allchar}, \ldots, \mathit{re.allchar})) = (\mathit{str.len}(s) = n)
@@ -2718,7 +2766,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(STR_IN_RE_SIGMA),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Strings - string in regular expression sigma star**
+   * **Strings -- string in regular expression sigma star**
    *
    * .. math::
    *   \mathit{str.in\_re}(s, \mathit{re}.\text{*}(\mathit{re}.\text{++}(\mathit{re.allchar}, \ldots, \mathit{re.allchar}))) = (\mathit{str.len}(s) \ \% \ n = 0)
@@ -2731,7 +2779,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(STR_IN_RE_SIGMA_STAR),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Strings - strings substring strip symbolic length**
+   * **Strings -- strings substring strip symbolic length**
    *
    * .. math::
    *   str.substr(s, n, m) = t
@@ -2744,7 +2792,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(MACRO_SUBSTR_STRIP_SYM_LENGTH),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Sets - empty tester evaluation**
+   * **Sets -- empty tester evaluation**
    *
    * .. math::
    *   \mathit{sets.is\_empty}(\epsilon) = \top
@@ -2759,6 +2807,15 @@ enum ENUM(ProofRewriteRule)
    * \endverbatim
    */
   EVALUE(SETS_IS_EMPTY_EVAL),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Sets -- sets insert elimination**
+   *
+   * .. math::
+   *   \mathit{sets.insert}(t_1, \ldots, t_n, S) = \texttt{set.union}(\texttt{sets.singleton}(t_1), \ldots, \texttt{sets.singleton}(t_n), S)
+   *
+   * \endverbatim
+   */
   EVALUE(SETS_INSERT_ELIM),
   // RARE rules
   // ${rules}$

--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -2329,6 +2329,8 @@ enum ENUM(ProofRewriteRule)
    * \endverbatim
    */
   EVALUE(DISTINCT_ELIM),
+  EVALUE(BV_TO_NAT_ELIM),
+  EVALUE(INT_TO_BV_ELIM),
   /**
    * \verbatim embed:rst:leading-asterisk
    * **Booleans -- Negation Normal Form with normalization**
@@ -2407,6 +2409,7 @@ enum ENUM(ProofRewriteRule)
    * \endverbatim
    */
   EVALUE(ARITH_STRING_PRED_SAFE_APPROX),
+  EVALUE(ARITH_POW_ELIM),
   /**
    * \verbatim embed:rst:leading-asterisk
    * **Equality -- Beta reduction**
@@ -2577,6 +2580,7 @@ enum ENUM(ProofRewriteRule)
    * \endverbatim
    */
   EVALUE(DT_CONS_EQ),
+  EVALUE(DT_MATCH_ELIM),
   /**
    * \verbatim embed:rst:leading-asterisk
    * **Bitvectors - Unsigned multiplication overflow detection elimination**
@@ -2755,6 +2759,7 @@ enum ENUM(ProofRewriteRule)
    * \endverbatim
    */
   EVALUE(SETS_IS_EMPTY_EVAL),
+  EVALUE(SETS_INSERT_ELIM),
   // RARE rules
   // ${rules}$
   /** Auto-generated from RARE rule arith-plus-zero */

--- a/proofs/eo/cpc/theories/Arith.eo
+++ b/proofs/eo/cpc/theories/Arith.eo
@@ -107,8 +107,8 @@
 ; Power function.
 ; disclaimer: This function is not a function in SMT-LIB. 
 (declare-const ^ (-> (! Type :var T :implicit)
-                     (! Type :var U :implicit)
-                     T U ($arith_typeunion T U)))
+                     (! T :requires (($is_arith_type T) true))
+                     T T))
 
 ; Unary negation, which is overloaded with binary subtraction. We distinguish
 ; these two operators in EunoiaC based on their arity when applied, and with

--- a/proofs/eo/cpc/theories/Arith.eo
+++ b/proofs/eo/cpc/theories/Arith.eo
@@ -108,7 +108,7 @@
 ; disclaimer: This function is not a function in SMT-LIB. 
 (declare-const ^ (-> (! Type :var T :implicit)
                      (! T :requires (($is_arith_type T) true))
-                     Int T))
+                     T T))
 
 ; Unary negation, which is overloaded with binary subtraction. We distinguish
 ; these two operators in EunoiaC based on their arity when applied, and with

--- a/proofs/eo/cpc/theories/Arith.eo
+++ b/proofs/eo/cpc/theories/Arith.eo
@@ -108,7 +108,7 @@
 ; disclaimer: This function is not a function in SMT-LIB. 
 (declare-const ^ (-> (! Type :var T :implicit)
                      (! T :requires (($is_arith_type T) true))
-                     T T))
+                     Int T))
 
 ; Unary negation, which is overloaded with binary subtraction. We distinguish
 ; these two operators in EunoiaC based on their arity when applied, and with

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -221,6 +221,8 @@ const char* toString(cvc5::ProofRewriteRule rule)
     case ProofRewriteRule::NONE: return "NONE";
     //================================================= ad-hoc rules
     case ProofRewriteRule::DISTINCT_ELIM: return "distinct-elim";
+    case ProofRewriteRule::BV_TO_NAT_ELIM:return "bv-to-nat-elim";
+    case ProofRewriteRule::INT_TO_BV_ELIM:return "int-to-bv-elim";
     case ProofRewriteRule::MACRO_BOOL_NNF_NORM: return "macro-bool-nnf-norm";
     case ProofRewriteRule::ARITH_DIV_BY_CONST_ELIM:
       return "arith-div-by-const-elim";
@@ -230,6 +232,8 @@ const char* toString(cvc5::ProofRewriteRule rule)
       return "arith-string-pred-safe-approx";
     case ProofRewriteRule::MACRO_ARITH_STRING_PRED_ENTAIL:
       return "macro-arith-string-pred-entail";
+    case ProofRewriteRule::ARITH_POW_ELIM:
+      return "arith-pow-elim";
     case ProofRewriteRule::BETA_REDUCE: return "beta-reduce";
     case ProofRewriteRule::ARRAYS_EQ_RANGE_EXPAND:
       return "arrays-eq-range-expand";
@@ -246,6 +250,7 @@ const char* toString(cvc5::ProofRewriteRule rule)
     case ProofRewriteRule::DT_COLLAPSE_TESTER_SINGLETON:
       return "dt-collapse-tester-singleton";
     case ProofRewriteRule::DT_CONS_EQ: return "dt-cons-eq";
+    case ProofRewriteRule::DT_MATCH_ELIM: return "dt-match-elim";
     case ProofRewriteRule::BV_UMULO_ELIMINATE: return "bv-umulo-eliminate";
     case ProofRewriteRule::BV_SMULO_ELIMINATE: return "bv-smulo-eliminate";
     case ProofRewriteRule::BV_ADD_COMBINE_LIKE_TERMS:
@@ -265,6 +270,7 @@ const char* toString(cvc5::ProofRewriteRule rule)
       return "macro-substr-strip-sym-length";
     case ProofRewriteRule::SETS_IS_EMPTY_EVAL:
       return "sets-is-empty-eval";
+    case ProofRewriteRule::SETS_INSERT_ELIM:return "sets-insert-elim";
       //================================================= RARE rules
       // clang-format off
       ${printer}$

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -221,8 +221,8 @@ const char* toString(cvc5::ProofRewriteRule rule)
     case ProofRewriteRule::NONE: return "NONE";
     //================================================= ad-hoc rules
     case ProofRewriteRule::DISTINCT_ELIM: return "distinct-elim";
-    case ProofRewriteRule::BV_TO_NAT_ELIM:return "bv-to-nat-elim";
-    case ProofRewriteRule::INT_TO_BV_ELIM:return "int-to-bv-elim";
+    case ProofRewriteRule::BV_TO_NAT_ELIM: return "bv-to-nat-elim";
+    case ProofRewriteRule::INT_TO_BV_ELIM: return "int-to-bv-elim";
     case ProofRewriteRule::MACRO_BOOL_NNF_NORM: return "macro-bool-nnf-norm";
     case ProofRewriteRule::ARITH_DIV_BY_CONST_ELIM:
       return "arith-div-by-const-elim";
@@ -232,8 +232,7 @@ const char* toString(cvc5::ProofRewriteRule rule)
       return "arith-string-pred-safe-approx";
     case ProofRewriteRule::MACRO_ARITH_STRING_PRED_ENTAIL:
       return "macro-arith-string-pred-entail";
-    case ProofRewriteRule::ARITH_POW_ELIM:
-      return "arith-pow-elim";
+    case ProofRewriteRule::ARITH_POW_ELIM: return "arith-pow-elim";
     case ProofRewriteRule::BETA_REDUCE: return "beta-reduce";
     case ProofRewriteRule::ARRAYS_EQ_RANGE_EXPAND:
       return "arrays-eq-range-expand";
@@ -270,7 +269,8 @@ const char* toString(cvc5::ProofRewriteRule rule)
       return "macro-substr-strip-sym-length";
     case ProofRewriteRule::SETS_IS_EMPTY_EVAL:
       return "sets-is-empty-eval";
-    case ProofRewriteRule::SETS_INSERT_ELIM:return "sets-insert-elim";
+    case ProofRewriteRule::SETS_INSERT_ELIM:
+      return "sets-insert-elim";
       //================================================= RARE rules
       // clang-format off
       ${printer}$

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -1361,7 +1361,10 @@ Node ArithRewriter::expandPowConst(NodeManager* nm, const Node& t)
   if (t[1].isConst())
   {
     const Rational& exp = t[1].getConst<Rational>();
-    Assert (exp.isIntegral());
+    if (!exp.isIntegral())
+    {
+      return Node::null();
+    }
     TNode base = t[0];
     if (exp.sgn() == 0)
     {

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -1361,12 +1361,13 @@ Node ArithRewriter::expandPowConst(NodeManager* nm, const Node& t)
   if (t[1].isConst())
   {
     const Rational& exp = t[1].getConst<Rational>();
+    Assert (exp.isIntegral());
     TNode base = t[0];
     if (exp.sgn() == 0)
     {
       return nm->mkConstRealOrInt(t.getType(), Rational(1));
     }
-    else if (exp.sgn() > 0 && exp.isIntegral())
+    else if (exp.sgn() > 0)
     {
       Rational r(expr::NodeValue::MAX_CHILDREN);
       if (exp <= r)

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -68,7 +68,7 @@ Node ArithRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
   {
     case ProofRewriteRule::ARITH_POW_ELIM:
     {
-      if (n.getKind()==Kind::POW)
+      if (n.getKind() == Kind::POW)
       {
         Node nx = expandPowConst(nodeManager(), n);
         if (!nx.isNull())
@@ -1356,25 +1356,32 @@ Node ArithRewriter::rewriteIneqToBv(Kind kind,
   return ineq;
 }
 
-Node ArithRewriter::expandPowConst(NodeManager * nm, const Node& t)
+Node ArithRewriter::expandPowConst(NodeManager* nm, const Node& t)
 {
   if (t[1].isConst())
   {
     const Rational& exp = t[1].getConst<Rational>();
     TNode base = t[0];
-    if(exp.sgn() == 0){
+    if (exp.sgn() == 0)
+    {
       return nm->mkConstRealOrInt(t.getType(), Rational(1));
-    }else if(exp.sgn() > 0 && exp.isIntegral()){
+    }
+    else if (exp.sgn() > 0 && exp.isIntegral())
+    {
       Rational r(expr::NodeValue::MAX_CHILDREN);
       if (exp <= r)
       {
         unsigned num = exp.getNumerator().toUnsignedInt();
         Node ret;
-        if( num==1 ){
+        if (num == 1)
+        {
           ret = base;
-        }else{
+        }
+        else
+        {
           NodeBuilder nb(Kind::MULT);
-          for(unsigned i=0; i < num; ++i){
+          for (unsigned i = 0; i < num; ++i)
+          {
             nb << base;
           }
           Assert(nb.getNumChildren() > 0);

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -51,6 +51,8 @@ namespace arith {
 ArithRewriter::ArithRewriter(NodeManager* nm, OperatorElim& oe)
     : TheoryRewriter(nm), d_opElim(oe)
 {
+  registerProofRewriteRule(ProofRewriteRule::ARITH_POW_ELIM,
+                           TheoryRewriteCtx::PRE_DSL);
   registerProofRewriteRule(ProofRewriteRule::ARITH_DIV_BY_CONST_ELIM,
                            TheoryRewriteCtx::PRE_DSL);
   registerProofRewriteRule(ProofRewriteRule::MACRO_ARITH_STRING_PRED_ENTAIL,
@@ -64,6 +66,18 @@ Node ArithRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
 {
   switch (id)
   {
+    case ProofRewriteRule::ARITH_POW_ELIM:
+    {
+      if (n.getKind()==Kind::POW)
+      {
+        Node nx = expandPowConst(nodeManager(), n);
+        if (!nx.isNull())
+        {
+          return nx;
+        }
+      }
+    }
+    break;
     case ProofRewriteRule::ARITH_DIV_BY_CONST_ELIM:
     {
       if (n.getKind() == Kind::DIVISION && n[1].isConst())
@@ -403,38 +417,10 @@ RewriteResponse ArithRewriter::postRewriteTerm(TNode t){
       case Kind::TO_INTEGER: return rewriteExtIntegerOp(t);
       case Kind::POW:
       {
-        if (t[1].isConst())
+        Node tx = expandPowConst(nodeManager(), t);
+        if (!tx.isNull())
         {
-          const Rational& exp = t[1].getConst<Rational>();
-          TNode base = t[0];
-          if(exp.sgn() == 0){
-            return RewriteResponse(
-                REWRITE_DONE,
-                nodeManager()->mkConstRealOrInt(t.getType(), Rational(1)));
-          }else if(exp.sgn() > 0 && exp.isIntegral()){
-            cvc5::internal::Rational r(expr::NodeValue::MAX_CHILDREN);
-            if (exp <= r)
-            {
-              unsigned num = exp.getNumerator().toUnsignedInt();
-              Node ret;
-              if( num==1 ){
-                ret = base;
-              }else{
-                NodeBuilder nb(Kind::MULT);
-                for(unsigned i=0; i < num; ++i){
-                  nb << base;
-                }
-                Assert(nb.getNumChildren() > 0);
-                ret = nb;
-              }
-              // ensure type is preserved
-              if (t.getType().isReal())
-              {
-                ret = rewriter::ensureReal(ret);
-              }
-              return RewriteResponse(REWRITE_AGAIN_FULL, ret);
-            }
-          }
+          return RewriteResponse(REWRITE_AGAIN_FULL, tx);
         }
         return RewriteResponse(REWRITE_DONE, t);
       }
@@ -1368,6 +1354,37 @@ Node ArithRewriter::rewriteIneqToBv(Kind kind,
     return ret;
   }
   return ineq;
+}
+
+Node ArithRewriter::expandPowConst(NodeManager * nm, const Node& t)
+{
+  if (t[1].isConst())
+  {
+    const Rational& exp = t[1].getConst<Rational>();
+    TNode base = t[0];
+    if(exp.sgn() == 0){
+      return nm->mkConstRealOrInt(t.getType(), Rational(1));
+    }else if(exp.sgn() > 0 && exp.isIntegral()){
+      Rational r(expr::NodeValue::MAX_CHILDREN);
+      if (exp <= r)
+      {
+        unsigned num = exp.getNumerator().toUnsignedInt();
+        Node ret;
+        if( num==1 ){
+          ret = base;
+        }else{
+          NodeBuilder nb(Kind::MULT);
+          for(unsigned i=0; i < num; ++i){
+            nb << base;
+          }
+          Assert(nb.getNumChildren() > 0);
+          ret = nb;
+        }
+        return ret;
+      }
+    }
+  }
+  return Node::null();
 }
 
 }  // namespace arith

--- a/src/theory/arith/arith_rewriter.h
+++ b/src/theory/arith/arith_rewriter.h
@@ -118,7 +118,7 @@ class ArithRewriter : public TheoryRewriter
   /**
    * Return the result of expanding (^ x c) for constant c.
    */
-  static Node expandPowConst(NodeManager * nm, const Node& n);
+  static Node expandPowConst(NodeManager* nm, const Node& n);
   /**
    * Rewrite inequality to bv. If applicable, return
    * the bitvector inequality that is the rewritten form of the arithmetic

--- a/src/theory/arith/arith_rewriter.h
+++ b/src/theory/arith/arith_rewriter.h
@@ -115,7 +115,10 @@ class ArithRewriter : public TheoryRewriter
 
   /** return rewrite */
   RewriteResponse returnRewrite(TNode t, Node ret, Rewrite r);
-
+  /**
+   * Return the result of expanding (^ x c) for constant c.
+   */
+  static Node expandPowConst(NodeManager * nm, const Node& n);
   /**
    * Rewrite inequality to bv. If applicable, return
    * the bitvector inequality that is the rewritten form of the arithmetic

--- a/src/theory/arith/kinds
+++ b/src/theory/arith/kinds
@@ -119,7 +119,7 @@ typerule NONLINEAR_MULT ::cvc5::internal::theory::arith::ArithOperatorTypeRule
 typerule SUB ::cvc5::internal::theory::arith::ArithOperatorTypeRule
 typerule NEG ::cvc5::internal::theory::arith::ArithOperatorTypeRule
 typerule DIVISION ::cvc5::internal::theory::arith::ArithOperatorTypeRule
-typerule POW ::cvc5::internal::theory::arith::ArithOperatorTypeRule
+typerule POW ::cvc5::internal::theory::arith::PowTypeRule
 
 typerule CONST_RATIONAL ::cvc5::internal::theory::arith::ArithConstantTypeRule
 typerule CONST_INTEGER ::cvc5::internal::theory::arith::ArithConstantTypeRule

--- a/src/theory/arith/nl/poly_conversion.cpp
+++ b/src/theory/arith/nl/poly_conversion.cpp
@@ -250,7 +250,7 @@ void collect_monomials(const lp_polynomial_context_t* ctx,
     Node var = d->d_vm(m->p[i].x);
     if (m->p[i].d > 1)
     {
-      Node exp = d->d_nm->mkConstReal(m->p[i].d);
+      Node exp = d->d_nm->mkConstInt(m->p[i].d);
       term = d->d_nm->mkNode(
           Kind::NONLINEAR_MULT, term, d->d_nm->mkNode(Kind::POW, var, exp));
     }

--- a/src/theory/arith/nl/poly_conversion.cpp
+++ b/src/theory/arith/nl/poly_conversion.cpp
@@ -250,7 +250,7 @@ void collect_monomials(const lp_polynomial_context_t* ctx,
     Node var = d->d_vm(m->p[i].x);
     if (m->p[i].d > 1)
     {
-      Node exp = d->d_nm->mkConstInt(m->p[i].d);
+      Node exp = d->d_nm->mkConstReal(m->p[i].d);
       term = d->d_nm->mkNode(
           Kind::NONLINEAR_MULT, term, d->d_nm->mkNode(Kind::POW, var, exp));
     }

--- a/src/theory/arith/theory_arith_type_rules.cpp
+++ b/src/theory/arith/theory_arith_type_rules.cpp
@@ -228,32 +228,28 @@ TypeNode IAndTypeRule::computeType(NodeManager* nodeManager,
   return nodeManager->integerType();
 }
 
-TypeNode Pow2TypeRule::preComputeType(NodeManager* nm, TNode n)
+TypeNode PowTypeRule::preComputeType(NodeManager* nm, TNode n)
 {
-  return nm->integerType();
+  return TypeNode::null();
 }
-TypeNode Pow2TypeRule::computeType(NodeManager* nodeManager,
+
+TypeNode PowTypeRule::computeType(NodeManager* nodeManager,
                                    TNode n,
                                    bool check,
                                    std::ostream* errOut)
 {
-  if (n.getKind() != Kind::POW2)
+  Assert (n.getKind() == Kind::POW);
+  TypeNode arg1 = n[0].getTypeOrNull();
+  TypeNode arg2 = n[1].getTypeOrNull();
+  TypeNode t = arg1.leastUpperBound(arg2);
+  if (t.isNull())
   {
-    InternalError() << "POW2 typerule invoked for " << n << " instead of POW2 kind";
-  }
-  if (check)
-  {
-    TypeNode arg1 = n[0].getTypeOrNull();
-    if (!isMaybeInteger(arg1))
+    if (errOut)
     {
-      if (errOut)
-      {
-        (*errOut) << "expecting integer terms";
-      }
-      return TypeNode::null();
+      (*errOut) << "expecting same arithmetic types to POW";
     }
   }
-  return nodeManager->integerType();
+  return t;
 }
 
 TypeNode IndexedRootPredicateTypeRule::preComputeType(NodeManager* nm, TNode n)

--- a/src/theory/arith/theory_arith_type_rules.cpp
+++ b/src/theory/arith/theory_arith_type_rules.cpp
@@ -240,16 +240,27 @@ TypeNode PowTypeRule::computeType(NodeManager* nodeManager,
 {
   Assert (n.getKind() == Kind::POW);
   TypeNode arg1 = n[0].getTypeOrNull();
-  TypeNode arg2 = n[1].getTypeOrNull();
-  TypeNode t = arg1.leastUpperBound(arg2);
-  if (t.isNull())
+  if (check)
   {
-    if (errOut)
+    if (!isMaybeRealOrInt(arg1))
     {
-      (*errOut) << "expecting same arithmetic types to POW";
+      if (errOut)
+      {
+        (*errOut) << "expecting arithmetic term for POW";
+      }
+      return TypeNode::null();
+    }
+    TypeNode arg2 = n[1].getTypeOrNull();
+    if (!isMaybeInteger(arg2))
+    {
+      if (errOut)
+      {
+        (*errOut) << "expecting integer exponent to POW";
+      }
+      return TypeNode::null();
     }
   }
-  return t;
+  return arg1;
 }
 
 TypeNode IndexedRootPredicateTypeRule::preComputeType(NodeManager* nm, TNode n)

--- a/src/theory/arith/theory_arith_type_rules.cpp
+++ b/src/theory/arith/theory_arith_type_rules.cpp
@@ -240,27 +240,17 @@ TypeNode PowTypeRule::computeType(NodeManager* nodeManager,
 {
   Assert (n.getKind() == Kind::POW);
   TypeNode arg1 = n[0].getTypeOrNull();
-  if (check)
+  TypeNode arg2 = n[1].getTypeOrNull();
+  TypeNode t = arg1.leastUpperBound(arg2);
+  if (t.isNull())
   {
-    if (!isMaybeRealOrInt(arg1))
+    if (errOut)
     {
-      if (errOut)
-      {
-        (*errOut) << "expecting arithmetic term for POW";
-      }
-      return TypeNode::null();
+      (*errOut) << "expecting same arithmetic types to POW";
     }
-    TypeNode arg2 = n[1].getTypeOrNull();
-    if (!isMaybeInteger(arg2))
-    {
-      if (errOut)
-      {
-        (*errOut) << "expecting integer exponent to POW";
-      }
-      return TypeNode::null();
-    }
+    return TypeNode::null();
   }
-  return arg1;
+  return t;
 }
 
 TypeNode IndexedRootPredicateTypeRule::preComputeType(NodeManager* nm, TNode n)

--- a/src/theory/arith/theory_arith_type_rules.h
+++ b/src/theory/arith/theory_arith_type_rules.h
@@ -121,10 +121,9 @@ class IAndTypeRule
 };
 
 /**
- * Type rule for the POW2 operator.
- * Always returns integerType.
+ * Type rule for the POW operator.
  */
-class Pow2TypeRule
+class PowTypeRule
 {
  public:
   static TypeNode preComputeType(NodeManager* nm, TNode n);

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -51,6 +51,8 @@ DatatypesRewriter::DatatypesRewriter(NodeManager* nm,
                            TheoryRewriteCtx::PRE_DSL);
   registerProofRewriteRule(ProofRewriteRule::DT_CONS_EQ,
                            TheoryRewriteCtx::PRE_DSL);
+  registerProofRewriteRule(ProofRewriteRule::DT_MATCH_ELIM,
+                           TheoryRewriteCtx::PRE_DSL);
 }
 
 Node DatatypesRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
@@ -138,6 +140,14 @@ Node DatatypesRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
         {
           return nn;
         }
+      }
+    }
+    break;
+    case ProofRewriteRule::DT_MATCH_ELIM:
+    {
+      if (n.getKind()==Kind::MATCH)
+      {
+        return expandMatch(n);
       }
     }
     break;
@@ -327,6 +337,7 @@ RewriteResponse DatatypesRewriter::postRewrite(TNode in)
 }
 Node DatatypesRewriter::expandMatch(Node in)
 {
+  Assert (in.getKind()==Kind::MATCH);
   NodeManager* nm = NodeManager::currentNM();
   // ensure we've type checked
   TypeNode tin = in.getType();

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -145,7 +145,7 @@ Node DatatypesRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
     break;
     case ProofRewriteRule::DT_MATCH_ELIM:
     {
-      if (n.getKind()==Kind::MATCH)
+      if (n.getKind() == Kind::MATCH)
       {
         return expandMatch(n);
       }
@@ -337,7 +337,7 @@ RewriteResponse DatatypesRewriter::postRewrite(TNode in)
 }
 Node DatatypesRewriter::expandMatch(Node in)
 {
-  Assert (in.getKind()==Kind::MATCH);
+  Assert(in.getKind() == Kind::MATCH);
   NodeManager* nm = NodeManager::currentNM();
   // ensure we've type checked
   TypeNode tin = in.getType();

--- a/src/theory/sets/theory_sets_rewriter.cpp
+++ b/src/theory/sets/theory_sets_rewriter.cpp
@@ -42,7 +42,6 @@ TheorySetsRewriter::TheorySetsRewriter(NodeManager* nm) : TheoryRewriter(nm)
                            TheoryRewriteCtx::DSL_SUBCALL);
   registerProofRewriteRule(ProofRewriteRule::SETS_INSERT_ELIM,
                            TheoryRewriteCtx::PRE_DSL),
-                           
 }
 
 Node TheorySetsRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
@@ -59,20 +58,18 @@ Node TheorySetsRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
     break;
     case ProofRewriteRule::SETS_INSERT_ELIM:
     {
-      if (node.getKind()==Kind::SET_INSERT)
+      if (node.getKind() == Kind::SET_INSERT)
       {
-        NodeManager * nm = nodeManager();
-        size_t setNodeIndex =  node.getNumChildren()-1;
+        NodeManager* nm = nodeManager();
+        size_t setNodeIndex = node.getNumChildren() - 1;
         Node elems = nm->mkNode(Kind::SET_SINGLETON, n[0]);
 
         for (size_t i = 1; i < setNodeIndex; ++i)
         {
           Node singleton = nm->mkNode(Kind::SET_SINGLETON, n[i]);
-          elems =
-              nm->mkNode(Kind::SET_UNION, elems, singleton);
+          elems = nm->mkNode(Kind::SET_UNION, elems, singleton);
         }
-        return 
-            nm->mkNode(Kind::SET_UNION, elems, n[setNodeIndex]);
+        return nm->mkNode(Kind::SET_UNION, elems, n[setNodeIndex]);
       }
     }
     break;
@@ -702,7 +699,7 @@ RewriteResponse TheorySetsRewriter::preRewrite(TNode node) {
   else if (k == Kind::SET_INSERT)
   {
     Node ret = rewriteViaRule(ProofRewriteRule::SETS_INSERT_ELIM, node);
-    return RewriteResponse( REWRITE_AGAIN, ret);
+    return RewriteResponse(REWRITE_AGAIN, ret);
   }
   else if (k == Kind::SET_SUBSET)
   {

--- a/src/theory/sets/theory_sets_rewriter.cpp
+++ b/src/theory/sets/theory_sets_rewriter.cpp
@@ -41,7 +41,7 @@ TheorySetsRewriter::TheorySetsRewriter(NodeManager* nm) : TheoryRewriter(nm)
   registerProofRewriteRule(ProofRewriteRule::SETS_IS_EMPTY_EVAL,
                            TheoryRewriteCtx::DSL_SUBCALL);
   registerProofRewriteRule(ProofRewriteRule::SETS_INSERT_ELIM,
-                           TheoryRewriteCtx::PRE_DSL),
+                           TheoryRewriteCtx::PRE_DSL);
 }
 
 Node TheorySetsRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
@@ -58,10 +58,10 @@ Node TheorySetsRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
     break;
     case ProofRewriteRule::SETS_INSERT_ELIM:
     {
-      if (node.getKind() == Kind::SET_INSERT)
+      if (n.getKind() == Kind::SET_INSERT)
       {
         NodeManager* nm = nodeManager();
-        size_t setNodeIndex = node.getNumChildren() - 1;
+        size_t setNodeIndex = n.getNumChildren() - 1;
         Node elems = nm->mkNode(Kind::SET_SINGLETON, n[0]);
 
         for (size_t i = 1; i < setNodeIndex; ++i)

--- a/src/theory/sets/theory_sets_rewriter.cpp
+++ b/src/theory/sets/theory_sets_rewriter.cpp
@@ -40,6 +40,9 @@ TheorySetsRewriter::TheorySetsRewriter(NodeManager* nm) : TheoryRewriter(nm)
   // as a premise to test emptiness of a set.
   registerProofRewriteRule(ProofRewriteRule::SETS_IS_EMPTY_EVAL,
                            TheoryRewriteCtx::DSL_SUBCALL);
+  registerProofRewriteRule(ProofRewriteRule::SETS_INSERT_ELIM,
+                           TheoryRewriteCtx::PRE_DSL),
+                           
 }
 
 Node TheorySetsRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
@@ -51,6 +54,25 @@ Node TheorySetsRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
       if (n.getKind() == Kind::SET_IS_EMPTY && n[0].isConst())
       {
         return nodeManager()->mkConst(n[0].getKind() == Kind::SET_EMPTY);
+      }
+    }
+    break;
+    case ProofRewriteRule::SETS_INSERT_ELIM:
+    {
+      if (node.getKind()==Kind::SET_INSERT)
+      {
+        NodeManager * nm = nodeManager();
+        size_t setNodeIndex =  node.getNumChildren()-1;
+        Node elems = nm->mkNode(Kind::SET_SINGLETON, n[0]);
+
+        for (size_t i = 1; i < setNodeIndex; ++i)
+        {
+          Node singleton = nm->mkNode(Kind::SET_SINGLETON, n[i]);
+          elems =
+              nm->mkNode(Kind::SET_UNION, elems, singleton);
+        }
+        return 
+            nm->mkNode(Kind::SET_UNION, elems, n[setNodeIndex]);
       }
     }
     break;
@@ -679,18 +701,8 @@ RewriteResponse TheorySetsRewriter::preRewrite(TNode node) {
   }
   else if (k == Kind::SET_INSERT)
   {
-    size_t setNodeIndex =  node.getNumChildren()-1;
-    Node insertedElements = nm->mkNode(Kind::SET_SINGLETON, node[0]);
-
-    for (size_t i = 1; i < setNodeIndex; ++i)
-    {
-      Node singleton = nm->mkNode(Kind::SET_SINGLETON, node[i]);
-      insertedElements =
-          nm->mkNode(Kind::SET_UNION, insertedElements, singleton);
-    }
-    return RewriteResponse(
-        REWRITE_AGAIN,
-        nm->mkNode(Kind::SET_UNION, insertedElements, node[setNodeIndex]));
+    Node ret = rewriteViaRule(ProofRewriteRule::SETS_INSERT_ELIM, node);
+    return RewriteResponse( REWRITE_AGAIN, ret);
   }
   else if (k == Kind::SET_SUBSET)
   {

--- a/src/theory/uf/theory_uf_rewriter.cpp
+++ b/src/theory/uf/theory_uf_rewriter.cpp
@@ -36,8 +36,8 @@ TheoryUfRewriter::TheoryUfRewriter(NodeManager* nm, Rewriter* rr)
                            TheoryRewriteCtx::PRE_DSL);
   registerProofRewriteRule(ProofRewriteRule::BV_TO_NAT_ELIM,
                            TheoryRewriteCtx::PRE_DSL),
-  registerProofRewriteRule(ProofRewriteRule::INT_TO_BV_ELIM,
-                           TheoryRewriteCtx::PRE_DSL),
+      registerProofRewriteRule(ProofRewriteRule::INT_TO_BV_ELIM,
+                               TheoryRewriteCtx::PRE_DSL),
 }
 
 RewriteResponse TheoryUfRewriter::postRewrite(TNode node)

--- a/src/theory/uf/theory_uf_rewriter.cpp
+++ b/src/theory/uf/theory_uf_rewriter.cpp
@@ -35,9 +35,9 @@ TheoryUfRewriter::TheoryUfRewriter(NodeManager* nm, Rewriter* rr)
   registerProofRewriteRule(ProofRewriteRule::BETA_REDUCE,
                            TheoryRewriteCtx::PRE_DSL);
   registerProofRewriteRule(ProofRewriteRule::BV_TO_NAT_ELIM,
-                           TheoryRewriteCtx::PRE_DSL),
+                           TheoryRewriteCtx::PRE_DSL);
       registerProofRewriteRule(ProofRewriteRule::INT_TO_BV_ELIM,
-                               TheoryRewriteCtx::PRE_DSL),
+                               TheoryRewriteCtx::PRE_DSL);
 }
 
 RewriteResponse TheoryUfRewriter::postRewrite(TNode node)

--- a/src/theory/uf/theory_uf_rewriter.cpp
+++ b/src/theory/uf/theory_uf_rewriter.cpp
@@ -36,8 +36,8 @@ TheoryUfRewriter::TheoryUfRewriter(NodeManager* nm, Rewriter* rr)
                            TheoryRewriteCtx::PRE_DSL);
   registerProofRewriteRule(ProofRewriteRule::BV_TO_NAT_ELIM,
                            TheoryRewriteCtx::PRE_DSL);
-      registerProofRewriteRule(ProofRewriteRule::INT_TO_BV_ELIM,
-                               TheoryRewriteCtx::PRE_DSL);
+  registerProofRewriteRule(ProofRewriteRule::INT_TO_BV_ELIM,
+                           TheoryRewriteCtx::PRE_DSL);
 }
 
 RewriteResponse TheoryUfRewriter::postRewrite(TNode node)

--- a/src/theory/uf/theory_uf_rewriter.cpp
+++ b/src/theory/uf/theory_uf_rewriter.cpp
@@ -34,6 +34,10 @@ TheoryUfRewriter::TheoryUfRewriter(NodeManager* nm, Rewriter* rr)
 {
   registerProofRewriteRule(ProofRewriteRule::BETA_REDUCE,
                            TheoryRewriteCtx::PRE_DSL);
+  registerProofRewriteRule(ProofRewriteRule::BV_TO_NAT_ELIM,
+                           TheoryRewriteCtx::PRE_DSL),
+  registerProofRewriteRule(ProofRewriteRule::INT_TO_BV_ELIM,
+                           TheoryRewriteCtx::PRE_DSL),
 }
 
 RewriteResponse TheoryUfRewriter::postRewrite(TNode node)
@@ -210,6 +214,22 @@ Node TheoryUfRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
       Node ret = lambda[1].substitute(
           vars.begin(), vars.end(), subs.begin(), subs.end());
       return ret;
+    }
+    break;
+    case ProofRewriteRule::BV_TO_NAT_ELIM:
+    {
+      if (n.getKind() == Kind::BITVECTOR_TO_NAT)
+      {
+        return arith::eliminateBv2Nat(n);
+      }
+    }
+    break;
+    case ProofRewriteRule::INT_TO_BV_ELIM:
+    {
+      if (n.getKind() == Kind::INT_TO_BITVECTOR)
+      {
+        return arith::eliminateInt2Bv(n);
+      }
     }
     break;
     default: break;

--- a/test/regress/cli/regress0/arith/bug549.cvc.smt2
+++ b/test/regress/cli/regress0/arith/bug549.cvc.smt2
@@ -3,4 +3,4 @@
 (set-option :incremental false)
 (declare-fun a () Real)
 (declare-fun b () Real)
-(check-sat-assuming ( (not (= (^ (* a b) 5.0) (* (* (* (* (* (* (* (* (* b a) a) a) a) b) b) b) b) a))) ))
+(check-sat-assuming ( (not (= (^ (* a b) 5) (* (* (* (* (* (* (* (* (* b a) a) a) a) b) b) b) b) a))) ))

--- a/test/regress/cli/regress0/arith/bug549.cvc.smt2
+++ b/test/regress/cli/regress0/arith/bug549.cvc.smt2
@@ -3,4 +3,4 @@
 (set-option :incremental false)
 (declare-fun a () Real)
 (declare-fun b () Real)
-(check-sat-assuming ( (not (= (^ (* a b) 5) (* (* (* (* (* (* (* (* (* b a) a) a) a) b) b) b) b) a))) ))
+(check-sat-assuming ( (not (= (^ (* a b) 5.0) (* (* (* (* (* (* (* (* (* b a) a) a) a) b) b) b) b) a))) ))

--- a/test/regress/cli/regress0/nl/issue10145-ir-pow.smt2
+++ b/test/regress/cli/regress0/nl/issue10145-ir-pow.smt2
@@ -1,4 +1,4 @@
 ; EXPECT: sat
 (set-logic ALL)
-(assert (= 0.0 (^ 0 4.0)))
+(assert (= 0.0 (^ 0.0 4.0)))
 (check-sat)

--- a/test/regress/cli/regress0/nl/issue10145-ir-pow.smt2
+++ b/test/regress/cli/regress0/nl/issue10145-ir-pow.smt2
@@ -1,4 +1,4 @@
 ; EXPECT: sat
 (set-logic ALL)
-(assert (= 0.0 (^ 0.0 4.0)))
+(assert (= 0.0 (^ 0.0 4)))
 (check-sat)

--- a/test/regress/cli/regress0/nl/issue10145-ir-pow.smt2
+++ b/test/regress/cli/regress0/nl/issue10145-ir-pow.smt2
@@ -1,4 +1,4 @@
 ; EXPECT: sat
 (set-logic ALL)
-(assert (= 0.0 (^ 0.0 4)))
+(assert (= 0.0 (^ 0.0 4.0)))
 (check-sat)

--- a/test/regress/cli/regress0/quantifiers/issue9602-rewrite-pow-type.smt2
+++ b/test/regress/cli/regress0/quantifiers/issue9602-rewrite-pow-type.smt2
@@ -1,6 +1,6 @@
 ; EXPECT: sat
 (set-logic ALL)
-(assert (forall ((t Int)) (<= 0.0 (* 1.0 (^ 0 1.0)))))
-(assert (forall ((t Int)) (<= 0.0 (* 1.0 (^ 2 1.0)))))
-(assert (forall ((t Int)) (<= 0.0 (* 1.0 (^ 3 3.0)))))
+(assert (forall ((t Int)) (<= 0.0 (* 1.0 (^ 0.0 1.0)))))
+(assert (forall ((t Int)) (<= 0.0 (* 1.0 (^ 2.0 1.0)))))
+(assert (forall ((t Int)) (<= 0.0 (* 1.0 (^ 3.0 3.0)))))
 (check-sat)

--- a/test/regress/cli/regress0/quantifiers/issue9602-rewrite-pow-type.smt2
+++ b/test/regress/cli/regress0/quantifiers/issue9602-rewrite-pow-type.smt2
@@ -1,6 +1,6 @@
 ; EXPECT: sat
 (set-logic ALL)
-(assert (forall ((t Int)) (<= 0.0 (* 1.0 (^ 0.0 1.0)))))
-(assert (forall ((t Int)) (<= 0.0 (* 1.0 (^ 2.0 1.0)))))
-(assert (forall ((t Int)) (<= 0.0 (* 1.0 (^ 3.0 3.0)))))
+(assert (forall ((t Int)) (<= 0.0 (* 1.0 (^ 0.0 1)))))
+(assert (forall ((t Int)) (<= 0.0 (* 1.0 (^ 2.0 1)))))
+(assert (forall ((t Int)) (<= 0.0 (* 1.0 (^ 3.0 3)))))
 (check-sat)

--- a/test/regress/cli/regress0/quantifiers/issue9602-rewrite-pow-type.smt2
+++ b/test/regress/cli/regress0/quantifiers/issue9602-rewrite-pow-type.smt2
@@ -1,6 +1,6 @@
 ; EXPECT: sat
 (set-logic ALL)
-(assert (forall ((t Int)) (<= 0.0 (* 1.0 (^ 0.0 1)))))
-(assert (forall ((t Int)) (<= 0.0 (* 1.0 (^ 2.0 1)))))
-(assert (forall ((t Int)) (<= 0.0 (* 1.0 (^ 3.0 3)))))
+(assert (forall ((t Int)) (<= 0.0 (* 1.0 (^ 0.0 1.0)))))
+(assert (forall ((t Int)) (<= 0.0 (* 1.0 (^ 2.0 1.0)))))
+(assert (forall ((t Int)) (<= 0.0 (* 1.0 (^ 3.0 3.0)))))
 (check-sat)

--- a/test/regress/cli/regress1/nl/issue9480-pow-pow2.smt2
+++ b/test/regress/cli/regress1/nl/issue9480-pow-pow2.smt2
@@ -4,5 +4,5 @@
 (set-logic QF_UFLIRA)
 (declare-fun f4 () Real)
 (declare-fun ___ (Real Real) Real)
-(assert (= 0.0 (^ (- (- 2.0)) (to_int (___ (/ f4 2.0) 1.0)))))
+(assert (= 0.0 (^ (- (- 2.0)) (___ (/ f4 2.0) 1.0))))
 (check-sat)

--- a/test/regress/cli/regress1/nl/issue9480-pow-pow2.smt2
+++ b/test/regress/cli/regress1/nl/issue9480-pow-pow2.smt2
@@ -1,8 +1,8 @@
 ; SCRUBBER: sed -e 's/(error.*/error/; s/(^.*//'
 ; EXPECT: error
 ; EXIT: 1
-(set-logic QF_UFLRA)
+(set-logic QF_UFLIRA)
 (declare-fun f4 () Real)
 (declare-fun ___ (Real Real) Real)
-(assert (= 0.0 (^ (- (- 2.0)) (___ (/ f4 2.0) 1.0))))
+(assert (= 0.0 (^ (- (- 2.0)) (to_int (___ (/ f4 2.0) 1.0)))))
 (check-sat)


### PR DESCRIPTION
Covers 10 more trusted steps in our regressions.

Also makes it so that POW does not accept mixed arithmetic.