### PR TITLE
Demote ProofRule::MACRO_RE_ELIM to a trusted step

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -1799,25 +1799,6 @@ enum ENUM(ProofRule)
   EVALUE(MACRO_STRING_INFERENCE),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Strings -- Regular expressions -- Macro elimination**
-   *
-   * .. math::
-   *
-   *   \inferrule{-\mid F,b}{F = F'}
-   *
-   * where :math:`F'` is the result of eliminating regular expressions from
-   * :math:`F` using the routine
-   * :math:`\texttt{strings::RegExpElimination::eliminate}(F, b)`.
-   * Here, :math:`b` is a Boolean indicating whether we are using aggressive
-   * eliminations. Notice this rule concludes :math:`F = F` if no eliminations
-   * are performed for :math:`F`.
-   *
-   * We do not currently support elaboration of this macro.
-   * \endverbatim
-   */
-  EVALUE(MACRO_RE_ELIM),
-  /**
-   * \verbatim embed:rst:leading-asterisk
    * **Arithmetic -- Adding inequalities**
    *
    * An arithmetic literal is a term of the form :math:`p \diamond c` where

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -156,7 +156,6 @@ const char* toString(ProofRule rule)
     case ProofRule::STRING_CODE_INJ: return "STRING_CODE_INJ";
     case ProofRule::STRING_SEQ_UNIT_INJ: return "STRING_SEQ_UNIT_INJ";
     case ProofRule::MACRO_STRING_INFERENCE: return "MACRO_STRING_INFERENCE";
-    case ProofRule::MACRO_RE_ELIM: return "MACRO_RE_ELIM";
     //================================================= Arith rules
     case ProofRule::MACRO_ARITH_SCALE_SUM_UB: return "MACRO_ARITH_SCALE_SUM_UB";
     case ProofRule::ARITH_SUM_UB: return "ARITH_SUM_UB";

--- a/src/proof/trust_id.cpp
+++ b/src/proof/trust_id.cpp
@@ -45,6 +45,7 @@ const char* toString(TrustId id)
     case TrustId::SUBS_MAP: return "SUBS_MAP";
     case TrustId::SUBS_EQ: return "SUBS_EQ";
     case TrustId::ARITH_PRED_CAST_TYPE: return "ARITH_PRED_CAST_TYPE";
+    case TrustId::RE_ELIM: return "RE_ELIM";
     case TrustId::QUANTIFIERS_PREPROCESS: return "QUANTIFIERS_PREPROCESS";
     case TrustId::SUBTYPE_ELIMINATION: return "SUBTYPE_ELIMINATION";
     case TrustId::MACRO_THEORY_REWRITE_RCONS:

--- a/src/proof/trust_id.h
+++ b/src/proof/trust_id.h
@@ -110,6 +110,20 @@ enum class TrustId : uint32_t
   SUBS_EQ,
   /** A step of the form (~ s t) = (~ (to_real s) (to_real t)) */
   ARITH_PRED_CAST_TYPE,
+  /**
+   * Strings -- Regular expression elimination
+   *
+   * .. math::
+   *   \inferrule{-\mid F,b}{F = F'}
+   *
+   * where :math:`F'` is the result of eliminating regular expressions from
+   * :math:`F` using the routine
+   * :math:`\texttt{strings::RegExpElimination::eliminate}(F, b)`.
+   * Here, :math:`b` is a Boolean indicating whether we are using aggressive
+   * eliminations. Notice this rule concludes :math:`F = F` if no eliminations
+   * are performed for :math:`F`.
+   */
+  RE_ELIM,
   /** A quantifiers preprocessing step that was given without a proof */
   QUANTIFIERS_PREPROCESS,
   /** A subtype elimination step that could not be processed */

--- a/src/theory/strings/proof_checker.cpp
+++ b/src/theory/strings/proof_checker.cpp
@@ -58,7 +58,6 @@ void StringProofRuleChecker::registerTo(ProofChecker* pc)
   pc->registerChecker(ProofRule::RE_UNFOLD_POS, this);
   pc->registerChecker(ProofRule::RE_UNFOLD_NEG, this);
   pc->registerChecker(ProofRule::RE_UNFOLD_NEG_CONCAT_FIXED, this);
-  pc->registerChecker(ProofRule::MACRO_RE_ELIM, this);
   pc->registerChecker(ProofRule::STRING_CODE_INJ, this);
   pc->registerChecker(ProofRule::STRING_SEQ_UNIT_INJ, this);
   // trusted rule
@@ -477,23 +476,6 @@ Node StringProofRuleChecker::checkInternal(ProofRule id,
           nodeManager(), skChild, reLen, isRev);
     }
     return conc;
-  }
-  else if (id == ProofRule::MACRO_RE_ELIM)
-  {
-    Assert(children.empty());
-    Assert(args.size() == 2);
-    bool isAgg;
-    if (!getBool(args[1], isAgg))
-    {
-      return Node::null();
-    }
-    Node ea = RegExpElimination::eliminate(args[0], isAgg);
-    // if we didn't eliminate, then this trivially proves the reflexive equality
-    if (ea.isNull())
-    {
-      ea = args[0];
-    }
-    return args[0].eqNode(ea);
   }
   else if (id == ProofRule::STRING_CODE_INJ)
   {

--- a/src/theory/strings/regexp_elim.cpp
+++ b/src/theory/strings/regexp_elim.cpp
@@ -81,9 +81,8 @@ TrustNode RegExpElimination::eliminateTrusted(Node atom)
     {
       ProofNodeManager* pnm = d_env.getProofNodeManager();
       Node eq = atom.eqNode(eatom);
-      Node aggn = NodeManager::currentNM()->mkConst(d_isAggressive);
       std::shared_ptr<ProofNode> pn =
-          pnm->mkNode(ProofRule::MACRO_RE_ELIM, {}, {atom, aggn}, eq);
+          pnm->mkTrustedNode(TrustId::RE_ELIM, {}, {}, eq);
       d_epg->setProofFor(eq, pn);
       return TrustNode::mkTrustRewrite(atom, eatom, d_epg.get());
     }


### PR DESCRIPTION
For uniformity, it is best if this rule is handled as a trust step as it is identical in purpose to a single step rewrite.