### PR TITLE
Initial proof setup for bv-to-int

### DIFF
--- a/src/preprocessing/passes/bv_to_int.cpp
+++ b/src/preprocessing/passes/bv_to_int.cpp
@@ -60,7 +60,7 @@ PreprocessingPassResult BVToInt::applyInternal(
     // ensure bv rewritten
     Node bvNode = (*assertionsToPreprocess)[i];
     Node bvnr = rewrite(bvNode);
-    if (bvnr!=bvNode)
+    if (bvnr != bvNode)
     {
       assertionsToPreprocess->replace(i, bvnr);
       bvNode = bvnr;
@@ -78,7 +78,7 @@ PreprocessingPassResult BVToInt::applyInternal(
     // ensure integer rewritten
     Node intNode = (*assertionsToPreprocess)[i];
     Node inr = rewrite(intNode);
-    if (inr!=intNode)
+    if (inr != intNode)
     {
       assertionsToPreprocess->replace(i, inr);
     }

--- a/src/preprocessing/passes/bv_to_int.cpp
+++ b/src/preprocessing/passes/bv_to_int.cpp
@@ -53,18 +53,16 @@ PreprocessingPassResult BVToInt::applyInternal(
   // this will always contain range constraints
   // and for options::SolveBVAsIntMode::BITWISE, it will
   // also include bitwise assertion constraints
-  std::vector<Node> additionalConstraints;
+  std::vector<TrustNode> additionalConstraints;
   std::map<Node, Node> skolems;
   for (uint64_t i = 0; i < assertionsToPreprocess->size(); ++i)
   {
     Node bvNode = (*assertionsToPreprocess)[i];
-    Node intNode =
+    TrustNode intNode =
         d_intBlaster.intBlast(bvNode, additionalConstraints, skolems);
-    Node rwNode = rewrite(intNode);
     Trace("bv-to-int-debug") << "bv node: " << bvNode << std::endl;
     Trace("bv-to-int-debug") << "int node: " << intNode << std::endl;
-    Trace("bv-to-int-debug") << "rw node: " << rwNode << std::endl;
-    assertionsToPreprocess->replace(i, rwNode);
+    assertionsToPreprocess->replaceTrusted(i, intNode);
   }
   addFinalizeAssertions(assertionsToPreprocess, additionalConstraints);
   addSkolemDefinitions(skolems);
@@ -96,13 +94,14 @@ void BVToInt::addSkolemDefinitions(const std::map<Node, Node>& skolems)
 
 void BVToInt::addFinalizeAssertions(
     AssertionPipeline* assertionsToPreprocess,
-    const std::vector<Node>& additionalConstraints)
+    const std::vector<TrustNode>& additionalConstraints)
 {
-  NodeManager* nm = nodeManager();
-  Node lemmas = nm->mkAnd(additionalConstraints);
-  assertionsToPreprocess->push_back(lemmas);
-  Trace("bv-to-int-debug") << "range constraints: " << lemmas.toString()
-                           << std::endl;
+  Trace("bv-to-int-debug") << "range constraints:" << std::endl;
+  for (const TrustNode& tlem : additionalConstraints)
+  {
+    Trace("bv-to-int-debug") << "- " << tlem.getProven() << std::endl;
+    assertionsToPreprocess->pushBackTrusted(tlem);
+  }
 }
 
 }  // namespace passes

--- a/src/preprocessing/passes/bv_to_int.h
+++ b/src/preprocessing/passes/bv_to_int.h
@@ -40,7 +40,7 @@ class BVToInt : public PreprocessingPass
 
   // Add the lemmas in `additionalConstraints` to the assertions pipeline.
   void addFinalizeAssertions(AssertionPipeline* assertionsToPreprocess,
-                             const std::vector<Node>& additionalConstraints);
+                             const std::vector<TrustNode>& additionalConstraints);
 
   // include the skolem map as substitutions
   void addSkolemDefinitions(const std::map<Node, Node>& skolems);

--- a/src/preprocessing/passes/bv_to_int.h
+++ b/src/preprocessing/passes/bv_to_int.h
@@ -39,8 +39,9 @@ class BVToInt : public PreprocessingPass
       AssertionPipeline* assertionsToPreprocess) override;
 
   // Add the lemmas in `additionalConstraints` to the assertions pipeline.
-  void addFinalizeAssertions(AssertionPipeline* assertionsToPreprocess,
-                             const std::vector<TrustNode>& additionalConstraints);
+  void addFinalizeAssertions(
+      AssertionPipeline* assertionsToPreprocess,
+      const std::vector<TrustNode>& additionalConstraints);
 
   // include the skolem map as substitutions
   void addSkolemDefinitions(const std::map<Node, Node>& skolems);

--- a/src/proof/trust_id.cpp
+++ b/src/proof/trust_id.cpp
@@ -51,6 +51,7 @@ const char* toString(TrustId id)
       return "MACRO_THEORY_REWRITE_RCONS";
     case TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE:
       return "MACRO_THEORY_REWRITE_RCONS_SIMPLE";
+    case TrustId::INT_BLASTER: return "INT_BLASTER";
     default: return "TrustId::Unknown";
   };
 }

--- a/src/proof/trust_id.h
+++ b/src/proof/trust_id.h
@@ -121,6 +121,8 @@ enum class TrustId : uint32_t
    * require the use of theory rewrites to prove.
    */
   MACRO_THEORY_REWRITE_RCONS_SIMPLE,
+  /** An unproven step from the int-blaster */
+  INT_BLASTER,
 };
 /** Converts a trust id to a string. */
 const char* toString(TrustId id);

--- a/src/theory/bv/int_blaster.cpp
+++ b/src/theory/bv/int_blaster.cpp
@@ -33,6 +33,7 @@
 #include "util/bitvector.h"
 #include "util/iand.h"
 #include "util/rational.h"
+#include "proof/proof.h"
 
 using namespace cvc5::internal::kind;
 using namespace cvc5::internal::theory;
@@ -70,7 +71,9 @@ IntBlaster::~IntBlaster() {}
 std::shared_ptr<ProofNode> IntBlaster::getProofFor(Node fact)
 {
   // proofs not yet supported
-  return nullptr;
+  CDProof cdp(d_env);
+  cdp.addTrustedStep(fact, TrustId::INT_BLASTER, {}, {});
+  return cdp.getProofFor(fact);
 }
 
 std::string IntBlaster::identify() const { return "IntBlaster"; }

--- a/src/theory/bv/int_blaster.cpp
+++ b/src/theory/bv/int_blaster.cpp
@@ -22,18 +22,18 @@
 #include <vector>
 
 #include "expr/node.h"
-#include "expr/node_traversal.h"
 #include "expr/node_algorithm.h"
+#include "expr/node_traversal.h"
 #include "expr/skolem_manager.h"
 #include "options/option_exception.h"
 #include "options/uf_options.h"
+#include "proof/proof.h"
 #include "theory/bv/theory_bv_utils.h"
 #include "theory/logic_info.h"
 #include "theory/rewriter.h"
 #include "util/bitvector.h"
 #include "util/iand.h"
 #include "util/rational.h"
-#include "proof/proof.h"
 
 using namespace cvc5::internal::kind;
 using namespace cvc5::internal::theory;

--- a/src/theory/bv/int_blaster.cpp
+++ b/src/theory/bv/int_blaster.cpp
@@ -73,10 +73,7 @@ std::shared_ptr<ProofNode> IntBlaster::getProofFor(Node fact)
   return nullptr;
 }
 
-std::string IntBlaster::identify() const
-{
-  return "IntBlaster";
-}
+std::string IntBlaster::identify() const { return "IntBlaster"; }
 
 void IntBlaster::addRangeConstraint(Node node,
                                     uint32_t size,
@@ -165,8 +162,8 @@ Node IntBlaster::makeBinary(Node n)
  * Translate n to Integers via post-order traversal.
  */
 TrustNode IntBlaster::intBlast(Node n,
-                          std::vector<TrustNode>& lemmas,
-                          std::map<Node, Node>& skolems)
+                               std::vector<TrustNode>& lemmas,
+                               std::map<Node, Node>& skolems)
 {
   // make sure the node is re-written
   Trace("int-blaster-debug") << "n before rewriting: " << n << std::endl;

--- a/src/theory/bv/int_blaster.cpp
+++ b/src/theory/bv/int_blaster.cpp
@@ -162,8 +162,8 @@ Node IntBlaster::makeBinary(Node n)
  * Translate n to Integers via post-order traversal.
  */
 TrustNode IntBlaster::trustedIntBlast(Node n,
-                               std::vector<TrustNode>& lemmas,
-                               std::map<Node, Node>& skolems)
+                                      std::vector<TrustNode>& lemmas,
+                                      std::map<Node, Node>& skolems)
 {
   // make sure the node is re-written
   Trace("int-blaster-debug") << "n before rewriting: " << n << std::endl;
@@ -254,7 +254,7 @@ TrustNode IntBlaster::trustedIntBlast(Node n,
   }
   Assert(d_intblastCache.find(n) != d_intblastCache.end());
   Node res = d_intblastCache[n].get();
-  if (res==n)
+  if (res == n)
   {
     return TrustNode::null();
   }
@@ -262,8 +262,8 @@ TrustNode IntBlaster::trustedIntBlast(Node n,
 }
 
 Node IntBlaster::intBlast(Node n,
-                    std::vector<Node>& lemmas,
-                    std::map<Node, Node>& skolems)
+                          std::vector<Node>& lemmas,
+                          std::map<Node, Node>& skolems)
 {
   std::vector<TrustNode> tlemmas;
   TrustNode tr = trustedIntBlast(n, tlemmas, skolems);

--- a/src/theory/bv/int_blaster.h
+++ b/src/theory/bv/int_blaster.h
@@ -22,10 +22,10 @@
 #include "context/cdhashset.h"
 #include "context/cdo.h"
 #include "options/smt_options.h"
-#include "smt/env_obj.h"
-#include "theory/arith/nl/iand_utils.h"
 #include "proof/proof_generator.h"
 #include "proof/trust_node.h"
+#include "smt/env_obj.h"
+#include "theory/arith/nl/iand_utils.h"
 
 namespace cvc5::internal {
 
@@ -129,18 +129,19 @@ class IntBlaster : protected EnvObj, public ProofGenerator
    * @return integer node that corresponds to n
    */
   TrustNode intBlast(Node n,
-                std::vector<TrustNode>& lemmas,
-                std::map<Node, Node>& skolems);
+                     std::vector<TrustNode>& lemmas,
+                     std::map<Node, Node>& skolems);
 
   /**
    * Get proof for fact, where fact may correspond to:
    * (1) An equality of the form (= n n') where n was rewritten to n' in the
    * method intBlast.
    * (2) A lemma added to lemmas in the method intBlast.
-   */ 
+   */
   std::shared_ptr<ProofNode> getProofFor(Node fact) override;
   /** identify */
   std::string identify() const override;
+
  protected:
   /**
    * A generic function that creates a logical shift node (either left or
@@ -162,10 +163,13 @@ class IntBlaster : protected EnvObj, public ProofGenerator
                        bool isLeftShift);
 
   /** Adds the constraint 0 <= node < 2^size to lemmas */
-  void addRangeConstraint(Node node, uint32_t size, std::vector<TrustNode>& lemmas);
+  void addRangeConstraint(Node node,
+                          uint32_t size,
+                          std::vector<TrustNode>& lemmas);
 
   /** Adds a constraint that encodes bitwise and */
-  void addBitwiseConstraint(Node bitwiseConstraint, std::vector<TrustNode>& lemmas);
+  void addBitwiseConstraint(Node bitwiseConstraint,
+                            std::vector<TrustNode>& lemmas);
 
   /** Returns a node that represents the bitwise negation of n. */
   Node createBVNotNode(Node n, uint32_t bvsize);

--- a/src/theory/bv/int_blaster.h
+++ b/src/theory/bv/int_blaster.h
@@ -128,10 +128,14 @@ class IntBlaster : protected EnvObj, public ProofGenerator
    * f. For functions with other signatures this is similar
    * @return integer node that corresponds to n
    */
-  TrustNode intBlast(Node n,
+  TrustNode trustedIntBlast(Node n,
                      std::vector<TrustNode>& lemmas,
                      std::map<Node, Node>& skolems);
 
+  /** Version without proof tracking */
+  Node intBlast(Node n,
+                     std::vector<Node>& lemmas,
+                     std::map<Node, Node>& skolems);
   /**
    * Get proof for fact, where fact may correspond to:
    * (1) An equality of the form (= n n') where n was rewritten to n' in the

--- a/src/theory/bv/int_blaster.h
+++ b/src/theory/bv/int_blaster.h
@@ -129,13 +129,13 @@ class IntBlaster : protected EnvObj, public ProofGenerator
    * @return integer node that corresponds to n
    */
   TrustNode trustedIntBlast(Node n,
-                     std::vector<TrustNode>& lemmas,
-                     std::map<Node, Node>& skolems);
+                            std::vector<TrustNode>& lemmas,
+                            std::map<Node, Node>& skolems);
 
   /** Version without proof tracking */
   Node intBlast(Node n,
-                     std::vector<Node>& lemmas,
-                     std::map<Node, Node>& skolems);
+                std::vector<Node>& lemmas,
+                std::map<Node, Node>& skolems);
   /**
    * Get proof for fact, where fact may correspond to:
    * (1) An equality of the form (= n n') where n was rewritten to n' in the

--- a/src/theory/bv/int_blaster.h
+++ b/src/theory/bv/int_blaster.h
@@ -24,6 +24,8 @@
 #include "options/smt_options.h"
 #include "smt/env_obj.h"
 #include "theory/arith/nl/iand_utils.h"
+#include "proof/proof_generator.h"
+#include "proof/trust_node.h"
 
 namespace cvc5::internal {
 
@@ -91,7 +93,7 @@ namespace cvc5::internal {
 ** op.
 **
 **/
-class IntBlaster : protected EnvObj
+class IntBlaster : protected EnvObj, public ProofGenerator
 {
   using CDNodeMap = context::CDHashMap<Node, Node>;
 
@@ -126,10 +128,19 @@ class IntBlaster : protected EnvObj
    * f. For functions with other signatures this is similar
    * @return integer node that corresponds to n
    */
-  Node intBlast(Node n,
-                std::vector<Node>& lemmas,
+  TrustNode intBlast(Node n,
+                std::vector<TrustNode>& lemmas,
                 std::map<Node, Node>& skolems);
 
+  /**
+   * Get proof for fact, where fact may correspond to:
+   * (1) An equality of the form (= n n') where n was rewritten to n' in the
+   * method intBlast.
+   * (2) A lemma added to lemmas in the method intBlast.
+   */ 
+  std::shared_ptr<ProofNode> getProofFor(Node fact) override;
+  /** identify */
+  std::string identify() const override;
  protected:
   /**
    * A generic function that creates a logical shift node (either left or
@@ -151,10 +162,10 @@ class IntBlaster : protected EnvObj
                        bool isLeftShift);
 
   /** Adds the constraint 0 <= node < 2^size to lemmas */
-  void addRangeConstraint(Node node, uint32_t size, std::vector<Node>& lemmas);
+  void addRangeConstraint(Node node, uint32_t size, std::vector<TrustNode>& lemmas);
 
   /** Adds a constraint that encodes bitwise and */
-  void addBitwiseConstraint(Node bitwiseConstraint, std::vector<Node>& lemmas);
+  void addBitwiseConstraint(Node bitwiseConstraint, std::vector<TrustNode>& lemmas);
 
   /** Returns a node that represents the bitwise negation of n. */
   Node createBVNotNode(Node n, uint32_t bvsize);
@@ -167,14 +178,14 @@ class IntBlaster : protected EnvObj
   Node createBVAndNode(Node x,
                        Node y,
                        uint32_t bvsize,
-                       std::vector<Node>& lemmas);
+                       std::vector<TrustNode>& lemmas);
 
   /** Returns a node that represents the bitwise or of x and y, by translation
    * to sum and bitwise and. */
   Node createBVOrNode(Node x,
                       Node y,
                       uint32_t bvsize,
-                      std::vector<Node>& lemmas);
+                      std::vector<TrustNode>& lemmas);
 
   /** Returns a node that represents the sum of x and y. */
   Node createBVAddNode(Node x, Node y, uint32_t bvsize);
@@ -323,7 +334,7 @@ class IntBlaster : protected EnvObj
    */
   Node translateWithChildren(Node original,
                              const std::vector<Node>& translated_children,
-                             std::vector<Node>& lemmas);
+                             std::vector<TrustNode>& lemmas);
 
   /**
    * Performs the actual translation to integers for nodes
@@ -331,7 +342,7 @@ class IntBlaster : protected EnvObj
    * symbols).
    */
   Node translateNoChildren(Node original,
-                           std::vector<Node>& lemmas,
+                           std::vector<TrustNode>& lemmas,
                            std::map<Node, Node>& skolems);
 
   /** Caches for the different functions */

--- a/src/theory/bv/int_blaster.h
+++ b/src/theory/bv/int_blaster.h
@@ -126,7 +126,8 @@ class IntBlaster : protected EnvObj, public ProofGenerator
    * ff((bv2nat x))), where k is the bit-width of the domain of f, i is the
    * bit-width of its range, and ff is a Int->Int function that corresponds to
    * f. For functions with other signatures this is similar
-   * @return integer node that corresponds to n
+   * @return trust node proving (= n n_i) where n_i is an integer node that
+   * corresponds to n
    */
   TrustNode trustedIntBlast(Node n,
                             std::vector<TrustNode>& lemmas,
@@ -139,8 +140,8 @@ class IntBlaster : protected EnvObj, public ProofGenerator
   /**
    * Get proof for fact, where fact may correspond to:
    * (1) An equality of the form (= n n') where n was rewritten to n' in the
-   * method intBlast.
-   * (2) A lemma added to lemmas in the method intBlast.
+   * method trustedIntBlast.
+   * (2) A lemma added to lemmas in the method trustedIntBlast.
    */
   std::shared_ptr<ProofNode> getProofFor(Node fact) override;
   /** identify */

--- a/test/unit/theory/theory_bv_int_blaster_white.cpp
+++ b/test/unit/theory/theory_bv_int_blaster_white.cpp
@@ -45,7 +45,7 @@ TEST_F(TestTheoryWhiteBvIntblaster, intblaster_constants)
 {
   Env& env = d_slvEngine->getEnv();
   // place holders for lemmas and skolem
-  std::vector<Node> lemmas;
+  std::vector<TrustNode> lemmas;
   std::map<Node, Node> skolems;
 
   // bit-vector constant representing the integer 7, with 4 bits
@@ -67,7 +67,7 @@ TEST_F(TestTheoryWhiteBvIntblaster, intblaster_symbolic_constant)
 {
   Env& env = d_slvEngine->getEnv();
   // place holders for lemmas and skolem
-  std::vector<Node> lemmas;
+  std::vector<TrustNode> lemmas;
   std::map<Node, Node> skolems;
 
   // bit-vector variable
@@ -88,7 +88,7 @@ TEST_F(TestTheoryWhiteBvIntblaster, intblaster_uf)
 {
   Env& env = d_slvEngine->getEnv();
   // place holders for lemmas and skolem
-  std::vector<Node> lemmas;
+  std::vector<TrustNode> lemmas;
   std::map<Node, Node> skolems;
 
   // uf from integers and bit-vectors to Bools
@@ -124,7 +124,7 @@ TEST_F(TestTheoryWhiteBvIntblaster, intblaster_with_children)
 {
   Env& env = d_slvEngine->getEnv();
   // place holders for lemmas and skolem
-  std::vector<Node> lemmas;
+  std::vector<TrustNode> lemmas;
   std::map<Node, Node> skolems;
   IntBlaster intBlaster(env, options::SolveBVAsIntMode::SUM, 1);
 
@@ -272,7 +272,7 @@ TEST_F(TestTheoryWhiteBvIntblaster, intblaster_bitwise)
 {
   Env& env = d_slvEngine->getEnv();
   // place holders for lemmas and skolem
-  std::vector<Node> lemmas;
+  std::vector<TrustNode> lemmas;
   std::map<Node, Node> skolems;
   IntBlaster intBlaster(env, options::SolveBVAsIntMode::BITWISE, 1);
 


### PR DESCRIPTION
Makes IntBlaster a proof generator that justifies the rewrites and lemmas it sends. For now, it gives trust steps of new id `TrustId::INT_BLASTER`.