### PR TITLE
Fix print benchmark for RegLan

### DIFF
--- a/src/smt/print_benchmark.cpp
+++ b/src/smt/print_benchmark.cpp
@@ -252,7 +252,8 @@ void PrintBenchmark::printDeclaredFuns(std::ostream& out,
     Assert(f.isVar());
     // do not print selectors, constructors, testers, updaters
     TypeNode ft = f.getType();
-    if (ft.isDatatypeSelector() || ft.isDatatypeConstructor () || ft.isDatatypeTester() || ft.isDatatypeUpdater())
+    if (ft.isDatatypeSelector() || ft.isDatatypeConstructor()
+        || ft.isDatatypeTester() || ft.isDatatypeUpdater())
     {
       continue;
     }

--- a/src/smt/print_benchmark.cpp
+++ b/src/smt/print_benchmark.cpp
@@ -250,8 +250,9 @@ void PrintBenchmark::printDeclaredFuns(std::ostream& out,
   for (const Node& f : funs)
   {
     Assert(f.isVar());
-    // do not print selectors, constructors
-    if (!f.getType().isFirstClass())
+    // do not print selectors, constructors, testers, updaters
+    TypeNode ft = f.getType();
+    if (ft.isDatatypeSelector() || ft.isDatatypeConstructor () || ft.isDatatypeTester() || ft.isDatatypeUpdater())
     {
       continue;
     }


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/11324.

The issue was we were skipping all non-first class types, when we should have just skipped datatype-specific types.