### PR TITLE
Allow cvc5 to build with C++20

### DIFF
--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -150,6 +150,7 @@ PfManager::PfManager(Env& env)
 PfManager::~PfManager() {}
 
 // TODO: Remove in favor of `std::erase_if` with C++ 20+ (see cvc5-wishues#137).
+#if __cplusplus < 202002L
 template <class T, class Alloc, class Pred>
 constexpr typename std::vector<T, Alloc>::size_type erase_if(
     std::vector<T, Alloc>& c, Pred pred)
@@ -160,6 +161,7 @@ constexpr typename std::vector<T, Alloc>::size_type erase_if(
   c.erase(it, c.end());
   return r;
 }
+#endif
 
 std::shared_ptr<ProofNode> PfManager::connectProofToAssertions(
     std::shared_ptr<ProofNode> pfn, Assertions& as, ProofScopeMode scopeMode)


### PR DESCRIPTION
Without this change, the call to `erase_if` becomes ambiguous in systems where `std::erase_if` also exists.

Restored and corrected from https://github.com/cvc5/cvc5/pull/9119#discussion_r964167327.