### PR TITLE
ci: Only install ethos and carcara when testing proofs

### DIFF
--- a/.github/actions/setup-cache/action.yml
+++ b/.github/actions/setup-cache/action.yml
@@ -3,6 +3,10 @@ description: Setup caches (ccache, contribs and dependencies)
 inputs:
   cache-key:
     default: "none"
+  install-ethos:
+    default: false
+  install-carcara:
+    default: false
   shell:
     default: bash
 
@@ -61,8 +65,13 @@ runs:
       if: steps.contrib-cache.outputs.cache-hit != 'true'
       shell: ${{ inputs.shell }}
       run: |
-        ./contrib/get-carcara-checker
-        ./contrib/get-ethos-checker
+        mkdir -p ./deps/bin
+        if [ "${{ inputs.install-carcara }}" = "true" ]; then
+          ./contrib/get-carcara-checker
+        fi
+        if [ "${{ inputs.install-ethos }}" = "true" ]; then
+          ./contrib/get-ethos-checker
+        fi
 
     - name: Setup dependencies cache
       uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,8 @@ jobs:
       uses: ./.github/actions/setup-cache
       with:
         cache-key: ${{ matrix.build.cache-key }}
+        install-ethos: ${{ contains(matrix.build.run_regression_args, '--tester cpc') }}
+        install-carcara: ${{ contains(matrix.build.run_regression_args, '--tester alethe') }}
         shell: ${{ matrix.build.shell }}
 
     - name: Configure and build

--- a/contrib/get-carcara-checker
+++ b/contrib/get-carcara-checker
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e -o pipefail
+
 # utility function to download a file
 function download {
   if [ -x "$(command -v wget)" ]; then

--- a/contrib/get-ethos-checker
+++ b/contrib/get-ethos-checker
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e -o pipefail
+
 # utility function to download a file
 function download {
   if [ -x "$(command -v wget)" ]; then

--- a/contrib/get-lfsc-checker
+++ b/contrib/get-lfsc-checker
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e -o pipefail
+
 # utility function to download a file
 function download {
   if [ -x "$(command -v wget)" ]; then


### PR DESCRIPTION
It also immediately terminates the scripts that retrieve the ethos and carcara checkers if any command within the script returns a non-zero exit status. This helps to pinpoint pipeline failures related to the setup of these checkers more quickly.