### PR TITLE
Add missing `#include`s

### DIFF
--- a/src/context/default_clean_up.h
+++ b/src/context/default_clean_up.h
@@ -18,6 +18,8 @@
 #ifndef CVC5__CONTEXT__DEFAULT_CLEAN_UP_H
 #define CVC5__CONTEXT__DEFAULT_CLEAN_UP_H
 
+#include <vector>
+
 namespace cvc5::context {
 
 template <class T>

--- a/src/proof/unsat_core.h
+++ b/src/proof/unsat_core.h
@@ -24,12 +24,9 @@
 #include <string>
 #include <vector>
 
-namespace cvc5::internal {
+#include "expr/node.h"
 
-template <bool ref_count>
-class NodeTemplate;
-typedef NodeTemplate<true> Node;
-typedef NodeTemplate<false> TNode;
+namespace cvc5::internal {
 
 /**
  * An unsat core, which can optionally be initialized as a list of names

--- a/src/prop/registrar.h
+++ b/src/prop/registrar.h
@@ -23,6 +23,8 @@
 #ifndef CVC5__PROP__REGISTRAR_H
 #define CVC5__PROP__REGISTRAR_H
 
+#include "expr/node.h"
+
 namespace cvc5::internal {
 namespace prop {
 

--- a/src/theory/arith/linear/arithvar_node_map.h
+++ b/src/theory/arith/linear/arithvar_node_map.h
@@ -26,6 +26,8 @@
 #include "context/cdlist.h"
 #include "context/cdhashmap.h"
 #include "context/cdo.h"
+#include "expr/node.h"
+#include "util/dense_map.h"
 
 namespace cvc5::internal {
 namespace theory {

--- a/src/theory/arith/linear/constraint_forward.h
+++ b/src/theory/arith/linear/constraint_forward.h
@@ -27,6 +27,9 @@
 #include "cvc5_private.h"
 
 namespace cvc5::internal {
+
+class Rational;
+
 namespace theory {
 namespace arith::linear {
 

--- a/src/theory/bv/theory_bv_rewrite_rules_core.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_core.h
@@ -20,6 +20,7 @@
 
 #include "theory/bv/theory_bv_rewrite_rules.h"
 #include "theory/bv/theory_bv_utils.h"
+#include "util/bitvector.h"
 
 namespace cvc5::internal {
 namespace theory {

--- a/src/theory/uf/equality_engine_types.h
+++ b/src/theory/uf/equality_engine_types.h
@@ -21,11 +21,10 @@
 #ifndef CVC5__THEORY__UF__EQUALITY_ENGINE_TYPES_H
 #define CVC5__THEORY__UF__EQUALITY_ENGINE_TYPES_H
 
-#include <string>
-#include <iostream>
-#include <sstream>
+#include <ostream>
 
 #include "util/hash.h"
+#include "expr/node.h"
 
 namespace cvc5::internal {
 namespace theory {

--- a/src/util/iand.h
+++ b/src/util/iand.h
@@ -19,6 +19,7 @@
 #define CVC5__IAND_H
 
 #include <iosfwd>
+#include <ostream>
 
 #include "base/exception.h"
 #include "util/integer.h"

--- a/src/util/indexed_root_predicate.h
+++ b/src/util/indexed_root_predicate.h
@@ -14,6 +14,7 @@
  */
 
 #include <cstdint>
+#include <ostream>
 
 #include "cvc5_public.h"
 

--- a/src/util/safe_print.h
+++ b/src/util/safe_print.h
@@ -42,6 +42,7 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <cstdlib>
 #include <cstring>
 #include <string>
 


### PR DESCRIPTION
Each of these is necessary for the header file to make sense in isolation. Wherever this commit adds `#include $A` to `$B.h`, this means that in trnaslation units, the includes happened to be ordered as
```
#include $A
...
#include $B.h
```

This change makes the translation units robust to reordering of the includes, and permits the use of precompiled headers.

In some cases, the previous code made an attempt to forward-declare other classes, but in fact the forward declaration was insufficient and only worked in the presence of a previously-`#included` full definition.

In more detail:

* Forward declaration is / would be insufficient:
  * `src/context/default_clean_up.h`: takes a `std::vector` by value
  * `src/proof/unsat_core.h`: holds `Node`s by value
  * `src/prop/registrar.h`: declares a function taking a `Node` by value
  * `src/theory/arith/linear/arithvar_node_map.h`: holds a `DenseMap` by value
  * `src/theory/bv/theory_bv_rewrite_rules_core.h`: stack-allocates `BitVector`
  * `src/theory/uf/equality_engine_types.h`: struct holds a `Node` field
* Missing forward-declarations:
  * `src/theory/arith/linear/constraint_forward.h`: needs `Rational`
  * `src/util/iand.h`: needs `ostream` overloads
  * `src/util/indexed_root_predicate.h`: needs `ostream` overloads
  * `src/util/safe_print.h`: needs `abort`