### PR TITLE
Add infrastructure for proofs for witness terms

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -234,6 +234,8 @@ libcvc5_add_sources(
   proof/theory_proof_step_buffer.h
   proof/unsat_core.cpp
   proof/unsat_core.h
+  proof/valid_witness_proof_generator.cpp
+  proof/valid_witness_proof_generator.h
   proof/alethe/alethe_let_binding.cpp
   proof/alethe/alethe_let_binding.h
   proof/alethe/alethe_node_converter.cpp

--- a/src/expr/elim_witness_converter.cpp
+++ b/src/expr/elim_witness_converter.cpp
@@ -48,6 +48,8 @@ Node ElimWitnessNodeConverter::postConvert(Node n)
     Assert(qn.getKind() == Kind::FORALL);
     Node k = skm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE,
                                    {qn, nm->mkConstInt(Rational(0))});
+    // save the non-normalized version, which makes it easier to e.g.
+    // track proofs
     d_exists.push_back(q.notNode());
     return k;
   }

--- a/src/expr/elim_witness_converter.cpp
+++ b/src/expr/elim_witness_converter.cpp
@@ -48,7 +48,7 @@ Node ElimWitnessNodeConverter::postConvert(Node n)
     Assert(qn.getKind() == Kind::FORALL);
     Node k = skm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE,
                                    {qn, nm->mkConstInt(Rational(0))});
-    d_exists.push_back(qn.notNode());
+    d_exists.push_back(q.notNode());
     return k;
   }
   return n;

--- a/src/proof/trust_id.cpp
+++ b/src/proof/trust_id.cpp
@@ -47,6 +47,7 @@ const char* toString(TrustId id)
     case TrustId::ARITH_PRED_CAST_TYPE: return "ARITH_PRED_CAST_TYPE";
     case TrustId::RE_ELIM: return "RE_ELIM";
     case TrustId::QUANTIFIERS_PREPROCESS: return "QUANTIFIERS_PREPROCESS";
+    case TrustId::VALID_WITNESS: return "VALID_WITNESS";
     case TrustId::SUBTYPE_ELIMINATION: return "SUBTYPE_ELIMINATION";
     case TrustId::MACRO_THEORY_REWRITE_RCONS:
       return "MACRO_THEORY_REWRITE_RCONS";

--- a/src/proof/trust_id.h
+++ b/src/proof/trust_id.h
@@ -124,7 +124,7 @@ enum class TrustId : uint32_t
   RE_ELIM,
   /** A quantifiers preprocessing step that was given without a proof */
   QUANTIFIERS_PREPROCESS,
-  /** 
+  /**
    * An existential corresponding to a witness term introduced e.g. in
    * quantifier instantiation
    */

--- a/src/proof/trust_id.h
+++ b/src/proof/trust_id.h
@@ -124,6 +124,11 @@ enum class TrustId : uint32_t
   RE_ELIM,
   /** A quantifiers preprocessing step that was given without a proof */
   QUANTIFIERS_PREPROCESS,
+  /** 
+   * An existential corresponding to a witness term introduced e.g. in
+   * quantifier instantiation
+   */
+  VALID_WITNESS,
   /** A subtype elimination step that could not be processed */
   SUBTYPE_ELIMINATION,
   /** A rewrite required for showing a macro theory rewrite */

--- a/src/proof/valid_witness_proof_generator.cpp
+++ b/src/proof/valid_witness_proof_generator.cpp
@@ -1,0 +1,38 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2024 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Valid witness proof generator utility.
+ */
+
+#include "proof/valid_witness_proof_generator.h"
+
+#include "proof/proof.h"
+
+namespace cvc5::internal {
+
+ValidWitnessProofGenerator::ValidWitnessProofGenerator(Env& env) : EnvObj(env) {}
+
+ValidWitnessProofGenerator::~ValidWitnessProofGenerator() {}
+
+std::shared_ptr<ProofNode> ValidWitnessProofGenerator::getProofFor(Node fact) 
+{
+  Trace("valid-witness") << "Prove " << fact << std::endl;
+  // proofs not yet supported
+  CDProof cdp(d_env);
+  cdp.addTrustedStep(fact, TrustId::VALID_WITNESS, {}, {});
+  return cdp.getProofFor(fact);
+}
+
+std::string ValidWitnessProofGenerator::identify() const { return "ValidWitnessProofGenerator"; }
+
+}  // namespace cvc5::internal
+

--- a/src/proof/valid_witness_proof_generator.h
+++ b/src/proof/valid_witness_proof_generator.h
@@ -1,0 +1,52 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2024 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Valid witness proof generator utility.
+ */
+
+#include "cvc5_private.h"
+
+#ifndef CVC5__PROOF__VALID_WITNESS_PROOF_GENERATOR_H
+#define CVC5__PROOF__VALID_WITNESS_PROOF_GENERATOR_H
+
+#include "proof/method_id.h"
+#include "proof/proof_generator.h"
+#include "smt/env_obj.h"
+
+namespace cvc5::internal {
+
+class ProofNode;
+class ProofNodeManager;
+
+/**
+ * Proof generator expected to prove (exists x. P) for all witness terms
+ * (witness x. P) introduced.
+ */
+class ValidWitnessProofGenerator : protected EnvObj, public ProofGenerator
+{
+ public:
+  /**
+   * @param env Reference to the environment
+   */
+  ValidWitnessProofGenerator(Env& env);
+  virtual ~ValidWitnessProofGenerator();
+  /**
+   * Get proof for fact.
+   */
+  std::shared_ptr<ProofNode> getProofFor(Node fact) override;
+  /** identify */
+  std::string identify() const override;
+};
+
+}  // namespace cvc5::internal
+
+#endif /* CVC5__PROOF__VALID_WITNESS_PROOF_GENERATOR_H */

--- a/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
@@ -57,6 +57,10 @@ CegInstantiator::CegInstantiator(Env& env,
       d_is_nested_quant(false),
       d_effort(CEG_INST_EFFORT_NONE)
 {
+  if (d_env.isTheoryProofProducing())
+  {
+    d_vwpg.reset(new ValidWitnessProofGenerator(env));
+  }
 }
 
 CegInstantiator::~CegInstantiator() {
@@ -1044,7 +1048,7 @@ bool CegInstantiator::doAddInstantiation(std::vector<Node>& vars,
     // add the existentials, if any witness term was eliminated
     for (const Node& q : exists)
     {
-      d_qim.addPendingLemma(q, InferenceId::QUANTIFIERS_CEGQI_WITNESS);
+      d_qim.addPendingLemma(q, InferenceId::QUANTIFIERS_CEGQI_WITNESS, LemmaProperty::NONE, d_vwpg.get());
     }
     return true;
   }

--- a/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
@@ -1048,7 +1048,10 @@ bool CegInstantiator::doAddInstantiation(std::vector<Node>& vars,
     // add the existentials, if any witness term was eliminated
     for (const Node& q : exists)
     {
-      d_qim.addPendingLemma(q, InferenceId::QUANTIFIERS_CEGQI_WITNESS, LemmaProperty::NONE, d_vwpg.get());
+      d_qim.addPendingLemma(q,
+                            InferenceId::QUANTIFIERS_CEGQI_WITNESS,
+                            LemmaProperty::NONE,
+                            d_vwpg.get());
     }
     return true;
   }

--- a/src/theory/quantifiers/cegqi/ceg_instantiator.h
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.h
@@ -25,6 +25,7 @@
 #include "theory/inference_id.h"
 #include "util/statistics_stats.h"
 #include "theory/quantifiers/cegqi/ceg_utils.h"
+#include "proof/valid_witness_proof_generator.h"
 
 namespace cvc5::internal {
 namespace theory {
@@ -415,6 +416,10 @@ class CegInstantiator : protected EnvObj
   static CegHandledStatus isCbqiSort(
       TypeNode tn, std::map<TypeNode, CegHandledStatus>& visited);
   //------------------------------------ end  static queries
+  /**
+   * A proof generator for witness terms.
+   */
+  std::unique_ptr<ValidWitnessProofGenerator> d_vwpg;
 };
 
 }  // namespace quantifiers

--- a/src/theory/quantifiers/cegqi/ceg_instantiator.h
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.h
@@ -21,11 +21,11 @@
 #include <vector>
 
 #include "expr/node.h"
+#include "proof/valid_witness_proof_generator.h"
 #include "smt/env_obj.h"
 #include "theory/inference_id.h"
-#include "util/statistics_stats.h"
 #include "theory/quantifiers/cegqi/ceg_utils.h"
-#include "proof/valid_witness_proof_generator.h"
+#include "util/statistics_stats.h"
 
 namespace cvc5::internal {
 namespace theory {


### PR DESCRIPTION
Witness terms are introduced and eliminated in CEGQI. This PR adds a dedicated proof generator for the exists that are introduced in this manner.

For now, we simply add TRUST steps of a new kind VALID_WITNESS.