### PR TITLE
Add trust id for arithmetic DIO lemmas

### DIFF
--- a/src/proof/trust_id.cpp
+++ b/src/proof/trust_id.cpp
@@ -38,8 +38,7 @@ const char* toString(TrustId id)
     case TrustId::ARITH_NL_COVERING_DIRECT: return "ARITH_NL_COVERING_DIRECT";
     case TrustId::ARITH_NL_COVERING_RECURSIVE:
       return "ARITH_NL_COVERING_RECURSIVE";
-    case TrustId::ARITH_DIO_LEMMA:
-      return "ARITH_DIO_LEMMA";
+    case TrustId::ARITH_DIO_LEMMA: return "ARITH_DIO_LEMMA";
     case TrustId::EXT_THEORY_REWRITE: return "EXT_THEORY_REWRITE";
     case TrustId::REWRITE_NO_ELABORATE: return "REWRITE_NO_ELABORATE";
     case TrustId::FLATTENING_REWRITE: return "FLATTENING_REWRITE";

--- a/src/proof/trust_id.cpp
+++ b/src/proof/trust_id.cpp
@@ -38,6 +38,8 @@ const char* toString(TrustId id)
     case TrustId::ARITH_NL_COVERING_DIRECT: return "ARITH_NL_COVERING_DIRECT";
     case TrustId::ARITH_NL_COVERING_RECURSIVE:
       return "ARITH_NL_COVERING_RECURSIVE";
+    case TrustId::ARITH_DIO_LEMMA:
+      return "ARITH_DIO_LEMMA";
     case TrustId::EXT_THEORY_REWRITE: return "EXT_THEORY_REWRITE";
     case TrustId::REWRITE_NO_ELABORATE: return "REWRITE_NO_ELABORATE";
     case TrustId::FLATTENING_REWRITE: return "FLATTENING_REWRITE";

--- a/src/proof/trust_id.h
+++ b/src/proof/trust_id.h
@@ -95,6 +95,8 @@ enum class TrustId : uint32_t
    * no :math:`x_i` exists that extends the cell and satisfies all assumptions.
    */
   ARITH_NL_COVERING_RECURSIVE,
+  /** A lemma from the DIO solver */
+  ARITH_DIO_LEMMA,
   /** An extended theory rewrite */
   EXT_THEORY_REWRITE,
   /** A rewrite whose proof could not be elaborated */

--- a/src/theory/arith/linear/theory_arith_private.cpp
+++ b/src/theory/arith/linear/theory_arith_private.cpp
@@ -1804,7 +1804,6 @@ bool TheoryArithPrivate::outputLemma(TNode lem, InferenceId id) {
 
 void TheoryArithPrivate::outputTrustedConflict(TrustNode conf, InferenceId id)
 {
-  // AlwaysAssert(!isProofEnabled() || conf.getGenerator() != nullptr);
   Trace("arith::channel") << "Arith trusted conflict: " << conf << std::endl;
   d_containing.outputTrustedConflict(conf, id);
 }

--- a/src/theory/arith/linear/theory_arith_private.cpp
+++ b/src/theory/arith/linear/theory_arith_private.cpp
@@ -1804,7 +1804,7 @@ bool TheoryArithPrivate::outputLemma(TNode lem, InferenceId id) {
 
 void TheoryArithPrivate::outputTrustedConflict(TrustNode conf, InferenceId id)
 {
-  //AlwaysAssert(!isProofEnabled() || conf.getGenerator() != nullptr);
+  // AlwaysAssert(!isProofEnabled() || conf.getGenerator() != nullptr);
   Trace("arith::channel") << "Arith trusted conflict: " << conf << std::endl;
   d_containing.outputTrustedConflict(conf, id);
 }
@@ -3400,9 +3400,10 @@ bool TheoryArithPrivate::postCheck(Theory::Effort effortLevel)
         if (isProofEnabled())
         {
           std::vector<Node> assump;
-          if (possibleConflict.getKind()==Kind::AND)
+          if (possibleConflict.getKind() == Kind::AND)
           {
-            assump.insert(assump.end(), possibleConflict.begin(), possibleConflict.end());
+            assump.insert(
+                assump.end(), possibleConflict.begin(), possibleConflict.end());
           }
           else
           {

--- a/src/theory/arith/linear/theory_arith_private.cpp
+++ b/src/theory/arith/linear/theory_arith_private.cpp
@@ -1804,7 +1804,7 @@ bool TheoryArithPrivate::outputLemma(TNode lem, InferenceId id) {
 
 void TheoryArithPrivate::outputTrustedConflict(TrustNode conf, InferenceId id)
 {
-  AlwaysAssert(!isProofEnabled() || conf.getGenerator()!=nullptr);
+  AlwaysAssert(!isProofEnabled() || conf.getGenerator() != nullptr);
   Trace("arith::channel") << "Arith trusted conflict: " << conf << std::endl;
   d_containing.outputTrustedConflict(conf, id);
 }
@@ -3399,8 +3399,8 @@ bool TheoryArithPrivate::postCheck(Theory::Effort effortLevel)
         Pf pf;
         if (isProofEnabled())
         {
-          pf =
-              d_pnm->mkTrustedNode(TrustId::ARITH_DIO_LEMMA, {}, {}, possibleConflict);
+          pf = d_pnm->mkTrustedNode(
+              TrustId::ARITH_DIO_LEMMA, {}, {}, possibleConflict);
         }
         raiseBlackBoxConflict(possibleConflict, pf);
         outputConflicts();

--- a/src/theory/arith/linear/theory_arith_private.cpp
+++ b/src/theory/arith/linear/theory_arith_private.cpp
@@ -3399,8 +3399,21 @@ bool TheoryArithPrivate::postCheck(Theory::Effort effortLevel)
         Pf pf;
         if (isProofEnabled())
         {
-          pf = d_pnm->mkTrustedNode(
-              TrustId::ARITH_DIO_LEMMA, {}, {}, possibleConflict);
+          std::vector<Node> assump;
+          if (possibleConflict.getKind()==Kind::AND)
+          {
+            assump.insert(assump.end(), possibleConflict.begin(), possibleConflict.end());
+          }
+          else
+          {
+            assump.push_back(possibleConflict);
+          }
+          Node falsen = nodeManager()->mkConst(false);
+          CDProof cdp(d_env);
+          cdp.addTrustedStep(falsen, TrustId::ARITH_DIO_LEMMA, assump, {});
+          Node npc = possibleConflict.notNode();
+          cdp.addStep(npc, ProofRule::SCOPE, {falsen}, assump);
+          pf = cdp.getProofFor(npc);
         }
         raiseBlackBoxConflict(possibleConflict, pf);
         outputConflicts();

--- a/src/theory/arith/linear/theory_arith_private.cpp
+++ b/src/theory/arith/linear/theory_arith_private.cpp
@@ -1804,7 +1804,7 @@ bool TheoryArithPrivate::outputLemma(TNode lem, InferenceId id) {
 
 void TheoryArithPrivate::outputTrustedConflict(TrustNode conf, InferenceId id)
 {
-  AlwaysAssert(!isProofEnabled() || conf.getGenerator() != nullptr);
+  //AlwaysAssert(!isProofEnabled() || conf.getGenerator() != nullptr);
   Trace("arith::channel") << "Arith trusted conflict: " << conf << std::endl;
   d_containing.outputTrustedConflict(conf, id);
 }

--- a/src/theory/arith/linear/theory_arith_private.cpp
+++ b/src/theory/arith/linear/theory_arith_private.cpp
@@ -1804,6 +1804,7 @@ bool TheoryArithPrivate::outputLemma(TNode lem, InferenceId id) {
 
 void TheoryArithPrivate::outputTrustedConflict(TrustNode conf, InferenceId id)
 {
+  AlwaysAssert(!isProofEnabled() || conf.getGenerator()!=nullptr);
   Trace("arith::channel") << "Arith trusted conflict: " << conf << std::endl;
   d_containing.outputTrustedConflict(conf, id);
 }
@@ -3395,7 +3396,13 @@ bool TheoryArithPrivate::postCheck(Theory::Effort effortLevel)
         revertOutOfConflict();
         Trace("arith::conflict") << "dio conflict   " << possibleConflict << endl;
         // TODO (project #37): justify (proofs in the DIO solver)
-        raiseBlackBoxConflict(possibleConflict);
+        Pf pf;
+        if (isProofEnabled())
+        {
+          pf =
+              d_pnm->mkTrustedNode(TrustId::ARITH_DIO_LEMMA, {}, {}, possibleConflict);
+        }
+        raiseBlackBoxConflict(possibleConflict, pf);
         outputConflicts();
         emmittedConflictOrSplit = true;
       }


### PR DESCRIPTION
This is the last known source of arithmetic not covered by proofs that are allowable with `--safe-options`.