### PR TITLE
Fix proof checking for ProofRule::CONCAT_CONFLICT_DEQ

### DIFF
--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -159,6 +159,7 @@ bool AlfPrinter::isHandled(const Options& opts, const ProofNode* pfn)
     case ProofRule::CONCAT_CSPLIT:
     case ProofRule::CONCAT_CPROP:
     case ProofRule::CONCAT_CONFLICT:
+    case ProofRule::CONCAT_CONFLICT_DEQ:
     case ProofRule::CONCAT_SPLIT:
     case ProofRule::CONCAT_LPROP:
     case ProofRule::STRING_LENGTH_POS:

--- a/src/theory/strings/proof_checker.cpp
+++ b/src/theory/strings/proof_checker.cpp
@@ -71,7 +71,8 @@ Node StringProofRuleChecker::checkInternal(ProofRule id,
   NodeManager* nm = nodeManager();
   // core rules for word equations
   if (id == ProofRule::CONCAT_EQ || id == ProofRule::CONCAT_UNIFY
-      || id == ProofRule::CONCAT_CONFLICT || id == ProofRule::CONCAT_SPLIT
+      || id == ProofRule::CONCAT_CONFLICT
+      || id == ProofRule::CONCAT_CONFLICT_DEQ || id == ProofRule::CONCAT_SPLIT
       || id == ProofRule::CONCAT_CSPLIT || id == ProofRule::CONCAT_LPROP
       || id == ProofRule::CONCAT_CPROP)
   {


### PR DESCRIPTION
The proof checker for this rule was not enabled, meaning we would never successfully use this rule in our internals.

Furthermore, this enables Eunoia output for this rule, which already has a definition in the CPC signature.