### PR TITLE
Add ProofRewriteRule::DT_CYCLE

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -2679,6 +2679,19 @@ enum ENUM(ProofRewriteRule)
   EVALUE(DT_CONS_EQ),
   /**
    * \verbatim embed:rst:leading-asterisk
+   * **Datatypes -- cycle**
+   *
+   * .. math::
+   *   (x = t[x]) = \bot
+   *
+   * where all terms on the path to :math:`x` in :math:`t[x]` are applications
+   * of constructors, and this path is non-empty.
+   *
+   * \endverbatim
+   */
+  EVALUE(DT_CYCLE),
+  /**
+   * \verbatim embed:rst:leading-asterisk
    * **Datatypes -- collapse tester**
    *
    * .. math::

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -257,6 +257,7 @@ const char* toString(cvc5::ProofRewriteRule rule)
     case ProofRewriteRule::DT_COLLAPSE_TESTER_SINGLETON:
       return "dt-collapse-tester-singleton";
     case ProofRewriteRule::DT_CONS_EQ: return "dt-cons-eq";
+    case ProofRewriteRule::DT_CYCLE: return "dt-cycle";
     case ProofRewriteRule::DT_COLLAPSE_UPDATER: return "dt-collapse-updater";
     case ProofRewriteRule::DT_UPDATER_ELIM: return "dt-updater-elim";
     case ProofRewriteRule::DT_MATCH_ELIM: return "dt-match-elim";

--- a/src/theory/datatypes/infer_proof_cons.cpp
+++ b/src/theory/datatypes/infer_proof_cons.cpp
@@ -356,6 +356,7 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
         {
           cdp->addStep(eq1, ProofRule::TRANS, {lastEq, eq}, {});
         }
+        success = true;
       }
     }
     break;

--- a/src/theory/datatypes/infer_proof_cons.cpp
+++ b/src/theory/datatypes/infer_proof_cons.cpp
@@ -319,6 +319,13 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
     break;
     case InferenceId::DATATYPES_CYCLE:
     {
+      // the conflict is of the form
+      // (and (= x (C1 ... x1 ...))
+      //      (= x1 (C2 ... x2 ...)) ....
+      //      (= x{n-1} (Cn ... xn ...)))
+      // We take the first n-1 equalities as a substitution and apply it to
+      // the right hand side of the last equality, and use DT_CYCLE to derive
+      // a conflict.
       Assert(!expv.empty());
       Node lastEq = expv[expv.size() - 1];
       Assert(lastEq.getKind() == Kind::EQUAL);

--- a/src/theory/datatypes/infer_proof_cons.cpp
+++ b/src/theory/datatypes/infer_proof_cons.cpp
@@ -322,8 +322,8 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
       // the conflict is of the form
       // (and (= x (C1 ... x1 ...))
       //      (= x1 (C2 ... x2 ...)) ....
-      //      (= x{n-1} (C2 ... xn ...))
-      //      (= xn (Cn ... x ...)))
+      //      (= x{n-1} (Cn ... xn ...))
+      //      (= xn (C{n+1} ... x ...)))
       // We take the first n-1 equalities as a substitution and apply it to
       // the right hand side of the last equality, and use DT_CYCLE to derive
       // a conflict.

--- a/src/theory/datatypes/infer_proof_cons.cpp
+++ b/src/theory/datatypes/infer_proof_cons.cpp
@@ -322,7 +322,8 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
       // the conflict is of the form
       // (and (= x (C1 ... x1 ...))
       //      (= x1 (C2 ... x2 ...)) ....
-      //      (= x{n-1} (Cn ... xn ...)))
+      //      (= x{n-1} (C2 ... xn ...))
+      //      (= xn (Cn ... x ...)))
       // We take the first n-1 equalities as a substitution and apply it to
       // the right hand side of the last equality, and use DT_CYCLE to derive
       // a conflict.


### PR DESCRIPTION
This is the last remaining rule for the core datatypes theory.

Eunoia definition will follow when datatypes are stable in Eunoia.