### PR TITLE
Clarifying documentation for interpolation

### DIFF
--- a/include/cvc5/c/cvc5.h
+++ b/include/cvc5/c/cvc5.h
@@ -4833,9 +4833,9 @@ CVC5_EXPORT void cvc5_add_plugin(Cvc5* cvc5, Cvc5Plugin* plugin);
 /**
  * Get an interpolant.
  *
- * Given that @f$A->B@f$ is valid,
+ * Given that @f$A \rightarrow B@f$ is valid,
  * this function determines a term @f$I@f$ 
- * over the shared variables of @f$A@f$ and @f$B$,
+ * over the shared variables of @f$A@f$ and @f$B@f$,
  * such that @f$A \rightarrow I@f$ and
  * @f$I \rightarrow B@f$ are valid, if such a term exits. @f$A@f$ is the
  * current set of assertions and @f$B@f$ is the conjecture, given as `conj`.

--- a/include/cvc5/c/cvc5.h
+++ b/include/cvc5/c/cvc5.h
@@ -4833,7 +4833,10 @@ CVC5_EXPORT void cvc5_add_plugin(Cvc5* cvc5, Cvc5Plugin* plugin);
 /**
  * Get an interpolant.
  *
- * This determines a term @f$I@f$ such that @f$A \rightarrow I@f$ and
+ * Given that @f$A->B@f$ is valid,
+ * this function determines a term @f$I@f$ 
+ * over the shared variables of @f$A@f$ and @f$B$,
+ * such that @f$A \rightarrow I@f$ and
  * @f$I \rightarrow B@f$ are valid, if such a term exits. @f$A@f$ is the
  * current set of assertions and @f$B@f$ is the conjecture, given as `conj`.
  *
@@ -4862,7 +4865,10 @@ CVC5_EXPORT Cvc5Term cvc5_get_interpolant(Cvc5* cvc5, Cvc5Term conj);
 /**
  * Get an interpolant
  *
- * This determines a term @f$I@f$, with respect to a given grammar, such that
+ * Given that @f$A->B@f$ is valid,
+ * this function determines a term @f$I@f$ 
+ * over the shared variables of @f$A@f$ and @f$B$, 
+ * with respect to a given grammar, such that
  * @f$A \rightarrow I@f$ and @f$I \rightarrow B@f$ are valid, if such a term
  * exits. @f$A@f$ is the current set of assertions and @f$B@f$ is the
  * conjecture, given as `conj`.

--- a/include/cvc5/c/cvc5.h
+++ b/include/cvc5/c/cvc5.h
@@ -4865,7 +4865,7 @@ CVC5_EXPORT Cvc5Term cvc5_get_interpolant(Cvc5* cvc5, Cvc5Term conj);
 /**
  * Get an interpolant
  *
- * Given that @f$A->B@f$ is valid,
+ * Given that @f$A \rightarrow B@f$ is valid,
  * this function determines a term @f$I@f$ 
  * over the shared variables of @f$A@f$ and @f$B@f$, 
  * with respect to a given grammar, such that

--- a/include/cvc5/c/cvc5.h
+++ b/include/cvc5/c/cvc5.h
@@ -4867,7 +4867,7 @@ CVC5_EXPORT Cvc5Term cvc5_get_interpolant(Cvc5* cvc5, Cvc5Term conj);
  *
  * Given that @f$A->B@f$ is valid,
  * this function determines a term @f$I@f$ 
- * over the shared variables of @f$A@f$ and @f$B$, 
+ * over the shared variables of @f$A@f$ and @f$B@f$, 
  * with respect to a given grammar, such that
  * @f$A \rightarrow I@f$ and @f$I \rightarrow B@f$ are valid, if such a term
  * exits. @f$A@f$ is the current set of assertions and @f$B@f$ is the

--- a/include/cvc5/cvc5.h
+++ b/include/cvc5/cvc5.h
@@ -6405,8 +6405,10 @@ class CVC5_EXPORT Solver
   /**
    * Get an interpolant.
    *
-   * This determines a term @f$I@f$ such that @f$A \rightarrow I@f$ and
-   * @f$I \rightarrow B@f$ are valid, if such a term exits. @f$A@f$ is the
+   * Given that @f$A\rightarrow B@f$ is valid, this function
+   * determines a term @f$I@f$ over the shared variables of
+   * @f$A@f$ and @f$B@f$, such that @f$A \rightarrow I@f$ and
+   * @f$I \rightarrow B@f$ are valid. @f$A@f$ is the
    * current set of assertions and @f$B@f$ is the conjecture, given as `conj`.
    *
    * SMT-LIB:
@@ -6433,10 +6435,15 @@ class CVC5_EXPORT Solver
   /**
    * Get an interpolant.
    *
-   * This determines a term @f$I@f$, with respect to a given grammar, such
-   * that @f$A \rightarrow I@f$ and @f$I \rightarrow B@f$ are valid, if such a
-   * term exits. @f$A@f$ is the current set of assertions and @f$B@f$ is the
-   * conjecture, given as `conj`.
+   *
+   *
+   * Given that @f$A\rightarrow B@f$ is valid, this function
+   * determines a term @f$I@f$ over the shared variables of
+   * @f$A@f$ and @f$B@f$, such that @f$A \rightarrow I@f$ and
+   * @f$I \rightarrow B@f$ are valid. 
+   * @f$I@f$ is constructed from the given grammar.
+   * @f$A@f$ is the
+   * current set of assertions and @f$B@f$ is the conjecture, given as `conj`.
    *
    * SMT-LIB:
    *

--- a/src/api/java/io/github/cvc5/Solver.java
+++ b/src/api/java/io/github/cvc5/Solver.java
@@ -3122,8 +3122,12 @@ public class Solver extends AbstractPointer
    * Get an interpolant.
    *
    * <p>
-   * This determines a term {@code I} such that {@code A->I} and {@code I->B}
-   * are valid, if such a term exits. {@code A} is the current set of
+   * Given that {@code A->B} is valid,
+   * this function determines a term {@code I} 
+   * over the shared variables of {@code A} and
+   * {@code B},
+   * such that {@code A->I} and {@code I->B}
+   * are valid. {@code A} is the current set of
    * assertions and {@code B} is the conjecture, given as {@code conj}.
    * </p>
    *
@@ -3154,7 +3158,11 @@ public class Solver extends AbstractPointer
    * Get an interpolant.
    *
    * <p>
-   * This determines a term {@code I}, with respect to a given grammar, such
+   * Given that {@code A->B} is valid,
+   * this function determines a term {@code I}, 
+   * over the shared variables of {@code A} and
+   * {@code B},
+   * with respect to a given grammar, such
    * that {@code A->I} and {@code I->B} are valid, if such a term exits.
    * {@code A} is the current set of assertions and {@code B} is the
    * conjecture, given as {@code conj}.

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -897,16 +897,7 @@ cdef class DatatypeSelector:
 # ----------------------------------------------------------------------------
 
 cdef class Op:
-    """
-        A cvc5 operator.
-
-        An operator is a term that represents certain operators,
-        instantiated with its required parameters, e.g.,
-        a term of kind
-        :py:obj:`BITVECTOR_EXTRACT <Kind.BITVECTOR_EXTRACT>`.
-
-        Wrapper class for :cpp:class:`cvc5::Op`.
-    """
+    """Wrapper class for :cpp:class:`cvc5::api::Op`."""
     cdef c_Op cop
     cdef TermManager tm
 
@@ -927,10 +918,10 @@ cdef class Op:
 
     def getKind(self):
         """
-            :return: The kind of this operator.
+            :return: the kind of this operator.
         """
-        return Kind(<int> self.cop.getKind())
-
+        return kind(<int> self.cop.getKind())
+    
     def isIndexed(self):
         """
             :return: True iff this operator is indexed.

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -897,7 +897,16 @@ cdef class DatatypeSelector:
 # ----------------------------------------------------------------------------
 
 cdef class Op:
-    """Wrapper class for :cpp:class:`cvc5::api::Op`."""
+    """
+        A cvc5 operator.
+
+        An operator is a term that represents certain operators,
+        instantiated with its required parameters, e.g.,
+        a term of kind
+        :py:obj:`BITVECTOR_EXTRACT <Kind.BITVECTOR_EXTRACT>`.
+
+        Wrapper class for :cpp:class:`cvc5::Op`.
+    """
     cdef c_Op cop
     cdef TermManager tm
 
@@ -918,10 +927,10 @@ cdef class Op:
 
     def getKind(self):
         """
-            :return: the kind of this operator.
+            :return: The kind of this operator.
         """
-        return kind(<int> self.cop.getKind())
-    
+        return Kind(<int> self.cop.getKind())
+
     def isIndexed(self):
         """
             :return: True iff this operator is indexed.

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -4316,7 +4316,7 @@ cdef class Solver:
 	    this function
             determines a term :math:`I`
 	    over the shared variables of 
-            :math`A` and :math`B`,
+            :math:`A` and :math:`B`,
 	    optionally with respect to a
             a given grammar, such that :math:`A \\rightarrow I` and
             :math:`I \\rightarrow B` are valid, if such a term exits.

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -4312,8 +4312,12 @@ cdef class Solver:
     def getInterpolant(self, Term conj, Grammar grammar=None):
         """
             Get an interpolant.
-
-            This determines a term :math:`I`, optionally with respect to a
+	    Assuming that :math:`A \\rightarrow B` is valid,
+	    this function
+            determines a term :math:`I`
+	    over the shared variables of 
+            :math`A` and :math`B`,
+	    optionally with respect to a
             a given grammar, such that :math:`A \\rightarrow I` and
             :math:`I \\rightarrow B` are valid, if such a term exits.
             :math:`A` is the current set of assertions and :math:`B` is the


### PR DESCRIPTION
This PR clarifies in the documentation that the interpolant is computed only if the implication between `A` and `B` is valid.