### PR TITLE
Make QUANT_MERGE_PRENEX not eliminate duplicate variables, update QUANT_UNUSED_VARS

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -2511,7 +2511,8 @@ enum ENUM(ProofRewriteRule)
    * .. math::
    *   \forall X.\> F = \forall X_1.\> F
    *
-   * where :math:`X_1` is the subset of :math:`X` that appear free in :math:`F`.
+   * where :math:`X_1` is the subset of :math:`X` that appear free in :math:`F`
+   * and :math:`X_1` does not contain duplicate variables.
    *
    * \endverbatim
    */

--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -2521,6 +2521,19 @@ enum ENUM(ProofRewriteRule)
    * **Quantifiers -- Merge prenex**
    *
    * .. math::
+   *   \forall X_1.\> \ldots \forall X_n.\> F = \forall X.\> F
+   *
+   * where :math:`X_1 \ldots X_n` are lists of variables and :math:`X` is the
+   * result of removing duplicates from :math:`X_1 \ldots X_n`.
+   *
+   * \endverbatim
+   */
+  EVALUE(MACRO_QUANT_MERGE_PRENEX),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Quantifiers -- Merge prenex**
+   *
+   * .. math::
    *   \forall X_1.\> \ldots \forall X_n.\> F = \forall X_1 \ldots X_n.\> F
    *
    * where :math:`X_1 \ldots X_n` are lists of variables.

--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -2519,7 +2519,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(QUANT_UNUSED_VARS),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Quantifiers -- Merge prenex**
+   * **Quantifiers -- Macro merge prenex**
    *
    * .. math::
    *   \forall X_1.\> \ldots \forall X_n.\> F = \forall X.\> F

--- a/proofs/eo/cpc/rules/Quantifiers.eo
+++ b/proofs/eo/cpc/rules/Quantifiers.eo
@@ -132,7 +132,7 @@
   )
 )
 
-; program: $mk_quant_unused_vars_rec
+; program: $mk_quant_unused_vars
 ; args:
 ; - Q (-> @List Bool Bool): The quantifier, expected to be forall or exists.
 ; - x @List: The list of variables of the quantified formula.
@@ -142,8 +142,9 @@
   (eo::match ((y @List))
     ($mk_quant_unused_vars_rec x F)
     (
-    (@list.nil F)
-    (y (Q y F)))))
+      (@list.nil F)
+      (y (Q y F))
+    )))
 
 ; rule: quant-unused-vars
 ; implements: ProofRewriteRule::QUANT_UNUSED_VARS

--- a/proofs/eo/cpc/rules/Quantifiers.eo
+++ b/proofs/eo/cpc/rules/Quantifiers.eo
@@ -116,18 +116,34 @@
 
 ;;;;; ProofRewriteRule::QUANT_UNUSED_VARS
 
-; program: $is_quant_unused_vars
+; program: $mk_quant_unused_vars_rec
 ; args:
-; - F Bool: The first formula in question.
-; - G Bool: The second formula in question.
-; return: true iff G is the result of removing unused variables from F.
-(program $is_quant_unused_vars ((x @List) (y @List) (F Bool) (Q (-> @List Bool Bool)))
-  (Bool Bool) Bool
+; - x @List: The list of variables of the quantified formula.
+; - F Bool: The body of the quantified formula.
+; return: the sublist of variables in x that should be quantified for F.
+(program $mk_quant_unused_vars_rec ((T Type) (xs @List :list) (x T) (F Bool))
+  (@List Bool) Bool
   (
-  (($is_quant_unused_vars (Q x F) (Q y F)) (eo::not ($contains_subterm_list F ($nary_diff @list @list.nil x y))))
-  (($is_quant_unused_vars (Q x F) F)       (eo::not ($contains_subterm_list F x)))
+  (($mk_quant_unused_vars_rec @list.nil F)    @list.nil)
+  (($mk_quant_unused_vars_rec (@list x xs) F) (eo::define ((r ($mk_quant_unused_vars_rec xs F)))
+                                              (eo::ite ($contains_subterm F x)
+                                                (eo::ite ($contains_subterm r x) r (eo::cons @list x r))
+                                                r)))
   )
 )
+
+; program: $mk_quant_unused_vars_rec
+; args:
+; - Q (-> @List Bool Bool): The quantifier, expected to be forall or exists.
+; - x @List: The list of variables of the quantified formula.
+; - F Bool: The body of the quantified formula.
+; return: the result of removing duplicate and unused variables from x.
+(define $mk_quant_unused_vars ((Q (-> @List Bool Bool)) (x @List) (F Bool))
+  (eo::match ((y @List))
+    ($mk_quant_unused_vars_rec x F)
+    (
+    (@list.nil F)
+    (y (Q y F)))))
 
 ; rule: quant-unused-vars
 ; implements: ProofRewriteRule::QUANT_UNUSED_VARS
@@ -136,10 +152,10 @@
 ; requires: >
 ;   The variables removed from the left hand side do not occur in its body.
 ; conclusion: The given equality.
-(declare-rule quant-unused-vars ((F Bool) (G Bool))
-  :args ((= F G))
-  :requires ((($is_quant_unused_vars F G) true))
-  :conclusion (= F G)
+(declare-rule quant-unused-vars ((Q (-> @List Bool Bool)) (x @List) (F Bool) (G Bool))
+  :args ((= (Q x F) G))
+  :requires ((($mk_quant_unused_vars Q x F) G))
+  :conclusion (= (Q x F) G)
 )
 
 ;;;;; ProofRewriteRule::QUANT_MERGE_PRENEX
@@ -150,7 +166,7 @@
 ; - F Bool: The formula for which we are merging prenexes.
 ; return: the result of merging all bound variables bound by Q in F.
 (program $mk_quant_merge_prenex ((Q (-> @List Bool)) (x @List) (F Bool))
-  ((-> @List Bool) Bool) Bool
+  ((-> @List Bool Bool) Bool) Bool
   (
   (($mk_quant_merge_prenex Q (Q x F))  (eo::match ((R (-> @List Bool)) (y @List) (G Bool))
                                          ($mk_quant_merge_prenex Q F)

--- a/proofs/eo/cpc/rules/Quantifiers.eo
+++ b/proofs/eo/cpc/rules/Quantifiers.eo
@@ -162,13 +162,13 @@
 
 ; program: $mk_quant_merge_prenex
 ; args:
-; - Q (-> @List Bool): The binding operator (forall or exists).
+; - Q (-> @List Bool Bool): The binding operator (forall or exists).
 ; - F Bool: The formula for which we are merging prenexes.
 ; return: the result of merging all bound variables bound by Q in F.
-(program $mk_quant_merge_prenex ((Q (-> @List Bool)) (x @List) (F Bool))
+(program $mk_quant_merge_prenex ((Q (-> @List Bool Bool)) (x @List) (F Bool))
   ((-> @List Bool Bool) Bool) Bool
   (
-  (($mk_quant_merge_prenex Q (Q x F))  (eo::match ((R (-> @List Bool)) (y @List) (G Bool))
+  (($mk_quant_merge_prenex Q (Q x F))  (eo::match ((R (-> @List Bool Bool)) (y @List) (G Bool))
                                          ($mk_quant_merge_prenex Q F)
                                          ; note that since this method returns Q terms only, R is Q
                                          (((R y G) (Q (eo::list_concat @list x y) G)))))
@@ -184,7 +184,7 @@
 ;   The right hand side of the equality is the result of merging quantifier
 ;   prenexes in its left hand side.
 ; conclusion: The given equality.
-(declare-rule quant-merge-prenex ((Q (-> @List Bool)) (x @List) (F Bool) (G Bool))
+(declare-rule quant-merge-prenex ((Q (-> @List Bool Bool)) (x @List) (F Bool) (G Bool))
   :args ((= (Q x F) G))
   :requires (((eo::or (eo::is_eq Q forall) (eo::is_eq Q exists)) true)
              (($mk_quant_merge_prenex Q (Q x F)) G))

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -241,6 +241,7 @@ const char* toString(cvc5::ProofRewriteRule rule)
       return "arrays-eq-range-expand";
     case ProofRewriteRule::EXISTS_ELIM: return "exists-elim";
     case ProofRewriteRule::QUANT_UNUSED_VARS: return "quant-unused-vars";
+    case ProofRewriteRule::MACRO_QUANT_MERGE_PRENEX: return "macro-quant-merge-prenex";
     case ProofRewriteRule::QUANT_MERGE_PRENEX: return "quant-merge-prenex";
     case ProofRewriteRule::MACRO_QUANT_MINISCOPE:
       return "macro-quant-miniscope";

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -241,7 +241,8 @@ const char* toString(cvc5::ProofRewriteRule rule)
       return "arrays-eq-range-expand";
     case ProofRewriteRule::EXISTS_ELIM: return "exists-elim";
     case ProofRewriteRule::QUANT_UNUSED_VARS: return "quant-unused-vars";
-    case ProofRewriteRule::MACRO_QUANT_MERGE_PRENEX: return "macro-quant-merge-prenex";
+    case ProofRewriteRule::MACRO_QUANT_MERGE_PRENEX:
+      return "macro-quant-merge-prenex";
     case ProofRewriteRule::QUANT_MERGE_PRENEX: return "quant-merge-prenex";
     case ProofRewriteRule::MACRO_QUANT_MINISCOPE:
       return "macro-quant-miniscope";

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -547,6 +547,7 @@ bool BasicRewriteRCons::ensureProofMacroQuantMergePrenex(CDProof* cdp, const Nod
                      << std::endl;
   theory::Rewriter* rr = d_env.getRewriter();
   Node qm = rr->rewriteViaRule(ProofRewriteRule::QUANT_MERGE_PRENEX, eq[0]);
+  Trace("brc-macro") << "...non-macro to " << qm << std::endl;
   if (qm.isNull())
   {
     Assert (false);

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -194,6 +194,12 @@ void BasicRewriteRCons::ensureProofForTheoryRewrite(
         handledMacro = true;
       }
       break;
+    case ProofRewriteRule::MACRO_QUANT_MERGE_PRENEX:
+      if (ensureProofMacroQuantMergePrenex(cdp, eq))
+      {
+        handledMacro = true;
+      }
+      break;
     case ProofRewriteRule::MACRO_QUANT_PARTITION_CONNECTED_FV:
       if (ensureProofMacroQuantPartitionConnectedFv(cdp, eq))
       {

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -541,6 +541,29 @@ bool BasicRewriteRCons::ensureProofMacroSubstrStripSymLength(CDProof* cdp,
   return true;
 }
 
+bool BasicRewriteRCons::ensureProofMacroQuantMergePrenex(CDProof* cdp, const Node& eq)
+{
+  Trace("brc-macro") << "Expand macro quant merge prenex for " << eq
+                     << std::endl;
+  theory::Rewriter* rr = d_env.getRewriter();
+  Node qm = rr->rewriteViaRule(ProofRewriteRule::QUANT_MERGE_PRENEX, q[0]);
+  Node equiv = eq[0].eqNode(qm);
+  cdp->addTheoryRewriteStep(equiv, ProofRewriteRule::QUANT_MERGE_PRENEX);
+  if (qm==eq[1])
+  {
+    return true;
+  }
+  // if variables were duplicated, remove them with QUANT_UNUSED_VARS
+  Node equiv2 = qm.eqNode(eq[1]);
+  if (!cdp->addTheoryRewriteStep(equiv2, ProofRewriteRule::QUANT_UNUSED_VARS))
+  {
+    Assert (false);
+    return false;
+  }
+  cdp->addStep(eq, ProofRule::TRANS, {equiv, equiv2}, {});
+  return true;
+}
+  
 bool BasicRewriteRCons::ensureProofMacroQuantPartitionConnectedFv(
     CDProof* cdp, const Node& eq)
 {

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -541,7 +541,8 @@ bool BasicRewriteRCons::ensureProofMacroSubstrStripSymLength(CDProof* cdp,
   return true;
 }
 
-bool BasicRewriteRCons::ensureProofMacroQuantMergePrenex(CDProof* cdp, const Node& eq)
+bool BasicRewriteRCons::ensureProofMacroQuantMergePrenex(CDProof* cdp,
+                                                         const Node& eq)
 {
   Trace("brc-macro") << "Expand macro quant merge prenex for " << eq
                      << std::endl;
@@ -550,12 +551,12 @@ bool BasicRewriteRCons::ensureProofMacroQuantMergePrenex(CDProof* cdp, const Nod
   Trace("brc-macro") << "...non-macro to " << qm << std::endl;
   if (qm.isNull())
   {
-    Assert (false);
+    Assert(false);
     return false;
   }
   Node equiv = eq[0].eqNode(qm);
   cdp->addTheoryRewriteStep(equiv, ProofRewriteRule::QUANT_MERGE_PRENEX);
-  if (qm==eq[1])
+  if (qm == eq[1])
   {
     return true;
   }
@@ -563,7 +564,7 @@ bool BasicRewriteRCons::ensureProofMacroQuantMergePrenex(CDProof* cdp, const Nod
   Node qmu = rr->rewriteViaRule(ProofRewriteRule::QUANT_UNUSED_VARS, qm);
   if (qmu.isNull())
   {
-    Assert (false);
+    Assert(false);
     return false;
   }
   Node equiv2 = qm.eqNode(qmu);
@@ -571,14 +572,14 @@ bool BasicRewriteRCons::ensureProofMacroQuantMergePrenex(CDProof* cdp, const Nod
   std::vector<Node> transEq;
   transEq.push_back(equiv);
   transEq.push_back(equiv2);
-  if (qmu!=eq[1])
+  if (qmu != eq[1])
   {
     // May be we removed too many variables, in this case we do the same
     // removal for the opposite side, which should give the same result.
     Node qmu2 = rr->rewriteViaRule(ProofRewriteRule::QUANT_UNUSED_VARS, eq[1]);
-    if (qmu2!=qmu)
+    if (qmu2 != qmu)
     {
-      Assert (false);
+      Assert(false);
       return false;
     }
     Node equiv3 = eq[1].eqNode(qmu2);
@@ -590,7 +591,7 @@ bool BasicRewriteRCons::ensureProofMacroQuantMergePrenex(CDProof* cdp, const Nod
   cdp->addStep(eq, ProofRule::TRANS, transEq, {});
   return true;
 }
-  
+
 bool BasicRewriteRCons::ensureProofMacroQuantPartitionConnectedFv(
     CDProof* cdp, const Node& eq)
 {

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -572,7 +572,8 @@ bool BasicRewriteRCons::ensureProofMacroQuantMergePrenex(CDProof* cdp, const Nod
   transEq.push_back(equiv2);
   if (qmu!=eq[1])
   {
-    // may be we removed too many variables
+    // May be we removed too many variables, in this case we do the same
+    // removal for the opposite side, which should give the same result.
     Node qmu2 = rr->rewriteViaRule(ProofRewriteRule::QUANT_UNUSED_VARS, eq[1]);
     if (qmu2!=qmu)
     {

--- a/src/rewriter/basic_rewrite_rcons.h
+++ b/src/rewriter/basic_rewrite_rcons.h
@@ -172,6 +172,16 @@ class BasicRewriteRCons : protected EnvObj
   bool ensureProofMacroSubstrStripSymLength(CDProof* cdp, const Node& eq);
   /**
    * Elaborate a rewrite eq that was proven by
+   * ProofRewriteRule::MACRO_QUANT_MERGE_PRENEX.
+   *
+   * @param cdp The proof to add to.
+   * @param eq The rewrite proven by
+   * ProofRewriteRule::MACRO_QUANT_MERGE_PRENEX.
+   * @return true if added a closed proof of eq to cdp.
+   */
+  bool ensureProofMacroQuantMergePrenex(CDProof* cdp, const Node& eq);
+  /**
+   * Elaborate a rewrite eq that was proven by
    * ProofRewriteRule::MACRO_QUANT_PARTITION_CONNECTED_FV.
    *
    * @param cdp The proof to add to.

--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -178,6 +178,13 @@ Node RewriteDbProofCons::preprocessClosureEq(CDProof* cdp,
   Node eqConv = ai.eqNode(bi);
   if (ai[0] == bi[0])
   {
+    ProofRewriteRule prid = d_env.getRewriter()->findRule(
+        ai, bi, theory::TheoryRewriteCtx::PRE_DSL);
+    if (prid != ProofRewriteRule::NONE)
+    {
+      // a simple theory rewrite happens to solve it, do not continue
+      return Node::null();
+    }
     std::vector<Node> cargs;
     ProofRule cr = expr::getCongRule(ai, cargs);
     // remains to prove their bodies are equal

--- a/src/theory/quantifiers/quantifiers_rewriter.cpp
+++ b/src/theory/quantifiers/quantifiers_rewriter.cpp
@@ -420,9 +420,14 @@ void QuantifiersRewriter::computeArgVec(const std::vector<Node>& args,
   std::map< Node, bool > visited;
   computeArgs( args, activeMap, n, visited );
   if( !activeMap.empty() ){
-    for( unsigned i=0; i<args.size(); i++ ){
-      if( activeMap.find( args[i] )!=activeMap.end() ){
-        activeArgs.push_back( args[i] );
+    std::map<Node, bool>::iterator it;
+    for (const Node& v : args)
+    {
+      it = activeMap.find(v);
+      if( it!=activeMap.end() ){
+        activeArgs.emplace_back(v);
+        // no longer active, which accounts for deleting duplicates
+        activeMap.erase(it);
       }
     }
   }

--- a/src/theory/quantifiers/quantifiers_rewriter.cpp
+++ b/src/theory/quantifiers/quantifiers_rewriter.cpp
@@ -103,7 +103,8 @@ QuantifiersRewriter::QuantifiersRewriter(NodeManager* nm,
                            TheoryRewriteCtx::PRE_DSL);
   registerProofRewriteRule(ProofRewriteRule::QUANT_UNUSED_VARS,
                            TheoryRewriteCtx::PRE_DSL);
-  // QUANT_MERGE_PRENEX is part of the reconstruction for MACRO_QUANT_MERGE_PRENEX
+  // QUANT_MERGE_PRENEX is part of the reconstruction for
+  // MACRO_QUANT_MERGE_PRENEX
   registerProofRewriteRule(ProofRewriteRule::MACRO_QUANT_MERGE_PRENEX,
                            TheoryRewriteCtx::PRE_DSL);
   registerProofRewriteRule(ProofRewriteRule::MACRO_QUANT_MINISCOPE,
@@ -168,7 +169,8 @@ Node QuantifiersRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
       // Don't check standard here, which can't be replicated in a proof checker
       // without modelling the patterns.
       // We remove duplicates if the macro version.
-      Node q = mergePrenex(n, false, id==ProofRewriteRule::MACRO_QUANT_MERGE_PRENEX);
+      Node q = mergePrenex(
+          n, false, id == ProofRewriteRule::MACRO_QUANT_MERGE_PRENEX);
       if (q != n)
       {
         return q;
@@ -424,7 +426,8 @@ void QuantifiersRewriter::computeArgVec(const std::vector<Node>& args,
     for (const Node& v : args)
     {
       it = activeMap.find(v);
-      if( it!=activeMap.end() ){
+      if (it != activeMap.end())
+      {
         activeArgs.emplace_back(v);
         // no longer active, which accounts for deleting duplicates
         activeMap.erase(it);

--- a/src/theory/quantifiers/quantifiers_rewriter.h
+++ b/src/theory/quantifiers/quantifiers_rewriter.h
@@ -237,9 +237,10 @@ class QuantifiersRewriter : public TheoryRewriter
    * @param q The quantified formula to prenex.
    * @param checkStd If true, we do not merge prenex for any non-standard
    * quantified formula
+   * @param rmDup If true, we remove duplicate variables.
    * @return The result of merging prenex in q.
    */
-  Node mergePrenex(const Node& q, bool checkStd);
+  Node mergePrenex(const Node& q, bool checkStd, bool rmDup);
   /**
    * Helper method for getVarElim, called when n has polarity pol in body.
    */

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1493,6 +1493,7 @@ set(regress_0_tests
   regress0/quantifiers/macros-real-arg.smt2
   regress0/quantifiers/matching-lia-1arg.smt2
   regress0/quantifiers/mbqi-simple.smt2
+  regress0/quantifiers/merge-shadow.smt2
   regress0/quantifiers/mix-complete-strat.smt2
   regress0/quantifiers/mix-match.smt2
   regress0/quantifiers/mix-simp.smt2

--- a/test/regress/cli/regress0/quantifiers/merge-shadow.smt2
+++ b/test/regress/cli/regress0/quantifiers/merge-shadow.smt2
@@ -1,0 +1,6 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-fun P (Int) Bool)
+(assert (forall ((x Int)) (forall ((x Int)) (P x))))
+(assert (not (P 100)))
+(check-sat)


### PR DESCRIPTION
Currently, the Eunoia definition of quant_merge_prenex is inaccurate since it does not handle duplicate variables.

Introduces a new macro for the current behavior and reconstruction to the version that does not eliminate duplicates, making the Eunoia definition accurate.

This also updates the Eunoia definition of quant_unused_vars to handle duplicates.

This should be merged before https://github.com/cvc5/cvc5/pull/11391, as that PR had an alternative fix which will be subsumed by this approach.