### PR TITLE
Simplify interface for ppAssert

### DIFF
--- a/src/preprocessing/passes/miplib_trick.cpp
+++ b/src/preprocessing/passes/miplib_trick.cpp
@@ -537,14 +537,14 @@ PreprocessingPassResult MipLibTrick::applyInternal(
                   n, false, nullptr, TrustId::PREPROCESS_MIPLIB_TRICK_LEMMA);
               TrustSubstitutionMap tnullMap(d_env, &fakeContext);
               CVC5_UNUSED SubstitutionMap& nullMap = tnullMap.get();
-              Theory::PPAssertStatus status CVC5_UNUSED;  // just for assertions
+              bool status CVC5_UNUSED;  // just for assertions
               status = te->solve(tgeq, tnullMap);
-              Assert(status == Theory::PP_ASSERT_STATUS_UNSOLVED)
+              Assert(!status)
                   << "unexpected solution from arith's ppAssert()";
               Assert(nullMap.empty())
                   << "unexpected substitution from arith's ppAssert()";
               status = te->solve(tleq, tnullMap);
-              Assert(status == Theory::PP_ASSERT_STATUS_UNSOLVED)
+              Assert(!status)
                   << "unexpected solution from arith's ppAssert()";
               Assert(nullMap.empty())
                   << "unexpected substitution from arith's ppAssert()";

--- a/src/preprocessing/passes/miplib_trick.cpp
+++ b/src/preprocessing/passes/miplib_trick.cpp
@@ -539,13 +539,11 @@ PreprocessingPassResult MipLibTrick::applyInternal(
               CVC5_UNUSED SubstitutionMap& nullMap = tnullMap.get();
               bool status CVC5_UNUSED;  // just for assertions
               status = te->solve(tgeq, tnullMap);
-              Assert(!status)
-                  << "unexpected solution from arith's ppAssert()";
+              Assert(!status) << "unexpected solution from arith's ppAssert()";
               Assert(nullMap.empty())
                   << "unexpected substitution from arith's ppAssert()";
               status = te->solve(tleq, tnullMap);
-              Assert(!status)
-                  << "unexpected solution from arith's ppAssert()";
+              Assert(!status) << "unexpected solution from arith's ppAssert()";
               Assert(nullMap.empty())
                   << "unexpected substitution from arith's ppAssert()";
               newVars.push_back(newVar);

--- a/src/preprocessing/passes/non_clausal_simp.cpp
+++ b/src/preprocessing/passes/non_clausal_simp.cpp
@@ -178,15 +178,13 @@ PreprocessingPassResult NonClausalSimp::applyInternal(
 
     TrustNode tlearnedLiteral =
         TrustNode::mkTrustLemma(learnedLiteral, d_llpg.get());
-    bool solveStatus =
-        d_preprocContext->getTheoryEngine()->solve(tlearnedLiteral,
-                                                   *newSubstitutions.get());
+    bool solveStatus = d_preprocContext->getTheoryEngine()->solve(
+        tlearnedLiteral, *newSubstitutions.get());
 
     if (solveStatus)
     {
       // The literal should rewrite to true
-      Trace("non-clausal-simplify")
-          << "solved " << learnedLiteral << std::endl;
+      Trace("non-clausal-simplify") << "solved " << learnedLiteral << std::endl;
       Assert(rewrite(nss.apply(learnedLiteral)).isConst());
     }
     else
@@ -224,8 +222,8 @@ PreprocessingPassResult NonClausalSimp::applyInternal(
         Assert(top_level_substs.apply(t) == t);
         Assert(nss.apply(t) == t);
         // also add to learned literal
-        ProofGenerator* cpg = constantPropagations->addSubstitutionSolved(
-            t, c, tlearnedLiteral);
+        ProofGenerator* cpg =
+            constantPropagations->addSubstitutionSolved(t, c, tlearnedLiteral);
         // We need to justify (= t c) as a literal, since it is reasserted
         // to the assertion pipeline below. We do this with the proof
         // generator returned by the above call.

--- a/src/preprocessing/passes/non_clausal_simp.cpp
+++ b/src/preprocessing/passes/non_clausal_simp.cpp
@@ -178,85 +178,71 @@ PreprocessingPassResult NonClausalSimp::applyInternal(
 
     TrustNode tlearnedLiteral =
         TrustNode::mkTrustLemma(learnedLiteral, d_llpg.get());
-    Theory::PPAssertStatus solveStatus =
+    bool solveStatus =
         d_preprocContext->getTheoryEngine()->solve(tlearnedLiteral,
                                                    *newSubstitutions.get());
 
-    switch (solveStatus)
+    if (solveStatus)
     {
-      case Theory::PP_ASSERT_STATUS_SOLVED:
+      // The literal should rewrite to true
+      Trace("non-clausal-simplify")
+          << "solved " << learnedLiteral << std::endl;
+      Assert(rewrite(nss.apply(learnedLiteral)).isConst());
+    }
+    else
+    {
+      TNode t;
+      TNode c;
+      if (learnedLiteral.getKind() == Kind::EQUAL
+          && (learnedLiteral[0].isConst() || learnedLiteral[1].isConst()))
       {
-        // The literal should rewrite to true
-        Trace("non-clausal-simplify")
-            << "solved " << learnedLiteral << std::endl;
-        Assert(rewrite(nss.apply(learnedLiteral)).isConst());
-        // else fall through
-        break;
-      }
-      case Theory::PP_ASSERT_STATUS_CONFLICT:
-      {
-        // If in conflict, we return false
-        Trace("non-clausal-simplify")
-            << "conflict while solving " << learnedLiteral << std::endl;
-        Node n = nm->mkConst<bool>(false);
-        assertionsToPreprocess->push_back(n);
-        return PreprocessingPassResult::CONFLICT;
-      }
-      default:
-        TNode t;
-        TNode c;
-        if (learnedLiteral.getKind() == Kind::EQUAL
-            && (learnedLiteral[0].isConst() || learnedLiteral[1].isConst()))
+        // constant propagation
+        if (learnedLiteral[0].isConst())
         {
-          // constant propagation
-          if (learnedLiteral[0].isConst())
-          {
-            t = learnedLiteral[1];
-            c = learnedLiteral[0];
-          }
-          else
-          {
-            t = learnedLiteral[0];
-            c = learnedLiteral[1];
-          }
-        }
-        else if (options().smt.simplificationBoolConstProp)
-        {
-          // From non-equalities, learn the Boolean equality. Notice that
-          // the equality case above is strictly more powerful that this, since
-          // e.g. (= t c) * { t -> c } also simplifies to true.
-          bool pol = learnedLiteral.getKind() != Kind::NOT;
-          c = nm->mkConst(pol);
-          t = pol ? learnedLiteral : learnedLiteral[0];
-        }
-        if (!t.isNull())
-        {
-          Assert(!t.isConst());
-          Assert(rewrite(cps.apply(t)) == t);
-          Assert(top_level_substs.apply(t) == t);
-          Assert(nss.apply(t) == t);
-          // also add to learned literal
-          ProofGenerator* cpg = constantPropagations->addSubstitutionSolved(
-              t, c, tlearnedLiteral);
-          // We need to justify (= t c) as a literal, since it is reasserted
-          // to the assertion pipeline below. We do this with the proof
-          // generator returned by the above call.
-          if (isProofEnabled())
-          {
-            d_llpg->notifyNewAssert(t.eqNode(c), cpg);
-          }
+          t = learnedLiteral[1];
+          c = learnedLiteral[0];
         }
         else
         {
-          // Keep the learned literal
-          learned_literals[j++] = learned_literals[i];
+          t = learnedLiteral[0];
+          c = learnedLiteral[1];
         }
-        // Its a literal that could not be processed as a substitution or
-        // conflict. In this case, we notify the context of the learned
-        // literal, which will process it with the learned literal manager.
-        d_preprocContext->notifyLearnedLiteral(learnedLiteral);
-        break;
-    }
+      }
+      else if (options().smt.simplificationBoolConstProp)
+      {
+        // From non-equalities, learn the Boolean equality. Notice that
+        // the equality case above is strictly more powerful that this, since
+        // e.g. (= t c) * { t -> c } also simplifies to true.
+        bool pol = learnedLiteral.getKind() != Kind::NOT;
+        c = nm->mkConst(pol);
+        t = pol ? learnedLiteral : learnedLiteral[0];
+      }
+      if (!t.isNull())
+      {
+        Assert(!t.isConst());
+        Assert(rewrite(cps.apply(t)) == t);
+        Assert(top_level_substs.apply(t) == t);
+        Assert(nss.apply(t) == t);
+        // also add to learned literal
+        ProofGenerator* cpg = constantPropagations->addSubstitutionSolved(
+            t, c, tlearnedLiteral);
+        // We need to justify (= t c) as a literal, since it is reasserted
+        // to the assertion pipeline below. We do this with the proof
+        // generator returned by the above call.
+        if (isProofEnabled())
+        {
+          d_llpg->notifyNewAssert(t.eqNode(c), cpg);
+        }
+      }
+      else
+      {
+        // Keep the learned literal
+        learned_literals[j++] = learned_literals[i];
+      }
+      // Its a literal that could not be processed as a substitution or
+      // conflict. In this case, we notify the context of the learned
+      // literal, which will process it with the learned literal manager.
+      d_preprocContext->notifyLearnedLiteral(learnedLiteral);
   }
 
 #ifdef CVC5_ASSERTIONS

--- a/src/preprocessing/passes/non_clausal_simp.cpp
+++ b/src/preprocessing/passes/non_clausal_simp.cpp
@@ -243,6 +243,7 @@ PreprocessingPassResult NonClausalSimp::applyInternal(
       // conflict. In this case, we notify the context of the learned
       // literal, which will process it with the learned literal manager.
       d_preprocContext->notifyLearnedLiteral(learnedLiteral);
+    }
   }
 
 #ifdef CVC5_ASSERTIONS

--- a/src/prop/zero_level_learner.cpp
+++ b/src/prop/zero_level_learner.cpp
@@ -431,8 +431,8 @@ bool ZeroLevelLearner::getSolved(const Node& lit, Subs& subs)
   context::Context dummyContext;
   theory::TrustSubstitutionMap subsOut(d_env, &dummyContext);
   TrustNode tlit = TrustNode::mkTrustLemma(lit);
-  theory::Theory::PPAssertStatus status = d_theoryEngine->solve(tlit, subsOut);
-  if (status == theory::Theory::PP_ASSERT_STATUS_SOLVED)
+  bool status = d_theoryEngine->solve(tlit, subsOut);
+  if (status)
   {
     Trace("level-zero-debug") << lit << " is solvable" << std::endl;
     // extract the substitution

--- a/src/prop/zero_level_learner.cpp
+++ b/src/prop/zero_level_learner.cpp
@@ -246,7 +246,8 @@ modes::LearnedLitType ZeroLevelLearner::computeLearnedLiteralType(
   Node lit = d_tsmap.apply(input, d_env.getRewriter());
   modes::LearnedLitType ltype =
       internal ? modes::LearnedLitType::INTERNAL : modes::LearnedLitType::INPUT;
-  if (internal || d_trackSimplifications)
+  // we don't try to solve for literals that simplify to constants
+  if ((internal || d_trackSimplifications) && !lit.isConst())
   {
     Subs ss;
     bool processed = false;

--- a/src/theory/arith/linear/linear_solver.cpp
+++ b/src/theory/arith/linear/linear_solver.cpp
@@ -50,8 +50,8 @@ void LinearSolver::presolve() { d_internal.presolve(); }
 
 void LinearSolver::notifyRestart() { d_internal.notifyRestart(); }
 
-bool LinearSolver::ppAssert(
-    TrustNode tin, TrustSubstitutionMap& outSubstitutions)
+bool LinearSolver::ppAssert(TrustNode tin,
+                            TrustSubstitutionMap& outSubstitutions)
 {
   return d_internal.ppAssert(tin, outSubstitutions);
 }

--- a/src/theory/arith/linear/linear_solver.cpp
+++ b/src/theory/arith/linear/linear_solver.cpp
@@ -50,7 +50,7 @@ void LinearSolver::presolve() { d_internal.presolve(); }
 
 void LinearSolver::notifyRestart() { d_internal.notifyRestart(); }
 
-Theory::PPAssertStatus LinearSolver::ppAssert(
+bool LinearSolver::ppAssert(
     TrustNode tin, TrustSubstitutionMap& outSubstitutions)
 {
   return d_internal.ppAssert(tin, outSubstitutions);

--- a/src/theory/arith/linear/linear_solver.h
+++ b/src/theory/arith/linear/linear_solver.h
@@ -73,7 +73,7 @@ class LinearSolver : protected EnvObj
   /** Notify restart */
   void notifyRestart();
   /** Preprocess assert */
-  Theory::PPAssertStatus ppAssert(TrustNode tin,
+  bool ppAssert(TrustNode tin,
                                   TrustSubstitutionMap& outSubstitutions);
   /** Preprocess static learn */
   void ppStaticLearn(TNode in, std::vector<TrustNode>& learned);

--- a/src/theory/arith/linear/linear_solver.h
+++ b/src/theory/arith/linear/linear_solver.h
@@ -73,8 +73,7 @@ class LinearSolver : protected EnvObj
   /** Notify restart */
   void notifyRestart();
   /** Preprocess assert */
-  bool ppAssert(TrustNode tin,
-                                  TrustSubstitutionMap& outSubstitutions);
+  bool ppAssert(TrustNode tin, TrustSubstitutionMap& outSubstitutions);
   /** Preprocess static learn */
   void ppStaticLearn(TNode in, std::vector<TrustNode>& learned);
 

--- a/src/theory/arith/linear/theory_arith_private.cpp
+++ b/src/theory/arith/linear/theory_arith_private.cpp
@@ -945,7 +945,7 @@ Node TheoryArithPrivate::getCandidateModelValue(TNode term)
   }
 }
 
-Theory::PPAssertStatus TheoryArithPrivate::ppAssert(
+bool TheoryArithPrivate::ppAssert(
     TrustNode tin, TrustSubstitutionMap& outSubstitutions)
 {
   TimerStat::CodeTimer codeTimer(d_statistics.d_simplifyTimer);
@@ -1005,7 +1005,7 @@ Theory::PPAssertStatus TheoryArithPrivate::ppAssert(
                           << minVar << " |-> " << elim << endl;
         Assert(elim.getType() == minVar.getType());
         outSubstitutions.addSubstitutionSolved(minVar, elim, tin);
-        return Theory::PP_ASSERT_STATUS_SOLVED;
+        return true;
       }
       else
       {
@@ -1032,7 +1032,7 @@ Theory::PPAssertStatus TheoryArithPrivate::ppAssert(
       break;
   }
 
-  return Theory::PP_ASSERT_STATUS_UNSOLVED;
+  return false;
 }
 
 void TheoryArithPrivate::ppStaticLearn(TNode n, std::vector<TrustNode>& learned)

--- a/src/theory/arith/linear/theory_arith_private.cpp
+++ b/src/theory/arith/linear/theory_arith_private.cpp
@@ -945,8 +945,8 @@ Node TheoryArithPrivate::getCandidateModelValue(TNode term)
   }
 }
 
-bool TheoryArithPrivate::ppAssert(
-    TrustNode tin, TrustSubstitutionMap& outSubstitutions)
+bool TheoryArithPrivate::ppAssert(TrustNode tin,
+                                  TrustSubstitutionMap& outSubstitutions)
 {
   TimerStat::CodeTimer codeTimer(d_statistics.d_simplifyTimer);
   TNode in = tin.getNode();

--- a/src/theory/arith/linear/theory_arith_private.h
+++ b/src/theory/arith/linear/theory_arith_private.h
@@ -471,7 +471,7 @@ private:
                           std::map<Node, Node>& arithModelIllTyped);
   void presolve();
   void notifyRestart();
-  Theory::PPAssertStatus ppAssert(TrustNode tin,
+  bool ppAssert(TrustNode tin,
                                   TrustSubstitutionMap& outSubstitutions);
   void ppStaticLearn(TNode in, std::vector<TrustNode>& learned);
 

--- a/src/theory/arith/linear/theory_arith_private.h
+++ b/src/theory/arith/linear/theory_arith_private.h
@@ -471,8 +471,7 @@ private:
                           std::map<Node, Node>& arithModelIllTyped);
   void presolve();
   void notifyRestart();
-  bool ppAssert(TrustNode tin,
-                                  TrustSubstitutionMap& outSubstitutions);
+  bool ppAssert(TrustNode tin, TrustSubstitutionMap& outSubstitutions);
   void ppStaticLearn(TNode in, std::vector<TrustNode>& learned);
 
   std::string identify() const { return std::string("TheoryArith"); }

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -212,7 +212,7 @@ TrustNode TheoryArith::ppStaticRewrite(TNode atom)
   return TrustNode::null();
 }
 
-Theory::PPAssertStatus TheoryArith::ppAssert(
+bool TheoryArith::ppAssert(
     TrustNode tin, TrustSubstitutionMap& outSubstitutions)
 {
   return d_internal.ppAssert(tin, outSubstitutions);

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -212,8 +212,8 @@ TrustNode TheoryArith::ppStaticRewrite(TNode atom)
   return TrustNode::null();
 }
 
-bool TheoryArith::ppAssert(
-    TrustNode tin, TrustSubstitutionMap& outSubstitutions)
+bool TheoryArith::ppAssert(TrustNode tin,
+                           TrustSubstitutionMap& outSubstitutions)
 {
   return d_internal.ppAssert(tin, outSubstitutions);
 }

--- a/src/theory/arith/theory_arith.h
+++ b/src/theory/arith/theory_arith.h
@@ -94,7 +94,7 @@ class TheoryArith : public Theory {
 
   void presolve() override;
   void notifyRestart() override;
-  PPAssertStatus ppAssert(TrustNode tin,
+  bool ppAssert(TrustNode tin,
                           TrustSubstitutionMap& outSubstitutions) override;
   /**
    * Preprocess rewrite terms, return the trust node encapsulating the

--- a/src/theory/arith/theory_arith.h
+++ b/src/theory/arith/theory_arith.h
@@ -94,8 +94,7 @@ class TheoryArith : public Theory {
 
   void presolve() override;
   void notifyRestart() override;
-  bool ppAssert(TrustNode tin,
-                          TrustSubstitutionMap& outSubstitutions) override;
+  bool ppAssert(TrustNode tin, TrustSubstitutionMap& outSubstitutions) override;
   /**
    * Preprocess rewrite terms, return the trust node encapsulating the
    * preprocessed form of n, and the proof generator that can provide the

--- a/src/theory/arrays/theory_arrays.cpp
+++ b/src/theory/arrays/theory_arrays.cpp
@@ -363,7 +363,7 @@ TrustNode TheoryArrays::ppRewrite(TNode term, std::vector<SkolemLemma>& lems)
   return TrustNode::null();
 }
 
-Theory::PPAssertStatus TheoryArrays::ppAssert(
+bool TheoryArrays::ppAssert(
     TrustNode tin, TrustSubstitutionMap& outSubstitutions)
 {
   TNode in = tin.getNode();
@@ -375,12 +375,12 @@ Theory::PPAssertStatus TheoryArrays::ppAssert(
       if (in[0].isVar() && d_valuation.isLegalElimination(in[0], in[1]))
       {
         outSubstitutions.addSubstitutionSolved(in[0], in[1], tin);
-        return PP_ASSERT_STATUS_SOLVED;
+        return true
       }
       if (in[1].isVar() && d_valuation.isLegalElimination(in[1], in[0]))
       {
         outSubstitutions.addSubstitutionSolved(in[1], in[0], tin);
-        return PP_ASSERT_STATUS_SOLVED;
+        return true;
       }
       break;
     }
@@ -398,7 +398,7 @@ Theory::PPAssertStatus TheoryArrays::ppAssert(
     default:
       break;
   }
-  return PP_ASSERT_STATUS_UNSOLVED;
+  return false;
 }
 
 

--- a/src/theory/arrays/theory_arrays.cpp
+++ b/src/theory/arrays/theory_arrays.cpp
@@ -375,7 +375,7 @@ bool TheoryArrays::ppAssert(
       if (in[0].isVar() && d_valuation.isLegalElimination(in[0], in[1]))
       {
         outSubstitutions.addSubstitutionSolved(in[0], in[1], tin);
-        return true
+        return true;
       }
       if (in[1].isVar() && d_valuation.isLegalElimination(in[1], in[0]))
       {

--- a/src/theory/arrays/theory_arrays.cpp
+++ b/src/theory/arrays/theory_arrays.cpp
@@ -363,8 +363,8 @@ TrustNode TheoryArrays::ppRewrite(TNode term, std::vector<SkolemLemma>& lems)
   return TrustNode::null();
 }
 
-bool TheoryArrays::ppAssert(
-    TrustNode tin, TrustSubstitutionMap& outSubstitutions)
+bool TheoryArrays::ppAssert(TrustNode tin,
+                            TrustSubstitutionMap& outSubstitutions)
 {
   TNode in = tin.getNode();
   switch(in.getKind()) {

--- a/src/theory/arrays/theory_arrays.h
+++ b/src/theory/arrays/theory_arrays.h
@@ -190,7 +190,7 @@ class TheoryArrays : public Theory {
   InferenceManager d_im;
 
  public:
-  PPAssertStatus ppAssert(TrustNode tin,
+  bool ppAssert(TrustNode tin,
                           TrustSubstitutionMap& outSubstitutions) override;
   TrustNode ppRewrite(TNode atom, std::vector<SkolemLemma>& lems) override;
 

--- a/src/theory/arrays/theory_arrays.h
+++ b/src/theory/arrays/theory_arrays.h
@@ -190,8 +190,7 @@ class TheoryArrays : public Theory {
   InferenceManager d_im;
 
  public:
-  bool ppAssert(TrustNode tin,
-                          TrustSubstitutionMap& outSubstitutions) override;
+  bool ppAssert(TrustNode tin, TrustSubstitutionMap& outSubstitutions) override;
   TrustNode ppRewrite(TNode atom, std::vector<SkolemLemma>& lems) override;
 
   /////////////////////////////////////////////////////////////////////////////

--- a/src/theory/booleans/theory_bool.cpp
+++ b/src/theory/booleans/theory_bool.cpp
@@ -40,15 +40,19 @@ TheoryBool::TheoryBool(Env& env, OutputChannel& out, Valuation valuation)
 {
 }
 
-Theory::PPAssertStatus TheoryBool::ppAssert(
+bool TheoryBool::ppAssert(
     TrustNode tin, TrustSubstitutionMap& outSubstitutions)
 {
   Assert(tin.getKind() == TrustNodeKind::LEMMA);
   TNode in = tin.getNode();
-  if (in.getKind() == Kind::CONST_BOOLEAN && !in.getConst<bool>())
+  if (in.getKind() == Kind::CONST_BOOLEAN)
   {
-    // If we get a false literal, we're in conflict
-    return PP_ASSERT_STATUS_CONFLICT;
+    if (in.getConst<bool>())
+    {
+      return true;
+    }
+    // should not be a false literal, which should be caught by preprocessing
+    Assert (in.getConst<bool>());
   }
 
   // Add the substitution from the variable to its value
@@ -58,7 +62,7 @@ Theory::PPAssertStatus TheoryBool::ppAssert(
     {
       outSubstitutions.addSubstitutionSolved(
           in[0], nodeManager()->mkConst<bool>(false), tin);
-      return PP_ASSERT_STATUS_SOLVED;
+      return true;
     }
     else if (in[0].getKind() == Kind::EQUAL && in[0][0].getType().isBoolean())
     {
@@ -66,12 +70,12 @@ Theory::PPAssertStatus TheoryBool::ppAssert(
       if (eq[0].isVar() && d_valuation.isLegalElimination(eq[0], eq[1]))
       {
         outSubstitutions.addSubstitutionSolved(eq[0], eq[1].notNode(), tin);
-        return PP_ASSERT_STATUS_SOLVED;
+        return true;
       }
       else if (eq[1].isVar() && d_valuation.isLegalElimination(eq[1], eq[0]))
       {
         outSubstitutions.addSubstitutionSolved(eq[1], eq[0].notNode(), tin);
-        return PP_ASSERT_STATUS_SOLVED;
+        return true;
       }
     }
   }
@@ -79,7 +83,7 @@ Theory::PPAssertStatus TheoryBool::ppAssert(
   {
     outSubstitutions.addSubstitutionSolved(
         in, nodeManager()->mkConst<bool>(true), tin);
-    return PP_ASSERT_STATUS_SOLVED;
+    return true;
   }
 
   // the positive Boolean equality case is handled in the default way

--- a/src/theory/booleans/theory_bool.cpp
+++ b/src/theory/booleans/theory_bool.cpp
@@ -40,8 +40,7 @@ TheoryBool::TheoryBool(Env& env, OutputChannel& out, Valuation valuation)
 {
 }
 
-bool TheoryBool::ppAssert(
-    TrustNode tin, TrustSubstitutionMap& outSubstitutions)
+bool TheoryBool::ppAssert(TrustNode tin, TrustSubstitutionMap& outSubstitutions)
 {
   Assert(tin.getKind() == TrustNodeKind::LEMMA);
   TNode in = tin.getNode();
@@ -52,7 +51,7 @@ bool TheoryBool::ppAssert(
       return true;
     }
     // should not be a false literal, which should be caught by preprocessing
-    Assert (in.getConst<bool>());
+    Assert(in.getConst<bool>());
   }
 
   // Add the substitution from the variable to its value

--- a/src/theory/booleans/theory_bool.h
+++ b/src/theory/booleans/theory_bool.h
@@ -36,7 +36,7 @@ class TheoryBool : public Theory {
   /** get the proof checker of this theory */
   ProofRuleChecker* getProofChecker() override;
 
-  PPAssertStatus ppAssert(TrustNode tin,
+  bool ppAssert(TrustNode tin,
                           TrustSubstitutionMap& outSubstitutions) override;
 
   std::string identify() const override;

--- a/src/theory/booleans/theory_bool.h
+++ b/src/theory/booleans/theory_bool.h
@@ -36,8 +36,7 @@ class TheoryBool : public Theory {
   /** get the proof checker of this theory */
   ProofRuleChecker* getProofChecker() override;
 
-  bool ppAssert(TrustNode tin,
-                          TrustSubstitutionMap& outSubstitutions) override;
+  bool ppAssert(TrustNode tin, TrustSubstitutionMap& outSubstitutions) override;
 
   std::string identify() const override;
 

--- a/src/theory/bv/theory_bv.cpp
+++ b/src/theory/bv/theory_bv.cpp
@@ -180,8 +180,7 @@ bool TheoryBV::collectModelValues(TheoryModel* m, const std::set<Node>& termSet)
 
 void TheoryBV::propagate(Effort e) { return d_internal->propagate(e); }
 
-bool TheoryBV::ppAssert(
-    TrustNode tin, TrustSubstitutionMap& outSubstitutions)
+bool TheoryBV::ppAssert(TrustNode tin, TrustSubstitutionMap& outSubstitutions)
 {
   Kind k = tin.getNode().getKind();
   if (k == Kind::EQUAL)

--- a/src/theory/bv/theory_bv.cpp
+++ b/src/theory/bv/theory_bv.cpp
@@ -180,14 +180,14 @@ bool TheoryBV::collectModelValues(TheoryModel* m, const std::set<Node>& termSet)
 
 void TheoryBV::propagate(Effort e) { return d_internal->propagate(e); }
 
-Theory::PPAssertStatus TheoryBV::ppAssert(
+bool TheoryBV::ppAssert(
     TrustNode tin, TrustSubstitutionMap& outSubstitutions)
 {
   Kind k = tin.getNode().getKind();
   if (k == Kind::EQUAL)
   {
-    auto status = Theory::ppAssert(tin, outSubstitutions);
-    if (status != Theory::PP_ASSERT_STATUS_UNSOLVED)
+    bool status = Theory::ppAssert(tin, outSubstitutions);
+    if (status)
     {
       return status;
     }
@@ -242,12 +242,12 @@ Theory::PPAssertStatus TheoryBV::ppAssert(
         if (d_valuation.isLegalElimination(extract[0], concat))
         {
           outSubstitutions.addSubstitutionSolved(extract[0], concat, tin);
-          return Theory::PP_ASSERT_STATUS_SOLVED;
+          return true;
         }
       }
     }
   }
-  return Theory::PP_ASSERT_STATUS_UNSOLVED;
+  return false;
 }
 
 TrustNode TheoryBV::ppRewrite(TNode t, std::vector<SkolemLemma>& lems)

--- a/src/theory/bv/theory_bv.h
+++ b/src/theory/bv/theory_bv.h
@@ -85,8 +85,7 @@ class TheoryBV : public Theory
 
   std::string identify() const override { return std::string("TheoryBV"); }
 
-  bool ppAssert(TrustNode in,
-                          TrustSubstitutionMap& outSubstitutions) override;
+  bool ppAssert(TrustNode in, TrustSubstitutionMap& outSubstitutions) override;
 
   TrustNode ppRewrite(TNode t, std::vector<SkolemLemma>& lems) override;
 

--- a/src/theory/bv/theory_bv.h
+++ b/src/theory/bv/theory_bv.h
@@ -85,7 +85,7 @@ class TheoryBV : public Theory
 
   std::string identify() const override { return std::string("TheoryBV"); }
 
-  PPAssertStatus ppAssert(TrustNode in,
+  bool ppAssert(TrustNode in,
                           TrustSubstitutionMap& outSubstitutions) override;
 
   TrustNode ppRewrite(TNode t, std::vector<SkolemLemma>& lems) override;

--- a/src/theory/quantifiers/theory_quantifiers.cpp
+++ b/src/theory/quantifiers/theory_quantifiers.cpp
@@ -107,8 +107,8 @@ void TheoryQuantifiers::presolve() {
   }
 }
 
-bool TheoryQuantifiers::ppAssert(
-    TrustNode tin, TrustSubstitutionMap& outSubstitutions)
+bool TheoryQuantifiers::ppAssert(TrustNode tin,
+                                 TrustSubstitutionMap& outSubstitutions)
 {
   if (d_qmacros != nullptr)
   {

--- a/src/theory/quantifiers/theory_quantifiers.cpp
+++ b/src/theory/quantifiers/theory_quantifiers.cpp
@@ -107,7 +107,7 @@ void TheoryQuantifiers::presolve() {
   }
 }
 
-Theory::PPAssertStatus TheoryQuantifiers::ppAssert(
+bool TheoryQuantifiers::ppAssert(
     TrustNode tin, TrustSubstitutionMap& outSubstitutions)
 {
   if (d_qmacros != nullptr)
@@ -123,12 +123,13 @@ Theory::PPAssertStatus TheoryQuantifiers::ppAssert(
         // add substitution solved, which ensures we track that eq depends on
         // tin, which can impact unsat cores.
         outSubstitutions.addSubstitutionSolved(eq[0], eq[1], tin);
-        return Theory::PP_ASSERT_STATUS_SOLVED;
+        return true;
       }
     }
   }
-  return Theory::PP_ASSERT_STATUS_UNSOLVED;
+  return false;
 }
+
 void TheoryQuantifiers::ppNotifyAssertions(
     const std::vector<Node>& assertions) {
   Trace("quantifiers-presolve")

--- a/src/theory/quantifiers/theory_quantifiers.h
+++ b/src/theory/quantifiers/theory_quantifiers.h
@@ -56,8 +56,7 @@ class TheoryQuantifiers : public Theory {
   /**
    * Preprocess assert, which solves for quantifier macros when enabled.
    */
-  bool ppAssert(TrustNode tin,
-                          TrustSubstitutionMap& outSubstitutions) override;
+  bool ppAssert(TrustNode tin, TrustSubstitutionMap& outSubstitutions) override;
   void ppNotifyAssertions(const std::vector<Node>& assertions) override;
   //--------------------------------- standard check
   /** Post-check, called after the fact queue of the theory is processed. */

--- a/src/theory/quantifiers/theory_quantifiers.h
+++ b/src/theory/quantifiers/theory_quantifiers.h
@@ -56,7 +56,7 @@ class TheoryQuantifiers : public Theory {
   /**
    * Preprocess assert, which solves for quantifier macros when enabled.
    */
-  PPAssertStatus ppAssert(TrustNode tin,
+  bool ppAssert(TrustNode tin,
                           TrustSubstitutionMap& outSubstitutions) override;
   void ppNotifyAssertions(const std::vector<Node>& assertions) override;
   //--------------------------------- standard check

--- a/src/theory/sets/theory_sets.cpp
+++ b/src/theory/sets/theory_sets.cpp
@@ -191,12 +191,12 @@ TrustNode TheorySets::ppRewrite(TNode n, std::vector<SkolemLemma>& lems)
   return d_internal->ppRewrite(n, lems);
 }
 
-Theory::PPAssertStatus TheorySets::ppAssert(
+bool TheorySets::ppAssert(
     TrustNode tin, TrustSubstitutionMap& outSubstitutions)
 {
   TNode in = tin.getNode();
   Trace("sets-proc") << "ppAssert : " << in << std::endl;
-  Theory::PPAssertStatus status = Theory::PP_ASSERT_STATUS_UNSOLVED;
+  bool status = false;
 
   // this is based off of Theory::ppAssert
   if (in.getKind() == Kind::EQUAL)
@@ -210,7 +210,7 @@ Theory::PPAssertStatus TheorySets::ppAssert(
       if (!in[0].getType().isSet() || !options().sets.setsExp)
       {
         outSubstitutions.addSubstitutionSolved(in[0], in[1], tin);
-        status = Theory::PP_ASSERT_STATUS_SOLVED;
+        status = true;
       }
     }
     else if (in[1].isVar() && d_valuation.isLegalElimination(in[1], in[0]))
@@ -218,7 +218,7 @@ Theory::PPAssertStatus TheorySets::ppAssert(
       if (!in[0].getType().isSet() || !options().sets.setsExp)
       {
         outSubstitutions.addSubstitutionSolved(in[1], in[0], tin);
-        status = Theory::PP_ASSERT_STATUS_SOLVED;
+        status = true;
       }
     }
   }

--- a/src/theory/sets/theory_sets.cpp
+++ b/src/theory/sets/theory_sets.cpp
@@ -191,8 +191,7 @@ TrustNode TheorySets::ppRewrite(TNode n, std::vector<SkolemLemma>& lems)
   return d_internal->ppRewrite(n, lems);
 }
 
-bool TheorySets::ppAssert(
-    TrustNode tin, TrustSubstitutionMap& outSubstitutions)
+bool TheorySets::ppAssert(TrustNode tin, TrustSubstitutionMap& outSubstitutions)
 {
   TNode in = tin.getNode();
   Trace("sets-proc") << "ppAssert : " << in << std::endl;

--- a/src/theory/sets/theory_sets.h
+++ b/src/theory/sets/theory_sets.h
@@ -81,8 +81,7 @@ class TheorySets : public Theory
    * and is_singleton.
    */
   TrustNode ppRewrite(TNode n, std::vector<SkolemLemma>& lems) override;
-  bool ppAssert(TrustNode tin,
-                          TrustSubstitutionMap& outSubstitutions) override;
+  bool ppAssert(TrustNode tin, TrustSubstitutionMap& outSubstitutions) override;
   void presolve() override;
   bool isEntailed(Node n, bool pol);
 

--- a/src/theory/sets/theory_sets.h
+++ b/src/theory/sets/theory_sets.h
@@ -81,7 +81,7 @@ class TheorySets : public Theory
    * and is_singleton.
    */
   TrustNode ppRewrite(TNode n, std::vector<SkolemLemma>& lems) override;
-  PPAssertStatus ppAssert(TrustNode tin,
+  bool ppAssert(TrustNode tin,
                           TrustSubstitutionMap& outSubstitutions) override;
   void presolve() override;
   bool isEntailed(Node n, bool pol);

--- a/src/theory/theory.cpp
+++ b/src/theory/theory.cpp
@@ -390,8 +390,7 @@ bool Theory::collectModelValues(TheoryModel* m, const std::set<Node>& termSet)
   return true;
 }
 
-bool Theory::ppAssert(TrustNode tin,
-                                        TrustSubstitutionMap& outSubstitutions)
+bool Theory::ppAssert(TrustNode tin, TrustSubstitutionMap& outSubstitutions)
 {
   Assert(tin.getKind() == TrustNodeKind::LEMMA);
   TNode in = tin.getNode();

--- a/src/theory/theory.cpp
+++ b/src/theory/theory.cpp
@@ -390,7 +390,7 @@ bool Theory::collectModelValues(TheoryModel* m, const std::set<Node>& termSet)
   return true;
 }
 
-Theory::PPAssertStatus Theory::ppAssert(TrustNode tin,
+bool Theory::ppAssert(TrustNode tin,
                                         TrustSubstitutionMap& outSubstitutions)
 {
   Assert(tin.getKind() == TrustNodeKind::LEMMA);
@@ -404,16 +404,16 @@ Theory::PPAssertStatus Theory::ppAssert(TrustNode tin,
     if (in[0].isVar() && d_valuation.isLegalElimination(in[0], in[1]))
     {
       outSubstitutions.addSubstitutionSolved(in[0], in[1], tin);
-      return PP_ASSERT_STATUS_SOLVED;
+      return true;
     }
     if (in[1].isVar() && d_valuation.isLegalElimination(in[1], in[0]))
     {
       outSubstitutions.addSubstitutionSolved(in[1], in[0], tin);
-      return PP_ASSERT_STATUS_SOLVED;
+      return true;
     }
   }
 
-  return PP_ASSERT_STATUS_UNSOLVED;
+  return false;
 }
 
 std::pair<bool, Node> Theory::entailmentCheck(TNode lit)

--- a/src/theory/theory.h
+++ b/src/theory/theory.h
@@ -589,16 +589,6 @@ class Theory : protected EnvObj
    */
   virtual void ppStaticLearn(TNode in, std::vector<TrustNode>& learned) {}
 
-  enum PPAssertStatus
-  {
-    /** Atom has been solved  */
-    PP_ASSERT_STATUS_SOLVED,
-    /** Atom has not been solved */
-    PP_ASSERT_STATUS_UNSOLVED,
-    /** Atom is inconsistent */
-    PP_ASSERT_STATUS_CONFLICT
-  };
-
   /**
    * Given a literal and its proof generator (encapsulated by trust node tin),
    * add the solved substitutions to the map, if any. The method should return
@@ -607,8 +597,13 @@ class Theory : protected EnvObj
    * Note that tin has trust node kind LEMMA. Its proof generator should be
    * taken into account when adding a substitution to outSubstitutions when
    * proofs are enabled.
+   * 
+   * @param tin The literal and its proof generator.
+   * @param outSubstitutions The substitution map to add to, if applicable.
+   * @return true iff the literal can be removed from the input, e.g. when
+   * the substitution it entails is added to outSubstitutions.
    */
-  virtual PPAssertStatus ppAssert(TrustNode tin,
+  virtual bool ppAssert(TrustNode tin,
                                   TrustSubstitutionMap& outSubstitutions);
 
   /**
@@ -812,20 +807,6 @@ inline std::ostream& operator<<(std::ostream& out,
                                 const cvc5::internal::theory::Theory& theory)
 {
   return out << theory.identify();
-}
-
-inline std::ostream& operator << (std::ostream& out, theory::Theory::PPAssertStatus status) {
-  switch (status) {
-  case theory::Theory::PP_ASSERT_STATUS_SOLVED:
-    out << "SOLVE_STATUS_SOLVED"; break;
-  case theory::Theory::PP_ASSERT_STATUS_UNSOLVED:
-    out << "SOLVE_STATUS_UNSOLVED"; break;
-  case theory::Theory::PP_ASSERT_STATUS_CONFLICT:
-    out << "SOLVE_STATUS_CONFLICT"; break;
-  default:
-    Unhandled();
-  }
-  return out;
 }
 
 }  // namespace theory

--- a/src/theory/theory.h
+++ b/src/theory/theory.h
@@ -597,14 +597,13 @@ class Theory : protected EnvObj
    * Note that tin has trust node kind LEMMA. Its proof generator should be
    * taken into account when adding a substitution to outSubstitutions when
    * proofs are enabled.
-   * 
+   *
    * @param tin The literal and its proof generator.
    * @param outSubstitutions The substitution map to add to, if applicable.
    * @return true iff the literal can be removed from the input, e.g. when
    * the substitution it entails is added to outSubstitutions.
    */
-  virtual bool ppAssert(TrustNode tin,
-                                  TrustSubstitutionMap& outSubstitutions);
+  virtual bool ppAssert(TrustNode tin, TrustSubstitutionMap& outSubstitutions);
 
   /**
    * Given a term of the theory coming from the input formula or

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -882,7 +882,7 @@ bool TheoryEngine::isLegalElimination(TNode x, TNode val)
   return tm->isLegalElimination(x, val);
 }
 
-theory::Theory::PPAssertStatus TheoryEngine::solve(
+bool TheoryEngine::solve(
     TrustNode tliteral, TrustSubstitutionMap& substitutionOut)
 {
   Assert(tliteral.getKind() == TrustNodeKind::LEMMA);
@@ -906,7 +906,7 @@ theory::Theory::PPAssertStatus TheoryEngine::solve(
     throw LogicException(ss.str());
   }
 
-  Theory::PPAssertStatus solveStatus =
+  bool solveStatus =
       d_theoryTable[tid]->ppAssert(tliteral, substitutionOut);
   Trace("theory::solve") << "TheoryEngine::solve(" << literal << ") => " << solveStatus << endl;
   return solveStatus;

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -882,8 +882,8 @@ bool TheoryEngine::isLegalElimination(TNode x, TNode val)
   return tm->isLegalElimination(x, val);
 }
 
-bool TheoryEngine::solve(
-    TrustNode tliteral, TrustSubstitutionMap& substitutionOut)
+bool TheoryEngine::solve(TrustNode tliteral,
+                         TrustSubstitutionMap& substitutionOut)
 {
   Assert(tliteral.getKind() == TrustNodeKind::LEMMA);
   // Reset the interrupt flag
@@ -906,8 +906,7 @@ bool TheoryEngine::solve(
     throw LogicException(ss.str());
   }
 
-  bool solveStatus =
-      d_theoryTable[tid]->ppAssert(tliteral, substitutionOut);
+  bool solveStatus = d_theoryTable[tid]->ppAssert(tliteral, substitutionOut);
   Trace("theory::solve") << "TheoryEngine::solve(" << literal << ") => " << solveStatus << endl;
   return solveStatus;
 }

--- a/src/theory/theory_engine.h
+++ b/src/theory/theory_engine.h
@@ -263,8 +263,13 @@ class TheoryEngine : protected EnvObj
    * Solve the given literal with a theory that owns it. The proof of tliteral
    * is carried in the trust node. The proof added to substitutionOut should
    * take this proof into account (when proofs are enabled).
+   *
+   * @param tin The literal and its proof generator.
+   * @param outSubstitutions The substitution map to add to, if applicable.
+   * @return true iff the literal can be removed from the input, e.g. when
+   * the substitution it entails is added to outSubstitutions.
    */
-  theory::Theory::PPAssertStatus solve(
+  bool solve(
       TrustNode tliteral, theory::TrustSubstitutionMap& substitutionOut);
 
   /**

--- a/src/theory/theory_engine.h
+++ b/src/theory/theory_engine.h
@@ -269,8 +269,7 @@ class TheoryEngine : protected EnvObj
    * @return true iff the literal can be removed from the input, e.g. when
    * the substitution it entails is added to outSubstitutions.
    */
-  bool solve(
-      TrustNode tliteral, theory::TrustSubstitutionMap& substitutionOut);
+  bool solve(TrustNode tliteral, theory::TrustSubstitutionMap& substitutionOut);
 
   /**
    * Preregister a Theory atom with the responsible theory (or


### PR DESCRIPTION
We never use `PP_ASSERT_STATUS_CONFLICT` currently, and moreover don't have proof support in the nonclausal simplifier if this ever were to be used, thus this PR simplifies the interface to return a bool (solved vs. unsolved).