### PR TITLE
Add proper interface for skolem information in Node

### DIFF
--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -3718,11 +3718,10 @@ SkolemId Term::getSkolemId() const
 {
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK_NOT_NULL;
-  internal::SkolemManager* skm = d_tm->d_nm->getSkolemManager();
-  CVC5_API_ARG_CHECK_EXPECTED(skm->isSkolemFunction(*d_node), *d_node)
+  CVC5_API_ARG_CHECK_EXPECTED(d_node->isSkolem(), *d_node)
       << "Term to be a skolem when calling getSkolemId";
   //////// all checks before this line
-  return skm->getId(*d_node);
+  return d_node->getSkolemId();
   ////////
   CVC5_API_TRY_CATCH_END;
 }
@@ -3731,29 +3730,11 @@ std::vector<Term> Term::getSkolemIndices() const
 {
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK_NOT_NULL;
-  internal::SkolemManager* skm = d_tm->d_nm->getSkolemManager();
-  CVC5_API_ARG_CHECK_EXPECTED(skm->isSkolemFunction(*d_node), *d_node)
+  CVC5_API_ARG_CHECK_EXPECTED(d_node->isSkolem(), *d_node)
       << "Term to be a skolem when calling getSkolemIndices";
   //////// all checks before this line
-  internal::Node cacheVal;
-  SkolemId id;
-  skm->isSkolemFunction(*d_node, id, cacheVal);
-  std::vector<Term> args;
-  if (!cacheVal.isNull())
-  {
-    if (cacheVal.getKind() == internal::Kind::SEXPR)
-    {
-      for (const internal::Node& nc : cacheVal)
-      {
-        args.push_back(Term(d_tm, nc));
-      }
-    }
-    else
-    {
-      args.push_back(Term(d_tm, cacheVal));
-    }
-  }
-  return args;
+  std::vector<internal::Node> indices = d_node->getSkolemIndices();
+  return Term::nodeVectorToTerms(d_tm, indices);
   ////////
   CVC5_API_TRY_CATCH_END;
 }

--- a/src/expr/CMakeLists.txt
+++ b/src/expr/CMakeLists.txt
@@ -43,6 +43,8 @@ libcvc5_add_sources(
   free_var_cache.h
   function_array_const.cpp
   function_array_const.h
+  internal_skolem_id.cpp
+  internal_skolem_id.h
   kind_map.h
   match_trie.cpp
   match_trie.h

--- a/src/expr/dtype_cons.cpp
+++ b/src/expr/dtype_cons.cpp
@@ -112,9 +112,7 @@ void DTypeConstructor::setSygus(Node op)
   if (op.getKind() == Kind::SKOLEM)
   {
     // check if stands for the "any constant" constructor
-    NodeManager* nm = NodeManager::currentNM();
-    SkolemManager* sm = nm->getSkolemManager();
-    if (sm->getInternalId(op) == InternalSkolemId::SYGUS_ANY_CONSTANT)
+    if (op.getInternalSkolemId() == InternalSkolemId::SYGUS_ANY_CONSTANT)
     {
       // mark with attribute, which is a faster lookup
       SygusAnyConstAttribute saca;

--- a/src/expr/internal_skolem_id.cpp
+++ b/src/expr/internal_skolem_id.cpp
@@ -1,0 +1,49 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds, Mudathir Mohamed, Aina Niemetz
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2024 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Implementation of skolem manager class.
+ */
+
+#include "expr/internal_skolem_id.h"
+
+#include <sstream>
+
+namespace cvc5::internal {
+
+const char* toString(InternalSkolemId id)
+{
+  switch (id)
+  {
+    case InternalSkolemId::SEQ_MODEL_BASE_ELEMENT:
+      return "SEQ_MODEL_BASE_ELEMENT";
+    case InternalSkolemId::IEVAL_NONE: return "IEVAL_NONE";
+    case InternalSkolemId::IEVAL_SOME: return "IEVAL_SOME";
+    case InternalSkolemId::SYGUS_ANY_CONSTANT: return "SYGUS_ANY_CONSTANT";
+    case InternalSkolemId::QUANTIFIERS_SYNTH_FUN_EMBED:
+      return "QUANTIFIERS_SYNTH_FUN_EMBED";
+    case InternalSkolemId::HO_TYPE_MATCH_PRED: return "HO_TYPE_MATCH_PRED";
+    case InternalSkolemId::MBQI_INPUT: return "MBQI_INPUT";
+    case InternalSkolemId::ABSTRACT_VALUE: return "ABSTRACT_VALUE";
+    case InternalSkolemId::QE_CLOSED_INPUT: return "QE_CLOSED_INPUT";
+    case InternalSkolemId::QUANTIFIERS_ATTRIBUTE_INTERNAL:
+      return "QUANTIFIERS_ATTRIBUTE_INTERNAL";
+    default: return "?";
+  }
+}
+
+std::ostream& operator<<(std::ostream& out, InternalSkolemId id)
+{
+  out << toString(id);
+  return out;
+}
+
+}  // namespace cvc5::internal

--- a/src/expr/internal_skolem_id.h
+++ b/src/expr/internal_skolem_id.h
@@ -1,0 +1,70 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds, Mudathir Mohamed, Kshitij Bansal
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2024 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Skolem manager utility.
+ */
+
+#include "cvc5_private.h"
+
+#ifndef CVC5__EXPR__INTERNAL_SKOLEM_ID_H
+#define CVC5__EXPR__INTERNAL_SKOLEM_ID_H
+
+#include <string>
+
+#include "expr/internal_skolem_id.h"
+
+namespace cvc5::internal {
+
+/**
+ * Internal skolem function identifier, used for identifying internal skolems
+ * that are not exported as part of the API.
+ *
+ * This is a subclassification of skolems whose SkolemId is INTERNAL. It is
+ * used to generate canonical skolems but without exporting to the API. Skolems
+ * can be created using mkInternalSkolemFunction below.
+ */
+enum class InternalSkolemId
+{
+  NONE,
+  /** Sequence model construction, element for base */
+  SEQ_MODEL_BASE_ELEMENT,
+  /** the "none" term, for instantiation evaluation */
+  IEVAL_NONE,
+  /** the "some" term, for instantiation evaluation */
+  IEVAL_SOME,
+  /** sygus "any constant" placeholder */
+  SYGUS_ANY_CONSTANT,
+  /**
+   * Quantifiers synth fun embedding, for function-to-synthesize, this the
+   * first order datatype variable for f.
+   */
+  QUANTIFIERS_SYNTH_FUN_EMBED,
+  /** Higher-order type match predicate, see HoTermDb */
+  HO_TYPE_MATCH_PRED,
+  /** Input variables for MBQI */
+  MBQI_INPUT,
+  /** abstract value for a term t */
+  ABSTRACT_VALUE,
+  /** Input variables for quantifier elimination of closed formulas */
+  QE_CLOSED_INPUT,
+  /** Skolem used for marking a quantified attribute */
+  QUANTIFIERS_ATTRIBUTE_INTERNAL
+};
+/** Converts an internal skolem function name to a string. */
+const char* toString(InternalSkolemId id);
+/** Writes an internal skolem function name to a stream. */
+std::ostream& operator<<(std::ostream& out, InternalSkolemId id);
+
+
+}  // namespace cvc5::internal
+
+#endif /* CVC5__EXPR__INTERNAL_SKOLEM_ID_H */

--- a/src/expr/node.cpp
+++ b/src/expr/node.cpp
@@ -23,6 +23,7 @@
 #include "expr/attribute.h"
 #include "expr/node_manager_attributes.h"
 #include "expr/type_checker.h"
+#include "expr/skolem_manager.h"
 
 using namespace std;
 
@@ -129,6 +130,7 @@ std::string NodeTemplate<ref_count>::getName() const
 template std::string NodeTemplate<true>::getName() const;
 template std::string NodeTemplate<false>::getName() const;
 
+template <bool ref_count>
 bool NodeTemplate<ref_count>::isSkolem() const
 {
   return getKind()==Kind::SKOLEM;
@@ -137,29 +139,32 @@ bool NodeTemplate<ref_count>::isSkolem() const
 template bool NodeTemplate<true>::isSkolem() const;
 template bool NodeTemplate<false>::isSkolem() const;
 
+template <bool ref_count>
 SkolemId NodeTemplate<ref_count>::getSkolemId() const
 {
   Assert (isSkolem());
-  return d_nv->getNodeManager()->getSkolemManager()->getSkolemId(*this);
+  return d_nv->getNodeManager()->getSkolemManager()->getId(*this);
 }
 
 template SkolemId NodeTemplate<true>::getSkolemId() const;
 template SkolemId NodeTemplate<false>::getSkolemId() const;
 
+template <bool ref_count>
 std::vector<Node> NodeTemplate<ref_count>::getSkolemIndices() const
 {
   Assert (isSkolem());
-  return d_nv->getNodeManager()->getSkolemManager()->getSkolemIndices(*this);
+  return d_nv->getNodeManager()->getSkolemManager()->getIndices(*this);
 }
 
 template std::vector<Node> NodeTemplate<true>::getSkolemIndices() const;
 template std::vector<Node> NodeTemplate<false>::getSkolemIndices() const;
 
+template <bool ref_count>
 InternalSkolemId NodeTemplate<ref_count>::getInternalSkolemId() const
 {
   Assert (isSkolem());
   Assert (getSkolemId()==SkolemId::INTERNAL);
-  return d_nv->getNodeManager()->getSkolemManager()->getInternalSkolemId(*this);
+  return d_nv->getNodeManager()->getSkolemManager()->getInternalId(*this);
 }
 
 template InternalSkolemId NodeTemplate<true>::getInternalSkolemId() const;

--- a/src/expr/node.cpp
+++ b/src/expr/node.cpp
@@ -142,7 +142,6 @@ template bool NodeTemplate<false>::isSkolem() const;
 template <bool ref_count>
 SkolemId NodeTemplate<ref_count>::getSkolemId() const
 {
-  Assert(isSkolem());
   return d_nv->getNodeManager()->getSkolemManager()->getId(*this);
 }
 
@@ -152,7 +151,6 @@ template SkolemId NodeTemplate<false>::getSkolemId() const;
 template <bool ref_count>
 std::vector<Node> NodeTemplate<ref_count>::getSkolemIndices() const
 {
-  Assert(isSkolem());
   return d_nv->getNodeManager()->getSkolemManager()->getIndices(*this);
 }
 
@@ -162,7 +160,6 @@ template std::vector<Node> NodeTemplate<false>::getSkolemIndices() const;
 template <bool ref_count>
 InternalSkolemId NodeTemplate<ref_count>::getInternalSkolemId() const
 {
-  Assert(isSkolem());
   Assert(getSkolemId() == SkolemId::INTERNAL);
   return d_nv->getNodeManager()->getSkolemManager()->getInternalId(*this);
 }

--- a/src/expr/node.cpp
+++ b/src/expr/node.cpp
@@ -22,8 +22,8 @@
 #include "base/output.h"
 #include "expr/attribute.h"
 #include "expr/node_manager_attributes.h"
-#include "expr/type_checker.h"
 #include "expr/skolem_manager.h"
+#include "expr/type_checker.h"
 
 using namespace std;
 
@@ -133,7 +133,7 @@ template std::string NodeTemplate<false>::getName() const;
 template <bool ref_count>
 bool NodeTemplate<ref_count>::isSkolem() const
 {
-  return getKind()==Kind::SKOLEM;
+  return getKind() == Kind::SKOLEM;
 }
 
 template bool NodeTemplate<true>::isSkolem() const;
@@ -142,7 +142,7 @@ template bool NodeTemplate<false>::isSkolem() const;
 template <bool ref_count>
 SkolemId NodeTemplate<ref_count>::getSkolemId() const
 {
-  Assert (isSkolem());
+  Assert(isSkolem());
   return d_nv->getNodeManager()->getSkolemManager()->getId(*this);
 }
 
@@ -152,7 +152,7 @@ template SkolemId NodeTemplate<false>::getSkolemId() const;
 template <bool ref_count>
 std::vector<Node> NodeTemplate<ref_count>::getSkolemIndices() const
 {
-  Assert (isSkolem());
+  Assert(isSkolem());
   return d_nv->getNodeManager()->getSkolemManager()->getIndices(*this);
 }
 
@@ -162,14 +162,14 @@ template std::vector<Node> NodeTemplate<false>::getSkolemIndices() const;
 template <bool ref_count>
 InternalSkolemId NodeTemplate<ref_count>::getInternalSkolemId() const
 {
-  Assert (isSkolem());
-  Assert (getSkolemId()==SkolemId::INTERNAL);
+  Assert(isSkolem());
+  Assert(getSkolemId() == SkolemId::INTERNAL);
   return d_nv->getNodeManager()->getSkolemManager()->getInternalId(*this);
 }
 
 template InternalSkolemId NodeTemplate<true>::getInternalSkolemId() const;
 template InternalSkolemId NodeTemplate<false>::getInternalSkolemId() const;
-  
+
 }  // namespace cvc5::internal
 
 namespace std {

--- a/src/expr/node.cpp
+++ b/src/expr/node.cpp
@@ -160,7 +160,6 @@ template std::vector<Node> NodeTemplate<false>::getSkolemIndices() const;
 template <bool ref_count>
 InternalSkolemId NodeTemplate<ref_count>::getInternalSkolemId() const
 {
-  Assert(getSkolemId() == SkolemId::INTERNAL);
   return d_nv->getNodeManager()->getSkolemManager()->getInternalId(*this);
 }
 

--- a/src/expr/node.cpp
+++ b/src/expr/node.cpp
@@ -129,6 +129,42 @@ std::string NodeTemplate<ref_count>::getName() const
 template std::string NodeTemplate<true>::getName() const;
 template std::string NodeTemplate<false>::getName() const;
 
+bool NodeTemplate<ref_count>::isSkolem() const
+{
+  return getKind()==Kind::SKOLEM;
+}
+
+template bool NodeTemplate<true>::isSkolem() const;
+template bool NodeTemplate<false>::isSkolem() const;
+
+SkolemId NodeTemplate<ref_count>::getSkolemId() const
+{
+  Assert (isSkolem());
+  return d_nv->getNodeManager()->getSkolemManager()->getSkolemId(*this);
+}
+
+template SkolemId NodeTemplate<true>::getSkolemId() const;
+template SkolemId NodeTemplate<false>::getSkolemId() const;
+
+std::vector<Node> NodeTemplate<ref_count>::getSkolemIndices() const
+{
+  Assert (isSkolem());
+  return d_nv->getNodeManager()->getSkolemManager()->getSkolemIndices(*this);
+}
+
+template std::vector<Node> NodeTemplate<true>::getSkolemIndices() const;
+template std::vector<Node> NodeTemplate<false>::getSkolemIndices() const;
+
+InternalSkolemId NodeTemplate<ref_count>::getInternalSkolemId() const
+{
+  Assert (isSkolem());
+  Assert (getSkolemId()==SkolemId::INTERNAL);
+  return d_nv->getNodeManager()->getSkolemManager()->getInternalSkolemId(*this);
+}
+
+template InternalSkolemId NodeTemplate<true>::getInternalSkolemId() const;
+template InternalSkolemId NodeTemplate<false>::getInternalSkolemId() const;
+  
 }  // namespace cvc5::internal
 
 namespace std {

--- a/src/expr/node.h
+++ b/src/expr/node.h
@@ -18,6 +18,8 @@
 #ifndef CVC5__NODE_H
 #define CVC5__NODE_H
 
+#include <cvc5/cvc5_skolem_id.h>
+
 #include <iostream>
 #include <map>
 #include <sstream>
@@ -26,11 +28,11 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
-#include <cvc5/cvc5_skolem_id.h>
 
 #include "base/check.h"
 #include "base/exception.h"
 #include "base/output.h"
+#include "expr/internal_skolem_id.h"
 #include "expr/kind.h"
 #include "expr/metakind.h"
 #include "expr/node_value.h"
@@ -38,7 +40,6 @@
 #include "options/language.h"
 #include "util/hash.h"
 #include "util/utility.h"
-#include "expr/internal_skolem_id.h"
 
 namespace cvc5::internal {
 
@@ -569,23 +570,23 @@ public:
    * @return true if this is a skolem function.
    */
   bool isSkolem() const;
-  
+
   /**
    * @return the skolem identifier of this node.
    */
   SkolemId getSkolemId() const;
-  
+
   /**
    * @return the skolem indices of this node.
    */
   std::vector<Node> getSkolemIndices() const;
-  
+
   /**
    * @return the internal skolem function id, for skolems whose id is
    * SkolemId::INTERNAL.
    */
   InternalSkolemId getInternalSkolemId() const;
-  
+
   /**
    * Returns the reference count of this node.
    * @return the refcount

--- a/src/expr/node.h
+++ b/src/expr/node.h
@@ -37,6 +37,7 @@
 #include "options/language.h"
 #include "util/hash.h"
 #include "util/utility.h"
+#include "expr/internal_skolem_id.h"
 
 namespace cvc5::internal {
 
@@ -563,6 +564,27 @@ public:
   template <class T>
   inline const T& getConst() const;
 
+  /**
+   * @return true if this is a skolem function.
+   */
+  bool isSkolem() const;
+  
+  /**
+   * @return the skolem identifier of this node.
+   */
+  SkolemId getSkolemId() const;
+  
+  /**
+   * @return the skolem indices of this node.
+   */
+  std::vector<Node> getSkolemIndices() const;
+  
+  /**
+   * @return the internal skolem function id, for skolems whose id is
+   * SkolemId::INTERNAL.
+   */
+  InternalSkolemId getInternalSkolemId() const;
+  
   /**
    * Returns the reference count of this node.
    * @return the refcount

--- a/src/expr/node.h
+++ b/src/expr/node.h
@@ -26,6 +26,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <cvc5/cvc5_skolem_id.h>
 
 #include "base/check.h"
 #include "base/exception.h"

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -219,6 +219,28 @@ SkolemId SkolemManager::getId(TNode k) const
   return SkolemId::NONE;
 }
 
+std::vector<Node> SkolemManager::getIndices(TNode k) const
+{
+  std::vector<Node> vec;
+  SkolemId id;
+  Node cacheVal;
+  if (isSkolemFunction(k, id, cacheVal))
+  {
+    if (!cacheVal.isNull())
+    {
+      if (cacheVal.getKind()==Kind::SEXPR)
+      {
+        vec.insert(vec.end(), cacheVal.begin(), cacheVal.end());
+      }
+      else
+      {
+        vec.push_back(cacheVal);
+      }
+    }
+  }
+  return vec;
+}
+
 InternalSkolemId SkolemManager::getInternalId(TNode k) const
 {
   SkolemId id;

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -39,33 +39,6 @@ struct UnpurifiedFormAttributeId
 };
 typedef expr::Attribute<UnpurifiedFormAttributeId, Node> UnpurifiedFormAttribute;
 
-const char* toString(InternalSkolemId id)
-{
-  switch (id)
-  {
-    case InternalSkolemId::SEQ_MODEL_BASE_ELEMENT:
-      return "SEQ_MODEL_BASE_ELEMENT";
-    case InternalSkolemId::IEVAL_NONE: return "IEVAL_NONE";
-    case InternalSkolemId::IEVAL_SOME: return "IEVAL_SOME";
-    case InternalSkolemId::SYGUS_ANY_CONSTANT: return "SYGUS_ANY_CONSTANT";
-    case InternalSkolemId::QUANTIFIERS_SYNTH_FUN_EMBED:
-      return "QUANTIFIERS_SYNTH_FUN_EMBED";
-    case InternalSkolemId::HO_TYPE_MATCH_PRED: return "HO_TYPE_MATCH_PRED";
-    case InternalSkolemId::MBQI_INPUT: return "MBQI_INPUT";
-    case InternalSkolemId::ABSTRACT_VALUE: return "ABSTRACT_VALUE";
-    case InternalSkolemId::QE_CLOSED_INPUT: return "QE_CLOSED_INPUT";
-    case InternalSkolemId::QUANTIFIERS_ATTRIBUTE_INTERNAL:
-      return "QUANTIFIERS_ATTRIBUTE_INTERNAL";
-    default: return "?";
-  }
-}
-
-std::ostream& operator<<(std::ostream& out, InternalSkolemId id)
-{
-  out << toString(id);
-  return out;
-}
-
 SkolemManager::SkolemManager() : d_skolemCounter(0) {}
 
 Node SkolemManager::mkPurifySkolem(Node t)

--- a/src/expr/skolem_manager.cpp
+++ b/src/expr/skolem_manager.cpp
@@ -228,7 +228,7 @@ std::vector<Node> SkolemManager::getIndices(TNode k) const
   {
     if (!cacheVal.isNull())
     {
-      if (cacheVal.getKind()==Kind::SEXPR)
+      if (cacheVal.getKind() == Kind::SEXPR)
       {
         vec.insert(vec.end(), cacheVal.begin(), cacheVal.end());
       }

--- a/src/expr/skolem_manager.h
+++ b/src/expr/skolem_manager.h
@@ -22,8 +22,8 @@
 
 #include <string>
 
-#include "expr/node.h"
 #include "expr/internal_skolem_id.h"
+#include "expr/node.h"
 
 namespace cvc5::internal {
 

--- a/src/expr/skolem_manager.h
+++ b/src/expr/skolem_manager.h
@@ -23,50 +23,11 @@
 #include <string>
 
 #include "expr/node.h"
+#include "expr/internal_skolem_id.h"
 
 namespace cvc5::internal {
 
 class ProofGenerator;
-
-/**
- * Internal skolem function identifier, used for identifying internal skolems
- * that are not exported as part of the API.
- *
- * This is a subclassification of skolems whose SkolemId is INTERNAL. It is
- * used to generate canonical skolems but without exporting to the API. Skolems
- * can be created using mkInternalSkolemFunction below.
- */
-enum class InternalSkolemId
-{
-  NONE,
-  /** Sequence model construction, element for base */
-  SEQ_MODEL_BASE_ELEMENT,
-  /** the "none" term, for instantiation evaluation */
-  IEVAL_NONE,
-  /** the "some" term, for instantiation evaluation */
-  IEVAL_SOME,
-  /** sygus "any constant" placeholder */
-  SYGUS_ANY_CONSTANT,
-  /**
-   * Quantifiers synth fun embedding, for function-to-synthesize, this the
-   * first order datatype variable for f.
-   */
-  QUANTIFIERS_SYNTH_FUN_EMBED,
-  /** Higher-order type match predicate, see HoTermDb */
-  HO_TYPE_MATCH_PRED,
-  /** Input variables for MBQI */
-  MBQI_INPUT,
-  /** abstract value for a term t */
-  ABSTRACT_VALUE,
-  /** Input variables for quantifier elimination of closed formulas */
-  QE_CLOSED_INPUT,
-  /** Skolem used for marking a quantified attribute */
-  QUANTIFIERS_ATTRIBUTE_INTERNAL
-};
-/** Converts an internal skolem function name to a string. */
-const char* toString(InternalSkolemId id);
-/** Writes an internal skolem function name to a stream. */
-std::ostream& operator<<(std::ostream& out, InternalSkolemId id);
 
 /**
  * A manager for skolems that can be used in proofs. This is designed to be

--- a/src/expr/skolem_manager.h
+++ b/src/expr/skolem_manager.h
@@ -168,11 +168,18 @@ class SkolemManager
    */
   bool isSkolemFunction(TNode k, SkolemId& id, Node& cacheVal) const;
   /**
-   * Get skolem function id
+   * @param k The skolem.
+   * @return skolem function id for k.
    */
   SkolemId getId(TNode k) const;
   /**
-   * Get the internal skolem function id, for skolems whose id is
+   * @param k The skolem.
+   * @return The list of skolem indices for k.
+   */
+  std::vector<Node> getIndices(TNode k) const;
+  /**
+   * @param k The skolem.
+   * @return the internal skolem function id, for skolem k whose id is
    * SkolemId::INTERNAL.
    */
   InternalSkolemId getInternalId(TNode k) const;

--- a/src/expr/sygus_grammar.cpp
+++ b/src/expr/sygus_grammar.cpp
@@ -19,10 +19,10 @@
 
 #include "expr/dtype.h"
 #include "expr/dtype_cons.h"
-#include "expr/skolem_manager.h"
 #include "printer/printer.h"
 #include "printer/smt2/smt2_printer.h"
 #include "theory/datatypes/sygus_datatype_utils.h"
+#include "expr/skolem_manager.h"
 #include "util/hash.h"
 
 namespace cvc5::internal {
@@ -235,10 +235,9 @@ void addSygusConstructor(DType& dt,
                          const std::unordered_map<Node, TypeNode>& ntsToUnres)
 {
   NodeManager* nm = NodeManager::currentNM();
-  SkolemManager* sm = nm->getSkolemManager();
   std::stringstream ss;
   if (rule.getKind() == Kind::SKOLEM
-      && sm->getInternalId(rule) == InternalSkolemId::SYGUS_ANY_CONSTANT)
+      && rule.getInternalSkolemId() == InternalSkolemId::SYGUS_ANY_CONSTANT)
   {
     ss << dt.getName() << "_any_constant";
     dt.addSygusConstructor(rule, ss.str(), {rule.getType()}, 0);
@@ -299,7 +298,6 @@ TypeNode SygusGrammar::resolve(bool allowAny)
   if (!isResolved())
   {
     NodeManager* nm = NodeManager::currentNM();
-    SkolemManager* sm = nm->getSkolemManager();
     Node bvl;
     if (!d_sygusVars.empty())
     {
@@ -324,7 +322,7 @@ TypeNode SygusGrammar::resolve(bool allowAny)
       for (const Node& rule : d_rules[ntSym])
       {
         if (rule.getKind() == Kind::SKOLEM
-            && sm->getInternalId(rule) == InternalSkolemId::SYGUS_ANY_CONSTANT)
+            && rule.getInternalSkolemId() == InternalSkolemId::SYGUS_ANY_CONSTANT)
         {
           allowConsts.insert(ntSym);
         }

--- a/src/theory/datatypes/sygus_datatype_utils.cpp
+++ b/src/theory/datatypes/sygus_datatype_utils.cpp
@@ -20,7 +20,6 @@
 #include "expr/dtype.h"
 #include "expr/dtype_cons.h"
 #include "expr/node_algorithm.h"
-#include "expr/skolem_manager.h"
 #include "expr/sygus_datatype.h"
 #include "smt/env.h"
 #include "theory/evaluator.h"
@@ -153,7 +152,7 @@ Node mkSygusTerm(const Node& op,
                  bool doBetaReduction)
 {
   NodeManager* nm = NodeManager::currentNM();
-  Assert(nm->getSkolemManager()->getInternalId(op)
+  Assert(op.getInternalSkolemId()
          != InternalSkolemId::SYGUS_ANY_CONSTANT);
   Trace("dt-sygus-util") << "Operator is " << op << std::endl;
   if (children.empty())

--- a/src/theory/datatypes/sygus_datatype_utils.cpp
+++ b/src/theory/datatypes/sygus_datatype_utils.cpp
@@ -152,8 +152,7 @@ Node mkSygusTerm(const Node& op,
                  bool doBetaReduction)
 {
   NodeManager* nm = NodeManager::currentNM();
-  Assert(op.getInternalSkolemId()
-         != InternalSkolemId::SYGUS_ANY_CONSTANT);
+  Assert(op.getInternalSkolemId() != InternalSkolemId::SYGUS_ANY_CONSTANT);
   Trace("dt-sygus-util") << "Operator is " << op << std::endl;
   if (children.empty())
   {

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -534,15 +534,12 @@ void TermDbSygus::registerEnumerator(Node e,
     d_env.output(OutputTag::SYGUS_ENUMERATOR) << "(sygus-enumerator";
     if (!f.isNull())
     {
-      SkolemManager* sm = nm->getSkolemManager();
-      Assert(sm->getInternalId(f)
+      Assert(f.getInternalSkolemId()
              == InternalSkolemId::QUANTIFIERS_SYNTH_FUN_EMBED);
-      Node ff;
-      SkolemId id;
-      sm->isSkolemFunction(f, id, ff);
+      std::vector<Node> ski = f.getSkolemIndices();
       // get the argument, which is stored after the internal identifier
-      Assert(ff.getKind() == Kind::SEXPR && ff.getNumChildren() == 2);
-      d_env.output(OutputTag::SYGUS_ENUMERATOR) << " :synth-fun " << ff[1];
+      Assert(ski.size() == 2);
+      d_env.output(OutputTag::SYGUS_ENUMERATOR) << " :synth-fun " << ski[1];
     }
     d_env.output(OutputTag::SYGUS_ENUMERATOR) << " :role " << erole;
     std::stringstream ss;


### PR DESCRIPTION
Currently, to know information about what kind of skolem a Node is requires manually looking up the appropriate `SkolemManager`.

This PR adds a proper interface to get skolem information from a `Node`.

This will be useful when eliminating calls to `NodeManager::currentNM`, as this information no longer needs to be accessed manually.

This PR cleans up a few low-level instances of this.