### PR TITLE
Refactoring set defaults for safe options, full strict proofs

### DIFF
--- a/src/options/arith_options.toml
+++ b/src/options/arith_options.toml
@@ -497,7 +497,7 @@ name   = "Arithmetic Theory"
   category   = "regular"
   long       = "nl-cov"
   type       = "bool"
-  default    = "false"
+  default    = "true"
   help       = "whether to use the cylindrical algebraic coverings solver for non-linear arithmetic"
 
 [[option]]

--- a/src/options/uf_options.toml
+++ b/src/options/uf_options.toml
@@ -6,7 +6,7 @@ name   = "Uninterpreted Functions Theory"
   category   = "expert"
   long       = "symmetry-breaker"
   type       = "bool"
-  default    = "false"
+  default    = "true"
   help       = "use UF symmetry breaker (Deharbe et al., CADE 2011)"
 
 [[option]]

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -967,7 +967,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
     // must set to false if libpoly is not enabled
     OPTION_EXCEPTION_IF_NOT(arith, nlCov, false, "configuring without --poly");
     SET_AND_NOTIFY(arith, nlCov, false, "no support for libpoly");
-    SET_AND_NOTIFY_VAL_SYM(
+    SET_AND_NOTIFY_IF_NOT_USER_VAL_SYM(
         arith, nlExt, options::NlExtMode::FULL, "no support for libpoly");
 #endif
   }

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -1111,12 +1111,9 @@ bool SetDefaults::incompatibleWithProofs(Options& opts,
     // symmetry breaking does not have proof support
     SET_AND_NOTIFY_VAL_SYM(uf, ufSymmetryBreaker, false, "full strict proofs");
     // CEGQI with deltas and infinities is not supported
-    SET_AND_NOTIFY(
-        quantifiers, cegqiMidpoint, true, "full strict proofs");
-    SET_AND_NOTIFY(
-        quantifiers, cegqiUseInfInt, false, "full strict proofs");
-    SET_AND_NOTIFY(
-        quantifiers, cegqiUseInfReal, false, "full strict proofs");
+    SET_AND_NOTIFY(quantifiers, cegqiMidpoint, true, "full strict proofs");
+    SET_AND_NOTIFY(quantifiers, cegqiUseInfInt, false, "full strict proofs");
+    SET_AND_NOTIFY(quantifiers, cegqiUseInfReal, false, "full strict proofs");
   }
   return false;
 }

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -685,7 +685,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
   }
 
   // by default, symmetry breaker is on only for non-incremental QF_UF
-  if (!opts.uf.ufSymmetryBreakerWasSetByUser && opts.uf.ufSymmetryBreaker)
+  if (!opts.uf.ufSymmetryBreakerWasSetByUser)
   {
     // Only applies to non-incremental QF_UF.
     bool qf_uf_noinc = logic.isPure(THEORY_UF) && !logic.isQuantified()
@@ -938,7 +938,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
 #ifdef CVC5_USE_POLY
   if (logic == LogicInfo("QF_UFNRA"))
   {
-    if (opts.arith.nlCov && !opts.arith.nlCovWasSetByUser)
+    if (!opts.arith.nlCov && !opts.arith.nlCovWasSetByUser)
     {
       SET_AND_NOTIFY(arith, nlCov, true, "QF_UFNRA");
       SET_AND_NOTIFY_IF_NOT_USER_VAL_SYM(
@@ -949,7 +949,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
            && logic.areRealsUsed() && !logic.areIntegersUsed()
            && !logic.areTranscendentalsUsed())
   {
-    if (opts.arith.nlCov && !opts.arith.nlCovWasSetByUser)
+    if (!opts.arith.nlCov && !opts.arith.nlCovWasSetByUser)
     {
       SET_AND_NOTIFY(arith, nlCov, true, "logic with reals");
       SET_AND_NOTIFY_IF_NOT_USER_VAL_SYM(

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -685,7 +685,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
   }
 
   // by default, symmetry breaker is on only for non-incremental QF_UF
-  if (!opts.uf.ufSymmetryBreakerWasSetByUser)
+  if (!opts.uf.ufSymmetryBreakerWasSetByUser && opts.uf.ufSymmetryBreaker)
   {
     // Only applies to non-incremental QF_UF.
     bool qf_uf_noinc = logic.isPure(THEORY_UF) && !logic.isQuantified()
@@ -938,9 +938,8 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
 #ifdef CVC5_USE_POLY
   if (logic == LogicInfo("QF_UFNRA"))
   {
-    if (!opts.arith.nlCov && !opts.arith.nlCovWasSetByUser)
+    if (opts.arith.nlCov && !opts.arith.nlCovWasSetByUser)
     {
-      SET_AND_NOTIFY(arith, nlCov, true, "QF_UFNRA");
       SET_AND_NOTIFY_IF_NOT_USER_VAL_SYM(
           arith, nlExt, options::NlExtMode::LIGHT, "QF_UFNRA");
     }
@@ -949,16 +948,15 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
            && logic.areRealsUsed() && !logic.areIntegersUsed()
            && !logic.areTranscendentalsUsed())
   {
-    if (!opts.arith.nlCov && !opts.arith.nlCovWasSetByUser)
+    if (opts.arith.nlCov && !opts.arith.nlCovWasSetByUser)
     {
-      SET_AND_NOTIFY(arith, nlCov, true, "logic with reals");
       SET_AND_NOTIFY_IF_NOT_USER_VAL_SYM(
           arith, nlExt, options::NlExtMode::LIGHT, "logic with reals");
     }
   }
   else
   {
-    SET_AND_NOTIFY(arith, nlCov, false, "logic without reals");
+    SET_AND_NOTIFY_IF_NOT_USER(arith, nlCov, false, "logic without reals");
   }
 #else
   if (opts.arith.nlCov)

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -56,14 +56,14 @@ namespace smt {
  * given value. Give an error message where reason is given.
  * Note this macro should be used if the value is concrete.
  */
-#define OPTION_EXCEPTION_IF_NOT(domain, optName, value, reason)             \
-  if (opts.write_##domain().optName##WasSetByUser                           \
-      && opts.write_##domain().optName != value)                            \
-  {                                                                         \
-    std::stringstream ss;                                                   \
-    ss << "Cannot use --" << options::domain::longName::optName             \
-         << " due to " << reason << ".";                                    \
-    throw OptionException(ss.str());                                        \
+#define OPTION_EXCEPTION_IF_NOT(domain, optName, value, reason)               \
+  if (opts.write_##domain().optName##WasSetByUser                             \
+      && opts.write_##domain().optName != value)                              \
+  {                                                                           \
+    std::stringstream ss;                                                     \
+    ss << "Cannot use --" << options::domain::longName::optName << " due to " \
+       << reason << ".";                                                      \
+    throw OptionException(ss.str());                                          \
   }
 /**
  * Set domain.optName to value due to reason. Notify if value changes.
@@ -685,7 +685,8 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
   }
 
   // By default, symmetry breaker is on only for non-incremental QF_UF.
-  // Note that if ufSymmetryBreaker is already set to false, we do not reenable it.
+  // Note that if ufSymmetryBreaker is already set to false, we do not reenable
+  // it.
   if (!opts.uf.ufSymmetryBreakerWasSetByUser && opts.uf.ufSymmetryBreaker)
   {
     // Only applies to non-incremental QF_UF.
@@ -947,17 +948,20 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
           arith, nlExt, options::NlExtMode::LIGHT, "QF_UFNRA");
     }
     else if (logic.isQuantified() && logic.isTheoryEnabled(theory::THEORY_ARITH)
-            && logic.areRealsUsed() && !logic.areIntegersUsed()
-            && !logic.areTranscendentalsUsed())
+             && logic.areRealsUsed() && !logic.areIntegersUsed()
+             && !logic.areTranscendentalsUsed())
     {
       // use only light nlExt techniques if we are using nlCov
       SET_AND_NOTIFY_IF_NOT_USER_VAL_SYM(
-            arith, nlExt, options::NlExtMode::LIGHT, "logic with reals");
-      
+          arith, nlExt, options::NlExtMode::LIGHT, "logic with reals");
     }
     else
     {
-      SET_AND_NOTIFY_IF_NOT_USER(arith, nlCov, false, "logic without reals, or involving integers or quantifiers");
+      SET_AND_NOTIFY_IF_NOT_USER(
+          arith,
+          nlCov,
+          false,
+          "logic without reals, or involving integers or quantifiers");
     }
 #else
     OPTION_EXCEPTION_IF_NOT(arith, nlCov, false, "configuring without --poly");

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -937,7 +937,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
         "any theory other than UF. ");
   }
 
-  // Note that if nlCov is set to false, we do not reenable it.
+  // Note that if nlCov is already set to false, we do not reenable it.
   if (opts.arith.nlCov)
   {
 #ifdef CVC5_USE_POLY
@@ -964,6 +964,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
           "logic without reals, or involving integers or quantifiers");
     }
 #else
+    // must set to false if libpoly is not enabled
     OPTION_EXCEPTION_IF_NOT(arith, nlCov, false, "configuring without --poly");
     SET_AND_NOTIFY(arith, nlCov, false, "no support for libpoly");
     SET_AND_NOTIFY_VAL_SYM(

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -1111,11 +1111,11 @@ bool SetDefaults::incompatibleWithProofs(Options& opts,
     // symmetry breaking does not have proof support
     SET_AND_NOTIFY_VAL_SYM(uf, ufSymmetryBreaker, false, "full strict proofs");
     // CEGQI with deltas and infinities is not supported
-    SET_AND_NOTIFY_IF_NOT_USER(
+    SET_AND_NOTIFY(
         quantifiers, cegqiMidpoint, true, "full strict proofs");
-    SET_AND_NOTIFY_IF_NOT_USER(
+    SET_AND_NOTIFY(
         quantifiers, cegqiUseInfInt, false, "full strict proofs");
-    SET_AND_NOTIFY_IF_NOT_USER(
+    SET_AND_NOTIFY(
         quantifiers, cegqiUseInfReal, false, "full strict proofs");
   }
   return false;

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -52,6 +52,20 @@ namespace cvc5::internal {
 namespace smt {
 
 /**
+ * Throw an option exception if domain.optName is set by the user and not the
+ * given value. Give an error message where reason is given.
+ * Note this macro should be used if the value is concrete.
+ */
+#define OPTION_EXCEPTION_IF_NOT(domain, optName, value, reason)             \
+  if (opts.write_##domain().optName##WasSetByUser                           \
+      && opts.write_##domain().optName != value)                            \
+  {                                                                         \
+    std::stringstream ss;                                                   \
+    ss << "Cannot use --" << options::domain::longName::optName             \
+         << " due to " << reason << ".";                                    \
+    throw OptionException(ss.str());                                        \
+  }
+/**
  * Set domain.optName to value due to reason. Notify if value changes.
  * Note this macro should be used if the value is concrete.
  */
@@ -140,6 +154,9 @@ void SetDefaults::setDefaultsPre(Options& opts)
     // enabled by default later
     SET_AND_NOTIFY_IF_NOT_USER(fp, fpExp, false, "safe options");
     SET_AND_NOTIFY_IF_NOT_USER(sets, setsExp, false, "safe options");
+    // specific options that are disabled
+    OPTION_EXCEPTION_IF_NOT(arith, nlCov, false, "safe options");
+    SET_AND_NOTIFY_IF_NOT_USER(arith, nlCov, false, "safe options");
   }
   // implied options
   if (opts.smt.debugCheckModels)
@@ -306,6 +323,13 @@ void SetDefaults::setDefaultsPre(Options& opts)
                        options::PropProofMode::SAT_EXTERNAL_PROVE,
                        "cadical");
       }
+    }
+    // upgrade to full strict if safe options
+    if (options().base.safeOptions
+        && opts.smt.proofMode == options::ProofMode::FULL)
+    {
+      SET_AND_NOTIFY_IF_NOT_USER(
+          smt, proofMode, options::ProofMode::FULL_STRICT, "safe options");
     }
   }
 
@@ -661,7 +685,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
   }
 
   // by default, symmetry breaker is on only for non-incremental QF_UF
-  if (!opts.uf.ufSymmetryBreakerWasSetByUser)
+  if (!opts.uf.ufSymmetryBreakerWasSetByUser && opts.uf.ufSymmetryBreaker)
   {
     // Only applies to non-incremental QF_UF.
     bool qf_uf_noinc = logic.isPure(THEORY_UF) && !logic.isQuantified()
@@ -671,8 +695,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
     // presolve.
     // We also disable it by default if safe unsat cores are enabled, or if
     // the proof mode is FULL_STRICT.
-    bool val = qf_uf_noinc && !safeUnsatCores(opts)
-               && opts.smt.proofMode != options::ProofMode::FULL_STRICT;
+    bool val = qf_uf_noinc && !safeUnsatCores(opts);
     SET_AND_NOTIFY_VAL_SYM(uf, ufSymmetryBreaker, val, "logic and options");
   }
 
@@ -915,7 +938,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
 #ifdef CVC5_USE_POLY
   if (logic == LogicInfo("QF_UFNRA"))
   {
-    if (!opts.arith.nlCov && !opts.arith.nlCovWasSetByUser)
+    if (opts.arith.nlCov && !opts.arith.nlCovWasSetByUser)
     {
       SET_AND_NOTIFY(arith, nlCov, true, "QF_UFNRA");
       SET_AND_NOTIFY_IF_NOT_USER_VAL_SYM(
@@ -926,29 +949,24 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
            && logic.areRealsUsed() && !logic.areIntegersUsed()
            && !logic.areTranscendentalsUsed())
   {
-    if (!opts.arith.nlCov && !opts.arith.nlCovWasSetByUser)
+    if (opts.arith.nlCov && !opts.arith.nlCovWasSetByUser)
     {
       SET_AND_NOTIFY(arith, nlCov, true, "logic with reals");
       SET_AND_NOTIFY_IF_NOT_USER_VAL_SYM(
           arith, nlExt, options::NlExtMode::LIGHT, "logic with reals");
     }
   }
+  else
+  {
+    SET_AND_NOTIFY(arith, nlCov, false, "logic without reals");
+  }
 #else
   if (opts.arith.nlCov)
   {
-    if (opts.arith.nlCovWasSetByUser)
-    {
-      std::stringstream ss;
-      ss << "Cannot use --" << options::arith::longName::nlCov
-         << " without configuring with --poly.";
-      throw OptionException(ss.str());
-    }
-    else
-    {
-      SET_AND_NOTIFY(arith, nlCov, false, "no support for libpoly");
-      SET_AND_NOTIFY_VAL_SYM(
-          arith, nlExt, options::NlExtMode::FULL, "no support for libpoly");
-    }
+    OPTION_EXCEPTION_IF_NOT(arith, nlCov, false, "configuring without --poly");
+    SET_AND_NOTIFY(arith, nlCov, false, "no support for libpoly");
+    SET_AND_NOTIFY_VAL_SYM(
+        arith, nlExt, options::NlExtMode::FULL, "no support for libpoly");
   }
 #endif
   if (logic.isTheoryEnabled(theory::THEORY_ARITH) && logic.areTranscendentalsUsed())
@@ -1085,6 +1103,18 @@ bool SetDefaults::incompatibleWithProofs(Options& opts,
     // that are not tracked.
     reason << "lemma inprocessing";
     return true;
+  }
+  if (opts.smt.proofMode == options::ProofMode::FULL_STRICT)
+  {
+    // symmetry breaking does not have proof support
+    SET_AND_NOTIFY_VAL_SYM(uf, ufSymmetryBreaker, false, "full strict proofs");
+    // CEGQI with deltas and infinities is not supported
+    SET_AND_NOTIFY_IF_NOT_USER(
+        quantifiers, cegqiMidpoint, true, "full strict proofs");
+    SET_AND_NOTIFY_IF_NOT_USER(
+        quantifiers, cegqiUseInfInt, false, "full strict proofs");
+    SET_AND_NOTIFY_IF_NOT_USER(
+        quantifiers, cegqiUseInfReal, false, "full strict proofs");
   }
   return false;
 }


### PR DESCRIPTION
This refactors setDefaults to disable nlCov if safe options is enabled, and to enable "full strict" proofs.

To simplify the logic, nlCov and ufSymmetryBreaker are now *true* by default and can be disabled.  This allows us to have disabling these options indicate that further changes should not reenable them.

It also ensures certain configurations of CEGQI are enabled with full strict proofs.