### PR TITLE
Fix issues with shared selectors in proofs

### DIFF
--- a/proofs/eo/cpc/theories/Datatypes.eo
+++ b/proofs/eo/cpc/theories/Datatypes.eo
@@ -59,5 +59,5 @@
 ; disclaimer: This function is not in the SMT-LIB standard.
 (declare-const nullable.lift (-> (! Type :var F :implicit) F ($get_type_nullable_lift F)))
 
-; skolems
-;SHARED_SELECTOR
+; shared selector
+(declare-const @shared_selector (-> (! Type :var D) (! Type :var T) Int D T))

--- a/src/proof/alf/alf_node_converter.cpp
+++ b/src/proof/alf/alf_node_converter.cpp
@@ -25,6 +25,7 @@
 #include "expr/dtype_cons.h"
 #include "expr/nary_term_util.h"
 #include "expr/sequence.h"
+#include "expr/sort_to_term.h"
 #include "printer/smt2/smt2_printer.h"
 #include "theory/builtin/generic_op.h"
 #include "theory/bv/theory_bv_utils.h"
@@ -41,7 +42,6 @@
 #include "util/rational.h"
 #include "util/regexp.h"
 #include "util/string.h"
-#include "expr/sort_to_term.h"
 
 using namespace cvc5::internal::kind;
 
@@ -528,12 +528,14 @@ Node AlfNodeConverter::getOperatorOfTerm(Node n, bool reqCast)
     else if (k == Kind::APPLY_SELECTOR)
     {
       // maybe a shared selector
-      if (op.getSkolemId()==SkolemId::SHARED_SELECTOR)
+      if (op.getSkolemId() == SkolemId::SHARED_SELECTOR)
       {
         std::vector<Node> kindices = op.getSkolemIndices();
         opName << "@shared_selector";
-        indices.push_back(typeAsNode(kindices[0].getConst<SortToTerm>().getType()));
-        indices.push_back(typeAsNode(kindices[1].getConst<SortToTerm>().getType()));
+        indices.push_back(
+            typeAsNode(kindices[0].getConst<SortToTerm>().getType()));
+        indices.push_back(
+            typeAsNode(kindices[1].getConst<SortToTerm>().getType()));
         indices.push_back(kindices[2]);
       }
       else

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -1109,11 +1109,14 @@ bool SetDefaults::incompatibleWithProofs(Options& opts,
   if (opts.smt.proofMode == options::ProofMode::FULL_STRICT)
   {
     // symmetry breaking does not have proof support
-    SET_AND_NOTIFY_VAL_SYM(uf, ufSymmetryBreaker, false, "full strict proofs");
+    SET_AND_NOTIFY(uf, ufSymmetryBreaker, false, "full strict proofs");
     // CEGQI with deltas and infinities is not supported
     SET_AND_NOTIFY(quantifiers, cegqiMidpoint, true, "full strict proofs");
     SET_AND_NOTIFY(quantifiers, cegqiUseInfInt, false, "full strict proofs");
     SET_AND_NOTIFY(quantifiers, cegqiUseInfReal, false, "full strict proofs");
+    // shared selectors are not supported
+    SET_AND_NOTIFY(
+        datatypes, dtSharedSelectors, false, "full strict proofs");
   }
   return false;
 }

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -1115,8 +1115,7 @@ bool SetDefaults::incompatibleWithProofs(Options& opts,
     SET_AND_NOTIFY(quantifiers, cegqiUseInfInt, false, "full strict proofs");
     SET_AND_NOTIFY(quantifiers, cegqiUseInfReal, false, "full strict proofs");
     // shared selectors are not supported
-    SET_AND_NOTIFY(
-        datatypes, dtSharedSelectors, false, "full strict proofs");
+    SET_AND_NOTIFY(datatypes, dtSharedSelectors, false, "full strict proofs");
   }
   return false;
 }

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -76,8 +76,7 @@ Node DatatypesRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
       Assert(tn.isDatatype());
       const DType& dt = tn.getDType();
       size_t i = utils::indexOf(n.getOperator());
-      bool sharedSel = d_opts.datatypes.dtSharedSelectors;
-      Node ticons = utils::getInstCons(t, dt, i, sharedSel);
+      Node ticons = utils::getInstCons(t, dt, i, false);
       return t.eqNode(ticons);
     }
     case ProofRewriteRule::DT_COLLAPSE_SELECTOR:

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -88,7 +88,7 @@ Node DatatypesRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
       }
       Node selector = n.getOperator();
       // shared selectors are not supported
-      if (selector.getSkolemId()==SkolemId::SHARED_SELECTOR)
+      if (selector.getSkolemId() == SkolemId::SHARED_SELECTOR)
       {
         return Node::null();
       }

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -76,6 +76,9 @@ Node DatatypesRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
       Assert(tn.isDatatype());
       const DType& dt = tn.getDType();
       size_t i = utils::indexOf(n.getOperator());
+      // Note that we set shared selectors to false. This proof rule will
+      // be (unintentionally) unsuccessful when reconstructing proofs of the
+      // rewriter when using shared selectors.
       Node ticons = utils::getInstCons(t, dt, i, false);
       return t.eqNode(ticons);
     }

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -87,6 +87,11 @@ Node DatatypesRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
         return Node::null();
       }
       Node selector = n.getOperator();
+      // shared selectors are not supported
+      if (selector.getSkolemId()==SkolemId::SHARED_SELECTOR)
+      {
+        return Node::null();
+      }
       size_t constructorIndex = utils::indexOf(n[0].getOperator());
       const DType& dt = utils::datatypeOf(selector);
       const DTypeConstructor& c = dt[constructorIndex];

--- a/src/theory/datatypes/proof_checker.cpp
+++ b/src/theory/datatypes/proof_checker.cpp
@@ -23,9 +23,8 @@ namespace cvc5::internal {
 namespace theory {
 namespace datatypes {
 
-DatatypesProofRuleChecker::DatatypesProofRuleChecker(NodeManager* nm,
-                                                     bool sharedSel)
-    : ProofRuleChecker(nm), d_sharedSel(sharedSel)
+DatatypesProofRuleChecker::DatatypesProofRuleChecker(NodeManager* nm)
+    : ProofRuleChecker(nm)
 {
 }
 

--- a/src/theory/datatypes/proof_checker.h
+++ b/src/theory/datatypes/proof_checker.h
@@ -30,7 +30,7 @@ namespace datatypes {
 class DatatypesProofRuleChecker : public ProofRuleChecker
 {
  public:
-  DatatypesProofRuleChecker(NodeManager* nm, bool sharedSel);
+  DatatypesProofRuleChecker(NodeManager* nm);
 
   /** Register all rules owned by this rule checker into pc. */
   void registerTo(ProofChecker* pc) override;
@@ -40,8 +40,6 @@ class DatatypesProofRuleChecker : public ProofRuleChecker
   Node checkInternal(ProofRule id,
                      const std::vector<Node>& children,
                      const std::vector<Node>& args) override;
-  /** Whether we are using shared selectors */
-  bool d_sharedSel;
 };
 
 }  // namespace datatypes

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -64,7 +64,7 @@ TheoryDatatypes::TheoryDatatypes(Env& env,
       d_state(env, valuation),
       d_im(env, *this, d_state),
       d_notify(d_im, *this),
-      d_checker(nodeManager(), options().datatypes.dtSharedSelectors),
+      d_checker(nodeManager()),
       d_cpacb(*this)
 {
   d_true = nodeManager()->mkConst(true);

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -723,6 +723,7 @@ set(regress_0_tests
   regress0/datatypes/pair-real-bool.smt2
   regress0/datatypes/par-updater-type-rule.smt2
   regress0/datatypes/parametric-alt-list.cvc.smt2
+  regress0/datatypes/pf-v2l60078.smt2
   regress0/datatypes/proj-issue172.smt2
   regress0/datatypes/proj-issue474-app-cons-value.smt2
   regress0/datatypes/proj-issue578-clash-pf.smt2

--- a/test/regress/cli/regress0/datatypes/pf-v2l60078.smt2
+++ b/test/regress/cli/regress0/datatypes/pf-v2l60078.smt2
@@ -1,0 +1,6 @@
+; EXPECT: unsat
+(set-logic QF_DT)
+(declare-datatypes ((n 0) (l 0) (t 0)) (((z)) ((l) (n (r l))) ((f))))
+(declare-fun x () l)
+(assert (and (not (= l (r x))) (not ((_ is n) (r x)))))
+(check-sat)

--- a/test/regress/cli/regress0/datatypes/pf-v2l60078.smt2
+++ b/test/regress/cli/regress0/datatypes/pf-v2l60078.smt2
@@ -1,6 +1,6 @@
 ; EXPECT: unsat
 (set-logic QF_DT)
-(declare-datatypes ((n 0) (l 0) (t 0)) (((z)) ((l) (n (r l))) ((f))))
+(declare-datatypes ((n 0) (l 0) (t 0)) (((z)) ((ln) (n (r l))) ((f))))
 (declare-fun x () l)
-(assert (and (not (= l (r x))) (not ((_ is n) (r x)))))
+(assert (and (not (= ln (r x))) (not ((_ is n) (r x)))))
 (check-sat)


### PR DESCRIPTION
We do not generally support shared selectors in proofs.

This disables them when full strict proofs are enabled, and makes the internal proof checker not support them.

It also adds proper printing support for them in the Eunoia signature in case they are enabled.