### PR TITLE
Fix issues with alpha equivalence with quantifiers with patterns

### DIFF
--- a/src/rewriter/rewrite_db_term_process.cpp
+++ b/src/rewriter/rewrite_db_term_process.cpp
@@ -157,11 +157,6 @@ Node RewriteDbNodeConverter::postConvert(Node n)
   return n;
 }
 
-bool RewriteDbNodeConverter::shouldTraverse(Node n)
-{
-  return n.getKind() != Kind::INST_PATTERN_LIST;
-}
-
 void RewriteDbNodeConverter::recordProofStep(const Node& n,
                                              const Node& ret,
                                              ProofRule r)

--- a/src/rewriter/rewrite_db_term_process.h
+++ b/src/rewriter/rewrite_db_term_process.h
@@ -72,8 +72,6 @@ class RewriteDbNodeConverter : public NodeConverter
   CDProof* d_proof;
   /** Record that n ---> ret, justifiable by proof rule r. */
   void recordProofStep(const Node& n, const Node& ret, ProofRule r);
-  /** Should we traverse n? */
-  bool shouldTraverse(Node n) override;
 };
 
 /** A proof producing version of the above class */

--- a/src/theory/builtin/proof_checker.cpp
+++ b/src/theory/builtin/proof_checker.cpp
@@ -479,7 +479,7 @@ Node BuiltinProofRuleChecker::checkInternal(ProofRule id,
   return Node::null();
 }
 
-Node BuiltinProofRuleChecker::getEncodeEqIntro(NodeManager * nm, const Node& n)
+Node BuiltinProofRuleChecker::getEncodeEqIntro(NodeManager* nm, const Node& n)
 {
   rewriter::RewriteDbNodeConverter rconv(nm);
   // run a single (small) step conversion

--- a/src/theory/builtin/proof_checker.cpp
+++ b/src/theory/builtin/proof_checker.cpp
@@ -420,9 +420,7 @@ Node BuiltinProofRuleChecker::checkInternal(ProofRule id,
   {
     Assert(children.empty());
     Assert(args.size() == 1);
-    rewriter::RewriteDbNodeConverter rconv(nodeManager());
-    // run a single (small) step conversion
-    Node ac = rconv.postConvert(args[0]);
+    Node ac = getEncodeEqIntro(nodeManager(), args[0]);
     return args[0].eqNode(ac);
   }
   else if (id == ProofRule::DSL_REWRITE)
@@ -479,6 +477,14 @@ Node BuiltinProofRuleChecker::checkInternal(ProofRule id,
   }
   // no rule
   return Node::null();
+}
+
+Node BuiltinProofRuleChecker::getEncodeEqIntro(NodeManager * nm, const Node& n)
+{
+  rewriter::RewriteDbNodeConverter rconv(nm);
+  // run a single (small) step conversion
+  Node nc = rconv.postConvert(n);
+  return nc;
 }
 
 bool BuiltinProofRuleChecker::getTheoryId(TNode n, TheoryId& tid)

--- a/src/theory/builtin/proof_checker.h
+++ b/src/theory/builtin/proof_checker.h
@@ -107,6 +107,12 @@ class BuiltinProofRuleChecker : public ProofRuleChecker
   static bool getTheoryId(TNode n, TheoryId& tid);
   /** Make a TheoryId into a node */
   static Node mkTheoryIdNode(TheoryId tid);
+  /** 
+   * @param nm The node manager.
+   * @param n The term to rewrite via ENCODE_EQ_INTRO.
+   * @return The equality concluded by ENCODE_EQ_INTRO for n.
+   */
+  static Node getEncodeEqIntro(NodeManager * nm, const Node& n);
 
   /** Register all rules owned by this rule checker into pc. */
   void registerTo(ProofChecker* pc) override;

--- a/src/theory/builtin/proof_checker.h
+++ b/src/theory/builtin/proof_checker.h
@@ -110,7 +110,8 @@ class BuiltinProofRuleChecker : public ProofRuleChecker
   /**
    * @param nm The node manager.
    * @param n The term to rewrite via ENCODE_EQ_INTRO.
-   * @return The equality concluded by ENCODE_EQ_INTRO for n.
+   * @return The right hand side of the equality concluded by ENCODE_EQ_INTRO
+   * for n.
    */
   static Node getEncodeEqIntro(NodeManager* nm, const Node& n);
 

--- a/src/theory/builtin/proof_checker.h
+++ b/src/theory/builtin/proof_checker.h
@@ -107,12 +107,12 @@ class BuiltinProofRuleChecker : public ProofRuleChecker
   static bool getTheoryId(TNode n, TheoryId& tid);
   /** Make a TheoryId into a node */
   static Node mkTheoryIdNode(TheoryId tid);
-  /** 
+  /**
    * @param nm The node manager.
    * @param n The term to rewrite via ENCODE_EQ_INTRO.
    * @return The equality concluded by ENCODE_EQ_INTRO for n.
    */
-  static Node getEncodeEqIntro(NodeManager * nm, const Node& n);
+  static Node getEncodeEqIntro(NodeManager* nm, const Node& n);
 
   /** Register all rules owned by this rule checker into pc. */
   void registerTo(ProofChecker* pc) override;

--- a/src/theory/quantifiers/alpha_equivalence.cpp
+++ b/src/theory/quantifiers/alpha_equivalence.cpp
@@ -19,6 +19,7 @@
 #include "proof/method_id.h"
 #include "proof/proof.h"
 #include "proof/proof_node.h"
+#include "theory/builtin/proof_checker.h"
 
 using namespace cvc5::internal::kind;
 
@@ -208,6 +209,38 @@ TrustNode AlphaEquivalence::reduceQuantifier(Node q)
   // if successfully computed the substitution above
   if (isProofEnabled() && !vars.empty())
   {
+    NodeManager * nm = nodeManager();
+    Node proveLem = lem;
+    CDProof cdp(d_env);
+    // remove patterns from both sides
+    if (q.getNumChildren()==3)
+    {
+      Node qo = q;
+      q = builtin::BuiltinProofRuleChecker::getEncodeEqIntro(nm, q);
+      if (q!=qo)
+      {
+        Node eqq = qo.eqNode(q);
+        cdp.addStep(eqq, ProofRule::ENCODE_EQ_INTRO, {}, {qo});
+        Node eqqs = q.eqNode(qo);
+        cdp.addStep(eqqs, ProofRule::SYMM, {eqq}, {});
+        Node eqq2 = ret.eqNode(q);
+        cdp.addStep(proveLem, ProofRule::TRANS, {eqq2, eqqs}, {});
+        proveLem = eqq2;
+      }
+    }
+    if (ret.getNumChildren()==3)
+    {
+      Node reto = ret;
+      ret = builtin::BuiltinProofRuleChecker::getEncodeEqIntro(nm, ret);
+      if (ret!=reto)
+      {
+        Node eqq = reto.eqNode(ret);
+        cdp.addStep(eqq, ProofRule::ENCODE_EQ_INTRO, {}, {reto});
+        Node eqq2 = ret.eqNode(q);
+        cdp.addStep(proveLem, ProofRule::TRANS, {eqq, eqq2}, {});
+        proveLem = eqq2;
+      }
+    }
     if (Configuration::isAssertionBuild())
     {
       // all variables should be unique since we are processing rewritten
@@ -217,7 +250,6 @@ TrustNode AlphaEquivalence::reduceQuantifier(Node q)
       std::unordered_set<Node> sset(subs.begin(), subs.end());
       Assert(sset.size() == subs.size());
     }
-    CDProof cdp(d_env);
     std::vector<Node> transEq;
     // if there is variable shadowing, we do an intermediate step with fresh
     // variables
@@ -252,7 +284,7 @@ TrustNode AlphaEquivalence::reduceQuantifier(Node q)
       {
         children.push_back(sret[2]);
       }
-      Node sreorder = nodeManager()->mkNode(Kind::FORALL, children);
+      Node sreorder = nm->mkNode(Kind::FORALL, children);
       Node eqqr = sret.eqNode(sreorder);
       if (cdp.addStep(eqqr, ProofRule::QUANT_VAR_REORDERING, {}, {eqqr}))
       {
@@ -292,7 +324,7 @@ TrustNode AlphaEquivalence::reduceQuantifier(Node q)
       if (transEq.size() > 1)
       {
         // TRANS of ALPHA_EQ and MACRO_SR_PRED_INTRO steps from above
-        cdp.addStep(lem, ProofRule::TRANS, transEq, {});
+        cdp.addStep(proveLem, ProofRule::TRANS, transEq, {});
       }
       std::shared_ptr<ProofNode> pn = cdp.getProofFor(lem);
       Trace("alpha-eq") << "Proof is " << *pn.get() << std::endl;

--- a/src/theory/quantifiers/alpha_equivalence.cpp
+++ b/src/theory/quantifiers/alpha_equivalence.cpp
@@ -209,15 +209,15 @@ TrustNode AlphaEquivalence::reduceQuantifier(Node q)
   // if successfully computed the substitution above
   if (isProofEnabled() && !vars.empty())
   {
-    NodeManager * nm = nodeManager();
+    NodeManager* nm = nodeManager();
     Node proveLem = lem;
     CDProof cdp(d_env);
     // remove patterns from both sides
-    if (q.getNumChildren()==3)
+    if (q.getNumChildren() == 3)
     {
       Node qo = q;
       q = builtin::BuiltinProofRuleChecker::getEncodeEqIntro(nm, q);
-      if (q!=qo)
+      if (q != qo)
       {
         Node eqq = qo.eqNode(q);
         cdp.addStep(eqq, ProofRule::ENCODE_EQ_INTRO, {}, {qo});
@@ -228,11 +228,11 @@ TrustNode AlphaEquivalence::reduceQuantifier(Node q)
         proveLem = eqq2;
       }
     }
-    if (ret.getNumChildren()==3)
+    if (ret.getNumChildren() == 3)
     {
       Node reto = ret;
       ret = builtin::BuiltinProofRuleChecker::getEncodeEqIntro(nm, ret);
-      if (ret!=reto)
+      if (ret != reto)
       {
         Node eqq = reto.eqNode(ret);
         cdp.addStep(eqq, ProofRule::ENCODE_EQ_INTRO, {}, {reto});

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1317,6 +1317,7 @@ set(regress_0_tests
   regress0/proofs/bvrewrite-ite.smt2
   regress0/proofs/bvrewrite-shlbyconst.smt2
   regress0/proofs/dd_ada_open.smt2
+  regress0/proofs/dd_alpha_eq_qpattern.smt2
   regress0/proofs/dd_bug787_beta_reduce.smt2
   regress0/proofs/dd_fv-bvl.smt2
   regress0/proofs/dd_ic_pf_764.smt2

--- a/test/regress/cli/regress0/proofs/dd_alpha_eq_qpattern.smt2
+++ b/test/regress/cli/regress0/proofs/dd_alpha_eq_qpattern.smt2
@@ -1,0 +1,9 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-sort g 0)
+(declare-sort c 0)
+(declare-datatypes ((u 0)) (((u))))
+(declare-fun i (u (Array Int Bool) (Array Int g) (Array Int c)) Bool)
+(assert (forall ((a u)) (forall ((s (Array Int Bool))) (forall ((t (Array Int g))) (forall ((st (Array Int c))) (! (distinct true (i a s t st)) :pattern ((i u s t st))))))))
+(assert (exists ((u u) (o (Array Int c)) (t (Array Int Bool)) (e (Array Int g))) (= true (i u t e o))))
+(check-sat)


### PR DESCRIPTION
Currently the proof support in the alpha equivalence quantifiers module was not handling this case properly.

A regression is added for the issue.