### PR TITLE
Make DT_CONS_EQ macro, elaborate to simpler version

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -2726,7 +2726,7 @@ enum ENUM(ProofRewriteRule)
   EVALUE(DT_COLLAPSE_TESTER_SINGLETON),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Datatypes -- constructor equality**
+   * **Datatypes -- Macro constructor equality**
    *
    * .. math::
    *   (t = s) = (t_1 = s_1 \wedge \ldots \wedge t_n = s_n)
@@ -2751,17 +2751,25 @@ enum ENUM(ProofRewriteRule)
    * .. math::
    *   (c(t_1, \ldots, t_n) = c(s_1, \ldots, s_n)) =
    *   (t_1 = s_1 \wedge \ldots \wedge t_n = s_n)
-   *
-   * or alternatively
-   *
-   * .. math::
-   *   (c(t_1, \ldots, t_n) = d(s_1, \ldots, s_m)) = false
-   *
-   * where :math:`c` and :math:`d` are distinct constructors.
+   * 
+   * where :math:`c` is a constructor.
    *
    * \endverbatim
    */
   EVALUE(DT_CONS_EQ),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Datatypes -- constructor equality clash**
+   *
+   * .. math::
+   *   (t = s) = false
+   * 
+   * where :math:`t` and :math:`s` have a subterm that are distinct constructors
+   * that occur in the same position (beneath other constructor applications).
+   *
+   * \endverbatim
+   */
+  EVALUE(DT_CONS_EQ_CLASH),
   /**
    * \verbatim embed:rst:leading-asterisk
    * **Datatypes -- cycle**

--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -2738,8 +2738,8 @@ enum ENUM(ProofRewriteRule)
    * .. math::
    *   (t = s) = false
    * 
-   * where :math:`t` and :math:`s` have a subterm that are distinct constructors
-   * that occur in the same position (beneath other constructor applications).
+   * where :math:`t` and :math:`s` have subterms that occur in the same
+   * position (beneath constructor applications) that are distinct.
    *
    * \endverbatim
    */
@@ -2764,8 +2764,9 @@ enum ENUM(ProofRewriteRule)
    * .. math::
    *   (t = s) = false
    * 
-   * where :math:`t` and :math:`s` have a subterm that are distinct constructors
-   * that occur in the same position (beneath other constructor applications).
+   * where :math:`t` and :math:`s` have subterms that occur in the same
+   * position (beneath constructor applications) that are distinct constructor
+   * applications.
    *
    * \endverbatim
    */

--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -2729,6 +2729,26 @@ enum ENUM(ProofRewriteRule)
    * **Datatypes -- constructor equality**
    *
    * .. math::
+   *   (t = s) = (t_1 = s_1 \wedge \ldots \wedge t_n = s_n)
+   *
+   * where :math:`t_1, \ldots, t_n` and :math:`s_1, \ldots, s_n` are subterms
+   * of :math:`t` and :math:`s` that occur at the same position respectively
+   * (beneath constructor applications), or alternatively
+   *
+   * .. math::
+   *   (t = s) = false
+   * 
+   * where :math:`t` and :math:`s` have a subterm that are distinct constructors
+   * that occur in the same position (beneath other constructor applications).
+   *
+   * \endverbatim
+   */
+  EVALUE(MACRO_DT_CONS_EQ),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Datatypes -- constructor equality**
+   *
+   * .. math::
    *   (c(t_1, \ldots, t_n) = c(s_1, \ldots, s_n)) =
    *   (t_1 = s_1 \wedge \ldots \wedge t_n = s_n)
    *

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -263,6 +263,7 @@ const char* toString(cvc5::ProofRewriteRule rule)
     case ProofRewriteRule::DT_COLLAPSE_TESTER: return "dt-collapse-tester";
     case ProofRewriteRule::DT_COLLAPSE_TESTER_SINGLETON:
       return "dt-collapse-tester-singleton";
+    case ProofRewriteRule::MACRO_DT_CONS_EQ: return "macro-dt-cons-eq";
     case ProofRewriteRule::DT_CONS_EQ: return "dt-cons-eq";
     case ProofRewriteRule::DT_CYCLE: return "dt-cycle";
     case ProofRewriteRule::DT_COLLAPSE_UPDATER: return "dt-collapse-updater";

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -265,6 +265,7 @@ const char* toString(cvc5::ProofRewriteRule rule)
       return "dt-collapse-tester-singleton";
     case ProofRewriteRule::MACRO_DT_CONS_EQ: return "macro-dt-cons-eq";
     case ProofRewriteRule::DT_CONS_EQ: return "dt-cons-eq";
+    case ProofRewriteRule::DT_CONS_EQ_CLASH: return "dt-cons-eq-clash";
     case ProofRewriteRule::DT_CYCLE: return "dt-cycle";
     case ProofRewriteRule::DT_COLLAPSE_UPDATER: return "dt-collapse-updater";
     case ProofRewriteRule::DT_UPDATER_ELIM: return "dt-updater-elim";

--- a/src/proof/conv_proof_generator.cpp
+++ b/src/proof/conv_proof_generator.cpp
@@ -23,6 +23,7 @@
 #include "proof/proof_checker.h"
 #include "proof/proof_node.h"
 #include "proof/proof_node_algorithm.h"
+#include "rewriter/rewrites.h"
 
 using namespace cvc5::internal::kind;
 
@@ -110,6 +111,18 @@ void TConvProofGenerator::addRewriteStep(Node t,
   {
     d_proof.addStep(eq, id, children, args);
   }
+}
+
+void TConvProofGenerator::addTheoryRewriteStep(Node t,
+                    Node s,
+                    ProofRewriteRule id,
+                    bool isPre,
+                    uint32_t tctx)
+{
+  std::vector<Node> sargs;
+  sargs.push_back(rewriter::mkRewriteRuleNode(id));
+  sargs.push_back(t.eqNode(s));
+  addRewriteStep(t, s, ProofRule::THEORY_REWRITE, {}, sargs, isPre, tctx);
 }
 
 bool TConvProofGenerator::hasRewriteStep(Node t,

--- a/src/proof/conv_proof_generator.cpp
+++ b/src/proof/conv_proof_generator.cpp
@@ -113,11 +113,8 @@ void TConvProofGenerator::addRewriteStep(Node t,
   }
 }
 
-void TConvProofGenerator::addTheoryRewriteStep(Node t,
-                    Node s,
-                    ProofRewriteRule id,
-                    bool isPre,
-                    uint32_t tctx)
+void TConvProofGenerator::addTheoryRewriteStep(
+    Node t, Node s, ProofRewriteRule id, bool isPre, uint32_t tctx)
 {
   std::vector<Node> sargs;
   sargs.push_back(rewriter::mkRewriteRuleNode(id));

--- a/src/proof/conv_proof_generator.h
+++ b/src/proof/conv_proof_generator.h
@@ -172,6 +172,12 @@ class TConvProofGenerator : protected EnvObj, public ProofGenerator
                       const std::vector<Node>& args,
                       bool isPre = false,
                       uint32_t tctx = 0);
+  /** Same as above, with a theory rewrite step */
+  void addTheoryRewriteStep(Node t,
+                      Node s,
+                      ProofRewriteRule id,
+                      bool isPre = false,
+                      uint32_t tctx = 0);
   /** Has rewrite step for term t */
   bool hasRewriteStep(Node t, uint32_t tctx = 0, bool isPre = false) const;
   /**

--- a/src/proof/conv_proof_generator.h
+++ b/src/proof/conv_proof_generator.h
@@ -174,10 +174,10 @@ class TConvProofGenerator : protected EnvObj, public ProofGenerator
                       uint32_t tctx = 0);
   /** Same as above, with a theory rewrite step */
   void addTheoryRewriteStep(Node t,
-                      Node s,
-                      ProofRewriteRule id,
-                      bool isPre = false,
-                      uint32_t tctx = 0);
+                            Node s,
+                            ProofRewriteRule id,
+                            bool isPre = false,
+                            uint32_t tctx = 0);
   /** Has rewrite step for term t */
   bool hasRewriteStep(Node t, uint32_t tctx = 0, bool isPre = false) const;
   /**

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -273,35 +273,37 @@ bool BasicRewriteRCons::ensureProofMacroBoolNnfNorm(CDProof* cdp,
   return true;
 }
 
-
 bool BasicRewriteRCons::ensureProofMacroDtConsEq(CDProof* cdp, const Node& eq)
 {
   Assert(eq.getKind() == Kind::EQUAL);
   Trace("brc-macro") << "Expand dt cons eq for " << eq << std::endl;
   TConvProofGenerator tcpg(d_env);
   theory::Rewriter* rr = d_env.getRewriter();
-  //bool isConflict = eq[1].isConst();
+  // bool isConflict = eq[1].isConst();
   std::unordered_set<TNode> visited;
   std::vector<TNode> visit;
   TNode cur;
   visit.push_back(eq[0]);
-  do {
+  do
+  {
     cur = visit.back();
     visit.pop_back();
-    if (visited.find(cur) == visited.end()) {
+    if (visited.find(cur) == visited.end())
+    {
       visited.insert(cur);
-      if (cur.getKind()==Kind::EQUAL)
+      if (cur.getKind() == Kind::EQUAL)
       {
         Node curRew = rr->rewriteViaRule(ProofRewriteRule::DT_CONS_EQ, cur);
         if (!curRew.isNull())
         {
-          tcpg.addTheoryRewriteStep(cur, curRew, ProofRewriteRule::DT_CONS_EQ, true);
+          tcpg.addTheoryRewriteStep(
+              cur, curRew, ProofRewriteRule::DT_CONS_EQ, true);
         }
       }
       else
       {
         // traverse AND
-        Assert (cur.getKind()==Kind::AND);
+        Assert(cur.getKind() == Kind::AND);
         visit.insert(visit.end(), cur.begin(), cur.end());
       }
     }
@@ -309,10 +311,10 @@ bool BasicRewriteRCons::ensureProofMacroDtConsEq(CDProof* cdp, const Node& eq)
   // get proof for rewriting, which should expand equalities
   std::shared_ptr<ProofNode> pfn = tcpg.getProofForRewriting(eq[0]);
   Node res = pfn->getResult();
-  Assert (res.getKind()==Kind::EQUAL);
+  Assert(res.getKind() == Kind::EQUAL);
   // the right hand side should rewrite to the other side
   Node rhs = res[1];
-  if (rhs==eq[1])
+  if (rhs == eq[1])
   {
     return true;
   }

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -288,6 +288,8 @@ bool BasicRewriteRCons::ensureProofMacroDtConsEq(CDProof* cdp, const Node& eq)
       cdp->addTheoryRewriteStep(eq, ProofRewriteRule::DT_CONS_EQ_CLASH);
       return true;
     }
+    // otherwise, we require proving the non-datatype constants are distinct
+    // this case is not yet handled.
     return false;
   }
   std::unordered_set<TNode> visited;

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -283,7 +283,7 @@ bool BasicRewriteRCons::ensureProofMacroDtConsEq(CDProof* cdp, const Node& eq)
   {
     // DT_CONS_EQ_CLASH may suffice if it is purely datatypes
     Node curRew = rr->rewriteViaRule(ProofRewriteRule::DT_CONS_EQ_CLASH, eq[0]);
-    if (curRew==eq[1])
+    if (curRew == eq[1])
     {
       cdp->addTheoryRewriteStep(eq, ProofRewriteRule::DT_CONS_EQ_CLASH);
       return true;

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -316,6 +316,7 @@ bool BasicRewriteRCons::ensureProofMacroDtConsEq(CDProof* cdp, const Node& eq)
   Node rhs = res[1];
   if (rhs == eq[1])
   {
+    cdp->addProof(pfn);
     return true;
   }
   // should rewrite via ACI_NORM
@@ -327,6 +328,7 @@ bool BasicRewriteRCons::ensureProofMacroDtConsEq(CDProof* cdp, const Node& eq)
     cdp->addStep(eq, ProofRule::TRANS, {res, eqa}, {});
     return true;
   }
+  AlwaysAssert(false) << "Failed to show " << rhs << " == " << eq[1] << std::endl;
   return false;
 }
 

--- a/src/rewriter/basic_rewrite_rcons.h
+++ b/src/rewriter/basic_rewrite_rcons.h
@@ -142,6 +142,15 @@ class BasicRewriteRCons : protected EnvObj
   bool ensureProofMacroBoolNnfNorm(CDProof* cdp, const Node& eq);
   /**
    * Elaborate a rewrite eq that was proven by
+   * ProofRewriteRule::MACRO_DT_CONS_EQ.
+   *
+   * @param cdp The proof to add to.
+   * @param eq The rewrite proven by ProofRewriteRule::MACRO_DT_CONS_EQ.
+   * @return true if added a closed proof of eq to cdp.
+   */
+  bool ensureProofMacroDtConsEq(CDProof* cdp, const Node& eq);
+  /**
+   * Elaborate a rewrite eq that was proven by
    * ProofRewriteRule::MACRO_ARITH_STRING_PRED_ENTAIL.
    *
    * This takes an equality of the form (r t1 t2) = c, where r is an arithmetic

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -152,7 +152,9 @@ Node DatatypesRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
     break;
     case ProofRewriteRule::DT_CONS_EQ:
     {
-      if (n.getKind() != Kind::EQUAL || n[0].getKind()!=Kind::APPLY_CONSTRUCTOR || n[1].getKind()!=Kind::APPLY_CONSTRUCTOR)
+      if (n.getKind() != Kind::EQUAL
+          || n[0].getKind() != Kind::APPLY_CONSTRUCTOR
+          || n[1].getKind() != Kind::APPLY_CONSTRUCTOR)
       {
         return Node::null();
       }

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -182,6 +182,8 @@ Node DatatypesRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
       {
         return Node::null();
       }
+      // do not look for constant clashing equality between non-datatypes
+      std::vector<Node> rew;
       if (utils::checkClash(n[0], n[1], rew, false))
       {
         return nodeManager()->mkConst(false);

--- a/src/theory/datatypes/theory_datatypes_utils.cpp
+++ b/src/theory/datatypes/theory_datatypes_utils.cpp
@@ -164,6 +164,12 @@ bool isNullaryConstructor(const DTypeConstructor& c)
 
 bool checkClash(Node n1, Node n2, std::vector<Node>& rew)
 {
+  std::vector<Node> path;
+  return checkClash(n1, n2, rew, path);
+}
+
+bool checkClash(Node n1, Node n2, std::vector<Node>& rew, bool checkNdtConst)
+{
   Trace("datatypes-rewrite-debug")
       << "Check clash : " << n1 << " " << n2 << std::endl;
   if (n1.getKind() == Kind::APPLY_CONSTRUCTOR
@@ -179,7 +185,7 @@ bool checkClash(Node n1, Node n2, std::vector<Node>& rew)
     Assert(n1.getNumChildren() == n2.getNumChildren());
     for (unsigned i = 0, size = n1.getNumChildren(); i < size; i++)
     {
-      if (checkClash(n1[i], n2[i], rew))
+      if (checkClash(n1[i], n2[i], rew, checkNdtConst))
       {
         return true;
       }
@@ -187,7 +193,7 @@ bool checkClash(Node n1, Node n2, std::vector<Node>& rew)
   }
   else if (n1 != n2)
   {
-    if (n1.isConst() && n2.isConst())
+    if (checkNdtConst && n1.isConst() && n2.isConst())
     {
       Trace("datatypes-rewrite-debug")
           << "Clash constants : " << n1 << " " << n2 << std::endl;

--- a/src/theory/datatypes/theory_datatypes_utils.cpp
+++ b/src/theory/datatypes/theory_datatypes_utils.cpp
@@ -162,12 +162,6 @@ bool isNullaryConstructor(const DTypeConstructor& c)
   return true;
 }
 
-bool checkClash(Node n1, Node n2, std::vector<Node>& rew)
-{
-  std::vector<Node> path;
-  return checkClash(n1, n2, rew, path);
-}
-
 bool checkClash(Node n1, Node n2, std::vector<Node>& rew, bool checkNdtConst)
 {
   Trace("datatypes-rewrite-debug")
@@ -193,6 +187,7 @@ bool checkClash(Node n1, Node n2, std::vector<Node>& rew, bool checkNdtConst)
   }
   else if (n1 != n2)
   {
+    // if checking equality between non-datatypes
     if (checkNdtConst && n1.isConst() && n2.isConst())
     {
       Trace("datatypes-rewrite-debug")
@@ -201,8 +196,7 @@ bool checkClash(Node n1, Node n2, std::vector<Node>& rew, bool checkNdtConst)
     }
     else
     {
-      Node eq = NodeManager::currentNM()->mkNode(Kind::EQUAL, n1, n2);
-      rew.push_back(eq);
+      rew.push_back(n1.eqNode(n2));
     }
   }
   return false;

--- a/src/theory/datatypes/theory_datatypes_utils.h
+++ b/src/theory/datatypes/theory_datatypes_utils.h
@@ -109,8 +109,14 @@ bool isNullaryConstructor(const DTypeConstructor& c);
  *   C( x, y ) and C( D( x ), y )
  *   C( D( x ), y ) and C( x, E( z ) )
  *   C( x, y ) and z
+ *
+ * @param n1 The first term.
+ * @param n2 The second term.
+ * @param rew The set of entailed equalities.
+ * @param checkNdtConst If true, we consider constants (of non-datatype type) to
+ * be a conflict.
  */
-bool checkClash(Node n1, Node n2, std::vector<Node>& rew);
+bool checkClash(Node n1, Node n2, std::vector<Node>& rew, bool checkNdtConst = true);
 
 }  // namespace utils
 }  // namespace datatypes

--- a/src/theory/datatypes/theory_datatypes_utils.h
+++ b/src/theory/datatypes/theory_datatypes_utils.h
@@ -116,7 +116,10 @@ bool isNullaryConstructor(const DTypeConstructor& c);
  * @param checkNdtConst If true, we consider constants (of non-datatype type) to
  * be a conflict.
  */
-bool checkClash(Node n1, Node n2, std::vector<Node>& rew, bool checkNdtConst = true);
+bool checkClash(Node n1,
+                Node n2,
+                std::vector<Node>& rew,
+                bool checkNdtConst = true);
 
 }  // namespace utils
 }  // namespace datatypes

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1353,6 +1353,7 @@ set(regress_0_tests
   regress0/proofs/open-pf-if-unordered-iff.smt2
   regress0/proofs/open-pf-rederivation.smt2
   regress0/proofs/other-optResRecons-corner-case.smt2
+  regress0/proofs/pfcheck-ufdt-distro.smt2
   regress0/proofs/project-issue317-inc-sat-conflictlit.smt2
   regress0/proofs/project-issue330-eqproof.smt2
   regress0/proofs/proj-issue326-nl-bounds-check.smt2


### PR DESCRIPTION
This fixes proof failures in datatypes involving the rule DT_CONS_EQ.

This rule currently involves a more complex implementation than what is documented and expected.

This fixes the documentation, makes it a macro, and introduces 2 new rules for its elaboration.  We then use the simpler version in the datatypes infer proof constructor.

The proof elaboration for this macro is not yet complete, but this fixes the open proof errors involving this rule, included is an example regression.