### PR TITLE
Add macro and elaboration for quantifiers prenex

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -2551,6 +2551,16 @@ enum ENUM(ProofRewriteRule)
   EVALUE(QUANT_MERGE_PRENEX),
   /**
    * \verbatim embed:rst:leading-asterisk
+   * **Quantifiers -- Macro prenex**
+   *
+   * .. math::
+   *   \forall X.\> F_1 \vee \forall Y.\> F_i \vee F_n = \forall X Z.\> F_1 \vee \ldots \vee F_n \{ Y \mapsto Z \}
+   *
+   * \endverbatim
+   */
+  EVALUE(MACRO_QUANT_PRENEX),
+  /**
+   * \verbatim embed:rst:leading-asterisk
    * **Quantifiers -- Macro miniscoping**
    *
    * .. math::

--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -2554,7 +2554,7 @@ enum ENUM(ProofRewriteRule)
    * **Quantifiers -- Macro prenex**
    *
    * .. math::
-   *   \forall X.\> F_1 \vee \forall Y.\> F_i \vee F_n = \forall X Z.\> F_1 \vee \ldots \vee F_n \{ Y \mapsto Z \}
+   *   (\forall X.\> F_1 \vee \cdots \vee (\forall Y.\> F_i) \vee \cdots \vee F_n) = (\forall X Z.\> F_1 \vee \cdots \vee F_i\{ Y \mapsto Z \} \vee \cdots \vee F_n)
    *
    * \endverbatim
    */

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -244,6 +244,7 @@ const char* toString(cvc5::ProofRewriteRule rule)
     case ProofRewriteRule::MACRO_QUANT_MERGE_PRENEX:
       return "macro-quant-merge-prenex";
     case ProofRewriteRule::QUANT_MERGE_PRENEX: return "quant-merge-prenex";
+    case ProofRewriteRule::MACRO_QUANT_PRENEX: return "macro-quant-prenex";
     case ProofRewriteRule::MACRO_QUANT_MINISCOPE:
       return "macro-quant-miniscope";
     case ProofRewriteRule::QUANT_MINISCOPE: return "quant-miniscope";

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -708,8 +708,7 @@ bool BasicRewriteRCons::ensureProofMacroQuantPrenex(CDProof* cdp,
     cdp->addStep(eqqb, cr, cpremises, cargs);
     cdp->addStep(eqqrs, ProofRule::TRANS, {eqqm, eqqb}, {});
   }
-  Node eqqr = body1.eqNode(body2);
-  cdp->addStep(eqqr, ProofRule::SYMM, {eqqrs}, {});
+  cdp->addStep(beq, ProofRule::SYMM, {eqqrs}, {});
   return true;
 }
 

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -649,7 +649,7 @@ bool BasicRewriteRCons::ensureProofMacroQuantPrenex(CDProof* cdp,
       rr->rewriteViaRule(ProofRewriteRule::QUANT_MERGE_PRENEX, umergeq);
   if (mergeq != eq[1])
   {
-    Assert(false) << "Failed merge step";
+    Trace("brc-macro") << "Failed merge step";
     return false;
   }
   Node eqq2 = umergeq.eqNode(mergeq);
@@ -661,7 +661,7 @@ bool BasicRewriteRCons::ensureProofMacroQuantPrenex(CDProof* cdp,
       rr->rewriteViaRule(ProofRewriteRule::QUANT_MINISCOPE_FV, body2);
   if (body2ms.isNull())
   {
-    Assert(false) << "Failed miniscope";
+    Trace("brc-macro") << "Failed miniscope";
     return false;
   }
   Node eqqm = body2.eqNode(body2ms);
@@ -672,7 +672,7 @@ bool BasicRewriteRCons::ensureProofMacroQuantPrenex(CDProof* cdp,
     if (body2ms.getKind() != body1.getKind()
         || body2ms.getNumChildren() != body1.getNumChildren())
     {
-      Assert(false) << "Failed after miniscope";
+      Trace("brc-macro") << "Failed after miniscope";
       return false;
     }
     // We may have used alpha equivalence to rename variables, thus we

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -668,7 +668,7 @@ bool BasicRewriteRCons::ensureProofMacroQuantPrenex(CDProof* cdp, const Node& eq
   // since then it would end up in the final proof. Instead we introduce a
   // trust step which will be filled based on the macro rule and elaborated.
   cdp->addTrustedStep(
-        eqqm, TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE, {}, {});
+        eqqm, TrustId::MACRO_THEORY_REWRITE_RCONS, {}, {});
   Node eqqrs = body2.eqNode(body1);
   if (body2ms!=body1)
   {

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -199,6 +199,12 @@ void BasicRewriteRCons::ensureProofForTheoryRewrite(
         handledMacro = true;
       }
       break;
+    case ProofRewriteRule::MACRO_QUANT_PRENEX:
+      if (ensureProofMacroQuantPrenex(cdp, eq))
+      {
+        handledMacro = true;
+      }
+      break;
     case ProofRewriteRule::MACRO_QUANT_PARTITION_CONNECTED_FV:
       if (ensureProofMacroQuantPartitionConnectedFv(cdp, eq))
       {
@@ -605,6 +611,99 @@ bool BasicRewriteRCons::ensureProofMacroQuantMergePrenex(CDProof* cdp,
     transEq.push_back(equiv3s);
   }
   cdp->addStep(eq, ProofRule::TRANS, transEq, {});
+  return true;
+}
+
+bool BasicRewriteRCons::ensureProofMacroQuantPrenex(CDProof* cdp, const Node& eq)
+{
+  NodeManager* nm = nodeManager();
+  Trace("brc-macro") << "Expand macro quant prenex for " << eq
+                     << std::endl;
+  Assert (eq[0].getKind()==Kind::FORALL);
+  Assert (eq[1].getKind()==Kind::FORALL);
+  Node body1 = eq[0][1];
+  Node body2 = eq[1][1];
+  // take the prenexed variables
+  size_t nvars1 = eq[0][0].getNumChildren();
+  std::vector<Node> newVars(eq[1][0].begin()+nvars1, eq[1][0].end());
+  Assert (!newVars.empty());
+  Node bvl = nm->mkNode(Kind::BOUND_VAR_LIST, newVars);
+  body2 = nm->mkNode(Kind::FORALL, bvl, body2);
+  Node umergeq = nm->mkNode(Kind::FORALL, eq[0][0], body2);
+  Node beq = body1.eqNode(body2);
+  // We set up the elaboration as follows:
+  //
+  // F = forall Y. G
+  // ------------------------------- CONG ------------------------ MERGE_PRENEX
+  // forall X. F = forall X. forall Y. G   forall X. forall Y. G = forall XY. G
+  // --------------------------------------------------------------- TRANS
+  // forall X. F = forall XY. G
+  //
+  // where the free assumption can be proven by miniscoping.
+  std::vector<Node> cargs;
+  ProofRule cr = expr::getCongRule(eq[0], cargs);
+  Node eqq = eq[0].eqNode(umergeq);
+  cdp->addStep(eqq, cr, {beq}, cargs);
+  theory::Rewriter* rr = d_env.getRewriter();
+  Node mergeq = rr->rewriteViaRule(ProofRewriteRule::QUANT_MERGE_PRENEX, umergeq);
+  if (mergeq!=eq[1])
+  {
+    Assert(false) << "Failed merge step";
+    return false;
+  }
+  Node eqq2 = umergeq.eqNode(mergeq);
+  cdp->addTheoryRewriteStep(eqq2, ProofRewriteRule::QUANT_MERGE_PRENEX);
+  cdp->addStep(eq, ProofRule::TRANS, {eqq, eqq2}, {});
+  Trace("brc-macro") << "Remains to prove: " << body1 << " == " << body2
+                     << std::endl;
+  Node body2ms = rr->rewriteViaRule(ProofRewriteRule::MACRO_QUANT_PARTITION_CONNECTED_FV, body2);
+  if (body2ms.isNull())
+  {
+    Assert(false) << "Failed miniscope";
+    return false;
+  }
+  Node eqqm = body2.eqNode(body2ms);
+  // Note that we have shown eqqm is provable by a theory rewrite
+  // MACRO_QUANT_PARTITION_CONNECTED_FV, but we don't introduce it here,
+  // since then it would end up in the final proof. Instead we introduce a
+  // trust step which will be filled based on the macro rule and elaborated.
+  cdp->addTrustedStep(
+        eqqm, TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE, {}, {});
+  Node eqqrs = body2.eqNode(body1);
+  if (body2ms!=body1)
+  {
+    if (body2ms.getKind()!=body1.getKind() || body2ms.getNumChildren()!=body1.getNumChildren())
+    {
+      Assert(false) << "Failed after miniscope";
+      return false;
+    }
+    // We may have used alpha equivalence to rename variables, thus we 
+    // introduce a CONG step where children that are disequal are given as
+    // subgoals.
+    std::vector<Node> cpremises;
+    for (size_t i=0, nchildren=body2ms.getNumChildren(); i<nchildren; i++)
+    {
+      Node eqc = body2ms[i].eqNode(body1[i]);
+      if (body2ms[i]==body1[i])
+      {
+        cdp->addStep(eqc, ProofRule::REFL, {}, {body2ms[i]});
+      }
+      else
+      {
+        // otherwise just add subgoal, likely alpha equivalence
+        cdp->addTrustedStep(
+          eqc, TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE, {}, {});
+      }
+      cpremises.push_back(eqc);
+    }
+    cargs.clear();
+    cr = expr::getCongRule(body2ms, cargs);
+    Node eqqb = body2ms.eqNode(body1);
+    cdp->addStep(eqqb, cr, cpremises, cargs);
+    cdp->addStep(eqqrs, ProofRule::TRANS, {eqqm, eqqb}, {});
+  }
+  Node eqqr = body1.eqNode(body2);
+  cdp->addStep(eqqr, ProofRule::SYMM, {eqqrs}, {});
   return true;
 }
 

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -694,6 +694,9 @@ bool BasicRewriteRCons::ensureProofMacroQuantPrenex(CDProof* cdp,
       {
         Trace("brc-macro") << "...subgoal " << eqc << std::endl;
         // otherwise just add subgoal, likely alpha equivalence
+        // Some of these goals cannot be currently proven since they involve
+        // multiple nested steps of miniscoping, combined with alpha
+        // equivalence.
         cdp->addTrustedStep(
             eqc, TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE, {}, {});
       }

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -661,6 +661,10 @@ bool BasicRewriteRCons::ensureProofMacroQuantPrenex(CDProof* cdp,
       rr->rewriteViaRule(ProofRewriteRule::QUANT_MINISCOPE_FV, body2);
   if (body2ms.isNull())
   {
+    // currently fails if we are doing
+    //   forall x. ite(C, forall Y. t, s) =
+    //   forall xy. ite(C, t, s)
+    // since we don't miniscope over ITE.
     Trace("brc-macro") << "Failed miniscope";
     return false;
   }

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -657,8 +657,8 @@ bool BasicRewriteRCons::ensureProofMacroQuantPrenex(CDProof* cdp,
   cdp->addStep(eq, ProofRule::TRANS, {eqq, eqq2}, {});
   Trace("brc-macro") << "Remains to prove: " << body1 << " == " << body2
                      << std::endl;
-  Node body2ms = rr->rewriteViaRule(
-      ProofRewriteRule::QUANT_MINISCOPE_FV, body2);
+  Node body2ms =
+      rr->rewriteViaRule(ProofRewriteRule::QUANT_MINISCOPE_FV, body2);
   if (body2ms.isNull())
   {
     Assert(false) << "Failed miniscope";

--- a/src/rewriter/basic_rewrite_rcons.h
+++ b/src/rewriter/basic_rewrite_rcons.h
@@ -182,6 +182,16 @@ class BasicRewriteRCons : protected EnvObj
   bool ensureProofMacroQuantMergePrenex(CDProof* cdp, const Node& eq);
   /**
    * Elaborate a rewrite eq that was proven by
+   * ProofRewriteRule::MACRO_QUANT_PRENEX.
+   *
+   * @param cdp The proof to add to.
+   * @param eq The rewrite proven by
+   * ProofRewriteRule::MACRO_QUANT_PRENEX.
+   * @return true if added a closed proof of eq to cdp.
+   */
+  bool ensureProofMacroQuantPrenex(CDProof* cdp, const Node& eq);
+  /**
+   * Elaborate a rewrite eq that was proven by
    * ProofRewriteRule::MACRO_QUANT_PARTITION_CONNECTED_FV.
    *
    * @param cdp The proof to add to.

--- a/src/theory/quantifiers/quantifiers_preprocess.cpp
+++ b/src/theory/quantifiers/quantifiers_preprocess.cpp
@@ -80,10 +80,11 @@ Node QuantifiersPreprocess::computePrenexAgg(
   }
   else
   {
-    std::unordered_set<Node> argsSet;
-    std::unordered_set<Node> nargsSet;
     Node q;
-    Node nn = d_qrew.computePrenex(q, n, argsSet, nargsSet, true, true);
+    std::vector<Node> args, nargs;
+    Node nn = d_qrew.computePrenex(q, n, args, nargs, true, true);
+    std::unordered_set<Node> argsSet(args.begin(), args.end());
+    std::unordered_set<Node> nargsSet(args.begin(), args.end());
     Assert(n != nn || argsSet.empty());
     Assert(n != nn || nargsSet.empty());
     if (n != nn)

--- a/src/theory/quantifiers/quantifiers_rewriter.cpp
+++ b/src/theory/quantifiers/quantifiers_rewriter.cpp
@@ -1060,18 +1060,18 @@ Node QuantifiersRewriter::computeCondSplit(Node body,
       // For the sake of proofs, if we are not splitting the first child,
       // we first rearrange so that it is first, which can be proven by
       // ACI_NORM.
-      std::vector<Node> split_children;
+      std::vector<Node> splitChildren;
       if (split_index != 0)
       {
-        split_children.push_back(body[split_index]);
+        splitChildren.push_back(body[split_index]);
         for (size_t i = 0; i < size; i++)
         {
           if (i != split_index)
           {
-            split_children.push_back(body[i]);
+            splitChildren.push_back(body[i]);
           }
         }
-        return nm->mkNode(Kind::OR, split_children);
+        return nm->mkNode(Kind::OR, splitChildren);
       }
       // This is expected to be proven by the RARE rule bool-or-and-distrib.
       std::vector<Node> children;
@@ -1082,11 +1082,11 @@ Node QuantifiersRewriter::computeCondSplit(Node body,
       for (TNode bci : body[split_index])
       {
         children[split_index] = bci;
-        split_children.push_back(nm->mkNode(Kind::OR, children));
+        splitChildren.push_back(nm->mkNode(Kind::OR, children));
       }
       // split the AND child, for example:
       //  ( x!=a ^ P(x) ) V Q(x) ---> ( x!=a V Q(x) ) ^ ( P(x) V Q(x) )
-      return nm->mkNode(Kind::AND, split_children);
+      return nm->mkNode(Kind::AND, splitChildren);
     }
   }
 

--- a/src/theory/quantifiers/quantifiers_rewriter.cpp
+++ b/src/theory/quantifiers/quantifiers_rewriter.cpp
@@ -108,6 +108,8 @@ QuantifiersRewriter::QuantifiersRewriter(NodeManager* nm,
   // MACRO_QUANT_MERGE_PRENEX
   registerProofRewriteRule(ProofRewriteRule::MACRO_QUANT_MERGE_PRENEX,
                            TheoryRewriteCtx::PRE_DSL);
+  registerProofRewriteRule(ProofRewriteRule::MACRO_QUANT_PRENEX,
+                           TheoryRewriteCtx::PRE_DSL);
   registerProofRewriteRule(ProofRewriteRule::MACRO_QUANT_MINISCOPE,
                            TheoryRewriteCtx::PRE_DSL);
   // QUANT_MINISCOPE is part of the reconstruction for MACRO_QUANT_MINISCOPE
@@ -177,6 +179,23 @@ Node QuantifiersRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
       if (q != n)
       {
         return q;
+      }
+    }
+    break;
+    case ProofRewriteRule::MACRO_QUANT_PRENEX:
+    {
+      if (n.getKind() == Kind::FORALL)
+      {
+        std::vector<Node> args, nargs;
+        Node nn = computePrenex(n, n[1], args, nargs, true, false);
+        Assert(nargs.empty());
+        if (!args.empty())
+        {
+          std::vector<Node> qargs(n[0].begin(), n[0].end());
+          qargs.insert(qargs.end(), args.begin(), args.end());
+          Node bvl = d_nm->mkNode(Kind::BOUND_VAR_LIST, qargs);
+          return d_nm->mkNode(Kind::FORALL, bvl, nn);
+        }
       }
     }
     break;
@@ -1038,12 +1057,28 @@ Node QuantifiersRewriter::computeCondSplit(Node body,
     }
     if (do_split)
     {
+      // For the sake of proofs, if we are not splitting the first child,
+      // we first rearrange so that it is first, which can be proven by
+      // ACI_NORM.
+      std::vector<Node> split_children;
+      if (split_index != 0)
+      {
+        split_children.push_back(body[split_index]);
+        for (size_t i = 0; i < size; i++)
+        {
+          if (i != split_index)
+          {
+            split_children.push_back(body[i]);
+          }
+        }
+        return nm->mkNode(Kind::OR, split_children);
+      }
+      // This is expected to be proven by the RARE rule bool-or-and-distrib.
       std::vector<Node> children;
       for (TNode bc : body)
       {
         children.push_back(bc);
       }
-      std::vector<Node> split_children;
       for (TNode bci : body[split_index])
       {
         children[split_index] = bci;
@@ -1690,8 +1725,8 @@ Node QuantifiersRewriter::computeVarElimination(Node body,
 
 Node QuantifiersRewriter::computePrenex(Node q,
                                         Node body,
-                                        std::unordered_set<Node>& args,
-                                        std::unordered_set<Node>& nargs,
+                                        std::vector<Node>& args,
+                                        std::vector<Node>& nargs,
                                         bool pol,
                                         bool prenexAgg) const
 {
@@ -1732,11 +1767,11 @@ Node QuantifiersRewriter::computePrenex(Node q,
       }
       if (pol)
       {
-        args.insert(subs.begin(), subs.end());
+        args.insert(args.end(), subs.begin(), subs.end());
       }
       else
       {
-        nargs.insert(subs.begin(), subs.end());
+        nargs.insert(nargs.end(), subs.begin(), subs.end());
       }
       Node newBody = body[1];
       newBody = newBody.substitute( terms.begin(), terms.end(), subs.begin(), subs.end() );
@@ -2332,7 +2367,7 @@ Node QuantifiersRewriter::computeOperation(Node f,
     }
     else
     {
-      std::unordered_set<Node> argsSet, nargsSet;
+      std::vector<Node> argsSet, nargsSet;
       n = computePrenex(f, n, argsSet, nargsSet, true, false);
       Assert(nargsSet.empty());
       args.insert(args.end(), argsSet.begin(), argsSet.end());

--- a/src/theory/quantifiers/quantifiers_rewriter.h
+++ b/src/theory/quantifiers/quantifiers_rewriter.h
@@ -203,8 +203,8 @@ class QuantifiersRewriter : public TheoryRewriter
    */
   Node computePrenex(Node q,
                      Node body,
-                     std::unordered_set<Node>& args,
-                     std::unordered_set<Node>& nargs,
+                     std::vector<Node>& args,
+                     std::vector<Node>& nargs,
                      bool pol,
                      bool prenexAgg) const;
   Node computeSplit(std::vector<Node>& args, Node body, QAttributes& qa) const;

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1346,6 +1346,7 @@ set(regress_0_tests
   regress0/proofs/issue9770-open-sat-proof.smt2
   regress0/proofs/issue9927.smt2
   regress0/proofs/lfsc-test-1.smt2
+  regress0/proofs/macro-quant-prenex-simple.smt2
   regress0/proofs/nomerge-alethe-pf.smt2
   regress0/proofs/no-proof-uc.smt2
   regress0/proofs/pp-only-proof.smt2

--- a/test/regress/cli/regress0/proofs/macro-quant-prenex-simple.smt2
+++ b/test/regress/cli/regress0/proofs/macro-quant-prenex-simple.smt2
@@ -1,0 +1,9 @@
+; EXPECT: unsat
+(set-logic UF)
+(declare-sort U 0)
+(declare-const u U)
+(declare-fun p (U U) Bool)
+(assert (distinct
+  (forall ((x U)) (or (p u x) (forall ((y U)) (p y x))))
+  (forall ((x U) (y U)) (or (p u x) (p y x)))))
+(check-sat)


### PR DESCRIPTION
This adds support for reconstruction of proofs of prenexing. This relies on miniscoping (in reverse), thus no new proof rule is necessary.

The reconstruction does not always work, which may lead to further proof holes, which will be addressed in future PRs.

A simple example is added which now has a complete proof.