### PR TITLE
Refactor proof post processor DSL to avoid subgoal tracking

### DIFF
--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -112,8 +112,7 @@ bool BasicRewriteRCons::postProve(
     }
   }
   if (!success && tmode != TheoryRewriteMode::NEVER
-      && tryTheoryRewrite(
-          cdp, eq, theory::TheoryRewriteCtx::POST_DSL))
+      && tryTheoryRewrite(cdp, eq, theory::TheoryRewriteCtx::POST_DSL))
   {
     success = true;
   }
@@ -165,10 +164,9 @@ void BasicRewriteRCons::ensureProofForEncodeTransform(CDProof* cdp,
   cdp->addStep(eq, ProofRule::EQ_RESOLVE, {eqi, equivs}, {});
 }
 
-void BasicRewriteRCons::ensureProofForTheoryRewrite(
-    CDProof* cdp,
-    ProofRewriteRule id,
-    const Node& eq)
+void BasicRewriteRCons::ensureProofForTheoryRewrite(CDProof* cdp,
+                                                    ProofRewriteRule id,
+                                                    const Node& eq)
 {
   bool handledMacro = false;
   switch (id)
@@ -1086,10 +1084,9 @@ bool BasicRewriteRCons::ensureProofArithPolyNormRel(CDProof* cdp,
   return true;
 }
 
-bool BasicRewriteRCons::tryTheoryRewrite(
-    CDProof* cdp,
-    const Node& eq,
-    theory::TheoryRewriteCtx ctx)
+bool BasicRewriteRCons::tryTheoryRewrite(CDProof* cdp,
+                                         const Node& eq,
+                                         theory::TheoryRewriteCtx ctx)
 {
   Assert(eq.getKind() == Kind::EQUAL);
   ProofRewriteRule prid = d_env.getRewriter()->findRule(eq[0], eq[1], ctx);

--- a/src/rewriter/basic_rewrite_rcons.h
+++ b/src/rewriter/basic_rewrite_rcons.h
@@ -64,15 +64,12 @@ class BasicRewriteRCons : protected EnvObj
    * @param cdp The proof to add to.
    * @param a The left hand side of the equality.
    * @param b The left hand side of the equality.
-   * @param subgoals The list of proofs introduced when proving eq that
-   * are trusted steps.
    * @param tmode Determines if/when to try THEORY_REWRITE.
    * @return true if we successfully added a proof of (= a b) to cdp.
    */
   bool prove(CDProof* cdp,
              Node a,
              Node b,
-             std::vector<std::shared_ptr<ProofNode>>& subgoals,
              TheoryRewriteMode tmode);
   /**
    * There are theory rewrites which cannot be expressed in RARE rules. In this
@@ -90,7 +87,6 @@ class BasicRewriteRCons : protected EnvObj
   bool postProve(CDProof* cdp,
                  Node a,
                  Node b,
-                 std::vector<std::shared_ptr<ProofNode>>& subgoals,
                  TheoryRewriteMode tmode);
   /**
    * Add to cdp a proof of eq from free asumption eqi, where eqi is the result
@@ -241,8 +237,7 @@ class BasicRewriteRCons : protected EnvObj
    */
   bool tryTheoryRewrite(CDProof* cdp,
                         const Node& eq,
-                        theory::TheoryRewriteCtx ctx,
-                        std::vector<std::shared_ptr<ProofNode>>& subgoals);
+                        theory::TheoryRewriteCtx ctx);
 };
 
 }  // namespace rewriter

--- a/src/rewriter/basic_rewrite_rcons.h
+++ b/src/rewriter/basic_rewrite_rcons.h
@@ -105,10 +105,9 @@ class BasicRewriteRCons : protected EnvObj
    * @param id The theory rewrite that proves eq.
    * @param eq The conclusion of the theory rewrite.
    */
-  void ensureProofForTheoryRewrite(
-      CDProof* cdp,
-      ProofRewriteRule id,
-      const Node& eq);
+  void ensureProofForTheoryRewrite(CDProof* cdp,
+                                   ProofRewriteRule id,
+                                   const Node& eq);
 
  private:
   /**

--- a/src/rewriter/basic_rewrite_rcons.h
+++ b/src/rewriter/basic_rewrite_rcons.h
@@ -79,8 +79,6 @@ class BasicRewriteRCons : protected EnvObj
    * @param cdp The proof to add to.
    * @param a The left hand side of the equality.
    * @param b The left hand side of the equality.
-   * @param subgoals The list of proofs introduced when proving eq that
-   * are trusted steps.
    * @param tmode Determines if/when to try THEORY_REWRITE.
    * @return true if we successfully added a proof of (= a b) to cdp.
    */
@@ -106,14 +104,11 @@ class BasicRewriteRCons : protected EnvObj
    * @param cdp The proof to add to.
    * @param id The theory rewrite that proves eq.
    * @param eq The conclusion of the theory rewrite.
-   * @param subgoals The list of proofs introduced when proving eq that
-   * are trusted steps.
    */
   void ensureProofForTheoryRewrite(
       CDProof* cdp,
       ProofRewriteRule id,
-      const Node& eq,
-      std::vector<std::shared_ptr<ProofNode>>& subgoals);
+      const Node& eq);
 
  private:
   /**

--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -130,8 +130,7 @@ bool RewriteDbProofCons::prove(
       Trace("rpc") << "...success (post-prove basic)" << std::endl;
       success = true;
     }
-    else if (eqi != eq
-             && d_trrc.postProve(cdp, eqi[0], eqi[1], tmode))
+    else if (eqi != eq && d_trrc.postProve(cdp, eqi[0], eqi[1], tmode))
     {
       Trace("rpc") << "...success (post-prove basic)" << std::endl;
       d_trrc.ensureProofForEncodeTransform(cdp, eq, eqi);
@@ -309,11 +308,10 @@ Node RewriteDbProofCons::preprocessClosureEq(CDProof* cdp,
   return eq;
 }
 
-bool RewriteDbProofCons::proveEq(
-    CDProof* cdp,
-    const Node& eqi,
-    int64_t recLimit,
-    int64_t stepLimit)
+bool RewriteDbProofCons::proveEq(CDProof* cdp,
+                                 const Node& eqi,
+                                 int64_t recLimit,
+                                 int64_t stepLimit)
 {
   // add one to recursion limit, since it is decremented whenever we
   // initiate the getMatches routine.
@@ -1005,9 +1003,7 @@ bool RewriteDbProofCons::proveInternalBase(const Node& eqi,
   return false;
 }
 
-bool RewriteDbProofCons::ensureProofInternal(
-    CDProof* cdp,
-    const Node& eqi)
+bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
 {
   // note we could use single internal cdp to improve subproof sharing
   NodeManager* nm = nodeManager();

--- a/src/rewriter/rewrite_db_proof_cons.h
+++ b/src/rewriter/rewrite_db_proof_cons.h
@@ -66,9 +66,6 @@ class RewriteDbProofCons : protected EnvObj
    * @param b The right hand side of the equality.
    * @param recLimit The recursion limit for this call.
    * @param stepLimit The step limit for this call.
-   * @param subgoals The list of proofs introduced when proving (= a b) that
-   * are trusted steps, and thus would require further elaboration from the
-   * caller of this method.
    * @param tmode Determines if/when to try THEORY_REWRITE.
    * @return true if we successfully added a proof of (= a b) to cdp
    */
@@ -77,7 +74,6 @@ class RewriteDbProofCons : protected EnvObj
              const Node& b,
              int64_t recLimit,
              int64_t stepLimit,
-             std::vector<std::shared_ptr<ProofNode>>& subgoals,
              TheoryRewriteMode tmode);
 
  private:
@@ -182,8 +178,6 @@ class RewriteDbProofCons : protected EnvObj
    * converted from eq using d_rdnc.
    * @param recLimit The recursion limit for this call.
    * @param stepLimit The step limit for this call.
-   * @param subgoals The list of proofs introduced when proving eq that
-   * are trusted steps.
    * @param tmode Determines if/when to try THEORY_REWRITE.
    * @return true if we successfully added a proof of (= a b) to cdp
    */
@@ -192,7 +186,6 @@ class RewriteDbProofCons : protected EnvObj
                          const Node& eqi,
                          int64_t recLimit,
                          int64_t stepLimit,
-                         std::vector<std::shared_ptr<ProofNode>>& subgoals,
                          TheoryRewriteMode tmode);
   /**
    * Prove and store the proof of eq with internal form eqi in cdp if possible,
@@ -202,15 +195,12 @@ class RewriteDbProofCons : protected EnvObj
    * @param eqi The equality we are trying to prove.
    * @param recLimit The recursion limit for this call.
    * @param stepLimit The step limit for this call.
-   * @param subgoals The list of proofs introduced when proving eq that
-   * are trusted steps.
    * @return true if we successfully added a proof of (= a b) to cdp
    */
   bool proveEq(CDProof* cdp,
                const Node& eqi,
                int64_t recLimit,
-               int64_t stepLimit,
-               std::vector<std::shared_ptr<ProofNode>>& subgoals);
+               int64_t stepLimit);
   /**
    * Prove internal, which is the main entry point for proven an equality eqi.
    * Returns the proof rule that was used to prove eqi, or
@@ -249,12 +239,9 @@ class RewriteDbProofCons : protected EnvObj
    *
    * @param cdp The proof to add the proof of eqi to
    * @param eqi The proven equality
-   * @param subgoals The list of proofs introduced when proving eq that
-   * are trusted steps.
    */
   bool ensureProofInternal(CDProof* cdp,
-                           const Node& eqi,
-                           std::vector<std::shared_ptr<ProofNode>>& subgoals);
+                           const Node& eqi);
   /** Return the evaluation of n, which uses local caching. */
   Node doEvaluate(const Node& n);
   /**

--- a/src/rewriter/rewrite_db_proof_cons.h
+++ b/src/rewriter/rewrite_db_proof_cons.h
@@ -240,8 +240,7 @@ class RewriteDbProofCons : protected EnvObj
    * @param cdp The proof to add the proof of eqi to
    * @param eqi The proven equality
    */
-  bool ensureProofInternal(CDProof* cdp,
-                           const Node& eqi);
+  bool ensureProofInternal(CDProof* cdp, const Node& eqi);
   /** Return the evaluation of n, which uses local caching. */
   Node doEvaluate(const Node& n);
   /**

--- a/src/smt/proof_post_processor_dsl.cpp
+++ b/src/smt/proof_post_processor_dsl.cpp
@@ -47,6 +47,7 @@ void ProofPostprocessDsl::reconstruct(
   ProofNodeUpdater pnu(d_env, *this, false);
   for (std::shared_ptr<ProofNode> p : pfs)
   {
+    d_traversing.clear();
     Trace("pp-dsl-process") << "BEGIN update" << std::endl;
     pnu.process(p);
     Trace("pp-dsl-process") << "END update" << std::endl;

--- a/src/smt/proof_post_processor_dsl.cpp
+++ b/src/smt/proof_post_processor_dsl.cpp
@@ -145,6 +145,9 @@ bool ProofPostprocessDsl::update(Node res,
     // if successful, we update the proof
     return true;
   }
+  // clean up traversing, since we are setting continueUpdate to false
+  Assert (!d_traversing.empty());
+  d_traversing.pop_back();
   // otherwise no update
   return false;
 }

--- a/src/smt/proof_post_processor_dsl.cpp
+++ b/src/smt/proof_post_processor_dsl.cpp
@@ -48,59 +48,7 @@ void ProofPostprocessDsl::reconstruct(
   for (std::shared_ptr<ProofNode> p : pfs)
   {
     pnu.process(p);
-  }
-  // We run until subgoals are empty. Note that this loop is only expected
-  // to run once, and moreover is guaranteed to run only once if the only
-  // trusted steps added have id MACRO_THEORY_REWRITE_RCONS_SIMPLE. However,
-  // in rare cases, an elaboration may require adding a trust step that itself
-  // expects to require theory rewrites to prove (MACRO_THEORY_REWRITE_RCONS)
-  // in which case this loop may run twice. We manually limit this loop to
-  // run no more than 2 times.
-  size_t iter = 0;
-  while (!d_subgoals.empty())
-  {
-    iter++;
-    if (iter >= 3)
-    {
-      // prevent any accidental infinite loops
-      break;
-    }
-    std::vector<std::shared_ptr<ProofNode>> sgs = d_subgoals;
-    Trace("pp-dsl") << "Also reconstruct proofs for " << sgs.size()
-                    << " subgoals..." << std::endl;
-    d_subgoals.clear();
-    // Do not use theory rewrites to fill in remaining subgoals. This prevents
-    // generating subgoals in proofs of subgoals.
-    rewriter::TheoryRewriteMode mprev = d_tmode;
-    TrustId tid;
-    for (std::shared_ptr<ProofNode> p : sgs)
-    {
-      // determine if we should disable theory rewrites, this is the case if the
-      // trust id is MACRO_THEORY_REWRITE_RCONS_SIMPLE.
-      d_tmode = mprev;
-      if (p->getRule() == ProofRule::TRUST)
-      {
-        getTrustId(p->getArguments()[0], tid);
-        if (tid == TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE)
-        {
-          d_tmode = rewriter::TheoryRewriteMode::NEVER;
-        }
-      }
-      pnu.process(p);
-    }
-    d_tmode = mprev;
-  }
-  // should never construct a subgoal for a step from a subgoal
-  if (!d_subgoals.empty())
-  {
-    Trace("pp-dsl") << "REM SUBGOALS: " << std::endl;
-    for (std::shared_ptr<ProofNode> p : d_subgoals)
-    {
-      Trace("pp-dsl") << "  " << p->getResult() << std::endl;
-      Trace("pp-dsl-warn") << "WARNING: unproven subgoal " << p->getResult()
-                           << std::endl;
-    }
-    d_subgoals.clear();
+    Assert(d_traversing.empty());
   }
 }
 
@@ -109,9 +57,31 @@ bool ProofPostprocessDsl::shouldUpdate(std::shared_ptr<ProofNode> pn,
                                        bool& continueUpdate)
 {
   ProofRule id = pn->getRule();
-  return id == ProofRule::TRUST || id == ProofRule::TRUST_THEORY_REWRITE;
+  continueUpdate = true;
+  // we should update if we
+  // - Have rule TRUST or TRUST_THEORY_REWRITE,
+  // - We have no premises
+  // - We are not already recursively expanding >= 3 steps of the above form.
+  // We check for the third criteria by tracking a d_traversing vector.
+  if ((id == ProofRule::TRUST || id == ProofRule::TRUST_THEORY_REWRITE) && pn->getChildren().empty() && d_traversing.size()<3)
+  {
+    d_traversing.push_back(pn);
+    return true;
+  }
+  return false;
 }
 
+bool ProofPostprocessDsl::shouldUpdatePost(std::shared_ptr<ProofNode> pn,
+                                       const std::vector<Node>& fa)
+{
+  // clean up d_traversing at post-traversal
+  if (!d_traversing.empty() && d_traversing.back()==pn)
+  {
+    d_traversing.pop_back();
+  }
+  return false;
+}
+  
 bool ProofPostprocessDsl::update(Node res,
                                  ProofRule id,
                                  const std::vector<Node>& children,
@@ -121,11 +91,7 @@ bool ProofPostprocessDsl::update(Node res,
 {
   continueUpdate = false;
   Assert(id == ProofRule::TRUST || id == ProofRule::TRUST_THEORY_REWRITE);
-  // don't try if children are non-empty
-  if (!children.empty())
-  {
-    return false;
-  }
+  Assert (children.empty());
   Assert(!res.isNull());
   bool reqTrueElim = false;
   // if not an equality, make (= res true).
@@ -136,22 +102,38 @@ bool ProofPostprocessDsl::update(Node res,
   }
   TheoryId tid = THEORY_LAST;
   MethodId mid = MethodId::RW_REWRITE;
+  rewriter::TheoryRewriteMode tm = d_tmode;
   // if theory rewrite, get diagnostic information
   if (id == ProofRule::TRUST_THEORY_REWRITE)
   {
     builtin::BuiltinProofRuleChecker::getTheoryId(args[1], tid);
     getMethodId(args[2], mid);
   }
+  else if (id==ProofRule::TRUST)
+  {
+    TrustId trid;
+    getTrustId(args[0], trid);
+    if (trid == TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE)
+    {
+      // If we are MACRO_THEORY_REWRITE_RCONS_SIMPLE, we do not use
+      // theory rewrites. This policy ensures that macro theory rewrites are
+      // disabled on rewrites which we use for their own reconstruction.
+      tm = rewriter::TheoryRewriteMode::NEVER;
+    }
+  }
   Trace("pp-dsl") << "Prove " << res << " from " << tid << " / " << mid
-                  << ", in mode " << d_tmode << std::endl;
+                  << ", in mode " << tm << std::endl;
   int64_t recLimit = options().proof.proofRewriteRconsRecLimit;
   int64_t stepLimit = options().proof.proofRewriteRconsStepLimit;
   // Attempt to reconstruct the proof of the equality into cdp using the
   // rewrite database proof reconstructor.
   // We record the subgoals in d_subgoals.
   if (d_rdbPc.prove(
-          cdp, res[0], res[1], recLimit, stepLimit, d_subgoals, d_tmode))
+          cdp, res[0], res[1], recLimit, stepLimit, tm))
   {
+    // we will update this again, in case the elaboration introduced
+    // new trust steps
+    continueUpdate = true;
     // If we made (= res true) above, conclude the original res.
     if (reqTrueElim)
     {

--- a/src/smt/proof_post_processor_dsl.cpp
+++ b/src/smt/proof_post_processor_dsl.cpp
@@ -63,7 +63,8 @@ bool ProofPostprocessDsl::shouldUpdate(std::shared_ptr<ProofNode> pn,
   // - We have no premises
   // - We are not already recursively expanding >= 3 steps of the above form.
   // We check for the third criteria by tracking a d_traversing vector.
-  if ((id == ProofRule::TRUST || id == ProofRule::TRUST_THEORY_REWRITE) && pn->getChildren().empty() && d_traversing.size()<3)
+  if ((id == ProofRule::TRUST || id == ProofRule::TRUST_THEORY_REWRITE)
+      && pn->getChildren().empty() && d_traversing.size() < 3)
   {
     d_traversing.push_back(pn);
     return true;
@@ -72,16 +73,16 @@ bool ProofPostprocessDsl::shouldUpdate(std::shared_ptr<ProofNode> pn,
 }
 
 bool ProofPostprocessDsl::shouldUpdatePost(std::shared_ptr<ProofNode> pn,
-                                       const std::vector<Node>& fa)
+                                           const std::vector<Node>& fa)
 {
   // clean up d_traversing at post-traversal
-  if (!d_traversing.empty() && d_traversing.back()==pn)
+  if (!d_traversing.empty() && d_traversing.back() == pn)
   {
     d_traversing.pop_back();
   }
   return false;
 }
-  
+
 bool ProofPostprocessDsl::update(Node res,
                                  ProofRule id,
                                  const std::vector<Node>& children,
@@ -91,7 +92,7 @@ bool ProofPostprocessDsl::update(Node res,
 {
   continueUpdate = false;
   Assert(id == ProofRule::TRUST || id == ProofRule::TRUST_THEORY_REWRITE);
-  Assert (children.empty());
+  Assert(children.empty());
   Assert(!res.isNull());
   bool reqTrueElim = false;
   // if not an equality, make (= res true).
@@ -109,7 +110,7 @@ bool ProofPostprocessDsl::update(Node res,
     builtin::BuiltinProofRuleChecker::getTheoryId(args[1], tid);
     getMethodId(args[2], mid);
   }
-  else if (id==ProofRule::TRUST)
+  else if (id == ProofRule::TRUST)
   {
     TrustId trid;
     getTrustId(args[0], trid);
@@ -128,8 +129,7 @@ bool ProofPostprocessDsl::update(Node res,
   // Attempt to reconstruct the proof of the equality into cdp using the
   // rewrite database proof reconstructor.
   // We record the subgoals in d_subgoals.
-  if (d_rdbPc.prove(
-          cdp, res[0], res[1], recLimit, stepLimit, tm))
+  if (d_rdbPc.prove(cdp, res[0], res[1], recLimit, stepLimit, tm))
   {
     // we will update this again, in case the elaboration introduced
     // new trust steps

--- a/src/smt/proof_post_processor_dsl.h
+++ b/src/smt/proof_post_processor_dsl.h
@@ -52,7 +52,7 @@ class ProofPostprocessDsl : protected EnvObj, public ProofNodeUpdaterCallback
                     bool& continueUpdate) override;
   /** Should proof pn be updated (post-traversal)? */
   bool shouldUpdatePost(std::shared_ptr<ProofNode> pn,
-                    const std::vector<Node>& fa) override;
+                        const std::vector<Node>& fa) override;
   /** Update the proof rule application. */
   bool update(Node res,
               ProofRule id,

--- a/src/smt/proof_post_processor_dsl.h
+++ b/src/smt/proof_post_processor_dsl.h
@@ -50,6 +50,9 @@ class ProofPostprocessDsl : protected EnvObj, public ProofNodeUpdaterCallback
   bool shouldUpdate(std::shared_ptr<ProofNode> pn,
                     const std::vector<Node>& fa,
                     bool& continueUpdate) override;
+  /** Should proof pn be updated (post-traversal)? */
+  bool shouldUpdatePost(std::shared_ptr<ProofNode> pn,
+                    const std::vector<Node>& fa) override;
   /** Update the proof rule application. */
   bool update(Node res,
               ProofRule id,
@@ -59,13 +62,14 @@ class ProofPostprocessDsl : protected EnvObj, public ProofNodeUpdaterCallback
               bool& continueUpdate) override;
 
  private:
+  /** Common constants */
   Node d_true;
   /** The rewrite database proof generator */
   rewriter::RewriteDbProofCons d_rdbPc;
   /** The default mode for if/when to try theory rewrites */
   rewriter::TheoryRewriteMode d_tmode;
-  /** The accumulated subgoals from calls to d_rdbPc */
-  std::vector<std::shared_ptr<ProofNode>> d_subgoals;
+  /** The current proofs we are traversing */
+  std::vector<std::shared_ptr<ProofNode>> d_traversing;
 };
 
 }  // namespace smt


### PR DESCRIPTION
This fixes a bug in how RARE proof reconstruction works for macro elaboration.

In particular, our subgoal tracking was incorrect if a macro was elaboarted to a single TRUST step as a subgoal, since the updater updates the current proof node in-place.  The PR https://github.com/cvc5/cvc5/pull/11441 introduces a case in our regressions for this.

To fix this, I've refactored the post-processor to a more elegant version which runs the proof node updater recursively. It tracks the depth of how many trust steps we've expanded in the current context using a `d_traversing` vector.

This makes explicit tracking of subgoals unecessary, the RARE proof reconstruction method is cleaned up as a result.