### PR TITLE
Add proof support for quantifiers term indexing conflicts

### DIFF
--- a/src/theory/quantifiers/ho_term_database.cpp
+++ b/src/theory/quantifiers/ho_term_database.cpp
@@ -156,7 +156,6 @@ bool HoTermDb::checkCongruentDisequal(TNode a, TNode b, std::vector<Node>& exp)
   {
     return false;
   }
-  exp.push_back(a.eqNode(b));
   // operators might be disequal
   Node af = getMatchOperator(a);
   Node bf = getMatchOperator(b);
@@ -164,7 +163,7 @@ bool HoTermDb::checkCongruentDisequal(TNode a, TNode b, std::vector<Node>& exp)
   {
     if (a.getKind() == Kind::APPLY_UF && b.getKind() == Kind::APPLY_UF)
     {
-      exp.push_back(af.eqNode(bf).negate());
+      exp.push_back(af.eqNode(bf));
       Assert(d_qstate.areEqual(af, bf))
           << af << " and " << bf << " are not equal";
     }

--- a/src/theory/quantifiers/term_database.cpp
+++ b/src/theory/quantifiers/term_database.cpp
@@ -52,6 +52,9 @@ class DeqCongProofGenerator : protected EnvObj, public ProofGenerator
   DeqCongProofGenerator(Env& env) : EnvObj(env) {}
   virtual ~DeqCongProofGenerator() {}
   /**
+   * The lemma is of the form:
+   * (=> (and (= ti si) .. (= tj sj)) (= (f t1 ... tn) (f s1 ... sn)))
+   * which can be proven by a congruence step.
    */
   std::shared_ptr<ProofNode> getProofFor(Node fact) override
   {

--- a/src/theory/quantifiers/term_database.cpp
+++ b/src/theory/quantifiers/term_database.cpp
@@ -90,7 +90,10 @@ class DeqCongProofGenerator : protected EnvObj, public ProofGenerator
       {
         cdp.addStep(eq, ProofRule::REFL, {}, {a[i]});
       }
-      Assert(std::find(assumps.begin(), assumps.end(), eq) != assumps.end());
+      else
+      {
+        Assert(std::find(assumps.begin(), assumps.end(), eq) != assumps.end());
+      }
     }
     cdp.addStep(fact[1], cr, premises, cargs);
     std::shared_ptr<ProofNode> pfn = cdp.getProofFor(fact[1]);

--- a/src/theory/quantifiers/term_database.cpp
+++ b/src/theory/quantifiers/term_database.cpp
@@ -90,6 +90,7 @@ class DeqCongProofGenerator : protected EnvObj, public ProofGenerator
       {
         cdp.addStep(eq, ProofRule::REFL, {}, {a[i]});
       }
+      Assert (std::find(assumps.begin(), assumps.end(), eq)!=assumps.end());
     }
     cdp.addStep(fact[1], cr, premises, cargs);
     std::shared_ptr<ProofNode> pfn = cdp.getProofFor(fact[1]);

--- a/src/theory/quantifiers/term_database.cpp
+++ b/src/theory/quantifiers/term_database.cpp
@@ -74,6 +74,8 @@ class DeqCongProofGenerator : protected EnvObj, public ProofGenerator
     CDProof cdp(d_env);
     if (a.getOperator() != b.getOperator())
     {
+      // TODO: wishue #158, likely corresponds to a higher-order term
+      // indexing conflict.
       cdp.addTrustedStep(fact, TrustId::QUANTIFIERS_PREPROCESS, {}, {});
       return cdp.getProofFor(fact);
     }

--- a/src/theory/quantifiers/term_database.cpp
+++ b/src/theory/quantifiers/term_database.cpp
@@ -23,6 +23,10 @@
 #include "options/smt_options.h"
 #include "options/theory_options.h"
 #include "options/uf_options.h"
+#include "proof/proof.h"
+#include "proof/proof_generator.h"
+#include "proof/proof_node_algorithm.h"
+#include "proof/proof_node_manager.h"
 #include "theory/quantifiers/ematching/trigger_term_info.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
 #include "theory/quantifiers/quantifiers_inference_manager.h"
@@ -39,6 +43,60 @@ namespace cvc5::internal {
 namespace theory {
 namespace quantifiers {
 
+/**
+ * A proof generator for proving simple congruence lemmas discovered by TermDb.
+ */
+class DeqCongProofGenerator : protected EnvObj, public ProofGenerator
+{
+ public:
+  DeqCongProofGenerator(Env& env) : EnvObj(env) {}
+  virtual ~DeqCongProofGenerator() {}
+  /**
+   */
+  std::shared_ptr<ProofNode> getProofFor(Node fact) override
+  {
+    AlwaysAssert(false);
+    Assert(fact.getKind() == Kind::IMPLIES);
+    Assert(fact[1].getKind() == Kind::EQUAL);
+    Node a = fact[1][0];
+    Node b = fact[1][1];
+    std::vector<Node> assumps;
+    if (fact[0].getKind() == Kind::AND)
+    {
+      assumps.insert(assumps.end(), fact[0].begin(), fact[0].end());
+    }
+    else
+    {
+      assumps.push_back(fact[0]);
+    }
+    CDProof cdp(d_env);
+    if (a.getOperator() != b.getOperator())
+    {
+      cdp.addTrustedStep(fact, TrustId::QUANTIFIERS_PREPROCESS, {}, {});
+      return cdp.getProofFor(fact);
+    }
+    Assert(a.getNumChildren() == b.getNumChildren());
+    std::vector<Node> cargs;
+    ProofRule cr = expr::getCongRule(a, cargs);
+    size_t nchild = a.getNumChildren();
+    std::vector<Node> premises;
+    for (size_t i = 0; i < nchild; i++)
+    {
+      Node eq = a[i].eqNode(b[i]);
+      premises.push_back(eq);
+      if (a[i] == b[i])
+      {
+        cdp.addStep(eq, ProofRule::REFL, {}, {a[i]});
+      }
+    }
+    cdp.addStep(fact[1], cr, premises, cargs);
+    std::shared_ptr<ProofNode> pfn = cdp.getProofFor(fact[1]);
+    return d_env.getProofNodeManager()->mkScope(pfn, assumps);
+  }
+  /** identify */
+  std::string identify() const override { return "DeqCongProofGenerator"; }
+};
+
 TermDb::TermDb(Env& env, QuantifiersState& qs, QuantifiersRegistry& qr)
     : QuantifiersUtil(env),
       d_qstate(qs),
@@ -48,7 +106,9 @@ TermDb::TermDb(Env& env, QuantifiersState& qs, QuantifiersRegistry& qr)
       d_typeMap(context()),
       d_ops(context()),
       d_opMap(context()),
-      d_inactive_map(context())
+      d_inactive_map(context()),
+      d_dcproof(options().smt.produceProofs ? new DeqCongProofGenerator(d_env)
+                                            : nullptr)
 {
   d_true = nodeManager()->mkConst(true);
   d_false = nodeManager()->mkConst(false);
@@ -390,19 +450,19 @@ void TermDb::computeUfTerms( TNode f ) {
         congruentCount++;
         continue;
       }
-      std::vector<Node> lits;
-      if (checkCongruentDisequal(at, n, lits))
+      std::vector<Node> antec;
+      if (checkCongruentDisequal(at, n, antec))
       {
         Assert(at.getNumChildren() == n.getNumChildren());
         for (size_t k = 0, size = at.getNumChildren(); k < size; k++)
         {
           if (at[k] != n[k])
           {
-            lits.push_back(nm->mkNode(Kind::EQUAL, at[k], n[k]).negate());
+            antec.push_back(nm->mkNode(Kind::EQUAL, at[k], n[k]));
             Assert(d_qstate.areEqual(at[k], n[k]));
           }
         }
-        Node lem = nm->mkOr(lits);
+        Node lem = nm->mkNode(Kind::IMPLIES, nm->mkAnd(antec), at.eqNode(n));
         if (TraceIsOn("term-db-lemma"))
         {
           Trace("term-db-lemma") << "Disequal congruent terms : " << at << " "
@@ -415,7 +475,10 @@ void TermDb::computeUfTerms( TNode f ) {
           }
           Trace("term-db-lemma") << "  add lemma : " << lem << std::endl;
         }
-        d_qim->addPendingLemma(lem, InferenceId::QUANTIFIERS_TDB_DEQ_CONG);
+        d_qim->addPendingLemma(lem,
+                               InferenceId::QUANTIFIERS_TDB_DEQ_CONG,
+                               LemmaProperty::NONE,
+                               d_dcproof.get());
         d_qstate.notifyInConflict();
         return;
       }
@@ -442,7 +505,6 @@ bool TermDb::checkCongruentDisequal(TNode a, TNode b, std::vector<Node>& exp)
 {
   if (d_qstate.areDisequal(a, b))
   {
-    exp.push_back(a.eqNode(b));
     return true;
   }
   return false;

--- a/src/theory/quantifiers/term_database.cpp
+++ b/src/theory/quantifiers/term_database.cpp
@@ -58,7 +58,6 @@ class DeqCongProofGenerator : protected EnvObj, public ProofGenerator
    */
   std::shared_ptr<ProofNode> getProofFor(Node fact) override
   {
-    AlwaysAssert(false);
     Assert(fact.getKind() == Kind::IMPLIES);
     Assert(fact[1].getKind() == Kind::EQUAL);
     Node a = fact[1][0];

--- a/src/theory/quantifiers/term_database.cpp
+++ b/src/theory/quantifiers/term_database.cpp
@@ -90,7 +90,7 @@ class DeqCongProofGenerator : protected EnvObj, public ProofGenerator
       {
         cdp.addStep(eq, ProofRule::REFL, {}, {a[i]});
       }
-      Assert (std::find(assumps.begin(), assumps.end(), eq)!=assumps.end());
+      Assert(std::find(assumps.begin(), assumps.end(), eq) != assumps.end());
     }
     cdp.addStep(fact[1], cr, premises, cargs);
     std::shared_ptr<ProofNode> pfn = cdp.getProofFor(fact[1]);

--- a/src/theory/quantifiers/term_database.h
+++ b/src/theory/quantifiers/term_database.h
@@ -36,6 +36,7 @@ namespace quantifiers {
 class QuantifiersState;
 class QuantifiersInferenceManager;
 class QuantifiersRegistry;
+class DeqCongProofGenerator;
 
 /** Context-dependent list of nodes */
 class DbList
@@ -263,6 +264,8 @@ class TermDb : public QuantifiersUtil {
    * of equality engine (for higher-order).
    */
   std::map<TypeNode, Node> d_ho_type_match_pred;
+  /** A proof generator for disequal congruent terms */
+  std::shared_ptr<DeqCongProofGenerator> d_dcproof;
   //----------------------------- implementation-specific
   /**
    * Finish reset internal, called at the end of reset(e). Returning false will
@@ -279,8 +282,8 @@ class TermDb : public QuantifiersUtil {
    * This method is called when terms a and b are indexed by the same operator,
    * and have equivalent arguments. This method checks if we are in conflict,
    * which is the case if a and b are disequal in the equality engine.
-   * If so, it adds the set of literals that are implied but do not hold, e.g.
-   * the equality (= a b).
+   * If so, it adds any additional arguments that explain why a = b, e.g. the
+   * equivalence of their operators if their operators are different.
    */
   virtual bool checkCongruentDisequal(TNode a, TNode b, std::vector<Node>& exp);
   //----------------------------- end implementation-specific

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2874,6 +2874,7 @@ set(regress_1_tests
   regress1/quantifiers/nra-interleave-inst.smt2
   regress1/quantifiers/opisavailable-12.smt2
   regress1/quantifiers/parametric-lists.smt2
+  regress1/quantifiers/pivc-deq-cong.smt2
   regress1/quantifiers/pool-decidable-arrays-1.smt2
   regress1/quantifiers/pool-example.smt2
   regress1/quantifiers/pool-tuple.smt2

--- a/test/regress/cli/regress1/quantifiers/pivc-deq-cong.smt2
+++ b/test/regress/cli/regress1/quantifiers/pivc-deq-cong.smt2
@@ -6,5 +6,5 @@
 (declare-fun a2 () (Array Int Int))
 (declare-fun a () (Array Int Int))
 (declare-fun i () Int)
-(assert (and (< i V) (<= 0 i) (or (forall ((? Int)) (= 1 (select a2 i)))) (forall ((? Int)) (= (select a ?) (select a2 ?))) (forall ((? Int)) (or (forall ((? Int)) (= 1 (select a2 ?))))) (forall ((? Int)) (or (distinct e (select a ?)) (> ? (- i 1)))) (or (and (= 1 V) (exists ((? Int)) (> 1 (select a 0)))) (exists ((? Int)) (and (<= ? i) (= e (select a ?)))))))
+(assert (and (< i V) (<= 0 i) (forall ((? Int)) (= 1 (select a2 i))) (forall ((? Int)) (= (select a ?) (select a2 ?))) (forall ((? Int)) (forall ((? Int)) (= 1 (select a2 ?)))) (forall ((? Int)) (or (distinct e (select a ?)) (> ? (- i 1)))) (or (and (= 1 V) (exists ((? Int)) (> 1 (select a 0)))) (exists ((? Int)) (and (<= ? i) (= e (select a ?)))))))
 (check-sat)

--- a/test/regress/cli/regress1/quantifiers/pivc-deq-cong.smt2
+++ b/test/regress/cli/regress1/quantifiers/pivc-deq-cong.smt2
@@ -1,0 +1,10 @@
+; COMMAND-LINE: --enum-inst
+; EXPECT: unsat
+(set-logic ALL)
+(declare-fun V () Int)
+(declare-fun e () Int)
+(declare-fun a2 () (Array Int Int))
+(declare-fun a () (Array Int Int))
+(declare-fun i () Int)
+(assert (and (< i V) (<= 0 i) (or (forall ((? Int)) (= 1 (select a2 i)))) (forall ((? Int)) (= (select a ?) (select a2 ?))) (forall ((? Int)) (or (forall ((? Int)) (= 1 (select a2 ?))))) (forall ((? Int)) (or (distinct e (select a ?)) (> ? (- i 1)))) (or (and (= 1 V) (exists ((? Int)) (> 1 (select a 0)))) (exists ((? Int)) (and (<= ? i) (= e (select a ?)))))))
+(check-sat)


### PR DESCRIPTION
A term indexing conflict can be explained by congruence.

A simple regression is added.

This should cover all remaining theory lemmas from quantifiers when safe mode is enabled.