### PR TITLE
Disable lfsc tester on t3_rw903

### DIFF
--- a/test/regress/cli/regress0/proofs/t3_rw903.smt2
+++ b/test/regress/cli/regress0/proofs/t3_rw903.smt2
@@ -1,5 +1,6 @@
 ; EXPECT: unsat
 ; DISABLE-TESTER: unsat-core
+; DISABLE-TESTER: lfsc
 (set-logic UFNIA)
 (declare-fun pow2 (Int) Int)
 (declare-fun intor (Int Int Int) Int)


### PR DESCRIPTION
This fixes a timeout in the nightlies.