### PR TITLE
Disable timeout regression

### DIFF
--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1390,7 +1390,6 @@ set(regress_0_tests
   regress0/proofs/subtype-elim-rare-fail.smt2
   regress0/proofs/str-term-276-indexof-eval.smt2
   regress0/proofs/t1-difficulty-filter.smt2
-  regress0/proofs/t3_rw903.smt2
   regress0/proofs/tricky-sat-assumption-incremental-bookeeping.smt2
   regress0/proofs/trust-subs-eq-open.smt2
   regress0/proofs/unused-def1.smt2
@@ -3829,6 +3828,8 @@ set(regression_disabled_tests
   regress0/datatypes/repeated-selectors-2769.smt2
   # unknown after change to lemma schema
   regress0/nl/nta/issue8208-red-nred.smt2
+  # times out on various configurations
+  regress0/proofs/t3_rw903.smt2
   # fails with unknown on some builds
   regress0/quantifiers/nl-sqrt2-q.smt2
   # need finite model finding command line in tptp regression


### PR DESCRIPTION
Seems to be unstable, leading to nightly failures.