### PR TITLE
Catch cases where list terms are used with illegal kinds in RARE rules

### DIFF
--- a/src/expr/nary_term_util.cpp
+++ b/src/expr/nary_term_util.cpp
@@ -100,6 +100,10 @@ bool getListVarContext(TNode n, std::map<Node, Node>& context)
           itc = context.find(cn);
           if (itc == context.end())
           {
+            if (!NodeManager::isNAryKind(cur.getKind()))
+            {
+              return false;
+            }
             context[cn] = cur;
           }
           else if (itc->second.getKind() != cur.getKind())

--- a/src/rewriter/rewrite_proof_rule.cpp
+++ b/src/rewriter/rewrite_proof_rule.cpp
@@ -45,8 +45,9 @@ void RewriteProofRule::init(ProofRewriteRule id,
   {
     if (!expr::getListVarContext(c, d_listVarCtx))
     {
-      Unhandled()
-          << "Ambiguous context for list variables in condition of rule " << id;
+      Unhandled() << "Ambiguous or illegal context for list variables in "
+                     "condition of rule "
+                  << id;
     }
     d_cond.push_back(c);
     if (c.getKind() == Kind::EQUAL && c[0].getKind() == Kind::BOUND_VARIABLE)
@@ -58,7 +59,8 @@ void RewriteProofRule::init(ProofRewriteRule id,
   d_context = context;
   if (!expr::getListVarContext(conc, d_listVarCtx))
   {
-    Unhandled() << "Ambiguous context for list variables in conclusion of rule "
+    Unhandled() << "Ambiguous or illegal context for list variables in "
+                   "conclusion of rule "
                 << id;
   }
 


### PR DESCRIPTION
This catches cases where `:list` variables are used e.g. as a child of a non-n-ary kind like IMPLIES.

Previously this was leading to segfaults on my dev branch where this was done accidentally.