### PR TITLE
Fix bug in sygus solver for trivially infeasible conjectures

### DIFF
--- a/src/smt/sygus_solver.cpp
+++ b/src/smt/sygus_solver.cpp
@@ -263,7 +263,12 @@ SynthResult SygusSolver::checkSynth(bool isNext)
     if (inferTrivial)
     {
       // must expand definitions first
-      Node ppBody = d_smtSolver.getPreprocessor()->applySubstitutions(body);
+      // We consider free variables in the rewritten form of the *body* of
+      // the existential, not the rewritten form of the existential itself,
+      // which could permit eliminating variables that are equal to terms
+      // involving functions to synthesize.
+      Node ppBody = body.getKind()==Kind::EXISTS ? body[1] : body;
+      ppBody = d_smtSolver.getPreprocessor()->applySubstitutions(ppBody);
       ppBody = rewrite(ppBody);
       std::unordered_set<Node> vs;
       expr::getVariables(ppBody, vs);

--- a/src/smt/sygus_solver.cpp
+++ b/src/smt/sygus_solver.cpp
@@ -347,16 +347,19 @@ SynthResult SygusSolver::checkSynth(bool isNext)
   Result r;
   if (usingSygusSubsolver())
   {
+    Trace("smt-sygus") << "SygusSolver: check sat with subsolver..." << std::endl;
     r = d_subsolver->checkSat();
   }
   else
   {
+    Trace("smt-sygus") << "SygusSolver: check sat with main solver..." << std::endl;
     std::vector<Node> query;
     query.push_back(d_conj);
     // use a single call driver
     SmtDriverSingleCall sdsc(d_env, d_smtSolver);
     r = sdsc.checkSat(query);
   }
+  Trace("smt-sygus") << "...got " << r << std::endl;
   // The result returned by the above call is typically "unknown", which may
   // or may not correspond to a state in which we solved the conjecture
   // successfully. Instead we call getSynthSolutions below. If this returns
@@ -424,14 +427,17 @@ bool SygusSolver::getSynthSolutions(std::map<Node, Node>& solMap)
   {
     ret = getSubsolverSynthSolutions(solMap);
   }
-  // also get solutions for trivial functions to synthesize
-  for (const Node& f : d_trivialFuns)
+  if (ret)
   {
-    Node sf = quantifiers::SygusUtils::mkSygusTermFor(f);
-    Trace("smt-debug") << "Got " << sf << " for trivial function " << f
-                       << std::endl;
-    Assert(f.getType() == sf.getType());
-    solMap[f] = sf;
+    // also get solutions for trivial functions to synthesize
+    for (const Node& f : d_trivialFuns)
+    {
+      Node sf = quantifiers::SygusUtils::mkSygusTermFor(f);
+      Trace("smt-debug") << "Got " << sf << " for trivial function " << f
+                        << std::endl;
+      Assert(f.getType() == sf.getType());
+      solMap[f] = sf;
+    }
   }
   return ret;
 }

--- a/src/theory/quantifiers/sygus/synth_engine.cpp
+++ b/src/theory/quantifiers/sygus/synth_engine.cpp
@@ -191,11 +191,9 @@ bool SynthEngine::checkConjecture(SynthConjecture* conj)
 bool SynthEngine::getSynthSolutions(
     std::map<Node, std::map<Node, Node> >& sol_map)
 {
-  // if no conjectures, we fail
-  if (d_conjs.empty())
-  {
-    return false;
-  }
+  // Note that d_conjs should be size one. If it has not been assigned,
+  // by convention we return true for this method, which may correspond to
+  // a case where all functions-to-synthesize were unconstrained.
   bool ret = true;
   for (unsigned i = 0, size = d_conjs.size(); i < size; i++)
   {

--- a/src/theory/quantifiers/sygus/synth_engine.cpp
+++ b/src/theory/quantifiers/sygus/synth_engine.cpp
@@ -191,6 +191,11 @@ bool SynthEngine::checkConjecture(SynthConjecture* conj)
 bool SynthEngine::getSynthSolutions(
     std::map<Node, std::map<Node, Node> >& sol_map)
 {
+  // if no conjectures, we fail
+  if (d_conjs.empty())
+  {
+    return false;
+  }
   bool ret = true;
   for (unsigned i = 0, size = d_conjs.size(); i < size; i++)
   {

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1950,6 +1950,7 @@ set(regress_0_tests
   regress0/sygus/cegqi-si-string-triv-2fun.sy
   regress0/sygus/cegqi-si-string-triv.sy
   regress0/sygus/check-generic-red.sy
+  regress0/sygus/constval-infeasible.sy
   regress0/sygus/const-var-test.sy
   regress0/sygus/declare-var-grammar-err.sy
   regress0/sygus/dt-no-syntax.sy

--- a/test/regress/cli/regress0/sygus/constval-infeasible.sy
+++ b/test/regress/cli/regress0/sygus/constval-infeasible.sy
@@ -1,0 +1,8 @@
+; COMMAND-LINE: --sygus-out=status
+; EXPECT: infeasible
+(set-logic ALL)
+(synth-fun constval ((x Int) ) Int)
+(declare-var x Int)
+(declare-var w Int)
+(constraint (= w (constval x)))
+(check-synth)


### PR DESCRIPTION
Currently, the sygus solver may return solutions for infeasible conjectures in a corner case where the conjecture is trivially infeasible.

This bug was introduced recently when we introduced a heuristic for removing unconstrained functions-to-synthesize.

It also adds a few more safe guards to ensure similar corner cases do not occur.

This adds a regression demonstrating the issue.