### PR TITLE
Explicitly add nl-cov to regressions that require it

### DIFF
--- a/test/regress/cli/regress0/arith/arith-rewrite-with-ran.smt2
+++ b/test/regress/cli/regress0/arith/arith-rewrite-with-ran.smt2
@@ -1,3 +1,4 @@
+; COMMAND-LINE: --nl-cov
 ; REQUIRES: poly
 ; EXPECT: sat
 (set-logic QF_NRA)

--- a/test/regress/cli/regress0/nl/issue3003.smt2
+++ b/test/regress/cli/regress0/nl/issue3003.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --nl-ext=none
+; COMMAND-LINE: --nl-ext=none --nl-cov
 ; EXPECT: sat
 ; REQUIRES: poly
 (set-logic QF_NRA)

--- a/test/regress/cli/regress0/nl/issue3652.smt2
+++ b/test/regress/cli/regress0/nl/issue3652.smt2
@@ -1,5 +1,6 @@
-;REQUIRES: poly
-;EXPECT: sat
+; COMMAND-LINE: --nl-cov
+; REQUIRES: poly
+; EXPECT: sat
 (set-logic QF_NRA)
 (declare-fun a () Real)
 (assert (= (* a a) 2))

--- a/test/regress/cli/regress0/nl/issue3719.smt2
+++ b/test/regress/cli/regress0/nl/issue3719.smt2
@@ -1,3 +1,4 @@
+; COMMAND-LINE: --nl-cov
 ; REQUIRES: poly
 (set-logic QF_NRA)
 (set-info :status sat)

--- a/test/regress/cli/regress0/nl/issue6547-ran-model.smt2
+++ b/test/regress/cli/regress0/nl/issue6547-ran-model.smt2
@@ -1,3 +1,4 @@
+; COMMAND-LINE: --nl-cov
 ; REQUIRES: poly
 ; EXPECT: sat
 (set-logic QF_NRA)

--- a/test/regress/cli/regress0/nl/issue6619-ran-model.smt2
+++ b/test/regress/cli/regress0/nl/issue6619-ran-model.smt2
@@ -1,3 +1,4 @@
+; COMMAND-LINE: --nl-cov
 ; REQUIRES: poly
 ; EXPECT: sat
 (set-logic QF_NRA)

--- a/test/regress/cli/regress0/nl/issue8226-ran-refinement.smt2
+++ b/test/regress/cli/regress0/nl/issue8226-ran-refinement.smt2
@@ -1,6 +1,6 @@
 ;; needs --check-models, as --debug-check-models does not trigger the issue
 ; REQUIRES: poly
-; COMMAND-LINE: --check-models
+; COMMAND-LINE: --check-models --nl-cov
 ; EXPECT: sat
 (set-logic QF_NRA)
 (declare-fun r1 () Real)

--- a/test/regress/cli/regress0/nl/proj-issue-444-memout-eqelim.smt2
+++ b/test/regress/cli/regress0/nl/proj-issue-444-memout-eqelim.smt2
@@ -1,3 +1,4 @@
+; COMMAND-LINE: --nl-cov
 ; REQUIRES: poly
 ; EXPECT: sat
 (set-logic QF_UFNRA)

--- a/test/regress/cli/regress0/nl/real-as-int.smt2
+++ b/test/regress/cli/regress0/nl/real-as-int.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --solve-real-as-int 
+; COMMAND-LINE: --solve-real-as-int
 ; EXPECT: sat
 (set-logic QF_NRA)
 (set-info :status sat)

--- a/test/regress/cli/regress0/nl/sin-cos-346-b-chunk-0169.smt2
+++ b/test/regress/cli/regress0/nl/sin-cos-346-b-chunk-0169.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --nl-ext-tplanes
+; COMMAND-LINE: --nl-ext-tplanes --nl-cov
 ; REQUIRES: poly
 ; EXPECT: sat
 (set-info :smt-lib-version 2.6)

--- a/test/regress/cli/regress0/nl/sqrt2-value.smt2
+++ b/test/regress/cli/regress0/nl/sqrt2-value.smt2
@@ -1,4 +1,5 @@
 ; SCRUBBER: sed -e 's/(_ real_algebraic_number <.*>)/value/'
+; COMMAND-LINE: --nl-cov
 ; REQUIRES: poly
 ; EXPECT: sat
 ; EXPECT: ((x value))

--- a/test/regress/cli/regress1/nl/approx-sqrt.smt2
+++ b/test/regress/cli/regress1/nl/approx-sqrt.smt2
@@ -1,3 +1,4 @@
+; COMMAND-LINE: --nl-cov
 ; REQUIRES: poly
 ; EXPECT: sat
 (set-logic QF_NRA)

--- a/test/regress/cli/regress1/nl/issue3300-approx-sqrt-witness.smt2
+++ b/test/regress/cli/regress1/nl/issue3300-approx-sqrt-witness.smt2
@@ -1,5 +1,5 @@
 ; SCRUBBER: sed -e 's/((x (_ real_algebraic_number .*/((x (_ real_algebraic_number/'
-; COMMAND-LINE: --produce-models
+; COMMAND-LINE: --produce-models --nl-cov
 ; REQUIRES: poly
 ; EXPECT: sat
 ; EXPECT: ((x (_ real_algebraic_number


### PR DESCRIPTION
This is in preparation for CI for "safe" mode.

Note `--nl-cov` will be disabled by default when safe options is enabled, and thus any regression requiring `nl-cov` to be enabled should explicitly have it marked in the regression, so that safe options ignores the regression.