### PR TITLE
Fix updated re consume

### DIFF
--- a/src/theory/strings/sequences_rewriter.cpp
+++ b/src/theory/strings/sequences_rewriter.cpp
@@ -1560,7 +1560,6 @@ Node SequencesRewriter::rewriteViaStrInReConsume(const Node& node)
   {
     return Node::null();
   }
-  std::vector<Node> children;
   // if star, we consider the body of the star
   bool isStar = (node[1].getKind()==Kind::REGEXP_STAR);
   size_t numIter = isStar ? 2 : 1;
@@ -1568,6 +1567,7 @@ Node SequencesRewriter::rewriteViaStrInReConsume(const Node& node)
   {
     int dir = isStar ? (i==0 ? 0 : 1) : -1;
     Node r = isStar ? node[1][0] : node[1];
+    std::vector<Node> children;
     utils::getConcat(r, children);
     std::vector<Node> mchildren;
     utils::getConcat(node[0], mchildren);

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -3291,6 +3291,7 @@ set(regress_1_tests
   regress1/strings/non_termination_regular_expression4.smt2
   regress1/strings/non-terminating-rewrite-aent.smt2
   regress1/strings/norn-13.smt2
+  regress1/strings/norn-153-consume.smt2
   regress1/strings/norn-360.smt2
   regress1/strings/norn-ab.smt2
   regress1/strings/norn-re-inter-none.smt2

--- a/test/regress/cli/regress1/strings/norn-153-consume.smt2
+++ b/test/regress/cli/regress1/strings/norn-153-consume.smt2
@@ -1,0 +1,8 @@
+; EXPECT: unsat
+(set-logic QF_SLIA)
+(declare-fun var_4 () String)
+(declare-fun var_5 () String)
+(assert (str.in_re (str.++ var_4 "z" var_5 ) (re.++ (re.* (re.++ (str.to_re "a") (re.++ (re.* (re.union (str.to_re "b") (str.to_re "a"))) (str.to_re "z")))) (re.++ (str.to_re "a") (re.* (re.union (str.to_re "b") (str.to_re "a")))))))
+(assert (str.in_re var_5 (re.* (str.to_re "b"))))
+(assert (str.in_re var_4 (re.* (str.to_re "a"))))
+(check-sat)


### PR DESCRIPTION
Fix in https://github.com/cvc5/cvc5/commit/f3fc80e36258b228e6e37ce57fbf378df3de13bc had a mistake where we did not reset the string we are consuming when considering the reverse direction. 
