### PR TITLE
Make RE derive conflicts an expert option

### DIFF
--- a/src/options/strings_options.toml
+++ b/src/options/strings_options.toml
@@ -19,7 +19,7 @@ name   = "Strings Theory"
 
 [[option]]
   name       = "stringLazyPreproc"
-  category   = "expert"
+  category   = "regular"
   long       = "strings-lazy-pp"
   type       = "bool"
   default    = "true"

--- a/src/options/strings_options.toml
+++ b/src/options/strings_options.toml
@@ -19,7 +19,7 @@ name   = "Strings Theory"
 
 [[option]]
   name       = "stringLazyPreproc"
-  category   = "regular"
+  category   = "expert"
   long       = "strings-lazy-pp"
   type       = "bool"
   default    = "true"
@@ -235,3 +235,11 @@ name   = "Strings Theory"
   type       = "bool"
   default    = "false"
   help       = "eager reduction of positive membership into concatenation"
+
+[[option]]
+  name       = "stringRegexpDeriveConflicts"
+  category   = "expert"
+  long       = "strings-re-derive-conf"
+  type       = "bool"
+  default    = "false"
+  help       = "use regular expression derive for conflict finding"

--- a/src/theory/strings/regexp_solver.cpp
+++ b/src/theory/strings/regexp_solver.cpp
@@ -614,7 +614,7 @@ bool RegExpSolver::deriveRegExp(Node x,
                          << ", r= " << r << std::endl;
   cvc5::internal::String s = getHeadConst(x);
   // only allow RE_DERIVE for concrete constant regular expressions
-  if (!s.empty()
+  if (options().strings.stringRegexpDeriveConflicts && !s.empty()
       && d_regexp_opr.getRegExpConstType(r) == RE_C_CONCRETE_CONSTANT)
   {
     Node conc = Node::null();

--- a/test/regress/cli/regress0/strings/issue4662-consume-nterm.smt2
+++ b/test/regress/cli/regress0/strings/issue4662-consume-nterm.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: 
+; COMMAND-LINE: --strings-re-derive-conf
 (set-logic QF_S)
 (set-info :status unsat)
 (declare-fun a () String)


### PR DESCRIPTION
The inference `STRINGS_RE_DERIVE` uses legacy code for deriving conflicts based on computing derivatives of regular expressions.

These kinds of conflicts are used in 2 regressions and never in SMT-LIB unsat proofs, since there are other inferences that take priority.

This disables this inference by default and makes it an expert option to enable it, for the sake of simplifying proofs.
