### PR TITLE
Regression tests for the conjecture generator

### DIFF
--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -3826,6 +3826,14 @@ set(regress_2_tests
   regress2/sygus/three.sy
   regress2/sygus/tp19.eqn_sygus_iter_98_0.sy
   regress2/typed_v1l50016-simp.cvc.smt2
+  regress2/ufdt/clam-goal48.smt2
+  regress2/ufdt/isaplanner-goal60.smt2
+  regress2/ufdt/tip2015-int_add_inv_left.smt2
+  regress2/ufdt/TIP-isaplanner-prop_20.smt2
+  regress2/ufdtlia/false-graph_bt_k.smt2
+  regress2/ufdtlia/false-graph_btp5.smt2
+  regress2/ufdtlia/false-show_bin_lists_assoc.smt2
+  regress2/uflia/ADTIND-mult-int.smt2
   regress2/uflia-error0.smt2
   regress2/xs-09-16-3-4-1-5.smtv1.smt2
 )

--- a/test/regress/cli/regress2/ufdt/TIP-isaplanner-prop_20.smt2
+++ b/test/regress/cli/regress2/ufdt/TIP-isaplanner-prop_20.smt2
@@ -1,0 +1,30 @@
+; COMMAND-LINE: --dt-stc-ind --conjecture-gen
+; DISABLE-TESTER: unsat-core
+; EXPECT: unsat
+(set-logic UFDT)
+(declare-datatypes ((Nat 0)) (((Z) (S (proj1-S Nat)))))
+(declare-datatypes ((list 0)) (((nil) (cons (head Nat) (tail list)))))
+(define-fun-rec len ((x list)) Nat
+  (match x
+    (((nil) Z)
+     ((cons h t) (S (len t))))))
+(define-fun-rec <=2 ((x Nat) (y Nat)) Bool
+  (match x
+    (((S px) (match y
+               (((S py) (<=2 px py))
+                ((Z) false))))
+     ((Z) true))))
+(define-fun-rec insort ((x Nat) (y list)) list
+  (match y
+    (((cons h t) (ite (<=2 x h) (cons x (cons h t))
+                                (cons h (insort x t))))
+     ((nil) (cons x nil)))))
+(define-fun-rec sort ((x list)) list
+  (match x
+    (((cons h t) (insort h (sort t)))
+     ((nil) nil))))
+(assert
+ (not
+  (forall ((xs list))
+    (= (len (sort xs)) (len xs)))))
+(check-sat)

--- a/test/regress/cli/regress2/ufdt/clam-goal48.smt2
+++ b/test/regress/cli/regress2/ufdt/clam-goal48.smt2
@@ -1,0 +1,21 @@
+; COMMAND-LINE: --dt-stc-ind --conjecture-gen
+; DISABLE-TESTER: unsat-core
+; EXPECT: unsat
+(set-logic UFDT)
+(declare-datatype Nat ((zero) (succ (pred Nat))))
+(declare-datatype Lst ((nil) (cons (head Nat) (tail Lst))))
+(declare-fun less (Nat Nat) Bool)
+(assert (forall ((x Nat)) (= (less x zero) false)))
+(assert (forall ((x Nat)) (= (less zero (succ x)) true)))
+(assert (forall ((x Nat) (y Nat)) (= (less (succ x) (succ y)) (less x y))))
+(declare-fun len (Lst) Nat)
+(assert (= (len nil) zero))
+(assert (forall ((x Nat) (y Lst)) (= (len (cons x y)) (succ (len y)))))
+(declare-fun insort (Nat Lst) Lst)
+(assert (forall ((i Nat)) (= (insort i nil) (cons i nil))))
+(assert (forall ((i Nat) (x Nat) (y Lst)) (= (insort i (cons x y)) (ite (less i x) (cons i (cons x y)) (cons x (insort i y))))))
+(declare-fun sort (Lst) Lst)
+(assert (= (sort nil) nil))
+(assert (forall ((x Nat) (y Lst)) (= (sort (cons x y)) (insort x (sort y)))))
+(assert (not (forall ((x Lst)) (= (len (sort x)) (len x)))))
+(check-sat)

--- a/test/regress/cli/regress2/ufdt/isaplanner-goal60.smt2
+++ b/test/regress/cli/regress2/ufdt/isaplanner-goal60.smt2
@@ -1,0 +1,13 @@
+; COMMAND-LINE: --dt-stc-ind --conjecture-gen
+; DISABLE-TESTER: unsat-core
+; EXPECT: unsat
+(set-logic UFDT)
+(declare-datatype Nat ((zero) (succ (pred Nat))))
+(declare-datatype Lst ((nil) (cons (head Nat) (tail Lst))))
+(declare-fun append (Lst Lst) Lst)
+(assert (forall ((x Lst)) (= (append nil x) x)))
+(assert (forall ((x Nat) (y Lst) (z Lst)) (= (append (cons x y) z) (cons x (append y z)))))
+(declare-fun last (Lst) Nat)
+(assert (forall ((x Nat) (y Lst)) (= (last (cons x y)) (ite (= y nil) x (last y)))))
+(assert (not (forall ((xs Lst) (ys Lst)) (=> (= ys nil) (= (last (append xs ys)) (last xs))))))
+(check-sat)

--- a/test/regress/cli/regress2/ufdt/tip2015-int_add_inv_left.smt2
+++ b/test/regress/cli/regress2/ufdt/tip2015-int_add_inv_left.smt2
@@ -1,0 +1,44 @@
+; COMMAND-LINE: --dt-stc-ind --conjecture-gen
+; DISABLE-TESTER: unsat-core
+; DISABLE-TESTER: cpc
+; DISABLE-TESTER: lfsc
+; EXPECT: unsat
+(set-logic UFDT)
+(declare-datatype Nat ((zero) (succ (p Nat))))
+(declare-datatype Integer ((P (proj1-P Nat)) (N (proj1-N Nat))))
+(define-fun zero2 () Integer 
+  (P zero))
+(define-fun-rec plus ((x Nat) (y Nat)) Nat
+  (match x
+    (((zero) y)
+     ((succ px) (succ (plus px y))))))
+(define-fun-rec neg ((x Integer)) Integer
+  (match x
+    (((N absx) (P (plus (succ zero) absx)))
+     ((P absx) (match absx
+                 (((zero) (P zero))
+                  ((succ pabsx) (N pabsx))))))))
+(define-fun-rec minus2 ((x Nat) (y Nat)) Integer
+  (let ((fail (match y
+                (((succ py) (match x
+                              (((succ px) (minus2 px py))
+                               ((zero) (N py)))))
+                 ((zero) (P x))))))
+    (match x
+      (((succ px) fail)
+       ((zero) (match y
+                 (((succ py) fail)
+                  ((zero) (P zero)))))))))
+(define-fun plus2 ((x Integer) (y Integer)) Integer
+  (match x
+    (((N absx) (match y
+                 (((N absy) (N (plus (plus (succ zero) absx) absy)))
+                  ((P absy) (minus2 absy (plus (succ zero) absx))))))
+     ((P absx) (match y
+                 (((N absy) (minus2 absx (plus (succ zero) absy)))
+                  ((P absy) (P (plus absx absy)))))))))
+(assert
+ (not
+  (forall ((x Integer))
+    (= (plus2 (neg x) x) zero2))))
+(check-sat)

--- a/test/regress/cli/regress2/ufdtlia/false-graph_bt_k.smt2
+++ b/test/regress/cli/regress2/ufdtlia/false-graph_bt_k.smt2
@@ -1,0 +1,213 @@
+; COMMAND-LINE: --dt-stc-ind --conjecture-gen
+; DISABLE-TESTER: unsat-core
+; EXPECT: unsat
+(set-logic UFDTLIA)
+(declare-datatypes ((pair3 0)) (((pair22 (proj1-pair2 Int) (proj2-pair2 Int)))))
+(declare-datatypes ((list6 0)) (((nil6) (cons6 (head6 Bool) (tail6 list6)))))
+(declare-datatypes ((list5 0)) (((nil5) (cons5 (head5 Int) (tail5 list5)))))
+(declare-datatypes ((list3 0)) (((nil2) (cons2 (head2 pair3) (tail2 list3)))))
+(declare-datatypes ((B 0)) (((I) (O))))
+(declare-datatypes ((list 0)) (((nil4) (cons4 (head4 B) (tail4 list)))))
+(declare-datatypes ((list4 0)) (((nil3) (cons3 (head3 list) (tail3 list4)))))
+(declare-datatypes ((pair 0)) (((pair2 (proj1-pair list) (proj2-pair list)))))
+(declare-datatypes ((list2 0)) (((nil) (cons (head pair) (tail list2)))))
+(define-fun-rec
+  primEnumFromTo
+  ((x Int) (y Int)) list5
+  (ite (< y x) nil5 (cons5 x (primEnumFromTo (+ 1 x) y))))
+(define-fun-rec
+  or2
+  ((x list6)) Bool
+  (ite (is-cons6 x) (or (head6 x) (or2 (tail6 x))) false))
+(define-fun-rec
+  maximum-maximum1
+  ((x Int) (y list3)) Int
+  (ite
+    (is-cons2 y)
+    (let
+      ((y3
+          (ite
+            (<= (proj1-pair2 (head2 y)) (proj2-pair2 (head2 y)))
+            (proj2-pair2 (head2 y)) (proj1-pair2 (head2 y)))))
+      (ite
+        (<= x y3) (maximum-maximum1 y3 (tail2 y))
+        (maximum-maximum1 x (tail2 y))))
+    x))
+(define-fun-rec
+  length
+  ((x list4)) Int (ite (is-cons3 x) (+ 1 (length (tail3 x))) 0))
+(define-fun-rec
+  last
+  ((x list) (y list4)) list
+  (ite (is-cons3 y) (last (head3 y) (tail3 y)) x))
+(define-fun-rec
+  dodeca6
+  ((x Int) (y list5)) list3
+  (ite
+    (is-cons5 y)
+    (cons2
+      (pair22 (+ (+ (+ x x) x) (head5 y))
+        (+ (+ (+ x x) x) (+ 1 (head5 y))))
+      (dodeca6 x (tail5 y)))
+    nil2))
+(define-fun-rec
+  dodeca5
+  ((x Int) (y list5)) list3
+  (ite
+    (is-cons5 y)
+    (cons2 (pair22 (+ (+ x x) (head5 y)) (+ (+ (+ x x) x) (head5 y)))
+      (dodeca5 x (tail5 y)))
+    nil2))
+(define-fun-rec
+  dodeca4
+  ((x Int) (y list5)) list3
+  (ite
+    (is-cons5 y)
+    (cons2 (pair22 (+ x (+ 1 (head5 y))) (+ (+ x x) (head5 y)))
+      (dodeca4 x (tail5 y)))
+    nil2))
+(define-fun-rec
+  dodeca3
+  ((x Int) (y list5)) list3
+  (ite
+    (is-cons5 y)
+    (cons2 (pair22 (+ x (head5 y)) (+ (+ x x) (head5 y)))
+      (dodeca3 x (tail5 y)))
+    nil2))
+(define-fun-rec
+  dodeca2
+  ((x Int) (y list5)) list3
+  (ite
+    (is-cons5 y)
+    (cons2 (pair22 (head5 y) (+ x (head5 y))) (dodeca2 x (tail5 y)))
+    nil2))
+(define-fun-rec
+  dodeca
+  ((x list5)) list3
+  (ite
+    (is-cons5 x)
+    (cons2 (pair22 (head5 x) (+ 1 (head5 x))) (dodeca (tail5 x)))
+    nil2))
+(define-fun-rec
+  bin
+  ((x Int)) list
+  (ite
+    (= x 0) nil4
+    (ite
+      (= (mod x 2) 0) (cons4 O (bin (div x 2)))
+      (cons4 I (bin (div x 2))))))
+(define-fun-rec
+  bgraph
+  ((x list3)) list2
+  (ite
+    (is-cons2 x)
+    (cons
+      (pair2 (bin (proj1-pair2 (head2 x))) (bin (proj2-pair2 (head2 x))))
+      (bgraph (tail2 x)))
+    nil))
+(define-fun-rec
+  beq
+  ((x list) (y list)) Bool
+  (ite
+    (is-cons4 x)
+    (ite
+      (is-O (head4 x))
+      (ite
+        (is-cons4 y) (ite (is-O (head4 y)) (beq (tail4 x) (tail4 y)) false)
+        false)
+      (ite
+        (is-cons4 y) (ite (is-O (head4 y)) false (beq (tail4 x) (tail4 y)))
+        false))
+    (not (is-cons4 y))))
+(define-fun-rec
+  bpath
+  ((x list) (y list) (z list2)) list6
+  (ite
+    (is-cons z)
+    (cons6
+      (or
+        (and (beq (proj1-pair (head z)) x) (beq (proj2-pair (head z)) y))
+        (and (beq (proj1-pair (head z)) y) (beq (proj2-pair (head z)) x)))
+      (bpath x y (tail z)))
+    nil6))
+(define-fun-rec
+  bpath2
+  ((x list4) (y list2)) Bool
+  (ite
+    (is-cons3 x)
+    (ite
+      (is-cons3 (tail3 x))
+      (and (or2 (bpath (head3 x) (head3 (tail3 x)) y))
+        (bpath2 (cons3 (head3 (tail3 x)) (tail3 (tail3 x))) y))
+      true)
+    true))
+(define-fun-rec
+  belem
+  ((x list) (y list4)) list6
+  (ite
+    (is-cons3 y) (cons6 (beq x (head3 y)) (belem x (tail3 y))) nil6))
+(define-fun
+  belem2
+  ((x list) (y list4)) Bool (or2 (belem x y)))
+(define-fun-rec
+  bunique
+  ((x list4)) Bool
+  (ite
+    (is-cons3 x)
+    (and (not (belem2 (head3 x) (tail3 x))) (bunique (tail3 x))) true))
+(define-fun
+  btour
+  ((x list4) (y list3)) Bool
+  (ite
+    (is-cons3 x)
+    (ite
+      (is-cons2 y)
+      (and (beq (head3 x) (last (head3 x) (tail3 x)))
+        (and
+          (bpath2 (cons3 (head3 x) (tail3 x))
+            (bgraph
+              (cons2 (pair22 (proj1-pair2 (head2 y)) (proj2-pair2 (head2 y)))
+                (tail2 y))))
+          (and (bunique (tail3 x))
+            (= (length (cons3 (head3 x) (tail3 x)))
+              (ite
+                (<= (proj1-pair2 (head2 y)) (proj2-pair2 (head2 y)))
+                (+ 1 (+ 1 (maximum-maximum1 (proj2-pair2 (head2 y)) (tail2 y))))
+                (+ 1
+                  (+ 1 (maximum-maximum1 (proj1-pair2 (head2 y)) (tail2 y)))))))))
+      false)
+    (not (is-cons2 y))))
+(define-fun-rec
+  ++
+  ((x list3) (y list3)) list3
+  (ite (is-cons2 x) (cons2 (head2 x) (++ (tail2 x) y)) y))
+(define-fun
+  dodeca7
+  ((x Int)) list3
+  (ite
+    (= x 0) nil2
+    (++ (cons2 (pair22 (- x 1) 0) (dodeca (primEnumFromTo 0 (- x 1))))
+      (++ (dodeca2 x (primEnumFromTo 0 x))
+        (++ (dodeca3 x (primEnumFromTo 0 x))
+          (++
+            (cons2 (pair22 x (+ (+ x x) (- x 1)))
+              (dodeca4 x (primEnumFromTo 0 (- x 1))))
+            (++ (dodeca5 x (primEnumFromTo 0 x))
+              (cons2 (pair22 (+ (+ (+ x x) x) (- x 1)) (+ (+ x x) x))
+                (dodeca6 x (primEnumFromTo 0 (- x 1)))))))))))
+(declare-const k Int)
+(assert
+  (not
+    (forall ((p list4))
+      (not
+        (btour p
+          (++ (cons2 (pair22 (- k 1) 0) (dodeca (primEnumFromTo 0 (- k 1))))
+            (++ (dodeca2 k (primEnumFromTo 0 k))
+              (++ (dodeca3 k (primEnumFromTo 0 k))
+                (++
+                  (cons2 (pair22 k (+ (+ k k) (- k 1)))
+                    (dodeca4 k (primEnumFromTo 0 (- k 1))))
+                  (++ (dodeca5 k (primEnumFromTo 0 k))
+                    (cons2 (pair22 (+ (+ (+ k k) k) (- k 1)) (+ (+ k k) k))
+                      (dodeca6 k (primEnumFromTo 0 (- k 1))))))))))))))
+(check-sat)

--- a/test/regress/cli/regress2/ufdtlia/false-graph_btp5.smt2
+++ b/test/regress/cli/regress2/ufdtlia/false-graph_btp5.smt2
@@ -1,0 +1,197 @@
+; COMMAND-LINE: --dt-stc-ind --conjecture-gen
+; DISABLE-TESTER: unsat-core
+; EXPECT: unsat
+(set-logic UFDTLIA)
+(declare-datatypes ((pair3 0))
+  (((pair22 (proj1-pair2 Int) (proj2-pair2 Int)))))
+(declare-datatypes ((list7 0))
+  (((nil7) (cons7 (head7 Bool) (tail7 list7)))))
+(declare-datatypes ((list6 0))
+  (((nil6) (cons6 (head6 Int) (tail6 list6)))))
+(declare-datatypes ((list3 0))
+  (((nil2) (cons2 (head2 pair3) (tail2 list3)))))
+(declare-datatypes ((list4 0))
+  (((nil3) (cons3 (head3 list3) (tail3 list4)))))
+(declare-datatypes ((B 0)) (((I) (O))))
+(declare-datatypes ((list 0))
+  (((nil5) (cons5 (head5 B) (tail5 list)))))
+(declare-datatypes ((list5 0))
+  (((nil4) (cons4 (head4 list) (tail4 list5)))))
+(declare-datatypes ((pair 0))
+  (((pair2 (proj1-pair list) (proj2-pair list)))))
+(declare-datatypes ((list2 0))
+  (((nil) (cons (head pair) (tail list2)))))
+(define-fun-rec
+  primEnumFromTo
+  ((x Int) (y Int)) list6
+  (ite (< y x) nil6 (cons6 x (primEnumFromTo (+ 1 x) y))))
+(define-fun-rec
+  petersen3
+  ((x Int) (y list6)) list3
+  (ite
+    (is-cons6 y)
+    (cons2 (pair22 (head6 y) (+ x (head6 y))) (petersen3 x (tail6 y)))
+    nil2))
+(define-fun-rec
+  petersen2
+  ((x list6)) list3
+  (ite
+    (is-cons6 x)
+    (cons2 (pair22 (head6 x) (+ 1 (head6 x))) (petersen2 (tail6 x)))
+    nil2))
+(define-fun-rec
+  petersen
+  ((x Int) (y list3)) list4
+  (ite
+    (is-cons2 y)
+    (cons3
+      (cons2 (pair22 (proj1-pair2 (head2 y)) (proj2-pair2 (head2 y)))
+        (cons2
+          (pair22 (+ x (proj1-pair2 (head2 y)))
+            (+ x (proj2-pair2 (head2 y))))
+          nil2))
+      (petersen x (tail2 y)))
+    nil3))
+(define-fun-rec
+  or2
+  ((x list7)) Bool
+  (ite (is-cons7 x) (or (head7 x) (or2 (tail7 x))) false))
+(define-fun-rec
+  maximum-maximum1
+  ((x Int) (y list3)) Int
+  (ite
+    (is-cons2 y)
+    (let
+      ((y3
+          (ite
+            (<= (proj1-pair2 (head2 y)) (proj2-pair2 (head2 y)))
+            (proj2-pair2 (head2 y)) (proj1-pair2 (head2 y)))))
+      (ite
+        (<= x y3) (maximum-maximum1 y3 (tail2 y))
+        (maximum-maximum1 x (tail2 y))))
+    x))
+(define-fun-rec
+  length
+  ((x list5)) Int (ite (is-cons4 x) (+ 1 (length (tail4 x))) 0))
+(define-fun-rec
+  last
+  ((x list) (y list5)) list
+  (ite (is-cons4 y) (last (head4 y) (tail4 y)) x))
+(define-fun-rec
+  bin
+  ((x Int)) list
+  (ite
+    (= x 0) nil5
+    (ite
+      (= (mod x 2) 0) (cons5 O (bin (div x 2)))
+      (cons5 I (bin (div x 2))))))
+(define-fun-rec
+  bgraph
+  ((x list3)) list2
+  (ite
+    (is-cons2 x)
+    (cons
+      (pair2 (bin (proj1-pair2 (head2 x))) (bin (proj2-pair2 (head2 x))))
+      (bgraph (tail2 x)))
+    nil))
+(define-fun-rec
+  beq
+  ((x list) (y list)) Bool
+  (ite
+    (is-cons5 x)
+    (ite
+      (is-O (head5 x))
+      (ite
+        (is-cons5 y) (ite (is-O (head5 y)) (beq (tail5 x) (tail5 y)) false)
+        false)
+      (ite
+        (is-cons5 y) (ite (is-O (head5 y)) false (beq (tail5 x) (tail5 y)))
+        false))
+    (not (is-cons5 y))))
+(define-fun-rec
+  bpath
+  ((x list) (y list) (z list2)) list7
+  (ite
+    (is-cons z)
+    (cons7
+      (or
+        (and (beq (proj1-pair (head z)) x) (beq (proj2-pair (head z)) y))
+        (and (beq (proj1-pair (head z)) y) (beq (proj2-pair (head z)) x)))
+      (bpath x y (tail z)))
+    nil7))
+(define-fun-rec
+  bpath2
+  ((x list5) (y list2)) Bool
+  (ite
+    (is-cons4 x)
+    (ite
+      (is-cons4 (tail4 x))
+      (and (or2 (bpath (head4 x) (head4 (tail4 x)) y))
+        (bpath2 (cons4 (head4 (tail4 x)) (tail4 (tail4 x))) y))
+      true)
+    true))
+(define-fun-rec
+  belem
+  ((x list) (y list5)) list7
+  (ite
+    (is-cons4 y) (cons7 (beq x (head4 y)) (belem x (tail4 y))) nil7))
+(define-fun
+  belem2
+  ((x list) (y list5)) Bool (or2 (belem x y)))
+(define-fun-rec
+  bunique
+  ((x list5)) Bool
+  (ite
+    (is-cons4 x)
+    (and (not (belem2 (head4 x) (tail4 x))) (bunique (tail4 x))) true))
+(define-fun
+  btour
+  ((x list5) (y list3)) Bool
+  (ite
+    (is-cons4 x)
+    (ite
+      (is-cons2 y)
+      (and (beq (head4 x) (last (head4 x) (tail4 x)))
+        (and
+          (bpath2 (cons4 (head4 x) (tail4 x))
+            (bgraph
+              (cons2 (pair22 (proj1-pair2 (head2 y)) (proj2-pair2 (head2 y)))
+                (tail2 y))))
+          (and (bunique (tail4 x))
+            (= (length (cons4 (head4 x) (tail4 x)))
+              (ite
+                (<= (proj1-pair2 (head2 y)) (proj2-pair2 (head2 y)))
+                (+ 1 (+ 1 (maximum-maximum1 (proj2-pair2 (head2 y)) (tail2 y))))
+                (+ 1
+                  (+ 1 (maximum-maximum1 (proj1-pair2 (head2 y)) (tail2 y)))))))))
+      false)
+    (not (is-cons2 y))))
+(define-fun-rec
+  ++
+  ((x list3) (y list3)) list3
+  (ite (is-cons2 x) (cons2 (head2 x) (++ (tail2 x) y)) y))
+(define-fun-rec
+  concat2
+  ((x list4)) list3
+  (ite (is-cons3 x) (++ (head3 x) (concat2 (tail3 x))) nil2))
+(define-fun
+  petersen4
+  ((x Int)) list3
+  (ite
+    (= x 0) nil2
+    (++
+      (concat2
+        (petersen x
+          (cons2 (pair22 (- x 1) 0) (petersen2 (primEnumFromTo 0 (- x 1))))))
+      (petersen3 x (primEnumFromTo 0 x)))))
+(assert
+  (not
+    (forall ((p list5))
+      (not
+        (btour p
+          (++
+            (concat2
+              (petersen 5
+                (cons2 (pair22 (- 5 1) 0) (petersen2 (primEnumFromTo 0 (- 5 1))))))
+            (petersen3 5 (primEnumFromTo 0 5))))))))
+(check-sat)

--- a/test/regress/cli/regress2/ufdtlia/false-show_bin_lists_assoc.smt2
+++ b/test/regress/cli/regress2/ufdtlia/false-show_bin_lists_assoc.smt2
@@ -1,0 +1,31 @@
+; COMMAND-LINE: --dt-stc-ind --conjecture-gen
+; DISABLE-TESTER: unsat-core
+; EXPECT: unsat
+(set-logic UFDTLIA)
+(declare-datatype B ((I) (O)))
+(declare-datatype list ((nil) (cons (head B) (tail list))))
+(define-fun half ((x Int)) Int
+  (div x 2))
+(define-fun-rec shw ((x Int)) list
+  (ite (= x 0) nil
+  (ite (= (mod x 2) 0) (cons O (shw (half x))) 
+                       (cons I (shw (half x))))))
+(define-fun double ((x Int)) Int 
+  (+ x x))
+(define-fun-rec rd ((x list)) Int
+  (match x
+    (((cons h t) (match h
+                   (((O) (double (rd t)))
+                    ((I) (+ 1 (double (rd t)))))))
+     ((nil) 0))))
+(define-fun-rec ++ ((x list) (y list)) list
+  (match x
+    (((cons h t) (cons h (++ t y)))
+     ((nil) y))))
+(define-fun hash ((x Int) (y Int)) Int
+  (rd (++ (shw x) (shw y))))
+(assert                                         
+ (not                                          
+  (forall ((x Int) (y Int) (z Int))           
+    (= (hash x (hash y z)) (hash (hash x y) z)))))
+(check-sat)

--- a/test/regress/cli/regress2/uflia/ADTIND-mult-int.smt2
+++ b/test/regress/cli/regress2/uflia/ADTIND-mult-int.smt2
@@ -1,0 +1,15 @@
+; COMMAND-LINE: --dt-stc-ind --conjecture-gen
+; DISABLE-TESTER: unsat-core
+; EXPECT: unsat
+(set-logic UFLIA)
+(define-fun-rec mult ((m Int) (n Int)) Int
+  (ite (> n 0) (+ m (mult m (- n 1)))
+               0))
+(assert
+ (forall ((m Int) (n Int))
+   (= (- (mult m n) n) (mult (- m 1) n))))
+(assert
+ (not
+  (forall ((m Int) (n Int))
+    (= (mult m n) (mult n m)))))
+(check-sat)


### PR DESCRIPTION
These are 8 tests for the conjecture generator. I have removed any irrelevant commands that I could identify, including assertions.

cvc5 takes <1 second to report 'unsat' for each test so long as the unsat core tester is disabled. Based on my observations cvc5 cannot solve them with induction switched on and conjecture generation switched off, making conjecture generation essential to get a quick 'unsat' response from the solver. 

These tests will help ensure that I do not worsen the performance of the conjecture generator as I clean it up. They might also help us identify which changes to other components of cvc5 can impact the conjecture generator.

Fixes #11520