### PR TITLE
Fixes and improvements for datatypes proof constructor

### DIFF
--- a/src/theory/datatypes/infer_proof_cons.cpp
+++ b/src/theory/datatypes/infer_proof_cons.cpp
@@ -144,7 +144,8 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
         if (n >= 0)
         {
           Node eq = tst.eqNode(conc);
-          cdp->addTheoryRewriteStep(eq, ProofRewriteRule::DT_INST);
+          // ensure the theory rewrite below is correct
+          tryRewriteRule(tst, conc, ProofRewriteRule::DT_INST, cdp);
           cdp->addStep(conc, ProofRule::EQ_RESOLVE, {tst, eq}, {});
           success = true;
         }
@@ -191,7 +192,7 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
         Node seq = sl.eqNode(sr);
         cdp->addStep(seq, ProofRule::CONG, {exp}, {asn, sop});
         Node sceq = sr.eqNode(concEq[1]);
-        cdp->addTheoryRewriteStep(sceq, ProofRewriteRule::DT_COLLAPSE_SELECTOR);
+        tryRewriteRule(sr, concEq[1], ProofRewriteRule::DT_COLLAPSE_SELECTOR, cdp);
         cdp->addStep(sl.eqNode(concEq[1]), ProofRule::TRANS, {seq, sceq}, {});
         if (conc.getKind() != Kind::EQUAL)
         {
@@ -264,13 +265,30 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
     break;
     case InferenceId::DATATYPES_LABEL_EXH:
     {
+      // partition to substitution / testers
+      std::vector<Node> expvs;
+      std::vector<Node> expvt;
+      std::map<Node, Node> tmap;
+      for (const Node& e : expv)
+      {
+        if (e.getKind() == Kind::NOT && e[0].getKind() == Kind::APPLY_TESTER)
+        {
+          expvt.push_back(e);
+          tmap[e[0].getOperator()] = e;
+        }
+        else if (e.getKind()==Kind::EQUAL)
+        {
+          expvs.push_back(e);
+        }
+      }
+      
       // Exhausted labels. For example, this proves ~is-cons(x) => is-nil(x)
       // We prove this by:
       // ------------------------ DT_SPLIT
       // is-cons(x) or is-nil(x)            ~is-cons(x)
       // ---------------------------------------------- CHAIN_RESOLUTION
       // is-nil(x)
-      Node tst = expv[0];
+      Node tst = expvt[0];
       Assert(tst.getKind() == Kind::NOT
              && tst[0].getKind() == Kind::APPLY_TESTER);
       Node t = tst[0][0];
@@ -286,16 +304,34 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
         premises.push_back(sconc);
         std::vector<Node> pols;
         std::vector<Node> lits;
-        for (const Node& e : expv)
+        std::map<Node, Node>::iterator itt;
+        for (const Node& e : sconc)
         {
-          if (e.getKind() != Kind::NOT || e[0].getKind() != Kind::APPLY_TESTER)
+          Node en = e.notNode();
+          premises.push_back(en);
+          pols.emplace_back(truen);
+          lits.emplace_back(e);
+          // must ensure we have a proof of en
+          Assert (e.getKind()==Kind::APPLY_TESTER);
+          bool successLit = false;
+          itt = tmap.find(e.getOperator());
+          if (itt!=tmap.end())
+          {
+            if (itt->second==en)
+            {
+              successLit = true;
+            }
+            else
+            {
+              // otherwise maybe equal modulo rewriting?
+              Trace("dt-ipc") << "exh-label: " << itt->second << " vs " << en << ", substitution " << expvs << std::endl;
+            }
+          }
+          if (!successLit)
           {
             curr = Node::null();
             break;
           }
-          premises.push_back(e);
-          pols.emplace_back(truen);
-          lits.emplace_back(e[0]);
         }
         if (!curr.isNull())
         {
@@ -376,6 +412,20 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
   else
   {
     Trace("dt-ipc") << "...success" << std::endl;
+  }
+}
+
+void InferProofCons::tryRewriteRule(TNode a, TNode b, ProofRewriteRule r, CDProof* cdp)
+{
+  Node eq = a.eqNode(b);
+  Node ar = d_env.getRewriter()->rewriteViaRule(r, a);
+  if (ar==b)
+  {
+    cdp->addTheoryRewriteStep(eq, r);
+  }
+  else
+  {
+    cdp->addTrustedStep(eq, TrustId::THEORY_INFERENCE_DATATYPES, {}, {});
   }
 }
 

--- a/src/theory/datatypes/infer_proof_cons.cpp
+++ b/src/theory/datatypes/infer_proof_cons.cpp
@@ -192,7 +192,8 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
         Node seq = sl.eqNode(sr);
         cdp->addStep(seq, ProofRule::CONG, {exp}, {asn, sop});
         Node sceq = sr.eqNode(concEq[1]);
-        tryRewriteRule(sr, concEq[1], ProofRewriteRule::DT_COLLAPSE_SELECTOR, cdp);
+        tryRewriteRule(
+            sr, concEq[1], ProofRewriteRule::DT_COLLAPSE_SELECTOR, cdp);
         cdp->addStep(sl.eqNode(concEq[1]), ProofRule::TRANS, {seq, sceq}, {});
         if (conc.getKind() != Kind::EQUAL)
         {
@@ -278,12 +279,12 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
           expvt.push_back(e);
           tmap[e[0].getOperator()] = e;
         }
-        else if (e.getKind()==Kind::EQUAL)
+        else if (e.getKind() == Kind::EQUAL)
         {
           expvs.push_back(e);
         }
       }
-      
+
       // Exhausted labels. For example, this proves ~is-cons(x) => is-nil(x)
       // We prove this by:
       // ------------------------ DT_SPLIT
@@ -307,7 +308,7 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
         std::map<Node, Node>::iterator itt;
         for (const Node& e : sconc)
         {
-          if (e==conc)
+          if (e == conc)
           {
             continue;
           }
@@ -316,12 +317,12 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
           pols.emplace_back(truen);
           lits.emplace_back(e);
           // must ensure we have a proof of en
-          Assert (e.getKind()==Kind::APPLY_TESTER);
+          Assert(e.getKind() == Kind::APPLY_TESTER);
           bool successLit = false;
           itt = tmap.find(e.getOperator());
-          if (itt!=tmap.end())
+          if (itt != tmap.end())
           {
-            if (itt->second==en)
+            if (itt->second == en)
             {
               successLit = true;
             }
@@ -331,11 +332,14 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
               // This is to handle e.g.
               // (and (not (is-cons x)) (= x y)) => (is-nil y)
               expvs[0] = itt->second;
-              Trace("dt-ipc") << "exh-label: " << itt->second << " vs " << en << ", substitution " << expvs << std::endl;
-              Node res = pc->checkDebug(ProofRule::MACRO_SR_PRED_TRANSFORM, expvs, {en});
-              if (res==en)
+              Trace("dt-ipc") << "exh-label: " << itt->second << " vs " << en
+                              << ", substitution " << expvs << std::endl;
+              Node res = pc->checkDebug(
+                  ProofRule::MACRO_SR_PRED_TRANSFORM, expvs, {en});
+              if (res == en)
               {
-                cdp->addStep(res, ProofRule::MACRO_SR_PRED_TRANSFORM, expvs, {en});
+                cdp->addStep(
+                    res, ProofRule::MACRO_SR_PRED_TRANSFORM, expvs, {en});
                 successLit = true;
               }
             }
@@ -428,11 +432,14 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
   }
 }
 
-void InferProofCons::tryRewriteRule(TNode a, TNode b, ProofRewriteRule r, CDProof* cdp)
+void InferProofCons::tryRewriteRule(TNode a,
+                                    TNode b,
+                                    ProofRewriteRule r,
+                                    CDProof* cdp)
 {
   Node eq = a.eqNode(b);
   Node ar = d_env.getRewriter()->rewriteViaRule(r, a);
-  if (ar==b)
+  if (ar == b)
   {
     cdp->addTheoryRewriteStep(eq, r);
   }

--- a/src/theory/datatypes/infer_proof_cons.h
+++ b/src/theory/datatypes/infer_proof_cons.h
@@ -18,9 +18,9 @@
 #ifndef CVC5__THEORY__DATATYPES__INFER_PROOF_CONS_H
 #define CVC5__THEORY__DATATYPES__INFER_PROOF_CONS_H
 
-#include "proof/proof.h"
 #include "context/cdhashmap.h"
 #include "expr/node.h"
+#include "proof/proof.h"
 #include "proof/proof_generator.h"
 #include "smt/env_obj.h"
 #include "theory/datatypes/inference.h"

--- a/src/theory/datatypes/infer_proof_cons.h
+++ b/src/theory/datatypes/infer_proof_cons.h
@@ -18,6 +18,7 @@
 #ifndef CVC5__THEORY__DATATYPES__INFER_PROOF_CONS_H
 #define CVC5__THEORY__DATATYPES__INFER_PROOF_CONS_H
 
+#include "proof/proof.h"
 #include "context/cdhashmap.h"
 #include "expr/node.h"
 #include "proof/proof_generator.h"
@@ -83,6 +84,11 @@ class InferProofCons : protected EnvObj, public ProofGenerator
    * information is stored in cdp.
    */
   void convert(InferenceId infer, TNode conc, TNode exp, CDProof* cdp);
+  /**
+   * Add a step a=b to cdp using ProofRewriteRule rule r if possible, or a
+   * trust step otherwise.
+   */
+  void tryRewriteRule(TNode a, TNode b, ProofRewriteRule r, CDProof* cdp);
   /**
    * Adds a step concluding t_i = s_i from C(t_1 ... t_n) = C(s_1 ... s_n),
    * where i is stored in the node narg.

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -734,6 +734,7 @@ set(regress_0_tests
   regress0/datatypes/proj-issue172.smt2
   regress0/datatypes/proj-issue474-app-cons-value.smt2
   regress0/datatypes/proj-issue578-clash-pf.smt2
+  regress0/datatypes/proj-issue752-ipc.smt2
   regress0/datatypes/rec1.cvc.smt2
   regress0/datatypes/rec2.cvc.smt2
   regress0/datatypes/rec4.cvc.smt2

--- a/test/regress/cli/regress0/datatypes/proj-issue752-ipc.smt2
+++ b/test/regress/cli/regress0/datatypes/proj-issue752-ipc.smt2
@@ -1,0 +1,6 @@
+; COMMAND-LINE: --produce-proofs --proof-check=eager
+; EXPECT: sat
+(set-logic QF_FFDT)
+(declare-datatypes ((d 0)) (((c (s Bool)) (_c (_s d)) (o (e Bool) (se Bool)))))
+(declare-const x d)
+(check-sat-assuming ((or ((_ is c) ((_ update e) x false)) (= x (_s x)))))


### PR DESCRIPTION
Makes one inference modulo equality of tester terms and makes it so that we fail gracefully if theory rewrites do not fit (e.g. if dt-share-sel is enabled).

Fixes https://github.com/cvc5/cvc5-projects/issues/752