### PR TITLE
Disable cpc on regression

### DIFF
--- a/test/regress/cli/regress1/quantifiers/cdt-0208-to.smt2
+++ b/test/regress/cli/regress1/quantifiers/cdt-0208-to.smt2
@@ -1,6 +1,6 @@
 ; COMMAND-LINE: --full-saturate-quant
 ; EXPECT: unsat
-
+; DISABLE-TESTER: cpc
 (set-logic ALL)
 (set-info :status unsat)
 (declare-sort A$ 0)


### PR DESCRIPTION
This was mistakenly reenabled on the last commit but fails in the nightlies.