### PR TITLE
Fix case of collect model info in strings related to cardinality

### DIFF
--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -685,8 +685,13 @@ bool TheoryStrings::collectModelInfoType(
               AlwaysAssert(!len_splits.empty());
               for (const std::pair<size_t, size_t>& sl : len_splits)
               {
-                Node s1 = nm->mkNode(Kind::STRING_LENGTH, col[sl.first][0]);
-                Node s2 = nm->mkNode(Kind::STRING_LENGTH, col[sl.second][0]);
+                // ensure we use proxy variables or else the split may be rewritten away
+                Node k1 = col[sl.first][0];
+                Node kp1 = d_termReg.getProxyVariableFor(k1);
+                Node k2 = col[sl.second][0];
+                Node kp2 = d_termReg.getProxyVariableFor(k2);
+                Node s1 = nm->mkNode(Kind::STRING_LENGTH, kp1.isNull() ? k1 : kp1);
+                Node s2 = nm->mkNode(Kind::STRING_LENGTH, kp2.isNull() ? k2 : kp2);
                 Node eq = s1.eqNode(s2);
                 Node spl = nm->mkNode(Kind::OR, eq, eq.negate());
                 d_im.lemma(spl, InferenceId::STRINGS_CMI_SPLIT);

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1680,6 +1680,7 @@ set(regress_0_tests
   regress0/seq/proj-issue604-reg-closure.smt2
   regress0/seq/proj-issue642-cycle-irr.smt2
   regress0/seq/proj-issue653.smt2
+  regress0/seq/proj-issue747-cmi-len-split.smt2
   regress0/seq/quant_len_trigger.smt2
   regress0/seq/query0-subtype-skel.smt2
   regress0/seq/query1-subtype.smt2

--- a/test/regress/cli/regress0/seq/proj-issue747-cmi-len-split.smt2
+++ b/test/regress/cli/regress0/seq/proj-issue747-cmi-len-split.smt2
@@ -1,0 +1,7 @@
+; EXPECT: sat
+(set-logic ALL)
+(declare-const x (Seq Bool))
+(declare-const x1 (Seq Bool))
+(assert (seq.suffixof (seq.replace_all x1 x (seq.unit (seq.suffixof x1 (seq.++ x1 x1)))) x))
+(assert (distinct x (seq.++ x1 x)))
+(check-sat)


### PR DESCRIPTION
The previous lemma would not be effective if the length of the term was rewritten.

Fixes https://github.com/cvc5/cvc5-projects/issues/747