### PR TITLE
Ensure lemmas from static learning are rewritten

### DIFF
--- a/src/preprocessing/assertion_pipeline.cpp
+++ b/src/preprocessing/assertion_pipeline.cpp
@@ -50,11 +50,8 @@ void AssertionPipeline::clear()
   d_substsIndices.clear();
 }
 
-void AssertionPipeline::push_back(Node n,
-                                  bool isInput,
-                                  ProofGenerator* pgen,
-                                  TrustId trustId,
-                 bool ensureRew)
+void AssertionPipeline::push_back(
+    Node n, bool isInput, ProofGenerator* pgen, TrustId trustId, bool ensureRew)
 {
   if (d_conflict)
   {
@@ -112,7 +109,11 @@ void AssertionPipeline::push_back(Node n,
     // add each conjunct
     for (const Node& nc : conjs)
     {
-      push_back(nc, false, d_andElimEpg.get(), TrustId::UNKNOWN_PREPROCESS_LEMMA, ensureRew);
+      push_back(nc,
+                false,
+                d_andElimEpg.get(),
+                TrustId::UNKNOWN_PREPROCESS_LEMMA,
+                ensureRew);
     }
     return;
   }
@@ -121,7 +122,7 @@ void AssertionPipeline::push_back(Node n,
     d_nodes.push_back(n);
     if (ensureRew)
     {
-      ensureRewritten(d_nodes.size()-1);
+      ensureRewritten(d_nodes.size() - 1);
     }
   }
   Trace("assert-pipeline") << "Assertions: ...new assertion " << n
@@ -142,7 +143,9 @@ void AssertionPipeline::push_back(Node n,
   }
 }
 
-void AssertionPipeline::pushBackTrusted(TrustNode trn, TrustId trustId, bool ensureRew)
+void AssertionPipeline::pushBackTrusted(TrustNode trn,
+                                        TrustId trustId,
+                                        bool ensureRew)
 {
   Assert(trn.getKind() == TrustNodeKind::LEMMA);
   // push back what was proven

--- a/src/preprocessing/assertion_pipeline.cpp
+++ b/src/preprocessing/assertion_pipeline.cpp
@@ -121,7 +121,7 @@ void AssertionPipeline::push_back(Node n,
     d_nodes.push_back(n);
     if (ensureRew)
     {
-      ensureRewritten(d_node.size()-1);
+      ensureRewritten(d_nodes.size()-1);
     }
   }
   Trace("assert-pipeline") << "Assertions: ...new assertion " << n
@@ -230,12 +230,11 @@ void AssertionPipeline::addSubstitutionNode(Node n,
   Assert(d_storeSubstsInAsserts);
   Assert(n.getKind() == Kind::EQUAL);
   size_t prevNodeSize = d_nodes.size();
-  push_back(n, false, pg, trustId);
+  // ensure rewritten here
+  push_back(n, false, pg, trustId, true);
   // remember this is a substitution index
   for (size_t i = prevNodeSize, newSize = d_nodes.size(); i < newSize; i++)
   {
-    // ensure rewritten
-    replace(i, rewrite(d_nodes[i]), d_rewpg.get());
     d_substsIndices.insert(i);
   }
 }

--- a/src/preprocessing/assertion_pipeline.cpp
+++ b/src/preprocessing/assertion_pipeline.cpp
@@ -53,7 +53,8 @@ void AssertionPipeline::clear()
 void AssertionPipeline::push_back(Node n,
                                   bool isInput,
                                   ProofGenerator* pgen,
-                                  TrustId trustId)
+                                  TrustId trustId,
+                 bool ensureRew)
 {
   if (d_conflict)
   {
@@ -111,13 +112,17 @@ void AssertionPipeline::push_back(Node n,
     // add each conjunct
     for (const Node& nc : conjs)
     {
-      push_back(nc, false, d_andElimEpg.get());
+      push_back(nc, false, d_andElimEpg.get(), TrustId::UNKNOWN_PREPROCESS_LEMMA, ensureRew);
     }
     return;
   }
   else
   {
     d_nodes.push_back(n);
+    if (ensureRew)
+    {
+      ensureRewritten(d_node.size()-1);
+    }
   }
   Trace("assert-pipeline") << "Assertions: ...new assertion " << n
                            << ", isInput=" << isInput << std::endl;
@@ -137,11 +142,11 @@ void AssertionPipeline::push_back(Node n,
   }
 }
 
-void AssertionPipeline::pushBackTrusted(TrustNode trn, TrustId trustId)
+void AssertionPipeline::pushBackTrusted(TrustNode trn, TrustId trustId, bool ensureRew)
 {
   Assert(trn.getKind() == TrustNodeKind::LEMMA);
   // push back what was proven
-  push_back(trn.getProven(), false, trn.getGenerator(), trustId);
+  push_back(trn.getProven(), false, trn.getGenerator(), trustId, ensureRew);
 }
 
 void AssertionPipeline::replace(size_t i,

--- a/src/preprocessing/assertion_pipeline.h
+++ b/src/preprocessing/assertion_pipeline.h
@@ -73,14 +73,17 @@ class AssertionPipeline : protected EnvObj
    * generator is not required and is ignored if isInput is true.
    * @param trustId The trust id to use if pg is not provided when isInput
    * is false and proofs are enabled.
+   * @param ensureRew If true, we rewrite all assertions added in this call.
    */
   void push_back(Node n,
                  bool isInput = false,
                  ProofGenerator* pg = nullptr,
-                 TrustId trustId = TrustId::UNKNOWN_PREPROCESS_LEMMA);
+                 TrustId trustId = TrustId::UNKNOWN_PREPROCESS_LEMMA,
+                 bool ensureRew = false);
   /** Same as above, with TrustNode */
   void pushBackTrusted(TrustNode trn,
-                       TrustId trustId = TrustId::UNKNOWN_PREPROCESS_LEMMA);
+                       TrustId trustId = TrustId::UNKNOWN_PREPROCESS_LEMMA,
+                 bool ensureRew = false);
 
   /**
    * Get the constant reference to the underlying assertions. It is only

--- a/src/preprocessing/assertion_pipeline.h
+++ b/src/preprocessing/assertion_pipeline.h
@@ -83,7 +83,7 @@ class AssertionPipeline : protected EnvObj
   /** Same as above, with TrustNode */
   void pushBackTrusted(TrustNode trn,
                        TrustId trustId = TrustId::UNKNOWN_PREPROCESS_LEMMA,
-                 bool ensureRew = false);
+                       bool ensureRew = false);
 
   /**
    * Get the constant reference to the underlying assertions. It is only

--- a/src/preprocessing/passes/non_clausal_simp.cpp
+++ b/src/preprocessing/passes/non_clausal_simp.cpp
@@ -82,7 +82,9 @@ PreprocessingPassResult NonClausalSimp::applyInternal(
   for (size_t i = 0, size = assertionsToPreprocess->size(); i < size; ++i)
   {
     AlwaysAssert(rewrite((*assertionsToPreprocess)[i])
-           == (*assertionsToPreprocess)[i]) << (*assertionsToPreprocess)[i] << " " << rewrite((*assertionsToPreprocess)[i]);
+                 == (*assertionsToPreprocess)[i])
+        << (*assertionsToPreprocess)[i] << " "
+        << rewrite((*assertionsToPreprocess)[i]);
     // Don't reprocess substitutions
     if (assertionsToPreprocess->isSubstsIndex(i))
     {

--- a/src/preprocessing/passes/non_clausal_simp.cpp
+++ b/src/preprocessing/passes/non_clausal_simp.cpp
@@ -81,10 +81,8 @@ PreprocessingPassResult NonClausalSimp::applyInternal(
   Trace("non-clausal-simplify") << "asserting to propagator" << std::endl;
   for (size_t i = 0, size = assertionsToPreprocess->size(); i < size; ++i)
   {
-    AlwaysAssert(rewrite((*assertionsToPreprocess)[i])
-                 == (*assertionsToPreprocess)[i])
-        << (*assertionsToPreprocess)[i] << " "
-        << rewrite((*assertionsToPreprocess)[i]);
+    Assert(rewrite((*assertionsToPreprocess)[i])
+           == (*assertionsToPreprocess)[i]) << (*assertionsToPreprocess)[i];
     // Don't reprocess substitutions
     if (assertionsToPreprocess->isSubstsIndex(i))
     {

--- a/src/preprocessing/passes/non_clausal_simp.cpp
+++ b/src/preprocessing/passes/non_clausal_simp.cpp
@@ -81,8 +81,8 @@ PreprocessingPassResult NonClausalSimp::applyInternal(
   Trace("non-clausal-simplify") << "asserting to propagator" << std::endl;
   for (size_t i = 0, size = assertionsToPreprocess->size(); i < size; ++i)
   {
-    Assert(rewrite((*assertionsToPreprocess)[i])
-           == (*assertionsToPreprocess)[i]) << (*assertionsToPreprocess)[i];
+    AlwaysAssert(rewrite((*assertionsToPreprocess)[i])
+           == (*assertionsToPreprocess)[i]) << (*assertionsToPreprocess)[i] << " " << rewrite((*assertionsToPreprocess)[i]);
     // Don't reprocess substitutions
     if (assertionsToPreprocess->isSubstsIndex(i))
     {

--- a/src/preprocessing/passes/static_learning.cpp
+++ b/src/preprocessing/passes/static_learning.cpp
@@ -60,8 +60,9 @@ PreprocessingPassResult StaticLearning::applyInternal(
     // add the lemmas to the end
     for (const TrustNode& trn : tlems)
     {
+      // ensure all learned lemmas are rewritten
       assertionsToPreprocess->pushBackTrusted(
-          trn, TrustId::PREPROCESS_STATIC_LEARNING_LEMMA);
+          trn, TrustId::PREPROCESS_STATIC_LEARNING_LEMMA, true);
     }
   }
   return PreprocessingPassResult::NO_CONFLICT;

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1287,6 +1287,7 @@ set(regress_0_tests
   regress0/preprocess/proj-issue683.smt2
   regress0/preprocess/proj-issue684.smt2
   regress0/preprocess/proj-issue685-gn.smt2
+  regress0/preprocess/proj-issue749-ensureRew.smt2
   regress0/preprocess/real-as-int-unk.smt2
   regress0/print_define_fun_internal.smt2
   regress0/print_lambda.cvc.smt2

--- a/test/regress/cli/regress0/preprocess/proj-issue749-ensureRew.smt2
+++ b/test/regress/cli/regress0/preprocess/proj-issue749-ensureRew.smt2
@@ -1,0 +1,5 @@
+; EXPECT: sat
+(set-logic QF_ABVFFLIA)
+(declare-const x Bool)
+(assert (= 0 (ite x 1 0)))
+(check-sat)


### PR DESCRIPTION
Adds this as a flag to pushing back assertions for convienience. 

Fixes https://github.com/cvc5/cvc5-projects/issues/749.