### PR TITLE
Add Eunoia definition of QUANT_DT_SPLIT

### DIFF
--- a/proofs/eo/cpc/rules/Quantifiers.eo
+++ b/proofs/eo/cpc/rules/Quantifiers.eo
@@ -1,6 +1,6 @@
 (include "../programs/Quantifiers.eo")
+(include "../programs/Datatypes.eo")
 (include "../theories/Quantifiers.eo")
-
 
 ; rule: instantiate
 ; implements: ProofRule::INSTANTIATE.
@@ -296,7 +296,7 @@
 ;    The result of eliminating x from F. This method does not evaluate if this
 ;    is not a variable elimination, i.e. if F does not begin with a disequality
 ;    between x and a term not containing x.
-(program $mk_quant_var_elim_eq ((T Type) (x T) (t Type) (F Bool :list))
+(program $mk_quant_var_elim_eq ((T Type) (x T) (t T) (F Bool :list))
   (T Bool) Bool
   (
   (($mk_quant_var_elim_eq x (not (= x t)))        ($mk_quant_var_elim_eq_subs x t false))
@@ -305,7 +305,7 @@
 )
 
 ; rule: quant-var-elim-eq
-; implements: QUANT_VAR_ELIM_EQ
+; implements: ProofRewriteRule::QUANT_VAR_ELIM_EQ
 ; args:
 ; - eq Bool: The equality whose left hand side is a quantified formula.
 ; requires: >
@@ -316,4 +316,65 @@
   :args ((= (forall (@list x) F) G))
   :requires ((($mk_quant_var_elim_eq x F) G))
   :conclusion (= (forall (@list x) F) G)
+)
+
+;;;;; ProofRewriteRule::QUANT_DT_SPLIT
+
+; program: $is_quant_dt_split_conj
+; args:
+; - x T: The variable we are eliminating.
+; - c C: The constructor term we are substituting x with.
+; - ys @List: The remaining list of variables of the left hand side we have yet to process.
+; - F Bool: The body of the left hand side of the equality.
+; - G Bool: The conjunct we are testing.
+; return: >
+;    The true iff G corresponds to a conjunct expected in the rule
+;    quant-dt-split for the current constructor.
+(program $is_quant_dt_split_conj ((T Type) (U Type) (C Type) (x T) (c C) (y U) (ys @List :list) (zs @List :list) (F Bool) (G Bool))
+  (T C @List Bool Bool) Bool
+  (
+    (($is_quant_dt_split_conj x c (@list y ys) F (forall (@list y zs) G)) (eo::requires ($contains_subterm zs y) false  ; ensure no shadowing
+                                                                            ($is_quant_dt_split_conj x c ys F (forall zs G))))
+    (($is_quant_dt_split_conj x c @list.nil F (forall (@list y zs) G))    (eo::requires ($contains_subterm zs y) false  ; ensure no shadowing
+                                                                            ($is_quant_dt_split_conj x (c y) @list.nil F (forall zs G))))
+    (($is_quant_dt_split_conj x c @list.nil F (forall @list.nil G))       ($is_quant_dt_split_conj x c @list.nil F G))
+    (($is_quant_dt_split_conj x c @list.nil F G)                          (eo::is_eq ($substitute x c F) G))
+  )
+)
+
+; program: $is_quant_dt_split
+; args:
+; - x T: The variable we are eliminating.
+; - cs eo::List: The list of constructors for x we have left to process.
+; - ys @List: The remaining list of variables of the left hand side.
+; - F Bool: The body of the left hand side of the equality.
+; - G Bool: The remaining conjuncts on the right hand side of the equality we have yet to process.
+; return: >
+;    The true iff splitting (forall (@list x ys) F) for the constructors
+;    remaining in cs is equal to the remaining conjuncts in G.
+(program $is_quant_dt_split ((T Type) (x T) (C Type) (c C) (cs eo::List :list) (ys @List) (F Bool) (g Bool) (G Bool :list))
+  (T eo::List @List Bool Bool) Bool
+  (
+    (($is_quant_dt_split x (eo::List::cons c cs) ys F (and g G)) (eo::requires
+                                                                    ($is_quant_dt_split_conj x c ys F g) true
+                                                                    ($is_quant_dt_split x cs ys F G)))
+    (($is_quant_dt_split x eo::List::nil ys F true)              true)
+    (($is_quant_dt_split x cs ys F g)                            ($is_quant_dt_split x cs ys F (and g)))  ; singleton case
+  )
+)
+
+; rule: quant-dt-split
+; implements: ProofRewriteRule::QUANT_DT_SPLIT
+; args:
+; - eq Bool: The equality whose left hand side is a quantified formula.
+; requires: >
+;   The right hand side of the equality is the result of a legal application
+;   of quantified datatypes splitting. In particular, G is a conjunction of
+;   quantified formulas obtained by taking the possible cases of constructors
+;   for x.
+; conclusion: The given equality.
+(declare-rule quant-dt-split ((T Type) (x T) (F Bool) (G Bool) (ys @List :list))
+  :args ((= (forall (@list x ys) F) G))
+  :requires ((($is_quant_dt_split x ($dt_get_constructors (eo::typeof x)) ys F G) true))
+  :conclusion (= (forall (@list x ys) F) G)
 )

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -284,6 +284,7 @@ bool AlfPrinter::isHandledTheoryRewrite(ProofRewriteRule id, const Node& n)
     case ProofRewriteRule::QUANT_MINISCOPE_OR:
     case ProofRewriteRule::QUANT_MINISCOPE_ITE:
     case ProofRewriteRule::QUANT_VAR_ELIM_EQ:
+    case ProofRewriteRule::QUANT_DT_SPLIT:
     case ProofRewriteRule::RE_LOOP_ELIM:
     case ProofRewriteRule::SETS_IS_EMPTY_EVAL:
     case ProofRewriteRule::SETS_INSERT_ELIM:


### PR DESCRIPTION
This rule is used ~140 times in SMT-LIB and 10 times in our regressions.