### PR TITLE
Do not throw an assertion failure when arithmetic model construction fails and a lemma has been sent.

### DIFF
--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -398,6 +398,10 @@ bool TheoryArith::collectModelValues(TheoryModel* m,
     {
       continue;
     }
+    else if (d_valuation.needCheck())
+    {
+      return false;
+    }
     Assert(false) << "A model equality could not be asserted: " << p.first
                   << " == " << p.second << std::endl;
     // If we failed to assert an equality, it is likely due to theory

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -400,6 +400,11 @@ bool TheoryArith::collectModelValues(TheoryModel* m,
     }
     else if (d_valuation.needCheck())
     {
+      // If a theory solver has already sent a lemma in this context, we
+      // know that theory engine will be called to recheck, so we can safely
+      // return unsuccessfully here. Note that the arithmetic solver itself
+      // may be the one that sent the lemma, for instance if we had buffered
+      // lemmas during the call to needsCheckLastEffort.
       return false;
     }
     Assert(false) << "A model equality could not be asserted: " << p.first


### PR DESCRIPTION
We are currently throwing an assertion failure when arithmetic model construction fails to assert an equality but a lemma (possibly a buffered NL from the arithmetic solver itself) has already been sent.  This case is benign as we know the theory engine will be called again to recheck. This PR makes us simply return unsuccessfully in such cases.

The assertion failure is currently firing on https://github.com/cvc5/cvc5/pull/11453, which makes an unrelated change to arithmetic.

Note that https://github.com/cvc5/cvc5/pull/11322 recently refactored the behavior.

On a related note, I have noticed the buffering of the NL solver lemmas is slightly nonsensical: depending on the order of which is called first (collectModelInfo or needsLastCallEffort), the arithmetic solver behaves differently. If the former is called first, we make no attempt to construct the model whereas if the latter is called first, we do. Making the behavior consistent (in either direction) leads to multiple regressions timing out. I will investigate this after this PR is merged.