### PR TITLE
Update policy on options exceptions

### DIFF
--- a/src/options/option_exception.cpp
+++ b/src/options/option_exception.cpp
@@ -17,4 +17,5 @@
 
 namespace cvc5::internal {
 const std::string OptionException::s_errPrefix = "Error in option parsing: ";
+const std::string FatalOptionException::s_errPrefix = "Fatal error in option parsing: ";
 }  // namespace cvc5::internal

--- a/src/options/option_exception.cpp
+++ b/src/options/option_exception.cpp
@@ -17,5 +17,6 @@
 
 namespace cvc5::internal {
 const std::string OptionException::s_errPrefix = "Error in option parsing: ";
-const std::string FatalOptionException::s_errPrefix = "Fatal error in option parsing: ";
+const std::string FatalOptionException::s_errPrefix =
+    "Fatal error in option parsing: ";
 }  // namespace cvc5::internal

--- a/src/options/option_exception.h
+++ b/src/options/option_exception.h
@@ -47,6 +47,29 @@ class CVC5_EXPORT OptionException : public cvc5::internal::Exception
   static const std::string s_errPrefix;
 }; /* class OptionException */
 
+/**
+ * Class representing an option-parsing exception such as badly-typed
+ * or missing arguments, arguments out of bounds, etc.
+ */
+class CVC5_EXPORT FatalOptionException : public cvc5::internal::Exception
+{
+ public:
+  FatalOptionException(const std::string& s) : cvc5::internal::Exception(s_errPrefix + s) {}
+
+  /**
+   * Get the error message without the prefix that is automatically added for
+   * OptionExceptions.
+   */
+  std::string getRawMessage() const
+  {
+    return getMessage().substr(s_errPrefix.size());
+  }
+
+ private:
+  /** The string to be added in front of the actual error message */
+  static const std::string s_errPrefix;
+}; /* class OptionException */
+
 }  // namespace cvc5::internal
 
 #endif /* CVC5__OPTION_EXCEPTION_H */

--- a/src/options/option_exception.h
+++ b/src/options/option_exception.h
@@ -49,7 +49,7 @@ class CVC5_EXPORT OptionException : public cvc5::internal::Exception
 
 /**
  * Class representing an option-parsing exception involving an illegal
- * combination of options. In contrast to OptionsException, it is treated as an
+ * combination of options. In contrast to OptionException, it is treated as an
  * unrecoverable exception in the API.
  *
  * At a high level, this exception is used when the user requests a legal

--- a/src/options/option_exception.h
+++ b/src/options/option_exception.h
@@ -54,7 +54,10 @@ class CVC5_EXPORT OptionException : public cvc5::internal::Exception
 class CVC5_EXPORT FatalOptionException : public cvc5::internal::Exception
 {
  public:
-  FatalOptionException(const std::string& s) : cvc5::internal::Exception(s_errPrefix + s) {}
+  FatalOptionException(const std::string& s)
+      : cvc5::internal::Exception(s_errPrefix + s)
+  {
+  }
 
   /**
    * Get the error message without the prefix that is automatically added for

--- a/src/options/option_exception.h
+++ b/src/options/option_exception.h
@@ -49,7 +49,23 @@ class CVC5_EXPORT OptionException : public cvc5::internal::Exception
 
 /**
  * Class representing an option-parsing exception such as badly-typed
- * or missing arguments, arguments out of bounds, etc.
+ * or missing arguments, arguments out of bounds, etc. This class is identical
+ * to the above one but is treated as an unrecoverable exception in the API.
+ *
+ * At a high level, this exception is used when the user requests a legal
+ * combination of options. It is *not* used in other cases, e.g. where the
+ * user requests an option that does not exist.
+ *
+ * In particular, we use this exception in two places:
+ * (1) If the SetDefaults detects an options misconfiguration e.g. at the
+ * beginning of a `check-sat` command, in which case any exception is treated
+ * as unrecoverable.
+ * (2) If we discover an illegal combination of options during a `set-option`
+ * command (e.g. due to restrictions on `safe-options`).
+ *
+ * The latter is made a fatal exception for consistency, since some
+ * options misconfigurations are discovered during SetDefaults and others
+ * are detected eagerly, where in either case we should abort.
  */
 class CVC5_EXPORT FatalOptionException : public cvc5::internal::Exception
 {

--- a/src/options/option_exception.h
+++ b/src/options/option_exception.h
@@ -52,20 +52,20 @@ class CVC5_EXPORT OptionException : public cvc5::internal::Exception
  * combination of options. In contrast to OptionException, it is treated as an
  * unrecoverable exception in the API.
  *
- * At a high level, this exception is used when the user requests a legal
- * combination of options. It is *not* used in other cases, e.g. where the
+ * At a high level, this exception is used when the user requests a illegal
+ * combination of options. It is *not* used in other cases, e.g., when the
  * user requests an option that does not exist.
  *
  * In particular, we use this exception in two places:
- * (1) If the SetDefaults detects an options misconfiguration e.g. at the
- * beginning of a `check-sat` command, in which case any exception is treated
- * as unrecoverable.
+ * (1) If the SetDefaults detects an options misconfiguration, e.g., at the
+ *     beginning of a `check-sat` command, in which case any exception is
+ *     treated as unrecoverable.
  * (2) If we discover an illegal combination of options during a `set-option`
- * command (e.g. due to restrictions on `safe-options`).
+ *     command (e.g., due to restrictions on `safe-options`).
  *
  * The latter is made a fatal exception for consistency, since some
  * options misconfigurations are discovered during SetDefaults and others
- * are detected eagerly, where in either case we should abort.
+ * are detected eagerly. In either case we should abort.
  */
 class CVC5_EXPORT FatalOptionException : public cvc5::internal::Exception
 {
@@ -78,6 +78,7 @@ class CVC5_EXPORT FatalOptionException : public cvc5::internal::Exception
   /**
    * Get the error message without the prefix that is automatically added for
    * OptionExceptions.
+   * @return The raw error message.
    */
   std::string getRawMessage() const
   {

--- a/src/options/option_exception.h
+++ b/src/options/option_exception.h
@@ -48,9 +48,9 @@ class CVC5_EXPORT OptionException : public cvc5::internal::Exception
 }; /* class OptionException */
 
 /**
- * Class representing an option-parsing exception such as badly-typed
- * or missing arguments, arguments out of bounds, etc. This class is identical
- * to the above one but is treated as an unrecoverable exception in the API.
+ * Class representing an option-parsing exception involving an illegal
+ * combination of options. In contrast to OptionsException, it is treated as an
+ * unrecoverable exception in the API.
  *
  * At a high level, this exception is used when the user requests a legal
  * combination of options. It is *not* used in other cases, e.g. where the

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -63,7 +63,7 @@ namespace smt {
     std::stringstream ss;                                                     \
     ss << "Cannot use --" << options::domain::longName::optName << " due to " \
        << reason << ".";                                                      \
-    throw OptionException(ss.str());                                          \
+    throw FatalOptionException(ss.str());                                          \
   }
 /**
  * Set domain.optName to value due to reason. Notify if value changes.
@@ -224,7 +224,7 @@ void SetDefaults::setDefaultsPre(Options& opts)
     {
       std::stringstream ss;
       ss << reasonNoProofs.str() << " not supported with proofs or unsat cores";
-      throw OptionException(ss.str());
+      throw FatalOptionException(ss.str());
     }
     SET_AND_NOTIFY(smt, produceProofs, true, "option requiring proofs");
   }
@@ -372,7 +372,7 @@ void SetDefaults::setDefaultsPre(Options& opts)
     {
       std::stringstream ss;
       ss << reasonNoProofs.str() << " not supported with proofs or unsat cores";
-      throw OptionException(ss.str());
+      throw FatalOptionException(ss.str());
     }
   }
   if (d_isInternalSubsolver)
@@ -397,7 +397,7 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
   {
     if (opts.quantifiers.sygusInst && isSygus(opts))
     {
-      throw OptionException(std::string(
+      throw FatalOptionException(std::string(
           "SyGuS instantiation quantifiers module cannot be enabled "
           "for SyGuS inputs."));
     }
@@ -425,7 +425,7 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
         ss << "for the combination of bit-vectors with arrays or uinterpreted ";
         ss << "functions. Try --" << options::bv::longName::bitblastMode << "="
            << options::BitblastMode::LAZY << ".";
-        throw OptionException(ss.str());
+        throw FatalOptionException(ss.str());
       }
       SET_AND_NOTIFY(
           bv, bitblastMode, options::BitblastMode::LAZY, "model generation");
@@ -438,7 +438,7 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
     else if (logic.isQuantified() || !logic.isPure(THEORY_BV))
     {
       // requested bitblast=eager in incremental mode, must be QF_BV only.
-      throw OptionException(
+      throw FatalOptionException(
           std::string("Eager bit-blasting is only support in incremental mode "
                       "if the logic is quantifier-free bit-vectors"));
     }
@@ -462,7 +462,7 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
       std::stringstream ss;
       ss << "solving bitvectors as integers is incompatible with --"
          << options::bv::longName::boolToBitvector << ".";
-      throw OptionException(ss.str());
+      throw FatalOptionException(ss.str());
     }
     if (logic.isTheoryEnabled(THEORY_BV))
     {
@@ -480,7 +480,7 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
   {
     if (opts.smt.produceModelsWasSetByUser)
     {
-      throw OptionException(std::string(
+      throw FatalOptionException(std::string(
           "Ackermannization currently does not support model generation."));
     }
     SET_AND_NOTIFY(smt, ackermann, false, "model generation");
@@ -560,7 +560,7 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
     {
       std::stringstream ss;
       ss << reasonNoQuant.str() << " not supported in quantified logics.";
-      throw OptionException(ss.str());
+      throw FatalOptionException(ss.str());
     }
   }
   // check if we have separation logic heap types
@@ -572,7 +572,7 @@ void SetDefaults::finalizeLogic(LogicInfo& logic, Options& opts) const
       std::stringstream ss;
       ss << reasonNoSepLogic.str()
          << " not supported when using separation logic.";
-      throw OptionException(ss.str());
+      throw FatalOptionException(ss.str());
     }
   }
 }
@@ -603,7 +603,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
       std::stringstream ss;
       ss << reasonNoInc.str() << " not supported with incremental solving. "
          << suggestNoInc.str();
-      throw OptionException(ss.str());
+      throw FatalOptionException(ss.str());
     }
   }
 
@@ -617,7 +617,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
     {
       std::stringstream ss;
       ss << reasonNoUc.str() << " not supported with unsat cores";
-      throw OptionException(ss.str());
+      throw FatalOptionException(ss.str());
     }
   }
   else
@@ -667,7 +667,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
     {
       if (opts.bv.boolToBitvectorWasSetByUser)
       {
-        throw OptionException(
+        throw FatalOptionException(
             "bool-to-bv != off not supported with CEGQI BV for quantified "
             "logics");
       }
@@ -777,7 +777,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
   {
     if (opts.bv.boolToBitvectorWasSetByUser)
     {
-      throw OptionException(
+      throw FatalOptionException(
           "bool-to-bv=all not supported for non-bitvector logics.");
     }
     SET_AND_NOTIFY_VAL_SYM(
@@ -925,7 +925,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
       {
         std::stringstream ss;
         ss << "Cannot use " << sOptNoModel << " with model generation.";
-        throw OptionException(ss.str());
+        throw FatalOptionException(ss.str());
       }
       SET_AND_NOTIFY(smt, produceModels, false, sOptNoModel);
     }
@@ -936,7 +936,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
         std::stringstream ss;
         ss << "Cannot use " << sOptNoModel
            << " with model generation (produce-assignments).";
-        throw OptionException(ss.str());
+        throw FatalOptionException(ss.str());
       }
       SET_AND_NOTIFY(smt, produceAssignments, false, sOptNoModel);
     }
@@ -947,7 +947,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
         std::stringstream ss;
         ss << "Cannot use " << sOptNoModel
            << " with model generation (check-models).";
-        throw OptionException(ss.str());
+        throw FatalOptionException(ss.str());
       }
       SET_AND_NOTIFY(smt, checkModels, false, sOptNoModel);
     }
@@ -956,7 +956,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
   if (opts.bv.bitblastMode == options::BitblastMode::EAGER
       && !logic.isPure(THEORY_BV) && logic.getLogicString() != "QF_UFBV")
   {
-    throw OptionException(
+    throw FatalOptionException(
         "Eager bit-blasting does not currently support theory combination with "
         "any theory other than UF. ");
   }
@@ -1588,7 +1588,7 @@ void SetDefaults::setDefaultsQuantifiers(const LogicInfo& logic,
     {
       std::stringstream ss;
       ss << reasonNoSygus.str() << " not supported in sygus.";
-      throw OptionException(ss.str());
+      throw FatalOptionException(ss.str());
     }
     // now, set defaults based on sygus
     setDefaultsSygus(opts);

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -63,7 +63,7 @@ namespace smt {
     std::stringstream ss;                                                     \
     ss << "Cannot use --" << options::domain::longName::optName << " due to " \
        << reason << ".";                                                      \
-    throw FatalOptionException(ss.str());                                          \
+    throw FatalOptionException(ss.str());                                     \
   }
 /**
  * Set domain.optName to value due to reason. Notify if value changes.

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -2169,7 +2169,7 @@ void SolverEngine::setOption(const std::string& key,
       // option exception
       std::stringstream ss;
       ss << "expert option " << key
-         << " cannot be set when safeOptions is true.";
+         << " cannot be set when safe-options is true.";
       // If we are setting to a default value, the exception can be avoided
       // by omitting the expert option.
       if (getOption(key) == value)
@@ -2195,7 +2195,7 @@ void SolverEngine::setOption(const std::string& key,
         // option exception
         std::stringstream ss;
         ss << "cannot set two regular options (" << d_safeOptsRegularOption
-           << " and " << key << ") when safeOptions is true.";
+           << " and " << key << ") when safe-options is true.";
         // similar to above, if setting to default value for either of the
         // regular options.
         for (size_t i = 0; i < 2; i++)

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -2160,7 +2160,7 @@ void SolverEngine::setOption(const std::string& key,
   {
     if (key == "trace")
     {
-      throw OptionException("cannot use trace messages with safe-options");
+      throw FatalOptionException("cannot use trace messages with safe-options");
     }
     // verify its a regular option
     options::OptionInfo oinfo = options::getInfo(getOptions(), key);
@@ -2179,7 +2179,7 @@ void SolverEngine::setOption(const std::string& key,
         ss << " The value for " << key << " is already its current value ("
            << value << "). Omitting this option may avoid this exception.";
       }
-      throw OptionException(ss.str());
+      throw FatalOptionException(ss.str());
     }
     else if (oinfo.category == options::OptionInfo::Category::REGULAR)
     {
@@ -2212,7 +2212,7 @@ void SolverEngine::setOption(const std::string& key,
                << rvalue << "). Omitting this option may avoid this exception.";
           }
         }
-        throw OptionException(ss.str());
+        throw FatalOptionException(ss.str());
       }
     }
   }

--- a/src/theory/bv/int_blaster.cpp
+++ b/src/theory/bv/int_blaster.cpp
@@ -25,9 +25,9 @@
 #include "expr/node_algorithm.h"
 #include "expr/node_traversal.h"
 #include "expr/skolem_manager.h"
-#include "options/option_exception.h"
 #include "options/uf_options.h"
 #include "proof/proof.h"
+#include "smt/logic_exception.h"
 #include "theory/bv/theory_bv_utils.h"
 #include "theory/logic_info.h"
 #include "theory/rewriter.h"
@@ -323,7 +323,7 @@ Node IntBlaster::translateWithChildren(
     */
    if (childrenTypesChanged(original) && logicInfo().isHigherOrder())
    {
-     throw OptionException("bv-to-int does not support higher order logic ");
+     throw LogicException("bv-to-int does not support higher order logic ");
    }
   // Translate according to the kind of the original node.
   switch (oldKind)
@@ -665,7 +665,7 @@ Node IntBlaster::translateWithChildren(
       returnNode = d_nm->mkNode(oldKind, translated_children);
       if (d_mode == options::SolveBVAsIntMode::BITWISE)
       {
-        throw OptionException(
+        throw LogicException(
             "--solve-bv-as-int=bitwise does not support quantifiers");
       }
       break;

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1170,6 +1170,7 @@ set(regress_0_tests
   regress0/options/safe-options2.smt2
   regress0/options/safe-options3.smt2
   regress0/options/safe-opts-warn.smt2
+  regress0/options/safe-options-fatal.smt2
   regress0/options/set-after-init.smt2
   regress0/options/set-and-get-options.smt2
   regress0/options/statistics.smt2

--- a/test/regress/cli/regress0/options/safe-options-fatal.smt2
+++ b/test/regress/cli/regress0/options/safe-options-fatal.smt2
@@ -1,6 +1,6 @@
 ; DISABLE-TESTER: dump
 ; REQUIRES: no-competition
-; EXPECT: (error "Fatal error in option parsing: expert option global-negate cannot be set when safeOptions is true.")
+; EXPECT: (error "Fatal error in option parsing: expert option global-negate cannot be set when safe-options is true.")
 ; EXIT: 1
 (set-logic ALL)
 (set-option :safe-options true)

--- a/test/regress/cli/regress0/options/safe-options-fatal.smt2
+++ b/test/regress/cli/regress0/options/safe-options-fatal.smt2
@@ -1,0 +1,8 @@
+; DISABLE-TESTER: dump
+; REQUIRES: no-competition
+; EXPECT: (error "Fatal error in option parsing: expert option global-negate cannot be set when safeOptions is true.")
+(set-logic ALL)
+(set-option :safe-options true)
+(set-option :global-negate true)
+; should immediately terminate without running this check-sat
+(check-sat)

--- a/test/regress/cli/regress0/options/safe-options-fatal.smt2
+++ b/test/regress/cli/regress0/options/safe-options-fatal.smt2
@@ -1,6 +1,7 @@
 ; DISABLE-TESTER: dump
 ; REQUIRES: no-competition
 ; EXPECT: (error "Fatal error in option parsing: expert option global-negate cannot be set when safeOptions is true.")
+; EXIT: 1
 (set-logic ALL)
 (set-option :safe-options true)
 (set-option :global-negate true)

--- a/test/regress/cli/regress0/options/safe-options1.smt2
+++ b/test/regress/cli/regress0/options/safe-options1.smt2
@@ -1,7 +1,7 @@
 ; DISABLE-TESTER: dump
 ; REQUIRES: no-competition
 ; COMMAND-LINE: --safe-options
-; EXPECT: (error "Fatal error in option parsing: expert option wf-checking cannot be set when safeOptions is true.")
+; EXPECT: (error "Fatal error in option parsing: expert option wf-checking cannot be set when safe-options is true.")
 ; EXIT: 1
 (set-logic ALL)
 (set-option :wf-checking true)

--- a/test/regress/cli/regress0/options/safe-options1.smt2
+++ b/test/regress/cli/regress0/options/safe-options1.smt2
@@ -1,5 +1,8 @@
+; DISABLE-TESTER: dump
+; REQUIRES: no-competition
 ; COMMAND-LINE: --safe-options
-; EXPECT: (error "Error in option parsing: expert option wf-checking cannot be set when safeOptions is true.")
+; EXPECT: (error "Fatal error in option parsing: expert option wf-checking cannot be set when safeOptions is true.")
+; EXIT: 1
 (set-logic ALL)
 (set-option :wf-checking true)
 

--- a/test/regress/cli/regress0/options/safe-options2.smt2
+++ b/test/regress/cli/regress0/options/safe-options2.smt2
@@ -1,6 +1,6 @@
 ; REQUIRES: no-competition
 ; COMMAND-LINE: --safe-options --global-negate
-; EXPECT-ERROR: (error "Fatal error in option parsing: expert option global-negate cannot be set when safeOptions is true.")
+; EXPECT-ERROR: (error "Fatal error in option parsing: expert option global-negate cannot be set when safe-options is true.")
 ; EXIT: 1
 ; DISABLE-TESTER: dump
 (set-logic ALL)

--- a/test/regress/cli/regress0/options/safe-options2.smt2
+++ b/test/regress/cli/regress0/options/safe-options2.smt2
@@ -1,8 +1,6 @@
 ; REQUIRES: no-competition
 ; COMMAND-LINE: --safe-options --global-negate
-; EXPECT-ERROR: (error "Error in option parsing: expert option global-negate cannot be set when safeOptions is true.")
-; EXPECT-ERROR:
-; EXPECT-ERROR: Please use --help to get help on command-line options.
+; EXPECT-ERROR: (error "Fatal error in option parsing: expert option global-negate cannot be set when safeOptions is true.")
 ; EXIT: 1
 ; DISABLE-TESTER: dump
 (set-logic ALL)

--- a/test/regress/cli/regress0/options/safe-opts-warn.smt2
+++ b/test/regress/cli/regress0/options/safe-opts-warn.smt2
@@ -1,6 +1,6 @@
 ; REQUIRES: no-competition
 ; COMMAND-LINE: --safe-options --no-fp-exp
-; EXPECT-ERROR: (error "Fatal error in option parsing: expert option fp-exp cannot be set when safeOptions is true. The value for fp-exp is already its current value (false). Omitting this option may avoid this exception.")
+; EXPECT-ERROR: (error "Fatal error in option parsing: expert option fp-exp cannot be set when safe-options is true. The value for fp-exp is already its current value (false). Omitting this option may avoid this exception.")
 ; EXIT: 1
 ; DISABLE-TESTER: dump
 (set-logic ALL)

--- a/test/regress/cli/regress0/options/safe-opts-warn.smt2
+++ b/test/regress/cli/regress0/options/safe-opts-warn.smt2
@@ -1,8 +1,6 @@
 ; REQUIRES: no-competition
 ; COMMAND-LINE: --safe-options --no-fp-exp
-; EXPECT-ERROR: (error "Error in option parsing: expert option fp-exp cannot be set when safeOptions is true. The value for fp-exp is already its current value (false). Omitting this option may avoid this exception.")
-; EXPECT-ERROR:
-; EXPECT-ERROR: Please use --help to get help on command-line options.
+; EXPECT-ERROR: (error "Fatal error in option parsing: expert option fp-exp cannot be set when safeOptions is true. The value for fp-exp is already its current value (false). Omitting this option may avoid this exception.")
 ; EXIT: 1
 ; DISABLE-TESTER: dump
 (set-logic ALL)

--- a/test/regress/cli/regress0/sygus/interpolant-gn.smt2
+++ b/test/regress/cli/regress0/sygus/interpolant-gn.smt2
@@ -1,4 +1,4 @@
-; EXPECT: (error "Error in option parsing: global negate not supported in sygus.")
+; EXPECT: (error "Fatal error in option parsing: global negate not supported in sygus.")
 ; EXIT: 1
 (set-logic ALL)
 (set-option :global-negate true)

--- a/test/regress/cli/regress2/bv_to_int_quantifiers_bvand.smt2
+++ b/test/regress/cli/regress2/bv_to_int_quantifiers_bvand.smt2
@@ -1,5 +1,5 @@
 ; COMMAND-LINE: --solve-bv-as-int=bitwise --bvand-integer-granularity=1
-; EXPECT: (error "Error in option parsing: --solve-bv-as-int=bitwise does not support quantifiers")
+; EXPECT: (error "--solve-bv-as-int=bitwise does not support quantifiers")
 ; EXIT: 1
 (set-logic BV)
 (declare-const x (_ BitVec 8))

--- a/test/unit/options/options_black.cpp
+++ b/test/unit/options/options_black.cpp
@@ -36,7 +36,7 @@ class TestBlackOptions : public TestApi
 {
  public:
   /**
-   * Sets setting options for option "name", including setting error values.
+   * Tests setting options for option "name", including error values.
    */
   void testSetOption(const std::string& name)
   {

--- a/test/unit/options/options_black.cpp
+++ b/test/unit/options/options_black.cpp
@@ -36,7 +36,7 @@ class TestBlackOptions : public TestApi
 {
  public:
   /**
-   * Sets setting options for option "name".
+   * Sets setting options for option "name", including setting error values.
    */
   void testSetOption(const std::string& name)
   {
@@ -154,6 +154,60 @@ class TestBlackOptions : public TestApi
     {
     }
   }
+  /**
+   * Sets a single valid option for option "name".
+   */
+  void testSetOptionOnce(const std::string& name)
+  {
+    auto info = d_solver->getOptionInfo(name);
+
+    try
+    {
+      std::visit(
+          overloaded{
+              [this, &name](const OptionInfo::VoidInfo& v) {
+                d_solver->setOption(name, "");
+              },
+              [this, &name](const OptionInfo::ValueInfo<bool>& v) {
+                d_solver->setOption(name, "false");
+              },
+              [this, &name](const OptionInfo::ValueInfo<std::string>& v) {
+                d_solver->setOption(name, "foo");
+              },
+              [this, &name](const OptionInfo::NumberInfo<int64_t>& v) {
+                std::pair<int64_t, int64_t> range{
+                    std::numeric_limits<int64_t>::min(),
+                    std::numeric_limits<int64_t>::max()};
+                d_solver->setOption(
+                    name, std::to_string((range.first + range.second) / 2));
+              },
+              [this, &name](const OptionInfo::NumberInfo<uint64_t>& v) {
+                std::pair<uint64_t, uint64_t> range{
+                    std::numeric_limits<uint64_t>::min(),
+                    std::numeric_limits<uint64_t>::max()};
+                d_solver->setOption(
+                    name, std::to_string((range.first + range.second) / 2));
+              },
+              [this, &name](const OptionInfo::NumberInfo<double>& v) {
+                std::pair<double, double> range{
+                    std::numeric_limits<double>::min(),
+                    std::numeric_limits<double>::max()};
+                d_solver->setOption(
+                    name, std::to_string((range.first + range.second) / 2));
+              },
+              [this, &name](const OptionInfo::ModeInfo& v) {
+                if (!v.modes.empty())
+                {
+                  d_solver->setOption(name, v.modes.first);
+                }
+              },
+          },
+          info.valueInfo);
+    }
+    catch (const CVC5ApiOptionException&)
+    {
+    }
+  }
 };
 
 TEST_F(TestBlackOptions, set)
@@ -216,7 +270,8 @@ TEST_F(TestBlackOptions, setSafe)
     {
       testing::internal::CaptureStdout();
     }
-    testSetOption(name);
+    // set the option once
+    testSetOptionOnce(name);
     if (muted.count(name))
     {
       testing::internal::GetCapturedStdout();

--- a/test/unit/options/options_black.cpp
+++ b/test/unit/options/options_black.cpp
@@ -198,7 +198,7 @@ class TestBlackOptions : public TestApi
               [this, &name](const OptionInfo::ModeInfo& v) {
                 if (!v.modes.empty())
                 {
-                  d_solver->setOption(name, v.modes.first);
+                  d_solver->setOption(name, v.modes[0]);
                 }
               },
           },


### PR DESCRIPTION
The motivation is to have a more consistent policy regarding whether an illegal combination of options is recoverable or unrecoverable. This is currently unintuitive since we are detecting some cases eagerly (in SolverEngine::setOptions) and some lazily (in SetDefaults::setDefaults). This makes both *un*recoverable.