### PR TITLE
ci: Add manual trigger for wheel publication

### DIFF
--- a/.github/workflows/package_pypi.yml
+++ b/.github/workflows/package_pypi.yml
@@ -4,6 +4,17 @@ on:
   schedule:
     - cron: '0 1 * * *'
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Tag of the release to build"
+        required: true
+      deploy_target:
+        type: choice
+        description: "Choose the deployment target"
+        options:
+        - None
+        - PyPI
+        - Test PyPI
 
 name: PyPi packaging
 
@@ -52,6 +63,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        ref: ${{ github.event.inputs.release_tag }}
 
     # Required by PEP-668
     - name: Set up Python virtual environment
@@ -123,10 +135,14 @@ jobs:
 
     - name: Install software for publishing the wheels
       run: |
+        python3 -m pip install -U packaging # See https://github.com/pypa/twine/issues/1216
         python3 -m pip install twine
 
     - name: Upload wheels to pypi.org
-      if: ${{ github.event_name == 'release' }}
+      if: >
+        github.event_name == 'release' ||
+        (github.event_name == 'workflow_dispatch' &&
+         github.event.inputs.deploy_target == 'PyPI')
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
@@ -139,7 +155,9 @@ jobs:
         echo "::endgroup::"
 
     - name: Upload wheels to test.pypi.org
-      if: false
+      if: >
+        github.event_name == 'workflow_dispatch' &&
+        github.event.inputs.deploy_target == 'Test PyPI'
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
It also applies a workaround for the Twine issue [#1216](https://github.com/pypa/twine/issues/1216).