### PR TITLE
Demote more string rewrites to the extended rewriter

### DIFF
--- a/src/theory/quantifiers/extended_rewrite.cpp
+++ b/src/theory/quantifiers/extended_rewrite.cpp
@@ -239,7 +239,7 @@ Node ExtendedRewriter::extendedRewrite(Node n) const
       TypeNode tret = ret[0].getType();
       if (tret.isInteger())
       {
-        theory::strings::ArithEntail ae(&d_rew);
+        strings::ArithEntail ae(&d_rew);
         new_ret = ae.rewritePredViaEntailment(ret);
         if (!new_ret.isNull())
         {
@@ -248,15 +248,7 @@ Node ExtendedRewriter::extendedRewrite(Node n) const
       }
       else if (tret.isStringLike())
       {
-        Node len0 = d_nm->mkNode(Kind::STRING_LENGTH, ret[0]);
-        Node len1 = d_nm->mkNode(Kind::STRING_LENGTH, ret[1]);
-        Node len_eq = len0.eqNode(len1);
-        len_eq = d_rew.rewrite(len_eq);
-        if (len_eq.isConst() && !len_eq.getConst<bool>())
-        {
-          new_ret = len_eq;
-          debugExtendedRewrite(ret, new_ret, "String EQUAL len entailment");
-        }
+        new_ret = extendedRewriteStrings(ret);
       }
     }
   }
@@ -264,7 +256,7 @@ Node ExtendedRewriter::extendedRewrite(Node n) const
   {
     if (ret[0].getType().isInteger())
     {
-      theory::strings::ArithEntail ae(&d_rew);
+      strings::ArithEntail ae(&d_rew);
       new_ret = ae.rewritePredViaEntailment(ret);
       if (!new_ret.isNull())
       {
@@ -1744,23 +1736,163 @@ Node ExtendedRewriter::extendedRewriteStrings(const Node& node) const
   Trace("q-ext-rewrite-debug")
       << "Extended rewrite strings : " << node << std::endl;
 
+  // allow recursive approximations
+  strings::ArithEntail ae(&d_rew, true);
+  strings::StringsEntail se(&d_rew, ae);
+  strings::SequencesRewriter sr(d_nm, ae, se, nullptr);
+
   Kind k = node.getKind();
   if (k == Kind::EQUAL)
   {
-    // allow recursive approximations
-    strings::ArithEntail ae(&d_rew, true);
-    strings::StringsEntail se(&d_rew, ae);
-    strings::SequencesRewriter sr(d_nm, ae, se, nullptr);
-    return sr.rewriteEqualityExt(node);
+    // we invoke the extended equality rewriter, which does standard
+    // rewrites, which notice are only invoked at preprocessing
+    // and not during Rewriter::rewrite.
+    Node ret = sr.rewriteEqualityExt(node);
+    if (ret != node)
+    {
+      debugExtendedRewrite(node, ret, "STR_EXT_EQ_REWRITE");
+      return ret;
+    }
+
+    // ------- length entailment
+    Node len0 = d_nm->mkNode(Kind::STRING_LENGTH, node[0]);
+    Node len1 = d_nm->mkNode(Kind::STRING_LENGTH, node[1]);
+    Node len_eq = len0.eqNode(len1);
+    len_eq = d_rew.rewrite(len_eq);
+    if (len_eq == d_false)
+    {
+      debugExtendedRewrite(node, d_false, "String EQUAL len entailment");
+      return d_false;
+    }
+
+    TypeNode stype = node[0].getType();
+    std::vector<Node> c[2];
+    for (unsigned i = 0; i < 2; i++)
+    {
+      strings::utils::getConcat(node[i], c[i]);
+    }
+
+    // ------- homogeneous constants
+    for (unsigned i = 0; i < 2; i++)
+    {
+      Node cn = se.checkHomogeneousString(node[i]);
+      if (!cn.isNull() && !strings::Word::isEmpty(cn))
+      {
+        Assert(cn.isConst());
+        Assert(strings::Word::getLength(cn) == 1);
+
+        // The operands of the concat on each side of the equality without
+        // constant strings
+        std::vector<Node> trimmed[2];
+        // Counts the number of `cn`s on each side
+        size_t numCns[2] = {0, 0};
+        for (size_t j = 0; j < 2; j++)
+        {
+          // Sort the operands of the concats on both sides of the equality
+          // (since both sides may only contain one char, the order does not
+          // matter)
+          std::sort(c[j].begin(), c[j].end());
+          for (const Node& cc : c[j])
+          {
+            if (cc.isConst())
+            {
+              // Count the number of `cn`s in the string constant and make
+              // sure that all chars are `cn`s
+              std::vector<Node> veccc = strings::Word::getChars(cc);
+              for (const Node& cv : veccc)
+              {
+                if (cv != cn)
+                {
+                  // This conflict case should mostly should be taken care of by
+                  // multiset reasoning in the strings rewriter, but we
+                  // recognize this conflict just in case.
+                  debugExtendedRewrite(node, d_false, "STR_EQ_CONST_NHOMOG");
+                  return d_false;
+                }
+                numCns[j]++;
+              }
+            }
+            else
+            {
+              trimmed[j].push_back(cc);
+            }
+          }
+        }
+
+        // We have to remove the same number of `cn`s from both sides, so the
+        // side with less `cn`s determines how many we can remove
+        size_t trimmedConst = std::min(numCns[0], numCns[1]);
+        for (size_t j = 0; j < 2; j++)
+        {
+          size_t diff = numCns[j] - trimmedConst;
+          if (diff != 0)
+          {
+            // Add a constant string to the side with more `cn`s to restore
+            // the difference in number of `cn`s
+            std::vector<Node> vec(diff, cn);
+            trimmed[j].push_back(strings::Word::mkWordFlatten(vec));
+          }
+        }
+
+        Node lhs = strings::utils::mkConcat(trimmed[i], stype);
+        Node ss = strings::utils::mkConcat(trimmed[1 - i], stype);
+        if (lhs != node[i] || ss != node[1 - i])
+        {
+          // e.g.
+          //  "AA" = y ++ x ---> "AA" = x ++ y if x < y
+          //  "AAA" = y ++ "A" ++ z ---> "AA" = y ++ z
+          //
+          // We generally don't apply the extended equality rewriter if the
+          // original node was an equality but we may be able to do additional
+          // rewriting here.
+          Node new_ret = lhs.eqNode(ss);
+          debugExtendedRewrite(node, new_ret, "STR_EQ_CONST_NHOMOG");
+          return new_ret;
+        }
+      }
+    }
+  }
+  else if (k == Kind::STRING_CONCAT)
+  {
+    // Sort adjacent operands in str.++ that all result in the same string or
+    // the empty string.
+    //
+    // E.g.: (str.++ ... (str.replace "A" x "") "A" (str.substr "A" 0 z) ...)
+    // --> (str.++ ... [sort those 3 arguments] ... )
+    std::vector<Node> vec(node.begin(), node.end());
+    size_t lastIdx = 0;
+    Node lastX;
+    for (size_t i = 0, nsize = vec.size(); i < nsize; i++)
+    {
+      Node s = se.getStringOrEmpty(vec[i]);
+      bool nextX = false;
+      if (s != lastX)
+      {
+        nextX = true;
+      }
+      if (nextX)
+      {
+        std::sort(vec.begin() + lastIdx, vec.begin() + i);
+        lastX = s;
+        lastIdx = i;
+      }
+    }
+    std::sort(vec.begin() + lastIdx, vec.end());
+    TypeNode tn = node.getType();
+    Node retNode = strings::utils::mkConcat(vec, tn);
+    if (retNode != node)
+    {
+      debugExtendedRewrite(node, retNode, "CONCAT_NORM_SORT");
+      return retNode;
+    }
   }
   else if (k == Kind::STRING_SUBSTR)
   {
     NodeManager* nm = d_nm;
     Node tot_len = d_rew.rewrite(nm->mkNode(Kind::STRING_LENGTH, node[0]));
-    strings::ArithEntail aent(&d_rew);
     // (str.substr s x y) --> "" if x < len(s) |= 0 >= y
     Node n1_lt_tot_len = d_rew.rewrite(nm->mkNode(Kind::LT, node[1], tot_len));
-    if (aent.checkWithAssumption(n1_lt_tot_len, d_intZero, node[2], false))
+    if (ae.checkWithAssumption(n1_lt_tot_len, d_intZero, node[2], false))
     {
       Node ret = strings::Word::mkEmptyWord(node.getType());
       debugExtendedRewrite(node, ret, "SS_START_ENTAILS_ZERO_LEN");
@@ -1769,7 +1901,7 @@ Node ExtendedRewriter::extendedRewriteStrings(const Node& node) const
 
     // (str.substr s x y) --> "" if 0 < y |= x >= str.len(s)
     Node non_zero_len = d_rew.rewrite(nm->mkNode(Kind::LT, d_intZero, node[2]));
-    if (aent.checkWithAssumption(non_zero_len, node[1], tot_len, false))
+    if (ae.checkWithAssumption(non_zero_len, node[1], tot_len, false))
     {
       Node ret = strings::Word::mkEmptyWord(node.getType());
       debugExtendedRewrite(node, ret, "SS_NON_ZERO_LEN_ENTAILS_OOB");
@@ -1778,7 +1910,7 @@ Node ExtendedRewriter::extendedRewriteStrings(const Node& node) const
     // (str.substr s x y) --> "" if x >= 0 |= 0 >= str.len(s)
     Node geq_zero_start =
         d_rew.rewrite(nm->mkNode(Kind::GEQ, node[1], d_intZero));
-    if (aent.checkWithAssumption(geq_zero_start, d_intZero, tot_len, false))
+    if (ae.checkWithAssumption(geq_zero_start, d_intZero, tot_len, false))
     {
       Node ret = strings::Word::mkEmptyWord(node.getType());
       debugExtendedRewrite(node, ret, "SS_GEQ_ZERO_START_ENTAILS_EMP_S");
@@ -1789,8 +1921,6 @@ Node ExtendedRewriter::extendedRewriteStrings(const Node& node) const
   {
     if (node[0] == node[2])
     {
-      theory::strings::ArithEntail ae(&d_rew);
-      theory::strings::StringsEntail se(&d_rew, ae);
       // (str.replace x y x) ---> (str.replace x (str.++ y1 ... yn) x)
       // if 1 >= (str.len x) and (= y "") ---> (= y1 "") ... (= yn "")
       if (se.checkLengthOne(node[0]))
@@ -1819,7 +1949,9 @@ Node ExtendedRewriter::extendedRewriteStrings(const Node& node) const
       }
     }
     Node cmp_con = d_nm->mkNode(Kind::STRING_CONTAINS, node[0], node[1]);
-    Node cmp_conr = d_rew.rewrite(cmp_con);
+    // note we make a full recursive call to extended rewrite here, which should
+    // be fine since the term we are rewriting is simpler than the current one.
+    Node cmp_conr = extendedRewrite(cmp_con);
     if (cmp_conr.getKind() == Kind::EQUAL || cmp_conr.getKind() == Kind::AND)
     {
       TypeNode stype = node.getType();
@@ -1873,6 +2005,53 @@ Node ExtendedRewriter::extendedRewriteStrings(const Node& node) const
         }
       }
     }
+  }
+  else if (k == Kind::STRING_CONTAINS)
+  {
+    if (node[0].getKind() == Kind::STRING_REPLACE)
+    {
+      // (str.contains (str.replace x y z) w) --->
+      //   (str.contains (str.replace x y "") w)
+      // if (str.contains z w) ---> false and (str.len w) = 1
+      if (se.checkLengthOne(node[1]))
+      {
+        Node ctn = se.checkContains(node[0][2], node[1]);
+        if (!ctn.isNull() && !ctn.getConst<bool>())
+        {
+          TypeNode stype = node[0].getType();
+          Node empty = strings::Word::mkEmptyWord(stype);
+          Node ret = d_nm->mkNode(
+              Kind::STRING_CONTAINS,
+              d_nm->mkNode(Kind::STRING_REPLACE, node[0][0], node[0][1], empty),
+              node[1]);
+          debugExtendedRewrite(node, ret, "CTN_REPL_SIMP_REPL");
+          return ret;
+        }
+      }
+    }
+    std::vector<Node> nc2;
+    strings::utils::getConcat(node[1], nc2);
+    for (const Node& n : nc2)
+    {
+      // (str.contains x (str.++ w (str.replace x y x) z)) --->
+      //   (= x (str.++ w (str.replace x y x) z))
+      //
+      if (n.getKind() == Kind::STRING_REPLACE && node[0] == n[0]
+          && node[0] == n[2])
+      {
+        Node ret = d_nm->mkNode(Kind::EQUAL, node[0], node[1]);
+        debugExtendedRewrite(node, ret, "CTN_REPL_SELF");
+        return ret;
+      }
+    }
+  }
+  // otherwise, the use of recursive approximations and rewriting via
+  // the entailment utilities may make a standard conditional rewrite
+  // applicable.
+  RewriteResponse rr = sr.postRewrite(node);
+  if (rr.d_node != node)
+  {
+    return rr.d_node;
   }
 
   return Node::null();


### PR DESCRIPTION
These rewrites have not shown to be important in practice and moreover are cumbersome to represent in proofs.

The behavior of the extended rewriter still is able to accomplish these rewrites. 

The extended rewriter is modified slightly in this PR to be more robust in general with further changes.