### PR TITLE
ci: Update Ubuntu runners to 22.04

### DIFF
--- a/.github/actions/configure-and-build/action.yml
+++ b/.github/actions/configure-and-build/action.yml
@@ -45,12 +45,7 @@ runs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
         
         cd build-shared/ && pwd=$(pwd)
-        if [[ "$RUNNER_OS" == "Windows" ]]; then
-          ccache --set-config="base_dir=$pwd"
-        else
-          # can not use `ccache --set-config=base_dir=` due to ccache bug, fixed with 3.7.10
-          $SED -i.orig -n -e '/^base_dir = /!p' -e "\$abase_dir = $pwd" $CCACHE_CONFIGPATH
-        fi
+        ccache --set-config="base_dir=$pwd"
         
         make -j${{ env.num_proc }}
 
@@ -70,12 +65,7 @@ runs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
 
         cd build-static/ && pwd=$(pwd)
-        if [[ "$RUNNER_OS" == "Windows" ]]; then
-          ccache --set-config="base_dir=$pwd"
-        else
-          # can not use `ccache --set-config=base_dir=` due to ccache bug, fixed with 3.7.10
-          $SED -i.orig -n -e '/^base_dir = /!p' -e "\$abase_dir = $pwd" $CCACHE_CONFIGPATH
-        fi
+        ccache --set-config="base_dir=$pwd"
 
         make -j${{ env.num_proc }}
 
@@ -90,11 +80,7 @@ runs:
       shell: ${{ inputs.shell }}
       run: |
         echo "::group::Reset ccache base_dir"
-        if [[ "$RUNNER_OS" == "Windows" ]]; then
-          ccache --set-config="base_dir="
-        else
-          $SED -i.orig -n -e '/^base_dir = /!p' -e "\$abase_dir =" $CCACHE_CONFIGPATH
-        fi
+        ccache --set-config="base_dir="
         echo "::endgroup::"
 
     - name: ccache Statistics

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -31,7 +31,6 @@ runs:
           libtinfo-dev \
           libfl-dev
         echo "SED=sed" >> $GITHUB_ENV
-        echo "CCACHE_CONFIGPATH=/home/runner/.ccache/ccache.conf" >> $GITHUB_ENV
         echo "::endgroup::"
 
     - name: Install software for cross-compiling for arm64 Linux
@@ -117,7 +116,6 @@ runs:
           ccache \
           gnu-sed
         echo "SED=gsed" >> $GITHUB_ENV
-        echo "CCACHE_CONFIGPATH=/Users/runner/Library/Preferences/ccache/ccache.conf" >> $GITHUB_ENV
         echo "num_proc=$(( $(sysctl -n hw.logicalcpu) + 1 ))" >> $GITHUB_ENV
         echo "::endgroup::"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           - ${{ startsWith(github.ref, 'refs/tags/') }}
         build:
           - name: ubuntu:production
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             config: production --auto-download --all-bindings --editline --docs --docs-ga -DBUILD_GMP=1
             cache-key: production
             strip-bin: strip
@@ -99,7 +99,7 @@ jobs:
             windows-build: true
 
           - name: wasm:production
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             config: production --static --static-binary --auto-download --wasm=JS --wasm-flags='-s MODULARIZE'
             cache-key: productionwasm
             wasm-build: true
@@ -107,7 +107,7 @@ jobs:
             build-static: true
 
           - name: ubuntu:production-clang
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             env: CC=clang CXX=clang++
             config: production --auto-download --no-poly
             cache-key: productionclang
@@ -116,7 +116,7 @@ jobs:
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
           - name: ubuntu:production-dbg
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             config: production --auto-download --assertions --tracing --unit-testing --all-bindings --editline --cocoa --gpl
             cache-key: dbg
             exclude_regress: 3-4
@@ -124,7 +124,7 @@ jobs:
             python-bindings: true
 
           - name: ubuntu:production-dbg-clang
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             env: CC=clang CXX=clang++
             config: production --auto-download --assertions --tracing --cln --gpl
             cache-key: dbgclang
@@ -133,7 +133,7 @@ jobs:
 
           # GPL versions
           - name: ubuntu:production-gpl
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             config: production --auto-download --editline --gpl --cln --glpk --cocoa -DBUILD_GMP=1 -DBUILD_CLN=1
             cache-key: production-gpl
             strip-bin: strip


### PR DESCRIPTION
CI currently builds cvc5 on Ubuntu 20.04 to ensure compatibility with this older OS version for dynamically linked binaries. However, the Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-01 (see [notice](https://github.com/actions/runner-images/issues/11101) here). Therefore, this PR updates the runners to Ubuntu 22.04.

Additionally, this PR removes a workaround previously required for old versions of ccache.