### PR TITLE
Add more regressions demonstrating tricky proof cases 

### DIFF
--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1367,7 +1367,6 @@ set(regress_0_tests
   regress0/proofs/dsl-rule-comp-types.smt2
   regress0/proofs/equal-eval-rw_340.smt2
   regress0/proofs/eval-rhs.smt2
-  regress0/proofs/exists-shadow-simple.smt2
   regress0/proofs/fixed-point-rew.smt2
   regress0/proofs/fixed-point-rew-conc.smt2
   regress0/proofs/indexof-eval-rw_155.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -34,6 +34,7 @@ set(regress_0_tests
   regress0/arith/bug549.cvc.smt2
   regress0/arith/bug569.smt2
   regress0/arith/dd_59_static_learn.smt2
+  regress0/arith/dd_cs_dekker.smt2
   regress0/arith/delta-minimized-row-vector-bug.smtv1.smt2
   regress0/arith/div-chainable.smt2
   regress0/arith/div.01.smt2
@@ -1366,6 +1367,7 @@ set(regress_0_tests
   regress0/proofs/dsl-rule-comp-types.smt2
   regress0/proofs/equal-eval-rw_340.smt2
   regress0/proofs/eval-rhs.smt2
+  regress0/proofs/exists-shadow-simple.smt2
   regress0/proofs/fixed-point-rew.smt2
   regress0/proofs/fixed-point-rew-conc.smt2
   regress0/proofs/indexof-eval-rw_155.smt2
@@ -1495,6 +1497,8 @@ set(regress_0_tests
   regress0/quantifiers/clock-3.smt2
   regress0/quantifiers/cond-var-elim-binary.smt2
   regress0/quantifiers/dd_german169_semi_eval.smt2
+  regress0/quantifiers/dd_p15_dio_lemma.smt2
+  regress0/quantifiers/dd_psyco_186-ineq-elim.smt2
   regress0/quantifiers/dd_quick_sort-q-rew.smt2
   regress0/quantifiers/dd_rts-quant-elim-eq-tester.smt2
   regress0/quantifiers/dd_spark2014-pat.smt2
@@ -1594,6 +1598,7 @@ set(regress_0_tests
   regress0/quantifiers/simp-len.smt2
   regress0/quantifiers/simp-typ-test.smt2
   regress0/quantifiers/ufnia-fv-delta.smt2
+  regress0/quantifiers/var-elim-ineq-simple.smt2
   regress0/quantifiers/veqt-delta.smt2
   regress0/quoted-symbols.smt2
   regress0/rec-fun-const-parse-bug.smt2
@@ -1877,6 +1882,7 @@ set(regress_0_tests
   regress0/strings/dd_norn_675.smt2
   regress0/strings/dd_rw_984.smt2
   regress0/strings/dd_slog_2087_ctn_split.smt2
+  regress0/strings/dd_slog_stranger_2020.smt2
   regress0/strings/delta-trust-subs.smt2
   regress0/strings/denghan-instance56567.smt2
   regress0/strings/distinct-witness-id.smt2
@@ -1958,6 +1964,8 @@ set(regress_0_tests
   regress0/strings/norn-simp-rew.smt2
   regress0/strings/nterm-pc-zalig.smt2
   regress0/strings/parser-syms.cvc.smt2
+  regress0/strings/prefix-multi-var.smt2
+  regress0/strings/prefix-multi-var-emp.smt2
   regress0/strings/prefix-simple-no-pf.smt2
   regress0/strings/prefix-suffix-eval.smt2
   regress0/strings/proj-issue316-regexp-ite.smt2
@@ -1979,6 +1987,7 @@ set(regress_0_tests
   regress0/strings/re-mem-eval-large.smt2
   regress0/strings/re-mem-include-rewrite.smt2
   regress0/strings/re-none-rewrites.smt2
+  regress0/strings/re-str-inference-missing.smt2
   regress0/strings/re-syntax.smt2
   regress0/strings/re.all.smt2
   regress0/strings/regexp_inclusion_reduction.smt2
@@ -3759,6 +3768,7 @@ set(regress_2_tests
   regress2/push-pop/DRAGON_4_e2_2799_e3_1915.lus.ic3.1.min.smt2
   regress2/quantifiers/AdditiveMethods_AdditiveMethods..ctor.smt2
   regress2/quantifiers/cee-event-wrong-sat.smt2
+  regress2/quantifiers/dd10_sdlx-fix-4.smt2
   regress2/quantifiers/gn-wrong-091018.smt2
   regress2/quantifiers/issue3481-unsat1.smt2
   regress2/quantifiers/javafe.ast.StandardPrettyPrint.319.smt2

--- a/test/regress/cli/regress0/arith/dd_cs_dekker.smt2
+++ b/test/regress/cli/regress0/arith/dd_cs_dekker.smt2
@@ -1,0 +1,11 @@
+; EXPECT: unsat
+; DISABLE-TESTER: alethe
+(set-logic ALL)
+(declare-fun o () Int)
+(declare-fun d () Int)
+(assert (<= d o))
+(assert (>= d o))
+(assert (<= o 0))
+(assert (>= o 0))
+(assert (= 1 (mod d 2)))
+(check-sat)

--- a/test/regress/cli/regress0/proofs/exists-shadow-simple.smt2
+++ b/test/regress/cli/regress0/proofs/exists-shadow-simple.smt2
@@ -1,0 +1,4 @@
+; EXPECT: unsat
+(set-logic ADTLIRA)
+(assert (exists ((k Int) (k Int)) false))
+(check-sat)

--- a/test/regress/cli/regress0/proofs/exists-shadow-simple.smt2
+++ b/test/regress/cli/regress0/proofs/exists-shadow-simple.smt2
@@ -1,4 +1,0 @@
-; EXPECT: unsat
-(set-logic ADTLIRA)
-(assert (exists ((k Int) (k Int)) false))
-(check-sat)

--- a/test/regress/cli/regress0/quantifiers/dd_p15_dio_lemma.smt2
+++ b/test/regress/cli/regress0/quantifiers/dd_p15_dio_lemma.smt2
@@ -1,0 +1,5 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-fun d () Int)
+(assert (forall ((v Int)) (or (= d (div v 2)) (= 0 (mod (div v 2) 2)))))
+(check-sat)

--- a/test/regress/cli/regress0/quantifiers/dd_psyco_186-ineq-elim.smt2
+++ b/test/regress/cli/regress0/quantifiers/dd_psyco_186-ineq-elim.smt2
@@ -1,0 +1,6 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-fun W () Bool)
+(assert (forall ((S Int) (S1 Int)) (or (not (and (>= 1 1) (>= S 0))) (= S (+ (- 1) (ite W 0 1))))))
+(assert W)
+(check-sat)

--- a/test/regress/cli/regress0/quantifiers/var-elim-ineq-simple.smt2
+++ b/test/regress/cli/regress0/quantifiers/var-elim-ineq-simple.smt2
@@ -7,5 +7,4 @@
 (forall ((x Int) (y Int)) (or (> x y) (> x b) (= x 2) (> y 0)))
 )
 )
-;(assert (forall ((x Int) (y Int)) (or (< x y) (< x b) (< y 0))))
 (check-sat)

--- a/test/regress/cli/regress0/quantifiers/var-elim-ineq-simple.smt2
+++ b/test/regress/cli/regress0/quantifiers/var-elim-ineq-simple.smt2
@@ -1,0 +1,11 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-fun a () Int)
+(declare-fun b () Int)
+(assert (or
+(forall ((x Int) (y Int)) (or (< x y) (< x b) (= x 2) (< y 0)))
+(forall ((x Int) (y Int)) (or (> x y) (> x b) (= x 2) (> y 0)))
+)
+)
+;(assert (forall ((x Int) (y Int)) (or (< x y) (< x b) (< y 0))))
+(check-sat)

--- a/test/regress/cli/regress0/strings/dd_slog_stranger_2020.smt2
+++ b/test/regress/cli/regress0/strings/dd_slog_stranger_2020.smt2
@@ -1,3 +1,5 @@
+; EXPECT: unsat
+(set-logic ALL)
 (declare-fun x () String)
 (assert (= "" (str.++ "" x)))
 (assert (str.in_re (str.++ (str.++ "f" x) "f") (re.++ (re.* re.allchar) (re.++ (str.to_re "{") (re.* re.allchar)))))

--- a/test/regress/cli/regress0/strings/dd_slog_stranger_2020.smt2
+++ b/test/regress/cli/regress0/strings/dd_slog_stranger_2020.smt2
@@ -1,0 +1,4 @@
+(declare-fun x () String)
+(assert (= "" (str.++ "" x)))
+(assert (str.in_re (str.++ (str.++ "f" x) "f") (re.++ (re.* re.allchar) (re.++ (str.to_re "{") (re.* re.allchar)))))
+(check-sat)

--- a/test/regress/cli/regress0/strings/prefix-multi-var-emp.smt2
+++ b/test/regress/cli/regress0/strings/prefix-multi-var-emp.smt2
@@ -1,0 +1,10 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-fun x () String)
+(declare-fun y () String)
+(declare-fun z () String)
+(declare-fun w () String)
+(declare-fun u () String)
+(assert (= "" (str.++ x y x w y z)))
+(assert (not (= w "")))
+(check-sat)

--- a/test/regress/cli/regress0/strings/prefix-multi-var.smt2
+++ b/test/regress/cli/regress0/strings/prefix-multi-var.smt2
@@ -1,0 +1,10 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-fun x () String)
+(declare-fun y () String)
+(declare-fun z () String)
+(declare-fun w () String)
+(declare-fun u () String)
+(assert (= (str.++ x y x w y z) (str.++ x x)))
+(assert (not (= w "")))
+(check-sat)

--- a/test/regress/cli/regress0/strings/re-str-inference-missing.smt2
+++ b/test/regress/cli/regress0/strings/re-str-inference-missing.smt2
@@ -1,0 +1,7 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-fun r () String)
+(assert (not (str.in_re r (re.++ (str.to_re "aa$b$c$$") (re.union (str.to_re "") ((_ re.loop 3 3) (re.range "0" "9")))))))
+(assert (str.in_re r (re.++ (str.to_re "aa$b$") (re.* (re.union (re.range "a" "z") (re.range "0" "9"))) (str.to_re "$$") (re.union (str.to_re "") ((_ re.loop 3 3) (re.range "0" "9"))))))
+(assert (str.in_re r (re.++ (str.to_re "aa$b$c$") (re.* re.allchar))))
+(check-sat)

--- a/test/regress/cli/regress2/quantifiers/dd10_sdlx-fix-4.smt2
+++ b/test/regress/cli/regress2/quantifiers/dd10_sdlx-fix-4.smt2
@@ -1,0 +1,29 @@
+; EXPECT: unsat
+; DISABLE-TESTER: proof
+(set-logic ALL)
+(declare-const x238 Bool)
+(declare-const x24 Bool)
+(declare-const x2 Bool)
+(declare-const x23 Bool)
+(declare-const x Bool)
+(declare-const x7 Bool)
+(declare-const x37 Bool)
+(declare-const x3 Bool)
+(declare-const x9 Bool)
+(declare-const x8 Bool)
+(declare-const x814 Bool)
+(declare-const x81 Bool)
+(declare-const x815 Bool)
+(declare-const x82 Bool)
+(assert (forall ((r Bool) (ri Bool) (Ve Bool) (e (_ BitVec 6)) (i Bool) (f Bool)) (exists ((er (_ BitVec 6)) (V Bool)) 
+(or 
+f 
+(and x37 x81 x23 x3 x8 x x815 x24 x238 ri x7 x2 x814 x82 (not (ite x82 false Ve))) 
+(not (= i (= (_ bv1 6) (ite Ve (_ bv0 6) (_ bv1 6))))) 
+(and 
+  x9 
+  (or 
+    (and x815 x8 x24 x814 x81 x7 x23 x82 x2 x238 x37 x3 (ite x9 false r) (= e (_ bv0 6))) 
+    (and x9 (= e (ite x9 (_ bv1 6) er)) (= e (ite x815 (_ bv0 6) (ite x82 (_ bv0 6) (ite x815 (_ bv0 6) (ite x9 er (ite ri (_ bv0 6) (_ bv1 6)))))))))
+)))))
+(check-sat)


### PR DESCRIPTION
Includes one regression where cvc5 fails to generate a proof, due to non-determinism in the rewriter.  I've opened https://github.com/cvc5/cvc5-projects/issues/760 to track this.