### PR TITLE
Add missing `const`s to iterator members

### DIFF
--- a/src/expr/node_value.h
+++ b/src/expr/node_value.h
@@ -97,7 +97,7 @@ class CVC5_EXPORT NodeValue
     explicit iterator(const_nv_iterator i) : d_i(i) {}
 
     /** Conversion of a TNode iterator to a Node iterator. */
-    inline operator NodeValue::iterator<NodeTemplate<true> >()
+    inline operator NodeValue::iterator<NodeTemplate<true> >() const
     {
       return iterator<NodeTemplate<true> >(d_i);
     }
@@ -136,11 +136,11 @@ class CVC5_EXPORT NodeValue
       return *this;
     }
 
-    iterator operator+(difference_type p) { return iterator(d_i + p); }
+    iterator operator+(difference_type p) const { return iterator(d_i + p); }
 
-    iterator operator-(difference_type p) { return iterator(d_i - p); }
+    iterator operator-(difference_type p) const { return iterator(d_i - p); }
 
-    difference_type operator-(iterator i) { return d_i - i.d_i; }
+    difference_type operator-(iterator i) const { return d_i - i.d_i; }
 
    private:
     const_nv_iterator d_i;


### PR DESCRIPTION
This is necessary to build against libc++ in newer LLVM versions.