### PR TITLE
More updates to classifications of options

### DIFF
--- a/src/options/decision_options.toml
+++ b/src/options/decision_options.toml
@@ -4,7 +4,7 @@ name   = "Decision Heuristics"
 [[option]]
   name       = "decisionMode"
   alias      = ["decision-mode"]
-  category   = "regular"
+  category   = "common"
   long       = "decision=MODE"
   type       = "DecisionMode"
   default    = "INTERNAL"

--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -80,6 +80,14 @@ name   = "Quantifiers"
   help       = "enable simple variable elimination for quantified formulas"
 
 [[option]]
+  name       = "varEntEqElimQuant"
+  category   = "expert"
+  long       = "var-ent-eq-elim-quant"
+  type       = "bool"
+  default    = "false"
+  help       = "enable variable elimination for quantified formulas that infers entailed equalities corresponding to eliminations"
+
+[[option]]
   name       = "varIneqElimQuant"
   category   = "regular"
   long       = "var-ineq-elim-quant"
@@ -212,7 +220,7 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "eMatching"
-  category   = "regular"
+  category   = "common"
   long       = "e-matching"
   type       = "bool"
   default    = "true"
@@ -515,7 +523,7 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "fullSaturateQuant"
-  category   = "regular"
+  category   = "common"
   long       = "full-saturate-quant"
   type       = "bool"
   default    = "false"
@@ -523,7 +531,7 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "enumInst"
-  category   = "regular"
+  category   = "common"
   long       = "enum-inst"
   type       = "bool"
   default    = "false"

--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -220,7 +220,7 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "eMatching"
-  category   = "common"
+  category   = "regular"
   long       = "e-matching"
   type       = "bool"
   default    = "true"

--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -150,7 +150,7 @@ name   = "SMT Layer"
 
 [[option]]
   name       = "produceUnsatCores"
-  category   = "regular"
+  category   = "common"
   long       = "produce-unsat-cores"
   type       = "bool"
   default    = "false"
@@ -192,7 +192,7 @@ name   = "SMT Layer"
 
 [[option]]
   name       = "checkUnsatCores"
-  category   = "regular"
+  category   = "common"
   long       = "check-unsat-cores"
   type       = "bool"
   default    = "false"
@@ -317,7 +317,7 @@ name   = "SMT Layer"
 
 [[option]]
   name       = "unconstrainedSimp"
-  category   = "regular"
+  category   = "expert"
   long       = "unconstrained-simp"
   type       = "bool"
   default    = "false"
@@ -333,7 +333,7 @@ name   = "SMT Layer"
 
 [[option]]
   name       = "sortInference"
-  category   = "regular"
+  category   = "expert"
   long       = "sort-inference"
   type       = "bool"
   default    = "false"

--- a/src/theory/quantifiers/quantifiers_rewriter.cpp
+++ b/src/theory/quantifiers/quantifiers_rewriter.cpp
@@ -1241,6 +1241,13 @@ Node QuantifiersRewriter::getVarElimEqString(Node lit,
                                              Node& var) const
 {
   Assert(lit.getKind() == Kind::EQUAL);
+  // The reasoning below involves equality entailment as
+  // (= (str.++ s x t) r) entails (= x (str.substr r (str.len s) _)),
+  // but these equalities are not equivalent.
+  if (!d_opts.quantifiers.varEntEqElimQuant)
+  {
+    return Node::null();
+  }
   NodeManager* nm = nodeManager();
   for (unsigned i = 0; i < 2; i++)
   {

--- a/test/regress/cli/regress1/quantifiers/issue2970-string-var-elim.smt2
+++ b/test/regress/cli/regress1/quantifiers/issue2970-string-var-elim.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE:
+; COMMAND-LINE: --var-ent-eq-elim-quant
 (set-logic ALL)
 (set-info :status unsat)
 (declare-fun s () String)


### PR DESCRIPTION
Makes the following changes:
- `produceUnsatCores`, `checkUnsatCores` are promoted to "common" as they are part of our core infrastructure.
- `fullSaturateQuant`/`enumInst` (which are an alias of one another) are promoted to "common". The justification is that this option is recommended to be used in addition to any other combination of options for quantifiers for those that prefer more effort + timeouts to unknowns.
- Similarly, `decisionMode` is promoted to "common", as it is intended to be used in combination with all other options, e.g. in portfolios.
- `unconstrainedSimp` and `sortInference` are demoted to "expert" since they do not meet the requirements of producing *models* (as well as proofs).
- A new expert option `varEntEqElimQuant` now guards a (seldom used) rewrite for quantifiers+strings that is hard to justify.