### PR TITLE
Simplify CPC and Eunoia definition of ARITH_POLY_NORM_REL

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -1929,7 +1929,7 @@ enum ENUM(ProofRule)
    * **Arithmetic -- Polynomial normalization for relations**
    *
    * .. math::
-   *  \inferrule{c_x \cdot (x_1 - x_2) = c_y \cdot (y_1 - y_2) \mid \diamond}
+   *  \inferrule{c_x \cdot (x_1 - x_2) = c_y \cdot (y_1 - y_2) \mid (x_1 \diamond x_2) = (y_1 \diamond y_2)}
    *            {(x_1 \diamond x_2) = (y_1 \diamond y_2)}
    *
    * where :math:`\diamond \in \{<, \leq, =, \geq, >\}` for arithmetic and

--- a/proofs/eo/cpc/Cpc.eo
+++ b/proofs/eo/cpc/Cpc.eo
@@ -333,12 +333,13 @@
 ;   are equal modulo polynomial normalization and some scaling factors. These
 ;   terms may be of arithmetic or bitvector type.
 ; args:
-; - r (-> U U Bool): The relation whose equivalence is proven by this rule.
-; conclusion: An equivalence between relations of the terms specified by eq.
-(declare-rule arith_poly_norm_rel ((U Type) (t U) (s U) (r (-> U U Bool)))
+; - eqr Bool: The equivalence between relations, proven by this rule.
+; conclusion: >
+;   An equivalence between relations specified by eqr and justified by eq.
+(declare-rule arith_poly_norm_rel ((U Type) (t U) (s U) (eqr Bool))
   :premises ((= t s))
-  :args (r)
-  :conclusion ($mk_poly_norm_rel t s r)
+  :args (eqr)
+  :conclusion ($mk_poly_norm_rel t s eqr)
 )
 
 ; define: $get_aci_normal_form

--- a/proofs/eo/cpc/programs/PolyNorm.eo
+++ b/proofs/eo/cpc/programs/PolyNorm.eo
@@ -276,19 +276,17 @@
 ; return: >
 ;   The conclusion of ProofRule::ARITH_POLY_NORM_REL. This program does not
 ;   evaluate if the input to this proof rule is invalid.
-(program $mk_poly_norm_rel ((U Type) (r (-> U U Bool)) (x U) (y U) (cx U) (cy U)
+(program $mk_poly_norm_rel ((U Type) (r (-> U U Bool)) (x U) (y U) (cx U) (cy U) (x1 U) (x2 U) (y1 U) (y2 U)
                             (n Int) (c (BitVec n)) (nil (BitVec n) :list) 
                             (xb1 (BitVec n)) (xb2 (BitVec n)) (yb1 (BitVec n)) (yb2 (BitVec n)))
-  (U U (-> U U Bool)) Bool
+  (U U Bool) Bool
   (
-    (($mk_poly_norm_rel (* cx x) (* cy y) r)
+    (($mk_poly_norm_rel (* cx x) (* cy y) (= (r x1 x2) (r y1 y2)))
         (eo::requires ($is_poly_norm_rel_consts (r cx cy)) true
-        (eo::match ((x1 U) (x2 U) (y1 U) (y2 U))
-          (@pair ($remove_to_real x) ($remove_to_real y))
-          (
-          ((@pair (- x1 x2) (- y1 y2)) (= (r x1 x2) (r y1 y2)))))
-          ))
-    (($mk_poly_norm_rel (bvmul c (bvsub xb1 xb2) nil) (bvmul c (bvsub yb1 yb2) nil) =)
+        (eo::requires ($remove_to_real x) (- x1 x2)
+        (eo::requires ($remove_to_real y) (- y1 y2)
+          (= (r x1 x2) (r y1 y2))))))
+    (($mk_poly_norm_rel (bvmul c (bvsub xb1 xb2) nil) (bvmul c (bvsub yb1 yb2) nil) (= (= xb1 xb2) (= yb1 yb2)))
         (eo::requires (eo::to_z c) 1
         (eo::requires (eo::to_z nil) 1
           (= (= xb1 xb2) (= yb1 yb2)))))

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -922,13 +922,6 @@ void AlfPrinter::getArgsFromProofRule(const ProofNode* pn,
   ProofRule r = pn->getRule();
   switch (r)
   {
-    case ProofRule::ARITH_POLY_NORM_REL:
-    {
-      Node op = d_tproc.getOperatorOfTerm(res[0]);
-      args.push_back(d_tproc.convert(op));
-      return;
-    }
-    break;
     case ProofRule::HO_CONG:
     {
       // argument is ignored

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -1313,7 +1313,6 @@ bool BasicRewriteRCons::ensureProofArithPolyNormRel(CDProof* cdp,
     Trace("brc-macro") << "...fail premise" << std::endl;
     return false;
   }
-  Node kn = ProofRuleChecker::mkKindNode(nodeManager(), eq[0].getKind());
   if (!cdp->addStep(eq, ProofRule::ARITH_POLY_NORM_REL, {premise}, {eq}))
   {
     Trace("brc-macro") << "...fail application" << std::endl;

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -1314,7 +1314,7 @@ bool BasicRewriteRCons::ensureProofArithPolyNormRel(CDProof* cdp,
     return false;
   }
   Node kn = ProofRuleChecker::mkKindNode(nodeManager(), eq[0].getKind());
-  if (!cdp->addStep(eq, ProofRule::ARITH_POLY_NORM_REL, {premise}, {kn}))
+  if (!cdp->addStep(eq, ProofRule::ARITH_POLY_NORM_REL, {premise}, {eq}))
   {
     Trace("brc-macro") << "...fail application" << std::endl;
     return false;

--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -1217,7 +1217,7 @@ bool RewriteDbProofCons::ensureProofInternal(
           cdp->addStep(cur,
                        ProofRule::ARITH_POLY_NORM_REL,
                        {pcur.d_vars[0]},
-                       {ProofRuleChecker::mkKindNode(nm, cur[0].getKind())});
+                       {cur});
         }
       }
       else if (pcur.d_id == RewriteProofStatus::DSL

--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -1214,10 +1214,8 @@ bool RewriteDbProofCons::ensureProofInternal(
         {
           cdp->addStep(
               pcur.d_vars[0], ProofRule::ARITH_POLY_NORM, {}, {pcur.d_vars[0]});
-          cdp->addStep(cur,
-                       ProofRule::ARITH_POLY_NORM_REL,
-                       {pcur.d_vars[0]},
-                       {cur});
+          cdp->addStep(
+              cur, ProofRule::ARITH_POLY_NORM_REL, {pcur.d_vars[0]}, {cur});
         }
       }
       else if (pcur.d_id == RewriteProofStatus::DSL

--- a/src/theory/arith/proof_checker.cpp
+++ b/src/theory/arith/proof_checker.cpp
@@ -413,10 +413,13 @@ Node ArithProofRuleChecker::checkInternal(ProofRule id,
     {
       Assert(children.size() == 1);
       Assert(args.size() == 1);
-      Kind k;
-      if (!getKind(args[0], k)
-          || (k != Kind::LT && k != Kind::LEQ && k != Kind::EQUAL
-              && k != Kind::GT && k != Kind::GEQ))
+      if (args[0].getKind()!=Kind::EQUAL)
+      {
+        return Node::null();
+      }
+      Kind k = args[0][0].getKind();
+      if (k != Kind::LT && k != Kind::LEQ && k != Kind::EQUAL
+              && k != Kind::GT && k != Kind::GEQ)
       {
         return Node::null();
       }
@@ -469,7 +472,12 @@ Node ArithProofRuleChecker::checkInternal(ProofRule id,
           return Node::null();
         }
       }
-      return nm->mkNode(k, x1, x2).eqNode(nm->mkNode(k, y1, y2));
+      Node ret = nm->mkNode(k, x1, x2).eqNode(nm->mkNode(k, y1, y2));
+      if (ret!=args[0])
+      {
+        return Node::null();
+      }
+      return ret;
     }
     default: return Node::null();
   }

--- a/src/theory/arith/proof_checker.cpp
+++ b/src/theory/arith/proof_checker.cpp
@@ -413,13 +413,13 @@ Node ArithProofRuleChecker::checkInternal(ProofRule id,
     {
       Assert(children.size() == 1);
       Assert(args.size() == 1);
-      if (args[0].getKind()!=Kind::EQUAL)
+      if (args[0].getKind() != Kind::EQUAL)
       {
         return Node::null();
       }
       Kind k = args[0][0].getKind();
-      if (k != Kind::LT && k != Kind::LEQ && k != Kind::EQUAL
-              && k != Kind::GT && k != Kind::GEQ)
+      if (k != Kind::LT && k != Kind::LEQ && k != Kind::EQUAL && k != Kind::GT
+          && k != Kind::GEQ)
       {
         return Node::null();
       }
@@ -473,7 +473,7 @@ Node ArithProofRuleChecker::checkInternal(ProofRule id,
         }
       }
       Node ret = nm->mkNode(k, x1, x2).eqNode(nm->mkNode(k, y1, y2));
-      if (ret!=args[0])
+      if (ret != args[0])
       {
         return Node::null();
       }

--- a/src/theory/uf/proof_checker.cpp
+++ b/src/theory/uf/proof_checker.cpp
@@ -127,10 +127,6 @@ Node UfProofRuleChecker::checkInternal(ProofRule id,
     }
     NodeManager* nm = nodeManager();
     Node l = nm->mkNode(k, lchildren);
-    if (l != args[0])
-    {
-      return Node::null();
-    }
     Node r = nm->mkNode(k, rchildren);
     return l.eqNode(r);
   }

--- a/src/theory/uf/proof_checker.cpp
+++ b/src/theory/uf/proof_checker.cpp
@@ -127,6 +127,10 @@ Node UfProofRuleChecker::checkInternal(ProofRule id,
     }
     NodeManager* nm = nodeManager();
     Node l = nm->mkNode(k, lchildren);
+    if (l != args[0])
+    {
+      return Node::null();
+    }
     Node r = nm->mkNode(k, rchildren);
     return l.eqNode(r);
   }


### PR DESCRIPTION
This change has a similar motivation to https://github.com/cvc5/cvc5/pull/11501.

In particular, it is unintuitive to store an internal kind as an argument to a proof rule which is exported.  Instead, we store the conclusion of the rule, analogous to ARITH_POLY_NORM. The Eunoia definition can be made more elegant.