### PR TITLE
Introduce a primative string utility `Word::hasOverlap`

### DIFF
--- a/src/expr/sequence.cpp
+++ b/src/expr/sequence.cpp
@@ -339,14 +339,6 @@ Sequence Sequence::substr(size_t i, size_t j) const
   return Sequence(getType(), retVec);
 }
 
-bool Sequence::noOverlapWith(const Sequence& y) const
-{
-  Assert(getType() == y.getType());
-  return y.find(*this) == std::string::npos
-         && this->find(y) == std::string::npos && this->overlap(y) == 0
-         && y.overlap(*this) == 0;
-}
-
 size_t Sequence::maxSize() { return std::numeric_limits<uint32_t>::max(); }
 
 std::ostream& operator<<(std::ostream& os, const Sequence& s)

--- a/src/expr/sequence.h
+++ b/src/expr/sequence.h
@@ -100,16 +100,6 @@ class Sequence
   /** Return the suffix of this sequence of size at most i */
   Sequence suffix(size_t i) const { return substr(size() - i, i); }
 
-  /**
-   * Checks if there is any overlap between this sequence and another sequence.
-   * This corresponds to checking whether one sequence contains the other and
-   * whether a subsequence of one is a prefix of the other and vice-versa.
-   *
-   * @param y The other sequence
-   * @return True if there is an overlap, false otherwise
-   */
-  bool noOverlapWith(const Sequence& y) const;
-
   /** sequence overlap
    *
    * if overlap returns m>0,

--- a/src/theory/quantifiers/extended_rewrite.cpp
+++ b/src/theory/quantifiers/extended_rewrite.cpp
@@ -2010,9 +2010,12 @@ Node ExtendedRewriter::extendedRewriteStrings(const Node& node) const
   {
     if (node[0].getKind() == Kind::STRING_REPLACE)
     {
+      TypeNode stype = node[0].getType();
+      Node empty = strings::Word::mkEmptyWord(stype);
       if (node[1].isConst() && node[0][1].isConst() && node[0][2].isConst())
       {
-        if (!strings::Word::hasBidirectionalOverlap(node[1], node[0][1])
+        if (node[1] != empty && node[0][1] != empty && node[0][2] != empty
+            && !strings::Word::hasBidirectionalOverlap(node[1], node[0][1])
             && !strings::Word::hasBidirectionalOverlap(node[1], node[0][2]))
         {
           // (str.contains (str.replace x c1 c2) c3) ---> (str.contains x c3)
@@ -2030,8 +2033,6 @@ Node ExtendedRewriter::extendedRewriteStrings(const Node& node) const
         Node ctn = se.checkContains(node[0][2], node[1]);
         if (!ctn.isNull() && !ctn.getConst<bool>())
         {
-          TypeNode stype = node[0].getType();
-          Node empty = strings::Word::mkEmptyWord(stype);
           Node ret = d_nm->mkNode(
               Kind::STRING_CONTAINS,
               d_nm->mkNode(Kind::STRING_REPLACE, node[0][0], node[0][1], empty),

--- a/src/theory/quantifiers/extended_rewrite.cpp
+++ b/src/theory/quantifiers/extended_rewrite.cpp
@@ -2010,6 +2010,18 @@ Node ExtendedRewriter::extendedRewriteStrings(const Node& node) const
   {
     if (node[0].getKind() == Kind::STRING_REPLACE)
     {
+      if (node[1].isConst() && node[0][1].isConst() && node[0][2].isConst())
+      {
+        if (!strings::Word::hasBidirectionalOverlap(node[1], node[0][1])
+            && !strings::Word::hasBidirectionalOverlap(node[1], node[0][2]))
+        {
+          // (str.contains (str.replace x c1 c2) c3) ---> (str.contains x c3)
+          // if there is no overlap between c1 and c3 and none between c2 and c3
+          Node ret = d_nm->mkNode(Kind::STRING_CONTAINS, node[0][0], node[1]);
+          debugExtendedRewrite(node, ret, "CTN_REPL_CNSTS_TO_CTN");
+          return ret;
+        }
+      }
       // (str.contains (str.replace x y z) w) --->
       //   (str.contains (str.replace x y "") w)
       // if (str.contains z w) ---> false and (str.len w) = 1

--- a/src/theory/strings/sequences_rewriter.cpp
+++ b/src/theory/strings/sequences_rewriter.cpp
@@ -2576,7 +2576,7 @@ Node SequencesRewriter::rewriteContains(Node node)
         if (node[0][i].isConst())
         {
           // if no overlap, we can split into disjunction
-          if (Word::noOverlapWith(node[0][i], node[1]))
+          if (!Word::hasBidirectionalOverlap(node[0][i], node[1]))
           {
             std::vector<Node> nc0;
             utils::getConcat(node[0], nc0);
@@ -2612,18 +2612,6 @@ Node SequencesRewriter::rewriteContains(Node node)
   }
   else if (node[0].getKind() == Kind::STRING_REPLACE)
   {
-    if (node[1].isConst() && node[0][1].isConst() && node[0][2].isConst())
-    {
-      if (Word::noOverlapWith(node[1], node[0][1])
-          && Word::noOverlapWith(node[1], node[0][2]))
-      {
-        // (str.contains (str.replace x c1 c2) c3) ---> (str.contains x c3)
-        // if there is no overlap between c1 and c3 and none between c2 and c3
-        Node ret = nm->mkNode(Kind::STRING_CONTAINS, node[0][0], node[1]);
-        return returnRewrite(node, ret, Rewrite::CTN_REPL_CNSTS_TO_CTN);
-      }
-    }
-
     if (node[0][0] == node[0][2])
     {
       // (str.contains (str.replace x y x) y) ---> (str.contains x y)

--- a/src/theory/strings/sequences_rewriter.cpp
+++ b/src/theory/strings/sequences_rewriter.cpp
@@ -2575,8 +2575,10 @@ Node SequencesRewriter::rewriteContains(Node node)
         // constant contains
         if (node[0][i].isConst())
         {
+          Assert (Word::getLength(node[0][i])!=0);
           // if no overlap, we can split into disjunction
-          if (!Word::hasBidirectionalOverlap(node[0][i], node[1]))
+          if (!Word::hasOverlap(node[0][i], node[1], false)
+              && !Word::hasOverlap(node[0][i], node[1], true))
           {
             std::vector<Node> nc0;
             utils::getConcat(node[0], nc0);

--- a/src/theory/strings/word.cpp
+++ b/src/theory/strings/word.cpp
@@ -425,7 +425,7 @@ bool Word::hasOverlap(TNode x, TNode y, bool rev)
 
 bool Word::hasBidirectionalOverlap(TNode x, TNode y)
 {
-  return hasOverlap(x,y,false) || hasOverlap(y,x,false);
+  return hasOverlap(x, y, false) || hasOverlap(y, x, false);
 }
 
 std::size_t Word::overlap(TNode x, TNode y)

--- a/src/theory/strings/word.cpp
+++ b/src/theory/strings/word.cpp
@@ -377,25 +377,55 @@ Node Word::suffix(TNode x, std::size_t i)
   return Node::null();
 }
 
-bool Word::noOverlapWith(TNode x, TNode y)
+bool Word::hasOverlap(TNode x, TNode y, bool rev)
 {
   Kind k = x.getKind();
   if (k == Kind::CONST_STRING)
   {
     Assert(y.getKind() == Kind::CONST_STRING);
     String sx = x.getConst<String>();
+    if (sx.empty())
+    {
+      // by convention, the empty string has no overlap (including with the
+      // empty string)
+      return false;
+    }
     String sy = y.getConst<String>();
-    return sx.noOverlapWith(sy);
+    if (rev)
+    {
+      return (sx.find(sy) != std::string::npos || sx.roverlap(sy) != 0);
+    }
+    else
+    {
+      return (sx.find(sy) == std::string::npos || sx.overlap(sy) != 0);
+    }
   }
   else if (k == Kind::CONST_SEQUENCE)
   {
     Assert(y.getKind() == Kind::CONST_SEQUENCE);
     const Sequence& sx = x.getConst<Sequence>();
+    if (sx.empty())
+    {
+      // same as above
+      return false;
+    }
     const Sequence& sy = y.getConst<Sequence>();
-    return sx.noOverlapWith(sy);
+    if (rev)
+    {
+      return (sx.find(sy) != std::string::npos || sx.roverlap(sy) != 0);
+    }
+    else
+    {
+      return (sx.find(sy) == std::string::npos || sx.overlap(sy) != 0);
+    }
   }
   Unimplemented();
   return false;
+}
+
+bool Word::hasBidirectionalOverlap(TNode x, TNode y)
+{
+  return hasOverlap(x,y,false) || hasOverlap(y,x,false);
 }
 
 std::size_t Word::overlap(TNode x, TNode y)

--- a/src/theory/strings/word.cpp
+++ b/src/theory/strings/word.cpp
@@ -383,12 +383,12 @@ bool Word::hasOverlap(TNode x, TNode y, bool rev)
   if (k == Kind::CONST_STRING)
   {
     Assert(y.getKind() == Kind::CONST_STRING);
+    const String& sx = x.getConst<String>();
     const String& sy = y.getConst<String>();
-    if (sy.empty())
+    if (sx.empty() || sy.empty())
     {
       return false;
     }
-    const String& sx = x.getConst<String>();
     if (rev)
     {
       return (sx.find(sy) != std::string::npos || sx.roverlap(sy) != 0);
@@ -401,12 +401,12 @@ bool Word::hasOverlap(TNode x, TNode y, bool rev)
   else if (k == Kind::CONST_SEQUENCE)
   {
     Assert(y.getKind() == Kind::CONST_SEQUENCE);
+    const Sequence& sx = x.getConst<Sequence>();
     const Sequence& sy = y.getConst<Sequence>();
-    if (sy.empty())
+    if (sx.empty() || sy.empty())
     {
       return false;
     }
-    const Sequence& sx = x.getConst<Sequence>();
     if (rev)
     {
       return (sx.find(sy) != std::string::npos || sx.roverlap(sy) != 0);

--- a/src/theory/strings/word.cpp
+++ b/src/theory/strings/word.cpp
@@ -395,7 +395,7 @@ bool Word::hasOverlap(TNode x, TNode y, bool rev)
     }
     else
     {
-      return (sx.find(sy) == std::string::npos || sx.overlap(sy) != 0);
+      return (sx.find(sy) != std::string::npos || sx.overlap(sy) != 0);
     }
   }
   else if (k == Kind::CONST_SEQUENCE)
@@ -413,7 +413,7 @@ bool Word::hasOverlap(TNode x, TNode y, bool rev)
     }
     else
     {
-      return (sx.find(sy) == std::string::npos || sx.overlap(sy) != 0);
+      return (sx.find(sy) != std::string::npos || sx.overlap(sy) != 0);
     }
   }
   Unimplemented();

--- a/src/theory/strings/word.cpp
+++ b/src/theory/strings/word.cpp
@@ -383,14 +383,12 @@ bool Word::hasOverlap(TNode x, TNode y, bool rev)
   if (k == Kind::CONST_STRING)
   {
     Assert(y.getKind() == Kind::CONST_STRING);
-    String sx = x.getConst<String>();
+    const String& sx = x.getConst<String>();
     if (sx.empty())
     {
-      // by convention, the empty string has no overlap (including with the
-      // empty string)
       return false;
     }
-    String sy = y.getConst<String>();
+    const String& sy = y.getConst<String>();
     if (rev)
     {
       return (sx.find(sy) != std::string::npos || sx.roverlap(sy) != 0);
@@ -406,7 +404,6 @@ bool Word::hasOverlap(TNode x, TNode y, bool rev)
     const Sequence& sx = x.getConst<Sequence>();
     if (sx.empty())
     {
-      // same as above
       return false;
     }
     const Sequence& sy = y.getConst<Sequence>();

--- a/src/theory/strings/word.cpp
+++ b/src/theory/strings/word.cpp
@@ -383,12 +383,12 @@ bool Word::hasOverlap(TNode x, TNode y, bool rev)
   if (k == Kind::CONST_STRING)
   {
     Assert(y.getKind() == Kind::CONST_STRING);
-    const String& sx = x.getConst<String>();
-    if (sx.empty())
+    const String& sy = y.getConst<String>();
+    if (sy.empty())
     {
       return false;
     }
-    const String& sy = y.getConst<String>();
+    const String& sx = x.getConst<String>();
     if (rev)
     {
       return (sx.find(sy) != std::string::npos || sx.roverlap(sy) != 0);
@@ -401,12 +401,12 @@ bool Word::hasOverlap(TNode x, TNode y, bool rev)
   else if (k == Kind::CONST_SEQUENCE)
   {
     Assert(y.getKind() == Kind::CONST_SEQUENCE);
-    const Sequence& sx = x.getConst<Sequence>();
-    if (sx.empty())
+    const Sequence& sy = y.getConst<Sequence>();
+    if (sy.empty())
     {
       return false;
     }
-    const Sequence& sy = y.getConst<Sequence>();
+    const Sequence& sx = x.getConst<Sequence>();
     if (rev)
     {
       return (sx.find(sy) != std::string::npos || sx.roverlap(sy) != 0);

--- a/src/theory/strings/word.h
+++ b/src/theory/strings/word.h
@@ -111,12 +111,30 @@ class Word
    * Checks if there is any overlap between word x and another word y. This
    * corresponds to checking whether one string contains the other and whether a
    * substring/subsequence of one is a prefix of the other and/or vice-versa.
-   * In particular, this method returns false if x is empty, and otherwise true
-   * when:
    *
-   * If rev=false, if x contains y, or a non-empty suffix of x is a prefix of y.
-   * If rev=true, if x contains y, or a non-empty prefix of x is a suffix of y.
-   *
+   * If rev=false, this method returns true if x is non-empty, and either
+   * x contains y, or a non-empty suffix of x is a prefix of y.
+   * Examples:
+   *   "", "" -> false
+   *   "", "a" -> false
+   *   "abc", "" -> true
+   *   "abc", "aa" -> false
+   *   "abc", "cd" -> true
+   *   "abc", "b" -> true
+   *   "abc", "abcd" -> true
+   *   "abc", "aab" -> false
+   * 
+   * If rev=true, this method returns true if x is non-empty, and either
+   * x contains y, or a non-empty prefix of x is a suffix of y.
+   * Examples:
+   *   "", "" -> false
+   *   "", "a" -> false
+   *   "abc", "" -> true
+   *   "abc", "aa" -> true
+   *   "abc", "cd" -> false
+   *   "abc", "b" -> true
+   *   "abc", "abcd" -> false
+   *   "abc", "aab" -> true
    *
    * @param x The first string
    * @param y The second string
@@ -131,7 +149,7 @@ class Word
 
   /** overlap
    *
-   * if overlap returns m>0,
+   * when overlap returns m,
    * then the maximal suffix of this string that is a prefix of y is of length
    * m.
    *
@@ -145,7 +163,7 @@ class Word
 
   /** reverse overlap
    *
-   * if roverlap returns m>0,
+   * when roverlap returns m,
    * then the maximal prefix of this word that is a suffix of y is of length m.
    *
    * For example, if x is "abcdef", then:

--- a/src/theory/strings/word.h
+++ b/src/theory/strings/word.h
@@ -113,10 +113,10 @@ class Word
    * substring/subsequence of one is a prefix of the other and/or vice-versa.
    * In particular, this method returns false if x is empty, and otherwise true
    * when:
-   * 
+   *
    * If rev=false, if x contains y, or a non-empty suffix of x is a prefix of y.
    * If rev=true, if x contains y, or a non-empty prefix of x is a suffix of y.
-   * 
+   *
    *
    * @param x The first string
    * @param y The second string

--- a/src/theory/strings/word.h
+++ b/src/theory/strings/word.h
@@ -110,13 +110,24 @@ class Word
   /**
    * Checks if there is any overlap between word x and another word y. This
    * corresponds to checking whether one string contains the other and whether a
-   * substring/subsequence of one is a prefix of the other and vice-versa.
+   * substring/subsequence of one is a prefix of the other and/or vice-versa.
+   * In particular, this method returns false if x is empty, and otherwise true
+   * when:
+   * 
+   * If rev=false, if x contains y, or a non-empty suffix of x is a prefix of y.
+   * If rev=true, if x contains y, or a non-empty prefix of x is a suffix of y.
+   * 
    *
    * @param x The first string
    * @param y The second string
+   * @param rev Whether we are checking the reverse direction.
    * @return True if there is an overlap, false otherwise
    */
-  static bool noOverlapWith(TNode x, TNode y);
+  static bool hasOverlap(TNode x, TNode y, bool rev);
+  /**
+   * Equivalent to hasOverlap(x, y, false) || hasOverlap(y, x, false).
+   */
+  static bool hasBidirectionalOverlap(TNode x, TNode y);
 
   /** overlap
    *

--- a/src/theory/strings/word.h
+++ b/src/theory/strings/word.h
@@ -112,24 +112,24 @@ class Word
    * corresponds to checking whether one string contains the other and whether a
    * substring/subsequence of one is a prefix of the other and/or vice-versa.
    *
-   * If rev=false, this method returns true if x is non-empty, and either
+   * If rev=false, this method returns true if y is non-empty, and either
    * x contains y, or a non-empty suffix of x is a prefix of y.
    * Examples:
    *   "", "" -> false
    *   "", "a" -> false
-   *   "abc", "" -> true
+   *   "abc", "" -> false
    *   "abc", "aa" -> false
    *   "abc", "cd" -> true
    *   "abc", "b" -> true
    *   "abc", "abcd" -> true
    *   "abc", "aab" -> false
-   * 
-   * If rev=true, this method returns true if x is non-empty, and either
+   *
+   * If rev=true, this method returns true if y is non-empty, and either
    * x contains y, or a non-empty prefix of x is a suffix of y.
    * Examples:
    *   "", "" -> false
    *   "", "a" -> false
-   *   "abc", "" -> true
+   *   "abc", "" -> false
    *   "abc", "aa" -> true
    *   "abc", "cd" -> false
    *   "abc", "b" -> true

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -472,13 +472,6 @@ String String::substr(std::size_t i, std::size_t j) const {
   return String(ret_vec);
 }
 
-bool String::noOverlapWith(const String& y) const
-{
-  return y.find(*this) == std::string::npos
-         && this->find(y) == std::string::npos && this->overlap(y) == 0
-         && y.overlap(*this) == 0;
-}
-
 bool String::isNumber() const {
   if (d_str.empty()) {
     return false;

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -168,16 +168,6 @@ class String
   /** Return the suffix of this string of size at most i */
   String suffix(std::size_t i) const { return substr(size() - i, i); }
 
-  /**
-   * Checks if there is any overlap between this string and another string. This
-   * corresponds to checking whether one string contains the other and whether a
-   * substring of one is a prefix of the other and vice-versa.
-   *
-   * @param y The other string
-   * @return True if there is an overlap, false otherwise
-   */
-  bool noOverlapWith(const String& y) const;
-
   /** string overlap
   *
   * if overlap returns m>0,

--- a/test/unit/theory/theory_strings_word_white.cpp
+++ b/test/unit/theory/theory_strings_word_white.cpp
@@ -39,11 +39,13 @@ TEST_F(TestTheoryWhiteStringsWord, strings)
   Node a = d_nodeManager->mkConst(String("a"));
   Node b = d_nodeManager->mkConst(String("b"));
   Node aa = d_nodeManager->mkConst(String("aa"));
+  Node aab = d_nodeManager->mkConst(String("aab"));
   Node aaaaa = d_nodeManager->mkConst(String("aaaaa"));
   Node abc = d_nodeManager->mkConst(String("abc"));
   Node bbc = d_nodeManager->mkConst(String("bbc"));
   Node cac = d_nodeManager->mkConst(String("cac"));
   Node abca = d_nodeManager->mkConst(String("abca"));
+  Node abcd = d_nodeManager->mkConst(String("abcd"));
 
   TypeNode stringType = d_nodeManager->stringType();
   ASSERT_TRUE(Word::mkEmptyWord(stringType) == empty);
@@ -103,12 +105,12 @@ TEST_F(TestTheoryWhiteStringsWord, strings)
   ASSERT_EQ(empty, Word::suffix(empty, 0));
   ASSERT_EQ(aa, Word::suffix(aaaaa, 2));
 
-  ASSERT_FALSE(Word::noOverlapWith(abc, empty));
-  ASSERT_TRUE(Word::noOverlapWith(cac, aa));
-  ASSERT_FALSE(Word::noOverlapWith(cac, abc));
-  ASSERT_TRUE(Word::noOverlapWith(cac, b));
-  ASSERT_FALSE(Word::noOverlapWith(cac, a));
-  ASSERT_FALSE(Word::noOverlapWith(abca, a));
+  ASSERT_FALSE(Word::hasBidirectalOverlap(abc, empty));
+  ASSERT_TRUE(Word::hasBidirectalOverlap(cac, aa));
+  ASSERT_FALSE(Word::hasBidirectalOverlap(cac, abc));
+  ASSERT_TRUE(Word::hasBidirectalOverlap(cac, b));
+  ASSERT_FALSE(Word::hasBidirectalOverlap(cac, a));
+  ASSERT_FALSE(Word::hasBidirectalOverlap(abca, a));
 
   ASSERT_TRUE(Word::overlap(abc, empty) == 0);
   ASSERT_TRUE(Word::overlap(aaaaa, abc) == 1);
@@ -121,6 +123,26 @@ TEST_F(TestTheoryWhiteStringsWord, strings)
   ASSERT_TRUE(Word::roverlap(cac, abc) == 1);
   ASSERT_TRUE(Word::roverlap(empty, abc) == 0);
   ASSERT_TRUE(Word::roverlap(aaaaa, aa) == 2);
+  
+  ASSERT_FALSE(Word::hasOverlap(empty, empty, false));
+  ASSERT_FALSE(Word::hasOverlap(empty, a, false));
+  ASSERT_FALSE(Word::hasOverlap(abc, empty, false));
+  ASSERT_FALSE(Word::hasOverlap(abc, aa, false));
+  ASSERT_TRUE(Word::hasOverlap(abc, cd, false));
+  ASSERT_TRUE(Word::hasOverlap(abc, b, false));
+  ASSERT_TRUE(Word::hasOverlap(abc, abcd, false));
+  ASSERT_FALSE(Word::hasOverlap(abc, aab, false));
+  
+  ASSERT_FALSE(Word::hasOverlap(empty, empty, true));
+  ASSERT_FALSE(Word::hasOverlap(empty, a, true));
+  ASSERT_FALSE(Word::hasOverlap(abc, empty, true));
+  ASSERT_TRUE(Word::hasOverlap(abc, aa, true));
+  ASSERT_FALSE(Word::hasOverlap(abc, cd, true));
+  ASSERT_TRUE(Word::hasOverlap(abc, b, true));
+  ASSERT_FALSE(Word::hasOverlap(abc, abcd, true));
+  ASSERT_TRUE(Word::hasOverlap(abc, aab, true));
+  
+  
 }
 }  // namespace test
 }  // namespace cvc5::internal

--- a/test/unit/theory/theory_strings_word_white.cpp
+++ b/test/unit/theory/theory_strings_word_white.cpp
@@ -46,6 +46,7 @@ TEST_F(TestTheoryWhiteStringsWord, strings)
   Node cac = d_nodeManager->mkConst(String("cac"));
   Node abca = d_nodeManager->mkConst(String("abca"));
   Node abcd = d_nodeManager->mkConst(String("abcd"));
+  Node cd = d_nodeManager->mkConst(String("cd"));
 
   TypeNode stringType = d_nodeManager->stringType();
   ASSERT_TRUE(Word::mkEmptyWord(stringType) == empty);
@@ -105,12 +106,12 @@ TEST_F(TestTheoryWhiteStringsWord, strings)
   ASSERT_EQ(empty, Word::suffix(empty, 0));
   ASSERT_EQ(aa, Word::suffix(aaaaa, 2));
 
-  ASSERT_FALSE(Word::hasBidirectalOverlap(abc, empty));
-  ASSERT_TRUE(Word::hasBidirectalOverlap(cac, aa));
-  ASSERT_FALSE(Word::hasBidirectalOverlap(cac, abc));
-  ASSERT_TRUE(Word::hasBidirectalOverlap(cac, b));
-  ASSERT_FALSE(Word::hasBidirectalOverlap(cac, a));
-  ASSERT_FALSE(Word::hasBidirectalOverlap(abca, a));
+  ASSERT_FALSE(Word::hasBidirectionalOverlap(abc, empty));
+  ASSERT_TRUE(Word::hasBidirectionalOverlap(cac, aa));
+  ASSERT_FALSE(Word::hasBidirectionalOverlap(cac, abc));
+  ASSERT_TRUE(Word::hasBidirectionalOverlap(cac, b));
+  ASSERT_FALSE(Word::hasBidirectionalOverlap(cac, a));
+  ASSERT_FALSE(Word::hasBidirectionalOverlap(abca, a));
 
   ASSERT_TRUE(Word::overlap(abc, empty) == 0);
   ASSERT_TRUE(Word::overlap(aaaaa, abc) == 1);


### PR DESCRIPTION
This operation will be at the heart of ~5 forthcoming proof rules. 

This PR deletes the primative "noOverlapWith" in favor of this new utility.

A rewrite that relies on this utility is demoted to the extended rewriter.

Unit tests are added for this utility.