### PR TITLE
Add Eunoia definitions of extended RE evaluation

### DIFF
--- a/proofs/eo/cpc/programs/Strings.eo
+++ b/proofs/eo/cpc/programs/Strings.eo
@@ -193,6 +193,66 @@
     ($str_eval_str_in_re_rec s 0 r @re.null)
     (str.in_re s r)))
 
+;;;;; first match utilities
+
+; define: $str_first_match_rec_smallest
+; args:
+; - s String: The string to inspect.
+; - r RegLan: The regular expression to inspect, assumed to contain s.
+; - m Int: The current prefix size of s we are considering.
+; - lens Int: The length of s.
+; return: >
+;   The size of the smallest prefix of s that is contained in r.
+(program $str_first_match_rec_smallest ((s String) (r RegLan) (n Int) (m Int) (lens Int))
+  (String RegLan Int Int) Int
+  (
+    (($str_first_match_rec_smallest s r m lens)   (eo::define ((ss (eo::extract s 0 (eo::add m -1))))
+                                                  (eo::ite ($str_eval_str_in_re ss r)
+                                                    m
+                                                    (eo::requires (eo::is_eq m lens) false
+                                                      ($str_first_match_rec_smallest s r (eo::add m 1) lens)))))
+  )
+)
+
+; define: $str_first_match_rec
+; args:
+; - s String: The string to inspect.
+; - r RegLan: The regular expression to inspect.
+; - n Int: The position of the original string we are searching.
+; - lens Int: The length of s.
+; return: >
+;   A pair of the form (n+n', n+m') where the first shortest match of r in s is
+;   at start position n' and end position m', or (-1, -1) if r does not match
+;   any substring of s.
+(program $str_first_match_rec ((s String) (r RegLan) (rs RegLan) (n Int) (lens Int))
+  (String RegLan RegLan Int Int) (@Pair Int Int)
+  (
+    (($str_first_match_rec s r rs n lens)  (eo::ite ($str_eval_str_in_re s rs)
+                                            ; found (superstring) match, now find the smallest exact match
+                                            (@pair n (eo::add n ($str_first_match_rec_smallest s r 0 lens)))
+                                            (eo::ite (eo::is_eq lens 0)
+                                              ; we are at the end of s, did not find a match
+                                              (@pair -1 -1)
+                                              ; move to the next position in s
+                                              (eo::define ((lsm1 (eo::add lens -1)))
+                                                ($str_first_match_rec (eo::extract s 1 lsm1) r rs (eo::add n 1) lsm1)))))
+  )
+)
+
+; define: $str_first_match
+; args:
+; - s String: The string to inspect.
+; - r RegLan: The regular expression to inspect.
+; return: >
+;   A pair of the form (n, m) where the first shortest match of r in s is at
+;   start position n and end position m, or (-1, -1) if r does not match any
+;   substring of s.
+(define $str_first_match ((s String) (r RegLan))
+  (eo::define ((lens (eo::len s)))
+  (eo::define ((rs (re.++ r re.all)))
+  (eo::requires (eo::is_str s) true
+    ($str_first_match_rec s r rs 0 lens)))))
+
 ;;-------------------- Skolem terms
 
 ; The following side conditions are used for computing terms that define

--- a/proofs/eo/cpc/programs/Strings.eo
+++ b/proofs/eo/cpc/programs/Strings.eo
@@ -218,6 +218,7 @@
 ; args:
 ; - s String: The string to inspect.
 ; - r RegLan: The regular expression to inspect.
+; - rs RegLan: Equivalent to (re.++ r re.all), used for finding whether a prefix of s is contained in r.
 ; - n Int: The position of the original string we are searching.
 ; - lens Int: The length of s.
 ; return: >

--- a/proofs/eo/cpc/rules/Strings.eo
+++ b/proofs/eo/cpc/rules/Strings.eo
@@ -641,3 +641,115 @@
                 ($str_multiset_overapprox t) false) true))
   :conclusion (= (str.contains t s) false)
 )
+
+;;;;; ProofRewriteRule::STR_INDEXOF_RE_EVAL
+
+; define: $str_eval_indexof_re
+; args:
+; - s String: A string.
+; - r RegLan: A regular expression to match.
+; - n Int: A start position.
+; return: >
+;   The result of evaluating (str.indexof_re s r n).
+(define $str_eval_indexof_re ((s String) (r RegLan) (n Int))
+  (eo::ite (eo::or (eo::gt n (eo::len s)) (eo::is_neg n))
+    -1
+    (eo::match ((sp Int) (ep Int))
+      ($str_first_match (eo::extract s n (eo::len s)) r)
+      (
+      ((@pair -1 -1) -1)
+      ((@pair sp ep) (eo::add n sp))
+      ))))
+
+
+; rule: str-indexof-re-eval
+; implements: ProofRewriteRule::STR_INDEXOF_RE_EVAL
+; args:
+; - eq Bool: The equality between a indexof_re term and an integer.
+; requires: >
+;   Evaluating the left hand side gives the right hand side.
+; conclusion: The given equality.
+(declare-rule str-indexof-re-eval ((s String) (r RegLan) (n Int) (m Int))
+  :args ((= (str.indexof_re s r n) m))
+  :requires ((($str_eval_indexof_re s r n) m))
+  :conclusion (= (str.indexof_re s r n) m)
+)
+
+;;;;; ProofRewriteRule::STR_REPLACE_RE_EVAL
+
+; define: $str_eval_indexof_re
+; args:
+; - s String: A string.
+; - r RegLan: A regular expression.
+; - t String: A string to replace with.
+; return: >
+;   The result of evaluating (str.replace_re s r t), which is either s or a
+;   concatenation of the prefix of s before the match, t and the suffix of s
+;   after the match.
+(define $str_eval_replace_re ((s String) (r RegLan) (t String))
+  (eo::match ((sp Int) (ep Int))
+    ($str_first_match s r)
+    (
+    ((@pair -1 -1) s)
+    ; note that t does not need to be a constant, so the returned term is a concat term
+    ((@pair sp ep) (str.++ (eo::extract s 0 (eo::add sp -1)) t (eo::extract s ep (eo::len s))))
+    )))
+
+; rule: str-replace-re-eval
+; implements: ProofRewriteRule::STR_REPLACE_RE_EVAL
+; args:
+; - eq Bool: The equality between a replace_re term and a string.
+; requires: >
+;   Evaluating the left hand side gives the right hand side.
+; conclusion: The given equality.
+(declare-rule str-replace-re-eval ((s String) (r RegLan) (t String) (u String))
+  :args ((= (str.replace_re s r t) u))
+  :requires ((($str_eval_replace_re s r t) u))
+  :conclusion (= (str.replace_re s r t) u)
+)
+
+;;;;; ProofRewriteRule::STR_REPLACE_RE_ALL_EVAL
+
+; program: $str_eval_replace_re_all_rec
+; args:
+; - s String: A string.
+; - r RegLan: A regular expression not containing the empty string.
+; - t String: A string to replace with.
+; - p @Pair: The result of finding the first match of r in s.
+; return: >
+;   The result of evaluating (str.replace_re_all s r t), which is a concatenation.
+(program $str_eval_replace_re_all_rec ((s String) (r RegLan) (t String) (sp Int) (ep Int))
+  (String RegLan String (@Pair Int Int)) String
+  (
+  (($str_eval_replace_re_all_rec "" r t (@pair -1 -1))  "")
+  (($str_eval_replace_re_all_rec s r t (@pair -1 -1))   (eo::cons str.++ s ""))
+  (($str_eval_replace_re_all_rec s r t (@pair sp ep))   (eo::define ((snext (eo::extract s ep (eo::len s))))
+                                                        (eo::cons str.++ (eo::extract s 0 (eo::add sp -1))
+                                                        (eo::cons str.++ t
+                                                          ($str_eval_replace_re_all_rec snext r t ($str_first_match snext r))))))
+  )
+)
+
+; define: $str_eval_replace_re_all
+; args:
+; - s String: A string.
+; - r RegLan: A regular expression.
+; - t String: A string to replace with.
+; return: >
+;   The result of evaluating (str.replace_re_all s r t).
+(define $str_eval_replace_re_all ((s String) (r RegLan) (t String))
+  (eo::define ((rnemp (re.inter r (re.comp (str.to_re ""))))) ; looking for non-empty matches
+  ($singleton_elim ($str_eval_replace_re_all_rec s rnemp t ($str_first_match s r)))))
+
+; rule: str-replace-re-all-eval
+; implements: ProofRewriteRule::STR_REPLACE_RE_ALL_EVAL
+; args:
+; - eq Bool: The equality between a replace_re_all term and a string.
+; requires: >
+;   Evaluating the left hand side gives the right hand side.
+; conclusion: The given equality.
+(declare-rule str-replace-re-all-eval ((s String) (r RegLan) (t String) (u String))
+  :args ((= (str.replace_re_all s r t) u))
+  :requires ((($str_eval_replace_re_all s r t) u))
+  :conclusion (= (str.replace_re_all s r t) u)
+)

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -292,6 +292,9 @@ bool AlfPrinter::isHandledTheoryRewrite(ProofRewriteRule id, const Node& n)
     case ProofRewriteRule::STR_IN_RE_SIGMA:
     case ProofRewriteRule::STR_IN_RE_SIGMA_STAR:
     case ProofRewriteRule::STR_IN_RE_CONSUME:
+    case ProofRewriteRule::STR_INDEXOF_RE_EVAL:
+    case ProofRewriteRule::STR_REPLACE_RE_EVAL:
+    case ProofRewriteRule::STR_REPLACE_RE_ALL_EVAL:
     case ProofRewriteRule::RE_INTER_UNION_INCLUSION:
     case ProofRewriteRule::BV_REPEAT_ELIM:
     case ProofRewriteRule::BV_BITWISE_SLICING: return true;

--- a/src/theory/strings/sequences_rewriter.cpp
+++ b/src/theory/strings/sequences_rewriter.cpp
@@ -1526,7 +1526,11 @@ Node SequencesRewriter::rewriteViaStrReplaceReAllEval(const Node& n)
       res.push_back(n[2]);
       rem = rem.substr(match.second);
     }
-    res.push_back(nm->mkConst(rem));
+    // only concatenate remainder if non-empty
+    if (rem.size()!=0)
+    {
+      res.push_back(nm->mkConst(rem));
+    }
     Node ret = utils::mkConcat(res, t);
     return ret;
   }
@@ -2921,29 +2925,11 @@ Node SequencesRewriter::rewriteIndexofRe(Node node)
 
   if (RegExpEntail::isConstRegExp(r))
   {
-    if (s.isConst() && n.isConst())
+    Node neval = rewriteViaStrIndexofReEval(node);
+    if (!neval.isNull())
     {
-      Rational nrat = n.getConst<Rational>();
-      cvc5::internal::Rational rMaxInt(cvc5::internal::String::maxSize());
-      if (nrat > rMaxInt)
-      {
-        // We know that, due to limitations on the size of string constants
-        // in our implementation, that accessing a position greater than
-        // rMaxInt is guaranteed to be out of bounds.
-        Node negone = nm->mkConstInt(Rational(-1));
-        return returnRewrite(node, negone, Rewrite::INDEXOF_RE_MAX_INDEX);
-      }
-
-      uint32_t start = nrat.getNumerator().toUnsignedInt();
-      Node rem = nm->mkConst(s.getConst<String>().substr(start));
-      std::pair<size_t, size_t> match = firstMatch(rem, r);
-      Node ret = nm->mkConstInt(
-          Rational(match.first == string::npos
-                       ? -1
-                       : static_cast<int64_t>(start + match.first)));
-      return returnRewrite(node, ret, Rewrite::INDEXOF_RE_EVAL);
+      return returnRewrite(node, neval, Rewrite::INDEXOF_RE_EVAL);
     }
-
     if (d_arithEntail.check(n, zero) && d_arithEntail.check(slen, n))
     {
       String emptyStr("");
@@ -3449,23 +3435,10 @@ Node SequencesRewriter::rewriteReplaceRe(Node node)
 
   if (RegExpEntail::isConstRegExp(y))
   {
-    if (x.isConst())
+    Node neval = rewriteViaStrReplaceReEval(node);
+    if (!neval.isNull())
     {
-      // str.replace_re("ZABCZ", re.++("A", _*, "C"), y) ---> "Z" ++ y ++ "Z"
-      std::pair<size_t, size_t> match = firstMatch(x, y);
-      if (match.first != string::npos)
-      {
-        String s = x.getConst<String>();
-        Node ret = nm->mkNode(Kind::STRING_CONCAT,
-                              nm->mkConst(s.substr(0, match.first)),
-                              z,
-                              nm->mkConst(s.substr(match.second)));
-        return returnRewrite(node, ret, Rewrite::REPLACE_RE_EVAL);
-      }
-      else
-      {
-        return returnRewrite(node, x, Rewrite::REPLACE_RE_EVAL);
-      }
+      return returnRewrite(node, neval, Rewrite::REPLACE_RE_EVAL);
     }
     // str.replace_re( x, y, z ) ---> z ++ x if "" in y ---> true
     String emptyStr("");
@@ -3492,33 +3465,10 @@ Node SequencesRewriter::rewriteReplaceReAll(Node node)
 
   if (RegExpEntail::isConstRegExp(y))
   {
-    if (x.isConst())
+    Node neval = rewriteViaStrReplaceReAllEval(node);
+    if (!neval.isNull())
     {
-      // str.replace_re_all("ZABCZAB", re.++("A", _*, "C"), y) --->
-      //   "Z" ++ y ++ "Z" ++ y
-      TypeNode t = x.getType();
-      Node emp = Word::mkEmptyWord(t);
-      Node yp = nm->mkNode(Kind::REGEXP_INTER,
-                           y,
-                           nm->mkNode(Kind::REGEXP_COMPLEMENT,
-                                      nm->mkNode(Kind::STRING_TO_REGEXP, emp)));
-      std::vector<Node> res;
-      String rem = x.getConst<String>();
-      std::pair<size_t, size_t> match(0, 0);
-      while (rem.size() != 0)
-      {
-        match = firstMatch(nm->mkConst(rem), yp);
-        if (match.first == string::npos)
-        {
-          break;
-        }
-        res.push_back(nm->mkConst(rem.substr(0, match.first)));
-        res.push_back(z);
-        rem = rem.substr(match.second);
-      }
-      res.push_back(nm->mkConst(rem));
-      Node ret = utils::mkConcat(res, t);
-      return returnRewrite(node, ret, Rewrite::REPLACE_RE_ALL_EVAL);
+      return returnRewrite(node, neval, Rewrite::REPLACE_RE_ALL_EVAL);
     }
     if (y.getKind()==Kind::REGEXP_NONE)
     {

--- a/src/theory/strings/sequences_rewriter.cpp
+++ b/src/theory/strings/sequences_rewriter.cpp
@@ -3458,7 +3458,6 @@ Node SequencesRewriter::rewriteReplaceRe(Node node)
 Node SequencesRewriter::rewriteReplaceReAll(Node node)
 {
   Assert(node.getKind() == Kind::STRING_REPLACE_RE_ALL);
-  NodeManager* nm = nodeManager();
   Node x = node[0];
   Node y = node[1];
   Node z = node[2];


### PR DESCRIPTION
This adds the Eunoia definition of the evaluation methods for the SMT-LIB standard operators `str.replace_re` and `str.replace_re_all`, and the cvc5-specific extension `str.indexof_re`.

It also updates the strings rewrite to call the reference implementations of these rules, which was missed in a previous PR.

Note these evaluators call `$str_eval_str_in_re` as a submethod, which would benefit automatically from future optimizations to this method.