### PR TITLE
Add Eunoia definition for more cases of STRING_REDUCTION

### DIFF
--- a/proofs/eo/cpc/programs/Strings.eo
+++ b/proofs/eo/cpc/programs/Strings.eo
@@ -433,62 +433,6 @@
 ; In the following, a "reduction predicate" refers to a formula that is used
 ; to axiomatize an extended string program in terms of (simpler) programs.
 
-; program: $str_reduction_substr
-; args:
-; - x (Seq U): The first argument to str.substr.
-; - n Int: The second argument to str.substr.
-; - m Int: The third argument to str.substr.
-; return: the reduction predicate for (str.substr x n m) of sort U.
-(program $str_reduction_substr ((U Type) (x (Seq U)) (n Int) (m Int))
-  ((Seq U) Int Int) Bool
-  (
-    (($str_reduction_substr x n m)
-      (eo::define ((k (@purify (str.substr x n m))))
-      (eo::define ((npm (+ n m)))
-      (eo::define ((k1 (@purify ($str_prefix x n))))
-      (eo::define ((k2 (@purify ($str_suffix_rem x npm))))
-      (ite
-        ; condition
-        (and (>= n 0)(> (str.len x) n) (> m 0))
-        ; if branch
-        (and (= x (str.++ k1 k k2))
-            (= (str.len k1) n)
-            (or (= (str.len k2) (- (str.len x) npm))
-                (= (str.len k2) 0))
-            (<= (str.len k) m))
-        ; else branch
-        (= k ($mk_emptystr (eo::typeof x)))
-        ))))))
-  )
-)
-
-; program: $str_reduction_indexof
-; args:
-; - x (Seq U): The first argument to str.indexof.
-; - y (Seq U): The second argument to str.indexof.
-; - n Int: The third argument to str.indexof.
-; return: the reduction predicate for (str.indexof x y n) of sort U.
-(program $str_reduction_indexof ((U Type) (x (Seq U)) (y (Seq U)) (n Int))
-  ((Seq U) (Seq U) Int) Bool
-  (
-    (($str_reduction_indexof x y n)
-      (eo::define ((k (@purify (str.indexof x y n))))
-      (eo::define ((xn (str.substr x n (- (str.len x) n))))
-      (eo::define ((k1 (@purify ($str_first_ctn_pre xn y))))
-      (eo::define ((k2 (@purify ($str_first_ctn_post xn y))))
-      (ite
-        (or (not (str.contains xn y)) (> n (str.len x)) (> 0 n))
-        (= k (eo::neg 1))
-        (ite
-          (= y ($mk_emptystr (eo::typeof x)))
-          (= k n)
-          (and (= xn (str.++ k1 y k2))
-              (not (str.contains
-                        (str.++ k1 (str.substr y 0 (- (str.len y) 1))) y))
-              (= k (+ n (str.len k1)))))))))))
-  )
-)
-
 ; program: $str_reduction_pred
 ; args:
 ; - t (Seq U): The string term.
@@ -499,8 +443,39 @@
                               (s String) (r RegLan) (t String))
   (T) Bool
   (
-    (($str_reduction_pred (str.substr x n m)) ($str_reduction_substr x n m))
-    (($str_reduction_pred (str.indexof x y n)) ($str_reduction_indexof x y n))
+    ; str.contains
+    (($str_reduction_pred (str.contains x y))
+      (eo::define ((k (@purify (str.contains x y))))
+      (= k (not (forall ((@var.str_index Int))
+        (or
+          (not (>= @var.str_index 0))
+          (not (<= @var.str_index (- (str.len x) (str.len y))))
+          (not (= (str.substr x @var.str_index (str.len y)) y))))))))
+    (($str_reduction_pred (str.substr x n m))
+      (eo::define ((k (@purify (str.substr x n m))))
+      (eo::define ((npm (+ n m)))
+      (eo::define ((k1 (@purify ($str_prefix x n))))
+      (eo::define ((k2 (@purify ($str_suffix_rem x npm))))
+      (ite (and (>= n 0)(> (str.len x) n) (> m 0))
+        (and (= x (str.++ k1 k k2))
+            (= (str.len k1) n)
+            (or (= (str.len k2) (- (str.len x) npm))
+                (= (str.len k2) 0))
+            (<= (str.len k) m))
+        (= k ($mk_emptystr (eo::typeof x)))))))))
+    (($str_reduction_pred (str.indexof x y n))
+      (eo::define ((k (@purify (str.indexof x y n))))
+      (eo::define ((xn (str.substr x n (- (str.len x) n))))
+      (eo::define ((k1 (@purify ($str_first_ctn_pre xn y))))
+      (eo::define ((k2 (@purify ($str_first_ctn_post xn y))))
+      (ite (or (not (str.contains xn y)) (> n (str.len x)) (> 0 n))
+        (= k -1)
+        (ite (= y ($mk_emptystr (eo::typeof x)))
+          (= k n)
+          (and (= xn (str.++ k1 y k2))
+              (not (str.contains
+                        (str.++ k1 (str.substr y 0 (- (str.len y) 1))) y))
+              (= k (+ n (str.len k1)))))))))))
     (($str_reduction_pred (str.replace x y z)) 
         (eo::define ((k (@purify (str.replace x y z))))
         (ite (= y ($mk_emptystr (eo::typeof y)))
@@ -649,12 +624,47 @@
                            (= (result @var.str_index)
                               (str.++ (str.substr s oindex (- ii oindex)) t (result (+ @var.str_index 1))))
                       ))))))))))))))))))
+    (($str_reduction_pred (str.indexof_re s r n))
+        (eo::define ((k (@purify (str.indexof_re s r n))))
+        (ite (or (> n (str.len s)) (> 0 n))
+          (= k -1)
+          (ite (str.in_re "" r)
+            (= k n)
+            (and (forall ((@var.str_index Int) (@var.str_length Int))
+                   (or
+                     (not (>= @var.str_index n))
+                     (not (< @var.str_index (ite (= k -1) (str.len s) k)))
+                     (not (> @var.str_length 0))
+                     (not (<= @var.str_length (- (str.len s) @var.str_index)))
+                     (not (str.in_re (str.substr s @var.str_index @var.str_length) r))))
+                 (or (= k -1)
+                     (and (>= k n)
+                          (not (forall ((@var.str_length Int)) (or
+                                 (not (>= @var.str_length 0))
+                                 (not (<= @var.str_length (- (str.len s) k)))
+                                 (not (str.in_re (str.substr s k @var.str_length) r))))))))))))
+    (($str_reduction_pred (str.<= s t))
+        (eo::define ((k (@purify (str.<= s t))))
+        (ite (= s t) k
+          (not (forall ((@var.str_index Int))
+            (or
+              (not (>= @var.str_index 0))
+              (not (<= @var.str_index (str.len s)))
+              (not (<= @var.str_index (str.len t)))
+              (not (= (str.substr s 0 @var.str_index) (str.substr t 0 @var.str_index)))
+              (ite k
+                (>= (str.to_code (str.substr s @var.str_index 1)) (str.to_code (str.substr t @var.str_index 1)))
+                (>= (str.to_code (str.substr t @var.str_index 1)) (str.to_code (str.substr s @var.str_index 1)))
+            )))))))
 
-    ; str.indexof_re
     ; str.to_lower
+    (($str_reduction_pred (str.to_lower x)) false)
     ; str.to_upper
+    (($str_reduction_pred (str.to_upper x)) false)
     ; str.rev
-    ; str.leq
+    (($str_reduction_pred (str.rev x))
+        (eo::define ((k (@purify (str.rev x))))
+          false))
   )
 )
 

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -214,8 +214,10 @@ bool AlfPrinter::isHandled(const Options& opts, const ProofNode* pfn)
       Kind k = pargs[0].getKind();
       switch (k)
       {
+        case Kind::STRING_CONTAINS:
         case Kind::STRING_SUBSTR:
         case Kind::STRING_INDEXOF:
+        case Kind::STRING_INDEXOF_RE:
         case Kind::STRING_REPLACE:
         case Kind::STRING_REPLACE_ALL:
         case Kind::STRING_REPLACE_RE:
@@ -223,7 +225,8 @@ bool AlfPrinter::isHandled(const Options& opts, const ProofNode* pfn)
         case Kind::STRING_STOI:
         case Kind::STRING_ITOS:
         case Kind::SEQ_NTH:
-        case Kind::STRING_UPDATE: return true;
+        case Kind::STRING_UPDATE:
+        case Kind::STRING_LEQ: return true;
         default:
           break;
       }

--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -286,46 +286,39 @@ Node StringsPreprocess::reduce(Node t,
     Node i = SkolemCache::mkIndexVar(nm, t);
     Node l = SkolemCache::mkLengthVar(nm, t);
     Node bvl = nm->mkNode(Kind::BOUND_VAR_LIST, i, l);
-    Node bound = nm->mkNode(
-        Kind::AND,
-        {
-            nm->mkNode(Kind::GEQ, i, n),
-            nm->mkNode(
-                Kind::LT, i, nm->mkNode(Kind::ITE, retNegOne, sLen, skk)),
-            nm->mkNode(Kind::GT, l, zero),
-            nm->mkNode(Kind::LEQ, l, nm->mkNode(Kind::SUB, sLen, i)),
-        });
-    Node body = nm->mkNode(Kind::OR,
-                           bound.negate(),
-                           nm->mkNode(Kind::STRING_IN_REGEXP,
-                                      nm->mkNode(Kind::STRING_SUBSTR, s, i, l),
-                                      r)
-                               .negate());
+    Node body = nm->mkNode(
+        Kind::OR,
+        {nm->mkNode(Kind::GEQ, i, n).notNode(),
+         nm->mkNode(Kind::LT, i, nm->mkNode(Kind::ITE, retNegOne, sLen, skk))
+             .notNode(),
+         nm->mkNode(Kind::GT, l, zero).notNode(),
+         nm->mkNode(Kind::LEQ, l, nm->mkNode(Kind::SUB, sLen, i)).notNode(),
+         nm->mkNode(Kind::STRING_IN_REGEXP,
+                    nm->mkNode(Kind::STRING_SUBSTR, s, i, l),
+                    r)
+             .notNode()});
     // forall il.
     //   n <= i < ite(skk = -1, len(s), skk) ^ 0 < l <= len(s) - i =>
     //     ~in_re(substr(s, i, l), r)
     Node firstMatch = utils::mkForallInternal(nm, bvl, body);
     Node bvll = nm->mkNode(Kind::BOUND_VAR_LIST, l);
-    Node validLen =
-        nm->mkNode(Kind::AND,
-                   nm->mkNode(Kind::GEQ, l, zero),
-                   nm->mkNode(Kind::LEQ, l, nm->mkNode(Kind::SUB, sLen, skk)));
-    Node matchBody =
-        nm->mkNode(Kind::AND,
-                   validLen,
-                   nm->mkNode(Kind::STRING_IN_REGEXP,
-                              nm->mkNode(Kind::STRING_SUBSTR, s, skk, l),
-                              r));
+    Node matchBody = nm->mkNode(
+        Kind::OR,
+        {nm->mkNode(Kind::GEQ, l, zero).notNode(),
+         nm->mkNode(Kind::LEQ, l, nm->mkNode(Kind::SUB, sLen, skk)).notNode(),
+         nm->mkNode(Kind::STRING_IN_REGEXP,
+                    nm->mkNode(Kind::STRING_SUBSTR, s, skk, l),
+                    r)
+             .notNode()});
     // skk != -1 =>
     //   skk >= n ^ exists l. (0 <= l < len(s) - skk) ^ in_re(substr(s, skk, l),
     //   r))
     Node match = nm->mkNode(
         Kind::OR,
         retNegOne,
-        nm->mkNode(
-            Kind::AND,
-            nm->mkNode(Kind::GEQ, skk, n),
-            utils::mkForallInternal(nm, bvll, matchBody.negate()).negate()));
+        nm->mkNode(Kind::AND,
+                   nm->mkNode(Kind::GEQ, skk, n),
+                   utils::mkForallInternal(nm, bvll, matchBody).negate()));
 
     // assert:
     // IF:   n > len(s) OR 0 > n
@@ -979,15 +972,21 @@ Node StringsPreprocess::reduce(Node t,
     Node b1 = SkolemCache::mkIndexVar(nm, t);
     Node b1v = NodeManager::mkNode(Kind::BOUND_VAR_LIST, b1);
     Node body = NodeManager::mkNode(
-        Kind::AND,
-        NodeManager::mkNode(Kind::LEQ, zero, b1),
+        Kind::OR,
+        NodeManager::mkNode(Kind::GEQ, b1, zero).notNode(),
         NodeManager::mkNode(
-            Kind::LEQ, b1, NodeManager::mkNode(Kind::SUB, lenx, lens)),
+            Kind::LEQ, b1, NodeManager::mkNode(Kind::SUB, lenx, lens))
+            .notNode(),
         NodeManager::mkNode(
             Kind::EQUAL,
             NodeManager::mkNode(Kind::STRING_SUBSTR, x, b1, lens),
-            s));
-    retNode = utils::mkForallInternal(nm, b1v, body.negate()).negate();
+            s)
+            .notNode());
+    Node k = sc->mkTypedSkolemCached(
+        nm->booleanType(), t, SkolemCache::SK_PURIFY, "ctn");
+    Node actn = utils::mkForallInternal(nm, b1v, body).negate();
+    asserts.push_back(k.eqNode(actn));
+    retNode = k;
   }
   else if (t.getKind() == Kind::STRING_LEQ)
   {
@@ -995,33 +994,33 @@ Node StringsPreprocess::reduce(Node t,
         nm->booleanType(), t, SkolemCache::SK_PURIFY, "ltp");
     Node k = SkolemCache::mkIndexVar(nm, t);
 
-    std::vector<Node> conj;
-    conj.push_back(nm->mkNode(Kind::GEQ, k, zero));
+    std::vector<Node> disj;
+    disj.push_back(nm->mkNode(Kind::GEQ, k, zero).notNode());
     Node substr[2];
     Node code[2];
     for (unsigned r = 0; r < 2; r++)
     {
       Node ta = t[r];
-      Node tb = t[1 - r];
       substr[r] = nm->mkNode(Kind::STRING_SUBSTR, ta, zero, k);
       code[r] = nm->mkNode(Kind::STRING_TO_CODE,
                            nm->mkNode(Kind::STRING_SUBSTR, ta, k, one));
-      conj.push_back(
-          nm->mkNode(Kind::LEQ, k, nm->mkNode(Kind::STRING_LENGTH, ta)));
+      disj.push_back(
+          nm->mkNode(Kind::LEQ, k, nm->mkNode(Kind::STRING_LENGTH, ta))
+              .notNode());
     }
-    conj.push_back(substr[0].eqNode(substr[1]));
+    disj.push_back(substr[0].eqNode(substr[1]).notNode());
     std::vector<Node> ite_ch;
     ite_ch.push_back(ltp);
     for (unsigned r = 0; r < 2; r++)
     {
-      ite_ch.push_back(nm->mkNode(Kind::LT, code[r], code[1 - r]));
+      ite_ch.push_back(nm->mkNode(Kind::GEQ, code[r], code[1 - r]));
     }
-    conj.push_back(nm->mkNode(Kind::ITE, ite_ch));
+    disj.push_back(nm->mkNode(Kind::ITE, ite_ch));
 
-    Node conjn = utils::mkForallInternal(nm,
-                                         nm->mkNode(Kind::BOUND_VAR_LIST, k),
-                                         nm->mkNode(Kind::AND, conj).negate())
-                     .negate();
+    Node conjn =
+        utils::mkForallInternal(
+            nm, nm->mkNode(Kind::BOUND_VAR_LIST, k), nm->mkNode(Kind::OR, disj))
+            .negate();
     // Intuitively, the reduction says either x and y are equal, or they have
     // some (maximal) common prefix after which their characters at position k
     // are distinct, and the comparison of their code matches the return value

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -3798,6 +3798,7 @@ set(regress_2_tests
   regress2/strings/replaceall-diffrange.smt2
   regress2/strings/replaceall-len-c.smt2
   regress2/strings/small-1.smt2
+  regress2/strings/str-contains-reduction.smt2
   regress2/strings/strings-alpha-card-65.smt2
   regress2/strings/update-ex3.smt2
   regress2/strings/update-ex4-seq.smt2

--- a/test/regress/cli/regress2/strings/str-contains-reduction.smt2
+++ b/test/regress/cli/regress2/strings/str-contains-reduction.smt2
@@ -1,0 +1,10 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-const x String)
+
+(assert (not (str.contains x "A")))
+(assert (not (str.contains x "B")))
+(assert (not (str.contains x "C")))
+
+(assert (= (str.to_code (str.substr x 2 1)) 66))
+(check-sat)


### PR DESCRIPTION
This should cover all remaining operators whose reduction could appear in an SMT-LIB benchmark.

Makes minor changes to the strings utility for the sake of uniformity.