### PR TITLE
Make RE_INTER_UNION_INCLUSION a macro, elaborate to simpler version

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -3150,7 +3150,7 @@ enum ENUM(ProofRewriteRule)
    * **Strings -- regular expression intersection/union inclusion**
    *
    * .. math::
-   *   (re.inter\ R) = \mathit{re.inter}(\mathit{re.none}, R_0)
+   *   \mathit{re.inter}(R) = \mathit{re.inter}(\mathit{re.none}, R_0)
    *
    * where :math:`R` is a list of regular expressions containing `r_1`,
    * `re.comp(r_2)` and the list :math:`R_0` where `r_2` is a superset of
@@ -3167,7 +3167,31 @@ enum ENUM(ProofRewriteRule)
    *
    * \endverbatim
    */
-  EVALUE(RE_INTER_UNION_INCLUSION),
+  EVALUE(MACRO_RE_INTER_UNION_INCLUSION),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Strings -- regular expression intersection inclusion**
+   *
+   * .. math::
+   *   \mathit{re.inter}(r_1, re.comp(r_2)) = \mathit{re.none}
+   *
+   * where :math:`r_2` is a superset of :math:`r_1`.
+   *
+   * \endverbatim
+   */
+  EVALUE(RE_INTER_INCLUSION),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Strings -- regular expression union inclusion**
+   *
+   * .. math::
+   *   \mathit{re.union}(r_1, re.comp(r_2)) = \mathit{re}.\text{*}(\mathit{re.allchar})
+   *
+   * where :math:`r_1` is a superset of :math:`r_2`.
+   *
+   * \endverbatim
+   */
+  EVALUE(RE_UNION_INCLUSION),
   /**
    * \verbatim embed:rst:leading-asterisk
    * **Strings -- regular expression membership evaluation**

--- a/proofs/eo/cpc/programs/Strings.eo
+++ b/proofs/eo/cpc/programs/Strings.eo
@@ -1357,57 +1357,6 @@
   )
 )
 
-; define: $str_check_re_union_inclusion
-; args:
-; - r RegLan: The regular expression to check.
-; return: >
-;   true if r is an application of re.union with 2 children for which
-;   regular expression inclusion shows r is equivalent to (re.* re.allchar).
-(define $str_check_re_union_inclusion ((r RegLan))
-  (eo::match ((r1 RegLan) (r2 RegLan))
-  r
-  (
-    ((re.union (re.comp r1) r2) ($str_re_includes r2 r1))
-    ((re.union r1 (re.comp r2)) ($str_re_includes r1 r2))
-  ))
-)
-
-; define: $str_check_re_inter_inclusion
-; args:
-; - r RegLan: The regular expression to check.
-; return: >
-;   true if r is an application of re.inter with 2 children for which
-;   regular expression inclusion shows r is equivalent to re.none.
-(define $str_check_re_inter_inclusion ((r RegLan))
-  (eo::match ((r1 RegLan) (r2 RegLan))
-  r
-  (
-    ((re.inter (re.comp r1) r2) ($str_re_includes r1 r2))
-    ((re.inter r1 (re.comp r2)) ($str_re_includes r2 r1))
-  ))
-)
-
-; program: $str_decompose_and_check_re_inter_union_inclusion
-; args:
-; - r : The regular expression to check.
-; - rr : The rewritten form of r.
-; return: >
-;   true if r can be rewritten to rr via the rule
-;   ProofRewriteRule::RE_INTER_UNION_INCLUSION. In particular, we first verify
-;   that rr has the result of the inclusion as the first child. We then subtract
-;   the remainder (rr1) to find the regular expressions that are relevant for this
-;   inference.
-(define $str_decompose_and_check_re_inter_union_inclusion ((r RegLan) (rr RegLan))
-  (eo::match ((rr1 RegLan :list))
-  rr
-  (
-  ((re.union (re.* re.allchar) rr1) ($str_check_re_union_inclusion ($nary_diff re.union re.none r rr1)))
-  ((re.* re.allchar)                ($str_check_re_union_inclusion r))
-  ((re.inter re.none rr1)           ($str_check_re_inter_inclusion ($nary_diff re.inter re.all r rr1)))
-  (re.none                          ($str_check_re_inter_inclusion r))
-  ))
-)
-
 ; program: $str_arith_entail_simple
 ; args:
 ; - n Int: An integer term to process.

--- a/proofs/eo/cpc/rules/Strings.eo
+++ b/proofs/eo/cpc/rules/Strings.eo
@@ -526,19 +526,32 @@
   :conclusion (= (re.loop l u r1) r2)
 )
 
-; rule: re-inter-union-inclusion
-; implements: ProofRewriteRule::RE_INTER_UNION_INCLUSION
+; rule: re-inter-inclusion
+; implements: ProofRewriteRule::RE_INTER_INCLUSION
 ; args:
 ; - eq Bool: The equality between regular expressions to prove.
 ; requires: >
-;   showing that the right hand side of the equality is the result of
-;   decomposing the left hand side into a result of a regular expression
-;   inclusion and a remainder.
+;   the left hand side is the intersection of the complement of a regular
+;   expression and one that it includes.
 ; conclusion: The given equality.
-(declare-rule re-inter-union-inclusion ((r1 RegLan) (r2 RegLan))
-  :args ((= r1 r2))
-  :requires ((($str_decompose_and_check_re_inter_union_inclusion r1 r2) true))
-  :conclusion (= r1 r2)
+(declare-rule re-inter-inclusion ((r1 RegLan) (r2 RegLan))
+  :args ((= (re.inter r1 (re.comp r2)) re.none))
+  :requires ((($str_re_includes r2 r1) true))
+  :conclusion (= (re.inter r1 (re.comp r2)) re.none)
+)
+
+; rule: re-union-inclusion
+; implements: ProofRewriteRule::RE_UNION_INCLUSION
+; args:
+; - eq Bool: The equality between regular expressions to prove.
+; requires: >
+;   the left hand side is the union of the complement of a regular
+;   expression and one that it is included by.
+; conclusion: The given equality.
+(declare-rule re-union-inclusion ((r1 RegLan) (r2 RegLan))
+  :args ((= (re.union r1 (re.comp r2)) (re.* re.allchar)))
+  :requires ((($str_re_includes r1 r2) true))
+  :conclusion (= (re.union r1 (re.comp r2)) (re.* re.allchar))
 )
 
 ; rule: str-in-re-concat-star-char

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -305,8 +305,10 @@ const char* toString(cvc5::ProofRewriteRule rule)
     case ProofRewriteRule::STR_REPLACE_RE_ALL_EVAL:
       return "str-replace-re-all-eval";
     case ProofRewriteRule::RE_LOOP_ELIM: return "re-loop-elim";
-    case ProofRewriteRule::RE_INTER_UNION_INCLUSION:
-      return "re-inter-union-inclusion";
+    case ProofRewriteRule::MACRO_RE_INTER_UNION_INCLUSION:
+      return "macro-re-inter-union-inclusion";
+    case ProofRewriteRule::RE_INTER_INCLUSION: return "re-inter-inclusion";
+    case ProofRewriteRule::RE_UNION_INCLUSION: return "re-union-inclusion";
     case ProofRewriteRule::STR_IN_RE_EVAL: return "str-in-re-eval";
     case ProofRewriteRule::STR_IN_RE_CONSUME: return "str-in-re-consume";
     case ProofRewriteRule::STR_IN_RE_CONCAT_STAR_CHAR:

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -300,7 +300,8 @@ bool AlfPrinter::isHandledTheoryRewrite(ProofRewriteRule id, const Node& n)
     case ProofRewriteRule::STR_INDEXOF_RE_EVAL:
     case ProofRewriteRule::STR_REPLACE_RE_EVAL:
     case ProofRewriteRule::STR_REPLACE_RE_ALL_EVAL:
-    case ProofRewriteRule::RE_INTER_UNION_INCLUSION:
+    case ProofRewriteRule::RE_INTER_INCLUSION:
+    case ProofRewriteRule::RE_UNION_INCLUSION:
     case ProofRewriteRule::BV_REPEAT_ELIM:
     case ProofRewriteRule::BV_BITWISE_SLICING: return true;
     case ProofRewriteRule::STR_OVERLAP_SPLIT_CTN:

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -1426,7 +1426,7 @@ bool BasicRewriteRCons::ensureProofArithPolyNormRel(CDProof* cdp,
     return false;
   }
   Node kn = ProofRuleChecker::mkKindNode(nodeManager(), eq[0].getKind());
-  if (!cdp->addStep(eq, ProofRule::ARITH_POLY_NORM_REL, {premise}, {eq}))
+  if (!cdp->addStep(eq, ProofRule::ARITH_POLY_NORM_REL, {premise}, {kn}))
   {
     Trace("brc-macro") << "...fail application" << std::endl;
     return false;

--- a/src/rewriter/basic_rewrite_rcons.h
+++ b/src/rewriter/basic_rewrite_rcons.h
@@ -171,6 +171,16 @@ class BasicRewriteRCons : protected EnvObj
   bool ensureProofMacroArithStringPredEntail(CDProof* cdp, const Node& eq);
   /**
    * Elaborate a rewrite eq that was proven by
+   * ProofRewriteRule::MACRO_RE_INTER_UNION_INCLUSION.
+   *
+   * @param cdp The proof to add to.
+   * @param eq The rewrite proven by
+   * ProofRewriteRule::MACRO_RE_INTER_UNION_INCLUSION.
+   * @return true if added a closed proof of eq to cdp.
+   */
+  bool ensureProofMacroReInterUnionInclusion(CDProof* cdp, const Node& eq);
+  /**
+   * Elaborate a rewrite eq that was proven by
    * ProofRewriteRule::MACRO_SUBSTR_STRIP_SYM_LENGTH.
    *
    * @param cdp The proof to add to.

--- a/src/theory/strings/sequences_rewriter.cpp
+++ b/src/theory/strings/sequences_rewriter.cpp
@@ -51,7 +51,7 @@ SequencesRewriter::SequencesRewriter(NodeManager* nm,
   d_false = nm->mkConst(false);
   registerProofRewriteRule(ProofRewriteRule::RE_LOOP_ELIM,
                            TheoryRewriteCtx::PRE_DSL);
-  registerProofRewriteRule(ProofRewriteRule::RE_INTER_UNION_INCLUSION,
+  registerProofRewriteRule(ProofRewriteRule::MACRO_RE_INTER_UNION_INCLUSION,
                            TheoryRewriteCtx::PRE_DSL);
   registerProofRewriteRule(ProofRewriteRule::STR_IN_RE_EVAL,
                            TheoryRewriteCtx::DSL_SUBCALL);
@@ -86,8 +86,11 @@ Node SequencesRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
   switch (id)
   {
     case ProofRewriteRule::RE_LOOP_ELIM: return rewriteViaReLoopElim(n);
-    case ProofRewriteRule::RE_INTER_UNION_INCLUSION:
-      return rewriteViaReInterUnionInclusion(n);
+    case ProofRewriteRule::MACRO_RE_INTER_UNION_INCLUSION:
+      return rewriteViaMacroReInterUnionInclusion(n);
+    case ProofRewriteRule::RE_INTER_INCLUSION:
+    case ProofRewriteRule::RE_UNION_INCLUSION:
+      return rewriteViaReInterUnionInclusion(id, n);
     case ProofRewriteRule::STR_IN_RE_EVAL: return rewriteViaStrInReEval(n);
     case ProofRewriteRule::STR_IN_RE_CONSUME:
       return rewriteViaStrInReConsume(n);
@@ -894,7 +897,7 @@ Node SequencesRewriter::rewriteStarRegExp(TNode node)
   return node;
 }
 
-Node SequencesRewriter::rewriteViaReInterUnionInclusion(const Node& node)
+Node SequencesRewriter::rewriteViaMacroReInterUnionInclusion(const Node& node)
 {
   Kind nk = node.getKind();
   if (nk != Kind::REGEXP_UNION && nk != Kind::REGEXP_INTER)
@@ -958,6 +961,33 @@ Node SequencesRewriter::rewriteViaReInterUnionInclusion(const Node& node)
         }
         return retNode;
       }
+    }
+  }
+  return Node::null();
+}
+
+Node SequencesRewriter::rewriteViaReInterUnionInclusion(ProofRewriteRule id,
+                                                        const Node& n)
+{
+  if (n.getNumChildren() != 2 || n[1].getKind() != Kind::REGEXP_COMPLEMENT)
+  {
+    return Node::null();
+  }
+  Kind k = n.getKind();
+  if (id == ProofRewriteRule::RE_INTER_INCLUSION)
+  {
+    if (k == Kind::REGEXP_INTER && RegExpEntail::regExpIncludes(n[1][0], n[0]))
+    {
+      return nodeManager()->mkNode(Kind::REGEXP_NONE);
+    }
+  }
+  else
+  {
+    Assert(id == ProofRewriteRule::RE_UNION_INCLUSION);
+    if (k == Kind::REGEXP_UNION && RegExpEntail::regExpIncludes(n[0], n[1][0]))
+    {
+      NodeManager* nm = nodeManager();
+      return nm->mkNode(Kind::REGEXP_STAR, nm->mkNode(Kind::REGEXP_ALLCHAR));
     }
   }
   return Node::null();
@@ -1107,7 +1137,7 @@ Node SequencesRewriter::rewriteAndOrRegExp(TNode node)
     }
   }
   // use inclusion tests
-  Node retNode = rewriteViaReInterUnionInclusion(node);
+  Node retNode = rewriteViaMacroReInterUnionInclusion(node);
   if (!retNode.isNull())
   {
     return returnRewrite(node, retNode, Rewrite::RE_ANDOR_INC_CONFLICT);

--- a/src/theory/strings/sequences_rewriter.h
+++ b/src/theory/strings/sequences_rewriter.h
@@ -147,8 +147,12 @@ class SequencesRewriter : public TheoryRewriter
   Node rewriteViaStrEqLenUnify(const Node& n, Rewrite& rule);
   /** Rewrite based on RE_LOOP_ELIM */
   Node rewriteViaReLoopElim(const Node& n);
-  /** Rewrite based on RE_INTER_UNION_INCLUSION */
-  Node rewriteViaReInterUnionInclusion(const Node& n);
+  /** Rewrite based on MACRO_RE_INTER_UNION_INCLUSION */
+  Node rewriteViaMacroReInterUnionInclusion(const Node& n);
+  /**
+   * Rewrite based on RE_INTER_INCLUSION, or RE_UNION_INCLUSION.
+   */
+  Node rewriteViaReInterUnionInclusion(ProofRewriteRule id, const Node& n);
   /** Rewrite based on STR_IN_RE_EVAL */
   Node rewriteViaStrInReEval(const Node& n);
   /** Rewrite based on STR_IN_RE_CONSUME */


### PR DESCRIPTION
This is work towards simplifying CPC and its formalism in Eunoia for the sake of further verification efforts.