### PR TITLE
Make unit tests for proofs more robust wrt rewrite rules

### DIFF
--- a/test/unit/api/c/capi_proof_black.cpp
+++ b/test/unit/api/c/capi_proof_black.cpp
@@ -100,13 +100,14 @@ class TestCApiBlackProof : public ::testing::Test
     cvc5_set_option(d_solver, "produce-proofs", "true");
     cvc5_set_option(d_solver, "proof-granularity", "dsl-rewrite");
     Cvc5Term x = cvc5_mk_const(d_tm, d_int, "x");
-    std::vector<Cvc5Term> args = {cvc5_mk_integer_int64(d_tm, 2), x};
-    Cvc5Term twox =
-        cvc5_mk_term(d_tm, CVC5_KIND_MULT, args.size(), args.data());
-    args = {x, x};
-    Cvc5Term xplusx =
-        cvc5_mk_term(d_tm, CVC5_KIND_ADD, args.size(), args.data());
-    args = {twox, xplusx};
+    Cvc5Term zero = cvc5_mk_integer_int64(d_tm, 2);
+    std::vector<Cvc5Term> args = {x, zero};
+    Cvc5Term geq =
+        cvc5_mk_term(d_tm, CVC5_KIND_GEQ, args.size(), args.data());
+    args = {zero, x};
+    Cvc5Term leq =
+        cvc5_mk_term(d_tm, CVC5_KIND_LEQ, args.size(), args.data());
+    args = {geq, leq};
     cvc5_assert_formula(
         d_solver,
         cvc5_mk_term(d_tm, CVC5_KIND_DISTINCT, args.size(), args.data()));

--- a/test/unit/api/cpp/api_proof_black.cpp
+++ b/test/unit/api/cpp/api_proof_black.cpp
@@ -62,9 +62,10 @@ class TestApiBlackProof : public TestApi
     d_solver->setOption("proof-granularity", "dsl-rewrite");
     Sort intSort = d_tm.getIntegerSort();
     Term x = d_tm.mkConst(intSort, "x");
-    Term twoX = d_tm.mkTerm(Kind::MULT, {d_tm.mkInteger(2), x});
-    Term xPlusX = d_tm.mkTerm(Kind::ADD, {x, x});
-    d_solver->assertFormula(d_tm.mkTerm(Kind::DISTINCT, {twoX, xPlusX}));
+    Term zero = d_tm.mkInteger(0);
+    Term geq = d_tm.mkTerm(Kind::GEQ, {x, zero});
+    Term leq = d_tm.mkTerm(Kind::LEQ, {zero, x});
+    d_solver->assertFormula(d_tm.mkTerm(Kind::DISTINCT, {geq, leq}));
     d_solver->checkSat();
     return d_solver->getProof().front();
   }

--- a/test/unit/api/java/ProofTest.java
+++ b/test/unit/api/java/ProofTest.java
@@ -84,10 +84,11 @@ class ProofTest
     d_solver.setOption("proof-granularity", "dsl-rewrite");
     Sort intSort = d_tm.getIntegerSort();
     Term x = d_tm.mkConst(intSort, "x");
-    Term twoX = d_tm.mkTerm(Kind.MULT, new Term[]{d_tm.mkInteger(2), x});
-    Term xPlusX = d_tm.mkTerm(Kind.ADD, new Term[]{x, x});
+    Term zero = d_tm.mkInteger(0);
+    Term geq = d_tm.mkTerm(Kind.GEQ, new Term[]{x, zero});
+    Term leq = d_tm.mkTerm(Kind.LEQ, new Term[]{zero, x});
     d_solver.assertFormula(
-        d_tm.mkTerm(Kind.DISTINCT, new Term[]{twoX, xPlusX}));
+        d_tm.mkTerm(Kind.DISTINCT, new Term[]{geq, leq}));
     d_solver.checkSat();
     return d_solver.getProof()[0];
   }

--- a/test/unit/api/python/test_proof.py
+++ b/test/unit/api/python/test_proof.py
@@ -63,9 +63,10 @@ def create_rewrite_proof(tm, solver):
     solver.setOption("proof-granularity", "dsl-rewrite")
     int_sort = tm.getIntegerSort()
     x = tm.mkConst(int_sort, "x")
-    two_x = tm.mkTerm(Kind.MULT, tm.mkInteger(2), x)
-    x_plus_x = tm.mkTerm(Kind.ADD, x, x)
-    solver.assertFormula(tm.mkTerm(Kind.DISTINCT, two_x, x_plus_x))
+    zero = tm.mkInteger(0)
+    geq = tm.mkTerm(Kind.GEQ, x, zero)
+    leq = tm.mkTerm(Kind.LEQ, zero, x)
+    solver.assertFormula(tm.mkTerm(Kind.DISTINCT, geq, leq))
     solver.checkSat()
     return solver.getProof()[0]
 


### PR DESCRIPTION
The helper method `create_rewrite_proof` no longer generates rewrite rule holes on my dev branch, since the given rewrite is handled by ARITH_POLY_NORM now.