### PR TITLE
Guard more cases of constant arrays in assertions

### DIFF
--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -158,27 +158,37 @@ bool hasSubtermKind(Kind k, Node n)
 }
 
 bool hasSubtermKinds(const std::unordered_set<Kind, kind::KindHashFunction>& ks,
-                     Node n)
+                     TNode n)
 {
   if (ks.empty())
   {
     return false;
   }
   std::unordered_set<TNode> visited;
+  return hasSubtermKinds(ks, n, visited)!=Kind::UNDEFINED_KIND;
+}
+
+Kind hasSubtermKinds(const std::unordered_set<Kind, kind::KindHashFunction>& ks,
+                     TNode n,
+                     std::unordered_set<TNode>& visited)
+{
+  Assert (!ks.empty());
   std::vector<TNode> visit;
   TNode cur;
   visit.push_back(n);
+  Kind k;
   do
   {
     cur = visit.back();
     visit.pop_back();
     if (visited.find(cur) == visited.end())
     {
-      visited.insert(cur);
-      if (ks.find(cur.getKind()) != ks.end())
+      k = cur.getKind();
+      if (ks.find(k) != ks.end())
       {
-        return true;
+        return k;
       }
+      visited.insert(cur);
       if (cur.hasOperator())
       {
         visit.push_back(cur.getOperator());
@@ -186,7 +196,7 @@ bool hasSubtermKinds(const std::unordered_set<Kind, kind::KindHashFunction>& ks,
       visit.insert(visit.end(), cur.begin(), cur.end());
     }
   } while (!visit.empty());
-  return false;
+  return Kind::UNDEFINED_KIND;
 }
 
 bool hasSubterm(TNode n, const std::vector<Node>& t, bool strict)

--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -165,14 +165,14 @@ bool hasSubtermKinds(const std::unordered_set<Kind, kind::KindHashFunction>& ks,
     return false;
   }
   std::unordered_set<TNode> visited;
-  return hasSubtermKinds(ks, n, visited)!=Kind::UNDEFINED_KIND;
+  return hasSubtermKinds(ks, n, visited) != Kind::UNDEFINED_KIND;
 }
 
 Kind hasSubtermKinds(const std::unordered_set<Kind, kind::KindHashFunction>& ks,
                      TNode n,
                      std::unordered_set<TNode>& visited)
 {
-  Assert (!ks.empty());
+  Assert(!ks.empty());
   std::vector<TNode> visit;
   TNode cur;
   visit.push_back(n);

--- a/src/expr/node_algorithm.h
+++ b/src/expr/node_algorithm.h
@@ -57,7 +57,17 @@ bool hasSubtermKind(Kind k, Node n);
  * @return true iff there is a term in n that has any kind ks
  */
 bool hasSubtermKinds(const std::unordered_set<Kind, kind::KindHashFunction>& ks,
-                     Node n);
+                     TNode n);
+
+/**
+ * @param ks The kinds of node to check
+ * @param n The node to search in.
+ * @param visited A cache of nodes we have already visited (and did not contain a kind in ks)
+ * @return the illegal kind we found
+ */
+Kind hasSubtermKinds(const std::unordered_set<Kind, kind::KindHashFunction>& ks,
+                     TNode n,
+                     std::unordered_set<TNode>& visited);
 
 /**
  * Check if the node n has a subterm that occurs in t.

--- a/src/expr/node_algorithm.h
+++ b/src/expr/node_algorithm.h
@@ -62,7 +62,8 @@ bool hasSubtermKinds(const std::unordered_set<Kind, kind::KindHashFunction>& ks,
 /**
  * @param ks The kinds of node to check
  * @param n The node to search in.
- * @param visited A cache of nodes we have already visited (and did not contain a kind in ks)
+ * @param visited A cache of nodes we have already visited (and did not contain
+ * a kind in ks)
  * @return the illegal kind we found
  */
 Kind hasSubtermKinds(const std::unordered_set<Kind, kind::KindHashFunction>& ks,

--- a/src/smt/smt_solver.cpp
+++ b/src/smt/smt_solver.cpp
@@ -15,6 +15,7 @@
 
 #include "smt/smt_solver.h"
 
+#include "options/arrays_options.h"
 #include "options/base_options.h"
 #include "options/main_options.h"
 #include "options/smt_options.h"
@@ -93,6 +94,20 @@ void SmtSolver::finishInit()
       pm->startProofLogging(options().base.out, d_asserts);
     }
   }
+
+  // Determine any illegal kinds that are dependent on options that need to be guarded here.
+  // Note that nearly all illegal kinds should be properly guarded by either the theory engine,
+  // theory solvers, or by theory rewriters. We only require special handling for rare cases,
+  // including array constants, where array constants *must* be rewritten by the rewriter
+  // for the purposes of model verification, but we do not want array constants to
+  // appear in assertions unless --arrays-exp is enabled.
+
+  // Array constants are not supported unless arraysExp is enabled
+  if (logicInfo().isTheoryEnabled(internal::theory::THEORY_ARRAYS)
+    && !options().arrays.arraysExp)
+  {
+    d_illegalKinds.insert(Kind::STORE_ALL);
+  }
 }
 
 void SmtSolver::resetAssertions()
@@ -134,6 +149,24 @@ void SmtSolver::preprocess(preprocessing::AssertionPipeline& ap)
 {
   TimerStat::CodeTimer paTimer(d_stats.d_processAssertionsTime);
   d_env.getResourceManager()->spendResource(Resource::PreprocessStep);
+
+  // check illegal kinds here
+  if (!d_illegalKinds.empty())
+  {
+    const std::vector<Node>& assertions = ap.ref();
+    std::unordered_set<TNode> visited;
+    for (const Node& a : assertions)
+    {
+      Kind k = expr::hasSubtermKinds(d_illegalKinds, a, visited);
+      if (k!=Kind::UNDEFINED_KIND)
+      {
+        std::stringstream ss;
+        ss << "ERROR: cannot handle assertion with term of kind " << k << " in this configuration";
+        throw LogicException(ss.str());
+      }
+    }
+  }
+
 
   // process the assertions with the preprocessor
   d_pp.process(ap);

--- a/src/smt/smt_solver.cpp
+++ b/src/smt/smt_solver.cpp
@@ -95,16 +95,17 @@ void SmtSolver::finishInit()
     }
   }
 
-  // Determine any illegal kinds that are dependent on options that need to be guarded here.
-  // Note that nearly all illegal kinds should be properly guarded by either the theory engine,
-  // theory solvers, or by theory rewriters. We only require special handling for rare cases,
-  // including array constants, where array constants *must* be rewritten by the rewriter
-  // for the purposes of model verification, but we do not want array constants to
-  // appear in assertions unless --arrays-exp is enabled.
+  // Determine any illegal kinds that are dependent on options that need to be
+  // guarded here. Note that nearly all illegal kinds should be properly guarded
+  // by either the theory engine, theory solvers, or by theory rewriters. We
+  // only require special handling for rare cases, including array constants,
+  // where array constants *must* be rewritten by the rewriter for the purposes
+  // of model verification, but we do not want array constants to appear in
+  // assertions unless --arrays-exp is enabled.
 
   // Array constants are not supported unless arraysExp is enabled
   if (logicInfo().isTheoryEnabled(internal::theory::THEORY_ARRAYS)
-    && !options().arrays.arraysExp)
+      && !options().arrays.arraysExp)
   {
     d_illegalKinds.insert(Kind::STORE_ALL);
   }
@@ -158,11 +159,12 @@ void SmtSolver::preprocess(preprocessing::AssertionPipeline& ap)
     for (const Node& a : assertions)
     {
       Kind k = expr::hasSubtermKinds(d_illegalKinds, a, visited);
-      if (k!=Kind::UNDEFINED_KIND)
+      if (k != Kind::UNDEFINED_KIND)
       {
         std::stringstream ss;
-        ss << "ERROR: cannot handle assertion with term of kind " << k << " in this configuration";
-        if (k==Kind::STORE_ALL)
+        ss << "ERROR: cannot handle assertion with term of kind " << k
+           << " in this configuration";
+        if (k == Kind::STORE_ALL)
         {
           ss << ", unless --arrays-exp is enabled";
         }
@@ -170,7 +172,6 @@ void SmtSolver::preprocess(preprocessing::AssertionPipeline& ap)
       }
     }
   }
-
 
   // process the assertions with the preprocessor
   d_pp.process(ap);

--- a/src/smt/smt_solver.cpp
+++ b/src/smt/smt_solver.cpp
@@ -95,16 +95,17 @@ void SmtSolver::finishInit()
     }
   }
 
-  // Determine any illegal kinds that are dependent on options that need to be guarded here.
-  // Note that nearly all illegal kinds should be properly guarded by either the theory engine,
-  // theory solvers, or by theory rewriters. We only require special handling for rare cases,
-  // including array constants, where array constants *must* be rewritten by the rewriter
-  // for the purposes of model verification, but we do not want array constants to
-  // appear in assertions unless --arrays-exp is enabled.
+  // Determine any illegal kinds that are dependent on options that need to be
+  // guarded here. Note that nearly all illegal kinds should be properly guarded
+  // by either the theory engine, theory solvers, or by theory rewriters. We
+  // only require special handling for rare cases, including array constants,
+  // where array constants *must* be rewritten by the rewriter for the purposes
+  // of model verification, but we do not want array constants to appear in
+  // assertions unless --arrays-exp is enabled.
 
   // Array constants are not supported unless arraysExp is enabled
   if (logicInfo().isTheoryEnabled(internal::theory::THEORY_ARRAYS)
-    && !options().arrays.arraysExp)
+      && !options().arrays.arraysExp)
   {
     d_illegalKinds.insert(Kind::STORE_ALL);
   }
@@ -158,15 +159,15 @@ void SmtSolver::preprocess(preprocessing::AssertionPipeline& ap)
     for (const Node& a : assertions)
     {
       Kind k = expr::hasSubtermKinds(d_illegalKinds, a, visited);
-      if (k!=Kind::UNDEFINED_KIND)
+      if (k != Kind::UNDEFINED_KIND)
       {
         std::stringstream ss;
-        ss << "ERROR: cannot handle assertion with term of kind " << k << " in this configuration";
+        ss << "ERROR: cannot handle assertion with term of kind " << k
+           << " in this configuration";
         throw LogicException(ss.str());
       }
     }
   }
-
 
   // process the assertions with the preprocessor
   d_pp.process(ap);

--- a/src/smt/smt_solver.cpp
+++ b/src/smt/smt_solver.cpp
@@ -95,17 +95,16 @@ void SmtSolver::finishInit()
     }
   }
 
-  // Determine any illegal kinds that are dependent on options that need to be
-  // guarded here. Note that nearly all illegal kinds should be properly guarded
-  // by either the theory engine, theory solvers, or by theory rewriters. We
-  // only require special handling for rare cases, including array constants,
-  // where array constants *must* be rewritten by the rewriter for the purposes
-  // of model verification, but we do not want array constants to appear in
-  // assertions unless --arrays-exp is enabled.
+  // Determine any illegal kinds that are dependent on options that need to be guarded here.
+  // Note that nearly all illegal kinds should be properly guarded by either the theory engine,
+  // theory solvers, or by theory rewriters. We only require special handling for rare cases,
+  // including array constants, where array constants *must* be rewritten by the rewriter
+  // for the purposes of model verification, but we do not want array constants to
+  // appear in assertions unless --arrays-exp is enabled.
 
   // Array constants are not supported unless arraysExp is enabled
   if (logicInfo().isTheoryEnabled(internal::theory::THEORY_ARRAYS)
-      && !options().arrays.arraysExp)
+    && !options().arrays.arraysExp)
   {
     d_illegalKinds.insert(Kind::STORE_ALL);
   }
@@ -159,15 +158,19 @@ void SmtSolver::preprocess(preprocessing::AssertionPipeline& ap)
     for (const Node& a : assertions)
     {
       Kind k = expr::hasSubtermKinds(d_illegalKinds, a, visited);
-      if (k != Kind::UNDEFINED_KIND)
+      if (k!=Kind::UNDEFINED_KIND)
       {
         std::stringstream ss;
-        ss << "ERROR: cannot handle assertion with term of kind " << k
-           << " in this configuration";
+        ss << "ERROR: cannot handle assertion with term of kind " << k << " in this configuration";
+        if (k==Kind::STORE_ALL)
+        {
+          ss << ", unless --arrays-exp is enabled";
+        }
         throw LogicException(ss.str());
       }
     }
   }
+
 
   // process the assertions with the preprocessor
   d_pp.process(ap);

--- a/src/smt/smt_solver.h
+++ b/src/smt/smt_solver.h
@@ -141,6 +141,8 @@ class SmtSolver : protected EnvObj
   Preprocessor d_pp;
   /** Assertions manager */
   Assertions d_asserts;
+  /** The illegal kinds that cannot appear in assertions */
+  std::unordered_set<Kind, kind::KindHashFunction> d_illegalKinds;
   /** Reference to the statistics of SolverEngine */
   SolverEngineStatistics& d_stats;
   /** The theory engine */

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -2013,6 +2013,7 @@ Node SolverEngine::getAbductNext()
   bool success = d_abductSolver->getAbductNext(abd);
   // notify the state of whether the get-abduct-next call was successful
   d_state->notifyGetAbduct(success);
+  endCall();
   Assert(success == !abd.isNull());
   return abd;
 }

--- a/test/regress/cli/regress0/array-const-real-parse.smt2
+++ b/test/regress/cli/regress0/array-const-real-parse.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --print-arith-lit-token
+; COMMAND-LINE: --arrays-exp --print-arith-lit-token
 (set-logic QF_AUFLIRA)
 (set-info :status sat)
 (declare-fun a () (Array Int Real))

--- a/test/regress/cli/regress0/arrays/constarr.cvc.smt2
+++ b/test/regress/cli/regress0/arrays/constarr.cvc.smt2
@@ -1,3 +1,4 @@
+; COMMAND-LINE: --arrays-exp
 ; EXPECT: unsat
 (set-logic ALL)
 (set-option :incremental true)

--- a/test/regress/cli/regress0/arrays/constarr.smt2
+++ b/test/regress/cli/regress0/arrays/constarr.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: --arrays-exp
+; EXPECT: unsat
 (set-logic QF_ALIA)
 (set-info :status unsat)
 (declare-const all1 (Array Int Int))

--- a/test/regress/cli/regress0/arrays/constarr2.cvc.smt2
+++ b/test/regress/cli/regress0/arrays/constarr2.cvc.smt2
@@ -1,3 +1,4 @@
+; COMMAND-LINE: --arrays-exp
 ; EXPECT: unsat
 (set-logic ALL)
 (set-option :incremental false)

--- a/test/regress/cli/regress0/arrays/constarr2.smt2
+++ b/test/regress/cli/regress0/arrays/constarr2.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: --arrays-exp
+; EXPECT: unsat
 (set-logic QF_ALIA)
 (set-info :status unsat)
 (declare-const all1 (Array Int Int))

--- a/test/regress/cli/regress0/arrays/issue4414-2.smt2
+++ b/test/regress/cli/regress0/arrays/issue4414-2.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: --arrays-exp
+; EXPECT: sat
 (set-option :check-models true)
 (set-option :check-unsat-cores true)
 (set-logic QF_ALIA)

--- a/test/regress/cli/regress0/arrays/issue7596-define-array-uminus.smt2
+++ b/test/regress/cli/regress0/arrays/issue7596-define-array-uminus.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --print-arith-lit-token
+; COMMAND-LINE: --arrays-exp --print-arith-lit-token
 (set-logic ALL)
 (set-info :status sat)
 (define-fun foo () (Array Int Int) ((as const (Array Int Int)) -1))

--- a/test/regress/cli/regress1/bug590.smt2
+++ b/test/regress/cli/regress1/bug590.smt2
@@ -1,3 +1,4 @@
+; COMMAND-LINE: --arrays-exp
 ; SCRUBBER: grep -o "unknown\|((charlst2 ("
 ; EXPECT: unknown
 ; EXPECT: ((charlst2 (

--- a/test/regress/cli/regress1/datatypes/cee-prs-small-dd2.smt2
+++ b/test/regress/cli/regress1/datatypes/cee-prs-small-dd2.smt2
@@ -1,5 +1,5 @@
-; COMMAND-LINE: --ee-mode=distributed
-; COMMAND-LINE: --ee-mode=central
+; COMMAND-LINE: --arrays-exp --ee-mode=distributed
+; COMMAND-LINE: --arrays-exp --ee-mode=central
 ; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)

--- a/test/regress/cli/regress1/datatypes/nested-rec-array-aa.smt2
+++ b/test/regress/cli/regress1/datatypes/nested-rec-array-aa.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: --arrays-exp
+; EXPECT: unsat
 (set-logic ALL)
 (set-info :status unsat)
 (set-option :dt-nested-rec true)

--- a/test/regress/cli/regress1/push-pop/cee-prs-small.smt2
+++ b/test/regress/cli/regress1/push-pop/cee-prs-small.smt2
@@ -1,5 +1,5 @@
-; COMMAND-LINE: -i --ee-mode=distributed
-; COMMAND-LINE: -i --ee-mode=central
+; COMMAND-LINE: --arrays-exp -i --ee-mode=distributed
+; COMMAND-LINE: --arrays-exp -i --ee-mode=central
 ; EXPECT: sat
 ; EXPECT: unsat
 (set-logic ALL)


### PR DESCRIPTION
Array constants could dissappear from assertions and not be recognized when arrays-exp is disabled. This behavior is inconsistent and also can lead to proof holes currently.

This introduces a standard place where we check for illegal kinds, possibly to be used for other kinds as well.