### PR TITLE
Improvements and optimizations for Eunoia quantifiers signature

### DIFF
--- a/proofs/eo/cpc/programs/Quantifiers.eo
+++ b/proofs/eo/cpc/programs/Quantifiers.eo
@@ -12,7 +12,8 @@
   (S S U) U
   (
   (($substitute x y (f a))         (_ ($substitute x y f) ($substitute x y a)))
-  (($substitute x y z)             (eo::ite (eo::is_eq z x) y z))
+  (($substitute x y x)             y)
+  (($substitute x y z)             z)
   )
 )
 

--- a/proofs/eo/cpc/programs/Quantifiers.eo
+++ b/proofs/eo/cpc/programs/Quantifiers.eo
@@ -11,26 +11,8 @@
   ((T Type) (U Type) (S Type) (x S) (y S) (f (-> T U)) (a T) (z U) (w T))
   (S S U) U
   (
-  (($substitute x y x)             y)
   (($substitute x y (f a))         (_ ($substitute x y f) ($substitute x y a)))
-  (($substitute x y z)             z)
-  )
-)
-
-; program: $substitute_list
-; args:
-; - arg1 @List: The list of domains of the substitution.
-; - arg2 @List: The list of ranges of the substitution.
-; - arg3 U: The term to process.
-; return: >
-;   The result of applying the substitutions specified by arg1
-;   and arg2 in order to arg3. In particular, the first element in the lists arg1
-;   and arg2 are processed first.
-(program $substitute_list ((T Type) (U Type) (F U) (x T) (xs @List :list) (t T) (ts @List :list))
-  (@List @List U) U
-  (
-    (($substitute_list (@list x xs) (@list t ts) F) ($substitute_list xs ts ($substitute x t F)))
-    (($substitute_list @list.nil @list.nil F)       F)
+  (($substitute x y z)             (eo::ite (eo::is_eq z x) y z))
   )
 )
 
@@ -62,6 +44,18 @@
   )
 )
 
+; program: $contains_aterm_list
+; args:
+; - t T: The term to process.
+; - xs @List: The list of terms to find.
+; return: true if any atomic (0-ary) subterm of t is in xs.
+(program $contains_aterm_list ((T Type) (U Type) (S Type) (x U) (f (-> T S)) (a T) (xs @List))
+  (T @List) Bool
+  (
+    (($contains_aterm_list (f a) xs)  (eo::ite ($contains_aterm_list f xs) true ($contains_aterm_list a xs)))
+    (($contains_aterm_list x xs)      (eo::not (eo::is_neg (eo::list_find @list xs x))))
+  )
+)
 
 ; program: $substitute_simul
 ; args:
@@ -74,9 +68,8 @@
   (S @List @List) S
   (
   (($substitute_simul (f a) xs ss)                  (_ ($substitute_simul f xs ss) ($substitute_simul a xs ss)))
-  (($substitute_simul x @list.nil @list.nil)        x)
-  (($substitute_simul x (@list x xs) (@list s ss))  s)  ; note that we do not substitute further since this is a simultaneous substitution.
-  (($substitute_simul x (@list y xs) (@list s ss))  ($substitute_simul x xs ss))
+  (($substitute_simul x xs ss)                      (eo::define ((i (eo::list_find @list xs x)))
+                                                      (eo::ite (eo::is_neg i) x (eo::list_nth @list ss i))))
   )
 )
 

--- a/proofs/eo/cpc/rules/Quantifiers.eo
+++ b/proofs/eo/cpc/rules/Quantifiers.eo
@@ -12,7 +12,7 @@
 (declare-rule instantiate ((F Bool) (xs @List) (ts @List))
   :premises ((forall xs F))
   :args (ts)
-  :conclusion ($substitute_list xs ts F))
+  :conclusion ($substitute_simul F xs ts))
 
 ; program: $mk_skolems
 ; args:
@@ -39,7 +39,7 @@
 ;   introduced via $mk_skolems.
 (declare-rule skolemize ((x @List) (G Bool))
   :premises ((not (forall x G)))
-  :conclusion ($substitute_list x ($mk_skolems x (forall x G) 0) (not G))
+  :conclusion ($substitute_simul (not G) x ($mk_skolems x (forall x G) 0))
 )
 
 ; rule: skolem_intro
@@ -66,8 +66,8 @@
 ;   B. The substitution is valid renaming due to the requirement check.
 (declare-rule alpha_equiv ((B Bool) (vs @List) (ts @List))
   :args (B vs ts)
-  :requires ((($contains_subterm_list B ts) false))
-  :conclusion (= B ($substitute_list vs ts B))
+  :requires ((($contains_aterm_list B ts) false))
+  :conclusion (= B ($substitute_simul B vs ts))
 )
 
 ; rule: beta-reduce
@@ -235,9 +235,9 @@
 (program $is_quant_miniscope_or ((x @List) (xs @List :list) (ys @List :list) (f Bool) (fs Bool :list) (g Bool) (gs Bool :list))
   (@List Bool Bool) Bool
   (
-  (($is_quant_miniscope_or x (or f fs) (or f gs))                     (eo::requires ($contains_subterm_list f x) false 
+  (($is_quant_miniscope_or x (or f fs) (or f gs))                     (eo::requires ($contains_aterm_list f x) false
                                                                         ($is_quant_miniscope_or x fs gs)))
-  (($is_quant_miniscope_or x (or f fs) (or (forall @list.nil f) gs))  (eo::requires ($contains_subterm_list f x) false 
+  (($is_quant_miniscope_or x (or f fs) (or (forall @list.nil f) gs))  (eo::requires ($contains_aterm_list f x) false
                                                                         ($is_quant_miniscope_or x fs gs)))
   (($is_quant_miniscope_or (@list x xs) (or f fs) (or (forall (@list x ys) f) gs))  
                                                                       (eo::requires ($contains_subterm gs x) false
@@ -273,7 +273,7 @@
 ; conclusion: The given equality.
 (declare-rule quant-miniscope-ite ((x @List) (A Bool) (F1 Bool) (F2 Bool) (G Bool))
   :args ((= (forall x (ite A F1 F2)) (ite A (forall x F1) (forall x F2))))
-  :requires ((($contains_subterm_list A x) false))
+  :requires ((($contains_aterm_list A x) false))
   :conclusion (= (forall x (ite A F1 F2)) (ite A (forall x F1) (forall x F2)))
 )
 


### PR DESCRIPTION
Notably substitutions are now proper substitutions and not computed as term substitutions, similarly searching for free variables is simplified by looking for atomic terms only. Also, substitutions for multiple variables are made significantly faster by leveraging eo::list operators.