### PR TITLE
Updates for string entail utility

### DIFF
--- a/proofs/eo/cpc/rules/Strings.eo
+++ b/proofs/eo/cpc/rules/Strings.eo
@@ -609,7 +609,7 @@
     ((Seq T)) (Seq T)
     (
       (($str_multiset_overapprox (str.++ s ss))        (eo::list_concat str.++ ($str_multiset_overapprox s) ($str_multiset_overapprox ss)))
-      (($str_multiset_overapprox (str.substr s n m))   ($str_to_flat_form s false))
+      (($str_multiset_overapprox (str.substr s n m))   ($str_multiset_overapprox s))
       (($str_multiset_overapprox (str.replace s t r))  (eo::list_concat str.++ ($str_multiset_overapprox s) ($str_multiset_overapprox r)))
       (($str_multiset_overapprox s)                    ($str_to_flat_form s false))
     )

--- a/src/theory/quantifiers/extended_rewrite.cpp
+++ b/src/theory/quantifiers/extended_rewrite.cpp
@@ -2042,8 +2042,20 @@ Node ExtendedRewriter::extendedRewriteStrings(const Node& node) const
         }
       }
     }
+    std::vector<Node> nc1;
+    strings::utils::getConcat(node[0], nc1);
     std::vector<Node> nc2;
     strings::utils::getConcat(node[1], nc2);
+
+    // extended component-wise containment
+    std::vector<Node> nc1rb;
+    std::vector<Node> nc1re;
+    if (se.componentContainsExt(nc1, nc2, nc1rb, nc1re) != -1)
+    {
+      debugExtendedRewrite(node, d_true, "CTN_COMPONENT_EXT");
+      return d_true;
+    }
+
     for (const Node& n : nc2)
     {
       // (str.contains x (str.++ w (str.replace x y x) z)) --->

--- a/src/theory/strings/strings_entail.cpp
+++ b/src/theory/strings/strings_entail.cpp
@@ -232,26 +232,28 @@ int StringsEntail::componentContains(std::vector<Node>& n1,
                                      bool computeRemainder,
                                      int remainderDir)
 {
-  return componentContainsInternal(false, n1, n2, nb, ne, computeRemainder, remainderDir);
+  return componentContainsInternal(
+      false, n1, n2, nb, ne, computeRemainder, remainderDir);
 }
 
 int StringsEntail::componentContainsExt(std::vector<Node>& n1,
-                      std::vector<Node>& n2,
-                      std::vector<Node>& nb,
-                      std::vector<Node>& ne,
-                      bool computeRemainder,
-                      int remainderDir)
+                                        std::vector<Node>& n2,
+                                        std::vector<Node>& nb,
+                                        std::vector<Node>& ne,
+                                        bool computeRemainder,
+                                        int remainderDir)
 {
-  return componentContainsInternal(true, n1, n2, nb, ne, computeRemainder, remainderDir);
+  return componentContainsInternal(
+      true, n1, n2, nb, ne, computeRemainder, remainderDir);
 }
 
 int StringsEntail::componentContainsInternal(bool isExt,
-                              std::vector<Node>& n1,
-                      std::vector<Node>& n2,
-                      std::vector<Node>& nb,
-                      std::vector<Node>& ne,
-                      bool computeRemainder,
-                      int remainderDir)
+                                             std::vector<Node>& n1,
+                                             std::vector<Node>& n2,
+                                             std::vector<Node>& nb,
+                                             std::vector<Node>& ne,
+                                             bool computeRemainder,
+                                             int remainderDir)
 {
   Assert(nb.empty());
   Assert(ne.empty());
@@ -266,7 +268,8 @@ int StringsEntail::componentContainsInternal(bool isExt,
     {
       Node n1rb;
       Node n1re;
-      if (componentContainsBase(isExt, n1[i], n2[0], n1rb, n1re, 0, computeRemainder))
+      if (componentContainsBase(
+              isExt, n1[i], n2[0], n1rb, n1re, 0, computeRemainder))
       {
         if (computeRemainder)
         {
@@ -328,7 +331,7 @@ int StringsEntail::componentContainsInternal(bool isExt,
             Node n1re_last;
             // last component of n2 must be a prefix
             if (componentContainsBase(isExt,
-              n1[i + j],
+                                      n1[i + j],
                                       n2[j],
                                       n1rb_last,
                                       n1re_last,
@@ -384,8 +387,13 @@ int StringsEntail::componentContainsInternal(bool isExt,
   return -1;
 }
 
-bool StringsEntail::componentContainsBase(
-    bool isExt, Node n1, Node n2, Node& n1rb, Node& n1re, int dir, bool computeRemainder)
+bool StringsEntail::componentContainsBase(bool isExt,
+                                          Node n1,
+                                          Node n2,
+                                          Node& n1rb,
+                                          Node& n1re,
+                                          int dir,
+                                          bool computeRemainder)
 {
   Assert(n1rb.isNull());
   Assert(n1re.isNull());

--- a/src/theory/strings/strings_entail.cpp
+++ b/src/theory/strings/strings_entail.cpp
@@ -520,8 +520,7 @@ bool StringsEntail::stripConstantEndpoints(std::vector<Node>& n1,
                                            std::vector<Node>& n2,
                                            std::vector<Node>& nb,
                                            std::vector<Node>& ne,
-                                           int dir,
-                                           bool isSimple)
+                                           int dir)
 {
   Assert(nb.empty());
   Assert(ne.empty());

--- a/src/theory/strings/strings_entail.cpp
+++ b/src/theory/strings/strings_entail.cpp
@@ -232,9 +232,31 @@ int StringsEntail::componentContains(std::vector<Node>& n1,
                                      bool computeRemainder,
                                      int remainderDir)
 {
+  return componentContainsInternal(false, n1, n2, nb, ne, computeRemainder, remainderDir);
+}
+
+int StringsEntail::componentContainsExt(std::vector<Node>& n1,
+                      std::vector<Node>& n2,
+                      std::vector<Node>& nb,
+                      std::vector<Node>& ne,
+                      bool computeRemainder,
+                      int remainderDir)
+{
+  return componentContainsInternal(true, n1, n2, nb, ne, computeRemainder, remainderDir);
+}
+
+int StringsEntail::componentContainsInternal(bool isExt,
+                              std::vector<Node>& n1,
+                      std::vector<Node>& n2,
+                      std::vector<Node>& nb,
+                      std::vector<Node>& ne,
+                      bool computeRemainder,
+                      int remainderDir)
+{
   Assert(nb.empty());
   Assert(ne.empty());
   Trace("strings-entail") << "Component contains: " << std::endl;
+  Trace("strings-entail") << "isExt = " << isExt << std::endl;
   Trace("strings-entail") << "n1 = " << n1 << std::endl;
   Trace("strings-entail") << "n2 = " << n2 << std::endl;
   // if n2 is a singleton, we can do optimized version here
@@ -244,7 +266,7 @@ int StringsEntail::componentContains(std::vector<Node>& n1,
     {
       Node n1rb;
       Node n1re;
-      if (componentContainsBase(n1[i], n2[0], n1rb, n1re, 0, computeRemainder))
+      if (componentContainsBase(isExt, n1[i], n2[0], n1rb, n1re, 0, computeRemainder))
       {
         if (computeRemainder)
         {
@@ -288,7 +310,8 @@ int StringsEntail::componentContains(std::vector<Node>& n1,
       Node n1rb_first;
       Node n1re_first;
       // first component of n2 must be a suffix
-      if (componentContainsBase(n1[i],
+      if (componentContainsBase(isExt,
+                                n1[i],
                                 n2[0],
                                 n1rb_first,
                                 n1re_first,
@@ -304,7 +327,8 @@ int StringsEntail::componentContains(std::vector<Node>& n1,
             Node n1rb_last;
             Node n1re_last;
             // last component of n2 must be a prefix
-            if (componentContainsBase(n1[i + j],
+            if (componentContainsBase(isExt,
+              n1[i + j],
                                       n2[j],
                                       n1rb_last,
                                       n1re_last,
@@ -361,7 +385,7 @@ int StringsEntail::componentContains(std::vector<Node>& n1,
 }
 
 bool StringsEntail::componentContainsBase(
-    Node n1, Node n2, Node& n1rb, Node& n1re, int dir, bool computeRemainder)
+    bool isExt, Node n1, Node n2, Node& n1rb, Node& n1re, int dir, bool computeRemainder)
 {
   Assert(n1rb.isNull());
   Assert(n1re.isNull());
@@ -421,7 +445,7 @@ bool StringsEntail::componentContainsBase(
         }
       }
     }
-    else if (computeRemainder)
+    else if (!isExt || computeRemainder)
     {
       // Note the cases below would require constructing new terms
       // as part of the remainder components. Thus, this is only checked
@@ -488,7 +512,8 @@ bool StringsEntail::stripConstantEndpoints(std::vector<Node>& n1,
                                            std::vector<Node>& n2,
                                            std::vector<Node>& nb,
                                            std::vector<Node>& ne,
-                                           int dir)
+                                           int dir,
+                                           bool isSimple)
 {
   Assert(nb.empty());
   Assert(ne.empty());
@@ -684,10 +709,6 @@ Node StringsEntail::checkContains(Node a, Node b)
     {
       prev = ctn;
       ctn = d_rewriter->rewriteContains(ctn);
-      if (ctn != prev)
-      {
-        ctn = d_rewriter->postProcessRewrite(prev, ctn);
-      }
     } while (prev != ctn && ctn.getKind() == Kind::STRING_CONTAINS);
   }
 
@@ -844,11 +865,11 @@ Node StringsEntail::checkHomogeneousString(Node a)
 Node StringsEntail::getMultisetApproximation(Node a)
 {
   NodeManager* nm = NodeManager::currentNM();
-  if (a.getKind() == Kind::STRING_SUBSTR)
+  while (a.getKind() == Kind::STRING_SUBSTR)
   {
-    return a[0];
+    a = a[0];
   }
-  else if (a.getKind() == Kind::STRING_REPLACE)
+  if (a.getKind() == Kind::STRING_REPLACE)
   {
     return getMultisetApproximation(
         nm->mkNode(Kind::STRING_CONCAT, a[0], a[2]));
@@ -986,21 +1007,18 @@ Node StringsEntail::inferEqsFromContains(Node x, Node y)
     cs.push_back(yiLen[0]);
   }
 
-  NodeBuilder nb(nm, Kind::AND);
   // (= x (str.++ y1' ... ym'))
-  if (!cs.empty())
-  {
-    nb << nm->mkNode(Kind::EQUAL, x, utils::mkConcat(cs, stype));
-  }
+  std::vector<Node> eqs;
+  Node mainEq = nm->mkNode(Kind::EQUAL, x, utils::mkConcat(cs, stype));
+  eqs.push_back(mainEq);
   // (= y1'' "") ... (= yk'' "")
   for (const Node& zeroLen : zeroLens)
   {
     Assert(std::find(y.begin(), y.end(), zeroLen[0]) != y.end());
-    nb << nm->mkNode(Kind::EQUAL, zeroLen[0], emp);
+    eqs.push_back(nm->mkNode(Kind::EQUAL, zeroLen[0], emp));
   }
-
   // (and (= x (str.++ y1' ... ym')) (= y1'' "") ... (= yk'' ""))
-  return nb.constructNode();
+  return nm->mkAnd(eqs);
 }
 
 Node StringsEntail::rewriteViaMacroSubstrStripSymLength(const Node& node,

--- a/src/theory/strings/strings_entail.h
+++ b/src/theory/strings/strings_entail.h
@@ -230,8 +230,7 @@ class StringsEntail
                                      std::vector<Node>& n2,
                                      std::vector<Node>& nb,
                                      std::vector<Node>& ne,
-                                     int dir = 0,
-                                     bool isSimple = true);
+                                     int dir = 0);
 
   /**
    * Checks whether a string term `a` is entailed to contain or not contain a

--- a/src/theory/strings/strings_entail.h
+++ b/src/theory/strings/strings_entail.h
@@ -189,11 +189,11 @@ class StringsEntail
    * and suffixes.
    */
   int componentContainsExt(std::vector<Node>& n1,
-                        std::vector<Node>& n2,
-                        std::vector<Node>& nb,
-                        std::vector<Node>& ne,
-                        bool computeRemainder = false,
-                        int remainderDir = 0);
+                           std::vector<Node>& n2,
+                           std::vector<Node>& nb,
+                           std::vector<Node>& ne,
+                           bool computeRemainder = false,
+                           int remainderDir = 0);
   /** strip constant endpoints
    * This function is used when rewriting str.contains( t1, t2 ), where
    * n1 is the vector form of t1
@@ -353,11 +353,11 @@ class StringsEntail
    */
   int componentContainsInternal(bool isExt,
                                 std::vector<Node>& n1,
-                        std::vector<Node>& n2,
-                        std::vector<Node>& nb,
-                        std::vector<Node>& ne,
-                        bool computeRemainder = false,
-                        int remainderDir = 0);
+                                std::vector<Node>& n2,
+                                std::vector<Node>& nb,
+                                std::vector<Node>& ne,
+                                bool computeRemainder = false,
+                                int remainderDir = 0);
   /** component contains base
    *
    * This function is a helper for the above function.
@@ -410,8 +410,13 @@ class StringsEntail
    * Since we do not wish to introduce new (symbolic) terms, we
    * instead return false, indicating that we cannot compute the remainder.
    */
-  bool componentContainsBase(
-      bool isExt, Node n1, Node n2, Node& n1rb, Node& n1re, int dir, bool computeRemainder);
+  bool componentContainsBase(bool isExt,
+                             Node n1,
+                             Node n2,
+                             Node& n1rb,
+                             Node& n1re,
+                             int dir,
+                             bool computeRemainder);
   /**
    * Simplifies a given node `a` s.t. the result is a concatenation of string
    * terms that can be interpreted as a multiset and which contains all

--- a/src/theory/strings/strings_entail.h
+++ b/src/theory/strings/strings_entail.h
@@ -184,6 +184,16 @@ class StringsEntail
                         std::vector<Node>& ne,
                         bool computeRemainder = false,
                         int remainderDir = 0);
+  /**
+   * Same as above, but with more advanced reasoning, e.g. to infer prefixes
+   * and suffixes.
+   */
+  int componentContainsExt(std::vector<Node>& n1,
+                        std::vector<Node>& n2,
+                        std::vector<Node>& nb,
+                        std::vector<Node>& ne,
+                        bool computeRemainder = false,
+                        int remainderDir = 0);
   /** strip constant endpoints
    * This function is used when rewriting str.contains( t1, t2 ), where
    * n1 is the vector form of t1
@@ -220,7 +230,8 @@ class StringsEntail
                                      std::vector<Node>& n2,
                                      std::vector<Node>& nb,
                                      std::vector<Node>& ne,
-                                     int dir = 0);
+                                     int dir = 0,
+                                     bool isSimple = true);
 
   /**
    * Checks whether a string term `a` is entailed to contain or not contain a
@@ -337,6 +348,16 @@ class StringsEntail
                                            std::vector<Node>& ch2);
 
  private:
+  /**
+   * Helper method for componentContains / componentContainsExt.
+   */
+  int componentContainsInternal(bool isExt,
+                                std::vector<Node>& n1,
+                        std::vector<Node>& n2,
+                        std::vector<Node>& nb,
+                        std::vector<Node>& ne,
+                        bool computeRemainder = false,
+                        int remainderDir = 0);
   /** component contains base
    *
    * This function is a helper for the above function.
@@ -390,7 +411,7 @@ class StringsEntail
    * instead return false, indicating that we cannot compute the remainder.
    */
   bool componentContainsBase(
-      Node n1, Node n2, Node& n1rb, Node& n1re, int dir, bool computeRemainder);
+      bool isExt, Node n1, Node n2, Node& n1rb, Node& n1re, int dir, bool computeRemainder);
   /**
    * Simplifies a given node `a` s.t. the result is a concatenation of string
    * terms that can be interpreted as a multiset and which contains all

--- a/test/regress/cli/regress0/strings/rewrites-v2.smt2
+++ b/test/regress/cli/regress0/strings/rewrites-v2.smt2
@@ -1,4 +1,5 @@
 ; COMMAND-LINE:
+; COMMAND-LINE: --ext-rewrite-pre=use
 ; EXPECT: unsat
 (set-info :smt-lib-version 2.6)
 (set-logic SLIA)

--- a/test/regress/cli/regress0/strings/rewrites-v2.smt2
+++ b/test/regress/cli/regress0/strings/rewrites-v2.smt2
@@ -1,5 +1,5 @@
 ; COMMAND-LINE:
-; COMMAND-LINE: --ext-rewrite-pre=use
+; COMMAND-LINE: --ext-rew-pre=use
 ; EXPECT: unsat
 (set-info :smt-lib-version 2.6)
 (set-logic SLIA)


### PR DESCRIPTION
These updates are motivated by forthcoming proof macros and elaboration.

This demotes one (seldom used) variant of a rewrite for "component contains" to the extended rewriter.