### PR TITLE
Remove DT_CLASH proof rule

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -1257,18 +1257,6 @@ enum ENUM(ProofRule)
    * \endverbatim
    */
   EVALUE(DT_SPLIT),
-  /**
-   * \verbatim embed:rst:leading-asterisk
-   * **Datatypes -- Clash**
-   *
-   * .. math::
-   *
-   *   \inferruleSC{\mathit{is}_{C_i}(t), \mathit{is}_{C_j}(t)\mid -}{\bot}
-   *   {if $i\neq j$}
-   *
-   * \endverbatim
-   */
-  EVALUE(DT_CLASH),
 
   /**
    * \verbatim embed:rst:leading-asterisk

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -121,7 +121,6 @@ const char* toString(ProofRule rule)
     case ProofRule::BV_EAGER_ATOM: return "BV_EAGER_ATOM";
     //================================================= Datatype rules
     case ProofRule::DT_SPLIT: return "DT_SPLIT";
-    case ProofRule::DT_CLASH: return "DT_CLASH";
     //================================================= Quantifiers rules
     case ProofRule::SKOLEM_INTRO: return "SKOLEM_INTRO";
     case ProofRule::SKOLEMIZE: return "SKOLEMIZE";

--- a/src/theory/datatypes/infer_proof_cons.cpp
+++ b/src/theory/datatypes/infer_proof_cons.cpp
@@ -251,12 +251,51 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
         //            is-C2(y)  y = x
         //            ----------------- MACRO_SR_PRED_TRANSFORM
         // is-C1(x)   is-C2(x)
-        // ------------------- DT_CLASH
+        // ------------------- 
         // false
-        cdp->addStep(fn,
-                     pol ? ProofRule::DT_CLASH : ProofRule::CONTRA,
-                     {tester1, tester1c},
-                     {});
+        // in the latter, case we prove this by DT_INST + rewriting below.
+        if (!pol)
+        {
+          cdp->addStep(fn, ProofRule::CONTRA,
+                      {tester1, tester1c},
+                      {});
+        }
+        else
+        {
+          // is-C1(x)
+          // ----------- DT_INST + EQ_RESOLVE
+          // x = C1(...)   is-C2(x)
+          // -----------   ----------- DT_INST + EQ_RESOLVE
+          // C1(...) = x   x = C2(...)
+          // ------------------------- TRANS
+          // C1(...) = C2(...)
+          // ----------------- MACRO_DT_CONS_EQ + EQ_RESOLVE
+          /// false
+          Rewriter * rr = d_env.getRewriter();
+          std::vector<Node> insts;
+          for (size_t i=0; i<2; i++)
+          {
+            Node t = i==0 ? tester1 : tester1c;
+            Node inst = rr->rewriteViaRule(ProofRewriteRule::DT_INST, tester1);
+            Assert (!inst.isNull());
+            Assert (inst.getKind()==Kind::EQUAL);
+            Node eq = t.eqNode(inst);
+            cdp->addTheoryRewriteStep(eq, ProofRewriteRule::DT_INST);
+            cdp->addStep(inst, ProofRule::EQ_RESOLVE, {t, eq}, {});
+            if (i==0)
+            {
+              Node insts = inst[1].eqNode(inst[0]);
+              cdp->addStep(insts, ProofRule::SYMM, {inst}, {});
+              inst = insts;
+            }
+            insts.push_back(inst);
+          }
+          Node ceq = inst[0][0].eqNode(inst[1][1]);
+          cdp->addStep(ceq, ProofRule::TRANS, inst, {});
+          Node ceqf = ceq.eqNode(fn);
+          tryRewriteRule(ceqf, conc, ProofRewriteRule::MACRO_DT_CONS_EQ, cdp);
+          cdp->addStep(fn, ProofRule::EQ_RESOLVE, {ceq, ceqf}, {});
+        }
         success = true;
       }
     }

--- a/src/theory/datatypes/infer_proof_cons.cpp
+++ b/src/theory/datatypes/infer_proof_cons.cpp
@@ -284,14 +284,14 @@ void InferProofCons::convert(InferenceId infer, TNode conc, TNode exp, CDProof* 
             cdp->addStep(inst, ProofRule::EQ_RESOLVE, {t, eq}, {});
             if (i==0)
             {
-              Node insts = inst[1].eqNode(inst[0]);
-              cdp->addStep(insts, ProofRule::SYMM, {inst}, {});
-              inst = insts;
+              Node instsym = inst[1].eqNode(inst[0]);
+              cdp->addStep(instsym, ProofRule::SYMM, {inst}, {});
+              inst = instsym;
             }
             insts.push_back(inst);
           }
-          Node ceq = inst[0][0].eqNode(inst[1][1]);
-          cdp->addStep(ceq, ProofRule::TRANS, inst, {});
+          Node ceq = insts[0][0].eqNode(insts[1][1]);
+          cdp->addStep(ceq, ProofRule::TRANS, insts, {});
           Node ceqf = ceq.eqNode(fn);
           tryRewriteRule(ceqf, conc, ProofRewriteRule::MACRO_DT_CONS_EQ, cdp);
           cdp->addStep(fn, ProofRule::EQ_RESOLVE, {ceq, ceqf}, {});

--- a/src/theory/datatypes/proof_checker.cpp
+++ b/src/theory/datatypes/proof_checker.cpp
@@ -37,7 +37,6 @@ Node DatatypesProofRuleChecker::checkInternal(ProofRule id,
                                               const std::vector<Node>& children,
                                               const std::vector<Node>& args)
 {
-  NodeManager* nm = nodeManager();
   if (id == ProofRule::DT_SPLIT)
   {
     Assert(children.empty());

--- a/src/theory/datatypes/proof_checker.cpp
+++ b/src/theory/datatypes/proof_checker.cpp
@@ -31,7 +31,6 @@ DatatypesProofRuleChecker::DatatypesProofRuleChecker(NodeManager* nm)
 void DatatypesProofRuleChecker::registerTo(ProofChecker* pc)
 {
   pc->registerChecker(ProofRule::DT_SPLIT, this);
-  pc->registerChecker(ProofRule::DT_CLASH, this);
 }
 
 Node DatatypesProofRuleChecker::checkInternal(ProofRule id,
@@ -50,18 +49,6 @@ Node DatatypesProofRuleChecker::checkInternal(ProofRule id,
     }
     const DType& dt = tn.getDType();
     return utils::mkSplit(args[0], dt);
-  }
-  else if (id == ProofRule::DT_CLASH)
-  {
-    Assert(children.size() == 2);
-    Assert(args.empty());
-    if (children[0].getKind() != Kind::APPLY_TESTER
-        || children[1].getKind() != Kind::APPLY_TESTER
-        || children[0][0] != children[1][0] || children[0] == children[1])
-    {
-      return Node::null();
-    }
-    return nm->mkConst(false);
   }
   // no rule
   return Node::null();


### PR DESCRIPTION
This rule is never used and redundant.

The code path (which I am not sure ever can be covered, based on the way datatypes propagates equalities) is updated to expand to existing rules.