### PR TITLE
Add remaining cases of STRING_REDUCTION in Eunoia

### DIFF
--- a/proofs/eo/cpc/programs/Strings.eo
+++ b/proofs/eo/cpc/programs/Strings.eo
@@ -22,6 +22,22 @@
   )
 )
 
+; define: $str_value_len
+; args:
+; - s (Seq T): The sequence term.
+; return: >
+;   The length of s, if it denotes a "value-like" sequence, that
+;   is, either a string literal or a concatentation of sequence units.
+(program $str_value_len ((T Type) (s (Seq T)) (e T) (ss (Seq T) :list))
+  ((Seq T)) Int
+  (
+    (($str_value_len (seq.++ (seq.unit e) ss))  (eo::add 1 ($str_value_len ss)))
+    (($str_value_len (@seq.empty (Seq T)))      0)
+    (($str_value_len (seq.unit e))              1)
+    (($str_value_len s)                         (eo::requires (eo::is_str s) true (eo::len s)))
+  )
+)
+
 ; define: $char_type_of
 ; args:
 ; - T Type: The string-like type to check.
@@ -418,27 +434,28 @@
 
 ;;-------------------- Reductions
 
-; define: $str_check_length_one_or_unit
-; args:
-; - s (Seq T): The sequence term.
-; return: true if s is a constant-like string of length one.
-(program $str_check_length_one_or_unit ((T Type) (s (Seq T)) (t T))
-  ((Seq T)) Bool
-  (
-    (($str_check_length_one_or_unit (seq.unit t))  true)
-    (($str_check_length_one_or_unit s)             (eo::is_eq (eo::len s) 1))
-  )
-)
 
-; In the following, a "reduction predicate" refers to a formula that is used
-; to axiomatize an extended string program in terms of (simpler) programs.
+; define: $str_reduction_pred_case_conv
+; args:
+; - k String: The purification skolem.
+; - x String: The string term argument.
+; - isLower Bool: Whether we are considering str.to_lower (resp. str.to_upper).
+; return: the reduction predicate for term for str.to_lower/str.to_upper applied to x.
+(define $str_reduction_pred_case_conv ((k String) (x String) (isLower Bool))
+  (and (= (str.len x) (str.len k))
+       (forall ((@var.str_index Int))
+         (or (not (>= @var.str_index 0))
+             (not (< @var.str_index (str.len k)))
+             (= (str.to_code (str.substr k @var.str_index 1))
+                (eo::define ((ci (str.to_code (str.substr x @var.str_index 1))))
+                (eo::ite isLower
+                  (ite (and (<= 65 ci) (<= ci 90)) (+ ci 32) ci)
+                  (ite (and (<= 97 ci) (<= ci 122)) (+ ci -32) ci))))))))
 
 ; program: $str_reduction_pred
 ; args:
 ; - t (Seq U): The string term.
 ; return: the reduction predicate for term t of sort s.
-; note: >
-;   The operators listed in comments are missing from the signature currently.
 (program $str_reduction_pred ((T Type) (U Type) (x (Seq U)) (y (Seq U)) (z (Seq U)) (n Int) (m Int)
                               (s String) (r RegLan) (t String))
   (T) Bool
@@ -540,7 +557,7 @@
         (eo::define ((k (@purify (str.update x n y))))
         (ite (and (>= n 0) (> (str.len x) n))
           (eo::define ((k1 (@purify ($str_prefix x n))))
-          (eo::define ((ys (eo::ite ($str_check_length_one_or_unit y) ; optimization for single characters
+          (eo::define ((ys (eo::ite (eo::is_eq ($str_value_len y) 1) ; optimization for single characters
                               y
                               (str.substr y 0 (- (str.len x) n)))))
           (eo::define ((k2 (@purify ($str_suffix_rem x (+ n (str.len ys))))))
@@ -655,10 +672,16 @@
                 (>= (str.to_code (str.substr s @var.str_index 1)) (str.to_code (str.substr t @var.str_index 1)))
                 (>= (str.to_code (str.substr t @var.str_index 1)) (str.to_code (str.substr s @var.str_index 1)))
             )))))))
-
-    ; str.to_lower
-    ; str.to_upper
-    ; str.rev
+    (($str_reduction_pred (str.to_lower x)) ($str_reduction_pred_case_conv (@purify (str.to_lower x)) x true))
+    (($str_reduction_pred (str.to_upper x)) ($str_reduction_pred_case_conv (@purify (str.to_upper x)) x false))
+    (($str_reduction_pred (str.rev x))
+        (eo::define ((k (@purify (str.rev x))))
+          (and (= (str.len x) (str.len k))
+              (forall ((@var.str_index Int))
+                (or
+                  (not (>= @var.str_index 0))
+                  (not (< @var.str_index (str.len k)))
+                  (= (str.substr k @var.str_index 1) (str.substr x (- (str.len x) (+ @var.str_index 1)) 1)))))))
   )
 )
 

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -231,7 +231,10 @@ bool AlfPrinter::isHandled(const Options& opts, const ProofNode* pfn)
         case Kind::STRING_ITOS:
         case Kind::SEQ_NTH:
         case Kind::STRING_UPDATE:
-        case Kind::STRING_LEQ: return true;
+        case Kind::STRING_LEQ:
+        case Kind::STRING_REV:
+        case Kind::STRING_TO_LOWER:
+        case Kind::STRING_TO_UPPER: return true;
         default:
           break;
       }

--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -910,10 +910,10 @@ Node StringsPreprocess::reduce(Node t,
                           nm->mkNode(Kind::ADD, ci, offset),
                           ci);
 
-    Node bound = nm->mkNode(Kind::AND,
-                            nm->mkNode(Kind::LEQ, zero, i),
-                            nm->mkNode(Kind::LT, i, lenr));
-    Node body = nm->mkNode(Kind::OR, bound.negate(), ri.eqNode(res));
+    Node body = nm->mkNode(Kind::OR,
+                           nm->mkNode(Kind::GEQ, i, zero).notNode(),
+                           nm->mkNode(Kind::LT, i, lenr).notNode(),
+                           ri.eqNode(res));
     Node rangeA = utils::mkForallInternal(nm, bvi, body);
 
     // upper 65 ... 90
@@ -947,10 +947,10 @@ Node StringsPreprocess::reduce(Node t,
     Node ssr = nm->mkNode(Kind::STRING_SUBSTR, r, i, one);
     Node ssx = nm->mkNode(Kind::STRING_SUBSTR, x, revi, one);
 
-    Node bound = nm->mkNode(Kind::AND,
-                            nm->mkNode(Kind::LEQ, zero, i),
-                            nm->mkNode(Kind::LT, i, lenr));
-    Node body = nm->mkNode(Kind::OR, bound.negate(), ssr.eqNode(ssx));
+    Node body = nm->mkNode(Kind::OR,
+                           nm->mkNode(Kind::GEQ, i, zero).notNode(),
+                           nm->mkNode(Kind::LT, i, lenr).notNode(),
+                           ssr.eqNode(ssx));
     Node rangeA = utils::mkForallInternal(nm, bvi, body);
     // assert:
     //   len(r) = len(x) ^

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -3808,6 +3808,7 @@ set(regress_2_tests
   regress2/strings/replaceall-diffrange.smt2
   regress2/strings/replaceall-len-c.smt2
   regress2/strings/small-1.smt2
+  regress2/strings/sred-cases.smt2
   regress2/strings/str-contains-reduction.smt2
   regress2/strings/strings-alpha-card-65.smt2
   regress2/strings/update-ex3.smt2

--- a/test/regress/cli/regress2/strings/sred-cases.smt2
+++ b/test/regress/cli/regress2/strings/sred-cases.smt2
@@ -1,0 +1,8 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-fun s () String)
+(assert (= (str.rev (str.to_lower s)) (str.to_upper s)))
+(assert (not (= s (str.to_lower s))))
+(assert (not (= s (str.to_upper s))))
+(assert (< (str.len s) 2))
+(check-sat)


### PR DESCRIPTION
Also updates one of the utility methods to a more general method which will be used in several places in the proof signature.

Updates the internal reduction to match the overall style.

This finishes the implementation of string reduction in Eunoia.

