### PR TITLE
Generalize BV poly norm eq to odd coefficients

### DIFF
--- a/proofs/eo/cpc/rules/BitVectors.eo
+++ b/proofs/eo/cpc/rules/BitVectors.eo
@@ -236,13 +236,13 @@
 ; args:
 ; - eqr Bool: The equivalence between equalities, proven by this rule.
 ; requires: >
-;   The constants cx and cy are one.
+;   The constants cx and cy are odd.
 ; conclusion: >
 ;   An equivalence between equalities specified by eqr and justified by eq.
 (declare-rule bv_poly_norm_eq ((n Int) (cx (BitVec n)) (xb1 (BitVec n)) (xb2 (BitVec n))
                                (cy (BitVec n)) (yb1 (BitVec n)) (yb2 (BitVec n)) (one (BitVec n) :list))
   :premises ((= (bvmul cx (bvsub xb1 xb2) one) (bvmul cy (bvsub yb1 yb2) one)))
   :args ((= (= xb1 xb2) (= yb1 yb2)))
-  :requires (((eo::to_z one) 1) ((eo::to_z cx) 1) ((eo::to_z cy) 1))
+  :requires (((eo::to_z one) 1) ((eo::zmod (eo::to_z cx) 2) 1) ((eo::zmod (eo::to_z cy) 2) 1))
   :conclusion (= (= xb1 xb2) (= yb1 yb2))
 )

--- a/src/theory/arith/arith_poly_norm.cpp
+++ b/src/theory/arith/arith_poly_norm.cpp
@@ -510,7 +510,7 @@ bool PolyNorm::isArithPolyNormRel(TNode a, TNode b, Rational& ca, Rational& cb)
     eqtn = a[0].getType().leastUpperBound(a[1].getType());
     eqtn = eqtn.leastUpperBound(b[0].getType().leastUpperBound(b[1].getType()));
     // could happen if we are comparing equalities of different types
-    if (eqtn.isNull() || (!eqtn.isRealOrInt() && !eqtn.isBitVector()))
+    if (!eqtn.isRealOrInt() && !eqtn.isBitVector())
     {
       return false;
     }

--- a/src/theory/arith/arith_poly_norm.cpp
+++ b/src/theory/arith/arith_poly_norm.cpp
@@ -510,7 +510,7 @@ bool PolyNorm::isArithPolyNormRel(TNode a, TNode b, Rational& ca, Rational& cb)
     eqtn = a[0].getType().leastUpperBound(a[1].getType());
     eqtn = eqtn.leastUpperBound(b[0].getType().leastUpperBound(b[1].getType()));
     // could happen if we are comparing equalities of different types
-    if (eqtn.isNull())
+    if (eqtn.isNull() || (!eqtn.isRealOrInt() && !eqtn.isBitVector()))
     {
       return false;
     }
@@ -521,6 +521,8 @@ bool PolyNorm::isArithPolyNormRel(TNode a, TNode b, Rational& ca, Rational& cb)
     // bitvector inequalities.
     return false;
   }
+  Trace("arith-poly-norm-rel")
+      << "Poly norm rel? " << a << " " << b << std::endl;
   // k is a handled binary relation, i.e. one that permits normalization
   // via subtracting the right side from the left.
   PolyNorm pa = PolyNorm::mkDiff(a[0], a[1]);
@@ -528,9 +530,46 @@ bool PolyNorm::isArithPolyNormRel(TNode a, TNode b, Rational& ca, Rational& cb)
   // if a non-arithmetic equality
   if (k == Kind::EQUAL && !eqtn.isRealOrInt())
   {
-    // pa and pb must be equal with no scaling factors.
+    Assert(eqtn.isBitVector());
     ca = Rational(1);
     cb = Rational(1);
+    Trace("arith-poly-norm-rel") << "...determine multiply factor" << std::endl;
+    for (const std::pair<const Node, Rational>& m : pa.d_polyNorm)
+    {
+      std::map<Node, Rational>::iterator itb = pb.d_polyNorm.find(m.first);
+      if (itb == pb.d_polyNorm.end())
+      {
+        // a monomial in a is not in b
+        return false;
+      }
+      // if this factor is odd
+      bool oddA = m.second.getNumerator().testBit(0);
+      bool oddB = itb->second.getNumerator().testBit(0);
+      if (oddA != oddB)
+      {
+        // an odd with an even
+        return false;
+      }
+      else if (oddA && oddB)
+      {
+        // Coefficients are both odd but not equal, multiply either side.
+        // Ensure that we take them modulo the bitwidth here.
+        Integer w = Integer(2).pow(eqtn.getBitVectorSize());
+        Integer ai = m.second.getNumerator().euclidianDivideRemainder(w);
+        Integer bi = itb->second.getNumerator().euclidianDivideRemainder(w);
+        if (ai != bi)
+        {
+          ca = Rational(bi);
+          cb = Rational(ai);
+        }
+        // else, coefficients are equal, we should just try 1 / 1
+        break;
+      }
+      // even with even is inconclusive
+    }
+    Trace("arith-poly-norm") << "...try " << ca << " / " << cb << std::endl;
+    pa.mulCoeffs(ca);
+    pb.mulCoeffs(cb);
     // Check for equality, taking modulo 2^w on coefficients.
     return areEqualPolyNormTyped(eqtn, pa, pb);
   }

--- a/src/theory/bv/proof_checker.cpp
+++ b/src/theory/bv/proof_checker.cpp
@@ -16,6 +16,7 @@
 #include "theory/bv/proof_checker.h"
 
 #include "theory/arith/arith_poly_norm.h"
+#include "theory/bv/theory_bv_utils.h"
 #include "util/bitvector.h"
 
 namespace cvc5::internal {
@@ -28,7 +29,7 @@ BVProofRuleChecker::BVProofRuleChecker(NodeManager* nm) : ProofRuleChecker(nm)
 void BVProofRuleChecker::registerTo(ProofChecker* pc)
 {
   pc->registerTrustedChecker(ProofRule::MACRO_BV_BITBLAST, this, 2);
-  pc->registerTrustedChecker(ProofRule::BV_BITBLAST_STEP, this, 2);
+  pc->registerChecker(ProofRule::BV_BITBLAST_STEP, this);
   pc->registerChecker(ProofRule::BV_POLY_NORM, this);
   pc->registerChecker(ProofRule::BV_POLY_NORM_EQ, this);
   pc->registerChecker(ProofRule::BV_EAGER_ATOM, this);
@@ -108,10 +109,8 @@ Node BVProofRuleChecker::checkInternal(ProofRule id,
     if (cx.getKind() == Kind::CONST_BITVECTOR
         && cy.getKind() == Kind::CONST_BITVECTOR)
     {
-      BitVector c1 = cx.getConst<BitVector>();
-      BitVector c2 = cy.getConst<BitVector>();
-      BitVector one = BitVector::mkOne(c1.getSize());
-      if (c1 != one || c2 != one)
+      // must be odd
+      if (!bv::utils::getBit(cx, 0) || !bv::utils::getBit(cy, 0))
       {
         return Node::null();
       }

--- a/src/theory/bv/proof_checker.cpp
+++ b/src/theory/bv/proof_checker.cpp
@@ -29,7 +29,7 @@ BVProofRuleChecker::BVProofRuleChecker(NodeManager* nm) : ProofRuleChecker(nm)
 void BVProofRuleChecker::registerTo(ProofChecker* pc)
 {
   pc->registerTrustedChecker(ProofRule::MACRO_BV_BITBLAST, this, 2);
-  pc->registerChecker(ProofRule::BV_BITBLAST_STEP, this);
+  pc->registerTrustedChecker(ProofRule::BV_BITBLAST_STEP, this, 2);
   pc->registerChecker(ProofRule::BV_POLY_NORM, this);
   pc->registerChecker(ProofRule::BV_POLY_NORM_EQ, this);
   pc->registerChecker(ProofRule::BV_EAGER_ATOM, this);


### PR DESCRIPTION
This uses the fact that (= x1 x2) <=> (= (bvmul c x1) (bvmul c x2)) when c is odd.

This extension is necessary to fill proofs for variable elimination for quantified bitvectors.