### PR TITLE
Add distinct values to RARE reconstruction strategy

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -2638,19 +2638,6 @@ enum ENUM(ProofRewriteRule)
   EVALUE(MACRO_ARRAYS_NORMALIZE_OP),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Arrays -- Macro distinct arrays**
-   *
-   * .. math::
-   *   (A = B) = \bot
-   *
-   * where :math:`A` and :math:`B` are distinct array values, that is,
-   * the Node::isConst method returns true for both.
-   *
-   * \endverbatim
-   */
-  EVALUE(MACRO_ARRAYS_DISTINCT_ARRAYS),
-  /**
-   * \verbatim embed:rst:leading-asterisk
    * **Arrays -- Macro normalize constant**
    *
    * .. math::
@@ -3370,21 +3357,6 @@ enum ENUM(ProofRewriteRule)
    * \endverbatim
    */
   EVALUE(MACRO_SUBSTR_STRIP_SYM_LENGTH),
-  /**
-   * \verbatim embed:rst:leading-asterisk
-   * **Sets -- distinct sets**
-   *
-   * .. math::
-   *   (A = B) = \bot
-   *
-   * where :math:`A` and :math:`B` are distinct set values, that is,
-   * the Node::isConst method returns true for both. This rule
-   * verifies that this returns true for both terms and that these
-   * terms are distinct.
-   *
-   * \endverbatim
-   */
-  EVALUE(MACRO_SETS_DISTINCT_SETS),
   /**
    * \verbatim embed:rst:leading-asterisk
    * **Sets -- sets intersection evaluate**

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -248,8 +248,6 @@ const char* toString(cvc5::ProofRewriteRule rule)
       return "macro-lambda-capture-avoid";
     case ProofRewriteRule::ARRAYS_SELECT_CONST: return "arrays-select-const";
     case ProofRewriteRule::MACRO_ARRAYS_NORMALIZE_OP: return "macro-arrays-normalize-op";
-    case ProofRewriteRule::MACRO_ARRAYS_DISTINCT_ARRAYS:
-      return "macro-arrays-distinct-arrays";
     case ProofRewriteRule::MACRO_ARRAYS_NORMALIZE_CONSTANT:
       return "macro-arrays-normalize-constant";
     case ProofRewriteRule::ARRAYS_EQ_RANGE_EXPAND:
@@ -325,8 +323,6 @@ const char* toString(cvc5::ProofRewriteRule rule)
     case ProofRewriteRule::STR_IN_RE_SIGMA_STAR: return "str-in-re-sigma-star";
     case ProofRewriteRule::MACRO_SUBSTR_STRIP_SYM_LENGTH:
       return "macro-substr-strip-sym-length";
-    case ProofRewriteRule::MACRO_SETS_DISTINCT_SETS:
-      return "macro-sets-distinct-sets";
     case ProofRewriteRule::MACRO_SETS_INTER_EVAL:
       return "macro-sets-inter-eval";
     case ProofRewriteRule::MACRO_SETS_MINUS_EVAL:

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -83,6 +83,17 @@ bool BasicRewriteRCons::prove(CDProof* cdp,
     return true;
   }
 
+  // if (= (= c1 c2) false) where c1, c2 are distinct values
+  if (a.getKind() == Kind::EQUAL && a[0].isConst() && a[1].isConst()
+      && b.isConst() && !b.getConst<bool>())
+  {
+    Node neq = a[0].eqNode(a[1]).notNode();
+    cdp->addStep(neq, ProofRule::DISTINCT_VALUES, {}, {a[0], a[1]});
+    cdp->addStep(eq, ProofRule::FALSE_INTRO, {neq}, {});
+    Trace("trewrite-rcons") << "...DISTINCT_VALUES" << std::endl;
+    return true;
+  }
+
   // try theory rewrite (pre-rare)
   if (tmode == TheoryRewriteMode::STANDARD)
   {

--- a/src/theory/arrays/theory_arrays_rewriter.cpp
+++ b/src/theory/arrays/theory_arrays_rewriter.cpp
@@ -66,8 +66,6 @@ void setMostFrequentValueCount(TNode store, uint64_t count)
 TheoryArraysRewriter::TheoryArraysRewriter(NodeManager* nm, Rewriter* r)
     : TheoryRewriter(nm), d_rewriter(r)
 {
-  registerProofRewriteRule(ProofRewriteRule::MACRO_ARRAYS_DISTINCT_ARRAYS,
-                           TheoryRewriteCtx::PRE_DSL);
   registerProofRewriteRule(ProofRewriteRule::MACRO_ARRAYS_NORMALIZE_CONSTANT,
                            TheoryRewriteCtx::PRE_DSL);
   registerProofRewriteRule(ProofRewriteRule::ARRAYS_SELECT_CONST,
@@ -82,16 +80,6 @@ Node TheoryArraysRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
 {
   switch (id)
   {
-    case ProofRewriteRule::MACRO_ARRAYS_DISTINCT_ARRAYS:
-    {
-      if (n.getKind() == Kind::EQUAL && n[0].isConst() && n[1].isConst()
-          && n[0] != n[1])
-      {
-        Assert(n[0].getType().isArray());
-        return d_nm->mkConst(false);
-      }
-    }
-    break;
     case ProofRewriteRule::MACRO_ARRAYS_NORMALIZE_CONSTANT:
     {
       if (n.getKind() == Kind::STORE && n[0].isConst() && n[1].isConst()

--- a/src/theory/sets/theory_sets_rewriter.cpp
+++ b/src/theory/sets/theory_sets_rewriter.cpp
@@ -46,8 +46,6 @@ TheorySetsRewriter::TheorySetsRewriter(NodeManager* nm,
                            TheoryRewriteCtx::DSL_SUBCALL);
   registerProofRewriteRule(ProofRewriteRule::SETS_INSERT_ELIM,
                            TheoryRewriteCtx::PRE_DSL);
-  registerProofRewriteRule(ProofRewriteRule::MACRO_SETS_DISTINCT_SETS,
-                           TheoryRewriteCtx::POST_DSL);
   registerProofRewriteRule(ProofRewriteRule::MACRO_SETS_INTER_EVAL,
                            TheoryRewriteCtx::POST_DSL);
   registerProofRewriteRule(ProofRewriteRule::MACRO_SETS_MINUS_EVAL,
@@ -82,16 +80,6 @@ Node TheorySetsRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
           elems = nm->mkNode(Kind::SET_UNION, singleton, elems);
         }
         return elems;
-      }
-    }
-    break;
-    case ProofRewriteRule::MACRO_SETS_DISTINCT_SETS:
-    {
-      if (n.getKind() == Kind::EQUAL && n[0].isConst() && n[1].isConst()
-          && n[0] != n[1])
-      {
-        Assert(n[0].getType().isSet());
-        return d_nm->mkConst(false);
       }
     }
     break;


### PR DESCRIPTION
Is checked after evaluate, thus will only apply to non-atomic types.

Subsumes 2 macro rules which are deleted.