### PR TITLE
Add Eunoia definition for ProofRewriteRule::DISTINCT_CARD_CONFLICT

### DIFF
--- a/proofs/eo/cpc/Cpc.eo
+++ b/proofs/eo/cpc/Cpc.eo
@@ -367,6 +367,43 @@
   :conclusion (= a b)
 )
 
+;;;;; ProofRewriteRule::DISTINCT_CARD_CONFLICT
+
+; program: $compute_card
+; args:
+; - T Type: The type.
+; return: The cardinality of T.
+; note: >
+;   This method is used for the proof rule ProofRewriteRule::DISTINCT_CARD_CONFLICT.
+;   We intentionally only handle finite types here, and moreover for simplicity
+;   limit this method to atomic types (Bool and BitVec) only.
+(program $compute_card ((n Int))
+  (Type) Int
+  (
+    (($compute_card Bool)       2)
+    (($compute_card (BitVec n)) ($arith_eval_int_pow_2 n))
+  )
+)
+
+; rule: distinct-card-conflict
+; implements: ProofRewriteRule::DISTINCT_CARD_CONFLICT
+; args:
+; - eq Bool: The equality to prove with this rule between an application of distinct D and false.
+; requires: >
+;   D is a pairwise application of distinct over a list of elements whose
+;   length is larger than the cardinality of the type of those elements.
+; conclusion: The given equality.
+(declare-rule distinct-card-conflict ((D Bool) (elems @List))
+  :args ((= D false))
+  :requires (((eo::define ((elems ($extract_pairwise_args distinct and D)))
+              (eo::define ((first (eo::list_nth @list elems 0)))
+                (eo::gt (eo::list_len @list elems) ($compute_card (eo::typeof first)))))
+              true))
+  :conclusion (= D false)
+)
+
+;;;;; trusted
+
 ; rule: trust
 ; premsies:
 ; - P: A conjunction of the premises passed to this rule.

--- a/proofs/eo/cpc/programs/Utils.eo
+++ b/proofs/eo/cpc/programs/Utils.eo
@@ -21,6 +21,19 @@
 (declare-const @list.nil @List)
 (declare-const @list (-> (! Type :var T :implicit) T @List @List) :right-assoc-nil @list.nil)
 
+; note: This is a forward declaration of $evaluate_list defined in Cpc.eo.
+(program $evaluate_list () (@List) @List)
+
+; define: $evaluate
+; args:
+; - t S: The term to evaluate.
+; return: The result of evaluating t.
+; note: >
+;   This method is defined in terms of the forward declaration $evaluate_list here.
+;   The implementation of this method depends on defining the evaluation for all
+;   theories and thus is contained in Cpc.eo.
+(define $evaluate ((T Type :implicit) (t T)) (eo::list_nth @list ($evaluate_list (@list t)) 0))
+
 ; program: $get_fun
 ; args:
 ; - t S: The term to inspect.
@@ -89,6 +102,9 @@
 ; define: $head
 ; args:
 ; - x S: The term to inspect.
+; return: >
+;   The head of x, where x is expected to be an application of an n-ary
+;   function marked :right-assoc-nil.
 ; return: the head of x, where x is expected to be a function application.
 (define $head ((S Type :implicit) (x S))
   (eo::match ((T Type) (U Type) (f (-> T U U)) (x1 T) (x2 U :list))
@@ -244,5 +260,61 @@
     (($result_combine b1 @result.null) b1)
     (($result_combine b1 b1)           b1)
     (($result_combine b1 b2)           @result.invalid)
+  )
+)
+;; =============== for pairwise
+
+; program: $is_pairwise
+; args:
+; - f (-> T T U): The pairwise operator, e.g. distinct.
+; - op (-> U U U): The combining operator, e.g. and for distinct.
+; - a T: The current LHS element we are checking.
+; - bs @List: The list of RHS elements that should be related to a next.
+; - B U: The term that is potentially a pairwise application of f for the given elements.
+; - rem @List: The list of elements we have yet to process on the LHS.
+; return: True if B is a pairwise application of f for the given arguments.
+(program $is_pairwise ((T Type) (U Type) (f (-> T T U)) (op (-> U U U)) (a T) (b T) (bs T :list) (B U :list) (rem @List :list))
+  ((-> T T U) (-> U U U) T @List U @List) Bool
+  (
+  (($is_pairwise f op a (@list b bs) (op (f a b) B) rem) ($is_pairwise f op a bs B rem))
+  (($is_pairwise f op a @list.nil B (@list b rem))       ($is_pairwise f op b rem B rem))
+  (($is_pairwise f op a @list.nil true @list.nil)        true)
+  )
+)
+
+; program: $extract_pairwise_args_rec
+; args:
+; - f (-> T T U): The pairwise operator, e.g. distinct.
+; - op (-> U U U): The combining operator, e.g. and for distinct.
+; - a T: The first LHS element.
+; - B U: The term that is potentially a pairwise application of f starting with a.
+; return: The list of arguments that a is related to.
+(program $extract_pairwise_args_rec ((T Type) (U Type) (f (-> T T U)) (op (-> U U U)) (a T) (b T) (c T) (B U :list))
+  ((-> T T U) (-> U U U) T U) @List
+  (
+  (($extract_pairwise_args_rec f op a (op (f a c) B)) (eo::cons @list c ($extract_pairwise_args_rec f op a B)))
+  (($extract_pairwise_args_rec f op a B)              @list.nil)  ; no further elements
+  )
+)
+
+; program: $extract_pairwise_args_rec
+; args:
+; - f (-> T T U): The pairwise operator, e.g. distinct.
+; - op (-> U U U): The combining operator, e.g. and for distinct.
+; - B U: The term that is potentially a pairwise application of f.
+; return: The list of arguments that are the input to the pairwise application of f.
+; note: >
+;   This method is required since desugaring is applied at compile time. This
+;   means to recognize whether a term originated from parsing e.g.
+;   (distinct a b c) is non-trivial: it requires a scan to confirm that
+;   its desugared version (and (distinct a b) (distinct a c) (distinct b c)) is
+;   indeed obtained by desugaring distinct in the expected way.
+(program $extract_pairwise_args ((T Type) (U Type) (f (-> T T U)) (op (-> U U U)) (a T) (b T) (B U :list))
+  ((-> T T U) (-> U U U) U) @List
+  (
+  (($extract_pairwise_args f op (op (f a b) B)) (eo::define ((D (op (f a b) B)))
+                                                (eo::define ((elems ($extract_pairwise_args_rec f op a D)))
+                                                  (eo::requires ($is_pairwise f op a elems D elems) true (eo::cons @list a elems)))))
+  (($extract_pairwise_args f op (f a b))        (@list a b)) ; binary case, trivial
   )
 )

--- a/proofs/eo/cpc/programs/Utils.eo
+++ b/proofs/eo/cpc/programs/Utils.eo
@@ -21,19 +21,6 @@
 (declare-const @list.nil @List)
 (declare-const @list (-> (! Type :var T :implicit) T @List @List) :right-assoc-nil @list.nil)
 
-; note: This is a forward declaration of $evaluate_list defined in Cpc.eo.
-(program $evaluate_list () (@List) @List)
-
-; define: $evaluate
-; args:
-; - t S: The term to evaluate.
-; return: The result of evaluating t.
-; note: >
-;   This method is defined in terms of the forward declaration $evaluate_list here.
-;   The implementation of this method depends on defining the evaluation for all
-;   theories and thus is contained in Cpc.eo.
-(define $evaluate ((T Type :implicit) (t T)) (eo::list_nth @list ($evaluate_list (@list t)) 0))
-
 ; program: $get_fun
 ; args:
 ; - t S: The term to inspect.

--- a/proofs/eo/cpc/programs/Utils.eo
+++ b/proofs/eo/cpc/programs/Utils.eo
@@ -260,12 +260,12 @@
 ; - B U: The term that is potentially a pairwise application of f for the given elements.
 ; - rem @List: The list of elements we have yet to process on the LHS.
 ; return: True if B is a pairwise application of f for the given arguments.
-(program $is_pairwise ((T Type) (U Type) (f (-> T T U)) (op (-> U U U)) (a T) (b T) (bs T :list) (B U :list) (rem @List :list))
+(program $is_pairwise ((T Type) (U Type) (f (-> T T U)) (op (-> U U U)) (a T) (b T) (bs T :list) (B U :list) (nil U) (rem @List :list))
   ((-> T T U) (-> U U U) T @List U @List) Bool
   (
   (($is_pairwise f op a (@list b bs) (op (f a b) B) rem) ($is_pairwise f op a bs B rem))
   (($is_pairwise f op a @list.nil B (@list b rem))       ($is_pairwise f op b rem B rem))
-  (($is_pairwise f op a @list.nil true @list.nil)        true)
+  (($is_pairwise f op a @list.nil nil @list.nil)         (eo::requires nil (eo::nil op) true))
   )
 )
 

--- a/proofs/eo/cpc/rules/Uf.eo
+++ b/proofs/eo/cpc/rules/Uf.eo
@@ -237,7 +237,7 @@
   (
   (($mk_distinct-elim (and (distinct x y) b))   (eo::cons and (not (= x y)) ($mk_distinct-elim b)))
   (($mk_distinct-elim true)                     true)
-  (($mk_distinct-elim (distinct x y))           (eo::cons and (not (= x y)) true))
+  (($mk_distinct-elim (distinct x y))           (not (= x y)))
   )
 )
 
@@ -249,7 +249,7 @@
 ; conclusion: The equality (= b1 b2).
 (declare-rule distinct-elim ((b1 Bool) (b2 Bool))
   :args ((= b1 b2))
-  :requires ((($singleton_elim ($mk_distinct-elim b1)) b2))
+  :requires ((($mk_distinct-elim b1) b2))
   :conclusion (= b1 b2)
 )
 

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -290,6 +290,7 @@ bool AlfPrinter::isHandledTheoryRewrite(ProofRewriteRule id, const Node& n)
   switch (id)
   {
     case ProofRewriteRule::DISTINCT_ELIM:
+    case ProofRewriteRule::DISTINCT_CARD_CONFLICT:
     case ProofRewriteRule::BETA_REDUCE:
     case ProofRewriteRule::LAMBDA_ELIM:
     case ProofRewriteRule::BV_TO_NAT_ELIM:

--- a/src/theory/builtin/theory_builtin_rewriter.cpp
+++ b/src/theory/builtin/theory_builtin_rewriter.cpp
@@ -47,9 +47,15 @@ Node TheoryBuiltinRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
     case ProofRewriteRule::DISTINCT_CARD_CONFLICT:
       if (n.getKind() == Kind::DISTINCT)
       {
-        if (n[0].getType().isCardinalityLessThan(n.getNumChildren()))
+        TypeNode tn = n[0].getType();
+        // we intentionally only handle booleans and bitvectors here
+        // for the sake of simplicity.
+        if (tn.isBoolean() || tn.isBitVector())
         {
-          return nodeManager()->mkConst(false);
+          if (tn.isCardinalityLessThan(n.getNumChildren()))
+          {
+            return nodeManager()->mkConst(false);
+          }
         }
       }
       break;
@@ -115,12 +121,15 @@ RewriteResponse TheoryBuiltinRewriter::doRewrite(TNode node)
       return RewriteResponse(REWRITE_DONE, rnode);
     }
     case Kind::DISTINCT:
-      if (node[0].getType().isCardinalityLessThan(node.getNumChildren()))
+    {
+      Node ret = rewriteViaRule(ProofRewriteRule::DISTINCT_CARD_CONFLICT, node);
+      if (!ret.isNull())
       {
         // Cardinality of type does not allow to find distinct values for all
         // children of this node.
         return RewriteResponse(REWRITE_DONE, nodeManager()->mkConst<bool>(false));
       }
+    }
       return RewriteResponse(REWRITE_DONE, blastDistinct(node));
     case Kind::APPLY_INDEXED_SYMBOLIC:
     {

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -292,6 +292,7 @@ set(regress_0_tests
   regress0/bv/bug733.smt2
   regress0/bv/bug734.smt2
   regress0/bv/bv-abstr-bug2.smt2
+  regress0/bv/bv-card-conflict.smt2
   regress0/bv/bv-int-collapse1.smt2
   regress0/bv/bv-int-collapse2.smt2
   regress0/bv/bv-options4.smt2

--- a/test/regress/cli/regress0/bv/bv-card-conflict.smt2
+++ b/test/regress/cli/regress0/bv/bv-card-conflict.smt2
@@ -1,0 +1,9 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-const a (_ BitVec 2))
+(declare-const b (_ BitVec 2))
+(declare-const c (_ BitVec 2))
+(declare-const d (_ BitVec 2))
+(declare-const e (_ BitVec 2))
+(assert (distinct a b c d e))
+(check-sat)


### PR DESCRIPTION
Also modifies the rewrite so we only apply it for Booleans and BitVectors.