### PR TITLE
Extend evaluator for applications of symbolic indexed operators

### DIFF
--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -376,7 +376,12 @@ bool AlfPrinter::canEvaluate(Node n)
     if (visited.find(cur) == visited.end())
     {
       visited.insert(cur);
-      switch (cur.getKind())
+      Kind k = cur.getKind();
+      if (k==Kind::APPLY_INDEXED_SYMBOLIC)
+      {
+        k = cur.getOperator().getConst<GenericOp>().getKind();
+      }
+      switch (k)
       {
         case Kind::ITE:
         case Kind::NOT:

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -34,6 +34,7 @@
 #include "smt/print_benchmark.h"
 #include "theory/strings/theory_strings_utils.h"
 #include "util/string.h"
+#include "theory/builtin/generic_op.h"
 
 namespace cvc5::internal {
 

--- a/src/theory/builtin/theory_builtin_rewriter.h
+++ b/src/theory/builtin/theory_builtin_rewriter.h
@@ -55,7 +55,7 @@ class TheoryBuiltinRewriter : public TheoryRewriter
   /**
    * Main entry point for rewriting APPLY_INDEXED_SYMBOLIC terms.
    */
-  Node rewriteApplyIndexedSymbolic(TNode node);
+  static Node rewriteApplyIndexedSymbolic(TNode node);
   /**
    * Blast distinct, which eliminates the distinct operator.
    */

--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -19,6 +19,7 @@
 
 #include "theory/bv/theory_bv_utils.h"
 #include "theory/rewriter.h"
+#include "theory/builtin/theory_builtin_rewriter.h"
 #include "theory/strings/theory_strings_utils.h"
 #include "theory/theory.h"
 #include "theory/uf/function_const.h"
@@ -242,6 +243,12 @@ EvalResult Evaluator::evalInternal(
           doEval = false;
         }
       }
+      else if (currNode.getKind()==Kind::APPLY_INDEXED_SYMBOLIC)
+      {
+        // we require special handling below to deal with symbolic indexed
+        // operators.
+        doEval = false;
+      }
     }
     for (const auto& currNodeChild : currNode)
     {
@@ -304,6 +311,19 @@ EvalResult Evaluator::evalInternal(
             // Rewrite the result now, if we use the rewriter. We will see below
             // if we are able to turn it into a valid EvalResult.
             currNodeVal = d_rr->rewrite(currNodeVal);
+          }
+          else if (currNodeVal.getKind()==Kind::APPLY_INDEXED_SYMBOLIC)
+          {
+            // To evaluate a symbolic indexed application, we reconstruct
+            // the node here, and verify that all its arguments are constant
+            // using rewriteApplyIndexedSymbolic.
+            // If successful, we evaluate the result in a separate recursive
+            // call, which will only recurse once.
+            Node rr = builtin::TheoryBuiltinRewriter::rewriteApplyIndexedSymbolic(currNodeVal);
+            if (rr!=currNodeVal)
+            {
+              currNodeVal = eval(rr, args, vals);
+            }
           }
         }
         needsReconstruct = false;


### PR DESCRIPTION
This ensures we can evaluate e.g. `(APPLY_INDEXED_SYMBOLIC{extract} 2 0 #b0001)`.  Note that all indexed operators are of kind APPLY_INDEXED_SYMBOLIC during RARE reconstruction.

This is work towards filling BV rewrite holes.

