### PR TITLE
Moved computation of irrelevant equivalence classes to separate function

### DIFF
--- a/src/theory/quantifiers/conjecture_generator.cpp
+++ b/src/theory/quantifiers/conjecture_generator.cpp
@@ -384,40 +384,7 @@ void ConjectureGenerator::check(Theory::Effort e, QEffort quant_e)
       d_conj_count = 0;
       std::vector<TNode> eqcs;
       getEquivalenceClasses(eqcs);
-      Trace("sg-proc") << "Determine ground EQC..." << std::endl;
-      bool success;
-      do{
-        success = false;
-        for( unsigned i=0; i<eqcs.size(); i++ ){
-          TNode r = eqcs[i];
-          if( d_ground_eqc_map.find( r )==d_ground_eqc_map.end() ){
-            std::vector< TNode > args;
-            Trace("sg-pat-debug") << "******* Get ground term for " << r << std::endl;
-            Node n;
-            if (Skolemize::isInductionTerm(options(), r))
-            {
-              n = d_op_arg_index[r].getGroundTerm( this, args );
-            }else{
-              n = r;
-            }
-            if( !n.isNull() ){
-              Trace("sg-pat") << "Ground term for eqc " << r << " : " << std::endl;
-              Trace("sg-pat") << "   " << n << std::endl;
-              d_ground_eqc_map[r] = n;
-              success = true;
-            }else{
-              Trace("sg-pat-debug") << "...could not find ground term." << std::endl;
-            }
-          }
-        }
-      }while( success );
-      //also get ground terms
-      d_ground_terms.clear();
-      for( unsigned i=0; i<eqcs.size(); i++ ){
-        TNode r = eqcs[i];
-        d_op_arg_index[r].getGroundTerms( this, d_ground_terms );
-      }
-      Trace("sg-proc") << "...done determine ground EQC" << std::endl;
+      computeIrrelevantEqcs(eqcs);
 
       //debug printing
       if( TraceIsOn("sg-gen-eqc") ){
@@ -896,6 +863,55 @@ void ConjectureGenerator::getEquivalenceClasses(std::vector<TNode>& eqcs)
   Assert(!d_bool_eqc[1].isNull());
   d_urelevant_terms.clear();
   Trace("sg-proc") << "...done get eq classes" << std::endl;
+}
+
+void ConjectureGenerator::computeIrrelevantEqcs(const std::vector<TNode>& eqcs)
+{
+  Trace("sg-proc") << "Determine ground EQC..." << std::endl;
+  bool success;
+  do
+  {
+    success = false;
+    for (unsigned i = 0; i < eqcs.size(); i++)
+    {
+      TNode r = eqcs[i];
+      if (d_ground_eqc_map.find(r) == d_ground_eqc_map.end())
+      {
+        std::vector<TNode> args;
+        Trace("sg-pat-debug")
+            << "******* Get ground term for " << r << std::endl;
+        Node n;
+        if (Skolemize::isInductionTerm(options(), r))
+        {
+          n = d_op_arg_index[r].getGroundTerm(this, args);
+        }
+        else
+        {
+          n = r;
+        }
+        if (!n.isNull())
+        {
+          Trace("sg-pat") << "Ground term for eqc " << r << " : " << std::endl;
+          Trace("sg-pat") << "   " << n << std::endl;
+          d_ground_eqc_map[r] = n;
+          success = true;
+        }
+        else
+        {
+          Trace("sg-pat-debug")
+              << "...could not find ground term." << std::endl;
+        }
+      }
+    }
+  } while (success);
+  // also get ground terms
+  d_ground_terms.clear();
+  for (unsigned i = 0; i < eqcs.size(); i++)
+  {
+    TNode r = eqcs[i];
+    d_op_arg_index[r].getGroundTerms(this, d_ground_terms);
+  }
+  Trace("sg-proc") << "...done determine ground EQC" << std::endl;
 }
 
 std::string ConjectureGenerator::identify() const { return "induction-cg"; }

--- a/src/theory/quantifiers/conjecture_generator.h
+++ b/src/theory/quantifiers/conjecture_generator.h
@@ -379,6 +379,35 @@ public:
    * relevant for conjecture generation.
    */
   void getEquivalenceClasses(std::vector<TNode>& eqcs);
+  /** compute irrelevant equivalence classes
+   *
+   * This function populates 'd_ground_eqc_map' with irrelevant equivalence
+   * classes.  In other words, it populates this map with key-value pairs
+   * where each key is an irrelevant term that is also the representative of
+   * some equivalence class.  The values are not important.
+   *
+   * In principle a term is *irrelevant* if and only if
+   *
+   *   1. it is not of inductive datatype sort,
+   *   2. OR it is of inductive datatype sort,
+   *     - AND it has an operator which is an *atomic trigger* but not a skolem
+   *     function,
+   *     - AND all of its immediate children -- the operator's arguments -- are
+   *     themselves irrelevant terms,
+   *   3. OR it is equivalent to an irrelevant term in the current model.
+   *
+   * The objective behind defining irrelevance this way is to narrow the set
+   * of *relevant* terms to datatype-sorted terms that are impossible to express
+   * using only non-datatype terms, constructors, selectors,
+   * uninterpreted functions, or other function-like symbols (atomic triggers).
+   *
+   * Consequently the set of relevant terms contains (among other terms)
+   * datatype-sorted skolem constants that represent "arbitrary" values of that
+   * sort rather than "concrete" values.  These are precisely the skolem
+   * constants we may want to translate into universally quantified variables
+   * when synthesizing conjectures.
+   */
+  void computeIrrelevantEqcs(const std::vector<TNode>& eqcs);
 public:  //for generalization
   //generalizations
   bool isGeneralization( TNode patg, TNode pat ) {


### PR DESCRIPTION
This commit moves the computation of irrelevant equivalence classes to a separate function and in the header file explains the *abstract* definition of irrelevant equivalence classes and why they are useful for conjecture generation.