### PR TITLE
Add rewrite level (normal/expert for rewrite rules)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1441,8 +1441,10 @@ set(REWRITES_FILES
   ${PROJECT_SOURCE_DIR}/src/theory/strings/rewrites
   ${PROJECT_SOURCE_DIR}/src/theory/strings/rewrites-regexp-membership
   ${PROJECT_SOURCE_DIR}/src/theory/uf/rewrites
-  # these files should only be enabled in expert builds and should
-  # be partitioned into their own proof signature
+)
+# these files should only be enabled in expert builds and should
+# be partitioned into their own proof signature
+set(REWRITES_FILES_EXPERT
   ${PROJECT_SOURCE_DIR}/src/theory/arith/rewrites-transcendentals
   ${PROJECT_SOURCE_DIR}/src/theory/sets/rewrites-card
 )

--- a/src/rewriter/CMakeLists.txt
+++ b/src/rewriter/CMakeLists.txt
@@ -37,7 +37,7 @@ set(mkrewrites_script ${CMAKE_CURRENT_LIST_DIR}/mkrewrites.py)
 set(REWRITE_OUTPUT_FILES
   rewrites.cpp
 )
-foreach(rewrite_in IN LISTS REWRITES_FILES)
+foreach(rewrite_in IN LISTS REWRITES_FILES REWRITES_FILES_EXPERT)
   # NOTE: In CMake 3.20+, the `cmake_path` command can be used instead
 
   get_filename_component(rewrite_parent ${rewrite_in} DIRECTORY)
@@ -70,12 +70,14 @@ add_custom_command(
       ${Python_EXECUTABLE}
       ${mkrewrites_script}
       rewrite-db
-      ${CMAKE_SOURCE_DIR}
-      ${CMAKE_BINARY_DIR}
-      ${REWRITES_FILES}
+      --src ${CMAKE_SOURCE_DIR}
+      --bin ${CMAKE_BINARY_DIR}
+      --rewrites_files ${REWRITES_FILES}
+      --rewrites_files_expert ${REWRITES_FILES_EXPERT}
     DEPENDS
       ${mkrewrites_script}
       ${REWRITES_FILES}
+      ${REWRITES_FILES_EXPERT}
       ${CMAKE_CURRENT_LIST_DIR}/theory_rewrites_template.cpp
       ${CMAKE_CURRENT_LIST_DIR}/rewrites_template.cpp
       ${CMAKE_SOURCE_DIR}/src/api/cpp/cvc5_proof_rule_template.cpp

--- a/src/rewriter/rewrite_db.cpp
+++ b/src/rewriter/rewrite_db.cpp
@@ -50,7 +50,8 @@ void RewriteDb::addRule(ProofRewriteRule id,
                         Node a,
                         Node b,
                         Node cond,
-                        Node context)
+                        Node context,
+                        Level _level)
 {
   NodeManager* nm = NodeManager::currentNM();
   std::vector<Node> fvsf = fvs;

--- a/src/rewriter/rewrite_db.h
+++ b/src/rewriter/rewrite_db.h
@@ -43,6 +43,12 @@ class IsListTypeClassCallback : public expr::TypeClassCallback
   uint32_t getTypeClass(TNode v) override;
 };
 
+enum class Level
+{
+  NORMAL,
+  EXPERT,
+};
+
 /**
  * A database of conditional rewrite rules. The rules of this class are
  * automatically populated based on the compilation of the rewrite rule files.
@@ -64,13 +70,15 @@ class RewriteDb
    * @param b The right hand side of the rule
    * @param cond The condition, or null if this is not a conditional rule
    * @param context The term context, if one exists
+   * @param level Whether this rule is expert
    */
   void addRule(ProofRewriteRule id,
                const std::vector<Node> fvs,
                Node a,
                Node b,
                Node cond,
-               Node context);
+               Node context,
+               Level level);
   /**
    * Get matches, which incrementally makes callbacks on the notify class
    * ntm for all rules that match eq.


### PR DESCRIPTION
Now each rewrite rule has a level. It is either normal or expert. Expert rules are by default not enabled. Use the `REWRITES_FILES_EXPERT` in `src/CMakeLists.txt` to define which rules are expert.