### PR TITLE
Fix several Eunoia rules for sequences

### DIFF
--- a/proofs/eo/cpc/programs/Strings.eo
+++ b/proofs/eo/cpc/programs/Strings.eo
@@ -53,8 +53,13 @@
 ; - y (Seq T): The second string.
 ; return: the concatenation of strings x and y, treated as lists.
 (define $str_concat ((T Type :implicit) (x (Seq T)) (y (Seq T)))
-  (eo::list_concat str.++ x y)
-)
+  (eo::list_concat str.++ x y))
+
+; define: $str_head
+; args:
+; - x (Seq T): The string, expected to be a non-empty concatentation.
+; return: the head (first child) of x.
+(define $str_head ((T Type :implicit) (x (Seq T))) (eo::list_nth str.++ x 0))
 
 ; define: $str_mk_nth
 ; args:
@@ -848,17 +853,15 @@
 
 ; program: $str_flatten_word
 ; args:
-; - t String: A string term, assumed to be a non-empty word constant.
+; - t String: A string term, assumed to be a string literal.
 ; return: >
 ;   The result of "flattening" t, for example given "AB", this returns the term
 ;   (str.++ "A" (str.++ "B" "")).
 (program $str_flatten_word ((t String))
   (String) String
   (
-    (($str_flatten_word t) 
-      (eo::ite ($str_check_length_one t)
-        ($str_cons t "")
-        ($str_cons (eo::extract t 0 0) ($str_flatten_word (eo::extract t 1 (eo::len t))))))
+    (($str_flatten_word "") "")
+    (($str_flatten_word t)  ($str_cons (eo::extract t 0 0) ($str_flatten_word (eo::extract t 1 (eo::len t)))))
   )
 )
 
@@ -1085,6 +1088,20 @@
 (define $str_to_flat_form ((U Type :implicit) (s (Seq U)) (rev Bool))
   ; intro, flatten, reverse
   ($str_rev rev ($str_flatten ($str_nary_intro s)))
+)
+
+; define: $str_to_nary_form
+; args:
+; - s (Seq U): The string term.
+; - rev Bool: Whether to reverse s.
+; return: >
+;   Converts a str.++ application into "nary form" so that we are ready to
+;   process its prefix. This consists of the following steps:
+;   (1) convert s to n-ary form if it is not already a str.++ application,
+;   (2) (optionally) reverse.
+(define $str_to_nary_form ((U Type :implicit) (s (Seq U)) (rev Bool))
+  ; intro, reverse
+  ($str_rev rev ($str_nary_intro s))
 )
 
 ; program: $re_str_to_flat_form

--- a/proofs/eo/cpc/programs/Strings.eo
+++ b/proofs/eo/cpc/programs/Strings.eo
@@ -965,39 +965,6 @@
   )
 )
 
-; program: $str_overlap_rec
-; args:
-; - nil (Seq U): The empty string.
-; - s (Seq U): The first string, expected to be in flattened form.
-; - t (Seq U): The second string, expected to be in flattened form.
-; return: >
-;   The minimum number of characters that must be skipped in s before
-;   string t can be compatible with it. See examples below.
-(program $str_overlap_rec ((U Type) (s (Seq U)) (s1 (Seq U) :list) (t (Seq U)) (nil (Seq U)))
-  ((Seq U) (Seq U) (Seq U)) Int
-  (
-  (($str_overlap_rec nil (str.++ s s1) t) (eo::ite ($nary_is_compatible str.++ nil (str.++ s s1) t)
-                                            0
-                                            (eo::add 1 ($str_overlap_rec nil s1 t))))
-  (($str_overlap_rec nil s t)             0)
-  )
-)
-
-; define: $str_overlap
-; args:
-; - s (Seq U): The first string, expected to be in flattened form.
-; - t (Seq U): The second string, expected to be in flattened form.
-; return: >
-;   The minimum number of characters that must be skipped in s before
-;   string t can be compatible with it. For example:
-;   $str_overlap (str.++ "A" "B" "C" "") (str.++ "B" "C" "D" "") = 1
-;   $str_overlap (str.++ "A" "B" "C" "") (str.++ "B" "") = 1
-;   $str_overlap (str.++ "A" "B" "C" "") (str.++ "E" "") = 3
-;   $str_overlap (str.++ "A" "B" "C" "") (str.++ "A" "A" "") = 3
-;   $str_overlap (str.++ "A" "B" "C" "") (str.++ "A" "") = 0
-(define $str_overlap ((U Type :implicit) (s (Seq U)) (t (Seq U)))
-  ($str_overlap_rec ($mk_emptystr (eo::typeof s)) s t))
-
 ; program: $str_mk_re_loop_elim_rec
 ; args:
 ; - n Int: The minimum number of iterations for a re.loop term.
@@ -1692,29 +1659,49 @@
 
 ;;;;; overlap utils
 
-; program: $str_has_overlap_rec
+; program: $str_overlap_rec
 ; args:
-; - nil (Seq U): The empty string.
 ; - s (Seq U): The first string, expected to be in flattened form.
 ; - t (Seq U): The second string, expected to be in flattened form.
 ; return: >
-;   Assuming t is non-empty, this method returns true if s contains t, or a
-;   non-empty suffix of s is a prefix of t.
-(program $str_has_overlap_rec ((U Type) (s (Seq U)) (s1 (Seq U) :list) (t (Seq U)) (nil (Seq U)))
-  ((Seq U) (Seq U) (Seq U)) Bool
+;   The minimum number of characters that must be skipped in s before
+;   string t can be compatible with it. See examples below.
+(program $str_overlap_rec ((s String) (s1 String :list) (t String))
+  (String String) Int
   (
-  (($str_has_overlap_rec nil (str.++ s s1) t) (eo::ite ($nary_is_compatible str.++ nil (str.++ s s1) t)
-                                                true
-                                                ($str_has_overlap_rec nil s1 t)))
-  (($str_has_overlap_rec nil nil t)           false)
+  (($str_overlap_rec (str.++ s s1) t) (eo::ite ($nary_is_compatible str.++ "" (str.++ s s1) t)
+                                        0
+                                        (eo::add 1 ($str_overlap_rec s1 t))))
+  (($str_overlap_rec s t)             0)
   )
 )
+
+; define: $str_overlap
+; args:
+; - s (Seq U): The first string, expected to be a string or sequence value.
+; - t (Seq U): The second string, expected to be a string or sequence value.
+; return: >
+;   The minimum number of characters that must be skipped in s before
+;   string t can be compatible with it. For example:
+;   $str_overlap (str.++ "A" "B" "C" "") (str.++ "B" "C" "D" "") = 1
+;   $str_overlap (str.++ "A" "B" "C" "") (str.++ "B" "") = 1
+;   $str_overlap (str.++ "A" "B" "C" "") (str.++ "E" "") = 3
+;   $str_overlap (str.++ "A" "B" "C" "") (str.++ "A" "A" "") = 3
+;   $str_overlap (str.++ "A" "B" "C" "") (str.++ "A" "") = 0
+(define $str_overlap ((U Type :implicit) (s (Seq U)) (t (Seq U)) (rev Bool))
+  (eo::match ((ss String) (ts String))
+    ($seq_to_string_pair s t)   ; ensure we have converted to strings at this point
+    (((@pair ss ts) (eo::requires (eo::is_str ss) true
+                    (eo::requires (eo::is_str ts) true
+                      ($str_overlap_rec
+                        ($str_rev rev ($str_flatten_word ss))
+                        ($str_rev rev ($str_flatten_word ts)))))))))
 
 
 ; program: $str_has_overlap
 ; args:
-; - s (Seq U): The first string, expected to be in flattened form.
-; - t (Seq U): The second string, expected to be non-empty and in flattened form.
+; - s (Seq U): The first string, expected to be a string or sequence value.
+; - t (Seq U): The second string, expected to be a string or sequence value.
 ; return: >
 ;   True if s is non-empty and contains t, or
 ;   a non-empty suffix of s is a prefix of t if rev is false, or
@@ -1723,10 +1710,9 @@
 ;   This method is equivalent to theory::strings::Word::hasOverlap in cvc5,
 ;   see theory/strings/word.h.
 (define $str_has_overlap ((U Type :implicit) (s (Seq U)) (t (Seq U)) (rev Bool))
-  (eo::requires (eo::is_str s) true
-  (eo::requires (eo::is_str t) true
-  (eo::define ((emp ($mk_emptystr (eo::typeof s))))
-    ($str_has_overlap_rec emp ($str_to_flat_form s rev) ($str_to_flat_form t rev))))))
+  ; Note that $str_overlap with always return a value <= the length of s.
+  ; There is overlap only when it is strictly less than the length of s.
+  (eo::gt ($str_value_len s) ($str_overlap s t rev)))
 
 ;;;;; evaluation utils
 

--- a/proofs/eo/cpc/programs/Strings.eo
+++ b/proofs/eo/cpc/programs/Strings.eo
@@ -3,6 +3,7 @@
 (include "../theories/Strings.eo")
 (include "../programs/Nary.eo")
 (include "../programs/PolyNorm.eo")
+(include "../programs/SeqToString.eo")
 
 
 ; This signature is used for both strings and sequences, where we often

--- a/proofs/eo/cpc/rules/Strings.eo
+++ b/proofs/eo/cpc/rules/Strings.eo
@@ -641,40 +641,49 @@
 ; args:
 ; - s (Seq T): the term.
 ; return: >
-;   The multiset over-approximation of s, which is a (flattened) concatenation
-;   term whose components represent an overapproximation of what s may contain.
+;   The multiset over-approximation of s, which is a (flattened) list of
+;   terms which represents an overapproximation of what s may contain.
+;   In particular, note that all string literals are broken up into string
+;   literals of size one.
 (program $str_multiset_overapprox ((T Type) (s (Seq T)) (ss (Seq T) :list) (t (Seq T)) (r (Seq T)) (n Int) (m Int))
-    ((Seq T)) (Seq T)
+    ((Seq T)) @List
     (
-      (($str_multiset_overapprox (str.++ s ss))        (eo::list_concat str.++ ($str_multiset_overapprox s) ($str_multiset_overapprox ss)))
+      (($str_multiset_overapprox (str.++ s ss))        (eo::list_concat @list ($str_multiset_overapprox s) ($str_multiset_overapprox ss)))
       (($str_multiset_overapprox (str.substr s n m))   ($str_multiset_overapprox s))
-      (($str_multiset_overapprox (str.replace s t r))  (eo::list_concat str.++ ($str_multiset_overapprox s) ($str_multiset_overapprox r)))
-      (($str_multiset_overapprox s)                    ($str_to_flat_form s false))
+      (($str_multiset_overapprox (str.replace s t r))  (eo::list_concat @list ($str_multiset_overapprox s) ($str_multiset_overapprox r)))
+      (($str_multiset_overapprox s)                    (eo::ite ($str_is_empty s)
+                                                          @list.nil
+                                                          (eo::ite (eo::is_str s)
+                                                            (eo::ite (eo::gt (eo::len s) 1)
+                                                              ; if a string constant of size > 1, flatten to characters and add to list
+                                                              ($str_multiset_overapprox ($str_flatten_word s))
+                                                              (@list s))
+                                                            (@list s))))
     )
 )
 
 ; program: $str_is_multiset_subset_strict
 ; args:
-; - s (Seq T): the multiset approximation of a string term.
-; - t (Seq T): the multiset (over)approximation of a string term.
-; - b Bool: whether we have found that a character from s was not contained in t.
+; - s (Seq T): a string term, expected to be in flattened form.
+; - xs @List: the multiset (over)approximation of a string term.
+; - nr @List: the accumulated list of previously processed terms from s that were not removed from xs.
 ; return: >
 ;   True if the string approximated by s is definitely not contained in the string
 ;   approximated by t. We compute this by iteratively removing the components of
-;   s from t, remembering if we have removed a character.
-; note: This method only supports strings currently.
-(program $str_is_multiset_subset_strict ((T Type :implicit) (id (Seq T)) (s (Seq T)) (ss (Seq T) :list) (t (Seq T)) (b Bool))
-    ((Seq T) (Seq T) Bool) Bool
+;   s from t, and then checking if a term in nr is provably distinct from the final xs.
+(program $str_is_multiset_subset_strict ((T Type :implicit) (emp (Seq T)) (s (Seq T)) (ss (Seq T) :list) (xs @List) (nr @List :list))
+    ((Seq T) @List @List) Bool
     (
-      (($str_is_multiset_subset_strict (str.++ s ss) t b) (eo::define ((tr ($nary_remove str.++ "" s t)))
-                                                            (eo::define ((nrem (eo::is_eq t tr)))
-                                                              ($str_is_multiset_subset_strict ss tr 
-                                                                ; we update b to true if we successfully remove a character from s
-                                                                (eo::ite b true (eo::ite nrem (eo::is_str s) false))))))
-      (($str_is_multiset_subset_strict s t b)             (eo::ite b 
-                                                            ; remaining characters in t must be constants only
-                                                            (eo::is_str ($str_from_flat_form t false))
-                                                            false))
+      (($str_is_multiset_subset_strict (str.++ s ss) xs nr) (eo::define ((xsr ($nary_remove @list @list.nil s xs)))
+                                                            (eo::define ((nrem (eo::is_eq xs xsr)))
+                                                              ($str_is_multiset_subset_strict ss xsr
+                                                                ; we add s to the accumulated list if it was not removed from xs
+                                                                (eo::ite nrem (@list s nr) nr)))))
+      (($str_is_multiset_subset_strict emp xs (@list s nr)) (eo::ite ($are_distinct_terms_list_rec s xs (eo::typeof s))
+                                                              ; if something was in s that is provably distinct from the remainder of t, we succeed
+                                                              true
+                                                              ($str_is_multiset_subset_strict emp xs nr)))
+      (($str_is_multiset_subset_strict emp xs nr)           false)
     )
 )
 
@@ -689,7 +698,7 @@
   :args ((= (str.contains t s) false))
   :requires ((($str_is_multiset_subset_strict
                 ($str_to_flat_form s false)
-                ($str_multiset_overapprox t) false) true))
+                ($str_multiset_overapprox t) @list.nil) true))
   :conclusion (= (str.contains t s) false)
 )
 
@@ -704,12 +713,14 @@
 ;   overlap with the second argument, and the second argument has not forward
 ;   overlap with the middle component of the first argument.
 ; conclusion: The given equality.
-(declare-rule str-overlap-split-ctn ((t String) (s String) (c String) (d String))
-  :args ((= (str.contains (str.++ t c s) d)
+(declare-rule str-overlap-split-ctn ((T Type) (emp (Seq T) :list)
+                                     (t (Seq T)) (s (Seq T)) (c (Seq T)) (d (Seq T)))
+  :args ((= (str.contains (str.++ t c s emp) d)
             (or (str.contains t d) (str.contains s d))))
-  :requires ((($str_has_overlap c d false) false)
+  :requires ((($str_is_empty emp) true)
+             (($str_has_overlap c d false) false)
              (($str_has_overlap d c false) false))
-  :conclusion (= (str.contains (str.++ t c s) d)
+  :conclusion (= (str.contains (str.++ t c s emp) d)
                  (or (str.contains t d) (str.contains s d)))
 )
 
@@ -724,14 +735,16 @@
 ;   and the last components of the arguments to contains have no reverse
 ;   overlap.
 ; conclusion: The given equality.
-(declare-rule str-overlap-endpoints-ctn ((c1 String) (s String) (c2 String)
-                                         (d1 String) (t String) (d2 String))
-  :args ((= (str.contains (str.++ c1 s c2) (str.++ d1 t d2))
-            (str.contains s (str.++ d1 t d2))))
-  :requires ((($str_has_overlap c1 d1 false) false)
+(declare-rule str-overlap-endpoints-ctn ((T Type) (emp (Seq T) :list)
+                                         (c1 (Seq T)) (s (Seq T)) (c2 (Seq T))
+                                         (d1 (Seq T)) (t (Seq T)) (d2 (Seq T)))
+  :args ((= (str.contains (str.++ c1 s c2 emp) (str.++ d1 t d2 emp))
+            (str.contains s (str.++ d1 t d2 emp))))
+  :requires ((($str_is_empty emp) true)
+             (($str_has_overlap c1 d1 false) false)
              (($str_has_overlap c2 d2 true) false))
-  :conclusion (= (str.contains (str.++ c1 s c2) (str.++ d1 t d2))
-                 (str.contains s (str.++ d1 t d2)))
+  :conclusion (= (str.contains (str.++ c1 s c2 emp) (str.++ d1 t d2 emp))
+                 (str.contains s (str.++ d1 t d2 emp)))
 )
 
 ;;;;; ProofRewriteRule::STR_OVERLAP_ENDPOINTS_INDEXOF
@@ -744,12 +757,14 @@
 ;  the last components of the first two arguments to indexof have no reverse
 ;  overlap.
 ; conclusion: The given equality.
-(declare-rule str-overlap-endpoints-indexof ((s String) (c String) (t String) (d String))
-  :args ((= (str.indexof (str.++ s c) (str.++ t d) 0)
-            (str.indexof s (str.++ t d) 0)))
-  :requires ((($str_has_overlap c d true) false))
-  :conclusion (= (str.indexof (str.++ s c) (str.++ t d) 0)
-                 (str.indexof s (str.++ t d) 0))
+(declare-rule str-overlap-endpoints-indexof ((T Type) (emp (Seq T) :list)
+                                             (s (Seq T)) (c (Seq T)) (t (Seq T)) (d (Seq T)))
+  :args ((= (str.indexof (str.++ s c emp) (str.++ t d emp) 0)
+            (str.indexof s (str.++ t d emp) 0)))
+  :requires ((($str_is_empty emp) true)
+             (($str_has_overlap c d true) false))
+  :conclusion (= (str.indexof (str.++ s c emp) (str.++ t d emp) 0)
+                 (str.indexof s (str.++ t d emp) 0))
 )
 
 ;;;;; ProofRewriteRule::STR_OVERLAP_REPLACE
@@ -763,14 +778,16 @@
 ;   overlap, and the last components of the first two arguments to replace have
 ;   no reverse overlap.
 ; conclusion: The given equality.
-(declare-rule str-overlap-endpoints-replace ((c1 String) (s String) (c2 String)
-                                             (d1 String) (t String) (d2 String) (r String))
-  :args ((= (str.replace (str.++ c1 s c2) (str.++ d1 t d2) r)
-            (str.++ c1 (str.replace s (str.++ d1 t d2) r) c2)))
-  :requires ((($str_has_overlap c1 d1 false) false)
+(declare-rule str-overlap-endpoints-replace ((T Type) (emp (Seq T) :list)
+                                             (c1 (Seq T)) (s (Seq T)) (c2 (Seq T))
+                                             (d1 (Seq T)) (t (Seq T)) (d2 (Seq T)) (r (Seq T)))
+  :args ((= (str.replace (str.++ c1 s c2 emp) (str.++ d1 t d2 emp) r)
+            (str.++ c1 (str.replace s (str.++ d1 t d2 emp) r) c2 emp)))
+  :requires ((($str_is_empty emp) true)
+             (($str_has_overlap c1 d1 false) false)
              (($str_has_overlap c2 d2 true) false))
-  :conclusion (= (str.replace (str.++ c1 s c2) (str.++ d1 t d2) r)
-                 (str.++ c1 (str.replace s (str.++ d1 t d2) r) c2))
+  :conclusion (= (str.replace (str.++ c1 s c2 emp) (str.++ d1 t d2 emp) r)
+                 (str.++ c1 (str.replace s (str.++ d1 t d2 emp) r) c2 emp))
 )
 
 ;;;;; ProofRewriteRule::STR_INDEXOF_RE_EVAL

--- a/proofs/eo/cpc/rules/Strings.eo
+++ b/proofs/eo/cpc/rules/Strings.eo
@@ -183,22 +183,20 @@
   :premises ((= t s) (not (= (str.len tc) 0)))
   :args (rev)
   :conclusion
-    (eo::match ((t1 (Seq U)) (t2 (Seq U)) (t3 (Seq U) :list))
-      ($str_rev rev t)
-      (((str.++ t1 t2 t3)
-        (eo::requires t1 tc
-          (eo::match ((s1 (Seq U)) (s2 (Seq U) :list))
-            ($str_rev rev ($str_nary_intro s))  ; must do nary intro when s is just a constant
-            (((str.++ s1 s2)
-                (eo::define ((sc ($str_to_flat_form s1 rev)))
-                (eo::define ((v (eo::add 1 ($str_overlap ($tail sc) ($str_to_flat_form t2 rev) false))))
-                  (= tc
-                    (eo::ite rev
-                      (eo::define ((oc ($str_suffix s1 v)))
-                      (str.++ (@purify ($str_prefix tc ($arith_mk_binary_minus (str.len tc) (str.len oc)))) oc))
-                      (eo::define ((oc ($str_prefix s1 v)))
-                      (str.++ oc (@purify ($str_suffix_rem tc (str.len oc)))))))
-                )))))))))
+    (eo::define ((tn ($str_to_nary_form t rev)))
+    (eo::define ((t1 ($str_head tn)))
+    (eo::define ((t2 (eo::list_nth str.++ tn 1))) ; get the second component
+    (eo::define ((s1 ($str_head ($str_to_nary_form s rev))))
+    (eo::define ((s1len (eo::len s1)))
+    (eo::define ((s1s (eo::ite rev (eo::extract s1 0 (eo::add s1len -2)) (eo::extract s1 1 s1len))))  ; remove one character from s1
+    (eo::define ((v (eo::add 1 ($str_overlap s1s t2 rev)))) ; get the overlap, plus one
+      (eo::requires t1 tc
+        (= tc
+          (eo::ite rev
+            (eo::define ((oc ($str_suffix s1 v)))
+              (str.++ (@purify ($str_prefix tc ($arith_mk_binary_minus (str.len tc) (str.len oc)))) oc))
+            (eo::define ((oc ($str_prefix s1 v)))
+              (str.++ oc (@purify ($str_suffix_rem tc (str.len oc)))))))))))))))
 )
 
 ; rule: concat_conflict

--- a/proofs/eo/cpc/rules/Strings.eo
+++ b/proofs/eo/cpc/rules/Strings.eo
@@ -191,7 +191,7 @@
             ($str_rev rev ($str_nary_intro s))  ; must do nary intro when s is just a constant
             (((str.++ s1 s2)
                 (eo::define ((sc ($str_to_flat_form s1 rev)))
-                (eo::define ((v (eo::add 1 ($str_overlap ($tail sc) ($str_to_flat_form t2 rev)))))
+                (eo::define ((v (eo::add 1 ($str_overlap ($tail sc) ($str_to_flat_form t2 rev) false))))
                   (= tc
                     (eo::ite rev
                       (eo::define ((oc ($str_suffix s1 v)))

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -326,15 +326,12 @@ bool AlfPrinter::isHandledTheoryRewrite(ProofRewriteRule id, const Node& n)
     case ProofRewriteRule::RE_INTER_INCLUSION:
     case ProofRewriteRule::RE_UNION_INCLUSION:
     case ProofRewriteRule::BV_REPEAT_ELIM:
-    case ProofRewriteRule::BV_BITWISE_SLICING: return true;
+    case ProofRewriteRule::BV_BITWISE_SLICING:
     case ProofRewriteRule::STR_OVERLAP_SPLIT_CTN:
     case ProofRewriteRule::STR_OVERLAP_ENDPOINTS_CTN:
     case ProofRewriteRule::STR_OVERLAP_ENDPOINTS_INDEXOF:
     case ProofRewriteRule::STR_OVERLAP_ENDPOINTS_REPLACE:
-    case ProofRewriteRule::STR_CTN_MULTISET_SUBSET:
-      // only strings are supported, since it is non-trivial to show
-      // distinctness of sequence characters.
-      return n[0][0].getType().isString();
+    case ProofRewriteRule::STR_CTN_MULTISET_SUBSET: return true;
     case ProofRewriteRule::STR_IN_RE_EVAL:
       Assert(n[0].getKind() == Kind::STRING_IN_REGEXP && n[0][0].isConst());
       return canEvaluateRegExp(n[0][1]);


### PR DESCRIPTION
This makes 6 proof rules in the strings signature applicable to sequences now.  

5 of these rules depended on "overlap" utilities which were not applicable to sequences; 1 of these rules (concat_cprop) was already unsoundly assuming sequence characters to be distinct.  The overlap utilities in the strings signature are updated to convert sequences -> strings if necessary, which should make the rules sound at the meta-level.

The other rule (multiset containment) is refactored to use the newly introduced distinct values side condition.