### PR TITLE
Do not use array constants in sygus grammars unless arraysExp is true

### DIFF
--- a/src/preprocessing/passes/synth_rew_rules.cpp
+++ b/src/preprocessing/passes/synth_rew_rules.cpp
@@ -71,7 +71,7 @@ std::map<TypeNode, TypeNode> SynthRewRulesPass::constructTopLevelGrammar(
   {
     return tlGrammarTypes;
   }
-  NodeManager * nm = env.getNodeManager();
+  NodeManager* nm = env.getNodeManager();
   // initialize the candidate rewrite
   std::unordered_map<TNode, bool> visited;
   std::unordered_map<TNode, bool>::iterator it;

--- a/src/preprocessing/passes/synth_rew_rules.cpp
+++ b/src/preprocessing/passes/synth_rew_rules.cpp
@@ -51,11 +51,11 @@ PreprocessingPassResult SynthRewRulesPass::applyInternal(
 }
 
 std::vector<TypeNode> SynthRewRulesPass::getGrammarsFrom(
-    NodeManager* nm, const std::vector<Node>& assertions, uint64_t nvars)
+    Env& env, const std::vector<Node>& assertions, uint64_t nvars)
 {
   std::vector<TypeNode> ret;
   std::map<TypeNode, TypeNode> tlGrammarTypes =
-      constructTopLevelGrammar(nm, assertions, nvars);
+      constructTopLevelGrammar(env, assertions, nvars);
   for (std::pair<const TypeNode, TypeNode> ttp : tlGrammarTypes)
   {
     ret.push_back(ttp.second);
@@ -64,13 +64,14 @@ std::vector<TypeNode> SynthRewRulesPass::getGrammarsFrom(
 }
 
 std::map<TypeNode, TypeNode> SynthRewRulesPass::constructTopLevelGrammar(
-    NodeManager* nm, const std::vector<Node>& assertions, uint64_t nvars)
+    Env& env, const std::vector<Node>& assertions, uint64_t nvars)
 {
   std::map<TypeNode, TypeNode> tlGrammarTypes;
   if (assertions.empty())
   {
     return tlGrammarTypes;
   }
+  NodeManager * nm = env.getNodeManager();
   // initialize the candidate rewrite
   std::unordered_map<TNode, bool> visited;
   std::unordered_map<TNode, bool>::iterator it;
@@ -148,7 +149,7 @@ std::map<TypeNode, TypeNode> SynthRewRulesPass::constructTopLevelGrammar(
             typesFound[tn] = true;
             // add the standard constants for this type
             theory::quantifiers::SygusGrammarCons::mkSygusConstantsForType(
-                nm, tn, consts[tn]);
+                env, tn, consts[tn]);
             // We prepend them so that they come first in the grammar
             // construction. The motivation is we'd prefer seeing e.g. "true"
             // instead of (= x x) as a canonical term.

--- a/src/preprocessing/passes/synth_rew_rules.h
+++ b/src/preprocessing/passes/synth_rew_rules.h
@@ -66,11 +66,11 @@ class SynthRewRulesPass : public PreprocessingPass
   SynthRewRulesPass(PreprocessingPassContext* preprocContext);
 
   static std::vector<TypeNode> getGrammarsFrom(
-      NodeManager* nm, const std::vector<Node>& assertions, uint64_t nvars);
+      Env& env, const std::vector<Node>& assertions, uint64_t nvars);
 
  protected:
   static std::map<TypeNode, TypeNode> constructTopLevelGrammar(
-      NodeManager* nm, const std::vector<Node>& assertions, uint64_t nvars);
+      Env& env, const std::vector<Node>& assertions, uint64_t nvars);
   PreprocessingPassResult applyInternal(
       AssertionPipeline* assertionsToPreprocess) override;
 };

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1030,9 +1030,8 @@ Node SolverEngine::findSynth(modes::FindSynthTarget fst, const TypeNode& gtn)
     }
     uint64_t nvars = options().quantifiers.sygusRewSynthInputNVars;
     std::vector<Node> asserts = getAssertionsInternal();
-    NodeManager* nm = d_env->getNodeManager();
     gtnu = preprocessing::passes::SynthRewRulesPass::getGrammarsFrom(
-        nm, asserts, nvars);
+        *d_env.get(), asserts, nvars);
     if (gtnu.empty())
     {
       Warning() << "Could not find grammar in find-synth :rewrite_input"

--- a/src/theory/incomplete_id.cpp
+++ b/src/theory/incomplete_id.cpp
@@ -42,6 +42,8 @@ const char* toString(IncompleteId i)
       return "QUANTIFIERS_MAX_INST_ROUNDS";
     case IncompleteId::QUANTIFIERS_SYGUS_SOLVED:
       return "QUANTIFIERS_SYGUS_SOLVED";
+    case IncompleteId::QUANTIFIERS_SYGUS_NO_WF_GRAMMAR:
+      return "QUANTIFIERS_SYGUS_NO_WF_GRAMMAR";
     case IncompleteId::SEP: return "SEP";
     case IncompleteId::SETS_HO_CARD: return "SETS_HO_CARD";
     case IncompleteId::SETS_RELS_CARD: return "SETS_RELS_CARD";

--- a/src/theory/incomplete_id.h
+++ b/src/theory/incomplete_id.h
@@ -57,6 +57,8 @@ enum class IncompleteId
   // we solved a negated synthesis conjecture and will terminate as a subsolver
   // with unknown
   QUANTIFIERS_SYGUS_SOLVED,
+  // we failed to construct a grammar for a function-to-synthesize
+  QUANTIFIERS_SYGUS_NO_WF_GRAMMAR,
   // incomplete due to separation logic
   SEP,
   // Higher order operators like sets.map were used in combination with set

--- a/src/theory/inference_id.cpp
+++ b/src/theory/inference_id.cpp
@@ -330,6 +330,8 @@ const char* toString(InferenceId i)
       return "QUANTIFIERS_SYGUS_COMPLETE_ENUM";
     case InferenceId::QUANTIFIERS_SYGUS_SC_INFEASIBLE:
       return "QUANTIFIERS_SYGUS_SC_INFEASIBLE";
+    case InferenceId::QUANTIFIERS_SYGUS_NO_WF_GRAMMAR:
+      return "QUANTIFIERS_SYGUS_NO_WF_GRAMMAR";
     case InferenceId::QUANTIFIERS_DSPLIT: return "QUANTIFIERS_DSPLIT";
     case InferenceId::QUANTIFIERS_CONJ_GEN_SPLIT:
       return "QUANTIFIERS_CONJ_GEN_SPLIT";

--- a/src/theory/inference_id.h
+++ b/src/theory/inference_id.h
@@ -461,6 +461,8 @@ enum class InferenceId
   QUANTIFIERS_SYGUS_COMPLETE_ENUM,
   // infeasible due to side condition (e.g. for abduction)
   QUANTIFIERS_SYGUS_SC_INFEASIBLE,
+  // infeasible due to non-well-founded grammar
+  QUANTIFIERS_SYGUS_NO_WF_GRAMMAR,
   //-------------------- dynamic splitting
   // a dynamic split from quantifiers
   QUANTIFIERS_DSPLIT,

--- a/src/theory/quantifiers/sygus/embedding_converter.cpp
+++ b/src/theory/quantifiers/sygus/embedding_converter.cpp
@@ -15,10 +15,10 @@
 
 #include "theory/quantifiers/sygus/embedding_converter.h"
 
-#include "smt/logic_exception.h"
 #include "options/base_options.h"
 #include "options/quantifiers_options.h"
 #include "printer/smt2/smt2_printer.h"
+#include "smt/logic_exception.h"
 #include "theory/datatypes/sygus_datatype_utils.h"
 #include "theory/quantifiers/sygus/sygus_grammar_cons.h"
 #include "theory/quantifiers/sygus/sygus_grammar_norm.h"
@@ -170,7 +170,10 @@ Node EmbeddingConverter::process(Node q,
       // array constants cannot be used
       if (!tn.isWellFounded())
       {
-        Warning() << "Warning: Failed to construct grammar for " << preGrammarType << " since no ground values can be generated for that type." << std::endl;
+        Warning() << "Warning: Failed to construct grammar for "
+                  << preGrammarType
+                  << " since no ground values can be generated for that type."
+                  << std::endl;
         return Node::null();
       }
     }

--- a/src/theory/quantifiers/sygus/embedding_converter.cpp
+++ b/src/theory/quantifiers/sygus/embedding_converter.cpp
@@ -170,9 +170,8 @@ Node EmbeddingConverter::process(Node q,
       // array constants cannot be used
       if (!tn.isWellFounded())
       {
-        std::stringstream ss;
-        ss << "Failed to construct grammar for " << preGrammarType << " since no ground values can be generated for that type";
-        throw LogicException(ss.str());
+        Warning() << "Warning: Failed to construct grammar for " << preGrammarType << " since no ground values can be generated for that type." << std::endl;
+        return Node::null();
       }
     }
     // Ensure the expanded definition forms are set. This is done after

--- a/src/theory/quantifiers/sygus/embedding_converter.cpp
+++ b/src/theory/quantifiers/sygus/embedding_converter.cpp
@@ -15,6 +15,7 @@
 
 #include "theory/quantifiers/sygus/embedding_converter.h"
 
+#include "smt/logic_exception.h"
 #include "options/base_options.h"
 #include "options/quantifiers_options.h"
 #include "printer/smt2/smt2_printer.h"
@@ -164,6 +165,15 @@ Node EmbeddingConverter::process(Node q,
       }
       tn = SygusGrammarCons::mkDefaultSygusType(
           d_env, preGrammarType, sfvl, trules);
+      // this can happen only in very rare cases, e.g. where we are asking
+      // to generate a grammar for arrays and no ground values exist and
+      // array constants cannot be used
+      if (!tn.isWellFounded())
+      {
+        std::stringstream ss;
+        ss << "Failed to construct grammar for " << preGrammarType << " since no ground values can be generated for that type";
+        throw LogicException(ss.str());
+      }
     }
     // Ensure the expanded definition forms are set. This is done after
     // normalization above.

--- a/src/theory/quantifiers/sygus/embedding_converter.h
+++ b/src/theory/quantifiers/sygus/embedding_converter.h
@@ -54,7 +54,7 @@ class EmbeddingConverter : protected EnvObj
    * to synthesis must be of the form
    *   templates[i]{ templates_arg[i] -> t }
    * for some t if !templates[i].isNull().
-   * 
+   *
    * This may return null if we are unable to construct a well founded
    * grammar for a function-to-synthesize, which indicates that it is not
    * possible to process this quantified formula with SyGuS.

--- a/src/theory/quantifiers/sygus/embedding_converter.h
+++ b/src/theory/quantifiers/sygus/embedding_converter.h
@@ -54,6 +54,10 @@ class EmbeddingConverter : protected EnvObj
    * to synthesis must be of the form
    *   templates[i]{ templates_arg[i] -> t }
    * for some t if !templates[i].isNull().
+   * 
+   * This may return null if we are unable to construct a well founded
+   * grammar for a function-to-synthesize, which indicates that it is not
+   * possible to process this quantified formula with SyGuS.
    */
   Node process(Node q,
                const std::map<Node, Node>& templates,

--- a/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
@@ -291,7 +291,7 @@ void SygusGrammarCons::addDefaultRulesTo(
       }
     }
     std::vector<Node> consts;
-    mkSygusConstantsForType(nm, tn, consts);
+    mkSygusConstantsForType(env, tn, consts);
     if (tsgcm == options::SygusGrammarConsMode::ANY_CONST)
     {
       // Use the any constant constructor. Notice that for types that don't
@@ -886,10 +886,11 @@ void SygusGrammarCons::addDefaultPredicateRulesTo(
   }
 }
 
-void SygusGrammarCons::mkSygusConstantsForType(NodeManager* nm,
+void SygusGrammarCons::mkSygusConstantsForType(const Env& env,
                                                const TypeNode& type,
                                                std::vector<Node>& ops)
 {
+  NodeManager * nm = env.getNodeManager();
   if (type.isRealOrInt())
   {
     ops.push_back(nm->mkConstRealOrInt(type, Rational(0)));

--- a/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
@@ -21,6 +21,7 @@
 #include "expr/dtype.h"
 #include "expr/dtype_cons.h"
 #include "expr/node_algorithm.h"
+#include "options/arrays_options.h"
 #include "options/quantifiers_options.h"
 #include "theory/bv/theory_bv_utils.h"
 #include "theory/strings/word.h"
@@ -923,6 +924,11 @@ void SygusGrammarCons::mkSygusConstantsForType(const Env& env,
     Node c = NodeManager::mkGroundTerm(type);
     // note that c should never contain an uninterpreted sort value
     Assert(!expr::hasSubtermKind(Kind::UNINTERPRETED_SORT_VALUE, c));
+    // don't use array constants if arraysExp is false
+    if (!env.getOptions().arrays.arraysExp && expr::hasSubtermKind(Kind::STORE_ALL, c))
+    {
+      return;
+    }
     ops.push_back(c);
   }
   else if (type.isRoundingMode())

--- a/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
@@ -891,7 +891,7 @@ void SygusGrammarCons::mkSygusConstantsForType(const Env& env,
                                                const TypeNode& type,
                                                std::vector<Node>& ops)
 {
-  NodeManager * nm = env.getNodeManager();
+  NodeManager* nm = env.getNodeManager();
   if (type.isRealOrInt())
   {
     ops.push_back(nm->mkConstRealOrInt(type, Rational(0)));
@@ -925,7 +925,8 @@ void SygusGrammarCons::mkSygusConstantsForType(const Env& env,
     // note that c should never contain an uninterpreted sort value
     Assert(!expr::hasSubtermKind(Kind::UNINTERPRETED_SORT_VALUE, c));
     // don't use array constants if arraysExp is false
-    if (!env.getOptions().arrays.arraysExp && expr::hasSubtermKind(Kind::STORE_ALL, c))
+    if (!env.getOptions().arrays.arraysExp
+        && expr::hasSubtermKind(Kind::STORE_ALL, c))
     {
       return;
     }

--- a/src/theory/quantifiers/sygus/sygus_grammar_cons.h
+++ b/src/theory/quantifiers/sygus/sygus_grammar_cons.h
@@ -101,7 +101,7 @@ class SygusGrammarCons
    * @param type The type to add constants for
    * @param op The vector to add the constants to
    */
-  static void mkSygusConstantsForType(NodeManager* nm,
+  static void mkSygusConstantsForType(const Env& env,
                                       const TypeNode& type,
                                       std::vector<Node>& ops);
 

--- a/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
@@ -453,7 +453,7 @@ TypeNode SygusGrammarNorm::normalizeSygusRec(TypeNode tn,
     {
       // add default constant constructors
       std::vector<Node> ops;
-      SygusGrammarCons::mkSygusConstantsForType(nodeManager(), sygus_type, ops);
+      SygusGrammarCons::mkSygusConstantsForType(d_env, sygus_type, ops);
       for (const Node& op : ops)
       {
         std::stringstream ss;

--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -173,7 +173,7 @@ void SynthConjecture::assign(Node q)
   // well-founded grammar. In this case, we fail immediately with "unknown".
   if (d_embed_quant.isNull())
   {
-    d_qim.lemma(d_quant.negate(), InferenceId::QUANTIFIERS_SYGUS_SC_INFEASIBLE);
+    d_qim.lemma(d_quant.negate(), InferenceId::QUANTIFIERS_SYGUS_NO_WF_GRAMMAR);
     d_qim.setRefutationUnsound(IncompleteId::QUANTIFIERS_SYGUS_NO_WF_GRAMMAR);
     return;
   }

--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -169,6 +169,15 @@ void SynthConjecture::assign(Node q)
   d_embed_quant = d_embConv->process(d_simp_quant, templates, templates_arg);
   Trace("cegqi") << "SynthConjecture : converted to embedding : "
                  << d_embed_quant << std::endl;
+  // In very rare cases, the above call will return null if we construct a
+  // well-founded grammar. In this case, we fail immediately with "unknown".
+  if (d_embed_quant.isNull())
+  {
+    d_qim.lemma(d_quant.negate(),
+                InferenceId::QUANTIFIERS_SYGUS_SC_INFEASIBLE);
+    d_qim.setRefutationUnsound(IncompleteId::QUANTIFIERS_SYGUS_NO_WF_GRAMMAR);
+    return;
+  }
 
   if (!sc.isNull())
   {

--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -173,8 +173,7 @@ void SynthConjecture::assign(Node q)
   // well-founded grammar. In this case, we fail immediately with "unknown".
   if (d_embed_quant.isNull())
   {
-    d_qim.lemma(d_quant.negate(),
-                InferenceId::QUANTIFIERS_SYGUS_SC_INFEASIBLE);
+    d_qim.lemma(d_quant.negate(), InferenceId::QUANTIFIERS_SYGUS_SC_INFEASIBLE);
     d_qim.setRefutationUnsound(IncompleteId::QUANTIFIERS_SYGUS_NO_WF_GRAMMAR);
     return;
   }

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -3789,6 +3789,7 @@ set(regress_2_tests
   regress2/quantifiers/dd10_sdlx-fix-4.smt2
   regress2/quantifiers/gn-wrong-091018.smt2
   regress2/quantifiers/issue3481-unsat1.smt2
+  regress2/quantifiers/issue10805-syqi-no-arr-const.smt2
   regress2/quantifiers/javafe.ast.StandardPrettyPrint.319.smt2
   regress2/quantifiers/javafe.ast.WhileStmt.447.smt2
   regress2/quantifiers/javafe.tc.CheckCompilationUnit.001.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1551,6 +1551,7 @@ set(regress_0_tests
   regress0/quantifiers/issue8466-syqi-bool.smt2
   regress0/quantifiers/issue8609-subtype-assert.smt2
   regress0/quantifiers/issue8821-enum-interleave-types.smt2
+  regress0/quantifiers/issue8912-syqi-arr-const.smt2
   regress0/quantifiers/issue8923-qe-push-pop.smt2
   regress0/quantifiers/issue9070-syqi-model.smt2
   regress0/quantifiers/issue9602-rewrite-pow-type.smt2

--- a/test/regress/cli/regress0/quantifiers/issue8912-syqi-arr-const.smt2
+++ b/test/regress/cli/regress0/quantifiers/issue8912-syqi-arr-const.smt2
@@ -1,3 +1,4 @@
+; COMMAND-LINE: --sygus-inst
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun r () (Array Int (Array Int Int)))

--- a/test/regress/cli/regress0/quantifiers/issue8912-syqi-arr-const.smt2
+++ b/test/regress/cli/regress0/quantifiers/issue8912-syqi-arr-const.smt2
@@ -1,0 +1,5 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-fun r () (Array Int (Array Int Int)))
+(assert (forall ((a (Array Int (Array Int Int)))) (= r a)))
+(check-sat)

--- a/test/regress/cli/regress1/quantifiers/issue8456-2-syqi-ic.smt2
+++ b/test/regress/cli/regress1/quantifiers/issue8456-2-syqi-ic.smt2
@@ -1,7 +1,5 @@
-; COMMAND-LINE: --sygus-inst
+; COMMAND-LINE: --sygus-inst --arrays-exp
 ; EXPECT: unsat
-;; Unary AND is not supported in Alethe
-; DISABLE-TESTER: alethe
 (set-logic ALL)
-(assert (and (forall ((v (Array (_ BitVec 1) Bool))) (select v (_ bv0 1)))))
+(assert (forall ((v (Array (_ BitVec 1) Bool))) (select v (_ bv0 1))))
 (check-sat)

--- a/test/regress/cli/regress1/sygus/issue3635.smt2
+++ b/test/regress/cli/regress1/sygus/issue3635.smt2
@@ -1,5 +1,5 @@
 ; EXPECT: sat
-; COMMAND-LINE: --sygus-inference=try
+; COMMAND-LINE: --sygus-inference=try --arrays-exp
 (set-logic ALL)
 (declare-fun a () (Array Int Int))
 (declare-fun b () (Array Int Int))

--- a/test/regress/cli/regress2/quantifiers/issue10805-syqi-no-arr-const.smt2
+++ b/test/regress/cli/regress2/quantifiers/issue10805-syqi-no-arr-const.smt2
@@ -1,0 +1,6 @@
+; COMMAND-LINE: --sygus-inst
+; EXPECT: unsat
+(set-logic ALL)
+(declare-const x (Array Bool (Array Bool Bool)))
+(assert (forall ((v (Array Bool (Array Bool Bool)))) (set.subset (set.singleton v) (set.singleton x))))
+(check-sat)


### PR DESCRIPTION
This ensures we don't introduce array constants in sygus grammars when `arraysExp` is false.

This makes us solve the benchmark on https://github.com/cvc5/cvc5/issues/10805 and https://github.com/cvc5/cvc5/issues/8912 with default options; using `--arrays-exp` on those issues still leads to the bad behavior.

Also makes the sygus solver more robust to failures when a non-well-founded grammar is generated.