### PR TITLE
Remove CONCAT_CONFLICT(_DEQ) rules

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -1486,42 +1486,6 @@ enum ENUM(ProofRule)
   EVALUE(CONCAT_UNIFY),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Strings -- Core rules -- Concatenation conflict**
-   *
-   * .. math::
-   *   \inferrule{(c_1 \cdot t) = (c_2 \cdot s)\mid \bot}{\bot}
-   *
-   * Alternatively for the reverse:
-   *
-   * .. math::
-   *   \inferrule{(t \cdot c_1) = (s \cdot c_2)\mid \top}{\bot}
-   *
-   * where :math:`c_1,\,c_2` are distinct (non-empty) string constants of the same length.
-   *
-   * \endverbatim
-   */
-  EVALUE(CONCAT_CONFLICT),
-  /**
-   * \verbatim embed:rst:leading-asterisk
-   * **Strings -- Core rules -- Concatenation conflict for disequal characters**
-   *
-   * .. math::
-   *   \inferrule{(t_1\cdot t) = (s_1 \cdot s), t_1 \neq s_1 \mid \bot}{\bot}
-   *
-   * Alternatively for the reverse:
-   *
-   * .. math::
-   *   \inferrule{(t\cdot t_1) = (s \cdot s_1), t_1 \neq s_1 \mid \top}{\bot}
-   *
-   * where :math:`t_1` and :math:`s_1` are applications of :math:`seq.unit`.
-   *
-   * This rule is used exclusively for sequences.
-   *
-   * \endverbatim
-   */
-  EVALUE(CONCAT_CONFLICT_DEQ),
-  /**
-   * \verbatim embed:rst:leading-asterisk
    * **Strings -- Core rules -- Concatenation split**
    *
    * .. math::

--- a/proofs/eo/cpc/rules/Strings.eo
+++ b/proofs/eo/cpc/rules/Strings.eo
@@ -188,49 +188,6 @@
               (str.++ oc (@purify ($str_suffix_rem tc (str.len oc)))))))))))))))
 )
 
-; rule: concat_conflict
-; implements: ProofRule::CONCAT_CONFLICT
-; premises:
-; - eq: An equality between strings t and s.
-; args:
-; - rev Bool: Whether we are reasoning about the end of strings t and s.
-; conclusion: >
-;   false if the prefix (resp. suffix) involves clashing characters at the same
-;   position.
-; note: This rule is used for strings only, not sequences.
-(declare-rule concat_conflict ((s String) (t String) (rev Bool))
-  :premises ((= s t))
-  :args (rev)
-  :conclusion
-      (eo::define ((cs ($str_head ($str_to_nary_form s rev))))
-      (eo::define ((ct ($str_head ($str_to_nary_form t rev))))
-        ; ensure they are disequal, return false
-        (eo::requires (eo::is_str cs) true
-        (eo::requires (eo::is_str ct) true
-        (eo::requires (eo::len cs) (eo::len ct)
-          false)))))
-)
-
-; rule: concat_conflict_deq
-; implements: ProofRule::CONCAT_CONFLICT_DEQ
-; premises:
-; - eq: An equality between strings s and t.
-; - cdeq: A disequality between two unit terms corresponding to children of s and t.
-; args:
-; - rev Bool: Whether we are reasoning about the end of strings s and t.
-; conclusion: >
-;   false if we can show that cdeq indeed refers to a prefix (resp. suffix) of s and t.
-; note: This rule is used for sequences only, not strings.
-(declare-rule concat_conflict_deq ((U Type) (s (Seq U)) (t (Seq U)) (x U) (y U) (rev Bool))
-  :premises ((= s t) (not (= (seq.unit x) (seq.unit y))))
-  :args (rev)
-  :conclusion
-    ; take the first character from each side, should give x and y
-    (eo::requires ($str_head ($str_to_nary_form s rev)) (seq.unit x)
-    (eo::requires ($str_head ($str_to_nary_form t rev)) (seq.unit y)
-        false))
-)
-
 ; rule: string_decompose
 ; implements: ProofRule::STRING_DECOMPOSE
 ; premises:

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -139,8 +139,6 @@ const char* toString(ProofRule rule)
     //================================================= String rules
     case ProofRule::CONCAT_EQ: return "CONCAT_EQ";
     case ProofRule::CONCAT_UNIFY: return "CONCAT_UNIFY";
-    case ProofRule::CONCAT_CONFLICT: return "CONCAT_CONFLICT";
-    case ProofRule::CONCAT_CONFLICT_DEQ: return "CONCAT_CONFLICT_DEQ";
     case ProofRule::CONCAT_SPLIT: return "CONCAT_SPLIT";
     case ProofRule::CONCAT_CSPLIT: return "CONCAT_CSPLIT";
     case ProofRule::CONCAT_LPROP: return "CONCAT_LPROP";

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -162,8 +162,6 @@ bool AlfPrinter::isHandled(const Options& opts, const ProofNode* pfn)
     case ProofRule::CONCAT_UNIFY:
     case ProofRule::CONCAT_CSPLIT:
     case ProofRule::CONCAT_CPROP:
-    case ProofRule::CONCAT_CONFLICT:
-    case ProofRule::CONCAT_CONFLICT_DEQ:
     case ProofRule::CONCAT_SPLIT:
     case ProofRule::CONCAT_LPROP:
     case ProofRule::STRING_LENGTH_POS:

--- a/src/proof/lfsc/lfsc_post_processor.cpp
+++ b/src/proof/lfsc/lfsc_post_processor.cpp
@@ -384,21 +384,6 @@ bool LfscProofPostprocessCallback::update(Node res,
       }
     }
     break;
-    case ProofRule::CONCAT_CONFLICT:
-    {
-      if (children.size() == 1)
-      {
-        // no need to change
-        return false;
-      }
-      Assert(children.size() == 2);
-      Assert(children[0].getKind() == Kind::EQUAL);
-      Assert(children[0][0].getType().isSequence());
-      // must use the sequences version of the rule
-      Node falsen = nm->mkConst(false);
-      addLfscRule(cdp, falsen, children, LfscRule::CONCAT_CONFLICT_DEQ, args);
-    }
-    break;
     case ProofRule::INSTANTIATE:
     {
       Node q = children[0];

--- a/src/proof/lfsc/lfsc_printer.cpp
+++ b/src/proof/lfsc/lfsc_printer.cpp
@@ -795,10 +795,6 @@ bool LfscPrinter::computeProofArgs(const ProofNode* pn,
          << d_tproc.convertType(children[0]->getResult()[0].getType()) << cs[0]
          << cs[1];
       break;
-    case ProofRule::CONCAT_CONFLICT:
-      pf << h << h << args[0].getConst<bool>()
-         << d_tproc.convertType(children[0]->getResult()[0].getType()) << cs[0];
-      break;
     case ProofRule::RE_UNFOLD_POS:
       if (children[0]->getResult()[1].getKind() != Kind::REGEXP_CONCAT)
       {
@@ -860,11 +856,6 @@ bool LfscPrinter::computeProofArgs(const ProofNode* pn,
         case LfscRule::PROCESS_SCOPE: pf << h << h << as[2] << cs[0]; break;
         case LfscRule::AND_INTRO2: pf << h << h << cs[0] << cs[1]; break;
         case LfscRule::ARITH_SUM_UB: pf << h << h << h << cs[0] << cs[1]; break;
-        case LfscRule::CONCAT_CONFLICT_DEQ:
-          pf << h << h << h << h << as[2].getConst<bool>()
-             << d_tproc.convertType(children[0]->getResult()[0].getType())
-             << cs[0] << cs[1];
-          break;
         case LfscRule::INSTANTIATE:
           pf << h << h << h << h << as[2] << cs[0];
           break;

--- a/src/proof/lfsc/lfsc_util.cpp
+++ b/src/proof/lfsc/lfsc_util.cpp
@@ -36,7 +36,6 @@ const char* toString(LfscRule id)
     case LfscRule::NOT_AND_REV: return "not_and_rev";
     case LfscRule::PROCESS_SCOPE: return "process_scope";
     case LfscRule::ARITH_SUM_UB: return "arith_sum_ub";
-    case LfscRule::CONCAT_CONFLICT_DEQ: return "concat_conflict_deq";
     case LfscRule::INSTANTIATE: return "instantiate";
     case LfscRule::SKOLEMIZE: return "skolemize";
     case LfscRule::BETA_REDUCE: return "beta_reduce";

--- a/src/proof/lfsc/lfsc_util.h
+++ b/src/proof/lfsc/lfsc_util.h
@@ -55,9 +55,6 @@ enum class LfscRule : uint32_t
   PROCESS_SCOPE,
   // arithmetic
   ARITH_SUM_UB,
-  // sequences uses a different form of the concat conflict rule which takes
-  // an explicit disequality
-  CONCAT_CONFLICT_DEQ,
 
   // form of quantifier rules varies from internal calculus
   INSTANTIATE,

--- a/src/theory/strings/infer_proof_cons.cpp
+++ b/src/theory/strings/infer_proof_cons.cpp
@@ -506,41 +506,6 @@ bool InferProofCons::convert(Env& env,
         // t1 ++ ... ++ tn == "". However, these are very rarely applied, let
         // alone for 2+ children. This case is intentionally unhandled here.
       }
-      else if (infer == InferenceId::STRINGS_N_CONST || infer == InferenceId::STRINGS_F_CONST
-               || infer == InferenceId::STRINGS_N_EQ_CONF)
-      {
-        // first, splice if necessary
-        mainEqCeq = spliceConstants(
-            env, ProofRule::CONCAT_CONFLICT, psb, mainEqCeq, conc, isRev);
-        // should be a constant conflict
-        std::vector<Node> childrenC;
-        childrenC.push_back(mainEqCeq);
-        // if it is between sequences, we require the explicit disequality
-        ProofRule r = ProofRule::CONCAT_CONFLICT;
-        if (mainEqCeq[0].getType().isSequence())
-        {
-          Assert(t0.isConst() && s0.isConst());
-          // We introduce an explicit disequality for the constants
-          Node deq = t0.eqNode(s0).notNode();
-          psb.addStep(ProofRule::MACRO_SR_PRED_INTRO, {}, {deq}, deq);
-          Assert(!deq.isNull());
-          childrenC.push_back(deq);
-          r = ProofRule::CONCAT_CONFLICT_DEQ;
-        }
-        std::vector<Node> argsC;
-        argsC.push_back(nodeIsRev);
-        Node conflict = psb.tryStep(r, childrenC, argsC);
-        if (conflict == conc)
-        {
-          useBuffer = true;
-          Trace("strings-ipc-core") << "...success!" << std::endl;
-        }
-        else
-        {
-          Trace("strings-ipc-core") << "...failed " << conflict << " via " << r
-                                    << " " << childrenC << std::endl;
-        }
-      }
       else if (infer == InferenceId::STRINGS_F_NCTN
                || infer == InferenceId::STRINGS_N_NCTN)
       {
@@ -665,6 +630,25 @@ bool InferProofCons::convert(Env& env,
                        .notNode();
           lenSuccess = convertLengthPf(lenReq, lenConstraint, psb);
           rule = ProofRule::CONCAT_CPROP;
+        }
+        else if (infer == InferenceId::STRINGS_N_CONST || infer == InferenceId::STRINGS_F_CONST
+                || infer == InferenceId::STRINGS_N_EQ_CONF)
+        {
+          // first, splice if necessary
+          mainEqCeq = spliceConstants(
+              env, ProofRule::CONCAT_UNIFY, psb, mainEqCeq, conc, isRev);
+          // should be a constant conflict
+          rule = ProofRule::CONCAT_UNIFY;
+          std::vector<Node> tvecs, svecs;
+          theory::strings::utils::getConcat(mainEqCeq[0], tvecs);
+          theory::strings::utils::getConcat(mainEqCeq[1], svecs);
+          t0 = tvecs[isRev ? tvecs.size() - 1 : 0];
+          s0 = svecs[isRev ? svecs.size() - 1 : 0];
+          lenReq = nm->mkNode(Kind::STRING_LENGTH, t0).eqNode(nm->mkNode(Kind::STRING_LENGTH, s0));
+          // should be shown by evaluation
+          lenSuccess = psb.applyPredIntro(lenReq, {});
+          // will conclude an equality between string/sequence values, which
+          // will rewrite to false.
         }
         if (!lenSuccess)
         {
@@ -1565,12 +1549,11 @@ Node InferProofCons::spliceConstants(Env& env,
       vec[index] = o;
       vec.insert(vec.begin() + index + (isRev ? 0 : 1), currR);
     }
-    else if (rule == ProofRule::CONCAT_UNIFY)
+    else if (rule == ProofRule::CONCAT_UNIFY && !conc.isNull() && conc.getKind()==Kind::EQUAL)
     {
       Trace("strings-ipc-splice")
           << "Splice cprop at " << currT << " / " << currS
           << ", for conclusion " << conc << std::endl;
-      Assert(!conc.isNull() && conc.getKind() == Kind::EQUAL);
       for (size_t j = 0; j < 2; j++)
       {
         Node src = j == 0 ? currT : currS;
@@ -1630,7 +1613,7 @@ Node InferProofCons::spliceConstants(Env& env,
         svec.insert(svec.begin() + si + 1, Word::suffix(currS, len - 1));
       }
     }
-    else if (rule == ProofRule::CONCAT_CONFLICT)
+    else if (rule == ProofRule::CONCAT_UNIFY && conc.isConst() && !conc.getConst<bool>())
     {
       if (!currT.isConst() || !currS.isConst())
       {

--- a/src/theory/strings/proof_checker.cpp
+++ b/src/theory/strings/proof_checker.cpp
@@ -43,8 +43,6 @@ void StringProofRuleChecker::registerTo(ProofChecker* pc)
 {
   pc->registerChecker(ProofRule::CONCAT_EQ, this);
   pc->registerChecker(ProofRule::CONCAT_UNIFY, this);
-  pc->registerChecker(ProofRule::CONCAT_CONFLICT, this);
-  pc->registerChecker(ProofRule::CONCAT_CONFLICT_DEQ, this);
   pc->registerChecker(ProofRule::CONCAT_SPLIT, this);
   pc->registerChecker(ProofRule::CONCAT_CSPLIT, this);
   pc->registerChecker(ProofRule::CONCAT_LPROP, this);
@@ -73,8 +71,7 @@ Node StringProofRuleChecker::checkInternal(ProofRule id,
   NodeManager* nm = nodeManager();
   // core rules for word equations
   if (id == ProofRule::CONCAT_EQ || id == ProofRule::CONCAT_UNIFY
-      || id == ProofRule::CONCAT_CONFLICT
-      || id == ProofRule::CONCAT_CONFLICT_DEQ || id == ProofRule::CONCAT_SPLIT
+      || id == ProofRule::CONCAT_SPLIT
       || id == ProofRule::CONCAT_CSPLIT || id == ProofRule::CONCAT_LPROP
       || id == ProofRule::CONCAT_CPROP)
   {
@@ -156,37 +153,6 @@ Node StringProofRuleChecker::checkInternal(ProofRule id,
         return Node::null();
       }
       return children[1][0][0].eqNode(children[1][1][0]);
-    }
-    else if (id == ProofRule::CONCAT_CONFLICT
-             || id == ProofRule::CONCAT_CONFLICT_DEQ)
-    {
-      Assert(children.size() >= 1 && children.size() <= 2);
-      if (!t0.isConst() || !s0.isConst() || t0 == s0)
-      {
-        // not constants
-        return Node::null();
-      }
-      if (Word::getLength(t0) != Word::getLength(s0))
-      {
-        // Not a conflict due to constants if not the same length
-        return Node::null();
-      }
-      // if a disequality was provided, ensure that it is correct
-      if (id == ProofRule::CONCAT_CONFLICT_DEQ)
-      {
-        if (children.size() != 2 || children[1].getKind() != Kind::NOT
-            || children[1][0].getKind() != Kind::EQUAL
-            || children[1][0][0] != t0 || children[1][0][1] != s0)
-        {
-          return Node::null();
-        }
-      }
-      else if (t0.getType().isSequence())
-      {
-        // we require the CONCAT_CONFLICT_DEQ for sequences
-        return Node::null();
-      }
-      return nm->mkConst(false);
     }
     else if (id == ProofRule::CONCAT_SPLIT)
     {

--- a/test/regress/cli/regress0/seq/seq-unify-pf.smt2
+++ b/test/regress/cli/regress0/seq/seq-unify-pf.smt2
@@ -1,5 +1,4 @@
 ; EXPECT: unsat
-; DISABLE-TESTER: cpc
 (set-logic ALL)
 (declare-fun x () Int)
 (declare-fun y () (Seq Int))
@@ -9,4 +8,5 @@
 (assert (= (seq.++ (seq.unit 0) (seq.unit 1) y (seq.unit x) (seq.unit 0) (seq.unit 1) y)
            (seq.++ (seq.unit 0) (seq.unit 1) z (seq.unit x) (seq.unit 1) (seq.unit 1) z))
 )
+; requires a distinct value inference after concat_unify
 (check-sat)


### PR DESCRIPTION
The CONCAT_CONFLICT rule stated:
```
c1 ++ x = c2 ++ y
-------------------------- CONCAT_CONFLICT if | c1 | = | c2 |
false
```

Note that this rule is redundant since we have a unify rule:
```
c1 ++ x = c2 ++ y   | c1 | = | c2 |
----------------------------------------------- CONCAT_UNIFY
c1 = c2
```

Where c1 = c2 can easily be rewritten to false, using EVALUTE (for strings) or DISTINCT_VALUES (for sequences).

This change is furthermore necessary since our current handling of the conflict rule for sequences was buggy (spurious proof checking failures).  A regression with this bug is reenabled.