### PR TITLE
More updates to safe options

### DIFF
--- a/src/options/datatypes_options.toml
+++ b/src/options/datatypes_options.toml
@@ -59,10 +59,10 @@ name   = "Datatypes Theory"
 
 [[option]]
   name       = "dtSharedSelectors"
-  category   = "regular"
+  category   = "expert"
   long       = "dt-share-sel"
   type       = "bool"
-  default    = "true"
+  default    = "false"
   help       = "internally use shared selectors across multiple constructors"
 
 [[option]]

--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -1597,7 +1597,7 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "cegqiUseInfInt"
-  category   = "regular"
+  category   = "expert"
   long       = "cegqi-inf-int"
   type       = "bool"
   default    = "false"
@@ -1605,7 +1605,7 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "cegqiUseInfReal"
-  category   = "regular"
+  category   = "expert"
   long       = "cegqi-inf-real"
   type       = "bool"
   default    = "false"
@@ -1629,10 +1629,10 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "cegqiMidpoint"
-  category   = "regular"
+  category   = "expert"
   long       = "cegqi-midpoint"
   type       = "bool"
-  default    = "false"
+  default    = "true"
   help       = "choose substitutions based on midpoints of lower and upper bounds for counterexample-based quantifier instantiation"
 
 [[option]]

--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -1632,7 +1632,7 @@ name   = "Quantifiers"
   category   = "expert"
   long       = "cegqi-midpoint"
   type       = "bool"
-  default    = "true"
+  default    = "false"
   help       = "choose substitutions based on midpoints of lower and upper bounds for counterexample-based quantifier instantiation"
 
 [[option]]
@@ -1663,7 +1663,7 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "cegqiBvIneqMode"
-  category   = "regular"
+  category   = "expert"
   long       = "cegqi-bv-ineq=MODE"
   type       = "CegqiBvIneqMode"
   default    = "EQ_BOUNDARY"

--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -3,7 +3,7 @@ name   = "SMT Layer"
 
 [[option]]
   name       = "ackermann"
-  category   = "regular"
+  category   = "expert"
   long       = "ackermann"
   type       = "bool"
   default    = "false"

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -886,12 +886,13 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
   // set all defaults in the quantifiers theory, which includes sygus
   setDefaultsQuantifiers(logic, opts);
 
-  // shared selectors are generally not good to combine with standard
-  // quantifier techniques e.g. E-matching
-  if (logic.isQuantified() && !usesSygus(opts))
+  // Shared selectors are generally not good to combine with standard
+  // quantifier techniques e.g. E-matching.
+  // We only enable them if SyGuS is enabled.
+  if (isSygus(opts))
   {
     SET_AND_NOTIFY_IF_NOT_USER(
-        datatypes, dtSharedSelectors, false, "quantified logic without SyGuS");
+        datatypes, dtSharedSelectors, true, "SyGuS");
   }
 
   if (opts.prop.minisatSimpMode == options::MinisatSimpMode::ALL)

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -139,25 +139,29 @@ void SetDefaults::setDefaultsPre(Options& opts)
   {
     // all "experimental" theories that are enabled by default should be
     // disabled here
-    SET_AND_NOTIFY_IF_NOT_USER(sep, sep, false, "safe options");
-    SET_AND_NOTIFY_IF_NOT_USER(bags, bags, false, "safe options");
-    SET_AND_NOTIFY_IF_NOT_USER(ff, ff, false, "safe options");
-    SET_AND_NOTIFY_IF_NOT_USER(fp, fp, false, "safe options");
+    SET_AND_NOTIFY(sep, sep, false, "safe options");
+    SET_AND_NOTIFY(bags, bags, false, "safe options");
+    SET_AND_NOTIFY(ff, ff, false, "safe options");
+    SET_AND_NOTIFY(fp, fp, false, "safe options");
     // expert extensions to theories
-    SET_AND_NOTIFY_IF_NOT_USER(uf, ufHoExp, false, "safe options");
-    SET_AND_NOTIFY_IF_NOT_USER(uf, ufCardExp, false, "safe options");
-    SET_AND_NOTIFY_IF_NOT_USER(datatypes, datatypesExp, false, "safe options");
-    SET_AND_NOTIFY_IF_NOT_USER(arith, arithExp, false, "safe options");
-    SET_AND_NOTIFY_IF_NOT_USER(sets, relsExp, false, "safe options");
-    SET_AND_NOTIFY_IF_NOT_USER(sets, setsCardExp, false, "safe options");
+    SET_AND_NOTIFY(uf, ufHoExp, false, "safe options");
+    SET_AND_NOTIFY(uf, ufCardExp, false, "safe options");
+    SET_AND_NOTIFY(datatypes, datatypesExp, false, "safe options");
+    SET_AND_NOTIFY(arith, arithExp, false, "safe options");
+    SET_AND_NOTIFY(sets, relsExp, false, "safe options");
+    SET_AND_NOTIFY(sets, setsCardExp, false, "safe options");
     // these are disabled by default but are listed here in case they are
     // enabled by default later
-    SET_AND_NOTIFY_IF_NOT_USER(fp, fpExp, false, "safe options");
-    SET_AND_NOTIFY_IF_NOT_USER(arrays, arraysExp, false, "safe options");
-    SET_AND_NOTIFY_IF_NOT_USER(sets, setsExp, false, "safe options");
+    SET_AND_NOTIFY(fp, fpExp, false, "safe options");
+    SET_AND_NOTIFY(arrays, arraysExp, false, "safe options");
+    SET_AND_NOTIFY(sets, setsExp, false, "safe options");
     // specific options that are disabled
     OPTION_EXCEPTION_IF_NOT(arith, nlCov, false, "safe options");
-    SET_AND_NOTIFY_IF_NOT_USER(arith, nlCov, false, "safe options");
+    SET_AND_NOTIFY(arith, nlCov, false, "safe options");
+    // never use symmetry breaker, which does not have proofs
+    SET_AND_NOTIFY(uf, ufSymmetryBreaker, false, "safe options");
+    // always use cegqi midpoint, which avoids virtual term substitution
+    SET_AND_NOTIFY(quantifiers, cegqiMidpoint, true, "safe options");
   }
   // implied options
   if (opts.smt.debugCheckModels)
@@ -1129,7 +1133,10 @@ bool SetDefaults::incompatibleWithProofs(Options& opts,
     SET_AND_NOTIFY_IF_NOT_USER_VAL_SYM(
         bv, bvSolver, options::BVSolver::BITBLAST_INTERNAL, "proofs");
   }
-  SET_AND_NOTIFY_IF_NOT_USER(arith, nlCovVarElim, false, "proofs");
+  if (options().arith.nlCov)
+  {
+    SET_AND_NOTIFY_IF_NOT_USER(arith, nlCovVarElim, false, "proofs");
+  }
   if (opts.smt.deepRestartMode != options::DeepRestartMode::NONE)
   {
     reason << "deep restarts";


### PR DESCRIPTION
`dt-share-sel` is now disabled by default and only enabled when using SyGuS. It is made an expert option since we do not support proofs for it.  Note this means that --sygus-inst no longer uses shared selectors. This is necessary since --sygus-inst may be combined with user provided datatypes.

`cegqi-midpoint` is now enabled by default when safe-options is enabled and made an expert option. This is because we do not support proofs with it disabled.  Note this leads to slight performance regression on pure quantified arithmetic logics (LIA and LRA) when safe-mode is enabled.

`cegqi-inf-int` and `cegqi-inf-real` are made expert since we do not support proofs for them.

The above changes are made so that safe-options with and without proofs uses the same set of options.

Furthermore: 

`cegqi-bv-ineq` is made expert since it uses invertibility conditions that are not in the proof signature, nor are found to be useful in practice.

`ackermann` is made expert since we do not support proofs or models for it currently, moreover we estimate it is difficult to add proof support for it from a theory standpoint.