### PR TITLE
ci: Use separate GitHub Action to set up CMake

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -15,26 +15,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Get minimum required CMake version
-      id: cmake
-      if: runner.os == 'Linux'
-      shell: ${{ inputs.shell }}
-      run: |
-        echo "::group::Get minimum required CMake version"
-        echo "version=$( \
-          grep "cmake_minimum_required" CMakeLists.txt | \
-          awk -F'[()]' '{print $2}' | \
-          awk '{print $2}' \
-        )" >> "$GITHUB_OUTPUT"
-        echo "::endgroup::"
-
-    - name: Setup CMake
-      # Exclude Linux ARM64 runners, which are currently unsupported
-      if: runner.os == 'Linux' && ! contains(runner.arch, 'ARM')
-      uses: jwlawson/actions-setup-cmake@v2
-      with:
-        cmake-version: '${{ steps.cmake.outputs.version }}.x'
-
     - name: Install Linux software
       if: runner.os == 'Linux'
       shell: ${{ inputs.shell }}

--- a/.github/actions/setup-cmake/action.yml
+++ b/.github/actions/setup-cmake/action.yml
@@ -1,0 +1,25 @@
+name: Setup CMake
+description: Find the minimum required CMake version and set it up
+inputs:
+  shell:
+    default: bash
+
+runs:
+  using: composite
+  steps:
+    - name: Find minimum required CMake version
+      id: cmake
+      shell: ${{ inputs.shell }}
+      run: |
+        echo "::group::Get minimum required CMake version"
+        echo "version=$( \
+          grep "cmake_minimum_required" CMakeLists.txt | \
+          awk -F'[()]' '{print $2}' | \
+          awk '{print $2}' \
+        )" >> "$GITHUB_OUTPUT"
+        echo "::endgroup::"
+
+    - name: Setup CMake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '${{ steps.cmake.outputs.version }}.x'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,13 @@ jobs:
 
     - uses: actions/checkout@v4
 
+    - name: Setup CMake
+      uses: ./.github/actions/setup-cmake
+      # Exclude Linux ARM64 runners, which are currently unsupported
+      if: runner.os == 'Linux' && ! contains(runner.arch, 'ARM')
+      with:
+        shell: ${{ matrix.build.shell }}
+
     - name: Install dependencies
       uses: ./.github/actions/install-dependencies
       with:


### PR DESCRIPTION
The `install-dependencies` GitHub Action is used in other repositories (e.g., [cvc5/cvc5_pythonic_api](https://github.com/cvc5/cvc5_pythonic_api)). This PR moves the setup of CMake to its own GitHub Action so that it is only run in the cvc5 repo.
