### PR TITLE
Add proof rewrite rule MACRO_BOOL_BV_INVERT_SOLVE

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -2459,6 +2459,19 @@ enum ENUM(ProofRewriteRule)
   EVALUE(MACRO_BOOL_NNF_NORM),
   /**
    * \verbatim embed:rst:leading-asterisk
+   * **Booleans -- Bitvector invert solve**
+   *
+   * .. math::
+   *   ((t_1 = t_2) = (x = r)) = \top
+   *
+   * where :math:`x` occurs on an invertible path in :math:`t_1 = t_2`
+   * and has solved form :math:`r`.
+   *
+   * \endverbatim
+   */
+  EVALUE(MACRO_BOOL_BV_INVERT_SOLVE),
+  /**
+   * \verbatim embed:rst:leading-asterisk
    * **Arithmetic -- Integer equality conflict**
    *
    * .. math::

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -231,6 +231,7 @@ const char* toString(cvc5::ProofRewriteRule rule)
     case ProofRewriteRule::BV_TO_NAT_ELIM: return "bv-to-nat-elim";
     case ProofRewriteRule::INT_TO_BV_ELIM: return "int-to-bv-elim";
     case ProofRewriteRule::MACRO_BOOL_NNF_NORM: return "macro-bool-nnf-norm";
+    case ProofRewriteRule::MACRO_BOOL_BV_INVERT_SOLVE: return "macro-bool-bv-invert-solve";
     case ProofRewriteRule::MACRO_ARITH_INT_EQ_CONFLICT:
       return "macro-arith-int-eq-conflict";
     case ProofRewriteRule::MACRO_ARITH_INT_GEQ_TIGHTEN:

--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -1703,14 +1703,6 @@ name   = "Quantifiers"
   default    = "false"
   help       = "try to solve non-linear bv literals using model value projections"
 
-[[option]]
-  name       = "cegqiBvConcInv"
-  category   = "expert"
-  long       = "cegqi-bv-concat-inv"
-  type       = "bool"
-  default    = "true"
-  help       = "compute inverse for concat over equalities rather than producing an invertibility condition"
-
 ### Reduction options
 
 [[option]]

--- a/src/theory/booleans/theory_bool_rewriter.cpp
+++ b/src/theory/booleans/theory_bool_rewriter.cpp
@@ -24,6 +24,8 @@
 #include "expr/algorithm/flatten.h"
 #include "expr/node_value.h"
 #include "proof/conv_proof_generator.h"
+#include "proof/proof.h"
+#include "theory/quantifiers/bv_inverter.h"
 #include "util/cardinality.h"
 
 namespace cvc5::internal {
@@ -35,6 +37,8 @@ TheoryBoolRewriter::TheoryBoolRewriter(NodeManager* nm) : TheoryRewriter(nm)
   d_true = nm->mkConst(true);
   d_false = nm->mkConst(false);
   registerProofRewriteRule(ProofRewriteRule::MACRO_BOOL_NNF_NORM,
+                           TheoryRewriteCtx::POST_DSL);
+  registerProofRewriteRule(ProofRewriteRule::MACRO_BOOL_BV_INVERT_SOLVE,
                            TheoryRewriteCtx::POST_DSL);
 }
 
@@ -48,6 +52,29 @@ Node TheoryBoolRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
       if (nn != n)
       {
         return nn;
+      }
+    }
+    break;
+    case ProofRewriteRule::MACRO_BOOL_BV_INVERT_SOLVE:
+    {
+      if (n.getKind() != Kind::EQUAL || n[0].getKind() != Kind::EQUAL
+          || n[1].getKind() != Kind::EQUAL)
+      {
+        return Node::null();
+      }
+      Node v = n[1][0];
+      TypeNode tn = v.getType();
+      if (!v.isVar() || !tn.isBitVector())
+      {
+        return Node::null();
+      }
+      std::unordered_set<Kind> disallowedKinds;
+      disallowedKinds.insert(Kind::BITVECTOR_CONCAT);
+      NodeManager* nm = nodeManager();
+      Node slv = getBvInvertSolve(nm, n[0], v, disallowedKinds);
+      if (slv == n[1][1])
+      {
+        return nm->mkConst(true);
       }
     }
     break;
@@ -278,6 +305,107 @@ Node TheoryBoolRewriter::computeNnfNorm(NodeManager* nm,
   Assert(visited.find(n) != visited.end());
   Assert(!visited.find(n)->second.isNull());
   return visited[n];
+}
+
+Node TheoryBoolRewriter::getBvInvertSolve(
+    NodeManager* nm,
+    const Node& lit,
+    const Node& var,
+    std::unordered_set<Kind>& disallowedKinds,
+    CDProof* cdp)
+{
+  quantifiers::BvInverter binv(nm);
+  // solve for the variable on this path using the inverter
+  std::vector<unsigned> path;
+  Node slit = binv.getPathToPv(lit, var, path);
+  // check if the path had a kind that does not preserve equivalence of the
+  // overall literal
+  if (!disallowedKinds.empty())
+  {
+    Node curr = lit;
+    for (size_t i = 0, npath = path.size(); i < npath; i++)
+    {
+      Trace("quant-velim-bv") << "On path: " << curr << std::endl;
+      if (disallowedKinds.find(curr.getKind()) != disallowedKinds.end())
+      {
+        slit = Node::null();
+        break;
+      }
+      unsigned p = path[npath - i - 1];
+      curr = curr[p];
+    }
+    Assert(slit.isNull() || curr == var);
+  }
+  if (slit.isNull())
+  {
+    return Node::null();
+  }
+  std::vector<Node> ts;
+  if (cdp != nullptr)
+  {
+    Node curr = lit;
+    for (size_t i = 0, npath = path.size(); i < npath; i++)
+    {
+      unsigned p = path[npath - i - 1];
+      curr = curr[p];
+      ts.push_back(curr);
+    }
+    Assert(ts.back() == var);
+    ts.pop_back();
+    std::reverse(ts.begin(), ts.end());
+  }
+  Node ret = binv.solveBvLit(var, lit, path, nullptr);
+  if (cdp != nullptr)
+  {
+    Node slvEq = var.eqNode(ret);
+    Trace("quant-velim-bv") << "Prove source: " << lit << std::endl;
+    Trace("quant-velim-bv") << "Prove target: " << slvEq << std::endl;
+    Trace("quant-velim-bv") << "Terms: " << ts << std::endl;
+    Node curr = slvEq;
+    // Each of the steps below can either be handled by BV_POLY_NORM_EQ,
+    // or the RARE rules bv-eq-xor-solve or bv-eq-not-solve.
+    std::vector<Node> transEq;
+    for (const Node& t : ts)
+    {
+      Node next = t.eqNode(curr[1][0]);
+      Trace("quant-velim-bv") << "- " << next << " == " << curr << std::endl;
+      Node eqc = next.eqNode(curr);
+      if (t.getKind() == Kind::BITVECTOR_XOR && curr[0] != t[0])
+      {
+        // flip to match the expected pattern of RARE rule bv-eq-xor-solve.
+        Node tf = nm->mkNode(Kind::BITVECTOR_XOR, t[1], t[0]);
+        Node nextf = tf.eqNode(curr[1][0]);
+        Node eqcf = nextf.eqNode(curr);
+        transEq.push_back(eqcf);
+        cdp->addTrustedStep(
+            eqcf, TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE, {}, {});
+        eqc = next.eqNode(nextf);
+      }
+      transEq.push_back(eqc);
+      cdp->addTrustedStep(
+          eqc, TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE, {}, {});
+      curr = next;
+    }
+    if (curr != lit)
+    {
+      // likely symmetry
+      Node eqc = lit.eqNode(curr);
+      transEq.push_back(eqc);
+      cdp->addTrustedStep(
+          eqc, TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE, {}, {});
+    }
+    Node eqf = lit.eqNode(slvEq);
+    if (transEq.size() > 1)
+    {
+      std::reverse(transEq.begin(), transEq.end());
+      cdp->addStep(eqf, ProofRule::TRANS, transEq, {});
+    }
+    else
+    {
+      Assert(transEq[0] == eqf);
+    }
+  }
+  return ret;
 }
 
 RewriteResponse TheoryBoolRewriter::postRewrite(TNode node) {

--- a/src/theory/booleans/theory_bool_rewriter.cpp
+++ b/src/theory/booleans/theory_bool_rewriter.cpp
@@ -314,7 +314,7 @@ Node TheoryBoolRewriter::getBvInvertSolve(
     std::unordered_set<Kind>& disallowedKinds,
     CDProof* cdp)
 {
-  quantifiers::BvInverter binv(nm);
+  quantifiers::BvInverter binv;
   // solve for the variable on this path using the inverter
   std::vector<unsigned> path;
   Node slit = binv.getPathToPv(lit, var, path);

--- a/src/theory/booleans/theory_bool_rewriter.h
+++ b/src/theory/booleans/theory_bool_rewriter.h
@@ -26,6 +26,7 @@
 namespace cvc5::internal {
 
 class TConvProofGenerator;
+class CDProof;
 
 namespace theory {
 namespace booleans {
@@ -60,6 +61,26 @@ class TheoryBoolRewriter : public TheoryRewriter
   static Node computeNnfNorm(NodeManager* nm,
                              const Node& n,
                              TConvProofGenerator* pg = nullptr);
+
+  /**
+   * Get BV invert solve, given input t1 = t2 and variable x, returns the solved
+   * form r for x, where x = r is equivalent to t1 = t2.
+   *
+   * @param nm Pointer to node manager.
+   * @param lit The node to rewrite.
+   * @param var The variable to solve for.
+   * @param disallowedKinds The set of kinds we are not allowed to traverse on
+   * the path to var.
+   * @param cdp If provided, we add a proof of (= lit ret) to cdp, where ret is
+   * the equality returned by this method.
+   * @return The right hand side r corresponding to the solved form for var in
+   * lit, or null if we fail.
+   */
+  static Node getBvInvertSolve(NodeManager* nm,
+                               const Node& lit,
+                               const Node& var,
+                               std::unordered_set<Kind>& disallowedKinds,
+                               CDProof* cdp = nullptr);
 
  protected:
   /**

--- a/src/theory/quantifiers/bv_inverter.cpp
+++ b/src/theory/quantifiers/bv_inverter.cpp
@@ -31,8 +31,8 @@ namespace cvc5::internal {
 namespace theory {
 namespace quantifiers {
 
-BvInverter::BvInverter(const Options& opts, Rewriter* r)
-    : d_opts(opts), d_rewriter(r)
+BvInverter::BvInverter(Rewriter* r)
+    : d_rewriter(r)
 {
 }
 
@@ -347,7 +347,7 @@ Node BvInverter::solveBvLit(Node sv,
     }
     else if (k == Kind::BITVECTOR_CONCAT)
     {
-      if (litk == Kind::EQUAL && d_opts.quantifiers.cegqiBvConcInv)
+      if (litk == Kind::EQUAL)
       {
         /* Compute inverse for s1 o x, x o s2, s1 o x o s2
          * (while disregarding that invertibility depends on si)

--- a/src/theory/quantifiers/bv_inverter.h
+++ b/src/theory/quantifiers/bv_inverter.h
@@ -26,9 +26,6 @@
 #include "expr/node.h"
 
 namespace cvc5::internal {
-
-class Options;
-
 namespace theory {
 
 class Rewriter;
@@ -56,7 +53,7 @@ class BvInverterQuery
 class BvInverter
 {
  public:
-  BvInverter(const Options& opts, Rewriter* r = nullptr);
+  BvInverter(Rewriter* r = nullptr);
   ~BvInverter() {}
   /** get dummy fresh variable of type tn, used as argument for sv */
   Node getSolveVariable(TypeNode tn);
@@ -128,8 +125,6 @@ class BvInverter
    * to this call is null.
    */
   Node getInversionNode(Node cond, TypeNode tn, BvInverterQuery* m);
-  /** Reference to options */
-  const Options& d_opts;
   /** (Optional) rewriter used as helper in getInversionNode */
   Rewriter* d_rewriter;
   /** Dummy variables for each type */

--- a/src/theory/quantifiers/quantifiers_rewriter.cpp
+++ b/src/theory/quantifiers/quantifiers_rewriter.cpp
@@ -1221,7 +1221,7 @@ Node QuantifiersRewriter::getVarElimEqBv(Node lit,
   std::vector<Node> active_args;
   computeArgVec(args, active_args, lit);
 
-  BvInverter binv(d_opts);
+  BvInverter binv;
   for (const Node& cvar : active_args)
   {
     // solve for the variable on this path using the inverter

--- a/src/theory/quantifiers/term_registry.cpp
+++ b/src/theory/quantifiers/term_registry.cpp
@@ -52,7 +52,7 @@ TermRegistry::TermRegistry(Env& env,
   if (options().quantifiers.cegqiBv)
   {
     // if doing instantiation for BV, need the inverter class
-    d_bvInvert.reset(new BvInverter(options(), env.getRewriter()));
+    d_bvInvert.reset(new BvInverter(env.getRewriter()));
   }
   if (options().quantifiers.sygus || options().quantifiers.sygusInst)
   {


### PR DESCRIPTION
This is based on the method for eliminating BV variables from quantified formulas here: https://github.com/cvc5/cvc5/blob/main/src/theory/quantifiers/quantifiers_rewriter.cpp#L1204

Also makes the BV inverter independent of options, which is required for proofs. A seldom used expert option is deleted.

The new method is amenable to be proof elaboration and will be called instead of the above method in a followup PR.