### PR TITLE
cmake: Remove workaround that got addressed on CMS side.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,8 @@ endif()
 #-----------------------------------------------------------------------------#
 # Tell CMake where to find our dependencies
 
+list(APPEND CMAKE_PREFIX_PATH "/home/an/git/dev/build-cms/deps")
+
 if(GLPK_DIR)
   list(APPEND CMAKE_PREFIX_PATH "${GLPK_DIR}")
 endif()
@@ -545,7 +547,7 @@ if(USE_CRYPTOMINISAT)
   # CryptoMiniSat requires pthreads support
   set(THREADS_PREFER_PTHREAD_FLAG ON)
   find_package(Threads REQUIRED)
-  find_package(CryptoMiniSat 5.8 REQUIRED)
+  find_package(CryptoMiniSat 5.11.2 REQUIRED)
   add_definitions(-DCVC5_USE_CRYPTOMINISAT)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,8 +66,6 @@ endif()
 #-----------------------------------------------------------------------------#
 # Tell CMake where to find our dependencies
 
-list(APPEND CMAKE_PREFIX_PATH "/home/an/git/dev/build-cms/deps")
-
 if(GLPK_DIR)
   list(APPEND CMAKE_PREFIX_PATH "${GLPK_DIR}")
 endif()

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -207,7 +207,7 @@ CryptoMiniSat (Optional SAT solver)
 can be used for solving bit-vector problems with eager bit-blasting. This
 dependency may improve performance. It can be downloaded and built
 automatically. Configure cvc5 with ``configure.sh --cryptominisat`` to build
-with this dependency.
+with this dependency. Minimum version required is ``5.11.2``.
 
 
 Kissat (Optional SAT solver)

--- a/cmake/FindCryptoMiniSat.cmake
+++ b/cmake/FindCryptoMiniSat.cmake
@@ -80,10 +80,6 @@ if(NOT CryptoMiniSat_FOUND_SYSTEM)
   set_target_properties(
     CryptoMiniSat PROPERTIES IMPORTED_LOCATION "${CryptoMiniSat_LIBRARIES}"
   )
-  set_target_properties(
-    CryptoMiniSat PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
-                             "${CryptoMiniSat_INCLUDE_DIR}"
-  )
 endif()
 
 set(CryptoMiniSat_FOUND TRUE)

--- a/cmake/FindCryptoMiniSat.cmake
+++ b/cmake/FindCryptoMiniSat.cmake
@@ -26,12 +26,6 @@ if(cryptominisat5_FOUND)
   set(CryptoMiniSat_FOUND_SYSTEM TRUE)
   add_library(CryptoMiniSat INTERFACE IMPORTED GLOBAL)
   target_link_libraries(CryptoMiniSat INTERFACE cryptominisat5)
-  # TODO(gereon): remove this when
-  # https://github.com/msoos/cryptominisat/pull/645 is merged
-  set_target_properties(
-    CryptoMiniSat PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
-                             "${CRYPTOMINISAT5_INCLUDE_DIRS}"
-  )
 endif()
 
 if(NOT CryptoMiniSat_FOUND_SYSTEM)


### PR DESCRIPTION
Workaround has been addressed since CMS version 5.11.2, we thus now require
this as the new minimum version for CMS.