### PR TITLE
Fix JNI string conversion to handle Unicode surrogate pairs

### DIFF
--- a/src/api/java/jni/term.cpp
+++ b/src/api/java/jni/term.cpp
@@ -548,16 +548,22 @@ JNIEXPORT jstring JNICALL Java_io_github_cvc5_Term_getStringValue(JNIEnv* env,
   Term* current = reinterpret_cast<Term*>(pointer);
   std::wstring termString = current->getStringValue();
 
-  size_t length = termString.length();
-  jchar* unicode = new jchar[length];
-  const wchar_t* s = termString.c_str();
-  for (size_t i = 0; i < length; i++)
-  {
-    unicode[i] = s[i];
+  std::u16string utf16String;
+  for (wchar_t wc : termString) {
+    if (wc <= 0xFFFF) {
+        // BMP character (directly store it)
+        utf16String.push_back(static_cast<char16_t>(wc));
+    } else {
+        // Convert to surrogate pair
+        wchar_t codepoint = wc - 0x10000;
+        char16_t highSurrogate = static_cast<char16_t>((codepoint >> 10) + 0xD800);
+        char16_t lowSurrogate = static_cast<char16_t>((codepoint & 0x3FF) + 0xDC00);
+        utf16String.push_back(highSurrogate);
+        utf16String.push_back(lowSurrogate);
+    }
   }
-  jstring ret = env->NewString(unicode, length);
-  delete[] unicode;
-  return ret;
+
+  return env->NewString(reinterpret_cast<const jchar*>(utf16String.c_str()), utf16String.length());
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, nullptr);
 }
 

--- a/src/api/java/jni/term.cpp
+++ b/src/api/java/jni/term.cpp
@@ -549,21 +549,28 @@ JNIEXPORT jstring JNICALL Java_io_github_cvc5_Term_getStringValue(JNIEnv* env,
   std::wstring termString = current->getStringValue();
 
   std::u16string utf16String;
-  for (wchar_t wc : termString) {
-    if (wc <= 0xFFFF) {
-        // BMP character (directly store it)
-        utf16String.push_back(static_cast<char16_t>(wc));
-    } else {
-        // Convert to surrogate pair
-        wchar_t codepoint = wc - 0x10000;
-        char16_t highSurrogate = static_cast<char16_t>((codepoint >> 10) + 0xD800);
-        char16_t lowSurrogate = static_cast<char16_t>((codepoint & 0x3FF) + 0xDC00);
-        utf16String.push_back(highSurrogate);
-        utf16String.push_back(lowSurrogate);
+  for (wchar_t wc : termString)
+  {
+    if (wc <= 0xFFFF)
+    {
+      // BMP character (directly store it)
+      utf16String.push_back(static_cast<char16_t>(wc));
+    }
+    else
+    {
+      // Convert to surrogate pair
+      wchar_t codepoint = wc - 0x10000;
+      char16_t highSurrogate =
+          static_cast<char16_t>((codepoint >> 10) + 0xD800);
+      char16_t lowSurrogate =
+          static_cast<char16_t>((codepoint & 0x3FF) + 0xDC00);
+      utf16String.push_back(highSurrogate);
+      utf16String.push_back(lowSurrogate);
     }
   }
 
-  return env->NewString(reinterpret_cast<const jchar*>(utf16String.c_str()), utf16String.length());
+  return env->NewString(reinterpret_cast<const jchar*>(utf16String.c_str()),
+                        utf16String.length());
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, nullptr);
 }
 

--- a/test/unit/api/java/TermTest.java
+++ b/test/unit/api/java/TermTest.java
@@ -786,6 +786,8 @@ class TermTest
     Term s1 = d_tm.mkString("abcde");
     assertTrue(s1.isStringValue());
     assertEquals(s1.getStringValue(), "abcde");
+    Term s2 = d_tm.mkString("\\u{200cb}", true);
+    assertEquals(s2.getStringValue(), Character.toString(0x200cb));
   }
 
   @Test


### PR DESCRIPTION
- Ensure correct conversion of `std::wstring` (UTF-32 on Linux/macOS, UTF-16 on Windows) to UTF-16 `std::u16string`
- Properly encode supplementary Unicode characters (> U+FFFF) as surrogate pairs

Fixes #11689