### PR TITLE
cadical: Make modelValue more robust.

### DIFF
--- a/src/prop/cadical.cpp
+++ b/src/prop/cadical.cpp
@@ -1212,7 +1212,8 @@ SatValue CadicalSolver::value(SatLiteral l) { return d_propagator->value(l); }
 SatValue CadicalSolver::modelValue(SatLiteral l)
 {
   Assert(d_inSatMode);
-  return toSatValueLit(d_solver->val(toCadicalLit(l)));
+  auto val = d_solver->val(toCadicalLit(l.getSatVariable()));
+  return toSatValueLit(l.isNegated() ? -val : val);
 }
 
 uint32_t CadicalSolver::getAssertionLevel() const


### PR DESCRIPTION
CaDiCaL versions 2.1.0 to 2.1.3 have an issue with CaDiCaL::val(int lit) where the handling for negative literals is incorrect (already reported to to the CaDiCaL dev team). This commit refactors querying of values from CaDiCaL to avoid this issue, and to make it more robust on our side wrt to future API changes. We now query the values of variables only and handle its negation depending on the phase of the literal on our side.

Note that current versions of cvc5 are not affected by this issue since they still use CaDiCaL 2.0.0.