### PR TITLE
Print the result to the most recent solver's output stream

### DIFF
--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -131,8 +131,7 @@ bool CommandExecutor::doCommandSingleton(Cmd* cmd)
 {
   bool status = solverInvoke(d_solver.get(),
                              d_symman->toSymManager(),
-                             cmd,
-                             d_solver->getDriverOptions().out());
+                             cmd);
 
   cvc5::Result res;
   bool hasResult = false;
@@ -219,8 +218,7 @@ bool CommandExecutor::doCommandSingleton(Cmd* cmd)
 
 bool CommandExecutor::solverInvoke(cvc5::Solver* solver,
                                    SymManager* sm,
-                                   Cmd* cmd,
-                                   std::ostream& out)
+                                   Cmd* cmd)
 {
   // print output for -o raw-benchmark
   if (solver->isOutputOn("raw-benchmark"))
@@ -240,7 +238,7 @@ bool CommandExecutor::solverInvoke(cvc5::Solver* solver,
     return true;
   }
 
-  cmd->invoke(solver, sm, out);
+  cmd->invokeAndPrintResult(solver, sm);
   return !cmd->fail();
 }
 

--- a/src/main/command_executor.h
+++ b/src/main/command_executor.h
@@ -120,8 +120,7 @@ class CommandExecutor
 
   bool solverInvoke(cvc5::Solver* solver,
                     parser::SymManager* sm,
-                    parser::Cmd* cmd,
-                    std::ostream& out);
+                    parser::Cmd* cmd);
 }; /* class CommandExecutor */
 
 

--- a/src/parser/commands.cpp
+++ b/src/parser/commands.cpp
@@ -131,6 +131,25 @@ void Cmd::invoke(cvc5::Solver* solver,
   out << std::flush;
 }
 
+void Cmd::invokeAndPrintResult(cvc5::Solver* solver,
+                               parser::SymManager* sm)
+{
+  invoke(solver, sm);
+  // the output stream reference is retrieved here since it might change after
+  // invoking a (set-option :out ...) command
+  std::ostream &out = solver->getDriverOptions().out();
+  if (!ok())
+  {
+    out << *d_commandStatus;
+  }
+  else
+  {
+    printResult(solver, out);
+  }
+  // always flush the output
+  out << std::flush;
+}
+
 std::string Cmd::toString() const
 {
   std::stringstream ss;

--- a/src/parser/commands.h
+++ b/src/parser/commands.h
@@ -81,6 +81,11 @@ class CVC5_EXPORT Cmd
   virtual void invoke(cvc5::Solver* solver,
                       parser::SymManager* sm,
                       std::ostream& out);
+  /**
+   * Same as invoke, but prints the result to the output stream associated to the solver.
+   */
+  virtual void invokeAndPrintResult(cvc5::Solver* solver,
+                                    parser::SymManager* sm);
 
   /**
    * @return A string representation of this result.


### PR DESCRIPTION
This fixes #11352 for the SMT-LIB interface. However, this solution does not prevent the problem at the API level. A more general solution is deferred to a future update.