### PR TITLE
Use encode conversion as a subcall in RARE reconstruction strategy

### DIFF
--- a/src/rewriter/rewrite_proof_status.cpp
+++ b/src/rewriter/rewrite_proof_status.cpp
@@ -33,6 +33,7 @@ const char* toString(RewriteProofStatus s)
     case RewriteProofStatus::ARITH_POLY_NORM: return "ARITH_POLY_NORM";
     case RewriteProofStatus::ACI_NORM: return "ACI_NORM";
     case RewriteProofStatus::ABSORB: return "ABSORB";
+    case RewriteProofStatus::ENCODE: return "ENCODE";
     case RewriteProofStatus::DSL: return "DSL";
     case RewriteProofStatus::THEORY_REWRITE: return "THEORY_REWRITE";
     default: Unreachable();

--- a/src/rewriter/rewrite_proof_status.h
+++ b/src/rewriter/rewrite_proof_status.h
@@ -41,6 +41,8 @@ enum class RewriteProofStatus : uint32_t
   ARITH_POLY_NORM,
   ACI_NORM,
   ABSORB,
+  // we can prove the encoded form of the goal (via rewrite_db_term_process)
+  ENCODE,
   // we have a DSL proof rule that proves this goal.
   DSL,
   // we have a THEORY_REWRITE that proves this goal.


### PR DESCRIPTION
This addresses another major performance issue in the RARE proof reconstruction.

In particular, we call the main solving strategy twice: once on the original, and once on the "converted" version of the equality-to-prove, which e.g. replaces bitvector constants with their symbolic equivalent `(@bv n m)` for the sake of matching.  In general we did this lazily since we do not want to unecessarily convert terms where it was unecessary to do so (e.g. `(bvadd x #b0001) ---> (bvadd #b0001 x)`.

However, this meant that a very simple rewrite like `(bvslt x #b0000) ---> false` would be expected to fail without conversion, running a full recursive search which is expensive, and then immediately succeed once we converted `(bvslt x #b0000)` to `(bvslt x (@bv 4 0))`.

This modifies the RARE reconstruction algorithm so that this conversion is instead a "tactic" on demand, i.e. one possible way of proving an equality.  In particular, `(bvslt x #b0000) ---> false` may be proven at recursion depth 1.