### PR TITLE
Bump CaDiCaL to version 2.1.3.

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -164,7 +164,7 @@ versions; more recent versions should be compatible.
   + module `tomli <https://pypi.org/project/tomli/>`_ (Python < 3.11)
   + module `pyparsing <https://pypi.org/project/pyparsing/>`_
 - `GMP v6.3 (GNU Multi-Precision arithmetic library) <https://gmplib.org>`_
-- `CaDiCaL >= 1.6.0 (SAT solver) <https://github.com/arminbiere/cadical>`_
+- `CaDiCaL >= 2.1.0 (SAT solver) <https://github.com/arminbiere/cadical>`_
 - `SymFPU <https://github.com/martin-cs/symfpu/tree/CVC4>`_
 
 If ``--auto-download`` is given, the Python modules will be installed automatically in

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 This file contains a summary of important user-visible changes.
 
+## Changes
+
+- Bumped CaDiCaL to version 2.1.3.
+
 cvc5 1.2.1
 ==========
 

--- a/cmake/FindCaDiCaL.cmake
+++ b/cmake/FindCaDiCaL.cmake
@@ -103,6 +103,11 @@ if(NOT CaDiCaL_FOUND_SYSTEM)
   if(NOT HAVE_UNLOCKED_IO)
     string(APPEND CaDiCaL_CXXFLAGS " -DNUNLOCKED")
   endif()
+  # check for closefrom
+  check_symbol_exists("closefrom" "fcntl.h" HAVE_CLOSEFROM)
+  if(NOT HAVE_CLOSEFROM)
+    string(APPEND CaDiCaL_CXXFLAGS " -DNCLOSEFROM")
+  endif()
 
   # On macOS, we have to set `-isysroot` to make sure that include headers are
   # found because they are not necessarily installed at /usr/include anymore.

--- a/cmake/FindCaDiCaL.cmake
+++ b/cmake/FindCaDiCaL.cmake
@@ -66,9 +66,9 @@ if(CaDiCaL_INCLUDE_DIR AND CaDiCaL_LIBRARIES)
   endif()
 
   # Minimum supported version
-  set(CaDiCaL_FIND_VERSION "1.6.0")
+  set(CaDiCaL_FIND_VERSION "2.1.0")
   # Maximum supported version
-  set(CaDiCaL_FIND_VERSION_MAX "2.0.0")
+  set(CaDiCaL_FIND_VERSION_MAX "2.1.3")
 
   # Set FOUND_SYSTEM to true; check_system_version will unset this if the
   # version is less than the minimum required
@@ -87,8 +87,8 @@ if(NOT CaDiCaL_FOUND_SYSTEM)
   include(CheckSymbolExists)
   include(ExternalProject)
 
-  set(CaDiCaL_VERSION "rel-2.0.0")
-  set(CaDiCaL_CHECKSUM "9afe5f6439442d854e56fc1fac3244ce241dbb490735939def8fd03584f89331")
+  set(CaDiCaL_VERSION "rel-2.1.2")
+  set(CaDiCaL_CHECKSUM "292c2bb8d712d6d05fce3d3df63b922b8fa45e03974a79f7bae5bf68c284f131")
 
   # avoid configure script and instantiate the makefile manually the configure
   # scripts unnecessarily fails for cross compilation thus we do the bare

--- a/cmake/FindCaDiCaL.cmake
+++ b/cmake/FindCaDiCaL.cmake
@@ -87,8 +87,8 @@ if(NOT CaDiCaL_FOUND_SYSTEM)
   include(CheckSymbolExists)
   include(ExternalProject)
 
-  set(CaDiCaL_VERSION "rel-2.1.2")
-  set(CaDiCaL_CHECKSUM "292c2bb8d712d6d05fce3d3df63b922b8fa45e03974a79f7bae5bf68c284f131")
+  set(CaDiCaL_VERSION "rel-2.1.3")
+  set(CaDiCaL_CHECKSUM "abfe890aa4ccda7b8449c7ad41acb113cfb8e7e8fbf5e49369075f9b00d70465")
 
   # avoid configure script and instantiate the makefile manually the configure
   # scripts unnecessarily fails for cross compilation thus we do the bare


### PR DESCRIPTION
With `--sat-solver=cadical --fpexp`, time limit 1200s:
```
  config                                status   total  solved     sat   unsat    best  timeout  memout  error  uniq  disagr    time_cpu      memory
 2025-03-04-run-cadical-2.1.2-non-inc  ee      438631  377959  176315  201644  223823    39082     594      3    35       0  12897008.6  46010844.5
 2025-03-04-run-cadical-2.1.3-non-inc  ee      438631  377943  176303  201640  218110    39100     595      3    20       0  12900912.7  45973768.6
 2025-03-04-run-cadical-2.0.0-non-inc  ee      438631  377204  175702  201502  148363    39868     597      3  1958       0  13106883.7  43463467.1
 ```
 On common:
 ```
  config                                status   total  solved     sat   unsat    best  timeout  memout  error  uniq  disagr  time_cpu      memory
 2025-03-04-run-cadical-2.1.2-non-inc  ok      375227  375227  174112  201115  291247        0       0      0     0       0  880723.7  11265510.4
 2025-03-04-run-cadical-2.0.0-non-inc  ok      375227  375227  174112  201115  195978        1       0      0     0       0  920268.1  11363245.6
 ```
 ```
 config                                status   total  solved     sat   unsat    best  timeout  memout  error  uniq  disagr  time_cpu      memory
 2025-03-04-run-cadical-2.1.3-non-inc  ok      375226  375226  174112  201114  292926        1       0      0     0       0  883857.6  11262576.2
 2025-03-04-run-cadical-2.0.0-non-inc  ok      375226  375226  174112  201114  197386        1       0      0     0       0  919856.6  11361930.4
 ```
 ```
 config                                status   total  solved     sat   unsat    best  timeout  memout  error  uniq  disagr   time_cpu      memory
 2025-03-04-run-cadical-2.1.2-non-inc  ok      377904  377904  176278  201626  256783        0       0      0     0       0  1048815.4  12883098.3
 2025-03-04-run-cadical-2.1.3-non-inc  ok      377904  377904  176278  201626  250107        0       0      0     0       0  1052740.0  12880720.2
 ```
 
 The uniques of 2.1.2 over 2.1.3 are all fairly close:
 ```
 benchmark                                                                                                                                                   config                                status  result  time_cpu  memory
 FP/20200911-Pine/1599120907623486000.smt2                                                                                                                   2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        281.1   268.1
 FP/20200911-Pine/1599121862728382000.smt2                                                                                                                   2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        289.9   245.6
 FP/20200911-Pine/1599121863427130000.smt2                                                                                                                   2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        292.6   246.9
 FP/20200911-Pine/1599121900004520000.smt2                                                                                                                   2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        273.1   293.7
 LRA/2010-Monniaux-QE/mjollnir3/formula_203.smt2                                                                                                             2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        286.6    67.8
 QF_ABV/brummayerbiere/wchains300se.smt2                                                                                                                     2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        294.3  2969.7
 QF_ABV/dwp_formulas/try5_small_difret_functions_wp_nl.find_subexp_node.il.wp.smt2                                                                           2025-03-04-run-cadical-2.1.2-non-inc  ok      unsat      290.1   323.2
 QF_BV/20210312-Bouvier/vlsat3_a27.smt2                                                                                                                      2025-03-04-run-cadical-2.1.2-non-inc  ok      unsat      289.0   160.6
 QF_BV/Sage2/bench_10005.smt2                                                                                                                                2025-03-04-run-cadical-2.1.2-non-inc  ok      unsat      299.6   166.1
 QF_BV/bruttomesso/core/ext_con_052_128_0512.smt2                                                                                                            2025-03-04-run-cadical-2.1.2-non-inc  ok      unsat      298.7   195.5
 QF_BV/float/add_01_1000_2.smt2                                                                                                                              2025-03-04-run-cadical-2.1.2-non-inc  ok      unsat      287.3   105.0
 QF_BV/uclid_contrib_smtcomp09/lf_bv_formula.smt2                                                                                                            2025-03-04-run-cadical-2.1.2-non-inc  ok      unsat      274.1   191.1
 QF_IDL/20210312-Bouvier/vlsat3_c13.smt2                                                                                                                     2025-03-04-run-cadical-2.1.2-non-inc  ok      unsat      255.8   127.2
 QF_IDL/20210312-Bouvier/vlsat3_c29.smt2                                                                                                                     2025-03-04-run-cadical-2.1.2-non-inc  ok      unsat      295.0   282.0
 QF_IDL/asp/BlockedNQueens/156.48.1960.36.1721259656.dat.smt2                                                                                                2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        271.5    87.0
 QF_IDL/asp/SchurNumbers/15.16.schur.lp.smt2                                                                                                                 2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        282.2   115.5
 QF_LIA/CAV_2009_benchmarks/smt/35-vars/problem_2__029.smt2                                                                                                  2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        300.1    26.2
 QF_LIA/nec-smt/large/checkpass_pwd/prp-20-38.smt2                                                                                                           2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        298.2   381.7
 QF_LIA/nec-smt/large/checkpass_pwd/prp-24-39.smt2                                                                                                           2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        299.4   487.9
 QF_LIA/nec-smt/large/getoption/prp-0-199.smt2                                                                                                               2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        292.1   777.2
 QF_LIA/nec-smt/large/getoption_group/prp-18-47.smt2                                                                                                         2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        295.6   745.5
 QF_LIA/nec-smt/large/int_from_list/prp-43-48.smt2                                                                                                           2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        287.3   359.6
 QF_LIA/nec-smt/large/int_from_list/prp-49-47.smt2                                                                                                           2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        296.3   477.5
 QF_LRA/LassoRanker/SV-COMP/min_rf_true-termination.c_Iteration1_Loop_4-pieceTemplate.smt2                                                                   2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        283.7   323.3
 QF_LRA/LassoRanker/Ultimate/yPositive-SIscaled100.bpl_Iteration1_Loop_3-pieceTemplate.smt2                                                                  2025-03-04-run-cadical-2.1.2-non-inc  ok      unsat      297.7   763.7
 QF_NIA/20170427-VeryMax/ITS/From_AProVE_2014__Velroyen08-alternDivWidening.jar-obl-8__p13256_edge_closing_0.smt2                                            2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        297.0   677.6
 QF_NIA/20170427-VeryMax/ITS/From_T2__consts2.t2__p18102_edge_closing_0.smt2                                                                                 2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        296.7   294.7
 QF_NIA/LassoRanker/ChenFlurMukhopadhyay-SAS2012-Ex3.08_true-termination.c_Iteration1_Loop+nonterminationTemplate_0.smt2                                     2025-03-04-run-cadical-2.1.2-non-inc  ok      unsat      297.5  1108.1
 QF_S/20230329-automatark-lu/instance13130.smt2                                                                                                              2025-03-04-run-cadical-2.1.2-non-inc  ok      unsat      281.5    93.7
 QF_SLIA/20230327-stringfuzz-lu/generated/manyregexes/many-regexes-00043-23.smt2                                                                             2025-03-04-run-cadical-2.1.2-non-inc  ok      unsat      287.9    72.5
 QF_SLIA/20230327-stringfuzz-lu/generated/manyregexes/many-regexes-00055-14.smt2                                                                             2025-03-04-run-cadical-2.1.2-non-inc  ok      unsat      253.4    46.1
 QF_SLIA/20230327-stringfuzz-lu/generated/variants/45f06f08.smt2                                                                                             2025-03-04-run-cadical-2.1.2-non-inc  ok      unsat      281.2    72.7
 QF_SLIA/20230331-transducer-plus/Duality/escapeString-trim.smt2                                                                                             2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        298.2   406.1
 QF_SLIA/20230331-transducer-plus/Equivalence/escapeString-toUpper.smt2                                                                                      2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        287.8   248.5
 QF_SLIA/20240411-redos_attack_detection/sat/1095_attack.smt2                                                                                                2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        245.3  3152.0
 QF_SLIA/20240411-redos_attack_detection/sat/1096_attack.smt2                                                                                                2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        295.0  3151.7
 QF_SLIA/20240411-redos_attack_detection/sat/126_attack.smt2                                                                                                 2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        293.1  6743.6
 QF_SLIA/20240411-redos_attack_detection/sat/12_attack.smt2                                                                                                  2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        286.2  1925.8
 QF_SLIA/20240411-redos_attack_detection/sat/1316_attack.smt2                                                                                                2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        273.5  2985.7
 QF_SLIA/20240411-redos_attack_detection/sat/1957_attack.smt2                                                                                                2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        294.6  3173.1
 QF_SLIA/20240411-redos_attack_detection/sat/2035_attack.smt2                                                                                                2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        248.5  2089.2
 QF_SLIA/20240411-redos_attack_detection/sat/2240_attack.smt2                                                                                                2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        291.4  2272.1
 QF_SLIA/20240411-redos_attack_detection/sat/2644_attack.smt2                                                                                                2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        292.3  4779.5
 QF_SLIA/20240411-redos_attack_detection/sat/2648_attack.smt2                                                                                                2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        288.4  4782.5
 QF_SLIA/20240411-redos_attack_detection/sat/2730_attack.smt2                                                                                                2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        299.5  4858.9
 QF_SLIA/20240411-redos_attack_detection/sat/3081_attack.smt2                                                                                                2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        274.1  1551.9
 QF_SLIA/20240411-redos_attack_detection/sat/330_attack.smt2                                                                                                 2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        273.9  2962.5
 QF_SLIA/20240411-redos_attack_detection/sat/585_attack.smt2                                                                                                 2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        297.5  2354.4
 QF_SLIA/20240411-redos_attack_detection/sat/612_attack.smt2                                                                                                 2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        291.6  3152.0
 QF_UFBV/2018-Goel-hwbench/QF_UFBV_bv_bv_pouring.2.prop1_ab_cti_max.smt2                                                                                     2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        272.8   701.8
 QF_UFIDL/20210312-Bouvier/vlsat3_f16.smt2                                                                                                                   2025-03-04-run-cadical-2.1.2-non-inc  ok      unsat      266.4    63.0
 QF_UFLRA/cpachecker-induction-svcomp14/cpachecker-induction.cs_fib_longer_false-unreach-call.i.smt2                                                         2025-03-04-run-cadical-2.1.2-non-inc  ok      sat        275.4  4747.5
 UFNIA/lahiri-cav09-storm-queries/serial_write_example_2_2_6_1.smt2                                                                                          2025-03-04-run-cadical-2.1.2-non-inc  ok      unsat      294.1  7288.3
 UFNIA/sledgehammer/Fundamental_Theorem_Algebra/z3.1031223.smt2                                                                                              2025-03-04-run-cadical-2.1.2-non-inc  ok      unsat      299.2   119.4
 UFNIA/spec_sharp/test14-CommandLineOptions.ssc.5.Microsoft.Boogie.CommandLineOptions.CommandLineParseState..ctor_System.optional...NonNullType.String.smt2  2025-03-04-run-cadical-2.1.2-non-inc  ok      unsat      269.5   757.5