### PR TITLE
Avoid deadlock in HO model construction

### DIFF
--- a/src/theory/theory_model_builder.cpp
+++ b/src/theory/theory_model_builder.cpp
@@ -588,7 +588,10 @@ bool TheoryEngineModelBuilder::buildModel(TheoryModel* tm)
         }
 
         // (3) Finally, process assignable information
-        evaluable = true;
+        // We are evaluable typically if we are not assignable. However the
+        // one exception is that higher-order variables when in HOL should be
+        // considered neither assignable nor evaluable, which we check for here.
+        evaluable = !n.isVar();
         // expressions that are not assignable should not be given assignment
         // exclusion sets
         Assert(!tm->getAssignmentExclusionSet(n, esetGroup, eset));
@@ -939,6 +942,8 @@ bool TheoryEngineModelBuilder::buildModel(TheoryModel* tm)
         ++i;
         if (evaluableEqc.find(*i2) != evaluableEqc.end())
         {
+          Trace("model-builder")
+              << "  ...do not assign to evaluatable eqc " << *i2 << std::endl;
           // we never assign to evaluable equivalence classes
           continue;
         }

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2936,6 +2936,7 @@ set(regress_1_tests
   regress1/quantifiers/cee-os-delta.smt2
   regress1/quantifiers/cdt-0208-to.smt2
   regress1/quantifiers/choice-move-delta-relt.smt2
+  regress1/quantifiers/choice-unk-ho-no-deadlock.smt2
   regress1/quantifiers/const.cvc.smt2
   regress1/quantifiers/constfunc.cvc.smt2
   regress1/quantifiers/dd.binary_trees.adb_1105_16_loop_invariant_init_1.smt2

--- a/test/regress/cli/regress1/quantifiers/choice-unk-ho-no-deadlock.smt2
+++ b/test/regress/cli/regress1/quantifiers/choice-unk-ho-no-deadlock.smt2
@@ -1,0 +1,6 @@
+; COMMAND-LINE: --mbqi-enum --pre-skolem-quant=on
+; EXPECT: unknown
+(set-logic HO_ALL)
+(declare-sort u 0)
+(assert (forall ((E (-> (-> u Bool) u))) (exists ((P (-> u Bool))) (and (exists ((X u)) (not (P X))) (P (E P))))))
+(check-sat-assuming ( true ))


### PR DESCRIPTION
This avoids a deadlock in HO model construction which was leading to assertion failures that models failed to build.

The issue was that all terms were either considered assignable (legal to assign a value in the model if not already assigned), or evaluable (waiting for its children to have values so that its value was the result of its evaluation).

In HO model construction, function variables are not considered "assignable" since we assign their values based on the `APPLY_UF` that involve them.  However, they are also not "evaluable" since they have no children. 

This checks for this case.

Note that our behavior became more strict recently https://github.com/cvc5/cvc5/pull/11322, which led to this failure.