### PR TITLE
Add a static build option for the JNI library

### DIFF
--- a/.github/actions/add-jar/action.yml
+++ b/.github/actions/add-jar/action.yml
@@ -25,15 +25,7 @@ runs:
         echo "::group::Create JAR contents (Linux)"
         mkdir ${{ inputs.jar-libs-dir }}
         cd ${{ inputs.jar-libs-dir }}
-        cat > filenames.txt <<EOF
-        libgmp.so.10
-        libpoly.so.0
-        libpolyxx.so.0
-        libcvc5.so.1
-        libcvc5parser.so.1
-        libcvc5jni.so
-        EOF
-        cat filenames.txt | xargs -I {} cp ${{ inputs.install-path }}/lib/{} .
+        cp ${{ inputs.install-path }}/lib/libcvc5jni.so .
         echo "::endgroup::"
 
     - name: Create JAR contents (macOS)
@@ -43,15 +35,7 @@ runs:
         echo "::group::Create JAR contents (macOS)"
         mkdir ${{ inputs.jar-libs-dir }}
         cd ${{ inputs.jar-libs-dir }}
-        cat > filenames.txt <<EOF
-        libgmp.10.dylib
-        libpoly.0.dylib
-        libpolyxx.0.dylib
-        libcvc5.1.dylib
-        libcvc5parser.1.dylib
-        libcvc5jni.dylib
-        EOF
-        cat filenames.txt | xargs -I {} cp ${{ inputs.install-path }}/lib/{} .
+        cp ${{ inputs.install-path }}/lib/libcvc5jni.dylib .
         echo "::endgroup::"
 
     - name: Create JAR contents (Windows)
@@ -61,17 +45,10 @@ runs:
         echo "::group::Create JAR contents (Windows)"
         mkdir ${{ inputs.jar-libs-dir }}
         cd ${{ inputs.jar-libs-dir }}
-        cat > filenames.txt <<EOF
-        libwinpthread-1.dll
-        libgcc_s_seh-1.dll
-        libstdc++-6.dll
-        libpoly.dll
-        libpolyxx.dll
-        libcvc5.dll
-        libcvc5parser.dll
-        cvc5jni.dll
-        EOF
-        cat filenames.txt | xargs -I {} cp ${{ inputs.install-path }}/bin/{} .
+        cp ${{ inputs.install-path }}/bin/libwinpthread-1.dll .
+        cp ${{ inputs.install-path }}/bin/libgcc_s_seh-1.dll .
+        cp ${{ inputs.install-path }}/bin/libstdc++-6.dll .
+        cp ${{ inputs.install-path }}/bin/cvc5jni.dll .
         echo "::endgroup::"
 
     - name: Create JAR

--- a/.github/actions/add-package/action.yml
+++ b/.github/actions/add-package/action.yml
@@ -35,7 +35,8 @@ runs:
         rm -rf ${{ inputs.build-dir }}/install/lib/site-packages
 
         if [[ "$RUNNER_OS" == "Windows" ]]; then
-          if [ -f ${{ inputs.build-dir }}/install/bin/libcvc5.dll ]; then
+          if [ -f ${{ inputs.build-dir }}/install/bin/libcvc5.dll ] || \
+             [ -f ${{ inputs.build-dir }}/install/bin/cvc5jni.dll ]; then
             cp /mingw64/bin/libgcc_s_seh-1.dll ${{ inputs.build-dir }}/install/bin/
             cp /mingw64/bin/libstdc++-6.dll ${{ inputs.build-dir }}/install/bin/
             cp /mingw64/bin/libwinpthread-1.dll ${{ inputs.build-dir }}/install/bin/

--- a/.github/actions/configure-and-build/action.yml
+++ b/.github/actions/configure-and-build/action.yml
@@ -61,7 +61,7 @@ runs:
       run: |
         echo "::group::Static build"
         ${{ inputs.configure-env }} ./configure.sh ${{ inputs.configure-config }} \
-          --prefix=$(pwd)/build-static/install --werror --static --name=build-static --no-java-bindings \
+          --prefix=$(pwd)/build-static/install --werror --static --name=build-static \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
 
         cd build-static/ && pwd=$(pwd)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
 
           - name: ubuntu:production-dbg
             os: ubuntu-22.04
-            config: production --auto-download --assertions --tracing --unit-testing --all-bindings --editline --cocoa --gpl
+            config: production --auto-download --assertions --tracing --unit-testing --all-bindings --editline --cocoa --gpl -DBUILD_GMP=1
             cache-key: dbg
             exclude_regress: 3-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester proof --tester dump
@@ -270,6 +270,7 @@ jobs:
         shell: ${{ matrix.build.shell }}
 
     - name: Create and add static package to latest and release
+      id: create-static-package
       if: matrix.build.package-name && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
       uses: ./.github/actions/add-package
       with:
@@ -284,7 +285,7 @@ jobs:
       if: matrix.build.java-bindings && matrix.build.package-name && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
       uses: ./.github/actions/add-jar
       with:
-        install-path: ${{ steps.create-shared-package.outputs.install-path }}
+        install-path: ${{ steps.create-static-package.outputs.install-path }}
         jar-libs-dir: cvc5-libs
         jar-name: ${{ matrix.build.package-name }}${{ matrix.build.gpl-tag }}-java-api
         github-token-latest: ${{ secrets.GITHUB_TOKEN }}

--- a/src/api/java/CMakeLists.txt
+++ b/src/api/java/CMakeLists.txt
@@ -212,8 +212,27 @@ if(NOT DEFINED JAVA_HOME AND NOT WIN32)
   message(STATUS "JAVA_HOME: ${JAVA_HOME}")
 endif()
 
-# find jni package
-find_package(JNI REQUIRED)
+if(BUILD_SHARED_LIBS)
+  # Find JNI package
+  find_package(JNI REQUIRED)
+else()
+  # When a static build is enabled, we still build a JNI shared library,
+  # but all cvc5 dependencies are statically linked to it. To do that,
+  # we need to find the shared JNI libraries for Java.
+  # Save the original suffixes
+  set(_original_suffixes "${CMAKE_FIND_LIBRARY_SUFFIXES}")
+  # Temporarily add appropriate suffixes to find JNI libraries
+  if (WIN32)
+    list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES .dll)
+  else()
+    list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES .so .dylib)
+  endif()
+  # Find JNI package
+  find_package(JNI REQUIRED)
+  # Restore the original suffixes
+  set(CMAKE_FIND_LIBRARY_SUFFIXES "${_original_suffixes}")
+endif()
+
 message(STATUS "JNI_FOUND            : ${JNI_FOUND}")
 message(STATUS "JNI_INCLUDE_DIRS     : ${JNI_INCLUDE_DIRS}")
 message(STATUS "JNI_LIBRARIES        : ${JNI_LIBRARIES} ")
@@ -248,8 +267,15 @@ set(jni_files
   jni/term.cpp
   jni/term_manager.cpp)
 
-add_library(cvc5jni ${jni_files})
+# Enforce the build of a shared library
+add_library(cvc5jni SHARED ${jni_files})
 add_dependencies(cvc5jni generate-jni-headers)
+
+if(WIN32 AND NOT BUILD_SHARED_LIBS)
+  # Ensure that cvc5jni does not expect DLL imports,
+  # but static linking
+  target_compile_definitions(cvc5jni PRIVATE CVC5_STATIC_DEFINE)
+endif()
 
 target_include_directories(cvc5jni PUBLIC ${JNI_INCLUDE_DIRS})
 target_include_directories(cvc5jni PUBLIC ${PROJECT_SOURCE_DIR}/src)

--- a/src/api/java/io/github/cvc5/Utils.java
+++ b/src/api/java/io/github/cvc5/Utils.java
@@ -34,16 +34,23 @@ import java.util.Locale;
 public class Utils
 {
   public enum OS {
-    WINDOWS, MAC, LINUX, UNKNOWN;
+    WINDOWS,
+    MAC,
+    LINUX,
+    UNKNOWN;
 
     public static final OS CURRENT = detectOS();
 
-    private static OS detectOS() {
-        String osName = System.getProperty("os.name").toLowerCase(Locale.ROOT);
-        if (osName.startsWith("windows")) return WINDOWS;
-        if (osName.startsWith("mac")) return MAC;
-        if (osName.startsWith("linux")) return LINUX;
-        return UNKNOWN;
+    private static OS detectOS()
+    {
+      String osName = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+      if (osName.startsWith("windows"))
+        return WINDOWS;
+      if (osName.startsWith("mac"))
+        return MAC;
+      if (osName.startsWith("linux"))
+        return LINUX;
+      return UNKNOWN;
     }
   }
 
@@ -128,18 +135,13 @@ public class Utils
       try
       {
         List<String> filenames;
-        switch (OS.CURRENT) {
+        switch (OS.CURRENT)
+        {
           case WINDOWS:
             filenames = Arrays.asList(
-              "libwinpthread-1.dll",
-              "libgcc_s_seh-1.dll",
-              "libstdc++-6.dll",
-              "cvc5jni.dll"
-            );
+                "libwinpthread-1.dll", "libgcc_s_seh-1.dll", "libstdc++-6.dll", "cvc5jni.dll");
             break;
-          case MAC:
-            filenames = Arrays.asList("libcvc5jni.dylib");
-            break;
+          case MAC: filenames = Arrays.asList("libcvc5jni.dylib"); break;
           default:
             // We assume it is Linux or a Unix-based system.
             // If not, there's nothing more we can do anyway.

--- a/src/api/java/io/github/cvc5/Utils.java
+++ b/src/api/java/io/github/cvc5/Utils.java
@@ -27,10 +27,26 @@ import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 public class Utils
 {
+  public enum OS {
+    WINDOWS, MAC, LINUX, UNKNOWN;
+
+    public static final OS CURRENT = detectOS();
+
+    private static OS detectOS() {
+        String osName = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+        if (osName.startsWith("windows")) return WINDOWS;
+        if (osName.startsWith("mac")) return MAC;
+        if (osName.startsWith("linux")) return LINUX;
+        return UNKNOWN;
+    }
+  }
+
   public static final String LIBPATH_IN_JAR = "/cvc5-libs";
 
   private static boolean areLibrariesLoaded = false;
@@ -38,42 +54,6 @@ public class Utils
   static
   {
     loadLibraries();
-  }
-
-  /**
-   * Reads a text file from the specified path within the JAR file and returns a list of library
-   * filenames.
-   * @param pathInJar The path to the text file inside the JAR
-   * @return a list of filenames read from the file
-   * @throws FileNotFoundException If the text file does not exist
-   * @throws IOException If an I/O error occurs
-   */
-  public static List<String> readLibraryFilenames(String pathInJar)
-      throws FileNotFoundException, IOException
-  {
-    List<String> filenames = new ArrayList<>();
-
-    // Load the input stream from the resource path within the JAR
-    try (InputStream inputStream = Utils.class.getResourceAsStream(pathInJar))
-    {
-      // Check if the input stream is null (resource not found)
-      if (inputStream == null)
-      {
-        throw new FileNotFoundException("Resource not found: " + pathInJar);
-      }
-
-      try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream)))
-      {
-        String line;
-        // Read each line from the file and add it to the list
-        while ((line = reader.readLine()) != null)
-        {
-          filenames.add(line);
-        }
-      }
-    }
-
-    return filenames;
   }
 
   /**
@@ -147,8 +127,24 @@ public class Utils
     {
       try
       {
-        // Try to extract the libraries from a JAR in the classpath
-        List<String> filenames = readLibraryFilenames(LIBPATH_IN_JAR + "/filenames.txt");
+        List<String> filenames;
+        switch (OS.CURRENT) {
+          case WINDOWS:
+            filenames = Arrays.asList(
+              "libwinpthread-1.dll",
+              "libgcc_s_seh-1.dll",
+              "libstdc++-6.dll",
+              "cvc5jni.dll"
+            );
+            break;
+          case MAC:
+            filenames = Arrays.asList("libcvc5jni.dylib");
+            break;
+          default:
+            // We assume it is Linux or a Unix-based system.
+            // If not, there's nothing more we can do anyway.
+            filenames = Arrays.asList("libcvc5jni.so");
+        }
 
         // Create a temporary directory to store the libraries
         Path tempDir = Files.createTempDirectory("cvc5-libs");


### PR DESCRIPTION
This PR enables static builds to work when Java bindings are also enabled (see discussion #11718). It generates a JNI shared library with all cvc5 dependencies statically linked to it. The CI takes advantage of this new build option to simplify the creation of self-contained Java API JARs.