### PR TITLE
Allow quoted symbols in indexed operators

### DIFF
--- a/src/parser/smt2/smt2_term_parser.cpp
+++ b/src/parser/smt2/smt2_term_parser.cpp
@@ -1253,9 +1253,11 @@ ParseOp Smt2TermParser::continueParseIndexedIdentifier(bool isOperator)
         }
         break;
       case Token::SYMBOL:
-      case Token::QUOTED_SYMBOL:
       case Token::HEX_LITERAL:
         // (_ char <hex_literal>) expects a hex literal
+        symbols.push_back(d_lex.tokenStr());
+        break;
+      case Token::QUOTED_SYMBOL:
         symbols.push_back(tokenStrToSymbol(tok));
         break;
       default:

--- a/src/parser/smt2/smt2_term_parser.cpp
+++ b/src/parser/smt2/smt2_term_parser.cpp
@@ -1253,9 +1253,10 @@ ParseOp Smt2TermParser::continueParseIndexedIdentifier(bool isOperator)
         }
         break;
       case Token::SYMBOL:
+      case Token::QUOTED_SYMBOL:
       case Token::HEX_LITERAL:
         // (_ char <hex_literal>) expects a hex literal
-        symbols.push_back(d_lex.tokenStr());
+        symbols.push_back(tokenStrToSymbol(tok));
         break;
       default:
         d_lex.unexpectedTokenError(

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1249,6 +1249,7 @@ set(regress_0_tests
   regress0/parser/issue10093.smt2
   regress0/parser/issue10156-bad-tester.smt2
   regress0/parser/issue10489.smt2
+  regress0/parser/issue11763-quoted-dt-cons.smt2
   regress0/parser/linear_arithmetic_err1.smt2
   regress0/parser/linear_arithmetic_err2.smt2
   regress0/parser/linear_arithmetic_err3.smt2

--- a/test/regress/cli/regress0/parser/issue11763-quoted-dt-cons.smt2
+++ b/test/regress/cli/regress0/parser/issue11763-quoted-dt-cons.smt2
@@ -1,0 +1,10 @@
+; EXPECT: sat
+(set-logic QF_UFDTLIA)
+(declare-datatype MyList (par (T) ((nelem) (|cons| (hd T) (tl (MyList T))))))
+
+(declare-fun a () (MyList Int))
+(assert (> (hd a) 50))
+(assert (not (and
+  ((_ is |cons|) a) (not ((_ is nelem) a))
+)))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/11736.

This is allowed by SMT-LIB, where a symbol can either be simple or quoted in any context.