### PR TITLE
Disable proof tester for regression.

### DIFF
--- a/test/regress/cli/regress2/quantifiers/issue10805-syqi-no-arr-const.smt2
+++ b/test/regress/cli/regress2/quantifiers/issue10805-syqi-no-arr-const.smt2
@@ -1,6 +1,7 @@
 ; COMMAND-LINE: --sygus-inst
 ; EXPECT: unsat
 ; DISABLE-TESTER: lfsc
+; DISABLE-TESTER: proof
 (set-logic ALL)
 (declare-const x (Array Bool (Array Bool Bool)))
 (assert (forall ((v (Array Bool (Array Bool Bool)))) (set.subset (set.singleton v) (set.singleton x))))


### PR DESCRIPTION
Currently times out in nightlies.