### PR TITLE
[proofs] [alethe] Fix handling of Alethe skolem definitions

### DIFF
--- a/src/proof/alethe/alethe_node_converter.cpp
+++ b/src/proof/alethe/alethe_node_converter.cpp
@@ -175,7 +175,7 @@ Node AletheNodeConverter::postConvert(Node n)
         {
           if (std::find(d_skolemsList.begin(), d_skolemsList.end(), n)
               == d_skolemsList.end())
-            {
+          {
             d_skolemsList.push_back(n);
           }
           return n;

--- a/src/proof/alethe/alethe_node_converter.cpp
+++ b/src/proof/alethe/alethe_node_converter.cpp
@@ -183,9 +183,26 @@ Node AletheNodeConverter::postConvert(Node n)
               Node sk = sm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE,
                                              cacheVals);
               Assert(!sk.isNull());
+              if (d_skolems.find(sk) != d_skolems.end())
+              {
+                continue;
+              }
               Assert(d_skolemsAux.find(sk) != d_skolemsAux.end())
                   << "Could not find sk " << sk;
               d_skolems[sk] = d_skolemsAux[sk];
+            }
+            // as a sanity check, if there is any aux skolem not saved, we do so
+            // here otherwise we would lose this definition, since we'll not
+            // build a witness for it in another oppontinury because the skolem
+            // will not be revisited
+            for (const auto& [sk, lostWitness] : d_skolemsAux)
+            {
+              if (d_skolems.find(sk) == d_skolems.end())
+              {
+                d_skolems[sk] = lostWitness;
+                Trace("alethe-conv") << "\twill lose witness for " << sk << ": "
+                                     << lostWitness << std::endl;
+              }
             }
             d_skolemsAux.clear();
           }

--- a/src/proof/alethe/alethe_node_converter.h
+++ b/src/proof/alethe/alethe_node_converter.h
@@ -66,7 +66,7 @@ class AletheNodeConverter : public BaseAlfNodeConverter
    */
   const std::map<Node, Node>& getSkolemDefinitions();
 
-  /** Retrive ordered list of Skolems.  This list is ordered so that a Skolem
+  /** Retrieve ordered list of Skolems.  This list is ordered so that a Skolem
    * whose definition depends on another Skolem will come after that Skolem.
    */
   const std::vector<Node>& getSkolemList();

--- a/src/proof/alethe/alethe_node_converter.h
+++ b/src/proof/alethe/alethe_node_converter.h
@@ -63,11 +63,13 @@ class AletheNodeConverter : public BaseAlfNodeConverter
   Node getOriginalAssumption(Node n);
 
   /** Retrieve a mapping between Skolems and their converted definitions.
-   *
-   * Note that this mapping is ordered in a way that a Skolem whose definition
-   * depends on another Skolem will come after that Skolem in the map.
    */
   const std::map<Node, Node>& getSkolemDefinitions();
+
+  /** Retrive ordered list of Skolems.  This list is ordered so that a Skolem
+   * whose definition depends on another Skolem will come after that Skolem.
+   */
+  const std::vector<Node>& getSkolemList();
 
   Node mkInternalSymbol(const std::string& name,
                         TypeNode tn,
@@ -104,8 +106,9 @@ class AletheNodeConverter : public BaseAlfNodeConverter
 
   /** Map between Skolems and their converted definitions. */
   std::map<Node, Node> d_skolems;
-  /** Auxiliary map for maintaining the expected order in the above map. */
-  std::map<Node, Node> d_skolemsAux;
+  /** Ordered Skolems such that a given entry does not have subterms occurring
+   * in subsequent entries. */
+  std::vector<Node> d_skolemsList;
 };
 
 }  // namespace proof

--- a/src/proof/alethe/alethe_printer.cpp
+++ b/src/proof/alethe/alethe_printer.cpp
@@ -173,10 +173,12 @@ void AletheProofPrinter::print(
   if (options().proof.proofAletheDefineSkolems)
   {
     const std::map<Node, Node>& skolemDefs = d_anc.getSkolemDefinitions();
-    for (const auto& [skolem, choice] : skolemDefs)
+    const std::vector<Node>& skolemList = d_anc.getSkolemList();
+    for (const auto& skolem : skolemList)
     {
+      Assert(skolemDefs.find(skolem) != skolemDefs.end());
       out << "(define-fun " << skolem << " () " << skolem.getType() << " ";
-      printTerm(out, choice);
+      printTerm(out, skolemDefs.at(skolem));
       out << ")" << std::endl;
     }
   }


### PR DESCRIPTION
The previous handling was much too complicated and buggy to guarantee that Skolem definitions were printed in the correct order. This commit simplifies this and fixes the issues.