### PR TITLE
More updates to safe options

### DIFF
--- a/src/options/arith_options.toml
+++ b/src/options/arith_options.toml
@@ -494,7 +494,7 @@ name   = "Arithmetic Theory"
 
 [[option]]
   name       = "nlCov"
-  category   = "regular"
+  category   = "expert"
   long       = "nl-cov"
   type       = "bool"
   default    = "true"

--- a/src/options/base_options.toml
+++ b/src/options/base_options.toml
@@ -133,7 +133,7 @@ name   = "Base"
   help       = "exit after preprocessing input"
 
 [[option]]
-  category   = "regular"
+  category   = "expert"
   short      = "t"
   long       = "trace=TAG"
   type       = "std::string"

--- a/src/options/proof_options.toml
+++ b/src/options/proof_options.toml
@@ -169,7 +169,7 @@ name   = "Proof"
 
 [[option]]
   name       = "printDotClusters"
-  category   = "regular"
+  category   = "expert"
   long       = "print-dot-clusters"
   type       = "bool"
   default    = "false"

--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -849,7 +849,7 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "quantSubCbqiTimeout"
-  category   = "regular"
+  category   = "expert"
   long       = "sub-cbqi-timeout=N"
   type       = "uint64_t"
   default    = "0"

--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -202,7 +202,7 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "mbqi"
-  category   = "expert"
+  category   = "regular"
   long       = "mbqi"
   type       = "bool"
   default    = "false"
@@ -210,7 +210,7 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "mbqiEnum"
-  category   = "expert"
+  category   = "regular"
   long       = "mbqi-enum"
   type       = "bool"
   default    = "false"

--- a/src/options/theory_options.toml
+++ b/src/options/theory_options.toml
@@ -60,7 +60,7 @@ name   = "Theory Layer"
 
 [[option]]
   name       = "eeMode"
-  category   = "expert"
+  category   = "regular"
   long       = "ee-mode=MODE"
   type       = "EqEngineMode"
   default    = "DISTRIBUTED"


### PR DESCRIPTION
Makes three expert options (mbqi, mbqi-enum, ee-mode) regular options, each does not require any additional proof support and has been tested over all of SMT-LIB in my latest tests.

Also makes `nl-cov` expert, as it is already manually disabled by default when safe options is enabled due to its lack of proofs.

Trace messages are marked expert. Also makes two further regular options expert as they pertain to variants of expert options.