### PR TITLE
Disable unsat core on regression

### DIFF
--- a/test/regress/cli/regress0/quantifiers/issue8912-syqi-arr-const.smt2
+++ b/test/regress/cli/regress0/quantifiers/issue8912-syqi-arr-const.smt2
@@ -1,5 +1,7 @@
 ; COMMAND-LINE: --sygus-inst
 ; EXPECT: unsat
+; unsat-core times out on some builds
+; DISABLE-TESTER: unsat-core
 (set-logic ALL)
 (declare-fun r () (Array Int (Array Int Int)))
 (assert (forall ((a (Array Int (Array Int Int)))) (= r a)))


### PR DESCRIPTION
Fixes a nightly failure https://cvc5-buildbot.stanford.edu/#/builders/16/builds/1254/steps/7/logs/stdio.