### PR TITLE
Miscellaneous changes to string rewriter

### DIFF
--- a/src/theory/strings/sequences_rewriter.cpp
+++ b/src/theory/strings/sequences_rewriter.cpp
@@ -1113,6 +1113,7 @@ Node SequencesRewriter::rewriteAndOrRegExp(TNode node)
         return returnRewrite(node, ni, Rewrite::RE_AND_EMPTY);
       }
       // otherwise, can ignore
+      changed = true;
     }
     else if (nik == Kind::REGEXP_STAR
              && ni[0].getKind() == Kind::REGEXP_ALLCHAR)
@@ -1122,6 +1123,7 @@ Node SequencesRewriter::rewriteAndOrRegExp(TNode node)
         return returnRewrite(node, ni, Rewrite::RE_OR_ALL);
       }
       // otherwise, can ignore
+      changed = true;
     }
     else if (std::find(node_vec.begin(), node_vec.end(), ni) == node_vec.end())
     {

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -47,9 +47,10 @@ TheoryStrings::TheoryStrings(Env& env, OutputChannel& out, Valuation valuation)
       d_statistics(statisticsRegistry()),
       d_state(env, d_valuation),
       d_termReg(env, *this, d_state, d_statistics),
-      d_arithEntail(env.getNodeManager(),
-                    d_env.getRewriter(),
-                    options().strings.stringRecArithApprox),
+      d_arithEntail(
+          env.getNodeManager(),
+          options().strings.stringRecArithApprox ? env.getRewriter() : nullptr,
+          options().strings.stringRecArithApprox),
       d_strEntail(d_env.getRewriter(), d_arithEntail),
       d_rewriter(env.getNodeManager(),
                  d_arithEntail,
@@ -96,9 +97,10 @@ TheoryStrings::TheoryStrings(Env& env, OutputChannel& out, Valuation valuation)
       d_absModelCounter(0),
       d_strGapModelCounter(0),
       d_cpacb(*this),
-      d_psrewPg(env.isTheoryProofProducing() ? new TrustProofGenerator(
-                    env, TrustId::STRINGS_PP_STATIC_REWRITE, {})
-                                             : nullptr)
+      d_psrewPg(env.isTheoryProofProducing()
+                    ? new TrustProofGenerator(
+                          env, TrustId::STRINGS_PP_STATIC_REWRITE, {})
+                    : nullptr)
 {
   d_termReg.finishInit(&d_im);
 


### PR DESCRIPTION
This fixes a missing case of rewriting RE inter/union.

It also ensures we do not pass the rewriter to the arithmetic utility, to avoid rewrites that cannot be constructed. It refactors the arithmetic entailment utility to do slightly more reasoning that is independent of the rewriter.

We have no more strings rewrite holes on main after this PR.