### PR TITLE
Pass NodeManager pointer to getNullTerminator

### DIFF
--- a/src/expr/aci_norm.cpp
+++ b/src/expr/aci_norm.cpp
@@ -30,9 +30,8 @@ using namespace cvc5::internal::kind;
 namespace cvc5::internal {
 namespace expr {
 
-Node getNullTerminator(Kind k, TypeNode tn)
+Node getNullTerminator(NodeManager* nm, Kind k, TypeNode tn)
 {
-  NodeManager* nm = tn.getNodeManager();
   Node nullTerm;
   switch (k)
   {
@@ -175,7 +174,7 @@ Node getACINormalForm(Node a)
     return a;
   }
   TypeNode atn = a.getType();
-  Node nt = getNullTerminator(k, atn);
+  Node nt = getNullTerminator(a.getNodeManager(), k, atn);
   if (nt.isNull())
   {
     // no null terminator, likely abstract type, return self

--- a/src/expr/aci_norm.h
+++ b/src/expr/aci_norm.h
@@ -35,7 +35,7 @@ namespace expr {
  *   (as seq.empty (Seq Int)) for (STRING_CONCAT, (Seq Int)
  *   #x0 for (BITVECTOR_OR, (_ BitVec 4))
  */
-Node getNullTerminator(Kind k, TypeNode tn);
+Node getNullTerminator(NodeManager* nm, Kind k, TypeNode tn);
 
 /**
  * @param k A kind

--- a/src/expr/nary_term_util.cpp
+++ b/src/expr/nary_term_util.cpp
@@ -208,7 +208,7 @@ Node narySubstitute(Node src,
           Assert(cur.getMetaKind() != metakind::PARAMETERIZED);
           if (children.empty())
           {
-            ret = getNullTerminator(cur.getKind(), cur.getType());
+            ret = getNullTerminator(nm, cur.getKind(), cur.getType());
             // if we don't know the null terminator, just return null now
             if (ret.isNull())
             {

--- a/src/proof/lfsc/lfsc_list_sc_node_converter.cpp
+++ b/src/proof/lfsc/lfsc_list_sc_node_converter.cpp
@@ -56,7 +56,7 @@ Node LfscListScNodeConverter::postConvert(Node n)
       children.push_back(f);
       // convert n, since this node will not be converted further
       children.push_back(d_conv.convert(n));
-      Node null = d_conv.getNullTerminator(k, tn);
+      Node null = d_conv.getNullTerminator(d_nm, k, tn);
       Assert(!null.isNull());
       // likewise, convert null
       children.push_back(d_conv.convert(null));
@@ -87,7 +87,7 @@ Node LfscListScNodeConverter::postConvert(Node n)
       std::vector<Node> nchildren(n.begin(), n.end());
       n = d_nm->mkNode(k, nchildren);
     }
-    Node null = d_conv.getNullTerminator(k, tn);
+    Node null = d_conv.getNullTerminator(d_nm, k, tn);
     AlwaysAssert(!null.isNull())
         << "No null terminator for " << k << ", " << tn;
     null = d_conv.convert(null);

--- a/src/proof/lfsc/lfsc_node_converter.cpp
+++ b/src/proof/lfsc/lfsc_node_converter.cpp
@@ -291,7 +291,7 @@ Node LfscNodeConverter::postConvert(Node n)
       return charVec[0];
     }
     std::reverse(charVec.begin(), charVec.end());
-    Node ret = postConvert(getNullTerminator(Kind::STRING_CONCAT, tn));
+    Node ret = postConvert(getNullTerminator(d_nm, Kind::STRING_CONCAT, tn));
     for (size_t i = 0, size = charVec.size(); i < size; i++)
     {
       ret = d_nm->mkNode(Kind::STRING_CONCAT, charVec[i], ret);
@@ -407,7 +407,7 @@ Node LfscNodeConverter::postConvert(Node n)
     // (from_bools t1 ... tn) is
     // (from_bools t1 (from_bools t2 ... (from_bools tn emptybv)))
     // where notice that each from_bools has a different type
-    Node curr = getNullTerminator(Kind::BITVECTOR_CONCAT, tn);
+    Node curr = getNullTerminator(d_nm, Kind::BITVECTOR_CONCAT, tn);
     for (size_t i = 0, nchild = n.getNumChildren(); i < nchild; ++i)
     {
       TypeNode bvt = d_nm->mkBitVectorType(i + 1);
@@ -457,7 +457,7 @@ Node LfscNodeConverter::postConvert(Node n)
     // This makes the AST above distinguishable from (or A B C D E),
     // which otherwise would both have representation:
     //   (or A (or B (or C (or D E))))
-    Node nullTerm = getNullTerminator(k, tn);
+    Node nullTerm = getNullTerminator(d_nm, k, tn);
     // Most operators simply get binarized
     Node ret;
     size_t istart = 0;
@@ -906,7 +906,7 @@ Node LfscNodeConverter::convertBitVector(const BitVector& bv)
   return ret;
 }
 
-Node LfscNodeConverter::getNullTerminator(Kind k, TypeNode tn)
+Node LfscNodeConverter::getNullTerminator(NodeManager* nm, Kind k, TypeNode tn)
 {
   Node nullTerm;
   switch (k)
@@ -934,7 +934,7 @@ Node LfscNodeConverter::getNullTerminator(Kind k, TypeNode tn)
     return nullTerm;
   }
   // otherwise, fall back to standard utility
-  return expr::getNullTerminator(k, tn);
+  return expr::getNullTerminator(nm, k, tn);
 }
 
 Kind LfscNodeConverter::getBuiltinKindForInternalSymbol(Node op) const

--- a/src/proof/lfsc/lfsc_node_converter.h
+++ b/src/proof/lfsc/lfsc_node_converter.h
@@ -51,7 +51,9 @@ class LfscNodeConverter : public NodeConverter
    *
    * For examples of null terminators, see aci_norm.h.
    */
-  Node getNullTerminator(Kind k, TypeNode tn = TypeNode::null());
+  Node getNullTerminator(NodeManager* nm,
+                         Kind k,
+                         TypeNode tn = TypeNode::null());
   /**
    * Return the properly named operator for n of the form (f t1 ... tn), where
    * f could be interpreted or uninterpreted.  This method is used for cases

--- a/src/proof/lfsc/lfsc_post_processor.cpp
+++ b/src/proof/lfsc/lfsc_post_processor.cpp
@@ -259,7 +259,7 @@ bool LfscProofPostprocessCallback::update(Node res,
       Node opEq = op.eqNode(op);
       cdp->addStep(opEq, ProofRule::REFL, {}, {op});
       size_t nchildren = children.size();
-      Node nullTerm = d_tproc.getNullTerminator(k, res[0].getType());
+      Node nullTerm = d_tproc.getNullTerminator(nm, k, res[0].getType());
       // Are we doing congruence of an n-ary operator? If so, notice that op
       // is a binary operator and we must apply congruence in a special way.
       // Note we use the first block of code if we have more than 2 children,
@@ -341,7 +341,7 @@ bool LfscProofPostprocessCallback::update(Node res,
     break;
     case ProofRule::AND_INTRO:
     {
-      Node cur = d_tproc.getNullTerminator(Kind::AND);
+      Node cur = d_tproc.getNullTerminator(nm, Kind::AND);
       size_t nchildren = children.size();
       for (size_t j = 0; j < nchildren; j++)
       {
@@ -363,7 +363,7 @@ bool LfscProofPostprocessCallback::update(Node res,
     case ProofRule::ARITH_SUM_UB:
     {
       // proof of null terminator base 0 = 0
-      Node zero = d_tproc.getNullTerminator(Kind::ADD, res[0].getType());
+      Node zero = d_tproc.getNullTerminator(nm, Kind::ADD, res[0].getType());
       Node cur = zero.eqNode(zero);
       cdp->addStep(cur, ProofRule::REFL, {}, {zero});
       for (size_t i = 0, size = children.size(); i < size; i++)
@@ -506,7 +506,7 @@ Node LfscProofPostprocessCallback::mkChain(Kind k,
   size_t nchildren = children.size();
   size_t i = 0;
   // do we have a null terminator? If so, we start with it.
-  Node ret = d_tproc.getNullTerminator(k, children[0].getType());
+  Node ret = d_tproc.getNullTerminator(nm, k, children[0].getType());
   if (ret.isNull())
   {
     ret = children[nchildren - 1];

--- a/src/proof/lfsc/lfsc_printer.cpp
+++ b/src/proof/lfsc/lfsc_printer.cpp
@@ -891,7 +891,7 @@ bool LfscPrinter::computeProofArgs(const ProofNode* pn,
             // notice we use d_tproc.getNullTerminator and not
             // expr::getNullTerminator here, which has subtle differences
             // e.g. re.empty vs (str.to_re "").
-            Node null = d_tproc.getNullTerminator(k, v.getType());
+            Node null = d_tproc.getNullTerminator(nm, k, v.getType());
             Node t;
             if (as[i].getNumChildren() == 1)
             {

--- a/src/rewriter/rewrite_proof_rule.cpp
+++ b/src/rewriter/rewrite_proof_rule.cpp
@@ -221,6 +221,7 @@ Node RewriteProofRule::getConclusionFor(
 {
   Assert(d_fvs.size() == ss.size());
   Node conc = getConclusion(true);
+  NodeManager* nm = conc.getNodeManager();
   std::unordered_map<TNode, Node> visited;
   Node ret = expr::narySubstitute(conc, d_fvs, ss, visited);
   // also compute for the condition
@@ -250,7 +251,7 @@ Node RewriteProofRule::getConclusionFor(
         // list context of the variable.
         Node subsCtx = visited[ctx];
         Assert(!subsCtx.isNull()) << "Failed to get context for " << ctx << " in " << d_id;
-        Node nt = expr::getNullTerminator(ctx.getKind(), subsCtx.getType());
+        Node nt = expr::getNullTerminator(nm, ctx.getKind(), subsCtx.getType());
         wargs.push_back(nt);
       }
       else


### PR DESCRIPTION
It passes a `NodeManager` pointer to `getNullTerminator` instead of retrieving it from `tn`, which can be null.

This fixes failures in nightlies.