### PR TITLE
Add simple missing BV rewrite rules

### DIFF
--- a/src/theory/bv/theory_bv_rewrite_rules_simplification.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_simplification.h
@@ -1275,6 +1275,25 @@ inline Node RewriteRule<NotUle>::apply(TNode node)
 /* -------------------------------------------------------------------------- */
 
 /**
+ * SltSelf
+ *
+ * a < a ==> false
+ */
+
+template<> inline
+bool RewriteRule<SltSelf>::applies(TNode node) {
+  return (node.getKind() == Kind::BITVECTOR_SLT && node[1] == node[0]);
+}
+
+template<> inline
+Node RewriteRule<SltSelf>::apply(TNode node) {
+  Trace("bv-rewrite") << "RewriteRule<SltSelf>(" << node << ")" << std::endl;
+  return utils::mkFalse(node.getNodeManager());
+}
+
+/* -------------------------------------------------------------------------- */
+
+/**
  * MultPow2
  *
  * (a * 2^k) ==> a[n-k-1:0] 0_k

--- a/src/theory/bv/theory_bv_rewriter.cpp
+++ b/src/theory/bv/theory_bv_rewriter.cpp
@@ -199,6 +199,7 @@ RewriteResponse TheoryBVRewriter::RewriteUlt(TNode node, bool prerewrite)
   Node resultNode =
       LinearRewriteStrategy<RewriteRule<EvalUlt>,  // if both arguments are
                                                    // constants evaluates
+                            RewriteRule<UltSelf>,
                             RewriteRule<UltOne>,
                             RewriteRule<UltOnes>,
                             RewriteRule<UltZero>,  // a < 0 rewrites to false,
@@ -222,6 +223,7 @@ RewriteResponse TheoryBVRewriter::RewriteSlt(TNode node, bool prerewrite)
 {
   Node resultNode =
       LinearRewriteStrategy<RewriteRule<EvalSlt>,
+                            RewriteRule<SltSelf>,
                             RewriteRule<MultSltMult>>::apply(node);
 
   return RewriteResponse(REWRITE_DONE, resultNode);


### PR DESCRIPTION
This ensures we rewrite `(bvult x x)` and `(bvslt x x)` to false.

These were formalized as RARE rules that were not covered in regressions/SMT-LIB.