### PR TITLE
Ensure BV inequality mode is uniformly handled in CEGQI

### DIFF
--- a/src/theory/quantifiers/cegqi/ceg_bv_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_bv_instantiator.cpp
@@ -136,13 +136,17 @@ Node BvInstantiator::hasProcessAssertion(CegInstantiator* ci,
                                          Node lit,
                                          CegInstEffort effort)
 {
-  NodeManager* nm = nodeManager();
-  ;
   if (effort == CEG_INST_EFFORT_FULL)
   {
     // always use model values at full effort
     return Node::null();
   }
+  return processAssertionInternal(ci, lit);
+}
+
+Node BvInstantiator::processAssertionInternal(CegInstantiator* ci, Node lit)
+{
+  NodeManager* nm = lit.getNodeManager();
   Node atom = lit.getKind() == Kind::NOT ? lit[0] : lit;
   bool pol = lit.getKind() != Kind::NOT;
   Kind k = atom.getKind();
@@ -530,6 +534,9 @@ Node BvInstantiator::rewriteAssertionForSolvePv(CegInstantiator* ci,
       }
     } while (!trace_visit.empty());
   }
+  // process again, to ensure the policy for cegqiBvIneqMode is handled after
+  // rewriting above.
+  result = processAssertionInternal(ci, result);
 
   return result;
 }

--- a/src/theory/quantifiers/cegqi/ceg_bv_instantiator.h
+++ b/src/theory/quantifiers/cegqi/ceg_bv_instantiator.h
@@ -156,6 +156,17 @@ class BvInstantiator : public Instantiator
                       Node lit,
                       Node alit,
                       CegInstEffort effort);
+  /**
+   * This method takes as input a literal lit, expected to be of kind
+   * EQUAL, BITVECTOR_ULT, or BITVECTOR_SLT, and returns the rewritten form
+   * of lit that we are expected to process. In particular, this method takes
+   * into account the option cegqiBvIneqMode, which determines how inequalities
+   * are processed.
+   * @param ci Pointer to the parent CegInstantiator.
+   * @param lit The literal.
+   * @return the rewritten form of the literal.
+   */
+  Node processAssertionInternal(CegInstantiator* ci, Node lit);
 };
 
 /** Bitvector instantiator preprocess


### PR DESCRIPTION
Previously we could rewrite a literal into a form and not re-process it according to the policy given by cegqiIneqBv.

This ensures that e.g. we never use invertibility conditions for inequalities when the policy says not to.