### PR TITLE
Fix a few missing cases of EVALUATE and ABSORB

### DIFF
--- a/proofs/eo/cpc/Cpc.eo
+++ b/proofs/eo/cpc/Cpc.eo
@@ -118,6 +118,7 @@
       (($run_evaluate (not b))             (eo::not ($run_evaluate b)))
       (($run_evaluate (ite b x y))         (eo::ite ($run_evaluate b) ($run_evaluate x) ($run_evaluate y)))
       (($run_evaluate (or x ys))           (eo::or ($run_evaluate x) ($run_evaluate ys)))
+      (($run_evaluate (=> x y))            (eo::or (eo::not ($run_evaluate x)) ($run_evaluate y)))
       (($run_evaluate (and x ys))          (eo::and ($run_evaluate x) ($run_evaluate ys)))
       (($run_evaluate (xor x y))           (eo::xor ($run_evaluate x) ($run_evaluate y)))
   
@@ -425,6 +426,7 @@
     ((and x1 x2)       false)
     ((re.union x1 x2)  re.all)
     ((re.inter x1 x2)  re.none)
+    ((re.++ x1 x2)     re.none)
     ((bvor xb1 xb2)    ($bv_ones ($bv_bitwidth (eo::typeof xb1))))
     ((bvand xb1 xb2)   (eo::to_bin ($bv_bitwidth (eo::typeof xb1)) 0))
     )

--- a/src/expr/aci_norm.cpp
+++ b/src/expr/aci_norm.cpp
@@ -261,6 +261,7 @@ Node getZeroElement(NodeManager* nm, Kind k, TypeNode tn)
       zeroTerm = nm->mkNode(Kind::REGEXP_ALL);
       break;
     case Kind::REGEXP_INTER:
+    case Kind::REGEXP_CONCAT:
       // empty language
       zeroTerm = nm->mkNode(Kind::REGEXP_NONE);
       break;
@@ -307,6 +308,7 @@ bool isAbsorb(Kind k)
     case Kind::AND:
     case Kind::REGEXP_UNION:
     case Kind::REGEXP_INTER:
+    case Kind::REGEXP_CONCAT:
     case Kind::BITVECTOR_AND:
     case Kind::BITVECTOR_OR: return true;
     default: break;

--- a/src/proof/alf/alf_printer.cpp
+++ b/src/proof/alf/alf_printer.cpp
@@ -416,6 +416,7 @@ bool AlfPrinter::canEvaluate(Node n)
         case Kind::NOT:
         case Kind::AND:
         case Kind::OR:
+        case Kind::IMPLIES:
         case Kind::XOR:
         case Kind::CONST_BOOLEAN:
         case Kind::CONST_INTEGER:

--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -666,10 +666,6 @@ bool RewriteDbProofCons::proveWithRule(RewriteProofStatus id,
   }
   else if (id == RewriteProofStatus::ABSORB)
   {
-    if (!target[1].isConst())
-    {
-      return false;
-    }
     Node zero = expr::getZeroElement(
         nodeManager(), target[0].getKind(), target[0].getType());
     if (zero != target[1])

--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -455,6 +455,13 @@ EvalResult Evaluator::evalInternal(
           results[currNode] = EvalResult(res);
           break;
         }
+        case Kind::IMPLIES:
+        {
+          bool res =
+              !results[currNode[0]].d_bool || results[currNode[1]].d_bool;
+          results[currNode] = EvalResult(res);
+          break;
+        }
         case Kind::XOR:
         {
           bool res = results[currNode[0]].d_bool;
@@ -1155,6 +1162,18 @@ EvalResult Evaluator::evalInternal(
           BitVector res = results[currNode[1]].d_bv;
           bool b = res.unsignedLessThanEq(results[currNode[0]].d_bv);
           results[currNode] = EvalResult(b);
+          break;
+        }
+        case Kind::BITVECTOR_REPEAT:
+        {
+          BitVector res = results[currNode[0]].d_bv;
+          unsigned amount =
+              currNode.getOperator().getConst<BitVectorRepeat>().d_repeatAmount;
+          for (size_t i = 1; i < amount; i++)
+          {
+            res = res.concat(res);
+          }
+          results[currNode] = EvalResult(res);
           break;
         }
         case Kind::BITVECTOR_SIGN_EXTEND:


### PR DESCRIPTION
Makes the following changes:
- IMPLIES and BITVECTOR_REPEAT were missing in the evaluator, the former was missing from the proof signature.
- REGEXP_CONCAT can be added as a case of ABSORB.
- The reconstruction strategy for ABSORB was too rigid as it required the "zero element" to be constant, which is not the case for regular expressions.