### PR TITLE
Fix use of EVALUATE in proof elaboration

### DIFF
--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -704,7 +704,8 @@ bool BasicRewriteRCons::ensureProofMacroArithStringPredEntail(CDProof* cdp,
   }
   // (>= approx 0) = true
   Node teq = approxRewGeq.eqNode(truen);
-  Node ev = evaluate(approxRewGeq, {}, {});
+  // do not use rewriter in evaluate
+  Node ev = evaluate(approxRewGeq, {}, {}, false);
   if (ev == truen)
   {
     Trace("brc-macro") << "- prove " << teq << " via evaluate" << std::endl;


### PR DESCRIPTION
Fixes a bug in the nightlies where sequence values would be evaluated, where this is not supported.

A recent regression was added to exercize this fix but the fix had not been merged.