### PR TITLE
fp_word_blaster: Refactor to not use NodeManager::currentNM()

### DIFF
--- a/src/theory/fp/fp_word_blaster.h
+++ b/src/theory/fp/fp_word_blaster.h
@@ -86,6 +86,33 @@ class traits
 typedef traits::bwt bwt;
 
 /**
+ * Utility class to work around the fact that SymFPU does not maintain state
+ * but needs access to the current NodeManager
+ */
+class SymFpuNM
+{
+ public:
+  static thread_local NodeManager* s_nm;
+
+  SymFpuNM(NodeManager* nm)
+  {
+    d_prev_nm = s_nm;
+    s_nm = nm;
+  }
+
+  ~SymFpuNM() { s_nm = d_prev_nm; }
+
+  static NodeManager* get()
+  {
+    assert(s_nm != nullptr);
+    return s_nm;
+  }
+
+ private:
+  NodeManager* d_prev_nm = nullptr;
+};
+
+/**
  * Wrap the cvc5::internal::Node types so that we can debug issues with this back-end
  */
 class nodeWrapper : public Node
@@ -255,7 +282,7 @@ class floatingPointTypeInfo : public FloatingPointSize
   floatingPointTypeInfo(unsigned exp, unsigned sig);
   floatingPointTypeInfo(const floatingPointTypeInfo& old);
 
-  TypeNode getTypeNode(void) const;
+  TypeNode getTypeNode(NodeManager* nm) const;
 };
 }  // namespace symfpuSymbolic
 
@@ -274,7 +301,7 @@ class FpWordBlaster
 {
  public:
   /** Constructor. */
-  FpWordBlaster(context::UserContext*);
+  FpWordBlaster(NodeManager* nm, context::UserContext*);
   /** Destructor. */
   ~FpWordBlaster();
 
@@ -304,6 +331,7 @@ class FpWordBlaster
   typedef context::CDHashMap<Node, ubv> ubvMap;
   typedef context::CDHashMap<Node, sbv> sbvMap;
 
+  NodeManager* d_nm;
   fpMap d_fpMap;
   rmMap d_rmMap;
   boolMap d_boolMap;

--- a/src/theory/fp/theory_fp.cpp
+++ b/src/theory/fp/theory_fp.cpp
@@ -42,7 +42,7 @@ namespace fp {
 /** Constructs a new instance of TheoryFp w.r.t. the provided contexts. */
 TheoryFp::TheoryFp(Env& env, OutputChannel& out, Valuation valuation)
     : Theory(THEORY_FP, env, out, valuation),
-      d_wordBlaster(new FpWordBlaster(userContext())),
+      d_wordBlaster(new FpWordBlaster(nodeManager(), userContext())),
       d_registeredTerms(userContext()),
       d_abstractionMap(userContext()),
       d_rewriter(nodeManager(), userContext(), options().fp.fpExp),

--- a/src/theory/fp/theory_fp_rewriter.cpp
+++ b/src/theory/fp/theory_fp_rewriter.cpp
@@ -1103,6 +1103,7 @@ RewriteResponse roundingModeBitBlast(NodeManager* nm,
 {
   Assert(node.getKind() == Kind::ROUNDINGMODE_BITBLAST);
 
+  symfpuSymbolic::SymFpuNM snm(nm);
   BitVector value;
 
   /* \todo fix the numbering of rounding modes so this doesn't need


### PR DESCRIPTION
This PR introduces a utility class, `SymFpuNM`, with a `thread_local` field to work around the fact that SymFPU does not maintain state but still requires access to the current node manager.