### PR TITLE
Use standard Eunoia list in CPC utils

### DIFF
--- a/contrib/get-ethos-checker
+++ b/contrib/get-ethos-checker
@@ -26,7 +26,7 @@ EO_DIR="$BASE_DIR/ethos-checker"
 mkdir -p $EO_DIR
 
 # download and unpack ethos
-ETHOS_VERSION="45098f6ef78b0d85bc0b9374d77585df92c39dcb"
+ETHOS_VERSION="dfc1333b7b91e137ee29779151420342a323a1b0"
 download "https://github.com/cvc5/ethos/archive/$ETHOS_VERSION.tar.gz" $BASE_DIR/tmp/ethos.tgz
 tar --strip 1 -xzf $BASE_DIR/tmp/ethos.tgz -C $EO_DIR
 

--- a/proofs/eo/cpc/programs/Utils.eo
+++ b/proofs/eo/cpc/programs/Utils.eo
@@ -16,10 +16,13 @@
 (declare-type @Pair (Type Type))
 (declare-const @pair (-> (! Type :var U :implicit) (! Type :var T :implicit) U T (@Pair U T)))
 
-; untyped list
-(declare-type @List ())
-(declare-const @list.nil @List)
-(declare-const @list (-> (! Type :var T :implicit) T @List @List) :right-assoc-nil @list.nil)
+; untyped list.
+; note: >
+;   We use this as a synonym for eo::List. We use this syntax as it avoids
+;   the usage of eo:: in proofs.
+(define @List () eo::List)
+(define @list.nil () eo::List::nil)
+(define @list () eo::List::cons)
 
 ; note: This is a forward declaration of $evaluate_list defined in Cpc.eo.
 (program $evaluate_list () (@List) @List)


### PR DESCRIPTION
This makes `@list` an alias of `eo::List`.  Note we still require the syntax `@list` since we do not want `eo::` to appear in proofs, thus it is made an alias.

Also updates the ethos version, which has included minor fixes.