### PR TITLE
Catch all mixed arithmetic cases with --strict-parsing

### DIFF
--- a/src/expr/subtype_elim_node_converter.cpp
+++ b/src/expr/subtype_elim_node_converter.cpp
@@ -52,6 +52,8 @@ Node SubtypeElimNodeConverter::postConvert(Node n)
         isRealTypeStrict(n[0].getType()) || isRealTypeStrict(n[1].getType());
   }
   // note that EQUAL is strictly typed so we don't need to handle it here
+  // also TO_REAL applied to reals is always rewritten, so it doesn't need to
+  // be handled.
   if (convertToRealChildren)
   {
     std::vector<Node> children;

--- a/src/parser/smt2/smt2_state.cpp
+++ b/src/parser/smt2/smt2_state.cpp
@@ -1600,12 +1600,14 @@ Term Smt2State::applyParseOp(const ParseOp& p, std::vector<Term>& args)
       // the SMT standard but not in our internal type checker are handled
       // here.
       Sort sreq; // if applicable, the sort which all arguments must be.
+      bool sameType = false;
       if (kind == Kind::ADD || kind == Kind::MULT || kind == Kind::SUB
           || kind == Kind::GEQ || kind == Kind::GT || kind == Kind::LEQ
           || kind == Kind::LT)
       {
         // no mixed arithmetic
         sreq = args[0].getSort();
+        sameType = true;
       }
       else if (kind == Kind::DIVISION
                || kind == Kind::TO_INTEGER || kind == Kind::IS_INTEGER)
@@ -1626,8 +1628,15 @@ Term Smt2State::applyParseOp(const ParseOp& p, std::vector<Term>& args)
           if (s != sreq)
           {
             std::stringstream ss;
-            ss << "Due to strict parsing, we require the arguments of " << kind
-               << " to have type " << sreq;
+            ss << "Due to strict parsing, we require the arguments of " << kind;
+            if (sameType)
+            {
+              ss << " to have the same type";
+            }
+            else
+            {
+              ss << " to have type " << sreq;
+            }
             parseError(ss.str());
           }
         }

--- a/src/parser/smt2/smt2_state.cpp
+++ b/src/parser/smt2/smt2_state.cpp
@@ -1595,20 +1595,27 @@ Term Smt2State::applyParseOp(const ParseOp& p, std::vector<Term>& args)
     }
     if (strictModeEnabled())
     {
-      Sort sreq;
+      // Catch cases of mixed arithmetic, which our internal type checker is
+      // lenient for. In particular, any case that is ill-typed according to
+      // the SMT standard but not in our internal type checker are handled
+      // here.
+      Sort sreq; // if applicable, the sort which all arguments must be.
       if (kind == Kind::ADD || kind == Kind::MULT || kind == Kind::SUB
           || kind == Kind::GEQ || kind == Kind::GT || kind == Kind::LEQ
           || kind == Kind::LT)
       {
+        // no mixed arithmetic
         sreq = args[0].getSort();
       }
-      else if (kind == Kind::DIVISION || kind == Kind::DIVISION_TOTAL
+      else if (kind == Kind::DIVISION
                || kind == Kind::TO_INTEGER || kind == Kind::IS_INTEGER)
       {
+        // must apply division, to_int, is_int to real only
         sreq = d_tm.getRealSort();
       }
-      else if (kind == Kind::TO_REAL)
+      else if (kind == Kind::TO_REAL || kind == Kind::ABS)
       {
+        // must apply to_real, abs to integer only
         sreq = d_tm.getIntegerSort();
       }
       if (!sreq.isNull())

--- a/src/parser/smt2/smt2_state.cpp
+++ b/src/parser/smt2/smt2_state.cpp
@@ -1593,6 +1593,37 @@ Term Smt2State::applyParseOp(const ParseOp& p, std::vector<Term>& args)
         }
       }
     }
+    if (strictModeEnabled())
+    {
+      Sort sreq;
+      if (kind == Kind::ADD || kind == Kind::MULT
+          || kind == Kind::SUB || kind == Kind::GEQ || kind == Kind::GT || kind == Kind::LEQ || kind == Kind::LT)
+      {
+        sreq = args[0].getSort();
+      }
+      else if (kind == Kind::DIVISION || kind == Kind::DIVISION_TOTAL
+              || kind == Kind::TO_INTEGER || kind == Kind::IS_INTEGER)
+      {
+        sreq = d_tm.getRealSort();
+      }
+      else if (kind == Kind::TO_REAL)
+      {
+        sreq = d_tm.getIntegerSort();
+      }
+      if (!sreq.isNull())
+      {
+        for (Term& i : args)
+        {
+          Sort s = i.getSort();
+          if (s!=sreq)
+          {
+            std::stringstream ss;
+            ss << "Due to strict parsing, we require the arguments of " << kind << " to have type " << sreq;
+            parseError(ss.str());
+          }
+        }
+      }
+    }
     if (!strictModeEnabled() && (kind == Kind::AND || kind == Kind::OR)
         && args.size() == 1)
     {

--- a/src/parser/smt2/smt2_state.cpp
+++ b/src/parser/smt2/smt2_state.cpp
@@ -1596,13 +1596,14 @@ Term Smt2State::applyParseOp(const ParseOp& p, std::vector<Term>& args)
     if (strictModeEnabled())
     {
       Sort sreq;
-      if (kind == Kind::ADD || kind == Kind::MULT
-          || kind == Kind::SUB || kind == Kind::GEQ || kind == Kind::GT || kind == Kind::LEQ || kind == Kind::LT)
+      if (kind == Kind::ADD || kind == Kind::MULT || kind == Kind::SUB
+          || kind == Kind::GEQ || kind == Kind::GT || kind == Kind::LEQ
+          || kind == Kind::LT)
       {
         sreq = args[0].getSort();
       }
       else if (kind == Kind::DIVISION || kind == Kind::DIVISION_TOTAL
-              || kind == Kind::TO_INTEGER || kind == Kind::IS_INTEGER)
+               || kind == Kind::TO_INTEGER || kind == Kind::IS_INTEGER)
       {
         sreq = d_tm.getRealSort();
       }
@@ -1615,10 +1616,11 @@ Term Smt2State::applyParseOp(const ParseOp& p, std::vector<Term>& args)
         for (Term& i : args)
         {
           Sort s = i.getSort();
-          if (s!=sreq)
+          if (s != sreq)
           {
             std::stringstream ss;
-            ss << "Due to strict parsing, we require the arguments of " << kind << " to have type " << sreq;
+            ss << "Due to strict parsing, we require the arguments of " << kind
+               << " to have type " << sreq;
             parseError(ss.str());
           }
         }

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1278,6 +1278,10 @@ set(regress_0_tests
   regress0/parser/sort-term-overload-simple-unsat.smt2
   regress0/parser/stdout-diag.smt2
   regress0/parser/strict-numeral.smt2
+  regress0/parser/strict-parsing-mixed-arith-1.smt2
+  regress0/parser/strict-parsing-mixed-arith-2.smt2
+  regress0/parser/strict-parsing-mixed-arith-3.smt2
+  regress0/parser/strict-parsing-mixed-arith-3b.smt2
   regress0/parser/lenient-numeral.smt2
   regress0/parser/strings20.smt2
   regress0/parser/strings25.smt2

--- a/test/regress/cli/regress0/parser/strict-parsing-mixed-arith-1.smt2
+++ b/test/regress/cli/regress0/parser/strict-parsing-mixed-arith-1.smt2
@@ -1,0 +1,8 @@
+; DISABLE-TESTER: dump
+; REQUIRES: no-competition
+; COMMAND-LINE: --strict-parsing
+; EXPECT: (error "Parse Error: strict-parsing-mixed-arith-1.smt2:7.20: Due to strict parsing, we require the arguments of ADD to have the same type")
+; EXIT: 1
+(set-logic ALL)
+(assert (= (+ 1 0.5) 1.5))
+(check-sat)

--- a/test/regress/cli/regress0/parser/strict-parsing-mixed-arith-2.smt2
+++ b/test/regress/cli/regress0/parser/strict-parsing-mixed-arith-2.smt2
@@ -1,0 +1,8 @@
+; DISABLE-TESTER: dump
+; REQUIRES: no-competition
+; COMMAND-LINE: --strict-parsing
+; EXPECT: (error "Parse Error: strict-parsing-mixed-arith-2.smt2:7.24: Due to strict parsing, we require the arguments of TO_REAL to have type Int")
+; EXIT: 1
+(set-logic ALL)
+(assert (= (to_real 0.0) 0.0))
+(check-sat)

--- a/test/regress/cli/regress0/parser/strict-parsing-mixed-arith-3.smt2
+++ b/test/regress/cli/regress0/parser/strict-parsing-mixed-arith-3.smt2
@@ -1,0 +1,9 @@
+; DISABLE-TESTER: dump
+; REQUIRES: no-competition
+; COMMAND-LINE: --strict-parsing
+; SCRUBBER: grep -o "Subexpressions must have the same type"
+; EXPECT: Subexpressions must have the same type
+; EXIT: 1
+(set-logic ALL)
+(assert (= 0 0.0))
+(check-sat)

--- a/test/regress/cli/regress0/parser/strict-parsing-mixed-arith-3b.smt2
+++ b/test/regress/cli/regress0/parser/strict-parsing-mixed-arith-3b.smt2
@@ -1,0 +1,6 @@
+; COMMAND-LINE: --strict-parsing
+; EXPECT: sat
+(set-logic QF_LRA)
+; ok since 0 is treated as 0.0 in this logic
+(assert (= 0 0.0))
+(check-sat)


### PR DESCRIPTION
Addresses the inconsistency on https://github.com/cvc5/cvc5/issues/11004.

This extends `--strict-parsing` to catch errors due to the use of mixed arithmetic.

The original benchmark on https://github.com/cvc5/cvc5/issues/11004 already fails with `--strict-parsing` due to several non-compliant uses of mixed arithmetic (e.g. equality between Int and Real). This extends these checks so that we catch all non-compliant uses of arithmetic, including `to_real` applied to a Real, as demonstrated by the minimal example on that issue.

We continue to support the (non-compliant) extension of `to_real` applied to reals when strict parsing is disabled (by default), which we interpret as a no-op. This extension disagrees with z3, which appears to insert a casting to int.