### PR TITLE
Optimize arithmetic proof generation with pred transform utility

### DIFF
--- a/src/theory/arith/arith_proof_utilities.cpp
+++ b/src/theory/arith/arith_proof_utilities.cpp
@@ -122,6 +122,19 @@ Node expandMacroSumUb(NodeManager* nm,
   return sumBounds;
 }
 
+std::shared_ptr<ProofNode> ensurePredTransform(ProofNodeManager* pnm,
+                                               std::shared_ptr<ProofNode>& pf,
+                                               const Node& pred)
+{
+  if (pf->getResult() == pred)
+  {
+    return pf;
+  }
+  // give the predicate as the expected result, which is important for
+  // performance (does not require proof checking).
+  return pnm->mkNode(ProofRule::MACRO_SR_PRED_TRANSFORM, {pf}, {pred}, pred);
+}
+
 }  // namespace arith
 }  // namespace theory
 }  // namespace cvc5::internal

--- a/src/theory/arith/arith_proof_utilities.h
+++ b/src/theory/arith/arith_proof_utilities.h
@@ -70,6 +70,21 @@ Node expandMacroSumUb(NodeManager* nm,
                       const std::vector<Node>& args,
                       CDProof* cdp);
 
+/**
+ * Return a proof that proves pred, based on pf.
+ * It is expected that pf proves a formula pred' such that pred and pred' are
+ * equivalent up to rewriting (via MACRO_SR_PRED_TRANSFORM).
+ * If pf is already a proof of pred, it is returned as-is.
+ *
+ * @param pnm Reference to the proof manager.
+ * @param pf The proof.
+ * @param pred The desired conclusion.
+ * @return The proof of pred.
+ */
+std::shared_ptr<ProofNode> ensurePredTransform(ProofNodeManager* pnm,
+                                               std::shared_ptr<ProofNode>& pf,
+                                               const Node& pred);
+
 }  // namespace arith
 }  // namespace theory
 }  // namespace cvc5::internal

--- a/src/theory/arith/linear/constraint.cpp
+++ b/src/theory/arith/linear/constraint.cpp
@@ -1121,26 +1121,23 @@ TrustNode Constraint::split()
     TypeNode type = lhs.getType();
     // Farkas proof that this works.
     auto nLeqPf = d_database->d_pnm->mkAssume(leqNode.negate());
-    auto gtPf = d_database->d_pnm->mkNode(
-        ProofRule::MACRO_SR_PRED_TRANSFORM, {nLeqPf}, {gtNode});
+    auto gtPf = ensurePredTransform(d_database->d_pnm, nLeqPf, gtNode);
     auto nGeqPf = d_database->d_pnm->mkAssume(geqNode.negate());
-    auto ltPf = d_database->d_pnm->mkNode(
-        ProofRule::MACRO_SR_PRED_TRANSFORM, {nGeqPf}, {ltNode});
+    auto ltPf = ensurePredTransform(d_database->d_pnm, nGeqPf, ltNode);
     std::vector<Pf> args{gtPf, ltPf};
     std::vector<Node> coeffs{nm->mkConstReal(-1), nm->mkConstReal(1)};
     std::vector<Node> coeffsUse = getMacroSumUbCoeff(nm, args, coeffs);
     auto sumPf = d_database->d_pnm->mkNode(
         ProofRule::MACRO_ARITH_SCALE_SUM_UB, args, coeffsUse);
-    auto botPf = d_database->d_pnm->mkNode(
-        ProofRule::MACRO_SR_PRED_TRANSFORM, {sumPf}, {nm->mkConst(false)});
+    auto botPf =
+        ensurePredTransform(d_database->d_pnm, sumPf, nm->mkConst(false));
     std::vector<Node> a = {leqNode.negate(), geqNode.negate()};
     auto notAndNotPf = d_database->d_pnm->mkScope(botPf, a);
     // No need to ensure that the expected node aggrees with `a` because we are
     // not providing an expected node.
     auto orNotNotPf =
         d_database->d_pnm->mkNode(ProofRule::NOT_AND, {notAndNotPf}, {});
-    auto orPf = d_database->d_pnm->mkNode(
-        ProofRule::MACRO_SR_PRED_TRANSFORM, {orNotNotPf}, {lemma});
+    auto orPf = ensurePredTransform(d_database->d_pnm, orNotNotPf, lemma);
     trustedLemma = d_database->d_pfGen->mkTrustNode(lemma, orPf);
   }
   else
@@ -1577,8 +1574,8 @@ TrustNode Constraint::externalExplainForPropagation(TNode lit) const
     }
     if (getProofLiteral() != lit)
     {
-      pfFromAssumptions = d_database->d_pnm->mkNode(
-          ProofRule::MACRO_SR_PRED_TRANSFORM, {pfFromAssumptions}, {lit});
+      pfFromAssumptions =
+          ensurePredTransform(d_database->d_pnm, pfFromAssumptions, lit);
     }
     auto pf = d_database->d_pnm->mkScope(pfFromAssumptions, assumptions);
     return d_database->d_pfGen->mkTrustedPropagation(
@@ -1601,8 +1598,7 @@ TrustNode Constraint::externalExplainConflict() const
   Node n = mkAndFromBuilder(d_database->nodeManager(), nb);
   if (d_database->isProofEnabled())
   {
-    auto pfNot2 = d_database->d_pnm->mkNode(
-        ProofRule::MACRO_SR_PRED_TRANSFORM, {pf1}, {not2});
+    auto pfNot2 = ensurePredTransform(d_database->d_pnm, pf1, not2);
     std::vector<Node> lits;
     if (n.getKind() == Kind::AND)
     {
@@ -1729,12 +1725,7 @@ std::shared_ptr<ProofNode> Constraint::externalExplain(
       pf = pnm->mkAssume(getWitness());
       // If the witness and literal differ, prove the difference through a
       // rewrite.
-      if (getWitness() != getProofLiteral())
-      {
-        Node plit = getProofLiteral();
-        pf = pnm->mkNode(
-            ProofRule::MACRO_SR_PRED_TRANSFORM, {pf}, {plit}, plit);
-      }
+      pf = ensurePredTransform(pnm, pf, getProofLiteral());
     }
   }
   else if (hasEqualityEngineProof())
@@ -1745,8 +1736,7 @@ std::shared_ptr<ProofNode> Constraint::externalExplain(
     {
       std::shared_ptr<ProofNode> a = pnm->mkAssume(getLiteral());
       Node plit = getProofLiteral();
-      pf = pnm->mkNode(
-          ProofRule::MACRO_SR_PRED_TRANSFORM, {a}, {plit}, plit);
+      pf = ensurePredTransform(pnm, a, plit);
     }
     Assert(lit.getKind() != Kind::AND);
     nb << lit;
@@ -1817,9 +1807,7 @@ std::shared_ptr<ProofNode> Constraint::externalExplain(
 
           // Provable rewrite the result
           Node falsen = nm->mkConst(false);
-          auto botPf = pnm->mkNode(ProofRule::MACRO_SR_PRED_TRANSFORM,
-                                   {sumPf},
-                                   {falsen}, falsen);
+          auto botPf = ensurePredTransform(pnm, sumPf, falsen);
 
           // Scope out the negated constraint, yielding a proof of the
           // constraint.
@@ -1831,9 +1819,7 @@ std::shared_ptr<ProofNode> Constraint::externalExplain(
           //
           // Prove that this is the literal (may need to clean a double-not)
           Node plit2 = getProofLiteral();
-          pf = pnm->mkNode(ProofRule::MACRO_SR_PRED_TRANSFORM,
-                           {maybeDoubleNotPf},
-                           {plit2}, plit2);
+          pf = ensurePredTransform(pnm, maybeDoubleNotPf, plit2);
 
           break;
         }
@@ -2102,32 +2088,28 @@ void ConstraintDatabase::proveOr(std::vector<TrustNode>& out,
     auto nm = nodeManager();
     Node alit = a->getNegation()->getProofLiteral();
     TypeNode type = alit[0].getType();
-    auto pf_neg_la = d_pnm->mkNode(ProofRule::MACRO_SR_PRED_TRANSFORM,
-                                   {d_pnm->mkAssume(la.negate())},
-                                   {alit});
+    auto pf_neg_la = d_pnm->mkAssume(la.negate());
+    pf_neg_la = ensurePredTransform(d_pnm, pf_neg_la, alit);
     Node blit = b->getNegation()->getProofLiteral();
-    auto pf_neg_lb = d_pnm->mkNode(ProofRule::MACRO_SR_PRED_TRANSFORM,
-                                   {d_pnm->mkAssume(lb.negate())},
-                                   {blit});
+    auto pf_neg_lb = d_pnm->mkAssume(lb.negate());
+    pf_neg_lb = ensurePredTransform(d_pnm, pf_neg_lb, blit);
     int sndSign = negateSecond ? -1 : 1;
     std::vector<Pf> args{pf_neg_la, pf_neg_lb};
     std::vector<Node> coeffs{nm->mkConstReal(Rational(-1 * sndSign)),
                              nm->mkConstReal(Rational(sndSign))};
     std::vector<Node> coeffsUse = getMacroSumUbCoeff(nm, args, coeffs);
-    auto bot_pf = d_pnm->mkNode(
-        ProofRule::MACRO_SR_PRED_TRANSFORM,
-        {d_pnm->mkNode(ProofRule::MACRO_ARITH_SCALE_SUM_UB, args, coeffsUse)},
-        {nm->mkConst(false)});
+    auto sumubpf =
+        d_pnm->mkNode(ProofRule::MACRO_ARITH_SCALE_SUM_UB, args, coeffsUse);
+    auto bot_pf = ensurePredTransform(d_pnm, sumubpf, nm->mkConst(false));
     std::vector<Node> as;
     std::transform(orN.begin(), orN.end(), std::back_inserter(as), [](Node n) {
       return n.negate();
     });
     // No need to ensure that the expected node aggrees with `as` because we
     // are not providing an expected node.
-    auto pf = d_pnm->mkNode(
-        ProofRule::MACRO_SR_PRED_TRANSFORM,
-        {d_pnm->mkNode(ProofRule::NOT_AND, {d_pnm->mkScope(bot_pf, as)}, {})},
-        {orN});
+    auto pf =
+        d_pnm->mkNode(ProofRule::NOT_AND, {d_pnm->mkScope(bot_pf, as)}, {});
+    pf = ensurePredTransform(d_pnm, pf, orN);
     out.push_back(d_pfGen->mkTrustNode(orN, pf));
   }
   else

--- a/src/theory/arith/linear/theory_arith_private.cpp
+++ b/src/theory/arith/linear/theory_arith_private.cpp
@@ -1414,26 +1414,21 @@ TrustNode TheoryArithPrivate::dioCutting()
       TypeNode type = gt[0].getType();
 
       Pf pfNotLeq = d_pnm->mkAssume(leq.getNode().negate());
-      Pf pfGt =
-          d_pnm->mkNode(ProofRule::MACRO_SR_PRED_TRANSFORM, {pfNotLeq}, {gt}, gt);
+      Pf pfGt = ensurePredTransform(d_pnm, pfNotLeq, gt);
       Pf pfNotGeq = d_pnm->mkAssume(geq.getNode().negate());
-      Pf pfLt =
-          d_pnm->mkNode(ProofRule::MACRO_SR_PRED_TRANSFORM, {pfNotGeq}, {lt}, lt);
+      Pf pfLt = ensurePredTransform(d_pnm, pfNotGeq, lt);
       std::vector<Pf> args{pfGt, pfLt};
       std::vector<Node> coeffs{nm->mkConstReal(-1), nm->mkConstReal(1)};
       std::vector<Node> coeffsUse = getMacroSumUbCoeff(nm, args, coeffs);
       Pf pfSum =
           d_pnm->mkNode(ProofRule::MACRO_ARITH_SCALE_SUM_UB, args, coeffsUse);
       Node falsen = nm->mkConst(false);
-      Pf pfBot = d_pnm->mkNode(ProofRule::MACRO_SR_PRED_TRANSFORM,
-                               {pfSum},
-                               {falsen}, falsen);
+      Pf pfBot = ensurePredTransform(d_pnm, pfSum, falsen);
       std::vector<Node> assumptions = {leq.getNode().negate(),
                                        geq.getNode().negate()};
       Pf pfNotAndNot = d_pnm->mkScope(pfBot, assumptions);
       Pf pfOr = d_pnm->mkNode(ProofRule::NOT_AND, {pfNotAndNot}, {});
-      Pf pfRewritten = d_pnm->mkNode(
-          ProofRule::MACRO_SR_PRED_TRANSFORM, {pfOr}, {rewrittenLemma}, rewrittenLemma);
+      Pf pfRewritten = ensurePredTransform(d_pnm, pfOr, rewrittenLemma);
       return d_pfGen->mkTrustNode(rewrittenLemma, pfRewritten);
     }
     else
@@ -1508,11 +1503,9 @@ ConstraintP TheoryArithPrivate::constraintFromFactQueue(TNode assertion)
         {
           Pf assume = d_pnm->mkAssume(assertion);
           std::vector<Node> assumptions = {assertion};
-          Pf pf =
-              d_pnm->mkScope(d_pnm->mkNode(ProofRule::MACRO_SR_PRED_TRANSFORM,
-                                           {d_pnm->mkAssume(assertion)},
-                                           {}),
-                             assumptions);
+          Node fn = nodeManager()->mkConst(false);
+          Pf pfb = ensurePredTransform(d_pnm, assume, fn);
+          Pf pf = d_pnm->mkScope(pfb, assumptions);
           raiseBlackBoxConflict(assertion, pf);
         }
         else
@@ -3769,8 +3762,7 @@ void TheoryArithPrivate::propagate(Theory::Effort e) {
             {pfAnt, exp.getGenerator()->getProofFor(exp.getProven())},
             {});
         // prove toProp (rewritten)
-        Pf pfConcRewritten = d_pnm->mkNode(
-            ProofRule::MACRO_SR_PRED_TRANSFORM, {pfConc}, {normalized});
+        Pf pfConcRewritten = ensurePredTransform(d_pnm, pfConc, normalized);
         Pf pfNotNormalized = d_pnm->mkAssume(notNormalized);
         // prove bottom from toProp and ~toProp
         Pf pfBot;
@@ -4552,11 +4544,9 @@ bool TheoryArithPrivate::rowImplicationCanBeApplied(RowIndex ridx, bool rowUp, C
         TypeNode type = pfLit[0].getType();
         // Assume the negated getLiteral version of the implied constaint
         // then rewrite it into proof normal form.
-        conflictPfs.push_back(
-            d_pnm->mkNode(ProofRule::MACRO_SR_PRED_TRANSFORM,
-                          {d_pnm->mkAssume(implied->getLiteral().negate())},
-                          {pfLit},
-                          pfLit));
+        auto pf = d_pnm->mkAssume(implied->getLiteral().negate());
+        pf = ensurePredTransform(d_pnm, pf, pfLit);
+        conflictPfs.push_back(pf);
         // Add the explaination proofs.
         for (const auto constraint : explain)
         {
@@ -4581,8 +4571,7 @@ bool TheoryArithPrivate::rowImplicationCanBeApplied(RowIndex ridx, bool rowUp, C
                                    conflictPfs,
                                    farkasCoefficientsUse);
         Node falsen = nm->mkConst(false);
-        auto botPf = d_pnm->mkNode(
-            ProofRule::MACRO_SR_PRED_TRANSFORM, {sumPf}, {falsen}, falsen);
+        auto botPf = ensurePredTransform(d_pnm, sumPf, falsen);
 
         // Prove the conflict
         std::vector<Node> assumptions;
@@ -4595,8 +4584,7 @@ bool TheoryArithPrivate::rowImplicationCanBeApplied(RowIndex ridx, bool rowUp, C
 
         // Convert it to a clause
         auto orNotNotPf = d_pnm->mkNode(ProofRule::NOT_AND, {notAndNotPf}, {});
-        clausePf = d_pnm->mkNode(
-            ProofRule::MACRO_SR_PRED_TRANSFORM, {orNotNotPf}, {clause}, clause);
+        clausePf = ensurePredTransform(d_pnm, orNotNotPf, clause);
 
         // Output it
         TrustNode trustedClause = d_pfGen->mkTrustNode(clause, clausePf);


### PR DESCRIPTION
Many of the low-level proof steps in arithmetic are suboptimal in terms of performance, for two reasons:
(1) They introduce spurious MACRO_SR_PRED_TRANSFORM steps (proving F from F).
(2) They do not provide an expected result, meaning that proof checking is invoked for these steps.

This addresses both issues.

This is work towards optimizing the performance of proofs in the arithmetic theory.