### PR TITLE
Do subproof merging when all processing RARE rewrites

### DIFF
--- a/src/proof/proof_node_updater.cpp
+++ b/src/proof/proof_node_updater.cpp
@@ -57,6 +57,11 @@ bool ProofNodeUpdaterCallback::canMerge(std::shared_ptr<ProofNode> pn)
   return true;
 }
 
+void ProofNodeUpdaterCallback::finalize(std::shared_ptr<ProofNode> pn)
+{
+  // do nothing
+}
+
 ProofNodeUpdater::ProofNodeUpdater(Env& env,
                                    ProofNodeUpdaterCallback& cb,
                                    bool mergeSubproofs,
@@ -142,6 +147,7 @@ void ProofNodeUpdater::processInternal(std::shared_ptr<ProofNode> pf,
       // nodes having this as a child that are not subproofs of pf.
       if (checkMergeProof(cur, resCache, cfaMap))
       {
+        Trace("pf-process-merge") << "...merged on previsit" << std::endl;
         visited[cur] = true;
         continue;
       }
@@ -193,7 +199,8 @@ void ProofNodeUpdater::processInternal(std::shared_ptr<ProofNode> pf,
       traversing.pop_back();
       visited[cur] = true;
       // finalize the node
-      if (cur->getRule() == ProofRule::SCOPE)
+      ProofRule id = cur->getRule();
+      if (id == ProofRule::SCOPE)
       {
         const std::vector<Node>& args = cur->getArguments();
         Assert(fa.size() >= args.size());
@@ -203,12 +210,21 @@ void ProofNodeUpdater::processInternal(std::shared_ptr<ProofNode> pf,
       // proof with the same result. Same as above, updating the contents here
       // is typically not necessary since references to this proof will be
       // replaced.
-      if (checkMergeProof(cur, resCache, cfaMap))
+      // maybe found a proof in the meantime, i.e. a subproof of the current
+      // proof with the same result. Same as above, updating the contents here
+      // is typically not necessary since references to this proof will be
+      // replaced.
+      if (!checkMergeProof(cur, resCache, cfaMap))
       {
-        visited[cur] = true;
-        continue;
+        runFinalize(cur, fa, resCache, resCacheNcWaiting, cfaMap, cfaAllowed);
       }
-      runFinalize(cur, fa, resCache, resCacheNcWaiting, cfaMap, cfaAllowed);
+      else
+      {
+        Trace("pf-process-merge") << "...merged on postvisit " << id << " / "
+                                  << cur->getRule() << std::endl;
+      }
+      // call the finalize callback, independent of whether it was merged
+      d_cb.finalize(cur);
     }
   } while (!visit.empty());
   Trace("pf-process") << "ProofNodeUpdater::process: finished" << std::endl;

--- a/src/proof/proof_node_updater.h
+++ b/src/proof/proof_node_updater.h
@@ -90,6 +90,8 @@ class ProofNodeUpdaterCallback
    * another proof, nor will its contents be replaced.
    */
   virtual bool canMerge(std::shared_ptr<ProofNode> pn);
+  /** Called when we are done processing pn */
+  virtual void finalize(std::shared_ptr<ProofNode> pn);
 };
 
 /**

--- a/src/smt/proof_post_processor_dsl.h
+++ b/src/smt/proof_post_processor_dsl.h
@@ -50,9 +50,6 @@ class ProofPostprocessDsl : protected EnvObj, public ProofNodeUpdaterCallback
   bool shouldUpdate(std::shared_ptr<ProofNode> pn,
                     const std::vector<Node>& fa,
                     bool& continueUpdate) override;
-  /** Should proof pn be updated (post-traversal)? */
-  bool shouldUpdatePost(std::shared_ptr<ProofNode> pn,
-                        const std::vector<Node>& fa) override;
   /** Update the proof rule application. */
   bool update(Node res,
               ProofRule id,
@@ -60,6 +57,8 @@ class ProofPostprocessDsl : protected EnvObj, public ProofNodeUpdaterCallback
               const std::vector<Node>& args,
               CDProof* cdp,
               bool& continueUpdate) override;
+  /** Finalize this proof node */
+  void finalize(std::shared_ptr<ProofNode> pn) override;
 
  private:
   /** Common constants */


### PR DESCRIPTION
This is a performance optimization for proof generation.

This makes a single run of a proof updater process all RARE rewrites in a single pass. This has the advantage that shared subgoals are only proven by the RARE reconstruction once.

This adds a new callback to the proof node updater callback "finalize" which is a clearer interface for when we are done processing a proof node.