### PR TITLE
Fix evaluator for BV repeat

### DIFF
--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -1169,11 +1169,12 @@ EvalResult Evaluator::evalInternal(
           BitVector res = results[currNode[0]].d_bv;
           unsigned amount =
               currNode.getOperator().getConst<BitVectorRepeat>().d_repeatAmount;
+          BitVector ret = res;
           for (size_t i = 1; i < amount; i++)
           {
-            res = res.concat(res);
+            ret = ret.concat(res);
           }
-          results[currNode] = EvalResult(res);
+          results[currNode] = EvalResult(ret);
           break;
         }
         case Kind::BITVECTOR_SIGN_EXTEND:


### PR DESCRIPTION
The evaluator is primarily used for sygus symmetry breaking and for RARE proof reconstruction. Moreover repeat is eliminated during rewriting, so this bug had a very minimal impact.  I discovered it due to a proof hole that appeared in my dev branch related to RARE reconstruction.