### PR TITLE
Add macro expansion for MACRO_QUANT_VAR_ELIM_INEQ

### DIFF
--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -26,8 +26,10 @@
 #include "rewriter/rewrite_db_term_process.h"
 #include "rewriter/rewrites.h"
 #include "smt/env.h"
+#include "theory/arith/arith_msum.h"
 #include "theory/arith/arith_poly_norm.h"
 #include "theory/arith/arith_proof_utilities.h"
+#include "theory/arith/arith_utilities.h"
 #include "theory/arith/rewriter/rewrite_atom.h"
 #include "theory/arrays/theory_arrays_rewriter.h"
 #include "theory/booleans/theory_bool_rewriter.h"
@@ -304,6 +306,12 @@ void BasicRewriteRCons::ensureProofForTheoryRewrite(CDProof* cdp,
         handledMacro = true;
       }
       break;
+    case ProofRewriteRule::MACRO_QUANT_VAR_ELIM_INEQ:
+      if (ensureProofMacroQuantVarElimIneq(cdp, eq))
+      {
+        handledMacro = true;
+      }
+      break;
     case ProofRewriteRule::MACRO_QUANT_DT_VAR_EXPAND:
       if (ensureProofMacroDtVarExpand(cdp, eq))
       {
@@ -354,6 +362,7 @@ void BasicRewriteRCons::ensureProofForTheoryRewrite(CDProof* cdp,
   }
   if (handledMacro)
   {
+    d_theoryRewriteMacroExpand << id;
     return;
   }
   // default, just add the rewrite
@@ -1788,6 +1797,7 @@ bool BasicRewriteRCons::ensureProofMacroStrInReInclusion(CDProof* cdp,
   cdp->addStep(eq, ProofRule::TRUE_INTRO, {eq[0]}, {});
   return true;
 }
+
 bool BasicRewriteRCons::ensureProofMacroQuantMergePrenex(CDProof* cdp,
                                                          const Node& eq)
 {
@@ -1939,8 +1949,7 @@ bool BasicRewriteRCons::ensureProofMacroQuantPrenex(CDProof* cdp,
       Node eqqm1 = ceuv.eqNode(body2ms);
       cdp->addTheoryRewriteStep(eqqm1, prr);
       eqqm = currEq[0].eqNode(body2ms);
-      cdp->addStep(
-          eqqm, ProofRule::TRANS, {eqce, eqqm1}, {});
+      cdp->addStep(eqqm, ProofRule::TRANS, {eqce, eqqm1}, {});
     }
     else
     {
@@ -2250,6 +2259,421 @@ bool BasicRewriteRCons::ensureProofMacroQuantVarElimEq(CDProof* cdp,
   return true;
 }
 
+bool BasicRewriteRCons::ensureProofMacroQuantVarElimIneq(CDProof* cdp,
+                                                         const Node& eq)
+{
+  Trace("brc-macro") << "Expand macro quant var elim ineq " << eq << std::endl;
+  // get info on the right hand side
+  std::unordered_set<Node> varsRhs;
+  std::vector<Node> litsRhs;
+  Node body = eq[1];
+  if (eq[1].getKind() == Kind::FORALL)
+  {
+    varsRhs.insert(eq[1][0].begin(), eq[1][0].end());
+    body = eq[1][1];
+  }
+  if (body.getKind() == Kind::OR)
+  {
+    litsRhs.insert(litsRhs.end(), body.begin(), body.end());
+  }
+  else if (!body.isConst())
+  {
+    litsRhs.push_back(body);
+  }
+  // determine the variable that was eliminated
+  Assert(eq[0].getKind() == Kind::FORALL);
+  Node elimVar;
+  for (const Node& v : eq[0][0])
+  {
+    if (varsRhs.find(v) == varsRhs.end())
+    {
+      elimVar = v;
+      break;
+    }
+  }
+  if (elimVar.isNull())
+  {
+    return false;
+  }
+  std::vector<Node> elimLits;
+  std::vector<Node> keepLits;
+  if (eq[0][1].getKind() == Kind::OR)
+  {
+    for (const Node& lit : eq[0][1])
+    {
+      if (std::find(litsRhs.begin(), litsRhs.end(), lit) == litsRhs.end())
+      {
+        elimLits.push_back(lit);
+      }
+      else
+      {
+        keepLits.push_back(lit);
+      }
+    }
+  }
+  else
+  {
+    Assert(litsRhs.empty());
+    elimLits.push_back(eq[0][1]);
+  }
+  Assert(!elimLits.empty());
+  Trace("brc-macro") << "Eliminated variable: " << elimVar << std::endl;
+  Trace("brc-macro") << "Eliminated lits: " << elimLits << std::endl;
+  Trace("brc-macro") << "Keep lits: " << keepLits << std::endl;
+  NodeManager* nm = nodeManager();
+  if (eq[0][0].getNumChildren() > 1)
+  {
+    // note that keepLits may be empty, e.g. for
+    // forall xy. x > y ---> forall y. false
+    Node bvle = nm->mkNode(Kind::BOUND_VAR_LIST, elimVar);
+    Node kdisj = nm->mkOr(keepLits);
+    Node edisj = nm->mkOr(elimLits);
+    Node lhsq = nm->mkNode(Kind::FORALL, bvle, eq[0][1]);
+    Trace("brc-macro") << "...Start with " << lhsq << std::endl;
+    Node por = nm->mkNode(Kind::OR, edisj, kdisj);
+    std::vector<Node> transEq;
+    Node lhsqg = lhsq;
+    if (eq[0][1] != por)
+    {
+      Node equiv = eq[0][1].eqNode(por);
+      if (!expr::isACINorm(eq[0][1], por))
+      {
+        return false;
+      }
+      cdp->addStep(equiv, ProofRule::ACI_NORM, {}, {equiv});
+      Node rhsq = nm->mkNode(Kind::FORALL, bvle, por);
+      Node equivc = lhsq.eqNode(rhsq);
+      std::vector<Node> cargs;
+      ProofRule cr = expr::getCongRule(lhsq, cargs);
+      cdp->addStep(equivc, cr, {equiv}, cargs);
+      transEq.push_back(equivc);
+      lhsqg = rhsq;
+      Trace("brc-macro") << "...ACI_NORM to " << lhsq << std::endl;
+    }
+    theory::Rewriter* rr = d_env.getRewriter();
+    Node mq = rr->rewriteViaRule(ProofRewriteRule::QUANT_MINISCOPE_OR, lhsqg);
+    if (mq.isNull())
+    {
+      return false;
+    }
+    Assert(mq != lhsqg);
+    Node equiv = lhsqg.eqNode(mq);
+    cdp->addTheoryRewriteStep(equiv, ProofRewriteRule::QUANT_MINISCOPE_OR);
+    transEq.push_back(equiv);
+    Trace("brc-macro") << "...miniscope to " << mq << std::endl;
+    if (mq.getKind() != Kind::OR || mq.getNumChildren() != 2)
+    {
+      return false;
+    }
+    std::vector<Node> corPremises;
+    Node qvi =
+        rr->rewriteViaRule(ProofRewriteRule::MACRO_QUANT_VAR_ELIM_INEQ, mq[0]);
+    if (qvi.isNull() || !qvi.isConst())
+    {
+      return false;
+    }
+    Assert(!qvi.getConst<bool>());
+    std::vector<Node> cpremises;
+    cpremises.push_back(mq[0].eqNode(qvi));
+    cpremises.push_back(mq[1].eqNode(mq[1]));
+    // immediately call this method again, which should not make any further
+    // recursive call.
+    if (!ensureProofMacroQuantVarElimIneq(cdp, cpremises[0]))
+    {
+      return false;
+    }
+    cdp->addStep(cpremises[1], ProofRule::REFL, {}, {mq[1]});
+    Node mqf = nm->mkNode(Kind::OR, qvi, mq[1]);
+    std::vector<Node> cargs;
+    ProofRule cr = expr::getCongRule(mq, cargs);
+    equiv = mq.eqNode(mqf);
+    cdp->addStep(equiv, cr, cpremises, cargs);
+    transEq.push_back(equiv);
+    Trace("brc-macro") << "...rewrite ineq (again) to " << mqf << std::endl;
+    equiv = mqf.eqNode(mq[1]);
+    cdp->addTrustedStep(
+        equiv, TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE, {}, {});
+    transEq.push_back(equiv);
+    Trace("brc-macro") << "...rewrite (simple) to " << mq[1] << std::endl;
+    Node eqBody = lhsq.eqNode(mq[1]);
+    cdp->addStep(eqBody, ProofRule::TRANS, transEq, {});
+    transEq.clear();
+    Assert(eq[1].getKind() == Kind::FORALL);
+
+    // now add back outermost variables
+    Node bcLhs = nm->mkNode(Kind::FORALL, eq[1][0], eqBody[0]);
+    Node bcLhsm =
+        rr->rewriteViaRule(ProofRewriteRule::QUANT_MERGE_PRENEX, bcLhs);
+    if (bcLhsm != eq[0])
+    {
+      // likely reorder?
+      equiv = eq[0].eqNode(bcLhsm);
+      if (!cdp->addStep(equiv, ProofRule::QUANT_VAR_REORDERING, {}, {equiv}))
+      {
+        Trace("brc-macro") << "...failed eq lhs" << std::endl;
+        return false;
+      }
+      transEq.push_back(equiv);
+    }
+    equiv = bcLhs.eqNode(bcLhsm);
+    cdp->addTheoryRewriteStep(equiv, ProofRewriteRule::QUANT_MERGE_PRENEX);
+    equiv = bcLhsm.eqNode(bcLhs);
+    cdp->addStep(equiv, ProofRule::SYMM, {equiv}, {});
+    transEq.push_back(equiv);
+    Node bcRhs = nm->mkNode(Kind::FORALL, eq[1][0], eqBody[1]);
+    if (bcRhs != eq[1])
+    {
+      Trace("brc-macro") << "...failed eq rhs" << std::endl;
+      return false;
+    }
+    cargs.clear();
+    cr = expr::getCongRule(bcLhs, cargs);
+    equiv = bcLhs.eqNode(bcRhs);
+    cdp->addStep(equiv, cr, {eqBody}, cargs);
+    transEq.push_back(equiv);
+    cdp->addStep(eq, ProofRule::TRANS, transEq, {});
+    return true;
+  }
+
+  // find the instantiation term
+  std::vector<Node> normLits;
+  bool isUpper = true;
+  bool isUpperSet = false;
+  TConvProofGenerator tcpg(d_env);
+  std::vector<Node> negLits;
+  for (const Node& lit : elimLits)
+  {
+    Trace("brc-macro") << "process elim lit: " << lit << std::endl;
+    Node negLit = lit.negate();
+    negLits.push_back(negLit);
+    bool pol = lit.getKind() != Kind::NOT;
+    Node atom = pol ? lit : lit[0];
+    // isolate
+    std::map<Node, Node> msum;
+    if (!theory::ArithMSum::getMonomialSumLit(atom, msum))
+    {
+      return false;
+    }
+    // store that this literal is upper/lower bound for itm->first
+    Kind k = atom.getKind();
+    Node veq_c;
+    Node val;
+    int ires = theory::ArithMSum::isolate(elimVar, msum, veq_c, val, k);
+    if (ires == 0 || !veq_c.isNull())
+    {
+      Trace("brc-macro") << "...failed isolate" << std::endl;
+      return false;
+    }
+    Trace("brc-macro") << "... processes to " << elimVar << " <> " << val
+                       << std::endl;
+    // rewrite it, should be provable with ARITH_POLY_NORM since monomials
+    // should be already rewritten.
+    val = rewrite(val);
+    Node nlit;
+    if (k == Kind::GEQ)
+    {
+      bool isUpperCurr = pol == (ires == 1);
+      if (isUpperSet && isUpper != isUpperCurr)
+      {
+        return false;
+      }
+      isUpper = isUpperCurr;
+      isUpperSet = true;
+      Trace("brc-macro") << "...is_upper = " << isUpperCurr << std::endl;
+      if (ires < 0)
+      {
+        k = Kind::LEQ;
+      }
+      if (pol)
+      {
+        k = theory::arith::negateKind(k);
+      }
+      nlit = nm->mkNode(k, elimVar, val);
+    }
+    else
+    {
+      Assert(k == Kind::EQUAL && pol);
+      nlit = nm->mkNode(Kind::EQUAL, elimVar, val).notNode();
+    }
+    Trace("brc-macro") << "...nlit is " << nlit << std::endl;
+    Trace("brc-macro") << "......from " << negLit << std::endl;
+    normLits.push_back(nlit);
+    if (negLit != nlit)
+    {
+      Trace("brc-macro") << "- rewrite " << negLit << " -> " << nlit
+                         << std::endl;
+      // should be provable by REFL or ARITH_POLY_NORM_REL
+      tcpg.addRewriteStep(negLit,
+                          nlit,
+                          nullptr,
+                          false,
+                          TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE);
+    }
+  }
+  Node eqnorm;
+  Node qnorm;
+  // In the following, we update (or ~L1 ... ~Ln) to (=> (and L1 ... Ln) false)
+  // and then prove (and L1 ... Ln). This makes it easier to match to existing
+  // rules.
+  // not necessary if single literal
+  if (normLits.size() > 1)
+  {
+    Node negBody = eq[0][1].negate();
+    Node negPremise = nm->mkAnd(negLits);
+    if (negBody != negPremise)
+    {
+      Trace("brc-macro") << "- rewrite de-morgan " << negBody << " -> "
+                         << negPremise << std::endl;
+      // by de-morgan
+      tcpg.addRewriteStep(negBody,
+                          negPremise,
+                          nullptr,
+                          true,
+                          TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE);
+    }
+    Node negRew = nm->mkNode(Kind::IMPLIES, negBody, nm->mkConst(false));
+    // F = (=> (not F) false)
+    Trace("brc-macro") << "- rewrite impl intro " << eq[0][1] << " -> "
+                       << negRew << std::endl;
+    tcpg.addRewriteStep(eq[0][1],
+                        negRew,
+                        nullptr,
+                        true,
+                        TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE);
+    Trace("brc-macro") << "...from " << eq[0] << std::endl;
+    std::shared_ptr<ProofNode> pfn = tcpg.getProofForRewriting(eq[0]);
+    eqnorm = pfn->getResult();
+    qnorm = eqnorm[1];
+    cdp->addProof(pfn);
+    Trace("brc-macro") << "...normalized to " << qnorm << std::endl;
+  }
+  else
+  {
+    qnorm = eq[0];
+  }
+  // Now have upper set. note if all disequalities we don't care about the
+  // value of isUpper
+  std::reverse(normLits.begin(), normLits.end());
+  // make the max or min of all terms based on isUpper
+  Node iterm;
+  for (const Node& nl : normLits)
+  {
+    Node atom = nl.getKind() == Kind::NOT ? nl[0] : nl;
+    Trace("brc-macro") << "...process normalized atom " << atom << std::endl;
+    Kind k = atom.getKind();
+    Node itc = atom[1];
+    if (k != Kind::GEQ && k != Kind::LEQ)
+    {
+      itc = rewrite(nm->mkNode(
+          Kind::ADD,
+          itc,
+          nm->mkConstRealOrInt(itc.getType(), Rational(isUpper ? -1 : 1))));
+    }
+    if (iterm.isNull())
+    {
+      iterm = itc;
+    }
+    else
+    {
+      iterm = nm->mkNode(Kind::ITE,
+                         nm->mkNode(isUpper ? Kind::LT : Kind::GEQ, itc, iterm),
+                         itc,
+                         iterm);
+    }
+  }
+  Trace("brc-macro") << "Instantiation term is: " << iterm << std::endl;
+  // instantiate
+  ProofChecker* pc = d_env.getProofNodeManager()->getChecker();
+  Node iarg = nm->mkNode(Kind::SEXPR, iterm);
+  Assert(qnorm[0].getNumChildren() == 1);
+  Trace("brc-macro") << "Instantiate: " << qnorm << " / " << iarg << std::endl;
+  Node inst = pc->checkDebug(ProofRule::INSTANTIATE, {qnorm}, {iarg});
+  cdp->addStep(inst, ProofRule::INSTANTIATE, {qnorm}, {iarg});
+  Trace("brc-macro") << "Have instantiation: " << inst << std::endl;
+  Node falsen = nm->mkConst(false);
+  if (normLits.size() > 1)
+  {
+    Assert(inst.getKind() == Kind::IMPLIES && inst[1] == falsen);
+    Assert(inst[0].getKind() == Kind::AND);
+    std::vector<Node> ipremises(inst[0].begin(), inst[0].end());
+    Node currTerm = iterm;
+    // always have proven iterm >= currTerm
+    Node src;
+    size_t index = 0;
+    do
+    {
+      Node next;
+      if (index + 1 < ipremises.size())
+      {
+        Assert(currTerm.getKind() == Kind::ITE);
+        Node p1 =
+            nm->mkNode(isUpper ? Kind::LEQ : Kind::GEQ, currTerm, currTerm[1]);
+        Trace("brc-macro") << "...have " << p1 << std::endl;
+        Node p2 =
+            nm->mkNode(isUpper ? Kind::LEQ : Kind::GEQ, currTerm, currTerm[2]);
+        cdp->addTrustedStep(
+            p1, TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE, {}, {});
+        Trace("brc-macro") << "...have " << p2 << std::endl;
+        cdp->addTrustedStep(
+            p2, TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE, {}, {});
+        if (currTerm != iterm)
+        {
+          Assert(!src.isNull());
+          // must prove iterm <= currTerm[2], for proving transitivity to the
+          // next literals
+          next = proveTransIneq(cdp, src, p2);
+          // must prove iterm <= currTerm[1], for proving the current literal
+          // below
+          src = proveTransIneq(cdp, src, p1);
+        }
+        else
+        {
+          src = p1;
+          next = p2;
+        }
+        currTerm = currTerm[2];
+      }
+      else
+      {
+        Trace("brc-macro") << "...base term " << currTerm << std::endl;
+        // src should already be set and entail the target below
+      }
+      // prove
+      Node tgt = ipremises[index];
+      index++;
+      Assert(!src.isNull());
+      if (src != tgt)
+      {
+        proveIneqWeaken(cdp, src, tgt);
+      }
+      src = next;
+    } while (!src.isNull());
+    cdp->addStep(inst[0], ProofRule::AND_INTRO, ipremises, {});
+    cdp->addStep(falsen, ProofRule::MODUS_PONENS, {inst[0], inst}, {});
+  }
+  else
+  {
+    Node ief = inst.eqNode(falsen);
+    Trace("brc-macro") << "Prove (base): " << ief << std::endl;
+    cdp->addTrustedStep(
+        ief, TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE, {}, {});
+    cdp->addStep(falsen, ProofRule::EQ_RESOLVE, {inst, ief}, {});
+  }
+  cdp->addStep(qnorm.notNode(), ProofRule::SCOPE, {falsen}, {qnorm});
+  Node qneqf = qnorm.eqNode(falsen);
+  cdp->addStep(qneqf, ProofRule::FALSE_INTRO, {qnorm.notNode()}, {});
+  Assert(eq[1] == falsen);
+  if (!eqnorm.isNull())
+  {
+    cdp->addStep(eq, ProofRule::TRANS, {eqnorm, qneqf}, {});
+  }
+  else
+  {
+    Assert(qneqf == eq);
+  }
+  return true;
+}
+
 bool BasicRewriteRCons::ensureProofMacroDtVarExpand(CDProof* cdp,
                                                     const Node& eq)
 {
@@ -2482,7 +2906,8 @@ bool BasicRewriteRCons::ensureProofArithPolyNormRel(CDProof* cdp,
     Trace("brc-macro") << "...fail premise" << std::endl;
     return false;
   }
-  ProofRule rrule = isBv ? ProofRule::BV_POLY_NORM_EQ : ProofRule::ARITH_POLY_NORM_REL;
+  ProofRule rrule =
+      isBv ? ProofRule::BV_POLY_NORM_EQ : ProofRule::ARITH_POLY_NORM_REL;
   if (!cdp->addStep(eq, rrule, {premise}, {eq}))
   {
     Trace("brc-macro") << "...fail application" << std::endl;

--- a/src/rewriter/basic_rewrite_rcons.h
+++ b/src/rewriter/basic_rewrite_rcons.h
@@ -319,6 +319,16 @@ class BasicRewriteRCons : protected EnvObj
   bool ensureProofMacroQuantVarElimEq(CDProof* cdp, const Node& eq);
   /**
    * Elaborate a rewrite eq that was proven by
+   * ProofRewriteRule::MACRO_QUANT_VAR_ELIM_INEQ.
+   *
+   * @param cdp The proof to add to.
+   * @param eq The rewrite proven by
+   * ProofRewriteRule::MACRO_QUANT_VAR_ELIM_INEQ.
+   * @return true if added a closed proof of eq to cdp.
+   */
+  bool ensureProofMacroQuantVarElimIneq(CDProof* cdp, const Node& eq);
+  /**
+   * Elaborate a rewrite eq that was proven by
    * ProofRewriteRule::MACRO_QUANT_DT_VAR_EXPAND.
    *
    * @param cdp The proof to add to.


### PR DESCRIPTION
This expands the macro `MACRO_QUANT_VAR_ELIM_INEQ` which for example proves:
`(forall ((x Int) (y Int)) (=> (> x a) (P y)) = (forall ((y Int)) (P y))`

The proof expansion is based on miniscoping `y`, instantiating `x` with a "max term" e.g. `a+1` in the above example, and rewriting the result.

This avoids having to introduce an new rule for this case.