### PR TITLE
Make proof constructor for strings more robust

### DIFF
--- a/src/theory/strings/infer_proof_cons.cpp
+++ b/src/theory/strings/infer_proof_cons.cpp
@@ -676,8 +676,7 @@ bool InferProofCons::convert(Env& env,
           Trace("strings-ipc-core") << "Main equality after " << rule << " "
                                     << mainEqMain << std::endl;
           // either equal or rewrites to it
-          std::vector<Node> cexp;
-          if (psb.applyPredTransform(mainEqMain, conc, cexp))
+          if (applyPredTransformConversion(mainEqMain, conc, psb))
           {
             // requires that length success is also true
             useBuffer = true;
@@ -903,43 +902,14 @@ bool InferProofCons::convert(Env& env,
           Trace("strings-ipc-red") << "...success!" << std::endl;
           useBuffer = true;
         }
+        else if (applyPredTransformConversion(red, conc, psb))
+        {
+          Trace("strings-ipc-red") << "...success!" << std::endl;
+          useBuffer = true;
+        }
         else
         {
-          std::vector<Node> cexp;
-          // get the equalities where the reduction is different
-          std::vector<Node> matchConds;
-          expr::getConversionConditions(red, conc, matchConds);
-          Trace("strings-ipc-red")
-              << "...need to prove " << matchConds << std::endl;
-          // To simplify the proof transformation step below, we manually
-          // unpurify skolems from the concluded reduction. This
-          // make it more likely the applyPredTransform step does not have to
-          // resort to original forms. In particular, the strings rewriter
-          // currently does not respect the property that if
-          // t ---> c for constant c, then getOriginalForm(t) ---> c. This
-          // means we should attempt to replay the term which was used by the
-          // strings skolem cache to justify k = c, which is its unpurified
-          // form t, not its original form.
-          for (const Node& mc : matchConds)
-          {
-            Node mcu = SkolemManager::getUnpurifiedForm(mc[0]);
-            if (mcu != mc[0])
-            {
-              Node mceq = mc[0].eqNode(mcu);
-              psb.addStep(ProofRule::SKOLEM_INTRO, {}, {mc[0]}, mceq);
-              cexp.push_back(mceq);
-            }
-          }
-          // either equal or rewrites to it
-          if (psb.applyPredTransform(red, conc, cexp))
-          {
-            Trace("strings-ipc-red") << "...success!" << std::endl;
-            useBuffer = true;
-          }
-          else
-          {
-            Trace("strings-ipc-red") << "...failed to reduce" << std::endl;
-          }
+          Trace("strings-ipc-red") << "...failed to reduce" << std::endl;
         }
       }
     }
@@ -1706,6 +1676,37 @@ std::string InferProofCons::identify() const
   return "strings::InferProofCons";
 }
 
+bool InferProofCons::applyPredTransformConversion(const Node& a,
+                                                  const Node& b,
+                                                  TheoryProofStepBuffer& psb)
+{
+  std::vector<Node> cexp;
+  // get the equalities where the reduction is different
+  std::vector<Node> matchConds;
+  expr::getConversionConditions(a, b, matchConds);
+  Trace("strings-ipc-red") << "...need to prove " << matchConds << std::endl;
+  // To simplify the proof transformation step below, we manually
+  // unpurify skolems from the concluded reduction. This
+  // make it more likely the applyPredTransform step does not have to
+  // resort to original forms. In particular, the strings rewriter
+  // currently does not respect the property that if
+  // t ---> c for constant c, then getOriginalForm(t) ---> c. This
+  // means we should attempt to replay the term which was used by the
+  // strings skolem cache to justify k = c, which is its unpurified
+  // form t, not its original form.
+  for (const Node& mc : matchConds)
+  {
+    Node mcu = SkolemManager::getUnpurifiedForm(mc[0]);
+    if (mcu != mc[0])
+    {
+      Node mceq = mc[0].eqNode(mcu);
+      psb.addStep(ProofRule::SKOLEM_INTRO, {}, {mc[0]}, mceq);
+      cexp.push_back(mceq);
+    }
+  }
+  // either equal or rewrites to it
+  return psb.applyPredTransform(a, b, cexp);
+}
 }  // namespace strings
 }  // namespace theory
 }  // namespace cvc5::internal

--- a/src/theory/strings/infer_proof_cons.h
+++ b/src/theory/strings/infer_proof_cons.h
@@ -211,6 +211,23 @@ class InferProofCons : protected EnvObj, public ProofGenerator
                               const Node& eq,
                               const Node& conc,
                               bool isRev);
+  /**
+   * Prove b assuming a, return true if successful.
+   * This method relies on applying MACRO_SR_PRED_TRANSFORM to prove a rewrites
+   * to b. To make things more robust, we additionally look for subterms where
+   * a and b differ, and prove these separately. This often corresponds to
+   * showing the equivalence between two skolems, e.g. where b contains a
+   * skolem for an unrewritten term and a contains a skolem for a rewritten
+   * term.
+   * @param a The first predicate.
+   * @param b The second predicate.
+   * @param psb Reference to proof step buffer.
+   * @return true if we successfully add a step proving b via
+   * MACRO_SR_PRED_TRANSFORM from a.
+   */
+  static bool applyPredTransformConversion(const Node& a,
+                                           const Node& b,
+                                           TheoryProofStepBuffer& psb);
   /** The lazy fact map */
   NodeInferInfoMap d_lazyFactMap;
   /** Reference to the statistics for the theory of strings/sequences. */


### PR DESCRIPTION
This fixes a proof hole that was encountered in a run of SMT-LIB with `--decision=internal` and was previously added as a regression (regress0/strings/dd_str_term_529.smt2).

It changes the strings inference proof constructor to use a more targetted method for proving equivalence between expected/actual conclusions for a variable splitting lemma.