### PR TITLE
Fix #10256 by adding a lock to protect the ApiManager singleton

### DIFF
--- a/src/api/java/jni/api_utilities.cpp
+++ b/src/api/java/jni/api_utilities.cpp
@@ -90,6 +90,7 @@ jobject ApiManager::addGlobalReference(JNIEnv* env,
                                        jlong pointer,
                                        jobject object)
 {
+  std::lock_guard<std::mutex> guard(globalLock);
   jobject reference = env->NewGlobalRef(object);
   d_globalReferences[pointer].push_back(reference);
   return reference;
@@ -97,11 +98,13 @@ jobject ApiManager::addGlobalReference(JNIEnv* env,
 
 void ApiManager::addPluginPointer(jlong pointer, jlong pluginPointer)
 {
+  std::lock_guard<std::mutex> guard(globalLock);
   d_pluginPointers[pointer].push_back(pluginPointer);
 }
 
 void ApiManager::deletePointer(JNIEnv* env, jlong pointer)
 {
+  std::lock_guard<std::mutex> guard(globalLock);
   const std::vector<jobject>& refs = d_globalReferences[pointer];
   for (jobject ref : refs)
   {

--- a/src/api/java/jni/api_utilities.h
+++ b/src/api/java/jni/api_utilities.h
@@ -19,6 +19,7 @@
 #include <cvc5/cvc5_parser.h>
 #include <jni.h>
 
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -182,6 +183,10 @@ class ApiManager
    * the deletePointer method is called
    */
   std::map<jlong, std::vector<jlong> > d_pluginPointers;
+  /**
+   * Global lock for the singleton
+   */
+  std::mutex globalLock;
 };
 
 /**


### PR DESCRIPTION
Hello everyone,
this PR will add a lock to the `ApiManager` singleton that is used in the JNI bindings to protect it from concurrent access. This will close #10256 and prevent CVC5 from crashing when multiple solver instances are used in parallel.

The original bug can be reproduced like this:
```
private static void runParallel(int pNumberOfInstances, Runnable pTask)
    throws InterruptedException {
  ExecutorService pool = Executors.newFixedThreadPool(pNumberOfInstances);

  // Latches make sure that all threads are started at the *exact* same time
  CountDownLatch ready = new CountDownLatch(pNumberOfInstances);
  CountDownLatch go = new CountDownLatch(1);
  CountDownLatch done = new CountDownLatch(pNumberOfInstances);

  for (int i = 0; i < pNumberOfInstances; i++) {
    pool.submit(
        () -> {
          ready.countDown();
          try {
            go.await();
            pTask.run();
          } catch (Throwable e) {
            // Ignore exceptions
          } finally {
            done.countDown();
          }
        });
  }
  Preconditions.checkArgument(ready.await(2, TimeUnit.SECONDS));
  go.countDown();
  Preconditions.checkArgument(done.await(10, TimeUnit.SECONDS));
}

@Test
public void jniBug() throws InterruptedException {
  for (int r = 0; r < 100; r++) {
    System.out.println("starting round " + r);
    runParallel(
        10,
        () -> {
          TermManager tm = new TermManager();
          tm.deletePointer();
        });
  }
}
```