### PR TITLE
Fix proof checking failure in lambda lifting

### DIFF
--- a/src/theory/uf/lambda_lift.cpp
+++ b/src/theory/uf/lambda_lift.cpp
@@ -21,6 +21,7 @@
 #include "smt/env.h"
 #include "theory/uf/function_const.h"
 #include "expr/sort_type_size.h"
+#include "proof/proof.h"
 
 using namespace cvc5::internal::kind;
 
@@ -55,8 +56,21 @@ TrustNode LambdaLift::lift(Node node)
   {
     return TrustNode::mkTrustLemma(assertion);
   }
-  return d_epg->mkTrustNode(
-      assertion, ProofRule::MACRO_SR_PRED_INTRO, {}, {assertion});
+  Node skolem = getSkolemFor(node);
+  Assert (!skolem.isNull());
+  Node eq = skolem.eqNode(node);
+  // --------------- MACRO_SR_PRED_INTRO
+  // k = lambda x. t
+  // ------------------- MACRO_SR_PRED_INTRO
+  // forall x. (k x) = t
+  // We do this in two steps, where k -> lambda x. t is used as a subsitution
+  // to avoid rare proof checking errors where the conclusion is not
+  // provable in one step.
+  CDProof cdp(d_env);
+  cdp.addStep(eq, ProofRule::MACRO_SR_PRED_INTRO, {}, {eq});
+  cdp.addStep(assertion, ProofRule::MACRO_SR_PRED_INTRO, {eq}, {assertion});
+  std::shared_ptr<ProofNode> pf = cdp.getProofFor(assertion);
+  return d_epg->mkTrustNode(assertion, pf);
 }
 
 bool LambdaLift::needsLift(const Node& lam)
@@ -165,15 +179,12 @@ bool LambdaLift::isLambdaFunction(TNode n) const
 
 Node LambdaLift::getAssertionFor(TNode node)
 {
-  TNode skolem = getSkolemFor(node);
-  if (skolem.isNull())
-  {
-    return Node::null();
-  }
   Node assertion;
   Node lambda = FunctionConst::toLambda(node);
   if (!lambda.isNull())
   {
+    TNode skolem = getSkolemFor(node);
+    Assert (!skolem.isNull());
     NodeManager* nm = node.getNodeManager();
     // The new assertion
     std::vector<Node> children;
@@ -211,8 +222,8 @@ Node LambdaLift::getAssertionFor(TNode node)
 Node LambdaLift::getSkolemFor(TNode node)
 {
   Node skolem;
-  Kind k = node.getKind();
-  if (k == Kind::LAMBDA)
+  Node lambda = FunctionConst::toLambda(node);
+  if (!lambda.isNull())
   {
     // if a lambda, return the purification variable for the node. We ignore
     // lambdas with free variables, which can occur beneath quantifiers

--- a/src/theory/uf/lambda_lift.cpp
+++ b/src/theory/uf/lambda_lift.cpp
@@ -65,7 +65,9 @@ TrustNode LambdaLift::lift(Node node)
   // forall x. (k x) = t
   // We do this in two steps, where k -> lambda x. t is used as a subsitution
   // to avoid rare proof checking errors where the conclusion is not
-  // provable in one step.
+  // provable in one step. In particular, in some rare cases we have that
+  // rewrite(toOriginal(rewrite(F))) is not true. For instance, we may end
+  // up with (@ (@ f a) b) = (f a b) which does not rewrite to true.
   CDProof cdp(d_env);
   cdp.addStep(eq, ProofRule::MACRO_SR_PRED_INTRO, {}, {eq});
   cdp.addStep(assertion, ProofRule::MACRO_SR_PRED_INTRO, {eq}, {assertion});

--- a/src/theory/uf/lambda_lift.cpp
+++ b/src/theory/uf/lambda_lift.cpp
@@ -17,11 +17,11 @@
 
 #include "expr/node_algorithm.h"
 #include "expr/skolem_manager.h"
+#include "expr/sort_type_size.h"
 #include "options/uf_options.h"
+#include "proof/proof.h"
 #include "smt/env.h"
 #include "theory/uf/function_const.h"
-#include "expr/sort_type_size.h"
-#include "proof/proof.h"
 
 using namespace cvc5::internal::kind;
 
@@ -57,7 +57,7 @@ TrustNode LambdaLift::lift(Node node)
     return TrustNode::mkTrustLemma(assertion);
   }
   Node skolem = getSkolemFor(node);
-  Assert (!skolem.isNull());
+  Assert(!skolem.isNull());
   Node eq = skolem.eqNode(node);
   // --------------- MACRO_SR_PRED_INTRO
   // k = lambda x. t
@@ -184,7 +184,7 @@ Node LambdaLift::getAssertionFor(TNode node)
   if (!lambda.isNull())
   {
     TNode skolem = getSkolemFor(node);
-    Assert (!skolem.isNull());
+    Assert(!skolem.isNull());
     NodeManager* nm = node.getNodeManager();
     // The new assertion
     std::vector<Node> children;


### PR DESCRIPTION
This impacts only the (expert) higher-order logic solver.

This fixes a proof failure that I noticed on a dev branch when using `--no-uf-lazy-ll`.

The benchmark that fails cannot be solved in a timeout and thus can't be added.