### PR TITLE
Final updates to safe-options to make cvc5 main fully proof producing in safe mode

### DIFF
--- a/src/options/bv_options.toml
+++ b/src/options/bv_options.toml
@@ -94,7 +94,7 @@ name   = "Bitvector Theory"
 
 [[option]]
   name       = "bvSolver"
-  category   = "regular"
+  category   = "expert"
   long       = "bv-solver=MODE"
   type       = "BVSolver"
   default    = "BITBLAST"

--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -89,7 +89,7 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "varIneqElimQuant"
-  category   = "regular"
+  category   = "expert"
   long       = "var-ineq-elim-quant"
   type       = "bool"
   default    = "true"
@@ -1647,7 +1647,7 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "cegqiBv"
-  category   = "regular"
+  category   = "expert"
   long       = "cegqi-bv"
   type       = "bool"
   default    = "true"

--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -357,7 +357,7 @@ name   = "SMT Layer"
 
 [[option]]
   name       = "solveBVAsInt"
-  category   = "regular"
+  category   = "expert"
   long       = "solve-bv-as-int=MODE"
   type       = "SolveBVAsIntMode"
   default    = "OFF"

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -162,6 +162,12 @@ void SetDefaults::setDefaultsPre(Options& opts)
     SET_AND_NOTIFY(uf, ufSymmetryBreaker, false, "safe options");
     // always use cegqi midpoint, which avoids virtual term substitution
     SET_AND_NOTIFY(quantifiers, cegqiMidpoint, true, "safe options");
+    // bv-solver must be bitblast-internal for proofs
+    SET_AND_NOTIFY(
+        bv, bvSolver, options::BVSolver::BITBLAST_INTERNAL, "safe options");
+    // proofs not yet supported on main
+    SET_AND_NOTIFY(quantifiers, varIneqElimQuant, false, "safe options");
+    SET_AND_NOTIFY(quantifiers, cegqiBv, false, "safe options");
   }
   // implied options
   if (opts.smt.debugCheckModels)
@@ -1086,8 +1092,14 @@ bool SetDefaults::usesInputConversion(const Options& opts,
 bool SetDefaults::incompatibleWithProofs(Options& opts,
                                          std::ostream& reason) const
 {
+  // For the sake of making the performance of cvc5 robust to whether or not
+  // proofs are enabled, any silent change to options in this method is
+  // recommended to either be:
+  // (A) be an expert (possibly internally managed) option,
+  // (B) be the forced configuration when safe-options is enabled.
   if (opts.prop.satSolver == options::SatSolverMode::CADICAL)
   {
+    // this is an expert option, ok to silently change
     SET_AND_NOTIFY(prop,
                    satSolver,
                    options::SatSolverMode::MINISAT,
@@ -1124,17 +1136,20 @@ bool SetDefaults::incompatibleWithProofs(Options& opts,
   // options that are automatically set to support proofs
   if (opts.bv.bvAssertInput)
   {
+    // this is an expert option, ok to silently change
     SET_AND_NOTIFY_VAL_SYM(bv, bvAssertInput, false, "proofs");
   }
   // If proofs are required and the user did not specify a specific BV solver,
   // we make sure to use the proof producing BITBLAST_INTERNAL solver.
   if (isFullPf)
   {
+    // this is always set by safe options, ok to silently change
     SET_AND_NOTIFY_IF_NOT_USER_VAL_SYM(
         bv, bvSolver, options::BVSolver::BITBLAST_INTERNAL, "proofs");
   }
   if (options().arith.nlCov)
   {
+    // this is an expert option, ok to silently change
     SET_AND_NOTIFY_IF_NOT_USER(arith, nlCovVarElim, false, "proofs");
   }
   if (opts.smt.deepRestartMode != options::DeepRestartMode::NONE)
@@ -1170,12 +1185,14 @@ bool SetDefaults::incompatibleWithProofs(Options& opts,
   }
   if (opts.smt.proofMode == options::ProofMode::FULL_STRICT)
   {
+    // these are always disabled by safe options, ok to silently change
     // symmetry breaking does not have proof support
     SET_AND_NOTIFY(uf, ufSymmetryBreaker, false, "full strict proofs");
     // CEGQI with deltas and infinities is not supported
     SET_AND_NOTIFY(quantifiers, cegqiMidpoint, true, "full strict proofs");
     SET_AND_NOTIFY(quantifiers, cegqiUseInfInt, false, "full strict proofs");
     SET_AND_NOTIFY(quantifiers, cegqiUseInfReal, false, "full strict proofs");
+    // this is an expert option, ok to silently change
     // shared selectors are not supported
     SET_AND_NOTIFY(datatypes, dtSharedSelectors, false, "full strict proofs");
   }

--- a/test/regress/cli/regress1/nl/nra-cad-performance.smt2
+++ b/test/regress/cli/regress1/nl/nra-cad-performance.smt2
@@ -1,4 +1,5 @@
 ; Source: NRA/keymaera/ETCS-essentials-live-range2.proof-node1388.smt2
+; COMMAND-LINE: --var-ineq-elim-quant
 ; EXPECT: unsat
 ; REQUIRES: poly
 (set-logic NRA)

--- a/test/regress/cli/run_regression.py
+++ b/test/regress/cli/run_regression.py
@@ -199,13 +199,12 @@ class DslProofTester(Tester):
             benchmark_info.benchmark_ext != ".sy"
             and "unsat" in benchmark_info.expected_output.split()
         )
-   # NOTE: can try add ["--safe-options"] + 
+
     def run_internal(self, benchmark_info):
         return super().run_internal(
             benchmark_info._replace(
-                command_line_args=
-                ["--safe-options"] + benchmark_info.command_line_args +
-                ["--check-proofs", "--proof-granularity=dsl-rewrite"]
+                command_line_args=benchmark_info.command_line_args +
+                ["--check-proofs", "--proof-granularity=dsl-rewrite", "--proof-check=lazy"]
             )
         )
 

--- a/test/regress/cli/run_regression.py
+++ b/test/regress/cli/run_regression.py
@@ -199,12 +199,13 @@ class DslProofTester(Tester):
             benchmark_info.benchmark_ext != ".sy"
             and "unsat" in benchmark_info.expected_output.split()
         )
-
+   # NOTE: can try add ["--safe-options"] + 
     def run_internal(self, benchmark_info):
         return super().run_internal(
             benchmark_info._replace(
-                command_line_args=benchmark_info.command_line_args +
-                ["--check-proofs", "--proof-granularity=dsl-rewrite", "--proof-check=lazy"]
+                command_line_args=
+                ["--safe-options"] + benchmark_info.command_line_args +
+                ["--check-proofs", "--proof-granularity=dsl-rewrite"]
             )
         )
 


### PR DESCRIPTION
Demotes `solve-bv-as-int`, `bv-solver`,  `var-ineq-elim-quant`, and `cegqi-bv` to expert.

Ensures the latter three are manually disabled by default with safe options.

Note that proof support for all 4 of these should be available in the near future in which case they can be reclassified to "regular".