### PR TITLE
Use proof rule EXISTS_STRING_LENGTH in cex-guided instantiation

### DIFF
--- a/src/expr/elim_witness_converter.cpp
+++ b/src/expr/elim_witness_converter.cpp
@@ -16,6 +16,7 @@
 #include "expr/elim_witness_converter.h"
 
 #include "expr/skolem_manager.h"
+#include "proof/valid_witness_proof_generator.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
 #include "util/rational.h"
 
@@ -32,36 +33,62 @@ Node ElimWitnessNodeConverter::postConvert(Node n)
   {
     Trace("elim-witness") << "Eliminate " << n << std::endl;
     NodeManager* nm = nodeManager();
-    SkolemManager* skm = nm->getSkolemManager();
-    std::vector<Node> nchildren(n.begin(), n.end());
-    nchildren[1] = nchildren[1].notNode();
-    // must mark that the quantified formula cannot be eliminated by rewriting,
-    // so that the form of the quantified formula is preserved for the
-    // introduction below.
-    Node psan =
-        theory::quantifiers::QuantAttributes::mkAttrPreserveStructure(nm);
-    Node ipl = nm->mkNode(Kind::INST_PATTERN_LIST, psan);
-    nchildren.push_back(ipl);
-    // make the quantified formula
-    Node q = nm->mkNode(Kind::FORALL, nchildren);
-    Node qn = getNormalFormFor(q);
-    // should still be a FORALL due to above
-    Assert(qn.getKind() == Kind::FORALL);
-    Node k = skm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE,
-                                   {qn, nm->mkConstInt(Rational(0))});
-    // save the non-normalized version, which makes it easier to e.g.
-    // track proofs
-    d_exists.push_back(q.notNode());
+    std::vector<Node> pats;
+    Node k;
+    if (n.getNumChildren() == 3)
+    {
+      // see if it has a proof specification marking, in which case we can
+      // introduce a skolem and axiom in the proper way
+      Assert(n[2].getKind() == Kind::INST_PATTERN_LIST);
+      ProofRule r;
+      std::vector<Node> args;
+      if (ValidWitnessProofGenerator::getProofSpec(nm, n[2][0], r, args))
+      {
+        k = ValidWitnessProofGenerator::mkSkolem(nm, r, args);
+        Node ax = ValidWitnessProofGenerator::mkAxiom(nm, k, r, args);
+        Assert(!ax.isNull());
+        if (!ax.isNull())
+        {
+          d_axioms.push_back(ax);
+        }
+      }
+    }
+    if (k.isNull())
+    {
+      SkolemManager* skm = nm->getSkolemManager();
+      std::vector<Node> nchildren(n.begin(), n.end());
+      nchildren[1] = nchildren[1].notNode();
+      // must mark that the quantified formula cannot be eliminated by rewriting,
+      // so that the form of the quantified formula is preserved for the
+      // introduction below.
+      Node psan =
+          theory::quantifiers::QuantAttributes::mkAttrPreserveStructure(nm);
+      Node ipl = nm->mkNode(Kind::INST_PATTERN_LIST, psan);
+      nchildren.push_back(ipl);
+      // make the quantified formula
+      Node q = nm->mkNode(Kind::FORALL, nchildren);
+      Node qn = getNormalFormFor(q);
+      // should still be a FORALL due to above
+      Assert(qn.getKind() == Kind::FORALL);
+      k = skm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE,
+                                    {qn, nm->mkConstInt(Rational(0))});
+      // save the non-normalized version, which makes it easier to e.g.
+      // track proofs
+      d_axioms.push_back(q.notNode());
+    }
     return k;
   }
   return n;
 }
 
-Node ElimWitnessNodeConverter::getNormalFormFor(const Node& q) { return q; }
-
-const std::vector<Node>& ElimWitnessNodeConverter::getExistentials() const
+const std::vector<Node>& ElimWitnessNodeConverter::getAxioms() const
 {
-  return d_exists;
+  return d_axioms;
+}
+
+Node ElimWitnessNodeConverter::getNormalFormFor(const Node& q)
+{
+  return q;
 }
 
 }  // namespace cvc5::internal

--- a/src/expr/elim_witness_converter.cpp
+++ b/src/expr/elim_witness_converter.cpp
@@ -58,9 +58,9 @@ Node ElimWitnessNodeConverter::postConvert(Node n)
       SkolemManager* skm = nm->getSkolemManager();
       std::vector<Node> nchildren(n.begin(), n.end());
       nchildren[1] = nchildren[1].notNode();
-      // must mark that the quantified formula cannot be eliminated by rewriting,
-      // so that the form of the quantified formula is preserved for the
-      // introduction below.
+      // must mark that the quantified formula cannot be eliminated by
+      // rewriting, so that the form of the quantified formula is preserved for
+      // the introduction below.
       Node psan =
           theory::quantifiers::QuantAttributes::mkAttrPreserveStructure(nm);
       Node ipl = nm->mkNode(Kind::INST_PATTERN_LIST, psan);
@@ -71,7 +71,7 @@ Node ElimWitnessNodeConverter::postConvert(Node n)
       // should still be a FORALL due to above
       Assert(qn.getKind() == Kind::FORALL);
       k = skm->mkSkolemFunction(SkolemId::QUANTIFIERS_SKOLEMIZE,
-                                    {qn, nm->mkConstInt(Rational(0))});
+                                {qn, nm->mkConstInt(Rational(0))});
       // save the non-normalized version, which makes it easier to e.g.
       // track proofs
       d_axioms.push_back(q.notNode());
@@ -86,9 +86,6 @@ const std::vector<Node>& ElimWitnessNodeConverter::getAxioms() const
   return d_axioms;
 }
 
-Node ElimWitnessNodeConverter::getNormalFormFor(const Node& q)
-{
-  return q;
-}
+Node ElimWitnessNodeConverter::getNormalFormFor(const Node& q) { return q; }
 
 }  // namespace cvc5::internal

--- a/src/expr/elim_witness_converter.h
+++ b/src/expr/elim_witness_converter.h
@@ -72,7 +72,7 @@ class ElimWitnessNodeConverter : protected EnvObj, public NodeConverter
   /**
    * Get the normal form of a quantified formula for which we are introducing
    * a skolem variable based on eliminating a witness term.
-  */
+   */
   virtual Node getNormalFormFor(const Node& q);
 
  private:

--- a/src/expr/elim_witness_converter.h
+++ b/src/expr/elim_witness_converter.h
@@ -27,8 +27,33 @@ namespace cvc5::internal {
 
 /**
  * Node converter to eliminate all terms of kind WITNESS. Each term replaced
- * in this way is captured by an existential, which can be obtained by
- * getExistentials.
+ * in this way is captured by a skolem that witnesses the axiom for that
+ * witness.
+ *
+ * Witness terms are required to track their justification as part of their
+ * AST. In particular, it is required that all terms of kind WITNESS are given
+ * an instantiation attribute of the form:
+ *   (INST_ATTRIBUTE "witness" (SEXPR r a1 ... an))
+ * where r is the (integer value of) a proof rule and a1...an are arguments
+ * to that proof rule. This instantiation attribute is always constructed
+ * assuming that ValidWitnessProofGenerator
+ * (proof/valid_witness_proof_generator.h) is used to construct the witness
+ * terms. These annotations are expected to be robust to rewriting and
+ * substitution, e.g. rewriting (SEXPR r a1 ... an) does not change whether
+ * it is a valid input to the definition of a proof rule. (Note this is not the
+ * case for ProofRule::EXISTS_INV_CONDITION, which is why
+ * ProofRule::MACRO_EXISTS_INV_CONDITION is used internally).
+ *
+ * For each witness of this form, we replace the witness by its corresponding
+ * skolem and collect its corresponding axiom, defining what lemma we can
+ * assume about it, which can be retrieved via ::getAxioms in this class.
+ *
+ * Note that we use WITNESS terms for two reasons:
+ * (1) (witness x (= x t)) can naturally rewrite to t, which we wish to
+ * infer when applicable by substitution + rewriting.
+ * (2) witness terms trigger this class to recognize when axioms should be
+ * added as lemmas. In other words, at the moment witness terms are
+ * eliminated, we ensure their axiom is recorded as well.
  */
 class ElimWitnessNodeConverter : protected EnvObj, public NodeConverter
 {
@@ -41,19 +66,18 @@ class ElimWitnessNodeConverter : protected EnvObj, public NodeConverter
    */
   Node postConvert(Node n) override;
   /**
-   * Get the existentials
+   * Get the axioms
    */
-  const std::vector<Node>& getExistentials() const;
-
+  const std::vector<Node>& getAxioms() const;
   /**
    * Get the normal form of a quantified formula for which we are introducing
    * a skolem variable based on eliminating a witness term.
-   */
+  */
   virtual Node getNormalFormFor(const Node& q);
 
  private:
-  /** The list of existentials introduced by eliminating witness */
-  std::vector<Node> d_exists;
+  /** The list of axioms introduced by eliminating witness */
+  std::vector<Node> d_axioms;
 };
 
 }  // namespace cvc5::internal

--- a/src/proof/alf/alf_node_converter.cpp
+++ b/src/proof/alf/alf_node_converter.cpp
@@ -733,7 +733,9 @@ bool AlfNodeConverter::isHandledSkolemId(SkolemId id)
     case SkolemId::BAGS_DISTINCT_ELEMENTS_SIZE:
     case SkolemId::BAGS_MAP_SUM:
     case SkolemId::TABLES_GROUP_PART:
-    case SkolemId::TABLES_GROUP_PART_ELEMENT: return true;
+    case SkolemId::TABLES_GROUP_PART_ELEMENT:
+    case SkolemId::WITNESS_STRING_LENGTH:
+    case SkolemId::WITNESS_INV_CONDITION: return true;
     default: break;
   }
   return false;

--- a/src/proof/alf/alf_node_converter.cpp
+++ b/src/proof/alf/alf_node_converter.cpp
@@ -734,8 +734,7 @@ bool AlfNodeConverter::isHandledSkolemId(SkolemId id)
     case SkolemId::BAGS_MAP_SUM:
     case SkolemId::TABLES_GROUP_PART:
     case SkolemId::TABLES_GROUP_PART_ELEMENT:
-    case SkolemId::WITNESS_STRING_LENGTH:
-    case SkolemId::WITNESS_INV_CONDITION: return true;
+    case SkolemId::WITNESS_STRING_LENGTH: return true;
     default: break;
   }
   return false;

--- a/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
@@ -1027,7 +1027,7 @@ bool CegInstantiator::doAddInstantiation(std::vector<Node>& vars,
       }
       PreprocessElimWitnessNodeConverter ewc(d_env, d_qstate.getValuation());
       Node sc = ewc.convert(s);
-      const std::vector<Node>& wexists = ewc.getExistentials();
+      const std::vector<Node>& wexists = ewc.getAxioms();
       exists.insert(exists.end(), wexists.begin(), wexists.end());
       svec.push_back(sc);
     }


### PR DESCRIPTION
Follow up to https://github.com/cvc5/cvc5/pull/11825.

Makes the witness elimination utility invoke the appropriate proof rule when available.

This is now available for `ProofRule::EXISTS_STRING_LENGTH`, which fills two proof holes on the regression `regress1/quantifiers/issue8344-cegqi-string-witness.smt2 `.