### PR TITLE
Export ParserEndOfFileException class

### DIFF
--- a/include/cvc5/cvc5_parser.h
+++ b/include/cvc5/cvc5_parser.h
@@ -412,7 +412,7 @@ class CVC5_EXPORT ParserException : public CVC5ApiException
  * An end of file exception.
  * If thrown, API objects can still be used
  */
-class ParserEndOfFileException : public ParserException
+class CVC5_EXPORT ParserEndOfFileException : public ParserException
 {
  public:
   /** default constructor */

--- a/test/binary/CMakeLists.txt
+++ b/test/binary/CMakeLists.txt
@@ -38,16 +38,13 @@ if (USE_EDITLINE)
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
   set_tests_properties(interactive_shell_parser_inc PROPERTIES LABELS "binary")
-  # TODO (see #10414): test this regardless of the guard
-  if (NOT APPLE)
-    add_test(
-      NAME interactive_shell_define_fun_rec_multiline
-      COMMAND
-      "${Python_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/test/binary/interactive_shell_define_fun_rec_multiline.py"
-      WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
-    )
-    set_tests_properties(interactive_shell_define_fun_rec_multiline PROPERTIES LABELS "binary")
-  endif()
+  add_test(
+    NAME interactive_shell_define_fun_rec_multiline
+    COMMAND
+    "${Python_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/test/binary/interactive_shell_define_fun_rec_multiline.py"
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+  )
+  set_tests_properties(interactive_shell_define_fun_rec_multiline PROPERTIES LABELS "binary")
   add_test(
     NAME issue_10258
     COMMAND


### PR DESCRIPTION
Fixes #10414 and duplicate #11146.

The function `InteractiveShell::readAndExecCommands()` is designed to catch `ParserEndOfFile` exceptions thrown by `Lexer::parseError`. However, if the exception class is not exported and the cvc5 binary is linked against a shared version of the cvc5 parser library, the exception is interpreted as its exported superclass, `ParserException`. This results in unintended behavior.