### PR TITLE
java: Fix cast of TermManager pointer in addPlugin

### DIFF
--- a/src/api/java/jni/api_plugin.cpp
+++ b/src/api/java/jni/api_plugin.cpp
@@ -19,7 +19,7 @@
 using namespace cvc5;
 
 ApiPlugin::ApiPlugin(TermManager& tm, JNIEnv* env, jobject plugin)
-    : Plugin(tm), d_env(env), d_tm(tm), d_plugin(plugin)
+    : Plugin(tm), d_env(env), d_plugin(plugin)
 {
 }
 

--- a/src/api/java/jni/api_plugin.h
+++ b/src/api/java/jni/api_plugin.h
@@ -59,8 +59,6 @@ class ApiPlugin : public cvc5::Plugin
 
   /** Reference to java environment */
   JNIEnv* d_env;
-  /** Reference to the term manager */
-  cvc5::TermManager& d_tm;
   /** Reference to java plugin object */
   jobject d_plugin;
 };

--- a/src/api/java/jni/solver.cpp
+++ b/src/api/java/jni/solver.cpp
@@ -1056,7 +1056,7 @@ Java_io_github_cvc5_Solver_addPlugin(JNIEnv* env,
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   Solver* solver = reinterpret_cast<Solver*>(pointer);
-  TermManager* tm = reinterpret_cast<TermManager*>(pointer);
+  TermManager* tm = reinterpret_cast<TermManager*>(termManagerPointer);
   ApiManager* am = ApiManager::currentAM();
   jobject pluginReference = am->addGlobalReference(env, pointer, plugin);
   ApiPlugin* p = new ApiPlugin(*tm, env, pluginReference);


### PR DESCRIPTION
Despite the incorrect cast of the `TermManager` pointer, we did not encounter any issues because the pointer is not used by the  `Plugin` C++ class.