### PR TITLE
java: Enhance concurrency by tracking global refs per solver instance

### DIFF
--- a/src/api/java/CMakeLists.txt
+++ b/src/api/java/CMakeLists.txt
@@ -277,6 +277,8 @@ message(STATUS "JAVA_AWT_INCLUDE_PATH: ${JAVA_AWT_INCLUDE_PATH}")
 set(jni_files
   jni/api_plugin.cpp
   jni/api_plugin.h
+  jni/api_solver.cpp
+  jni/api_solver.h
   jni/api_utilities.cpp
   jni/datatype.cpp
   jni/command.cpp

--- a/src/api/java/jni/api_solver.cpp
+++ b/src/api/java/jni/api_solver.cpp
@@ -1,0 +1,50 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Daniel Larraz
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2025 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The cvc5 Java API.
+ */
+ 
+#include <cvc5/cvc5.h>
+
+#include "api_solver.h"
+#include "api_plugin.h"
+
+using namespace cvc5;
+
+ApiSolver::ApiSolver(TermManager& tm) : Solver(tm) {}
+
+jobject ApiSolver::addGlobalReference(JNIEnv* env, jobject object)
+{
+  jobject reference = env->NewGlobalRef(object);
+  d_globalReferences.push_back(reference);
+  return reference;
+}
+
+void ApiSolver::addPluginPointer(jlong pluginPointer)
+{
+  d_pluginPointers.push_back(pluginPointer);
+}
+
+void ApiSolver::deletePointers(JNIEnv* env)
+{
+  for (jobject ref : d_globalReferences)
+  {
+    env->DeleteGlobalRef(ref);
+  }
+  for (jlong p : d_pluginPointers)
+  {
+    ApiPlugin* plugin = reinterpret_cast<ApiPlugin*>(p);
+    delete plugin;
+  }
+  d_globalReferences.clear();
+  d_pluginPointers.clear();
+}

--- a/src/api/java/jni/api_solver.cpp
+++ b/src/api/java/jni/api_solver.cpp
@@ -12,10 +12,11 @@
  *
  * The cvc5 Java API.
  */
- 
-#include <cvc5/cvc5.h>
 
 #include "api_solver.h"
+
+#include <cvc5/cvc5.h>
+
 #include "api_plugin.h"
 
 using namespace cvc5;

--- a/src/api/java/jni/api_solver.h
+++ b/src/api/java/jni/api_solver.h
@@ -29,6 +29,9 @@ class ApiSolver : public cvc5::Solver
   /**
    * Create a new global reference to the object referred to by the obj
    * argument, and store the object to be disposed of later.
+   *
+   * Intended for objects requiring global lifetime management across JNI calls.
+   * Currently used for oracles and plugins.
    */
   jobject addGlobalReference(JNIEnv* env, jobject object);
   /**

--- a/src/api/java/jni/api_solver.h
+++ b/src/api/java/jni/api_solver.h
@@ -1,0 +1,56 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Daniel Larraz
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2025 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The cvc5 Java API.
+ */
+
+#ifndef CVC5__API_SOLVER_H
+#define CVC5__API_SOLVER_H
+#include <cvc5/cvc5.h>
+#include <jni.h>
+
+class ApiSolver : public cvc5::Solver
+{
+ public:
+  /**
+   * Construct an ApiSolver.
+   */
+  ApiSolver(cvc5::TermManager& tm);
+
+  /**
+   * Create a new global reference to the object referred to by the obj
+   * argument, and store the object to be disposed of later.
+   */
+  jobject addGlobalReference(JNIEnv* env, jobject object);
+  /**
+   * Store a plugin pointer to be deleted later.
+   */
+  void addPluginPointer(jlong pluginPointer);
+  /**
+   * Delete pointers and global references.
+   */
+  void deletePointers(JNIEnv* env);
+
+ private:
+  /**
+   * A vector of jni global references that need to be freed when
+   * the deletePointers method is called.
+   */
+  std::vector<jobject> d_globalReferences;
+  /**
+   * A vector of ApiPlugin pointers that need to be freed when
+   * the deletePointers method is called.
+   */
+  std::vector<jlong> d_pluginPointers;
+};
+
+#endif  // CVC5__API_SOLVER_H

--- a/src/api/java/jni/api_utilities.cpp
+++ b/src/api/java/jni/api_utilities.cpp
@@ -18,8 +18,6 @@
 #include <string>
 #include <vector>
 
-#include "api_plugin.h"
-
 jobjectArray getStringArrayFromStringVector(
     JNIEnv* env, const std::vector<std::string>& cStrings)
 {
@@ -78,41 +76,4 @@ cvc5::Term applyOracle(JNIEnv* env,
   jlong termPointer = env->GetLongField(jTerm, pointer);
   cvc5::Term* term = reinterpret_cast<cvc5::Term*>(termPointer);
   return *term;
-}
-
-ApiManager* ApiManager::currentAM()
-{
-  static ApiManager am;
-  return &am;
-}
-
-jobject ApiManager::addGlobalReference(JNIEnv* env,
-                                       jlong pointer,
-                                       jobject object)
-{
-  jobject reference = env->NewGlobalRef(object);
-  d_globalReferences[pointer].push_back(reference);
-  return reference;
-}
-
-void ApiManager::addPluginPointer(jlong pointer, jlong pluginPointer)
-{
-  d_pluginPointers[pointer].push_back(pluginPointer);
-}
-
-void ApiManager::deletePointer(JNIEnv* env, jlong pointer)
-{
-  const std::vector<jobject>& refs = d_globalReferences[pointer];
-  for (jobject ref : refs)
-  {
-    env->DeleteGlobalRef(ref);
-  }
-  const std::vector<jlong>& pointers = d_pluginPointers[pointer];
-  for (jlong p : pointers)
-  {
-    ApiPlugin* plugin = reinterpret_cast<ApiPlugin*>(p);
-    delete plugin;
-  }
-  d_globalReferences.erase(pointer);
-  d_pluginPointers.erase(pointer);
 }

--- a/src/api/java/jni/api_utilities.h
+++ b/src/api/java/jni/api_utilities.h
@@ -145,7 +145,6 @@ jobject getDoubleObject(JNIEnv* env, double value);
  */
 jobject getBooleanObject(JNIEnv* env, bool value);
 
-
 /**
  * @param env jni environment
  * @param solverRef a global reference to java Solver object

--- a/src/api/java/jni/api_utilities.h
+++ b/src/api/java/jni/api_utilities.h
@@ -145,44 +145,6 @@ jobject getDoubleObject(JNIEnv* env, double value);
  */
 jobject getBooleanObject(JNIEnv* env, bool value);
 
-/**
- * The java api manager.
- *
- * It is a singleton that is accessible via ApiManager::currentAM().
- */
-class ApiManager
-{
- public:
-  /**
-   * Get the singleton instance.
-   */
-  static ApiManager* currentAM();
-  /**
-   * Create a new global reference to the object referred to by the obj
-   * argument, and store the object to be disposed of later.
-   */
-  jobject addGlobalReference(JNIEnv* env, jlong pointer, jobject object);
-  /**
-   * Store a plugin pointer to be deleted later.
-   */
-  void addPluginPointer(jlong pointer, jlong pluginPointer);
-  /**
-   * Delete resources associated with pointer.
-   */
-  void deletePointer(JNIEnv* env, jlong pointer);
-
- private:
-  /**
-   * A map from pointers to jni global references that need to be freed when
-   * the deletePointer method is called
-   */
-  std::map<jlong, std::vector<jobject> > d_globalReferences;
-  /**
-   * A map to ApiPlugin pointers that need to be freed when
-   * the deletePointer method is called
-   */
-  std::map<jlong, std::vector<jlong> > d_pluginPointers;
-};
 
 /**
  * @param env jni environment

--- a/src/api/java/jni/solver.cpp
+++ b/src/api/java/jni/solver.cpp
@@ -17,9 +17,9 @@
 
 #include "api/java/jni/api_utilities.h"
 #include "api_plugin.h"
+#include "api_solver.h"
 #include "api_utilities.h"
 #include "io_github_cvc5_Solver.h"
-#include "api_solver.h"
 
 using namespace cvc5;
 

--- a/src/api/java/jni/solver.cpp
+++ b/src/api/java/jni/solver.cpp
@@ -19,6 +19,7 @@
 #include "api_plugin.h"
 #include "api_utilities.h"
 #include "io_github_cvc5_Solver.h"
+#include "api_solver.h"
 
 using namespace cvc5;
 
@@ -33,7 +34,7 @@ JNIEXPORT jlong JNICALL Java_io_github_cvc5_Solver_newSolver(JNIEnv* env,
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   TermManager* tm = reinterpret_cast<TermManager*>(tmPointer);
-  Solver* solver = new Solver(*tm);
+  ApiSolver* solver = new ApiSolver(*tm);
   return reinterpret_cast<jlong>(solver);
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, 0);
 }
@@ -47,8 +48,9 @@ JNIEXPORT void JNICALL Java_io_github_cvc5_Solver_deletePointer(JNIEnv* env,
                                                                 jobject,
                                                                 jlong pointer)
 {
-  ApiManager::currentAM()->deletePointer(env, pointer);
-  delete (reinterpret_cast<Solver*>(pointer));
+  ApiSolver* api_solver = reinterpret_cast<ApiSolver*>(pointer);
+  api_solver->deletePointers(env);
+  delete api_solver;
 }
 
 /*
@@ -1024,9 +1026,8 @@ Java_io_github_cvc5_Solver_declareOracleFun(JNIEnv* env,
                                             jobject oracle)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
-  ApiManager* am = ApiManager::currentAM();
-  jobject oracleReference = am->addGlobalReference(env, pointer, oracle);
-  Solver* solver = reinterpret_cast<Solver*>(pointer);
+  ApiSolver* api_solver = reinterpret_cast<ApiSolver*>(pointer);
+  jobject oracleReference = api_solver->addGlobalReference(env, oracle);
   const char* s = env->GetStringUTFChars(jSymbol, nullptr);
   std::string cSymbol(s);
   Sort* sort = reinterpret_cast<Sort*>(sortPointer);
@@ -1037,7 +1038,7 @@ Java_io_github_cvc5_Solver_declareOracleFun(JNIEnv* env,
         return term;
       };
   Term* retPointer =
-      new Term(solver->declareOracleFun(cSymbol, sorts, *sort, fn));
+      new Term(api_solver->declareOracleFun(cSymbol, sorts, *sort, fn));
   return reinterpret_cast<jlong>(retPointer);
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, 0);
 }
@@ -1055,13 +1056,12 @@ Java_io_github_cvc5_Solver_addPlugin(JNIEnv* env,
                                      jobject plugin)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
-  Solver* solver = reinterpret_cast<Solver*>(pointer);
+  ApiSolver* api_solver = reinterpret_cast<ApiSolver*>(pointer);
   TermManager* tm = reinterpret_cast<TermManager*>(termManagerPointer);
-  ApiManager* am = ApiManager::currentAM();
-  jobject pluginReference = am->addGlobalReference(env, pointer, plugin);
+  jobject pluginReference = api_solver->addGlobalReference(env, plugin);
   ApiPlugin* p = new ApiPlugin(*tm, env, pluginReference);
-  am->addPluginPointer(pointer, reinterpret_cast<jlong>(p));
-  solver->addPlugin(*p);
+  api_solver->addPluginPointer(reinterpret_cast<jlong>(p));
+  api_solver->addPlugin(*p);
 
   CVC5_JAVA_API_TRY_CATCH_END(env);
 }

--- a/src/api/java/jni/term_manager.cpp
+++ b/src/api/java/jni/term_manager.cpp
@@ -43,7 +43,6 @@ JNIEXPORT jlong JNICALL Java_io_github_cvc5_TermManager_newTermManager(JNIEnv*,
 JNIEXPORT void JNICALL Java_io_github_cvc5_TermManager_deletePointer(
     JNIEnv* env, jobject, jlong pointer)
 {
-  ApiManager::currentAM()->deletePointer(env, pointer);
   delete (reinterpret_cast<TermManager*>(pointer));
 }
 


### PR DESCRIPTION
This fixes #10256 by enabling different threads to concurrently run and free the memory of their own solver instances.