### PR TITLE
Remove spurious handling of witness in model values

### DIFF
--- a/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
@@ -1434,14 +1434,6 @@ void CegInstantiator::processAssertions() {
 Node CegInstantiator::getModelValue(Node n)
 {
   Node mv = d_treg.getModel()->getValue(n);
-  // if the model value is not constant, it may require some processing
-  if (!mv.isConst())
-  {
-    // Witness terms with identifiers may appear in the model. We require
-    // dropping their annotations here.
-    AnnotationElimNodeConverter aenc(nodeManager());
-    mv = aenc.convert(mv);
-  }
   return mv;
 }
 

--- a/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
@@ -1434,6 +1434,8 @@ void CegInstantiator::processAssertions() {
 Node CegInstantiator::getModelValue(Node n)
 {
   Node mv = d_treg.getModel()->getValue(n);
+  // if mv is a witness term, we require keeping its annotation, which may
+  // specify its proof.
   return mv;
 }
 

--- a/src/theory/quantifiers/proof_checker.cpp
+++ b/src/theory/quantifiers/proof_checker.cpp
@@ -17,6 +17,7 @@
 
 #include "expr/node_algorithm.h"
 #include "expr/skolem_manager.h"
+#include "proof/valid_witness_proof_generator.h"
 #include "theory/builtin/proof_checker.h"
 #include "theory/quantifiers/skolemize.h"
 
@@ -39,6 +40,7 @@ void QuantifiersProofRuleChecker::registerTo(ProofChecker* pc)
   pc->registerChecker(ProofRule::INSTANTIATE, this);
   pc->registerChecker(ProofRule::ALPHA_EQUIV, this);
   pc->registerChecker(ProofRule::QUANT_VAR_REORDERING, this);
+  pc->registerChecker(ProofRule::EXISTS_STRING_LENGTH, this);
 }
 
 Node QuantifiersProofRuleChecker::checkInternal(
@@ -76,6 +78,11 @@ Node QuantifiersProofRuleChecker::checkInternal(
     Assert(children.size() == 1);
     // note we may have more arguments than just the term vector
     if (children[0].getKind() != Kind::FORALL || args.empty())
+    {
+      return Node::null();
+    }
+    if (args[0].getKind() != Kind::SEXPR
+        || args[0].getNumChildren() != children[0][0].getNumChildren())
     {
       return Node::null();
     }
@@ -147,6 +154,13 @@ Node QuantifiersProofRuleChecker::checkInternal(
       return Node::null();
     }
     return eq;
+  }
+  else if (id == ProofRule::EXISTS_STRING_LENGTH)
+  {
+    Node k = ValidWitnessProofGenerator::mkSkolem(nodeManager(), id, args);
+    Node exists =
+        ValidWitnessProofGenerator::mkAxiom(nodeManager(), k, id, args);
+    return exists;
   }
 
   // no rule


### PR DESCRIPTION
Followup to https://github.com/cvc5/cvc5/pull/11835, ensures that annotations on witness terms are preserved, which is required for tracking proofs.

Also adds missing checks and cases in quantifiers proof checker, which had not been added.