### PR TITLE
Use more typical style for initializing vector in partition generator

### DIFF
--- a/src/theory/partition_generator.cpp
+++ b/src/theory/partition_generator.cpp
@@ -170,7 +170,8 @@ std::vector<Node> PartitionGenerator::collectLiterals(LiteralListType litType)
     }
     case LEMMA:
     {
-      std::vector<Node> lemmaNodes(d_lemmaLiterals.begin(), d_lemmaLiterals.end());
+      std::vector<Node> lemmaNodes(d_lemmaLiterals.begin(),
+                                   d_lemmaLiterals.end());
       unfilteredLiterals = lemmaNodes;
       break;
     }

--- a/src/theory/partition_generator.cpp
+++ b/src/theory/partition_generator.cpp
@@ -170,9 +170,7 @@ std::vector<Node> PartitionGenerator::collectLiterals(LiteralListType litType)
     }
     case LEMMA:
     {
-      std::vector<Node> lemmaNodes(d_lemmaLiterals.size());
-      std::copy(
-          d_lemmaLiterals.begin(), d_lemmaLiterals.end(), lemmaNodes.begin());
+      std::vector<Node> lemmaNodes(d_lemmaLiterals.begin(), d_lemmaLiterals.end());
       unfilteredLiterals = lemmaNodes;
       break;
     }


### PR DESCRIPTION
Fixes compilation errors in latest windows builds.

FYI @amaleewilson 