### PR TITLE
Fix corner case of block models

### DIFF
--- a/src/smt/model_blocker.cpp
+++ b/src/smt/model_blocker.cpp
@@ -83,7 +83,7 @@ Node ModelBlocker::getModelBlocker(const std::vector<Node>& assertions,
     std::vector<TNode> visit;
     visit.insert(visit.end(), asserts.begin(), asserts.end());
     TNode cur;
-    do
+    while (!visit.empty())
     {
       cur = visit.back();
       visit.pop_back();
@@ -214,7 +214,7 @@ Node ModelBlocker::getModelBlocker(const std::vector<Node>& assertions,
           }
         }
       }
-    } while (!visit.empty());
+    }
   }
   else
   {

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2865,6 +2865,7 @@ set(regress_1_tests
   regress1/proj-issue623-bv2nat-static.smt2
   regress1/proj-issue634-diff-mc.smt2
   regress1/proj-issue719-zll-repeat.smt2
+  regress1/proj-issue764-block-model.smt2
   regress1/proof00.smt2
   regress1/proofs/add_two_base.smt2
   regress1/proofs/alpha-eq-var-shadow.smt2

--- a/test/regress/cli/regress1/proj-issue764-block-model.smt2
+++ b/test/regress/cli/regress1/proj-issue764-block-model.smt2
@@ -1,0 +1,7 @@
+(set-logic QF_UF)
+(set-option :global-declarations true)
+(set-option :produce-models true)
+(declare-const _x0 Bool)
+(declare-const _x1 Bool)
+(check-sat)
+(block-model :literals)

--- a/test/regress/cli/regress1/proj-issue764-block-model.smt2
+++ b/test/regress/cli/regress1/proj-issue764-block-model.smt2
@@ -1,3 +1,4 @@
+; EXPECT: sat
 (set-logic QF_UF)
 (set-option :global-declarations true)
 (set-option :produce-models true)


### PR DESCRIPTION
Occurs when assertions are empty. Fixes https://github.com/cvc5/cvc5-projects/issues/764.