### PR TITLE
Introduced non-closed converter, more robust guard for non-closed terms in model blocker

### DIFF
--- a/src/expr/CMakeLists.txt
+++ b/src/expr/CMakeLists.txt
@@ -121,6 +121,8 @@ libcvc5_add_sources(
   sygus_term_enumerator.h
   variadic_trie.cpp
   variadic_trie.h
+  non_closed_node_converter.cpp
+  non_closed_node_converter.h
 )
 
 libcvc5_add_sources(GENERATED

--- a/src/expr/non_closed_node_converter.cpp
+++ b/src/expr/non_closed_node_converter.cpp
@@ -19,7 +19,9 @@
 
 namespace cvc5::internal {
 
-NonClosedNodeConverter::NonClosedNodeConverter(Env& env) : EnvObj(env), NodeConverter(nodeManager()) {
+NonClosedNodeConverter::NonClosedNodeConverter(Env& env)
+    : EnvObj(env), NodeConverter(nodeManager())
+{
   // some kinds may appear in model values that cannot be asserted
   d_nonClosedKinds.insert(Kind::STORE_ALL);
   d_nonClosedKinds.insert(Kind::CODATATYPE_BOUND_VARIABLE);
@@ -27,13 +29,12 @@ NonClosedNodeConverter::NonClosedNodeConverter(Env& env) : EnvObj(env), NodeConv
   // may appear in certain models e.g. strings of excessive length
   d_nonClosedKinds.insert(Kind::WITNESS);
   d_nonClosedKinds.insert(Kind::REAL_ALGEBRAIC_NUMBER);
-  
 }
 NonClosedNodeConverter::~NonClosedNodeConverter() {}
 Node NonClosedNodeConverter::postConvert(Node n)
 {
   Kind k = n.getKind();
-  if (d_nonClosedKinds.find(k)!=d_nonClosedKinds.end())
+  if (d_nonClosedKinds.find(k) != d_nonClosedKinds.end())
   {
     Node sk = SkolemManager::mkPurifySkolem(n);
     d_purifySkolems.push_back(sk);
@@ -41,7 +42,9 @@ Node NonClosedNodeConverter::postConvert(Node n)
   }
   return n;
 }
-const std::vector<Node>& NonClosedNodeConverter::getSkolems() const { return d_purifySkolems; }
+const std::vector<Node>& NonClosedNodeConverter::getSkolems() const
+{
+  return d_purifySkolems;
+}
 
 }  // namespace cvc5::internal
-

--- a/src/expr/non_closed_node_converter.cpp
+++ b/src/expr/non_closed_node_converter.cpp
@@ -1,0 +1,47 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds, Daniel Larraz
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2025 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Implementation of non-closed node conversion
+ */
+
+#include "expr/non_closed_node_converter.h"
+
+#include "expr/skolem_manager.h"
+
+namespace cvc5::internal {
+
+NonClosedNodeConverter::NonClosedNodeConverter(Env& env) : EnvObj(env), NodeConverter(nodeManager()) {
+  // some kinds may appear in model values that cannot be asserted
+  d_nonClosedKinds.insert(Kind::STORE_ALL);
+  d_nonClosedKinds.insert(Kind::CODATATYPE_BOUND_VARIABLE);
+  d_nonClosedKinds.insert(Kind::UNINTERPRETED_SORT_VALUE);
+  // may appear in certain models e.g. strings of excessive length
+  d_nonClosedKinds.insert(Kind::WITNESS);
+  d_nonClosedKinds.insert(Kind::REAL_ALGEBRAIC_NUMBER);
+  
+}
+NonClosedNodeConverter::~NonClosedNodeConverter() {}
+Node NonClosedNodeConverter::postConvert(Node n)
+{
+  Kind k = n.getKind();
+  if (d_nonClosedKinds.find(k)!=d_nonClosedKinds.end())
+  {
+    Node sk = SkolemManager::mkPurifySkolem(n);
+    d_purifySkolems.push_back(sk);
+    return sk;
+  }
+  return n;
+}
+const std::vector<Node>& NonClosedNodeConverter::getSkolems() const { return d_purifySkolems; }
+
+}  // namespace cvc5::internal
+

--- a/src/expr/non_closed_node_converter.cpp
+++ b/src/expr/non_closed_node_converter.cpp
@@ -15,10 +15,10 @@
 
 #include "expr/non_closed_node_converter.h"
 
-#include "expr/skolem_manager.h"
 #include "expr/node_algorithm.h"
-#include "smt/env.h"
+#include "expr/skolem_manager.h"
 #include "options/arrays_options.h"
+#include "smt/env.h"
 
 namespace cvc5::internal {
 
@@ -49,7 +49,8 @@ bool NonClosedNodeConverter::isClosed(const Env& env, const Node& n)
   return !expr::hasSubtermKinds(ncks, n);
 }
 
-void NonClosedNodeConverter::getNonClosedKinds(const Env& env, std::unordered_set<Kind, kind::KindHashFunction>& ncks)
+void NonClosedNodeConverter::getNonClosedKinds(
+    const Env& env, std::unordered_set<Kind, kind::KindHashFunction>& ncks)
 {
   // some kinds may appear in model values that cannot be asserted
   if (!env.getOptions().arrays.arraysExp)

--- a/src/expr/non_closed_node_converter.h
+++ b/src/expr/non_closed_node_converter.h
@@ -47,8 +47,11 @@ class NonClosedNodeConverter : protected EnvObj, public NodeConverter
   Node postConvert(Node n) override;
   /** Get the purification skolems introduced */
   const std::vector<Node>& getSkolems() const;
-
+  /** Is this node "closed", i.e. able to be re-asserted in a normal input? */
+  static bool isClosed(const Env& env, const Node& n);
  private:
+  /** Get the non-closed kinds, based on the options */
+  static void getNonClosedKinds(const Env& env, std::unordered_set<Kind, kind::KindHashFunction>& ncks);
   /** Kinds that cannot appear in queries */
   std::unordered_set<Kind, kind::KindHashFunction> d_nonClosedKinds;
   /** The skolems we introduced */

--- a/src/expr/non_closed_node_converter.h
+++ b/src/expr/non_closed_node_converter.h
@@ -49,9 +49,11 @@ class NonClosedNodeConverter : protected EnvObj, public NodeConverter
   const std::vector<Node>& getSkolems() const;
   /** Is this node "closed", i.e. able to be re-asserted in a normal input? */
   static bool isClosed(const Env& env, const Node& n);
+
  private:
   /** Get the non-closed kinds, based on the options */
-  static void getNonClosedKinds(const Env& env, std::unordered_set<Kind, kind::KindHashFunction>& ncks);
+  static void getNonClosedKinds(
+      const Env& env, std::unordered_set<Kind, kind::KindHashFunction>& ncks);
   /** Kinds that cannot appear in queries */
   std::unordered_set<Kind, kind::KindHashFunction> d_nonClosedKinds;
   /** The skolems we introduced */

--- a/src/expr/non_closed_node_converter.h
+++ b/src/expr/non_closed_node_converter.h
@@ -1,0 +1,60 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds, Daniel Larraz
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2025 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Implementation of non-closed node conversion
+ */
+
+#include "cvc5_private.h"
+
+#ifndef CVC5__PROOF__EXPR__NON_CLOSED_NODE_CONVERTER_H
+#define CVC5__PROOF__EXPR__NON_CLOSED_NODE_CONVERTER_H
+
+#include "expr/node.h"
+#include "expr/node_converter.h"
+#include "expr/type_node.h"
+
+#include "smt/env_obj.h"
+
+namespace cvc5::internal {
+
+/**
+ * This converts a node into one that can be given as an ordinary input
+ * to theory solvers.
+ *
+ * Note this converter is necessary since models for certain types e.g.
+ * uninterpreted sorts, codatatypes, arrays, involve terms that cannot be
+ * re-asserted to the solver as input.
+ * 
+ * Other types may conditionally use model values that are also illegal in
+ * inputs e.g.:
+ * - Real algebraic numbers (RAN) for the reals,
+ * - Witness terms for strings (for strings of excessive length).
+ */
+class NonClosedNodeConverter :  protected EnvObj, public NodeConverter
+{
+ public:
+  NonClosedNodeConverter(Env& env);
+  ~NonClosedNodeConverter();
+  /** convert node n as described above during post-order traversal */
+  Node postConvert(Node n) override;
+  /** Get the purification skolems introduced */
+  const std::vector<Node>& getSkolems() const;
+ private:
+  /** Kinds that cannot appear in queries */
+  std::unordered_set<Kind, kind::KindHashFunction> d_nonClosedKinds;
+  /** The skolems we introduced */
+  std::vector<Node> d_purifySkolems;
+};
+
+}  // namespace cvc5::internal
+
+#endif

--- a/src/expr/non_closed_node_converter.h
+++ b/src/expr/non_closed_node_converter.h
@@ -21,7 +21,6 @@
 #include "expr/node.h"
 #include "expr/node_converter.h"
 #include "expr/type_node.h"
-
 #include "smt/env_obj.h"
 
 namespace cvc5::internal {
@@ -33,13 +32,13 @@ namespace cvc5::internal {
  * Note this converter is necessary since models for certain types e.g.
  * uninterpreted sorts, codatatypes, arrays, involve terms that cannot be
  * re-asserted to the solver as input.
- * 
+ *
  * Other types may conditionally use model values that are also illegal in
  * inputs e.g.:
  * - Real algebraic numbers (RAN) for the reals,
  * - Witness terms for strings (for strings of excessive length).
  */
-class NonClosedNodeConverter :  protected EnvObj, public NodeConverter
+class NonClosedNodeConverter : protected EnvObj, public NodeConverter
 {
  public:
   NonClosedNodeConverter(Env& env);
@@ -48,6 +47,7 @@ class NonClosedNodeConverter :  protected EnvObj, public NodeConverter
   Node postConvert(Node n) override;
   /** Get the purification skolems introduced */
   const std::vector<Node>& getSkolems() const;
+
  private:
   /** Kinds that cannot appear in queries */
   std::unordered_set<Kind, kind::KindHashFunction> d_nonClosedKinds;

--- a/src/smt/model_blocker.cpp
+++ b/src/smt/model_blocker.cpp
@@ -18,13 +18,13 @@
 #include "base/modal_exception.h"
 #include "expr/node.h"
 #include "expr/node_algorithm.h"
+#include "expr/non_closed_node_converter.h"
+#include "expr/subs.h"
 #include "options/base_options.h"
 #include "theory/logic_info.h"
 #include "theory/quantifiers/term_util.h"
 #include "theory/rewriter.h"
 #include "theory/theory_model.h"
-#include "expr/subs.h"
-#include "expr/non_closed_node_converter.h"
 
 using namespace cvc5::internal::kind;
 

--- a/src/smt/model_blocker.cpp
+++ b/src/smt/model_blocker.cpp
@@ -24,6 +24,7 @@
 #include "theory/rewriter.h"
 #include "theory/theory_model.h"
 #include "expr/subs.h"
+#include "expr/non_closed_node_converter.h"
 
 using namespace cvc5::internal::kind;
 
@@ -252,9 +253,8 @@ Node ModelBlocker::getModelBlocker(const std::vector<Node>& assertions,
     std::unordered_set<Node> terms;
     for (const Node& n : nodesToBlock)
     {
-      TypeNode tn = n.getType();
       Node v = m->getValue(n);
-      if (tn.isClosedEnumerable())
+      if (NonClosedNodeConverter::isClosed(d_env, v))
       {
         // if its type is closed enumerable, then we can block its value
         Node a = n.eqNode(v);
@@ -265,6 +265,7 @@ Node ModelBlocker::getModelBlocker(const std::vector<Node>& assertions,
         nonClosedValue[n] = v;
         // otherwise we will block (dis)equality with other variables of its
         // type below
+        TypeNode tn = n.getType();
         nonClosedEnum[tn].push_back(n);
       }
     }


### PR DESCRIPTION
Introduces a node converter to eliminate terms that are not "closed", i.e. may appear in models but can't be reasserted to the solver.  This will be used e.g. for model-based quantifier instantiation in a later PR.

This utility can also be used to make the model blocker more robust, e.g. to not introduce witness terms for certain string models.

Fixes https://github.com/cvc5/cvc5-projects/issues/766.