### PR TITLE
ci: Update cibuildwheel to v2.23.3

### DIFF
--- a/.github/workflows/package_pypi.yml
+++ b/.github/workflows/package_pypi.yml
@@ -131,7 +131,7 @@ jobs:
           DYLD_LIBRARY_PATH="$(pwd)/install/lib:$DYLD_LIBRARY_PATH"
           MACOSX_DEPLOYMENT_TARGET=${{ matrix.macos-target }}
         CIBW_TEST_COMMAND: python {project}/examples/api/python/quickstart.py
-        CIBW_TEST_SKIP: "cp38-macosx_*:arm64" # Silence warning. See: https://github.com/pypa/cibuildwheel/pull/1171
+        CIBW_TEST_SKIP: "cp38-macosx_arm64" # Silence warning. See: https://github.com/pypa/cibuildwheel/pull/1171
 
     # - uses: actions/upload-artifact@v4
     #   with:

--- a/.github/workflows/package_pypi.yml
+++ b/.github/workflows/package_pypi.yml
@@ -109,13 +109,14 @@ jobs:
       run: echo "bin=$(cygpath -m $(dirname $(which gcc)))" >> $GITHUB_OUTPUT
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.22.0
+      uses: pypa/cibuildwheel@v2.23.3
       with:
         package-dir: ./build/src/api/python/
       env:
         CIBW_ALLOW_EMPTY: True
         CIBW_BUILD: "${{ github.event.inputs.python_versions || '*' }}"
         CIBW_SKIP: "cp36-* pp*-win* *-win32 *-manylinux_i686 *-musllinux_*"
+        CIBW_ENABLE: pypy
         CIBW_ARCHS_LINUX: "${{ matrix.arch }}"
         CIBW_BEFORE_ALL_LINUX: bash ./contrib/cibw/before_all_linux.sh ${{ matrix.gpl }}
         CIBW_BEFORE_ALL_MACOS: bash ./contrib/cibw/before_all_macos.sh ${{ matrix.gpl }}
@@ -130,6 +131,7 @@ jobs:
           DYLD_LIBRARY_PATH="$(pwd)/install/lib:$DYLD_LIBRARY_PATH"
           MACOSX_DEPLOYMENT_TARGET=${{ matrix.macos-target }}
         CIBW_TEST_COMMAND: python {project}/examples/api/python/quickstart.py
+        CIBW_TEST_SKIP: "cp38-macosx_*:arm64" # Silence warning. See: https://github.com/pypa/cibuildwheel/pull/1171
 
     # - uses: actions/upload-artifact@v4
     #   with:


### PR DESCRIPTION
This PR also includes changes to silence a few warnings. Specifically, it explicitly enables PyPy builds, as they will be disabled by default starting with cibuildwheel version 3. Additionally, it skips tests for CPython 3.8 arm64 wheels, since these cannot be executed even on Apple Silicon machines (see https://github.com/pypa/cibuildwheel/pull/1171).