### PR TITLE
Fix equalities in bitvector ppStaticRewrite

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -3156,6 +3156,19 @@ enum ENUM(ProofRewriteRule)
   EVALUE(MACRO_BV_EQ_SOLVE),
   /**
    * \verbatim embed:rst:leading-asterisk
+   * **Bitvectors -- Macro bitwise equal **
+   *
+   * .. math::
+   *    a = b
+   *
+   * where :math:`a` is rewritten to :math:`b` by the internal rewrite
+   * rule BitwiseEq.
+   *
+   * \endverbatim
+   */
+  EVALUE(MACRO_BV_BITWISE_EQ),
+  /**
+   * \verbatim embed:rst:leading-asterisk
    * **Bitvectors -- Unsigned multiplication overflow detection elimination**
    *
    * .. math::

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -303,6 +303,7 @@ const char* toString(cvc5::ProofRewriteRule rule)
     case ProofRewriteRule::MACRO_BV_CONCAT_CONSTANT_MERGE:
       return "macro-bv-concat-constant-merge";
     case ProofRewriteRule::MACRO_BV_EQ_SOLVE: return "macro-bv-eq-solve";
+    case ProofRewriteRule::MACRO_BV_BITWISE_EQ: return "macro-bv-bitwise-eq";
     case ProofRewriteRule::BV_UMULO_ELIM: return "bv-umulo-elim";
     case ProofRewriteRule::BV_SMULO_ELIM: return "bv-smulo-elim";
     case ProofRewriteRule::BV_BITWISE_SLICING: return "bv-bitwise-slicing";

--- a/src/options/bv_options.toml
+++ b/src/options/bv_options.toml
@@ -70,10 +70,10 @@ name   = "Bitvector Theory"
 
 [[option]]
   name       = "bitwiseEq"
-  category   = "regular"
+  category   = "expert"
   long       = "bitwise-eq"
   type       = "bool"
-  default    = "true"
+  default    = "false"
   help       = "lift equivalence with one-bit bit-vectors to be boolean operations"
 
 [[option]]

--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -348,6 +348,7 @@ void BasicRewriteRCons::ensureProofForTheoryRewrite(CDProof* cdp,
     case ProofRewriteRule::MACRO_BV_MULT_SLT_MULT:
     case ProofRewriteRule::MACRO_BV_CONCAT_EXTRACT_MERGE:
     case ProofRewriteRule::MACRO_BV_CONCAT_CONSTANT_MERGE:
+    case ProofRewriteRule::MACRO_BV_BITWISE_EQ:
       handledMacro = d_bvRewElab.ensureProofFor(cdp, id, eq);
       break;
     default: break;

--- a/src/theory/bv/macro_rewrite_elaborator.cpp
+++ b/src/theory/bv/macro_rewrite_elaborator.cpp
@@ -51,6 +51,8 @@ bool MacroRewriteElaborator::ensureProofFor(CDProof* cdp,
       return ensureProofForMultSltMult(cdp, eq);
     case ProofRewriteRule::MACRO_BV_AND_OR_XOR_CONCAT_PULLUP:
       return ensureProofForAndOrXorConcatPullup(cdp, eq);
+    case ProofRewriteRule::MACRO_BV_BITWISE_EQ:
+      return ensureProofForBitwiseEq(cdp, eq);
     default: break;
   }
   return false;
@@ -418,6 +420,11 @@ bool MacroRewriteElaborator::ensureProofForAndOrXorConcatPullup(CDProof* cdp,
       equiv2, TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE, {}, {});
   cdp->addStep(eq, ProofRule::TRANS, {equiv1, equiv2}, {});
   return true;
+}
+
+bool MacroRewriteElaborator::ensureProofForBitwiseEq(CDProof* cdp, const Node& eq)
+{
+  return false;
 }
 
 Node MacroRewriteElaborator::proveCong(CDProof* cdp,

--- a/src/theory/bv/macro_rewrite_elaborator.h
+++ b/src/theory/bv/macro_rewrite_elaborator.h
@@ -91,6 +91,14 @@ class MacroRewriteElaborator : protected EnvObj
    */
   bool ensureProofForAndOrXorConcatPullup(CDProof* cdp, const Node& eq);
   /**
+   * Elaborate a rewrite eq that was proven by MACRO_BV_BITWISE_EQ.
+   *
+   * @param cdp The proof to add to.
+   * @param eq The rewrite proven.
+   * @return true if added a closed proof of eq to cdp.
+   */
+  bool ensureProofForBitwiseEq(CDProof* cdp, const Node& eq);
+  /**
    * Prove congruence for left hand side term n.
    * If n is a term of the form (f t1 ... tn), this proves
    *  (= (f t1 ... sn) (f s1 .... sn))

--- a/src/theory/bv/theory_bv.cpp
+++ b/src/theory/bv/theory_bv.cpp
@@ -202,26 +202,10 @@ TrustNode TheoryBV::ppRewrite(TNode t, std::vector<SkolemLemma>& lems)
 {
   Trace("theory-bv-pp-rewrite") << "ppRewrite " << t << "\n";
   Node res = t;
-  if (options().bv.bitwiseEq && RewriteRule<BitwiseEq>::applies(t))
-  {
-    res = RewriteRule<BitwiseEq>::run<false>(t);
-  }
   // useful on QF_BV/space/ndist
-  else if (RewriteRule<UltAddOne>::applies(t))
+  if (RewriteRule<UltAddOne>::applies(t))
   {
     res = RewriteRule<UltAddOne>::run<false>(t);
-  }
-  // Useful for BV/2017-Preiner-scholl-smt08, but not for QF_BV
-  else if (options().bv.rwExtendEq)
-  {
-    if (RewriteRule<SignExtendEqConst>::applies(t))
-    {
-      res = RewriteRule<SignExtendEqConst>::run<false>(t);
-    }
-    else if (RewriteRule<ZeroExtendEqConst>::applies(t))
-    {
-      res = RewriteRule<ZeroExtendEqConst>::run<false>(t);
-    }
   }
   // When int-blasting, it is better to handle most overflow operators
   // natively, rather than to eliminate them eagerly.
@@ -247,6 +231,31 @@ TrustNode TheoryBV::ppStaticRewrite(TNode atom)
     if (RewriteRule<SolveEq>::applies(atom))
     {
       Node res = RewriteRule<SolveEq>::run<false>(atom);
+      if (res != atom)
+      {
+        return TrustNode::mkTrustRewrite(atom, res);
+      }
+    }
+    if (options().bv.bitwiseEq && RewriteRule<BitwiseEq>::applies(atom))
+    {
+      Node res = RewriteRule<BitwiseEq>::run<false>(atom);
+      if (res != atom)
+      {
+        return TrustNode::mkTrustRewrite(atom, res);
+      }
+    }
+    // Useful for BV/2017-Preiner-scholl-smt08, but not for QF_BV
+    if (options().bv.rwExtendEq)
+    {
+      Node res;
+      if (RewriteRule<SignExtendEqConst>::applies(atom))
+      {
+        res = RewriteRule<SignExtendEqConst>::run<false>(atom);
+      }
+      else if (RewriteRule<ZeroExtendEqConst>::applies(atom))
+      {
+        res = RewriteRule<ZeroExtendEqConst>::run<false>(atom);
+      }
       if (res != atom)
       {
         return TrustNode::mkTrustRewrite(atom, res);

--- a/src/theory/bv/theory_bv_rewriter.cpp
+++ b/src/theory/bv/theory_bv_rewriter.cpp
@@ -60,6 +60,8 @@ TheoryBVRewriter::TheoryBVRewriter(NodeManager* nm) : TheoryRewriter(nm)
                            TheoryRewriteCtx::POST_DSL);
   registerProofRewriteRule(ProofRewriteRule::MACRO_BV_CONCAT_CONSTANT_MERGE,
                            TheoryRewriteCtx::POST_DSL);
+  registerProofRewriteRule(ProofRewriteRule::MACRO_BV_BITWISE_EQ,
+                           TheoryRewriteCtx::POST_DSL);
   registerProofRewriteRule(ProofRewriteRule::BV_UMULO_ELIM,
                            TheoryRewriteCtx::POST_DSL);
   registerProofRewriteRule(ProofRewriteRule::BV_SMULO_ELIM,
@@ -139,6 +141,8 @@ Node TheoryBVRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
       BV_PROOF_REWRITE_CASE(ConcatExtractMerge)
     case ProofRewriteRule::MACRO_BV_CONCAT_CONSTANT_MERGE:
       BV_PROOF_REWRITE_CASE(ConcatConstantMerge)
+    case ProofRewriteRule::MACRO_BV_BITWISE_EQ:
+      BV_PROOF_REWRITE_CASE(BitwiseEq)
     case ProofRewriteRule::BV_UMULO_ELIM:
       BV_PROOF_REWRITE_CASE(UmuloEliminate)
     case ProofRewriteRule::BV_SMULO_ELIM:

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -181,6 +181,7 @@ set(regress_0_tests
   regress0/aufbv/bug580.delta.smt2
   regress0/aufbv/cee-small-shared-eq.smt2
   regress0/aufbv/dd_644_ph7.smt2
+  regress0/aufbv/dd.fifo32bc06k08.delta01.smtv1.smt2
   regress0/aufbv/diseqprop.01.smtv1.smt2
   regress0/aufbv/dubreva005ue.delta01.smtv1.smt2
   regress0/aufbv/fifo32bc06k08.delta01.smtv1.smt2

--- a/test/regress/cli/regress0/aufbv/dd.fifo32bc06k08.delta01.smtv1.smt2
+++ b/test/regress/cli/regress0/aufbv/dd.fifo32bc06k08.delta01.smtv1.smt2
@@ -1,0 +1,4 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-fun a () (Array (_ BitVec 6) (_ BitVec 32)))
+(check-sat-assuming ((not (= (_ bv0 1) (bvand (bvcomp (_ bv1 32) (select a (_ bv0 6))) (ite (= a (store a (_ bv0 6) (_ bv0 32))) (_ bv1 1) (_ bv0 1)))))))


### PR DESCRIPTION
The BV solver had cases to rewrite equalities in ppRewrite, which is not called on equalities.

These rewrites are moved to the appropriate place (ppStaticRewrite).

The "bitwise equal" rewrites were enabled by default (despite being dead code to the above mistake).  Enabling them again led to worse performance on SMT-LIB logics with BV (+268-425).

Moreover we do not have RARE rules that cover this case.  This option is thus demoted to "expert" and disabled by default.

Thus, this PR preserves behavior but ensures these rewrites are fired if the user requests them.