### PR TITLE
Fix open proof in incremental mode due to overwrite

### DIFF
--- a/src/preprocessing/assertion_pipeline.cpp
+++ b/src/preprocessing/assertion_pipeline.cpp
@@ -95,7 +95,12 @@ void AssertionPipeline::push_back(
             // Never overwrite here. This is because the assumption we would
             // overwrite might be at a lower user context. Overwriting the
             // assumption can lead to open proofs in incremental mode.
-            d_andElimEpg->addStep(nc[jj], ProofRule::AND_ELIM, {nc}, {in}, false, CDPOverwrite::NEVER);
+            d_andElimEpg->addStep(nc[jj],
+                                  ProofRule::AND_ELIM,
+                                  {nc},
+                                  {in},
+                                  false,
+                                  CDPOverwrite::NEVER);
             toProcess.emplace_back(nc[jj]);
           }
         }

--- a/src/preprocessing/assertion_pipeline.cpp
+++ b/src/preprocessing/assertion_pipeline.cpp
@@ -92,7 +92,10 @@ void AssertionPipeline::push_back(
           {
             size_t jj = (nchild-1)-j;
             Node in = nm->mkConstInt(Rational(jj));
-            d_andElimEpg->addStep(nc[jj], ProofRule::AND_ELIM, {nc}, {in});
+            // Never overwrite here. This is because the assumption we would
+            // overwrite might be at a lower user context. Overwriting the
+            // assumption can lead to open proofs in incremental mode.
+            d_andElimEpg->addStep(nc[jj], ProofRule::AND_ELIM, {nc}, {in}, false, CDPOverwrite::NEVER);
             toProcess.emplace_back(nc[jj]);
           }
         }

--- a/src/smt/preprocess_proof_generator.cpp
+++ b/src/smt/preprocess_proof_generator.cpp
@@ -36,7 +36,6 @@ PreprocessProofGenerator::PreprocessProofGenerator(Env& env,
     : EnvObj(env),
       d_ctx(c ? c : &d_context),
       d_src(d_ctx),
-      d_helperProofs(env, d_ctx, "PreprocessHelper"),
       d_inputPf(env, c, "InputProof"),
       d_trustPf(env, c, "PreprocessTrustProof"),
       d_name(name)
@@ -171,7 +170,7 @@ std::shared_ptr<ProofNode> PreprocessProofGenerator::getProofFor(Node f)
       std::shared_ptr<ProofNode> pfr = (*it).second.toProofNode();
       if (pfr != nullptr)
       {
-        Trace("smt-pppg-debug") << "...add provided " << *pfr << std::endl;
+        Trace("smt-pppg-debug") << "...add provided " << *pfr << " from " << (*it).second.getGenerator()->identify() << std::endl;
         Assert(pfr->getResult() == proven);
         cdp.addProof(pfr);
         proofStepProcessed = true;
@@ -242,11 +241,6 @@ std::shared_ptr<ProofNode> PreprocessProofGenerator::getProofFor(Node f)
   // Note F_1 may have been given a proof if it was not an input assumption.
 
   return cdp.getProofFor(f);
-}
-
-LazyCDProof* PreprocessProofGenerator::allocateHelperProof()
-{
-  return d_helperProofs.allocateProof(nullptr, d_ctx);
 }
 
 std::string PreprocessProofGenerator::identify() const { return d_name; }

--- a/src/smt/preprocess_proof_generator.cpp
+++ b/src/smt/preprocess_proof_generator.cpp
@@ -170,7 +170,9 @@ std::shared_ptr<ProofNode> PreprocessProofGenerator::getProofFor(Node f)
       std::shared_ptr<ProofNode> pfr = (*it).second.toProofNode();
       if (pfr != nullptr)
       {
-        Trace("smt-pppg-debug") << "...add provided " << *pfr << " from " << (*it).second.getGenerator()->identify() << std::endl;
+        Trace("smt-pppg-debug")
+            << "...add provided " << *pfr << " from "
+            << (*it).second.getGenerator()->identify() << std::endl;
         Assert(pfr->getResult() == proven);
         cdp.addProof(pfr);
         proofStepProcessed = true;

--- a/src/smt/preprocess_proof_generator.h
+++ b/src/smt/preprocess_proof_generator.h
@@ -114,13 +114,6 @@ class PreprocessProofGenerator : protected EnvObj, public ProofGenerator
   std::shared_ptr<ProofNode> getProofFor(Node f) override;
   /** Identify */
   std::string identify() const override;
-  /**
-   * Allocate a helper proof. This returns a fresh lazy proof object that
-   * remains alive in the context. This feature is used to construct
-   * helper proofs for preprocessing, e.g. to support the skeleton of proofs
-   * that connect AssertionPipeline::conjoin steps.
-   */
-  LazyCDProof* allocateHelperProof();
 
  private:
   /**
@@ -140,8 +133,6 @@ class PreprocessProofGenerator : protected EnvObj, public ProofGenerator
    * (2) A trust node LEMMA proving n.
    */
   NodeTrustNodeMap d_src;
-  /** A context-dependent list of LazyCDProof, allocated for conjoin steps */
-  CDProofSet<LazyCDProof> d_helperProofs;
   /**
    * A cd proof for input assertions, this is an empty proof that intentionally
    * returns (ASSUME f) for all f.

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1457,6 +1457,7 @@ set(regress_0_tests
   regress0/proofs/proj-issue698.smt2
   regress0/proofs/proj-issue711-open-sat-proof.smt2
   regress0/proofs/proj-issue723-rdb-step.smt2
+  regress0/proofs/proj-issue765-open.smt2
   regress0/proofs/proof-components.smt2
   regress0/proofs/qgu-fuzz-1-bool-sat.smt2
   regress0/proofs/qgu-fuzz-2-bool-chainres-checking.smt2

--- a/test/regress/cli/regress0/proofs/proj-issue765-open.smt2
+++ b/test/regress/cli/regress0/proofs/proj-issue765-open.smt2
@@ -1,0 +1,14 @@
+; EXPECT: unsat
+; EXPECT: unsat
+(set-logic ALL)
+(set-option :incremental true)
+(declare-const x Bool)
+(declare-const x1 Bool)
+(declare-const x2 Bool)
+(assert (= x (and (or x (not x)) (or (not x) (ite x2 x1 false))) (and (or x (not x)) (or (not x) (ite x2 x1 false)))))
+(push)
+(assert (and false (= x (and (or x (not x)) (or (not x) (ite x2 x1 false))) (and (or x (not x)) (or (not x) (ite x2 x1 false))))))
+(check-sat)
+(pop)
+(assert (not x2))
+(check-sat)


### PR DESCRIPTION
Ensures we don't overwrite assumptions that come from a lower user context level.

Also deletes some dead code found while debugging.

Fixes https://github.com/cvc5/cvc5-projects/issues/765.