### PR TITLE
Purification for nested sequence constants

### DIFF
--- a/src/theory/inference_id.cpp
+++ b/src/theory/inference_id.cpp
@@ -543,7 +543,8 @@ const char* toString(InferenceId i)
       return "STRINGS_REGISTER_TERM_ATOMIC";
     case InferenceId::STRINGS_REGISTER_TERM: return "STRINGS_REGISTER_TERM";
     case InferenceId::STRINGS_CMI_SPLIT: return "STRINGS_CMI_SPLIT";
-    case InferenceId::STRINGS_CONST_SEQ_PURIFY: return "STRINGS_CONST_SEQ_PURIFY";
+    case InferenceId::STRINGS_CONST_SEQ_PURIFY:
+      return "STRINGS_CONST_SEQ_PURIFY";
 
     case InferenceId::UF_BREAK_SYMMETRY: return "UF_BREAK_SYMMETRY";
     case InferenceId::UF_CARD_CLIQUE: return "UF_CARD_CLIQUE";

--- a/src/theory/inference_id.cpp
+++ b/src/theory/inference_id.cpp
@@ -543,6 +543,7 @@ const char* toString(InferenceId i)
       return "STRINGS_REGISTER_TERM_ATOMIC";
     case InferenceId::STRINGS_REGISTER_TERM: return "STRINGS_REGISTER_TERM";
     case InferenceId::STRINGS_CMI_SPLIT: return "STRINGS_CMI_SPLIT";
+    case InferenceId::STRINGS_CONST_SEQ_PURIFY: return "STRINGS_CONST_SEQ_PURIFY";
 
     case InferenceId::UF_BREAK_SYMMETRY: return "UF_BREAK_SYMMETRY";
     case InferenceId::UF_CARD_CLIQUE: return "UF_CARD_CLIQUE";

--- a/src/theory/inference_id.h
+++ b/src/theory/inference_id.h
@@ -908,6 +908,8 @@ enum class InferenceId
   STRINGS_REGISTER_TERM,
   // a split during collect model info
   STRINGS_CMI_SPLIT,
+  // constant sequence purification
+  STRINGS_CONST_SEQ_PURIFY,
   //-------------------------------------- end strings theory
 
   //-------------------------------------- uf theory

--- a/src/theory/strings/term_registry.cpp
+++ b/src/theory/strings/term_registry.cpp
@@ -212,13 +212,13 @@ void TermRegistry::preRegisterTerm(TNode n)
   {
     Node nc = utils::mkConcatForConstSequence(n);
     Kind nck = nc.getKind();
-    if (nck!=Kind::CONST_SEQUENCE)
+    if (nck != Kind::CONST_SEQUENCE)
     {
       std::vector<Node> eqs;
       std::vector<Node> children;
       for (const Node& ncc : nc)
       {
-        if (ncc.getKind()==Kind::CONST_SEQUENCE)
+        if (ncc.getKind() == Kind::CONST_SEQUENCE)
         {
           Node skolem = SkolemManager::mkPurifySkolem(ncc);
           children.push_back(skolem);
@@ -232,7 +232,8 @@ void TermRegistry::preRegisterTerm(TNode n)
       Node ret = nodeManager()->mkNode(nck, children);
       eqs.push_back(n.eqNode(ret));
       Node lem = nodeManager()->mkAnd(eqs);
-      Trace("strings-preregister") << "Const sequence lemma: " << lem << std::endl;
+      Trace("strings-preregister")
+          << "Const sequence lemma: " << lem << std::endl;
       d_im->lemma(lem, InferenceId::STRINGS_CONST_SEQ_PURIFY);
     }
   }

--- a/src/theory/strings/term_registry.cpp
+++ b/src/theory/strings/term_registry.cpp
@@ -210,6 +210,19 @@ void TermRegistry::preRegisterTerm(TNode n)
   }
   else if (k == Kind::CONST_SEQUENCE)
   {
+    // If we are a constant sequence that has "nested" constant sequences
+    // implicitly, e.g. for sequences of sequences, then we must ensure that
+    // all subterms of this constant are also considered as terms by the
+    // solver. Otherwise, these terms would be hidden inside of the sequence
+    // constant. To do so, we ensure a purify skolem is introduced for each
+    // subterm. For example, for the sequence constant t:
+    //   (str.++ (as seq.empty (Seq Int)) (seq.unit (str.++ 0 1)))
+    // We add the lemma:
+    //   k1 = (as seq.empty (Seq Int)) ^ k2 = (seq.unit (str.++ 0 1)) ^
+    //   t = (str.++ k1 k2).
+    // The right hand sides of the first two equalties will lead to
+    // preregistering these sequence constants in the same way.
+    // These lemmas can be justified trivially by MACRO_SR_PRED_INTRO.
     Node nc = utils::mkConcatForConstSequence(n);
     Kind nck = nc.getKind();
     if (nck != Kind::CONST_SEQUENCE)

--- a/src/theory/strings/term_registry.cpp
+++ b/src/theory/strings/term_registry.cpp
@@ -208,6 +208,34 @@ void TermRegistry::preRegisterTerm(TNode n)
   {
     d_hasSeqUpdate = true;
   }
+  else if (k == Kind::CONST_SEQUENCE)
+  {
+    Node nc = utils::mkConcatForConstSequence(n);
+    Kind nck = nc.getKind();
+    if (nck!=Kind::CONST_SEQUENCE)
+    {
+      std::vector<Node> eqs;
+      std::vector<Node> children;
+      for (const Node& ncc : nc)
+      {
+        if (ncc.getKind()==Kind::CONST_SEQUENCE)
+        {
+          Node skolem = SkolemManager::mkPurifySkolem(ncc);
+          children.push_back(skolem);
+          eqs.push_back(skolem.eqNode(ncc));
+        }
+        else
+        {
+          children.push_back(ncc);
+        }
+      }
+      Node ret = nodeManager()->mkNode(nck, children);
+      eqs.push_back(n.eqNode(ret));
+      Node lem = nodeManager()->mkAnd(eqs);
+      Trace("strings-preregister") << "Const sequence lemma: " << lem << std::endl;
+      d_im->lemma(lem, InferenceId::STRINGS_CONST_SEQ_PURIFY);
+    }
+  }
   if (options().strings.stringEagerReg)
   {
     registerTerm(n);
@@ -377,7 +405,8 @@ TrustNode TermRegistry::getRegisterTermLemma(Node n)
   //  for variables, split on empty vs positive length
   //  for concat/const/replace, introduce proxy var and state length relation
   Node lsum;
-  if (n.getKind() != Kind::STRING_CONCAT && !n.isConst())
+  Kind nk = n.getKind();
+  if (nk != Kind::STRING_CONCAT && !n.isConst())
   {
     Node lsumb = nm->mkNode(Kind::STRING_LENGTH, n);
     lsum = rewrite(lsumb);
@@ -394,13 +423,13 @@ TrustNode TermRegistry::getRegisterTermLemma(Node n)
   // If we are introducing a proxy for a constant or concat term, we do not
   // need to send lemmas about its length, since its length is already
   // implied.
-  if (n.isConst() || n.getKind() == Kind::STRING_CONCAT)
+  if (n.isConst() || nk == Kind::STRING_CONCAT)
   {
     // do not send length lemma for sk.
     registerTermAtomic(sk, LENGTH_IGNORE);
   }
   Node skl = nm->mkNode(Kind::STRING_LENGTH, sk);
-  if (n.getKind() == Kind::STRING_CONCAT)
+  if (nk == Kind::STRING_CONCAT)
   {
     std::vector<Node> nodeVec;
     NodeNodeMap::const_iterator itl;

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -868,35 +868,6 @@ void TheoryStrings::preRegisterTerm(TNode n)
   // this term here since preRegisterTerm is already called recursively on all
   // subterms in preregistered literals.
   d_extTheory.registerTerm(n);
-  if (n.getKind()==Kind::CONST_SEQUENCE)
-  {
-    Node nc = utils::mkConcatForConstSequence(n);
-    Trace("ajr-temp") << "Const sequence: " << nc << std::endl;
-    Kind nck = nc.getKind();
-    if (nck!=Kind::CONST_SEQUENCE)
-    {
-      std::vector<Node> eqs;
-      std::vector<Node> children;
-      for (const Node& ncc : nc)
-      {
-        if (ncc.getKind()==Kind::CONST_SEQUENCE)
-        {
-          Node k = SkolemManager::mkPurifySkolem(ncc);
-          children.push_back(k);
-          eqs.push_back(k.eqNode(ncc));
-        }
-        else
-        {
-          children.push_back(ncc);
-        }
-      }
-      Node ret = nodeManager()->mkNode(nck, children);
-      eqs.push_back(n.eqNode(ret));
-      Node lem = nodeManager()->mkAnd(eqs);
-      Trace("ajr-temp") << "Const sequence lemma: " << lem << std::endl;
-      d_im.lemma(lem, InferenceId::STRINGS_CONST_SEQ_PURIFY);
-    }
-  }
 }
 
 bool TheoryStrings::preNotifyFact(

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1757,6 +1757,7 @@ set(regress_0_tests
   regress0/seq/issue9696-unit-type-cmi.smt2
   regress0/seq/len_simplify.smt2
   regress0/seq/mixed-types-seq-nth.smt2
+  regress0/seq/nested-const-unsat.smt2
   regress0/seq/nth-model-semi-eval.smt2
   regress0/seq/nth-oob.smt2
   regress0/seq/nth-unit.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1771,6 +1771,7 @@ set(regress_0_tests
   regress0/seq/proj-issue604-reg-closure.smt2
   regress0/seq/proj-issue642-cycle-irr.smt2
   regress0/seq/proj-issue653.smt2
+  regress0/seq/proj-issue665-nested-const.smt2
   regress0/seq/proj-issue708-explain.smt2
   regress0/seq/proj-issue747-cmi-len-split.smt2
   regress0/seq/proj-issue753-ae.smt2

--- a/test/regress/cli/regress0/seq/nested-const-unsat.smt2
+++ b/test/regress/cli/regress0/seq/nested-const-unsat.smt2
@@ -1,0 +1,7 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-const x1 (Seq (Seq (Seq Bool))))
+(assert (seq.suffixof x1 (seq.unit (seq.unit (seq.unit false)))))
+(assert (= (str.len x1) 1))
+(assert (seq.suffixof x1 (seq.unit (seq.unit (seq.unit true)))))
+(check-sat)

--- a/test/regress/cli/regress0/seq/proj-issue665-nested-const.smt2
+++ b/test/regress/cli/regress0/seq/proj-issue665-nested-const.smt2
@@ -1,0 +1,10 @@
+; EXPECT: sat
+(set-logic ALL)
+(declare-const _x (Seq Bool))
+(declare-const x3 (Seq Bool))
+(declare-const x (Seq Bool))
+(assert (not (seq.contains x x3)))
+(declare-const x1 (Seq (Seq (Seq Bool))))
+(assert (seq.contains x (seq.replace _x x x3)))
+(assert (seq.suffixof x1 (seq.unit (seq.unit (seq.unit false)))))
+(check-sat)


### PR DESCRIPTION
Constant sequences are represented as atomic terms. This can lead to issues as the "subterms" of that sequence constant do not participate e.g. in theory combination, nor are considered for model building.

This corrects this by a scheme which "purifies" nested sequence constants recursively.

Fixes https://github.com/cvc5/cvc5-projects/issues/665