### PR TITLE
Reuse the single-query smtcomp script for unsat-cores and model-validation

### DIFF
--- a/contrib/competitions/smt-comp/run-script-smtcomp-current-model-validation
+++ b/contrib/competitions/smt-comp/run-script-smtcomp-current-model-validation
@@ -3,28 +3,24 @@
 cvc5=$(dirname "$(readlink -f "$0")")/cvc5
 bench="$1"
 
-logic=$(expr "$(grep -m1 '^[^;]*set-logic' "$bench")" : ' *(set-logic  *\([A-Z_]*\) *) *$')
+# Output other than "sat"/"unsat" is either written to stderr or to "err.log"
+# in the directory specified by $2 if it has been set (e.g. when running on
+# StarExec).
+out_file=/dev/stderr
 
-# use: finishwith [params..]
-# to run cvc5 and let it output whatever it will to stdout.
-function finishwith {
-  $cvc5 -L smt2.6 --no-incremental --no-type-checking --no-interactive --fp-exp "$@" $bench
-}
+if [ -n "$STAREXEC_WALLCLOCK_LIMIT" ]; then
+  # If we are running on StarExec, don't print to `/dev/stderr/` even when $2
+  # is not provided.
+  out_file="/dev/null"
+fi
 
-case "$logic" in
+if [ -n "$2" ]; then
+  out_file="$2/err.log"
+fi
 
-QF_LRA)
-  finishwith --no-restrict-pivots --use-soi --new-prop
-  ;;
-QF_LIA)
-  finishwith --miplib-trick --miplib-trick-subs=4 --use-approx --lemmas-on-replay-failure --replay-early-close-depth=4 --replay-lemma-reject-cut=128 --replay-reject-cut=512 --use-soi --pb-rewrites --ite-simp --simp-ite-compress
-  ;;
-QF_BV)
-  finishwith --bv-assert-input
-  ;;
-*)
-  # just run the default
-  finishwith
-  ;;
-
+result="$({ $cvc5 -L smt2.6 --no-incremental --no-type-checking --no-interactive --fp-exp --use-portfolio $bench; } 2>&1)"
+case "$result" in
+  sat|unsat) echo "$result"; exit 0;;
+  *)         echo "$result" &> "$out_file";;
 esac
+

--- a/contrib/competitions/smt-comp/run-script-smtcomp-current-unsat-cores
+++ b/contrib/competitions/smt-comp/run-script-smtcomp-current-unsat-cores
@@ -3,72 +3,24 @@
 cvc5=$(dirname "$(readlink -f "$0")")/cvc5
 bench="$1"
 
-logic=$(expr "$(grep -m1 '^[^;]*set-logic' "$bench")" : ' *(set-logic  *\([A-Z_]*\) *) *$')
+# Output other than "sat"/"unsat" is either written to stderr or to "err.log"
+# in the directory specified by $2 if it has been set (e.g. when running on
+# StarExec).
+out_file=/dev/stderr
 
-# use: finishwith [params..]
-# to run cvc5 and let it output whatever it will to stdout.
-function finishwith {
-  $cvc5 -L smt2.6 --no-incremental --no-type-checking --no-interactive --fp-exp "$@" $bench
-}
+if [ -n "$STAREXEC_WALLCLOCK_LIMIT" ]; then
+  # If we are running on StarExec, don't print to `/dev/stderr/` even when $2
+  # is not provided.
+  out_file="/dev/null"
+fi
 
-case "$logic" in
+if [ -n "$2" ]; then
+  out_file="$2/err.log"
+fi
 
-QF_LRA)
-  finishwith --no-restrict-pivots --use-soi --new-prop
-  ;;
-QF_LIA)
-  finishwith --miplib-trick --miplib-trick-subs=4 --use-approx --lemmas-on-replay-failure --replay-early-close-depth=4 --replay-lemma-reject-cut=128 --replay-reject-cut=512 --use-soi
-  ;;
-QF_NIA)
-  finishwith --nl-ext-tplanes
-  ;;
-# all logics with UF + quantifiers should either fall under this or special cases below
-ALIA|AUFLIA|AUFLIRA|AUFNIRA|UF|UFBVLIA|UFIDL|UFLIA|UFLRA|UFNIA|UFDT|UFDTLIA|UFDTLIRA|AUFDTLIA|AUFDTLIRA|AUFBV|AUFBVDTLIA|AUFBVFP|AUFNIA|UFFPDTLIRA|UFFPDTNIRA|ABVFP|BVFP|FP)
-  finishwith --full-saturate-quant
-  ;;
-UFBV)
-  finishwith --finite-model-find
-  ;;
-BV)
-  finishwith --full-saturate-quant --decision=internal
-  ;;
-LIA|LRA)
-  finishwith --full-saturate-quant --cegqi-nested-qe --decision=internal
-  ;;
-NIA|NRA)
-  finishwith --full-saturate-quant --cegqi-nested-qe --decision=internal
-  ;;
-QF_AUFBV)
-  finishwith --decision=stoponly
-  ;;
-QF_ABV)
-  finishwith
-  ;;
-QF_UFBV)
-  finishwith
-  ;;
-QF_BV)
-  finishwith
-  ;;
-QF_AUFLIA)
-  finishwith --no-arrays-eager-index --arrays-eager-lemmas --decision=justification
-  ;;
-QF_AX)
-  finishwith --no-arrays-eager-index --arrays-eager-lemmas --decision=internal
-  ;;
-QF_AUFNIA)
-  finishwith --decision=justification --no-arrays-eager-index --arrays-eager-lemmas
-  ;;
-QF_ALIA)
-  finishwith --decision=stoponly --no-arrays-eager-index --arrays-eager-lemmas
-  ;;
-QF_S|QF_SLIA)
-  finishwith --strings-exp
-  ;;
-*)
-  # just run the default
-  finishwith
-  ;;
-
+result="$({ $cvc5 -L smt2.6 --no-incremental --no-type-checking --no-interactive --fp-exp --use-portfolio $bench; } 2>&1)"
+case "$result" in
+  sat|unsat) echo "$result"; exit 0;;
+  *)         echo "$result" &> "$out_file";;
 esac
 


### PR DESCRIPTION
This PR uses a copy of `run-script-smtcomp-current` for both `run-script-smtcomp-current-model-validation` and `run-script-smtcomp-current-unsat-cores`, so that all three scripts use the same sequence of strategies.