### PR TITLE
Restore patch for cross-compiling Libpoly

### DIFF
--- a/cmake/FindPoly.cmake
+++ b/cmake/FindPoly.cmake
@@ -52,6 +52,16 @@ if(NOT Poly_FOUND_SYSTEM)
 
   set(Poly_VERSION "0.2.0")
 
+  set(POLY_PATCH_KWD PATCH_COMMAND)
+  check_if_cross_compiling(CCWIN "Windows" "")
+  if(CCWIN)
+    set(POLY_PATCH_CMD
+      PATCH_COMMAND
+        ${CMAKE_SOURCE_DIR}/cmake/deps-utils/Poly-windows-patch.sh <SOURCE_DIR>
+    )
+    set(POLY_PATCH_KWD COMMAND)
+  endif()
+
   # On Windows, CMake's default install action places DLLs into the runtime
   # path (/bin) after doing the build with 'ExternalProject_Add'
   if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
@@ -129,8 +139,8 @@ if(NOT Poly_FOUND_SYSTEM)
     # We only want to install the headers and the position-independent version
     # of the static libraries, so remove the installation targets for the other
     # versions of LibPoly
-    set(POLY_PATCH_CMD
-      PATCH_COMMAND
+    set(POLY_PATCH_CMD ${POLY_PATCH_CMD}
+      ${POLY_PATCH_KWD}
         sed -ri.orig
           "/TARGETS (poly|polyxx|static_poly|static_polyxx) /d"
           <SOURCE_DIR>/src/CMakeLists.txt

--- a/cmake/deps-utils/Poly-windows-patch.sh
+++ b/cmake/deps-utils/Poly-windows-patch.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Roughly following https://stackoverflow.com/a/44383330/2375725
+# Avoid %z and %llu format specifiers
+find $1/ -type f ! -name "*.orig" -exec \
+     sed -i.orig "s/%z[diu]/%\\\" PRIu64 \\\"/g" {} +
+find $1/ -type f ! -name "*.orig" -exec \
+     sed -i.orig "s/%ll[du]/%\\\" PRIu64 \\\"/g" {} +
+
+# Make sure the new macros are available
+find $1/ -type f ! -name "*.orig" -exec \
+     sed -i.orig "s/#include <stdio.h>/#include <stdio.h>\\n#include <inttypes.h>/" {} +
+find $1/ -type f ! -name "*.orig" -exec \
+     sed -i.orig "s/#include <cstdio>/#include <cstdio>\\n#include <inttypes.h>/" {} +


### PR DESCRIPTION
The patch is still necessary when cross-compiling Libpoly for Windows on our Ubuntu 20 nightly runner. We will reconsider its removal once the runner has been upgraded.