### PR TITLE
Remove obsolete Python requirements files

### DIFF
--- a/contrib/requirements_build.txt
+++ b/contrib/requirements_build.txt
@@ -1,2 +1,0 @@
-tomli
-pyparsing

--- a/contrib/requirements_python_dev.txt
+++ b/contrib/requirements_python_dev.txt
@@ -1,3 +1,0 @@
-setuptools
-Cython>=3.0.0
-pytest


### PR DESCRIPTION
These files were created a long time ago to facilitate the manual installation of the project's Python module dependencies. However, our build system has since been extended to install these dependencies automatically.