### PR TITLE
Use model directly for arithmetic values in strings

### DIFF
--- a/src/theory/strings/model_cons.h
+++ b/src/theory/strings/model_cons.h
@@ -22,6 +22,7 @@
 
 namespace cvc5::internal {
 namespace theory {
+class TheoryModel;
 namespace strings {
 
 /**
@@ -61,8 +62,14 @@ class ModelCons : protected EnvObj
    * lts[i] for all elements in col.
    *
    * Must assign lts to *concrete* lengths.
+   * 
+   * @param m Pointer to the theory model.
+   * @param n The list of string terms.
+   * @param cols Populated as a partition of n based on their lengths.
+   * @param lts The list of lengths for each set in the parition cols.
    */
-  virtual void separateByLength(const std::vector<Node>& n,
+  virtual void separateByLength(TheoryModel * m,
+                                const std::vector<Node>& n,
                                 std::vector<std::vector<Node>>& cols,
                                 std::vector<Node>& lts) = 0;
   /**

--- a/src/theory/strings/model_cons_default.cpp
+++ b/src/theory/strings/model_cons_default.cpp
@@ -47,18 +47,23 @@ void ModelConsDefault::getStringRepresentativesFrom(
   }
 }
 
-void ModelConsDefault::separateByLength(const std::vector<Node>& ns,
+void ModelConsDefault::separateByLength(TheoryModel * m,
+                                        const std::vector<Node>& ns,
                                         std::vector<std::vector<Node>>& cols,
                                         std::vector<Node>& lts)
 {
   d_state.separateByLength(ns, cols, lts);
   // look up the values of each length term
-  Valuation& val = d_state.getValuation();
   for (Node& ll : lts)
   {
-    if (!ll.isConst())
+    // Previously we called Valuation::getCandidateModelValue for this purpose,
+    // which relied on the arithmetic theory solver to confirm the value of ll.
+    // However, it is better to simply ask the model object (which the
+    // arithmetic solver has already populated for us). Moreover this
+    // avoids assertion failures when using ee-mode=central.
+    if (!ll.isConst() && m->hasTerm(ll))
     {
-      ll = val.getCandidateModelValue(ll);
+      ll = m->getRepresentative(ll);
     }
   }
 }

--- a/src/theory/strings/model_cons_default.h
+++ b/src/theory/strings/model_cons_default.h
@@ -51,7 +51,8 @@ class ModelConsDefault : public ModelCons
    * It furthermore computes the model value for each of these length
    * terms based on the valuation class.
    */
-  void separateByLength(const std::vector<Node>& ns,
+  void separateByLength(TheoryModel * m,
+                        const std::vector<Node>& ns,
                         std::vector<std::vector<Node>>& cols,
                         std::vector<Node>& lts) override;
   /** Get the normal form for n from the core solver */

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -319,7 +319,7 @@ bool TheoryStrings::collectModelInfoType(
   std::vector<std::vector<Node>> col;
   std::vector<Node> lts;
   const std::vector<Node> repVec(repSet.at(tn).begin(), repSet.at(tn).end());
-  mc->separateByLength(repVec, col, lts);
+  mc->separateByLength(m, repVec, col, lts);
   Assert(col.size() == lts.size());
   // indices in col that have lengths that are too big to represent
   std::unordered_set<size_t> oobIndices;

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1990,6 +1990,7 @@ set(regress_0_tests
   regress0/strings/issue11197-str-ipc.smt2
   regress0/strings/issue11703-re-uf.smt2
   regress0/strings/issue11710-numeric-max.smt2
+  regress0/strings/issue11890-eec-model.smt2
   regress0/strings/issue1189.smt2
   regress0/strings/issue2958.smt2
   regress0/strings/issue3440.smt2

--- a/test/regress/cli/regress0/strings/issue11890-eec-model.smt2
+++ b/test/regress/cli/regress0/strings/issue11890-eec-model.smt2
@@ -1,0 +1,9 @@
+; COMMAND-LINE: --ee-mode=central
+; EXPECT: sat
+(set-logic QF_SLIA)
+(declare-fun x () String)
+(declare-fun y () String)
+(declare-fun z () Int)
+(assert (not (= (str.substr x 1 (str.indexof y x 0)) (str.at x (str.indexof y x 1)))))
+(check-sat)
+(exit)


### PR DESCRIPTION
This simplifies string model construction by asking the model object directly for models of length terms, instead of the Valuation class which asks the appropriate theory solver.

The latter leads to spurious assertion failures when `--ee-mode=central` is enabled since be may have chosen a term for representative that is not shared.

Fixes https://github.com/cvc5/cvc5/issues/11890