### PR TITLE
Always throw errors to regular output channel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,9 @@ This file contains a summary of important user-visible changes.
 ## Changes
 
 - Bumped CaDiCaL to version 2.1.3.
+- Corrected an issue with where errors are printed. Based on the SMT-LIB
+  standard, we now always print user-facing errors on the regular output
+  channel of the solver (stdout by default).
 
 cvc5 1.2.1
 ==========

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char* argv[])
 #ifdef CVC5_COMPETITION_MODE
     solver->getDriverOptions().out() << "unknown" << std::endl;
 #endif
-    std::cerr << "(error \"" << e.getMessage() << "\")" << std::endl
+    solver->getDriverOptions().out() << "(error \"" << e.getMessage() << "\")" << std::endl
               << std::endl
               << "Please use --help to get help on command-line options."
               << std::endl;
@@ -51,7 +51,7 @@ int main(int argc, char* argv[])
 #ifdef CVC5_COMPETITION_MODE
     solver->getDriverOptions().out() << "unknown" << std::endl;
 #endif
-    std::cerr << "(error \"" << e.getMessage() << "\")" << std::endl
+    solver->getDriverOptions().out() << "(error \"" << e.getMessage() << "\")" << std::endl
               << std::endl
               << "Please use --help to get help on command-line options."
               << std::endl;

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -41,20 +41,22 @@ int main(int argc, char* argv[])
 #ifdef CVC5_COMPETITION_MODE
     solver->getDriverOptions().out() << "unknown" << std::endl;
 #endif
-    solver->getDriverOptions().out() << "(error \"" << e.getMessage() << "\")" << std::endl
-              << std::endl
-              << "Please use --help to get help on command-line options."
-              << std::endl;
+    solver->getDriverOptions().out()
+        << "(error \"" << e.getMessage() << "\")" << std::endl
+        << std::endl
+        << "Please use --help to get help on command-line options."
+        << std::endl;
   }
   catch (OptionException& e)
   {
 #ifdef CVC5_COMPETITION_MODE
     solver->getDriverOptions().out() << "unknown" << std::endl;
 #endif
-    solver->getDriverOptions().out() << "(error \"" << e.getMessage() << "\")" << std::endl
-              << std::endl
-              << "Please use --help to get help on command-line options."
-              << std::endl;
+    solver->getDriverOptions().out()
+        << "(error \"" << e.getMessage() << "\")" << std::endl
+        << std::endl
+        << "Please use --help to get help on command-line options."
+        << std::endl;
   }
   catch (cvc5::CVC5ApiException& e)
   {

--- a/test/regress/cli/regress0/nl/proj-issue-425.smt2
+++ b/test/regress/cli/regress0/nl/proj-issue-425.smt2
@@ -1,6 +1,6 @@
 ; COMMAND-LINE: --solve-int-as-bv=5524936381719514648
-; EXPECT-ERROR: Error in option parsing
-; ERROR-SCRUBBER: grep -o "Error in option parsing"
+; EXPECT: Error in option parsing
+; SCRUBBER: grep -o "Error in option parsing"
 ; DISABLE-TESTER: dump
 ; REQUIRES: no-competition
 ; EXIT: 1

--- a/test/regress/cli/regress0/options/didyoumean.smt2
+++ b/test/regress/cli/regress0/options/didyoumean.smt2
@@ -1,6 +1,6 @@
 ; DISABLE-TESTER: dump
 ; REQUIRES: no-competition
 ; COMMAND-LINE: --input-agnuage
-; ERROR-SCRUBBER: grep -o "[a-zA-Z-]+"
-; ERROR-EXPECT: --input-language
+; SCRUBBER: grep -o "input-language"
+; EXPECT: input-language
 ; EXIT: 1

--- a/test/regress/cli/regress1/nl/iand-big-gran.smt2
+++ b/test/regress/cli/regress1/nl/iand-big-gran.smt2
@@ -1,6 +1,6 @@
 ; COMMAND-LINE: --bvand-integer-granularity=9
-; EXPECT-ERROR: Error in option parsing
-; ERROR-SCRUBBER: grep -o "Error in option parsing"
+; EXPECT: Error in option parsing
+; SCRUBBER: grep -o "Error in option parsing"
 ; DISABLE-TESTER: dump
 ; REQUIRES: no-competition
 ; EXIT: 1

--- a/test/regress/cli/run_regression.py
+++ b/test/regress/cli/run_regression.py
@@ -362,7 +362,7 @@ class CpcTester(Tester):
             )
             # if we throw an admissible error (with text "in safe mode"), we
             # allow the benchmark to be skipped.
-            if benchmark_info.safe_mode and (re.search(r'in safe mode', output.decode()) or re.search(r'in safe mode', error.decode())):
+            if benchmark_info.safe_mode and (re.search(r'in safe mode', output.decode()):
                 return EXIT_SKIP
             cpc_sig_dir = os.path.abspath(g_args.cpc_sig_dir)
             tmpf.write(("(include \"" + cpc_sig_dir + "/cpc/Cpc.eo\")").encode())
@@ -719,7 +719,7 @@ def run_benchmark(benchmark_info):
     )
     # For all testers, if we throw an admissible error (with text
     # "in safe mode"), we allow the benchmark to be skipped.
-    if benchmark_info.safe_mode and (re.search(r'in safe mode', output.decode()) or re.search(r'in safe mode', error.decode())):
+    if benchmark_info.safe_mode and (re.search(r'in safe mode', output.decode()):
         return (output, error, EXIT_SKIP)
 
     # If a scrubber command has been specified then apply it to the output.


### PR DESCRIPTION
Based on the SMT-LIB, the regular output channel should be used for all user-facing errors.