### PR TITLE
Fix issue with ee-mode central with arrays

### DIFF
--- a/src/theory/theory.cpp
+++ b/src/theory/theory.cpp
@@ -641,7 +641,7 @@ eq::EqualityEngine* Theory::getEqualityEngine()
 
 bool Theory::expUsingCentralEqualityEngine(TheoryId id)
 {
-  return id != THEORY_ARITH;
+  return id != THEORY_ARITH && id != THEORY_ARRAYS;
 }
 
 theory::Assertion Theory::get()

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -158,7 +158,7 @@ void TheoryUF::postCheck(Effort level)
       d_csolver->check();
     }
     // check with the higher-order extension at full effort
-    if (fullEffort(level) && logicInfo().isHigherOrder())
+    if (fullEffort(level) && d_ho!=nullptr)
     {
       d_ho->check();
     }
@@ -167,7 +167,9 @@ void TheoryUF::postCheck(Effort level)
 
 void TheoryUF::notifyFact(TNode atom, bool pol, TNode fact, bool isInternal)
 {
-  if (d_state.isInConflict())
+  // if we are in conflict, or higher-order and finite model finding are
+  // disabled, then return immediately.
+  if (d_state.isInConflict() || (d_ho==nullptr && d_thss==nullptr))
   {
     return;
   }
@@ -181,7 +183,7 @@ void TheoryUF::notifyFact(TNode atom, bool pol, TNode fact, bool isInternal)
   {
     case Kind::EQUAL:
     {
-      if (logicInfo().isHigherOrder() && options().uf.ufHoExt)
+      if (d_ho!=nullptr && options().uf.ufHoExt)
       {
         if (!pol && !d_state.isInConflict() && atom[0].getType().isFunction())
         {

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -158,7 +158,7 @@ void TheoryUF::postCheck(Effort level)
       d_csolver->check();
     }
     // check with the higher-order extension at full effort
-    if (fullEffort(level) && d_ho!=nullptr)
+    if (fullEffort(level) && logicInfo().isHigherOrder())
     {
       d_ho->check();
     }
@@ -167,9 +167,7 @@ void TheoryUF::postCheck(Effort level)
 
 void TheoryUF::notifyFact(TNode atom, bool pol, TNode fact, bool isInternal)
 {
-  // if we are in conflict, or higher-order and finite model finding are
-  // disabled, then return immediately.
-  if (d_state.isInConflict() || (d_ho==nullptr && d_thss==nullptr))
+  if (d_state.isInConflict())
   {
     return;
   }
@@ -183,7 +181,7 @@ void TheoryUF::notifyFact(TNode atom, bool pol, TNode fact, bool isInternal)
   {
     case Kind::EQUAL:
     {
-      if (d_ho!=nullptr && options().uf.ufHoExt)
+      if (logicInfo().isHigherOrder() && options().uf.ufHoExt)
       {
         if (!pol && !d_state.isInConflict() && atom[0].getType().isFunction())
         {

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -163,6 +163,7 @@ set(regress_0_tests
   regress0/arrays/issue9043_4.smt2
   regress0/arrays/issue10494.smt2
   regress0/arrays/issue10494-2.smt2
+  regress0/arrays/issue11889-eec-unsat.smt2
   regress0/arrays/proj-issue322-has-term.smt2
   regress0/arrays/proj-issue391-minisat-elim.smt2
   regress0/arrays/proj-issue467-cm.smt2

--- a/test/regress/cli/regress0/arrays/issue11889-eec-unsat.smt2
+++ b/test/regress/cli/regress0/arrays/issue11889-eec-unsat.smt2
@@ -1,0 +1,10 @@
+; COMMAND-LINE: --ee-mode=central
+; EXPECT: unsat
+(set-logic QF_AUFLIA)
+(declare-fun a () (Array Int Int))
+(declare-fun x () Int)
+(declare-fun y () Int)
+(declare-fun g ((Array Int Int)) Int)
+(declare-fun f (Int) Int)
+(assert (and (distinct (f x) (f y)) (= (store a y 0) (store a x 0)) (distinct (g a) (g (store a y 0)))))
+(check-sat)


### PR DESCRIPTION
The array theory requires explicitly being notified about disequalities between arrays.

When ee-mode=central, we did not configure arrays to request these notifications.

Fixes https://github.com/cvc5/cvc5/issues/11889.