### PR TITLE
Update proof checker scripts

### DIFF
--- a/contrib/get-carcara-checker
+++ b/contrib/get-carcara-checker
@@ -50,8 +50,8 @@ chmod +x $BASE_DIR/bin/cvc5-carcara-check.sh
 
 cat << EOF > $BASE_DIR/bin/cvc5-alethe-proof.sh
 #!/usr/bin/env bash
-# call cvc5 and remove the first line of the output (should be "unsat")
-\$@ --dump-proofs --proof-format=alethe | tail -n +2
+# call cvc5 and remove the first line of the output (should be "unsat", "(", ")")
+\$@ --dump-proofs --proof-format=alethe | tail -n +3 | head -n -1
 EOF
 chmod +x $BASE_DIR/bin/cvc5-alethe-proof.sh
 

--- a/contrib/get-ethos-checker
+++ b/contrib/get-ethos-checker
@@ -60,10 +60,10 @@ chmod +x $BASE_DIR/bin/cpc_gen_and_check.sh
 cat << EOF > $BASE_DIR/bin/cpc_gen.sh
 #!/usr/bin/env bash
 
-# call cvc5 and remove the first line of the output (should be "unsat")
+# call cvc5 and remove the first line of the output (should be "unsat", "(", ")")
 echo "(include \"$SIG_DIR/Cpc.eo\")"
 echo "(include \"$SIG_DIR/expert/CpcExpert.eo\")"
-\$@ --dump-proofs --proof-format=cpc --proof-granularity=dsl-rewrite | tail -n +2
+\$@ --dump-proofs | tail -n +3 | head -n -1
 EOF
 chmod +x $BASE_DIR/bin/cpc_gen.sh
 

--- a/contrib/get-lfsc-checker
+++ b/contrib/get-lfsc-checker
@@ -62,8 +62,8 @@ chmod +x $BASE_DIR/bin/lfsc_gen_and_check.sh
 cat << EOF > $BASE_DIR/bin/lfsc_gen.sh
 #!/usr/bin/env bash
 
-# call cvc5 and remove the first line of the output (should be "unsat")
-\$@ --dump-proofs --proof-format=lfsc | tail -n +2
+# call cvc5 and remove the first, second and last lines of the output (should be "unsat", "(", ")")
+\$@ --dump-proofs --proof-format=lfsc | tail -n +3 | head -n -1
 EOF
 chmod +x $BASE_DIR/bin/lfsc_gen.sh
 


### PR DESCRIPTION
This was missing from https://github.com/cvc5/cvc5/pull/11883, we did not update the proof checker scripts to show an example of how to process proof output.