### PR TITLE
cmake: Ensure the Python API is built when build-tests is invoked

### DIFF
--- a/test/api/python/CMakeLists.txt
+++ b/test/api/python/CMakeLists.txt
@@ -13,6 +13,9 @@
 # The build system configuration.
 ##
 
+add_custom_target(build-pyapitests)
+add_dependencies(build-tests build-pyapitests)
+
 if(WIN32)
   set(CVC5_PYAPI_TEST_DIR ${CMAKE_BINARY_DIR}/cvc5-pyapi-test)
 
@@ -21,7 +24,7 @@ if(WIN32)
 
   # Install the cvc5 Python bindings in the build directory to run tests.
   # On Windows, adding the directory with the Python bindings to PYTHONPATH
-  # is not enought because Python only searches for DLL dependencies for
+  # is not enough because Python only searches for DLL dependencies for
   # extension modules in system paths and the directory containing the PYD file.
   # Specifically, since Python 3.8, PATH and the current working directory are
   # no longer used for this purpose. See:
@@ -41,7 +44,7 @@ if(WIN32)
 
   add_custom_target(setup-cvc5-pyapi DEPENDS ${CVC5_PYAPI_TEST_DIR})
 
-  add_dependencies(build-tests setup-cvc5-pyapi)
+  add_dependencies(build-pyapitests setup-cvc5-pyapi)
 
   # Get path to the python bindings installed in the build directory
   execute_process(COMMAND
@@ -53,6 +56,7 @@ if(WIN32)
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 else()
   set(PYTHON_MODULE_PATH ${CMAKE_BINARY_DIR}/src/api/python)
+  add_dependencies(build-pyapitests cvc5_python_api)
 endif()
 
 # Add Python bindings API tests.


### PR DESCRIPTION
It also adds a rule, named `pyapitests`, to build only the Python unit tests, similar to the C API test rule (`capitests`).