### PR TITLE
cmake: Enforce C17 for building GMP.

### DIFF
--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -75,7 +75,11 @@ if(NOT GMP_FOUND_SYSTEM)
   set(GMP_VERSION "6.3.0")
 
   set(GMP_INCLUDE_DIR "${DEPS_BASE}/include/")
+
+  # Newer versions of gcc use C23 as default C standard but GMP (as of 6.3.0)
+  # only supports C17. Thus, we fix it to C17.
   set(GMP_CFLAGS "-std=gnu17")
+
   if(BUILD_SHARED_LIBS)
     set(LINK_OPTS --enable-shared --disable-static)
     if(CMAKE_SYSTEM_NAME STREQUAL "Windows")

--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -75,7 +75,7 @@ if(NOT GMP_FOUND_SYSTEM)
   set(GMP_VERSION "6.3.0")
 
   set(GMP_INCLUDE_DIR "${DEPS_BASE}/include/")
-  set(CONFIGURE_ENV ${CONFIGURE_ENV} env "CFLAGS=-std=gnu17")
+  set(GMP_CFLAGS "-std=gnu17")
   if(BUILD_SHARED_LIBS)
     set(LINK_OPTS --enable-shared --disable-static)
     if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
@@ -113,10 +113,11 @@ if(NOT GMP_FOUND_SYSTEM)
     if (CMAKE_CROSSCOMPILING_MACOS)
       set(CONFIGURE_ENV
         ${CONFIGURE_ENV}
-        env "CFLAGS=--target=${TOOLCHAIN_PREFIX}"
         env "LDFLAGS=-arch ${CMAKE_OSX_ARCHITECTURES}")
+      set(GMP_CFLAGS "${GMP_CFLAGS} --target=${TOOLCHAIN_PREFIX}")
     endif()
   endif()
+  set(CONFIGURE_ENV ${CONFIGURE_ENV} env "CFLAGS=${GMP_CFLAGS}")
 
   # `CC_FOR_BUILD`, `--host`, and `--build` are passed to `configure` to ensure
   # that cross-compilation works (as suggested in the GMP documentation).

--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -75,6 +75,7 @@ if(NOT GMP_FOUND_SYSTEM)
   set(GMP_VERSION "6.3.0")
 
   set(GMP_INCLUDE_DIR "${DEPS_BASE}/include/")
+  set(CONFIGURE_ENV ${CONFIGURE_ENV} env "CFLAGS=-std=gnu17")
   if(BUILD_SHARED_LIBS)
     set(LINK_OPTS --enable-shared --disable-static)
     if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
@@ -100,7 +101,7 @@ if(NOT GMP_FOUND_SYSTEM)
 
   # Since makeinfo just builds the documentation for GMP,
   # it is possible to get around this issue by just disabling it:
-  set(CONFIGURE_ENV env "MAKEINFO=true")
+  set(CONFIGURE_ENV ${CONFIGURE_ENV} env "MAKEINFO=true")
 
   if(CMAKE_CROSSCOMPILING OR CMAKE_CROSSCOMPILING_MACOS)
     set(CONFIGURE_OPTS


### PR DESCRIPTION
Newer compiler version use c23 as default, which is not supported when building GMP as an external project. This fixes the version to build with to 17.