### PR TITLE
Update portfolio to support get-model and get-unsat-core

### DIFF
--- a/src/main/portfolio_driver.h
+++ b/src/main/portfolio_driver.h
@@ -41,6 +41,10 @@ class ExecutionContext
   std::optional<std::string> d_logic;
   /* Whether a check-sat command has been read */
   bool d_hasReadCheckSat = false;
+  /** The last stored declarations and named terms **/
+  std::vector<cvc5::Sort> d_sorts;
+  std::vector<cvc5::Term> d_terms;
+  std::map<cvc5::Term, std::string> d_named_terms;
 
   /** Retrieve the solver object from the command executor */
   Solver& solver() { return *d_executor->getSolver(); }
@@ -60,6 +64,21 @@ class ExecutionContext
   bool solveContinuous(parser::InputParser* parser,
                        bool stopAtSetLogic,
                        bool stopAtCheckSat = false);
+
+  /**
+   * Store the current declarations and named terms to be used by
+   * continueAfterSolving().
+   */
+  void storeDeclarationsAndNamedTerms();
+
+  /**
+   * Read commands from the parser and continuously execute them.
+   * If a (get-model) command is detected, the last stored declarations are
+   * used. If a (get-unsat-core) command is detected, the last stored named
+   * terms are used. Returns true if the commands were executed without
+   * interruption.
+   */
+  bool continueAfterSolving(parser::InputParser* parser);
 
   /**
    * Execute a check-sat command.


### PR DESCRIPTION
This change is required to run cvc5's internal portfolio in the SMT Competition's unsat-core and model-validation tracks.