### PR TITLE
More updates to options categories

### DIFF
--- a/src/options/mkoptions.py
+++ b/src/options/mkoptions.py
@@ -70,7 +70,7 @@ OPTION_ATTR_ALL = OPTION_ATTR_REQ + [
 CATEGORY_VALUES = ['common', 'expert', 'regular', 'undocumented']
 
 # legal values for the "no_support" field
-NO_SUPPORT_VALUES = ['proofs', 'models']
+NO_SUPPORT_VALUES = ['proofs', 'models', 'unsat-cores']
 
 ################################################################################
 ################################################################################

--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -190,6 +190,7 @@ name   = "Quantifiers"
   long       = "ext-rewrite-quant"
   type       = "bool"
   default    = "false"
+  no_support = ["proofs"]
   help       = "apply extended rewriting to bodies of quantified formulas"
 
 [[option]]
@@ -841,10 +842,11 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "quantSubCbqi"
-  category   = "expert"
+  category   = "regular"
   long       = "sub-cbqi"
   type       = "bool"
   default    = "false"
+  no_support = ["proofs"]
   help       = "Enable conflict-based instantiation subsolver strategy"
 
 [[option]]
@@ -1587,10 +1589,11 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "cegqiNestedQE"
-  category   = "expert"
+  category   = "regular"
   long       = "cegqi-nested-qe"
   type       = "bool"
   default    = "false"
+  no_support = ["proofs"]
   help       = "process nested quantified formulas with quantifier elimination in counterexample-based quantifier instantiation"
 
 # CEGQI for arithmetic
@@ -1717,10 +1720,11 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "macrosQuant"
-  category   = "expert"
+  category   = "regular"
   long       = "macros-quant"
   type       = "bool"
   default    = "false"
+  no_support = ["proofs"]
   help       = "perform quantifiers macro expansion"
 
 [[option]]
@@ -1779,7 +1783,7 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "hoElim"
-  category   = "regular"
+  category   = "expert"
   long       = "ho-elim"
   type       = "bool"
   default    = "false"
@@ -1787,7 +1791,7 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "hoElimStoreAx"
-  category   = "regular"
+  category   = "expert"
   long       = "ho-elim-store-ax"
   type       = "bool"
   default    = "true"

--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -47,6 +47,7 @@ name   = "SMT Layer"
   long       = "learned-rewrite"
   type       = "bool"
   default    = "false"
+  no_support = ["unsat-cores"]
   help       = "rewrite the input based on learned literals"
 
 [[option]]
@@ -234,7 +235,7 @@ name   = "SMT Layer"
 
 [[option]]
   name       = "checkSynthSol"
-  category   = "regular"
+  category   = "common"
   long       = "check-synth-sol"
   type       = "bool"
   default    = "false"
@@ -475,7 +476,7 @@ name   = "SMT Layer"
 
 [[option]]
   name       = "checkInterpolants"
-  category   = "regular"
+  category   = "common"
   long       = "check-interpolants"
   type       = "bool"
   default    = "false"
@@ -483,7 +484,7 @@ name   = "SMT Layer"
 
 [[option]]
   name       = "checkAbducts"
-  category   = "regular"
+  category   = "common"
   long       = "check-abducts"
   type       = "bool"
   default    = "false"

--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -47,7 +47,7 @@ name   = "SMT Layer"
   long       = "learned-rewrite"
   type       = "bool"
   default    = "false"
-  no_support = ["unsat-cores"]
+  no_support = ["proofs", "unsat-cores"]
   help       = "rewrite the input based on learned literals"
 
 [[option]]

--- a/src/options/strings_options.toml
+++ b/src/options/strings_options.toml
@@ -19,10 +19,11 @@ name   = "Strings Theory"
 
 [[option]]
   name       = "stringLazyPreproc"
-  category   = "expert"
+  category   = "regular"
   long       = "strings-lazy-pp"
   type       = "bool"
   default    = "true"
+  no_support = ["proofs"]
   help       = "perform string preprocessing lazily"
 
 [[option]]
@@ -107,10 +108,11 @@ name   = "Strings Theory"
 
 [[option]]
   name       = "regExpElim"
-  category   = "expert"
+  category   = "regular"
   long       = "re-elim=MODE"
   type       = "RegExpElimMode"
   default    = "OFF"
+  no_support = ["proofs"]
   help       = "regular expression elimination mode"
   help_mode  = "Regular expression elimination modes."
 [[option.mode.OFF]]


### PR DESCRIPTION
Includes re-enabling several options that were recently "regular" but were demoted to expert options due to lack of proofs.

Also adds a few missing "no_support" fields, and demote 2 HO options to "expert" as higher-order is an expert theory.

Also promotes `--check-X` options to common.