### PR TITLE
ci: Use the lowest supported Java version for each platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
             strip-bin: strip
             python-bindings: true
             java-bindings: true
+            java-version: 11
             check-examples: true
             package-name: cvc5-macOS-arm64
             macos-target: 11.0
@@ -203,6 +204,13 @@ jobs:
     steps:
 
     - uses: actions/checkout@v4
+
+    # Ensure that the Java bindings, Java API tests, and Java examples are compatible
+    # with the minimum required Java version (currently Java 8).
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.build.java-version || '8' }}
 
     - name: Setup CMake
       uses: ./.github/actions/setup-cmake

--- a/src/api/java/CMakeLists.txt
+++ b/src/api/java/CMakeLists.txt
@@ -103,13 +103,6 @@ add_custom_target(generate-java-types DEPENDS ${JAVA_TYPES_FILES})
 
 # find java
 find_package(Java 1.8 COMPONENTS Development REQUIRED)
-if(Java_VERSION_MAJOR GREATER_EQUAL 9)
-  # Compile option --release is available from JDK 9 onwards.
-  # It ensures the compiled classes are compatible with
-  # the minimum required version. It expects a single number
-  # and does not support 1.X syntax used in JDK < 9.
-  set(CMAKE_JAVA_COMPILE_FLAGS "--release" "8")
-endif()
 include(UseJava)
 
 # specify java source files

--- a/test/unit/api/java/TermTest.java
+++ b/test/unit/api/java/TermTest.java
@@ -787,7 +787,7 @@ class TermTest
     assertTrue(s1.isStringValue());
     assertEquals(s1.getStringValue(), "abcde");
     Term s2 = d_tm.mkString("\\u{200cb}", true);
-    assertEquals(s2.getStringValue(), Character.toString(0x200cb));
+    assertEquals(s2.getStringValue(), new String(Character.toChars(0x200cb)));
   }
 
   @Test


### PR DESCRIPTION
This PR uses Java 8 in CI, except on macOS arm64, where the minimum supported Java version is 11. This ensures that the Java bindings, Java API tests, and Java examples are compatible with the minimum required Java version. It also ensures that the published Java bindings on GitHub can run with this older version. Previously, CMake enforced compatibility for the Java bindings, but not for the Java API tests or the Java examples. This change provides a more centralized solution.

This PR also fixes a Java unit test to make it compatible with Java 8.