### PR TITLE
Disable another timeout regression

### DIFF
--- a/test/regress/cli/regress0/fp/word-blast.smt2
+++ b/test/regress/cli/regress0/fp/word-blast.smt2
@@ -1,5 +1,5 @@
 ; DISABLE-TESTER: lfsc
-
+; DISABLE-TESTER: proof
 ; COMMAND-LINE: --fp-lazy-wb
 ; EXPECT: unsat
 (set-logic QF_BVFP)

--- a/test/regress/cli/regress1/quantifiers/bug802.smt2
+++ b/test/regress/cli/regress1/quantifiers/bug802.smt2
@@ -1,4 +1,4 @@
-
+; DISABLE-TESTER: proof
 ; DISABLE-TESTER: lfsc
 (set-logic BV)
 (set-info :source | 


### PR DESCRIPTION
Fixes failure in nightlies.

This benchmark was recently reenabled for (dsl) proofs, but appears to timeout in some builds.