### PR TITLE
Refactoring CPC to avoid constructs that cannot be typed

### DIFF
--- a/proofs/eo/cpc/Cpc.eo
+++ b/proofs/eo/cpc/Cpc.eo
@@ -442,17 +442,18 @@
   )
 )
 
-; define: $is_absorb
+; program: $is_absorb
 ; args:
 ; - t U: The term to compute whether it simplifies to a zero element.
 ; - zero U: The zero element of the function of t.
 ; return: >
 ;   true, if zero is the zero element for t and is found as a subterm of t beneath f-applications.
-(define $is_absorb ((S Type :implicit) (t S) (zero S))
-  (eo::requires ($get_zero t) zero  ; verify that we are using the right zero
-  (eo::match ((T Type) (U Type) (f (-> U U U)) (t1 U) (t2 U))
-    t
-    (((f t1 t2) ($is_absorb_rec f t zero))))))
+(program $is_absorb ((T Type) (U Type) (f (-> U U U)) (t1 T) (t2 T) (zero T))
+  (T T) Bool
+  (
+  (($is_absorb (f t1 t2) zero) ($is_absorb_rec f (f t1 t2) zero))
+  )
+)
 
 ; rule: absorb
 ; implements: ProofRule::ABSORB
@@ -463,7 +464,7 @@
 ; conclusion: The given equality.
 (declare-rule absorb ((U Type) (t U) (zero U))
   :args ((= t zero))
-  :requires ((($is_absorb t zero) true))
+  :requires ((($get_zero t) zero) (($is_absorb t zero) true))
   :conclusion (= t zero)
 )
 

--- a/proofs/eo/cpc/Cpc.eo
+++ b/proofs/eo/cpc/Cpc.eo
@@ -427,20 +427,18 @@
 ; - t S: The term to compute whether it simplifies to a zero element.
 ; return: >
 ;   The zero element for t, if it is found.
-(define $get_zero ((S Type :implicit) (t S))
-  (eo::match ((b1 Bool) (b2 Bool :list)
-              (r1 RegLan) (r2 RegLan :list)
-              (m Int) (xb1 (BitVec m)) (xb2 (BitVec m) :list))
-    t
-    (
-    ((or b1 b2)        true)
-    ((and b1 b2)       false)
-    ((re.union r1 r2)  re.all)
-    ((re.inter r1 r2)  re.none)
-    ((re.++ r1 r2)     re.none)
-    ((bvor xb1 xb2)    ($bv_ones ($bv_bitwidth (eo::typeof xb1))))
-    ((bvand xb1 xb2)   (eo::to_bin ($bv_bitwidth (eo::typeof xb1)) 0))
-    )
+(program $get_zero ((S Type) (b1 Bool) (b2 Bool :list)
+                    (r1 RegLan) (r2 RegLan :list)
+                    (m Int) (xb1 (BitVec m)) (xb2 (BitVec m) :list))
+  (S) S
+  (
+  (($get_zero (or b1 b2))        true)
+  (($get_zero (and b1 b2))       false)
+  (($get_zero (re.union r1 r2))  re.all)
+  (($get_zero (re.inter r1 r2))  re.none)
+  (($get_zero (re.++ r1 r2))     re.none)
+  (($get_zero (bvor xb1 xb2))    ($bv_ones ($bv_bitwidth (eo::typeof xb1))))
+  (($get_zero (bvand xb1 xb2))   (eo::to_bin ($bv_bitwidth (eo::typeof xb1)) 0))
   )
 )
 

--- a/proofs/eo/cpc/Cpc.eo
+++ b/proofs/eo/cpc/Cpc.eo
@@ -347,7 +347,7 @@
 
 ;;;;; ProofRule::ACI_NORM
 
-; define: $get_aci_normal_form
+; program: $get_aci_normal_form
 ; args:
 ; - t S: The term to compute the normal form for.
 ; return: >
@@ -355,26 +355,24 @@
 ;   particular, if t is an application of a known operator that has the property
 ;   of being either associative and commutative (resp. associative) we call
 ;   the method $get_aci_norm (resp. $get_a_norm).
-(define $get_aci_normal_form ((S Type :implicit) (t S))
-  (eo::match ((T Type) (x T)
-              (b1 Bool) (b2 Bool :list)
-              (r1 RegLan) (r2 RegLan :list)
-              (m Int) (xb1 (BitVec m)) (xb2 (BitVec m) :list)
-              (U Type) (xs1 (Seq U)) (xs2 (Seq U) :list))
-    t
-    (
-      ((or b1 b2)        ($get_aci_norm t true))
-      ((and b1 b2)       ($get_aci_norm t true))
-      ((re.union r1 r2)  ($get_aci_norm t true))
-      ((re.inter r1 r2)  ($get_aci_norm t true))
-      ((bvor xb1 xb2)    ($get_aci_norm t true))
-      ((bvand xb1 xb2)   ($get_aci_norm t true))
-      ((bvxor xb1 xb2)   ($get_aci_norm t false))
-      ((str.++ xs1 xs2)  ($get_a_norm t))
-      ((re.++ r1 r2)     ($get_a_norm t))
-      ((concat xb1 xb2)  ($get_a_norm t))
-      (x                 x)
-    )
+(program $get_aci_normal_form ((T Type) (x T)
+                               (b1 Bool) (b2 Bool :list)
+                               (r1 RegLan) (r2 RegLan :list)
+                               (m Int) (xb1 (BitVec m)) (xb2 (BitVec m) :list)
+                               (U Type) (xs1 (Seq U)) (xs2 (Seq U) :list))
+  (T) T
+  (
+    (($get_aci_normal_form (or b1 b2))        ($get_aci_norm (or b1 b2) true))
+    (($get_aci_normal_form (and b1 b2))       ($get_aci_norm (and b1 b2) true))
+    (($get_aci_normal_form (re.union r1 r2))  ($get_aci_norm (re.union r1 r2) true))
+    (($get_aci_normal_form (re.inter r1 r2))  ($get_aci_norm (re.inter r1 r2) true))
+    (($get_aci_normal_form (bvor xb1 xb2))    ($get_aci_norm (bvor xb1 xb2) true))
+    (($get_aci_normal_form (bvand xb1 xb2))   ($get_aci_norm (bvand xb1 xb2) true))
+    (($get_aci_normal_form (bvxor xb1 xb2))   ($get_aci_norm (bvxor xb1 xb2) false))
+    (($get_aci_normal_form (str.++ xs1 xs2))  ($get_a_norm (str.++ xs1 xs2)))
+    (($get_aci_normal_form (re.++ r1 r2))     ($get_a_norm (re.++ r1 r2)))
+    (($get_aci_normal_form (concat xb1 xb2))  ($get_a_norm (concat xb1 xb2)))
+    (($get_aci_normal_form x)                 x)
   )
 )
 

--- a/proofs/eo/cpc/expert/CpcExpert.eo
+++ b/proofs/eo/cpc/expert/CpcExpert.eo
@@ -37,7 +37,7 @@
 (declare-parameterized-const @shared_selector ((D Type :opaque) (T Type :opaque) (n Int :opaque)) (-> D T))
 
 
-; define: $get_aci_normal_form_expert
+; program: $get_aci_normal_form_expert
 ; args:
 ; - t S: The term to compute the normal form for.
 ; return: >
@@ -45,14 +45,12 @@
 ;   particular, if t is an application of a known (expert) operator that has the property
 ;   of being either associative and commutative (resp. associative) we call
 ;   the method $get_aci_norm (resp. $get_a_norm).
-(define $get_aci_normal_form_expert ((S Type :implicit) (t S))
-  (eo::match ((x1 Bool) (x2 Bool :list) (m Int) (xf1 (FiniteField m)) (xf2 (FiniteField m) :list))
-    t
-    (
-      ((sep x1 x2)       ($get_aci_norm t true))
-      ((ff.add xf1 xf2)  ($get_aci_norm t true))
-      ((ff.mul xf1 xf2)  ($get_aci_norm t true))
-    )
+(program $get_aci_normal_form_expert ((T Type) (x1 Bool) (x2 Bool :list) (m Int) (xf1 (FiniteField m)) (xf2 (FiniteField m) :list))
+  (T) T
+  (
+    (($get_aci_normal_form_expert (sep x1 x2))       ($get_aci_norm (sep x1 x2) true))
+    (($get_aci_normal_form_expert (ff.add xf1 xf2))  ($get_aci_norm (ff.add xf1 xf2) true))
+    (($get_aci_normal_form_expert (ff.mul xf1 xf2))  ($get_aci_norm (ff.mul xf1 xf2) true))
   )
 )
 

--- a/proofs/eo/cpc/expert/theories/FiniteFields.eo
+++ b/proofs/eo/cpc/expert/theories/FiniteFields.eo
@@ -5,12 +5,16 @@
 ;   symbols over this sort are also not part of the SMT-LIB standard.
 (declare-const FiniteField (-> Int Type))
 
-; define: $bv_bitwidth
+; program: $ff_size
 ; args:
 ; - T Type: The finite field type.
 ; return: The (integer value) size for a given finite field type.
-(define $ff_size ((T Type))
-  (eo::match ((n Int)) T (((FiniteField n) n))))
+(program $ff_size ((n Int))
+  (Type) Int
+  (
+  (($ff_size (FiniteField n)) n)
+  )
+)
 
 ; A finite field constant is a term having 2 integer children.
 ; note: we do not support the native syntax for finite field values.

--- a/proofs/eo/cpc/programs/Strings.eo
+++ b/proofs/eo/cpc/programs/Strings.eo
@@ -40,12 +40,15 @@
   )
 )
 
-; define: $char_type_of
+; program: $char_type_of
 ; args:
 ; - T Type: The string-like type to check.
 ; return: the character type of the string-like type T
-(define $char_type_of ((T Type)) 
-  (eo::match ((U Type)) T (((Seq U) U)))
+(program $char_type_of ((U Type))
+  (Type) Type
+  (
+  (($char_type_of (Seq U)) U)
+  )
 )
 
 ; define: $str_concat

--- a/proofs/eo/cpc/programs/Utils.eo
+++ b/proofs/eo/cpc/programs/Utils.eo
@@ -102,31 +102,6 @@
 (define $compare_var ((T Type :implicit) (U Type :implicit) (a T) (b U))
   (eo::cmp b a))
 
-; define: $head
-; args:
-; - x S: The term to inspect.
-; return: >
-;   The head of x, where x is expected to be an application of an n-ary
-;   function marked :right-assoc-nil.
-; return: the head of x, where x is expected to be a function application.
-(define $head ((S Type :implicit) (x S))
-  (eo::match ((T Type) (U Type) (f (-> T U U)) (x1 T) (x2 U :list))
-    x
-    (((f x1 x2) x1)))
-)
-
-; define: $tail
-; args:
-; - x S: The term to inspect.
-; return: >
-;   The tail of x, where x is expected to be an application of an n-ary
-;   function marked :right-assoc-nil.
-(define $tail ((U Type :implicit) (x U))
-  (eo::match ((T Type) (U Type) (f (-> T U U)) (x1 T) (x2 U :list))
-    x
-    (((f x1 x2) x2)))
-)
-
 ; program: $singleton_elim
 ; args:
 ; - s S: The term to proces.

--- a/proofs/eo/cpc/rules/Arith.eo
+++ b/proofs/eo/cpc/rules/Arith.eo
@@ -42,15 +42,14 @@
 ; args:
 ; - F Bool: A conjunction of arithmetic relations.
 ; return: the arithmetic relation that is implied by adding each of the relations in F together.
-(program $mk_arith_sum_ub ((T Type) (U Type) (r (-> T U Bool)) (a T) (b U) (tail Bool :list))
-    (Bool) Bool
-    (
-        (($mk_arith_sum_ub true)               (= 0 0))
-        (($mk_arith_sum_ub (and (r a b) tail)) 
-          (eo::match ((S Type) (V Type) (r2 (-> S V Bool)) (a2 S :list) (b2 V :list))
-            ($mk_arith_sum_ub tail)
-            (((r2 a2 b2) ($arith_rel_sum r r2 (+ a a2) (+ b b2))))))
-    )
+(program $mk_arith_sum_ub ((T Type) (U Type) (r (-> T U Bool)) (a T) (b U) (tail Bool :list)
+                           (S Type) (V Type) (r2 (-> S V Bool)) (a2 S :list) (b2 V :list) (acc Bool))
+  (Bool Bool) Bool
+  (
+    (($mk_arith_sum_ub true acc)                      acc)
+    (($mk_arith_sum_ub (and (r a b) tail) (r2 a2 b2)) ($mk_arith_sum_ub tail ($arith_rel_sum r r2 (+ a a2) (+ b b2))))
+
+  )
 )
 
 ; rule: arith_sum_ub
@@ -62,7 +61,7 @@
 ;   relations in F together.
 (declare-rule arith_sum_ub ((F Bool))
   :premise-list F and
-  :conclusion ($mk_arith_sum_ub F)
+  :conclusion ($mk_arith_sum_ub ($nary_reverse F) (= 0 0))
 )
 
 ;;;;; ProofRule::ARITH_MULT_POS
@@ -431,30 +430,28 @@
       (=> (> v 0) (and lb (< u (* v (+ k 1)))))
       (=> (< v 0) (and lb (< u (* v (+ k -1))))))))))
 
-; define: $arith_reduction_pred
+; program: $arith_reduction_pred
 ; args:
 ; - t T: The term we are considering, which is expected to be an application of an extended arithmetic operator.
 ; return: the reduction predicate for term t.
-(define $arith_reduction_pred ((T Type :implicit) (t T))
-  (eo::match ((U Type) (V Type) (r Real) (a Int) (b Int) (u U) (v V))
-    t
-    (
-    ((is_int u)       (eo::define ((k (@purify (to_int u))))
-                        (and (= t (= (- u k) 0/1)) ($arith_to_int_reduction u))))
-    ((to_int u)       (eo::define ((k (@purify (to_int u))))
-                        (and (= t k) ($arith_to_int_reduction u))))
-    ((/ u v)          (eo::define ((ur (eo::ite (eo::eq (eo::typeof u) Int) (to_real u) u)))
-                        (= t (ite (= v ($arith_mk_zero (eo::typeof v))) (@div_by_zero ur) (/_total u v)))))
-    ((div a b)        (= t (ite (= b 0) (@int_div_by_zero a) (div_total a b))))
-    ((mod a b)        (= t (ite (= b 0) (@mod_by_zero a) (mod_total a b))))
-    ((/_total u v)    (eo::define ((k (@purify (/_total u v))))
-                        (and (= t k) (=> (not (= v ($arith_mk_zero (eo::typeof v)))) (= (* v k) u)))))
-    ((div_total a b)  (eo::define ((k (@purify (div_total a b))))
-                        (and (= t k) ($arith_int_div_total_reduction a b))))
-    ((mod_total a b)  (eo::define ((k (@purify (div_total a b))))
-                        (and (= t (- a (* b k))) ($arith_int_div_total_reduction a b))))
-    ((abs u)          (= t (ite (< u ($arith_mk_zero (eo::typeof u))) (- u) u)))
-    )
+(program $arith_reduction_pred ((T Type) (U Type) (V Type) (r Real) (a Int) (b Int) (u U) (v V))
+  (T) Bool
+  (
+  (($arith_reduction_pred (is_int u))       (eo::define ((k (@purify (to_int u))))
+                                              (and (= (is_int u) (= (- u k) 0/1)) ($arith_to_int_reduction u))))
+  (($arith_reduction_pred (to_int u))       (eo::define ((k (@purify (to_int u))))
+                                              (and (= (to_int u) k) ($arith_to_int_reduction u))))
+  (($arith_reduction_pred (/ u v))          (eo::define ((ur (eo::ite (eo::eq (eo::typeof u) Int) (to_real u) u)))
+                                              (= (/ u v) (ite (= v ($arith_mk_zero (eo::typeof v))) (@div_by_zero ur) (/_total u v)))))
+  (($arith_reduction_pred (div a b))        (= (div a b) (ite (= b 0) (@int_div_by_zero a) (div_total a b))))
+  (($arith_reduction_pred (mod a b))        (= (mod a b) (ite (= b 0) (@mod_by_zero a) (mod_total a b))))
+  (($arith_reduction_pred (/_total u v))    (eo::define ((k (@purify (/_total u v))))
+                                              (and (= (/_total u v) k) (=> (not (= v ($arith_mk_zero (eo::typeof v)))) (= (* v k) u)))))
+  (($arith_reduction_pred (div_total a b))  (eo::define ((k (@purify (div_total a b))))
+                                              (and (= (div_total a b) k) ($arith_int_div_total_reduction a b))))
+  (($arith_reduction_pred (mod_total a b))  (eo::define ((k (@purify (div_total a b))))
+                                              (and (= (mod_total a b) (- a (* b k))) ($arith_int_div_total_reduction a b))))
+  (($arith_reduction_pred (abs u))          (= (abs u) (ite (< u ($arith_mk_zero (eo::typeof u))) (- u) u)))
   )
 )
 

--- a/proofs/eo/cpc/rules/BitVectors.eo
+++ b/proofs/eo/cpc/rules/BitVectors.eo
@@ -183,23 +183,23 @@
 ;   (bvand x #b0011) as a, this program will return
 ;   (concat (bvand ((_ extract 3 2) #b0011) ((_ extract 3 2) x))
 ;           (bvand ((_ extract 1 0) #b0011) ((_ extract 1 0) x))).
-(define $bv_mk_bitwise_slicing ((n Int :implicit) (a (BitVec n)))
-  (eo::match ((m Int) (f (-> (BitVec m) (BitVec m) (BitVec m))) (a1 (BitVec m)) (a2 (BitVec m) :list))
-    a
-    (
-    ((f a1 a2)    ($singleton_elim
-                  (eo::define ((c ($bv_get_first_const_child a)))
-                  (eo::requires ($bv_is_bitwise_slicing_op f) true
-                  (eo::requires (eo::eq c @bv_empty) false
-                  (eo::define ((wm1 (eo::add (eo::len c) -1)))
-                  ($bv_mk_bitwise_slicing_rec
-                    f
-                    c
-                    (eo::define ((nil (eo::nil f a1 a2)))
-                      ($singleton_elim ($nary_diff f nil a (eo::cons f c nil))))  ; remove the constant and recollect
-                    ($nary_reverse ($bv_mk_bitblast_step_const c))                ; convert the constant to a bitlist
-                    ($bv_bit_set c wm1) wm1 wm1)))))))
-    )
+(program $bv_mk_bitwise_slicing
+  ((n Int) (m Int) (f (-> (BitVec m) (BitVec m) (BitVec m))) (a1 (BitVec n)) (a2 (BitVec n) :list))
+  ((BitVec n)) (BitVec n)
+  (
+  (($bv_mk_bitwise_slicing (f a1 a2))
+              ($singleton_elim
+                (eo::define ((c ($bv_get_first_const_child (f a1 a2))))
+                (eo::requires ($bv_is_bitwise_slicing_op f) true
+                (eo::requires (eo::eq c @bv_empty) false
+                (eo::define ((wm1 (eo::add (eo::len c) -1)))
+                ($bv_mk_bitwise_slicing_rec
+                  f
+                  c
+                  (eo::define ((nil (eo::nil f a1 a2)))
+                    ($singleton_elim ($nary_diff f nil (f a1 a2) (eo::cons f c nil))))  ; remove the constant and recollect
+                  ($nary_reverse ($bv_mk_bitblast_step_const c))                ; convert the constant to a bitlist
+                  ($bv_bit_set c wm1) wm1 wm1)))))))
   )
 )
 

--- a/proofs/eo/cpc/rules/Booleans.eo
+++ b/proofs/eo/cpc/rules/Booleans.eo
@@ -138,13 +138,10 @@
 ; conclusion: >
 ;   The result of the chain resolution of the premises clauses for
 ;   the given polarities and pivots.
-(declare-rule chain_resolution ((Cs Bool) (pols @List) (lits @List))
-    :premise-list Cs and
+(declare-rule chain_resolution ((Cs Bool) (C1 Bool) (C2 Bool :list) (pols @List) (lits @List))
+    :premise-list (and C1 C2) and
     :args (pols lits)
-    :conclusion
-        (eo::match ((C1 Bool) (C2 Bool :list))
-            Cs
-            (((and C1 C2) ($chain_resolve_rec ($to_clause C1) C2 pols lits))))
+    :conclusion ($chain_resolve_rec C1 C2 pols lits)
 )
 
 ; program: $factor_literals

--- a/proofs/eo/cpc/rules/Booleans.eo
+++ b/proofs/eo/cpc/rules/Booleans.eo
@@ -138,7 +138,7 @@
 ; conclusion: >
 ;   The result of the chain resolution of the premises clauses for
 ;   the given polarities and pivots.
-(declare-rule chain_resolution ((Cs Bool) (C1 Bool) (C2 Bool :list) (pols @List) (lits @List))
+(declare-rule chain_resolution ((C1 Bool) (C2 Bool :list) (pols @List) (lits @List))
     :premise-list (and C1 C2) and
     :args (pols lits)
     :conclusion ($chain_resolve_rec C1 C2 pols lits)

--- a/proofs/eo/cpc/rules/Quantifiers.eo
+++ b/proofs/eo/cpc/rules/Quantifiers.eo
@@ -134,19 +134,19 @@
   )
 )
 
-; program: $mk_quant_unused_vars
+; program: $mk_quant
 ; args:
 ; - Q (-> @List Bool Bool): The quantifier, expected to be forall or exists.
 ; - x @List: The list of variables of the quantified formula.
 ; - F Bool: The body of the quantified formula.
-; return: the result of removing duplicate and unused variables from x.
-(define $mk_quant_unused_vars ((Q (-> @List Bool Bool)) (x @List) (F Bool))
-  (eo::match ((y @List))
-    ($mk_quant_unused_vars_rec x F)
-    (
-      (@list.nil F)
-      (y (Q y F))
-    )))
+; return: The quantified formula (Q x F), or just F is x is the empty list.
+(program $mk_quant ((Q (-> @List Bool Bool)) (x @List) (F Bool))
+  ((-> @List Bool Bool) @List Bool) Bool
+  (
+  (($mk_quant Q @list.nil F) F)
+  (($mk_quant Q x F) (Q x F))
+  )
+)
 
 ; rule: quant-unused-vars
 ; implements: ProofRewriteRule::QUANT_UNUSED_VARS
@@ -157,7 +157,7 @@
 ; conclusion: The given equality.
 (declare-rule quant-unused-vars ((Q (-> @List Bool Bool)) (x @List) (F Bool) (G Bool))
   :args ((= (Q x F) G))
-  :requires ((($mk_quant_unused_vars Q x F) G))
+  :requires ((($mk_quant Q ($mk_quant_unused_vars_rec x F) F) G))
   :conclusion (= (Q x F) G)
 )
 

--- a/proofs/eo/cpc/rules/Quantifiers.eo
+++ b/proofs/eo/cpc/rules/Quantifiers.eo
@@ -168,14 +168,11 @@
 ; - Q (-> @List Bool Bool): The binding operator (forall or exists).
 ; - F Bool: The formula for which we are merging prenexes.
 ; return: the result of merging all bound variables bound by Q in F.
-(program $mk_quant_merge_prenex ((Q (-> @List Bool Bool)) (x @List) (F Bool))
-  ((-> @List Bool Bool) Bool) Bool
+(program $mk_quant_merge_prenex ((Q (-> @List Bool Bool)) (x @List) (y @List) (F Bool))
+  ((-> @List Bool Bool) Bool @List) Bool
   (
-  (($mk_quant_merge_prenex Q (Q x F))  (eo::match ((R (-> @List Bool Bool)) (y @List) (G Bool))
-                                         ($mk_quant_merge_prenex Q F)
-                                         ; note that since this method returns Q terms only, R is Q
-                                         (((R y G) (Q (eo::list_concat @list x y) G)))))
-  (($mk_quant_merge_prenex Q F)        (Q @list.nil F))
+  (($mk_quant_merge_prenex Q (Q x F) y)  ($mk_quant_merge_prenex Q F (eo::list_concat @list y x)))
+  (($mk_quant_merge_prenex Q F y)        (Q y F))
   )
 )
 
@@ -190,7 +187,7 @@
 (declare-rule quant-merge-prenex ((Q (-> @List Bool Bool)) (x @List) (F Bool) (G Bool))
   :args ((= (Q x F) G))
   :requires (((eo::or (eo::eq Q forall) (eo::eq Q exists)) true)
-             (($mk_quant_merge_prenex Q (Q x F)) G))
+             (($mk_quant_merge_prenex Q (Q x F) @list.nil) G))
   :conclusion (= (Q x F) G)
 )
 

--- a/proofs/eo/cpc/rules/Strings.eo
+++ b/proofs/eo/cpc/rules/Strings.eo
@@ -755,6 +755,20 @@
 
 ;;;;; ProofRewriteRule::STR_INDEXOF_RE_EVAL
 
+; define: $str_eval_indexof_re_in_bound
+; args:
+; - res (@Pair Int Int): The result of finding (a suffix of) string s in r.
+; - n Int: A start position.
+; return: >
+;   The result of evaluating (str.indexof_re s r n), assuming n is in bounds.
+(program $str_eval_indexof_re_in_bound ((sp Int) (ep Int) (n Int))
+  ((@Pair Int Int) Int) Int
+  (
+  (($str_eval_indexof_re_in_bound (@pair -1 -1) n) -1)
+  (($str_eval_indexof_re_in_bound (@pair sp ep) n) (eo::add n sp))
+  )
+)
+
 ; define: $str_eval_indexof_re
 ; args:
 ; - s String: A string.
@@ -765,13 +779,7 @@
 (define $str_eval_indexof_re ((s String) (r RegLan) (n Int))
   (eo::ite (eo::or (eo::gt n (eo::len s)) (eo::is_neg n))
     -1
-    (eo::match ((sp Int) (ep Int))
-      ($str_first_match (eo::extract s n (eo::len s)) r)
-      (
-      ((@pair -1 -1) -1)
-      ((@pair sp ep) (eo::add n sp))
-      ))))
-
+    ($str_eval_indexof_re_in_bound ($str_first_match (eo::extract s n (eo::len s)) r) n)))
 
 ; rule: str-indexof-re-eval
 ; implements: ProofRewriteRule::STR_INDEXOF_RE_EVAL

--- a/proofs/eo/cpc/rules/Strings.eo
+++ b/proofs/eo/cpc/rules/Strings.eo
@@ -298,6 +298,33 @@
 
 ;;;;; ProofRule::RE_UNFOLD_POS
 
+; program: $mk_re_unfold_pos
+; args:
+; - t String: The string.
+; - r RegLan: The regular expression.
+; return: The conclusion for rule RE_UNFOLD_POS.
+(program $mk_re_unfold_pos ((t String) (r1 RegLan) (r2 RegLan :list))
+  (String RegLan) Bool
+  (
+    (($mk_re_unfold_pos t (re.* r1))
+        (eo::match ((k1 String) (k2 String) (k3 String) (M Bool :list))
+        ($re_unfold_pos_concat t (re.++ r1 (re.* r1) r1))
+        (((@pair (str.++ k1 k2 k3) M)
+            (or
+            (= t "")
+            (str.in_re t r1)
+            (and
+                (eo::cons and (= t (str.++ k1 k2 k3)) M)
+                (not (= k1 ""))
+                (not (= k3 ""))))))))
+    (($mk_re_unfold_pos t (re.++ r1 r2))
+        (eo::match ((tk String) (M Bool :list))
+        ($re_unfold_pos_concat t (re.++ r1 r2))
+        (((@pair tk M)
+            (eo::define ((teq (= t tk))) (eo::ite (eo::eq M true) teq (and teq M)))))))
+  )
+)
+
 ; rule: re_unfold_pos
 ; implements: ProofRule::RE_UNFOLD_POS
 ; premises:
@@ -308,30 +335,30 @@
 ;   r if the latter is a regular expression concatenation.
 (declare-rule re_unfold_pos ((t String) (r RegLan))
   :premises ((str.in_re t r))
-  :conclusion
-    (eo::match ((r1 RegLan) (r2 RegLan :list))
-      r
-      (
-        ((re.* r1)
-            (eo::match ((k1 String) (k2 String) (k3 String) (M Bool :list))
-            ($re_unfold_pos_concat t (re.++ r1 r r1))
-            (((@pair (str.++ k1 k2 k3) M)
-                (or 
-                (= t "") 
-                (str.in_re t r1)
-                (and
-                    (eo::cons and (= t (str.++ k1 k2 k3)) M)
-                    (not (= k1 ""))
-                    (not (= k3 ""))))))))
-        ((re.++ r1 r2)
-            (eo::match ((tk String) (M Bool :list))
-            ($re_unfold_pos_concat t r)
-            (((@pair tk M)
-                (eo::define ((teq (= t tk))) (eo::ite (eo::eq M true) teq (and teq M)))))))
-    ))
+  :conclusion ($mk_re_unfold_pos t r)
+
 )
 
 ;;;;; ProofRule::RE_UNFOLD_NEG_CONCAT_FIXED
+
+; program: $mk_re_unfold_neg_concat_fixed
+; args:
+; - s String: The string.
+; - r RegLan: The regular expression.
+; - rev Bool: Whether we are in the reverse direction.
+; return: The conclusion for rule RE_UNFOLD_NEG_CONCAT_FIXED.
+(program $mk_re_unfold_neg_concat_fixed ((s String) (r1 RegLan) (r2 RegLan :list) (rev Bool))
+  (String RegLan Bool) Bool
+  (
+    (($mk_re_unfold_neg_concat_fixed s (re.++ r1 r2) rev)
+        (eo::define ((n ($str_fixed_len_re r1)))
+          (eo::ite rev
+          (or (not (str.in_re ($str_suffix s n) r1))
+              (not (str.in_re ($str_prefix s (- (str.len s) n)) ($singleton_elim ($str_rev rev r2)))))
+          (or (not (str.in_re ($str_prefix s n) r1))
+              (not (str.in_re ($str_suffix_rem s n) ($singleton_elim r2)))))))
+  )
+)
 
 ; rule: re_unfold_neg_concat_fixed
 ; implements: ProofRule::RE_UNFOLD_NEG_CONCAT_FIXED
@@ -347,17 +374,7 @@
 (declare-rule re_unfold_neg_concat_fixed ((s String) (r RegLan) (rev Bool))
   :premises ((not (str.in_re s r)))
   :args (rev)
-  :conclusion
-    (eo::match ((r1 RegLan) (r2 RegLan :list))
-      ($str_rev rev r)
-      (
-        ((re.++ r1 r2) (eo::define ((n ($str_fixed_len_re r1)))
-                       (eo::ite rev
-                       (or (not (str.in_re ($str_suffix s n) r1))
-                           (not (str.in_re ($str_prefix s (- (str.len s) n)) ($singleton_elim ($str_rev rev r2)))))
-                       (or (not (str.in_re ($str_prefix s n) r1))
-                           (not (str.in_re ($str_suffix_rem s n) ($singleton_elim r2)))))))
-    ))
+  :conclusion ($mk_re_unfold_neg_concat_fixed s ($str_rev rev r) rev)
 )
 
 ;;;;; ProofRule::RE_UNFOLD_NEG

--- a/proofs/eo/cpc/rules/Strings.eo
+++ b/proofs/eo/cpc/rules/Strings.eo
@@ -788,23 +788,25 @@
 
 ;;;;; ProofRewriteRule::STR_REPLACE_RE_EVAL
 
-; define: $str_eval_indexof_re
+; program: $str_eval_indexof_re
 ; args:
 ; - s String: A string.
 ; - r RegLan: A regular expression.
 ; - t String: A string to replace with.
+; - res (@Pair Int Int): The result of finding the first match of s in r.
 ; return: >
 ;   The result of evaluating (str.replace_re s r t), which is either s or a
 ;   concatenation of the prefix of s before the match, t and the suffix of s
 ;   after the match.
-(define $str_eval_replace_re ((s String) (r RegLan) (t String))
-  (eo::match ((sp Int) (ep Int))
-    ($str_first_match s r)
-    (
-    ((@pair -1 -1) s)
-    ; note that t does not need to be a constant, so the returned term is a concat term
-    ((@pair sp ep) (str.++ (eo::extract s 0 (eo::add sp -1)) t (eo::extract s ep (eo::len s))))
-    )))
+(program $str_eval_replace_re ((s String) (r RegLan) (t String) (sp Int) (ep Int))
+  (String RegLan String (@Pair Int Int)) String
+  (
+  (($str_eval_replace_re s r t (@pair -1 -1)) s)
+  ; note that t does not need to be a constant, so the returned term is a concat term
+  (($str_eval_replace_re s r t (@pair sp ep))
+    (str.++ (eo::extract s 0 (eo::add sp -1)) t (eo::extract s ep (eo::len s))))
+  )
+)
 
 ; rule: str-replace-re-eval
 ; implements: ProofRewriteRule::STR_REPLACE_RE_EVAL
@@ -815,7 +817,7 @@
 ; conclusion: The given equality.
 (declare-rule str-replace-re-eval ((s String) (r RegLan) (t String) (u String))
   :args ((= (str.replace_re s r t) u))
-  :requires ((($str_eval_replace_re s r t) u))
+  :requires ((($str_eval_replace_re s r t ($str_first_match s r)) u))
   :conclusion (= (str.replace_re s r t) u)
 )
 

--- a/proofs/eo/cpc/rules/Strings.eo
+++ b/proofs/eo/cpc/rules/Strings.eo
@@ -274,13 +274,11 @@
 ; return: >
 ;   The concatenation of the strings in E is in the concatenation of the regular
 ;   expressions in E.
-(program $mk_re_concat ((Es Bool :list) (s String) (r RegLan))
-  (Bool) Bool
+(program $mk_re_concat ((Es Bool :list) (s String) (r RegLan) (s1 String) (r1 RegLan))
+  (Bool Bool) Bool
   (
-  (($mk_re_concat (and (str.in_re s r) Es)) (eo::match ((s1 String) (r1 RegLan))
-                                              ($mk_re_concat Es)
-                                              (((str.in_re s1 r1) (str.in_re (eo::cons str.++ s s1) (eo::cons re.++ r r1))))))
-  (($mk_re_concat true)                     (str.in_re "" @re.empty))
+  (($mk_re_concat (and (str.in_re s r) Es) (str.in_re s1 r1)) ($mk_re_concat Es (str.in_re (eo::cons str.++ s s1) (eo::cons re.++ r r1))))
+  (($mk_re_concat true (str.in_re s1 r1))                     (str.in_re s1 r1))
   )
 )
 
@@ -293,7 +291,7 @@
 ;   expressions in E.
 (declare-rule re_concat ((E Bool))
   :premise-list E and
-  :conclusion ($mk_re_concat E)
+  :conclusion ($mk_re_concat ($nary_reverse E) (str.in_re "" @re.empty))
 )
 
 ;;;;; ProofRule::RE_UNFOLD_POS
@@ -379,6 +377,32 @@
 
 ;;;;; ProofRule::RE_UNFOLD_NEG
 
+
+; program: $mk_re_unfold_neg
+; args:
+; - s String: The string.
+; - r RegLan: The regular expression.
+; return: The conclusion for rule RE_UNFOLD_NEG.
+(program $mk_re_unfold_neg ((t String) (r1 RegLan) (r2 RegLan :list))
+  (String RegLan) Bool
+  (
+    (($mk_re_unfold_neg t (re.* r1))
+      (and
+        (not (= t ""))
+        (forall ((@var.str_index Int))
+          (or (<= @var.str_index 0)
+              (< (str.len t) @var.str_index)
+              (not (str.in_re ($str_prefix t @var.str_index) r1))
+              (not (str.in_re ($str_suffix_rem t @var.str_index) (re.* r1)))))))
+    (($mk_re_unfold_neg t (re.++ r1 r2))
+      (forall ((@var.str_index Int))
+        (or (< @var.str_index 0)
+            (< (str.len t) @var.str_index)
+            (not (str.in_re ($str_prefix t @var.str_index) r1))
+            (not (str.in_re ($str_suffix_rem t @var.str_index) ($singleton_elim r2))))))
+  )
+)
+
 ; rule: re_unfold_neg
 ; implements: ProofRule::RE_UNFOLD_NEG
 ; premises:
@@ -389,25 +413,7 @@
 ;   corresponding decomposition of r.
 (declare-rule re_unfold_neg ((t String) (r RegLan))
   :premises ((not (str.in_re t r)))
-  :conclusion
-    (eo::match ((r1 RegLan) (r2 RegLan :list))
-      r
-      (
-        ((re.* r1)
-          (and
-            (not (= t ""))
-            (forall ((@var.str_index Int))
-              (or (<= @var.str_index 0)
-                  (< (str.len t) @var.str_index)
-                  (not (str.in_re ($str_prefix t @var.str_index) r1))
-                  (not (str.in_re ($str_suffix_rem t @var.str_index) r))))))
-        ((re.++ r1 r2)
-          (forall ((@var.str_index Int))
-            (or (< @var.str_index 0)
-                (< (str.len t) @var.str_index)
-                (not (str.in_re ($str_prefix t @var.str_index) r1))
-                (not (str.in_re ($str_suffix_rem t @var.str_index) ($singleton_elim r2))))))
-    ))
+  :conclusion ($mk_re_unfold_neg t r)
 )
 
 ;;;;; ProofRule::STRING_EXT

--- a/proofs/eo/cpc/rules/Uf.eo
+++ b/proofs/eo/cpc/rules/Uf.eo
@@ -217,13 +217,10 @@
 ;   the premises E. Note that the first equality in E should be an equality
 ;   between the functions that are respectively applied to the arguments given by
 ;   the remaining equalities.
-(declare-rule ho_cong ((T Type) (U Type) (E Bool) (f (-> T U)))
-    :premise-list E and
+(declare-rule ho_cong ((T Type) (t1 T) (t2 T) (tail Bool :list))
+    :premise-list (and (= t1 t2) tail) and
     :args ()
-    :conclusion
-        (eo::match ((t1 U) (t2 U) (tail Bool :list))
-        E
-        (((and (= t1 t2) tail) ($mk_ho_cong t1 t2 tail))))
+    :conclusion ($mk_ho_cong t1 t2 tail)
 )
 
 ;;-------------------- Instances of THEORY_REWRITE

--- a/proofs/eo/cpc/rules/Uf.eo
+++ b/proofs/eo/cpc/rules/Uf.eo
@@ -15,6 +15,18 @@
 
 ;;;;; ProofRule::SYMM
 
+; program: $mk_symm
+; args:
+; - E Bool: An equality or disequality.
+; return: The result of flipping the equality or disequality.
+(program $mk_symm ((T Type) (t1 T) (t2 T))
+  (Bool) Bool
+  (
+    (($mk_symm (= t1 t2))       (= t2 t1))
+    (($mk_symm (not (= t1 t2))) (not (= t2 t1)))
+  )
+)
+
 ; rule: symm
 ; implements: ProofRule::SYMM
 ; args:
@@ -22,13 +34,7 @@
 ; conclusion: The inverted version of the (dis)equality F.
 (declare-rule symm ((F Bool))
     :premises (F)
-    :conclusion
-        (eo::match ((T Type) (t1 T) (t2 T))
-            F
-            (
-                ((= t1 t2)       (= t2 t1))
-                ((not (= t1 t2)) (not (= t2 t1)))
-            ))
+    :conclusion ($mk_symm F)
 )
 
 ;;;;; ProofRule::TRANS
@@ -59,12 +65,9 @@
 ;   An equality between the left hand side of the first equality
 ;   and the right hand side of the last equality, assuming that the right hand
 ;   side of each equality matches the left hand side of the one that follows it.
-(declare-rule trans ((T Type) (U Type) (E Bool) (f (-> T U)))
-    :premise-list E and
-    :conclusion
-        (eo::match ((t1 U) (t2 U) (tail Bool :list))
-        E
-        (((and (= t1 t2) tail) ($mk_trans t1 t2 tail))))
+(declare-rule trans ((T Type) (t1 T) (t2 T) (tail Bool :list))
+    :premise-list (and (= t1 t2) tail) and
+    :conclusion ($mk_trans t1 t2 tail)
 )
 
 ;;;;; ProofRule::CONG

--- a/proofs/eo/cpc/theories/BitVectors.eo
+++ b/proofs/eo/cpc/theories/BitVectors.eo
@@ -5,12 +5,15 @@
 (declare-const BitVec (-> Int Type))
 (declare-consts <binary> (BitVec (eo::len eo::self)))
 
-; define: $bv_bitwidth
+; program: $bv_bitwidth
 ; args:
 ; - T Type: The bitvector type.
 ; return: The (integer value) bitwidth for a given bit-vector type.
-(define $bv_bitwidth ((T Type))
-  (eo::match ((n Int)) T (((BitVec n) n)))
+(program $bv_bitwidth ((n Int))
+  (Type) Int
+  (
+  (($bv_bitwidth (BitVec n)) n)
+  )
 )
 
 ; bvsize


### PR DESCRIPTION
This is work towards increasing the precision in the definition of CPC. This means that in general `eo::match` should not be used. 

This refactors the signature to eliminate roughly half of the occurrences of `eo::match`. The others will be addressed in followup PRs.