### PR TITLE
Catch illegal code points in wstring mkString API function

### DIFF
--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -6362,7 +6362,9 @@ Term TermManager::mkString(const std::wstring& s)
   CVC5_API_TRY_CATCH_BEGIN;
   for (size_t i = 0, n = s.size(); i < n; ++i)
   {
-    CVC5_API_CHECK(static_cast<unsigned>(s[i])<internal::String::num_codes()) << "Expected unicode string whose characters are less than code point " << internal::String::num_codes();
+    CVC5_API_CHECK(static_cast<unsigned>(s[i]) < internal::String::num_codes())
+        << "Expected unicode string whose characters are less than code point "
+        << internal::String::num_codes();
   }
   //////// all checks before this line
   return mkValHelper(internal::String(s));

--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -6360,6 +6360,10 @@ Term TermManager::mkString(const std::string& s, bool useEscSequences)
 Term TermManager::mkString(const std::wstring& s)
 {
   CVC5_API_TRY_CATCH_BEGIN;
+  for (size_t i = 0, n = s.size(); i < n; ++i)
+  {
+    CVC5_API_CHECK(static_cast<unsigned>(s[i])<internal::String::num_codes()) << "Expected unicode string whose characters are less than code point " << internal::String::num_codes();
+  }
   //////// all checks before this line
   return mkValHelper(internal::String(s));
   ////////

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -36,7 +36,11 @@ String::String(const std::wstring& s)
   d_str.resize(s.size());
   for (size_t i = 0, n = s.size(); i < n; ++i)
   {
-    d_str[i] = static_cast<unsigned>(s[i]);
+    unsigned u = static_cast<unsigned>(s[i]);
+#ifdef CVC5_ASSERTIONS
+    Assert(u < num_codes());
+#endif
+    d_str[i] = u;
   }
 }
 

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1238,6 +1238,7 @@ set(regress_0_tests
   regress0/parser/issue10813-1.smt2
   regress0/parser/issue10813-2.smt2
   regress0/parser/issue10889-sexpr-eof.smt2
+  regress0/parser/issue11935-err-code-point.smt2
   regress0/parser/issue5163.smt2
   regress0/parser/issue6908-get-value-uc.smt2
   regress0/parser/issue7274.smt2

--- a/test/regress/cli/regress0/parser/issue11935-err-code-point.smt2
+++ b/test/regress/cli/regress0/parser/issue11935-err-code-point.smt2
@@ -1,0 +1,8 @@
+; DISABLE-TESTER: dump
+; SCRUBBER: grep -o 'Expected unicode string whose characters are less than code point'
+; EXPECT: Expected unicode string whose characters are less than code point
+; EXIT: 1
+(set-logic ALL)
+(declare-const x String)
+(assert (= (str.++ x "T") (_ char #x93A83)))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/11935.