### PR TITLE
Update usages of eo::nil to new syntax

### DIFF
--- a/contrib/get-ethos-checker
+++ b/contrib/get-ethos-checker
@@ -26,7 +26,7 @@ EO_DIR="$BASE_DIR/ethos-checker"
 mkdir -p $EO_DIR
 
 # download and unpack ethos
-ETHOS_VERSION="3c7d4319fca6f39479304ba2ab55bbb4ac7d0896"
+ETHOS_VERSION="bf13253bf0149a487f90a8ac904656aec602f524"
 download "https://github.com/cvc5/ethos/archive/$ETHOS_VERSION.tar.gz" $BASE_DIR/tmp/ethos.tgz
 tar --strip 1 -xzf $BASE_DIR/tmp/ethos.tgz -C $EO_DIR
 

--- a/contrib/get-ethos-checker
+++ b/contrib/get-ethos-checker
@@ -26,7 +26,7 @@ EO_DIR="$BASE_DIR/ethos-checker"
 mkdir -p $EO_DIR
 
 # download and unpack ethos
-ETHOS_VERSION="f39df1edf2de19e04b40bdf74867519965adcce2"
+ETHOS_VERSION="3c7d4319fca6f39479304ba2ab55bbb4ac7d0896"
 download "https://github.com/cvc5/ethos/archive/$ETHOS_VERSION.tar.gz" $BASE_DIR/tmp/ethos.tgz
 tar --strip 1 -xzf $BASE_DIR/tmp/ethos.tgz -C $EO_DIR
 

--- a/proofs/eo/cpc/programs/AciNorm.eo
+++ b/proofs/eo/cpc/programs/AciNorm.eo
@@ -70,7 +70,8 @@
 (define $get_aci_norm ((T Type :implicit) (t T) (isi Bool))
   (eo::match ((S Type) (U Type) (V Type) (f (-> S U V)) (x S) (y U :list))
     t
-    (((f x y) (eo::define ((id (eo::nil f x y))) ($singleton_elim_aci f id ($get_aci_norm_rec f id t isi))))))
+    (((f x y) (eo::define ((id (eo::nil f (eo::typeof (f x y)))))
+                ($singleton_elim_aci f id ($get_a_norm_rec f id t))))))
 )
 
 ;; =============== for ACI_NORM associative
@@ -98,6 +99,7 @@
 (define $get_a_norm ((T Type :implicit) (t T))
   (eo::match ((S Type) (U Type) (V Type) (f (-> S U V)) (x S) (y U :list))
     t
-    (((f x y) (eo::define ((id (eo::nil f x y))) ($singleton_elim_aci f id ($get_a_norm_rec f id t))))))
+    (((f x y) (eo::define ((id (eo::nil f (eo::typeof (f x y))))) 
+                ($singleton_elim_aci f id ($get_a_norm_rec f id t))))))
 )
 

--- a/proofs/eo/cpc/programs/AciNorm.eo
+++ b/proofs/eo/cpc/programs/AciNorm.eo
@@ -71,7 +71,7 @@
   (eo::match ((S Type) (U Type) (V Type) (f (-> S U V)) (x S) (y U :list))
     t
     (((f x y) (eo::define ((id (eo::nil f (eo::typeof (f x y)))))
-                ($singleton_elim_aci f id ($get_a_norm_rec f id t))))))
+                ($singleton_elim_aci f id ($get_aci_norm_rec f id t isi))))))
 )
 
 ;; =============== for ACI_NORM associative
@@ -99,7 +99,7 @@
 (define $get_a_norm ((T Type :implicit) (t T))
   (eo::match ((S Type) (U Type) (V Type) (f (-> S U V)) (x S) (y U :list))
     t
-    (((f x y) (eo::define ((id (eo::nil f (eo::typeof (f x y))))) 
+    (((f x y) (eo::define ((id (eo::nil f (eo::typeof (f x y)))))
                 ($singleton_elim_aci f id ($get_a_norm_rec f id t))))))
 )
 

--- a/proofs/eo/cpc/programs/BitVectors.eo
+++ b/proofs/eo/cpc/programs/BitVectors.eo
@@ -88,4 +88,4 @@
 ;   This is a helpful method for constructing n-ary terms with exactly two
 ;   children.
 (define $nary_app ((T Type :implicit) (U Type :implicit) (V Type :implicit) (f (-> T U V)) (a T) (b U))
-  (f a (f b (eo::nil f a b))))
+  (f a (f b (eo::nil f (eo::typeof a)))))

--- a/proofs/eo/cpc/programs/Nary.eo
+++ b/proofs/eo/cpc/programs/Nary.eo
@@ -89,7 +89,7 @@
     ((L Type) (cons (-> L L L)) (x L) (xs L :list))
     (L) L
     (
-        (($nary_reverse (cons x xs)) (eo::define ((nil (eo::nil cons x xs))) ($nary_reverse_rec cons nil (cons x xs) nil)))
+        (($nary_reverse (cons x xs)) (eo::define ((nil (eo::nil cons (eo::typeof (cons x xs))))) ($nary_reverse_rec cons nil (cons x xs) nil)))
         (($nary_reverse x)           x)
     )
 )

--- a/proofs/eo/cpc/programs/Utils.eo
+++ b/proofs/eo/cpc/programs/Utils.eo
@@ -137,7 +137,7 @@
 (program $singleton_elim ((T Type) (S Type) (U Type) (f (-> T U S)) (x S) (x1 T) (x2 T :list))
   (S) S
   (
-    (($singleton_elim (f x1 x2))  (eo::ite (eo::eq x2 (eo::nil f x1 x2)) x1 (f x1 x2)))
+    (($singleton_elim (f x1 x2))  (eo::ite (eo::eq x2 (eo::nil f (eo::typeof (f x1 x2)))) x1 (f x1 x2)))
     (($singleton_elim x)          x)
   )
 )
@@ -182,7 +182,7 @@
   (
   (($is_pairwise f op a (@list b bs) (op (f a b) B) rem) ($is_pairwise f op a bs B rem))
   (($is_pairwise f op a @list.nil B (@list b rem))       ($is_pairwise f op b rem B rem))
-  (($is_pairwise f op a @list.nil nil @list.nil)         (eo::requires nil (eo::nil op) true))
+  (($is_pairwise f op a @list.nil nil @list.nil)         (eo::requires nil (eo::nil op (eo::typeof a)) true))
   )
 )
 

--- a/proofs/eo/cpc/rules/BitVectors.eo
+++ b/proofs/eo/cpc/rules/BitVectors.eo
@@ -195,7 +195,7 @@
                   ($bv_mk_bitwise_slicing_rec
                     f
                     c
-                    (eo::define ((nil (eo::nil f a1 a2)))
+                    (eo::define ((nil (eo::nil f (eo::typeof a1))))
                       ($singleton_elim ($nary_diff f nil a (eo::cons f c nil))))  ; remove the constant and recollect
                     ($nary_reverse ($bv_mk_bitblast_step_const c))                ; convert the constant to a bitlist
                     ($bv_bit_set c wm1) wm1 wm1)))))))


### PR DESCRIPTION
Updates the ethos version to the one supporting the new syntax for `eo::nil`.