### PR TITLE
Fix 11932

### DIFF
--- a/src/theory/ff/sub_theory.cpp
+++ b/src/theory/ff/sub_theory.cpp
@@ -63,6 +63,7 @@ Result SubTheory::postCheck(Theory::Effort e)
 {
   d_conflict.clear();
   d_model.clear();
+  bool modelSet = false;
   if (e == Theory::EFFORT_FULL)
   {
     try
@@ -172,6 +173,7 @@ Result SubTheory::postCheck(Theory::Effort e)
             Assert(d_model.empty());
             const auto nm = nodeManager();
             Trace("ff::model") << "Model GF(" << size() << "):" << std::endl;
+            modelSet = true;
             for (const auto& [idx, node] : enc.nodeIndets())
             {
               if (isFfLeaf(node))
@@ -189,7 +191,7 @@ Result SubTheory::postCheck(Theory::Effort e)
       {
         Unreachable() << options().ff.ffSolver << std::endl;
       }
-      AlwaysAssert((!d_conflict.empty() ^ !d_model.empty()) || d_facts.empty());
+      AlwaysAssert((!d_conflict.empty() ^ modelSet) || d_facts.empty());
       return d_facts.empty() || d_conflict.empty() ? Result::SAT
                                                    : Result::UNSAT;
     }

--- a/src/theory/ff/sub_theory.cpp
+++ b/src/theory/ff/sub_theory.cpp
@@ -63,7 +63,9 @@ Result SubTheory::postCheck(Theory::Effort e)
 {
   d_conflict.clear();
   d_model.clear();
-  bool modelSet = false;
+  // on some branches, we'll overwrite this result
+  Result result = {
+      Result::UNKNOWN, UnknownExplanation::UNKNOWN_REASON, "internal"};
   if (e == Theory::EFFORT_FULL)
   {
     try
@@ -73,11 +75,11 @@ Result SubTheory::postCheck(Theory::Effort e)
       {
         std::vector<Node> facts{};
         std::copy(d_facts.begin(), d_facts.end(), std::back_inserter(facts));
-        auto result = split(facts, size(), d_env);
-        if (result.has_value())
+        const auto optModel = split(facts, size(), d_env);
+        if (optModel.has_value())
         {
           const auto nm = nodeManager();
-          for (const auto& [var, val] : result.value())
+          for (const auto& [var, val] : optModel.value())
           {
             d_model.insert({var, nm->mkConst<FiniteFieldValue>(val)});
           }
@@ -114,7 +116,7 @@ Result SubTheory::postCheck(Theory::Effort e)
           for (const auto& var : CoCoA::indets(enc.polyRing()))
           {
             CoCoA::BigInt characteristic = CoCoA::characteristic(coeffRing());
-            long power = CoCoA::LogCardinality(coeffRing());
+            const long power = CoCoA::LogCardinality(coeffRing());
             CoCoA::BigInt size = CoCoA::power(characteristic, power);
             generators.push_back(CoCoA::power(var, size) - var);
           }
@@ -130,6 +132,7 @@ Result SubTheory::postCheck(Theory::Effort e)
         if (is_trivial)
         {
           Trace("ff::gb") << "Trivial GB" << std::endl;
+          result = Result::UNSAT;
           if (options().ff.ffTraceGb)
           {
             std::vector<size_t> coreIndices = tracer.trace(basis.front());
@@ -164,16 +167,16 @@ Result SubTheory::postCheck(Theory::Effort e)
 
           if (root.empty())
           {
-            // UNSAT
+            result = Result::UNSAT;
             setTrivialConflict();
           }
           else
           {
-            // SAT: populate d_model from the root
+            result = Result::SAT;
+            // populate d_model from the root
             Assert(d_model.empty());
             const auto nm = nodeManager();
             Trace("ff::model") << "Model GF(" << size() << "):" << std::endl;
-            modelSet = true;
             for (const auto& [idx, node] : enc.nodeIndets())
             {
               if (isFfLeaf(node))
@@ -191,9 +194,8 @@ Result SubTheory::postCheck(Theory::Effort e)
       {
         Unreachable() << options().ff.ffSolver << std::endl;
       }
-      AlwaysAssert((!d_conflict.empty() ^ modelSet) || d_facts.empty());
-      return d_facts.empty() || d_conflict.empty() ? Result::SAT
-                                                   : Result::UNSAT;
+      AlwaysAssert(result.getStatus() != Result::UNKNOWN);
+      return result;
     }
     catch (FfTimeoutException& exc)
     {

--- a/src/theory/ff/theory_ff_rewriter.cpp
+++ b/src/theory/ff/theory_ff_rewriter.cpp
@@ -184,6 +184,31 @@ Node TheoryFiniteFieldsRewriter::postRewriteFfMult(TNode t)
   return mkNary(Kind::FINITE_FIELD_MULT, std::move(factors));
 }
 
+Node TheoryFiniteFieldsRewriter::postRewriteFfBitsum(TNode t)
+{
+  const TypeNode field = t.getType();
+  Assert(field.isFiniteField());
+
+  FiniteFieldValue one = FiniteFieldValue::mkOne(field.getFfSize());
+  FiniteFieldValue two = one + one;
+  FiniteFieldValue multiplier = one;
+  FiniteFieldValue acc = FiniteFieldValue::mkZero(field.getFfSize());
+
+  for (const auto& child : t)
+  {
+    if (child.isConst())
+    {
+      acc = acc + child.getConst<FiniteFieldValue>();
+    }
+    else
+    {
+      return t;
+    }
+    multiplier *= two;
+  }
+  return nodeManager()->mkConst(acc);
+}
+
 Node TheoryFiniteFieldsRewriter::postRewriteFfEq(TNode t)
 {
   Assert(t.getKind() == Kind::EQUAL);
@@ -220,6 +245,8 @@ RewriteResponse TheoryFiniteFieldsRewriter::postRewrite(TNode t)
     }
     case Kind::FINITE_FIELD_MULT:
       return RewriteResponse(REWRITE_DONE, postRewriteFfMult(t));
+    case Kind::FINITE_FIELD_BITSUM:
+      return RewriteResponse(REWRITE_DONE, postRewriteFfBitsum(t));
     case Kind::EQUAL: return RewriteResponse(REWRITE_DONE, postRewriteFfEq(t));
     default: return RewriteResponse(REWRITE_DONE, t);
   }

--- a/src/theory/ff/theory_ff_rewriter.h
+++ b/src/theory/ff/theory_ff_rewriter.h
@@ -76,27 +76,35 @@ class TheoryFiniteFieldsRewriter : public TheoryRewriter
   RewriteResponse preRewrite(TNode node) override;
 
  private:
+
   /** Make n-ary node */
   Node mkNary(Kind k, std::vector<Node>&& children);
+
   /** Parse as a product with a constant scalar
    *
    *  If there is no constant scalar, returns a 1.
    */
   std::pair<Node, FiniteFieldValue> parseScalar(TNode t);
+
   /** preRewrite negation */
   Node preRewriteFfNeg(TNode t);
+
   /** preRewrite addition */
   Node preRewriteFfAdd(TNode t);
   /** postRewrite addition */
   Node postRewriteFfAdd(TNode t);
+
   /** preRewrite multiplication */
   Node preRewriteFfMult(TNode t);
   /** postRewrite multiplication */
   Node postRewriteFfMult(TNode t);
+
   /** postRewrite equality */
   Node postRewriteFfEq(TNode t);
-  /** postRewrite multiplication */
+
+  /** postRewrite bitsum */
   Node postRewriteFfBitsum(TNode t);
+
 }; /* class TheoryFiniteFieldsRewriter */
 
 }  // namespace ff

--- a/src/theory/ff/theory_ff_rewriter.h
+++ b/src/theory/ff/theory_ff_rewriter.h
@@ -95,6 +95,8 @@ class TheoryFiniteFieldsRewriter : public TheoryRewriter
   Node postRewriteFfMult(TNode t);
   /** postRewrite equality */
   Node postRewriteFfEq(TNode t);
+  /** postRewrite multiplication */
+  Node postRewriteFfBitsum(TNode t);
 }; /* class TheoryFiniteFieldsRewriter */
 
 }  // namespace ff

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -856,6 +856,7 @@ set(regress_0_tests
   regress0/ff/negneg.smt2
   regress0/ff/issue10937.smt2
   regress0/ff/issue11107.smt2
+  regress0/ff/issue11932.smt2
   regress0/ff/proj-issue705.smt2
   regress0/ff/proj-issue748-safe.smt2
   regress0/ff/randcompile-sound-3i-5t-circ.smt2

--- a/test/regress/cli/regress0/ff/issue11932.smt2
+++ b/test/regress/cli/regress0/ff/issue11932.smt2
@@ -1,0 +1,10 @@
+; REQUIRES: cocoa
+; EXPECT: sat
+; COMMAND-LINE: --ff-solver split
+; COMMAND-LINE: --ff-solver gb
+(set-info :smt-lib-version 2.6)
+(set-info :category "crafted")
+(set-logic QF_FF)
+(define-sort F2 () (_ FiniteField 2))
+(assert (= (as ff-9 F2) (ff.bitsum (as ff-9 F2) (as ff-10 F2))))
+(check-sat)


### PR DESCRIPTION
changes:
* acknowledge the models can be empty in a SAT formula
   * along the way, clean up control flow in `SubTheory::postCheck`
* rewrite constant-argument `FINITE_FIELD_BITSUM`s

fixes #11932