### PR TITLE
Refactor CPC Booleans and UF to avoid eo::match

### DIFF
--- a/proofs/eo/cpc/rules/Booleans.eo
+++ b/proofs/eo/cpc/rules/Booleans.eo
@@ -138,13 +138,10 @@
 ; conclusion: >
 ;   The result of the chain resolution of the premises clauses for
 ;   the given polarities and pivots.
-(declare-rule chain_resolution ((Cs Bool) (pols @List) (lits @List))
-    :premise-list Cs and
+(declare-rule chain_resolution ((C1 Bool) (C2 Bool :list) (pols @List) (lits @List))
+    :premise-list (and C1 C2) and
     :args (pols lits)
-    :conclusion
-        (eo::match ((C1 Bool) (C2 Bool :list))
-            Cs
-            (((and C1 C2) ($chain_resolve_rec ($to_clause C1) C2 pols lits))))
+    :conclusion ($chain_resolve_rec C1 C2 pols lits)
 )
 
 ; rule: factoring

--- a/proofs/eo/cpc/rules/Uf.eo
+++ b/proofs/eo/cpc/rules/Uf.eo
@@ -15,6 +15,18 @@
 
 ;;;;; ProofRule::SYMM
 
+; program: $mk_symm
+; args:
+; - E Bool: An equality or disequality.
+; return: The result of flipping the equality or disequality.
+(program $mk_symm ((T Type) (t1 T) (t2 T))
+  (Bool) Bool
+  (
+    (($mk_symm (= t1 t2))       (= t2 t1))
+    (($mk_symm (not (= t1 t2))) (not (= t2 t1)))
+  )
+)
+
 ; rule: symm
 ; implements: ProofRule::SYMM
 ; args:
@@ -22,13 +34,7 @@
 ; conclusion: The inverted version of the (dis)equality F.
 (declare-rule symm ((F Bool))
     :premises (F)
-    :conclusion
-        (eo::match ((T Type) (t1 T) (t2 T))
-            F
-            (
-                ((= t1 t2)       (= t2 t1))
-                ((not (= t1 t2)) (not (= t2 t1)))
-            ))
+    :conclusion ($mk_symm F)
 )
 
 ;;;;; ProofRule::TRANS
@@ -59,12 +65,9 @@
 ;   An equality between the left hand side of the first equality
 ;   and the right hand side of the last equality, assuming that the right hand
 ;   side of each equality matches the left hand side of the one that follows it.
-(declare-rule trans ((T Type) (U Type) (E Bool) (f (-> T U)))
-    :premise-list E and
-    :conclusion
-        (eo::match ((t1 U) (t2 U) (tail Bool :list))
-        E
-        (((and (= t1 t2) tail) ($mk_trans t1 t2 tail))))
+(declare-rule trans ((T Type) (t1 T) (t2 T) (tail Bool :list))
+    :premise-list (and (= t1 t2) tail) and
+    :conclusion ($mk_trans t1 t2 tail)
 )
 
 ;;;;; ProofRule::CONG
@@ -214,13 +217,10 @@
 ;   the premises E. Note that the first equality in E should be an equality
 ;   between the functions that are respectively applied to the arguments given by
 ;   the remaining equalities.
-(declare-rule ho_cong ((T Type) (U Type) (E Bool) (f (-> T U)))
-    :premise-list E and
+(declare-rule ho_cong ((T Type) (t1 T) (t2 T) (tail Bool :list))
+    :premise-list (and (= t1 t2) tail) and
     :args ()
-    :conclusion
-        (eo::match ((t1 U) (t2 U) (tail Bool :list))
-        E
-        (((and (= t1 t2) tail) ($mk_ho_cong t1 t2 tail))))
+    :conclusion ($mk_ho_cong t1 t2 tail)
 )
 
 ;;-------------------- Instances of THEORY_REWRITE


### PR DESCRIPTION
Marking this as 1.2.2 as it slightly improves the definition of `chain_resolution` which is our biggest bottleneck at the moment.