### PR TITLE
Annotate signatures of programs in CPC using :signature

### DIFF
--- a/contrib/get-ethos-checker
+++ b/contrib/get-ethos-checker
@@ -26,7 +26,7 @@ EO_DIR="$BASE_DIR/ethos-checker"
 mkdir -p $EO_DIR
 
 # download and unpack ethos
-ETHOS_VERSION="bf13253bf0149a487f90a8ac904656aec602f524"
+ETHOS_VERSION="91b05d7ef95186418c1ed2f14dea580d8b421287"
 download "https://github.com/cvc5/ethos/archive/$ETHOS_VERSION.tar.gz" $BASE_DIR/tmp/ethos.tgz
 tar --strip 1 -xzf $BASE_DIR/tmp/ethos.tgz -C $EO_DIR
 

--- a/proofs/eo/cpc/Cpc.eo
+++ b/proofs/eo/cpc/Cpc.eo
@@ -105,7 +105,7 @@
                        (xb (BitVec m)) (yb (BitVec m)) (ybs (BitVec m) :list) (zbs (BitVec n) :list)
                        (sx (Seq T)) (sy (Seq T)) (sz (Seq T)) (sys (Seq T) :list)
                        (ssx String) (ssy String) (ssz String))
-    (S) S
+    :signature (S) S
     (
       ; core
       (($run_evaluate (= x y))             (eo::define ((ex ($run_evaluate x)))
@@ -313,7 +313,7 @@
 ; - ts @List: The list of terms to evaluate.
 ; return: The list containing the result of evaluating the terms in ts.
 (program $evaluate_list ((U Type) (t U) (ts @List :list))
-  (@List) @List
+  :signature (@List) @List
   (
   (($evaluate_list (@list t ts))  (eo::cons @list ($run_evaluate t) ($evaluate_list ts)))
   (($evaluate_list @list.nil)     @list.nil)
@@ -413,7 +413,7 @@
 ; return: >
 ;   true, if zero is found as a subterm of t beneath f-applications.
 (program $is_absorb_rec ((U Type) (V Type) (W Type) (f (-> U U U)) (a U) (b U) (zero U))
-  ((-> U U U) V W) Bool
+  :signature ((-> U U U) V W) Bool
   (
     (($is_absorb_rec f zero zero)     true)
     (($is_absorb_rec f (f a b) zero)  (eo::ite ($is_absorb_rec f a zero)
@@ -481,7 +481,7 @@
 ;   We intentionally only handle finite types here, and moreover for simplicity
 ;   limit this method to atomic types (Bool and BitVec) only.
 (program $compute_card ((n Int))
-  (Type) Int
+  :signature (Type) Int
   (
     (($compute_card Bool)       2)
     (($compute_card (BitVec n)) ($arith_eval_int_pow_2 n))

--- a/proofs/eo/cpc/expert/theories/SetsExt.eo
+++ b/proofs/eo/cpc/expert/theories/SetsExt.eo
@@ -37,9 +37,8 @@
 ;   The "join" of c1 and c2, that is, if the last child of c1 is the same as the
 ;   first child of c2, then those 2 children are dropped and c1 and c2 are
 ;   appended together. Otherwise, this program does not evaluate.
-(program $tuple_type_join
-    ((x Type) (xs Type :list) (y Type) (ys Type :list))
-    (Type Type) Type
+(program $tuple_type_join ((x Type) (xs Type :list) (y Type) (ys Type :list))
+    :signature (Type Type) Type
     (
       (($tuple_type_join (Tuple x xs) (Tuple y ys))
         (eo::ite (eo::eq xs UnitTuple)

--- a/proofs/eo/cpc/expert/theories/SetsExt.eo
+++ b/proofs/eo/cpc/expert/theories/SetsExt.eo
@@ -37,7 +37,8 @@
 ;   The "join" of c1 and c2, that is, if the last child of c1 is the same as the
 ;   first child of c2, then those 2 children are dropped and c1 and c2 are
 ;   appended together. Otherwise, this program does not evaluate.
-(program $tuple_type_join ((x Type) (xs Type :list) (y Type) (ys Type :list))
+(program $tuple_type_join
+    ((x Type) (xs Type :list) (y Type) (ys Type :list))
     :signature (Type Type) Type
     (
       (($tuple_type_join (Tuple x xs) (Tuple y ys))

--- a/proofs/eo/cpc/programs/AciNorm.eo
+++ b/proofs/eo/cpc/programs/AciNorm.eo
@@ -14,7 +14,7 @@
 ;   This method is similar in purpose to $singleton_elim, but insists that
 ;   the function and its nil terminator are provided explicitly.
 (program $singleton_elim_aci ((T Type) (S Type) (U Type) (W Type) (f (-> T U S)) (id S) (x S) (x1 T) (x2 U :list))
-  ((-> T U S) W W) W
+  :signature ((-> T U S) W W) W
   (
     (($singleton_elim_aci f id (f x1 x2))  (eo::ite (eo::eq x2 id) x1 (f x1 x2)))
     (($singleton_elim_aci f id x)          x)
@@ -28,7 +28,7 @@
 ; - s S: The term to process.
 ; return: the result of normalizing s based on associative+identity reasoning.
 (program $get_a_norm_rec ((T Type) (S Type) (U Type) (f (-> S S S)) (id S) (x S) (x1 S) (x2 S :list))
-  ((-> S S S) T T) T
+  :signature ((-> S S S) T T) T
   (
     (($get_a_norm_rec f id (f id x2))  ($get_a_norm_rec f id x2))
     (($get_a_norm_rec f id (f x1 x2))  (eo::list_concat f ($get_a_norm_rec f id x1) ($get_a_norm_rec f id x2)))
@@ -42,7 +42,7 @@
 ; - t T: The term to process.
 ; return: the result of normalizing t based on associative+identity+idempotent reasoning.
 (program $get_ai_norm ((T Type ) (S Type) (U Type) (V Type) (f (-> S U V)) (x S) (y U))
-  (T) T
+  :signature (T) T
   (
     (($get_ai_norm (f x y)) (eo::define ((id (eo::nil f (eo::typeof (f x y)))))
                               ($singleton_elim_aci f id (eo::list_setof f ($get_a_norm_rec f id (f x y))))))
@@ -54,7 +54,7 @@
 ; - t T: The term to process.
 ; return: the result of normalizing t based on associative+identity reasoning.
 (program $get_a_norm ((T Type) (S Type) (U Type) (V Type) (f (-> S U V)) (x S) (y U))
-  (T) T
+  :signature (T) T
   (
     (($get_a_norm (f x y))  (eo::define ((id (eo::nil f (eo::typeof (f x y)))))
                               ($singleton_elim_aci f id ($get_a_norm_rec f id (f x y)))))
@@ -73,7 +73,7 @@
 ; - b S: The second term, expected to be normalized for ACI_NORM.
 ; return: true if a can be shown to be equivalent to b.
 (program $aci_norm_eq ((S Type) (U Type) (V Type) (t S) (s S) (f (-> S U V)) (x S) (y U))
-  (S S) Bool
+  :signature (S S) Bool
   (
   (($aci_norm_eq t t) true)
   (($aci_norm_eq (@aci_sorted f t) t) true)

--- a/proofs/eo/cpc/programs/Arith.eo
+++ b/proofs/eo/cpc/programs/Arith.eo
@@ -75,7 +75,7 @@
 ; return: The log base 2 of x.
 ; note: Helper method for $arith_eval_int_log_2 below.
 (program $arith_eval_int_log_2_rec ((x Int))
-  (Int) Int
+  :signature (Int) Int
   (
   (($arith_eval_int_log_2_rec 1) 0)
   (($arith_eval_int_log_2_rec x) (eo::add 1 ($arith_eval_int_log_2_rec (eo::zdiv x 2))))
@@ -97,7 +97,7 @@
 ; return: 2 to the power of x.
 ; note: Helper method for $arith_eval_int_pow_2 below.
 (program $arith_eval_int_pow_2_rec ((x Int))
-  (Int) Int
+  :signature (Int) Int
   (
   (($arith_eval_int_pow_2_rec 0) 1)
   (($arith_eval_int_pow_2_rec x) (eo::mul 2 ($arith_eval_int_pow_2_rec (eo::add x -1))))
@@ -121,7 +121,7 @@
 ; return: true iff x is a power of two.
 ; note: Helper method for $arith_eval_is_pow_2 below.
 (program $arith_eval_int_is_pow_2_rec ((x Int))
-  (Int) Bool
+  :signature (Int) Bool
   (
   (($arith_eval_int_is_pow_2_rec 1) true)
   (($arith_eval_int_is_pow_2_rec x) (eo::ite (eo::eq (eo::zmod x 2) 0)
@@ -148,7 +148,7 @@
 ; - a T: The term to muliply.
 ; return: The result of multiplying a, n times.
 (program $arith_unfold_pow_rec ((T Type) (n Int) (a T) (Any Type))
-  (Int T) Any
+  :signature (Int T) Any
   (
     (($arith_unfold_pow_rec 0 a)  1)
     (($arith_unfold_pow_rec n a)  (eo::cons * a ($arith_unfold_pow_rec (eo::add n -1) a)))

--- a/proofs/eo/cpc/programs/BitVectors.eo
+++ b/proofs/eo/cpc/programs/BitVectors.eo
@@ -36,7 +36,7 @@
 ; - b (BitVec m): The bitvector term.
 ; return: The result of concatenating b n times.
 (program $bv_unfold_repeat_rec ((m Int) (n Int) (b (BitVec m)) (Any Type))
-  (Int (BitVec m)) Any
+  :signature (Int (BitVec m)) Any
   (
     (($bv_unfold_repeat_rec 0 b)  (eo::to_bin 0 0))
     (($bv_unfold_repeat_rec n b)  (eo::cons concat b ($bv_unfold_repeat_rec (eo::add n -1) b)))
@@ -62,7 +62,7 @@
 ;   The first direct child of a that it is a bitvector constant if one exists,
 ;   or the term @bv_empty otherwise.
 (program $bv_get_first_const_child ((n Int) (k Int) (f (-> (BitVec n) (BitVec n) (BitVec n))) (a (BitVec n)) (b (BitVec n) :list))
-  ((BitVec n)) (BitVec n)
+  :signature ((BitVec n)) (BitVec n)
   (
     (($bv_get_first_const_child (f a b))  (eo::ite (eo::is_bin a) a ($bv_get_first_const_child b)))
   )

--- a/proofs/eo/cpc/programs/Bitblasting.eo
+++ b/proofs/eo/cpc/programs/Bitblasting.eo
@@ -36,7 +36,8 @@
 ; - l Int: The number of elements in the prefix left to extract.
 ; - t L: The term to process, which is expected to be a cons-list.
 ; return: the prefix of t consisting of at most l children.
-(program $bv_bitblast_prefix ((n Int) (t (BitVec n)) (b Bool) (a (BitVec n) :list) (l Int))
+(program $bv_bitblast_prefix
+  ((n Int) (t (BitVec n)) (b Bool) (a (BitVec n) :list) (l Int))
   :signature (Int (BitVec n)) (BitVec l)
   (
     (($bv_bitblast_prefix 0 t)                   @bv_empty)
@@ -53,7 +54,8 @@
 ; - t L: The term to process, which is expected to be a cons-list.
 ; return: >
 ;   The subsequent of t between indices l and u inclusive.
-(program $bv_bitblast_subsequence ((n Int) (t (BitVec n)) (b Bool) (a (BitVec n) :list) (u Int) (l Int))
+(program $bv_bitblast_subsequence
+  ((n Int) (t (BitVec n)) (b Bool) (a (BitVec n) :list) (u Int) (l Int))
   :signature (Int Int (BitVec n)) (BitVec (eo::add u (eo::neg l)))
   (
     (($bv_bitblast_subsequence l u @bv_empty)      @bv_empty)

--- a/proofs/eo/cpc/programs/Bitblasting.eo
+++ b/proofs/eo/cpc/programs/Bitblasting.eo
@@ -9,7 +9,7 @@
 ; - b2 Bool: The second Boolean.
 ; return: the result of applying f to b1 and b2.
 (program $bv_bitblast_binary_app ((T Type) (f (-> T T Bool)) (a Bool) (b Bool))
-  ((-> T T Bool) Bool Bool) Bool
+  :signature ((-> T T Bool) Bool Bool) Bool
   (
   (($bv_bitblast_binary_app and a b)  (and a b))
   (($bv_bitblast_binary_app or a b)   (or a b))
@@ -24,7 +24,7 @@
 ; - n Int: The number of times to repeat it.
 ; return: the list of bits containing b, n times.
 (program $bv_bitblast_repeat ((b Bool) (n Int) (Any Type))
-  (Bool Int) Any
+  :signature (Bool Int) Any
   (
     (($bv_bitblast_repeat b 0)  @bv_empty)
     (($bv_bitblast_repeat b n)  (eo::cons @from_bools b ($bv_bitblast_repeat b (eo::add n -1))))
@@ -36,9 +36,8 @@
 ; - l Int: The number of elements in the prefix left to extract.
 ; - t L: The term to process, which is expected to be a cons-list.
 ; return: the prefix of t consisting of at most l children.
-(program $bv_bitblast_prefix
-  ((n Int) (t (BitVec n)) (b Bool) (a (BitVec n) :list) (l Int))
-  (Int (BitVec n)) (BitVec l)
+(program $bv_bitblast_prefix ((n Int) (t (BitVec n)) (b Bool) (a (BitVec n) :list) (l Int))
+  :signature (Int (BitVec n)) (BitVec l)
   (
     (($bv_bitblast_prefix 0 t)                   @bv_empty)
     (($bv_bitblast_prefix l @bv_empty)           @bv_empty)
@@ -54,9 +53,8 @@
 ; - t L: The term to process, which is expected to be a cons-list.
 ; return: >
 ;   The subsequent of t between indices l and u inclusive.
-(program $bv_bitblast_subsequence
-  ((n Int) (t (BitVec n)) (b Bool) (a (BitVec n) :list) (u Int) (l Int))
-  (Int Int (BitVec n)) (BitVec (eo::add u (eo::neg l)))
+(program $bv_bitblast_subsequence ((n Int) (t (BitVec n)) (b Bool) (a (BitVec n) :list) (u Int) (l Int))
+  :signature (Int Int (BitVec n)) (BitVec (eo::add u (eo::neg l)))
   (
     (($bv_bitblast_subsequence l u @bv_empty)      @bv_empty)
     (($bv_bitblast_subsequence 0 u t)
@@ -85,7 +83,7 @@
 ; - a (Bitvec n): The list of bits.
 ; return: the result of applying f to each bit in a.
 (program $bv_bitblast_apply_unary ((f (-> Bool Bool)) (b1 Bool) (n Int) (m Int) (a1 (BitVec m) :list))
-  ((-> Bool Bool) (BitVec n)) (BitVec n)
+  :signature ((-> Bool Bool) (BitVec n)) (BitVec n)
   (
   (($bv_bitblast_apply_unary f @bv_empty)           @bv_empty)
   (($bv_bitblast_apply_unary f (@from_bools b1 a1)) (eo::cons @from_bools (f b1) ($bv_bitblast_apply_unary f a1)))
@@ -99,7 +97,7 @@
 ; - a2 (Bitvec n): The second list of bits.
 ; return: the result of applying f pairwise to the bits of a1 and a2.
 (program $bv_bitblast_apply_binary ((T Type) (f (-> T T Bool)) (b1 Bool) (b2 Bool) (n Int) (m Int) (a1 (BitVec m) :list) (a2 (BitVec m) :list))
-  ((-> T T Bool) (BitVec n) (BitVec n)) (BitVec n)
+  :signature ((-> T T Bool) (BitVec n) (BitVec n)) (BitVec n)
   (
   (($bv_bitblast_apply_binary f @bv_empty @bv_empty)                     @bv_empty)
   (($bv_bitblast_apply_binary f (@from_bools b1 a1) (@from_bools b2 a2)) (eo::cons @from_bools ($bv_bitblast_binary_app f b1 b2) ($bv_bitblast_apply_binary f a1 a2)))
@@ -113,7 +111,7 @@
 ; - a2 (Bitvec n): The else branch, a list of bits.
 ; return: the bitlist having bits that are ITEs whose condition is b and whose branches are a1 and a2.
 (program $bv_bitblast_apply_ite ((bc Bool) (n Int) (m Int) (b1 Bool) (a1 (BitVec m) :list) (b2 Bool) (a2 (BitVec m) :list))
-  (Bool (BitVec n) (BitVec n)) (BitVec n)
+  :signature (Bool (BitVec n) (BitVec n)) (BitVec n)
   (
   (($bv_bitblast_apply_ite bc @bv_empty @bv_empty)                      @bv_empty)
   (($bv_bitblast_apply_ite bc (@from_bools b1 a1) (@from_bools b2 a2))  (eo::cons @from_bools (ite bc b1 b2) ($bv_bitblast_apply_ite bc a1 a2)))
@@ -146,7 +144,7 @@
 ; - y T: The right hand side of the equality we have left to process.
 ; return: the bitblasted term for (= x y).
 (program $bv_mk_bitblast_step_eq_rec ((n Int) (nm1 Int) (b1 Bool) (b2 Bool) (a1 (BitVec nm1) :list) (a2 (BitVec nm1) :list))
-  ((BitVec n) (BitVec n)) Bool
+  :signature ((BitVec n) (BitVec n)) Bool
   (
   (($bv_mk_bitblast_step_eq_rec @bv_empty @bv_empty)                      true)
   (($bv_mk_bitblast_step_eq_rec (@from_bools b1 a1) (@from_bools b2 a2))  (eo::cons and (= b1 b2) ($bv_mk_bitblast_step_eq_rec a1 a2)))
@@ -170,7 +168,7 @@
 ; - res Bool: The accumulated result.
 ; return: the bitblasted term for (bvult x y).
 (program $bv_bitblast_ult_rec ((n Int) (b1 Bool) (b2 Bool) (a1 (BitVec n) :list) (a2 (BitVec n) :list) (res Bool))
-  ((BitVec n) (BitVec n) Bool) Bool
+  :signature ((BitVec n) (BitVec n) Bool) Bool
   (
   (($bv_bitblast_ult_rec @bv_empty @bv_empty res)                      res)
   (($bv_bitblast_ult_rec (@from_bools b1 a1) (@from_bools b2 a2) res)  ($bv_bitblast_ult_rec a1 a2 (or (and (= b1 b2) res) (and (not b1) b2))))
@@ -184,7 +182,7 @@
 ; - orEqual Bool: If true, we are processing (bvule x y), otherwise we are processing (bvult x y).
 ; return: the bitblasted term for the unsigned inequality between x and y.
 (program $bv_bitblast_ult ((n Int) (b1 Bool) (b2 Bool) (a1 (BitVec n) :list) (a2 (BitVec n) :list) (orEqual Bool))
-  ((BitVec n) (BitVec n) Bool) Bool
+  :signature ((BitVec n) (BitVec n) Bool) Bool
   (
   (($bv_bitblast_ult (@from_bools b1 a1) (@from_bools b2 a2) orEqual)  (eo::define ((res (and (not b1) b2)))
                                                                        (eo::define ((res2 (eo::ite orEqual (or res (= b1 b2)) res)))
@@ -199,7 +197,7 @@
 ; - orEqual Bool: If true, we are processing (bvsle x y), otherwise we are processing (bvslt x y).
 ; return: the bitblasted term for the signed inequality between x and y.
 (program $bv_bitblast_slt_impl ((n Int) (b1 Bool) (b2 Bool) (a1 (BitVec n) :list) (a2 (BitVec n) :list) (orEqual Bool))
-  ((BitVec n) (BitVec n) Bool) Bool
+  :signature ((BitVec n) (BitVec n) Bool) Bool
   (
   ; bitwidth one case is handled separately
   (($bv_bitblast_slt_impl (@from_bools b1) (@from_bools b2) orEqual)        (eo::ite orEqual (or (= b1 b2) (and b1 (not b2))) (and b1 (not b2))))
@@ -239,7 +237,7 @@
 ;   the concatenation term to this method to match the bitblasted form that is
 ;   generated.
 (program $bv_mk_bitblast_step_concat_rec ((n Int) (a1 (BitVec n)) (m Int) (a2 (BitVec m) :list))
-  ((BitVec n)) (BitVec n)
+  :signature ((BitVec n)) (BitVec n)
   (
   (($bv_mk_bitblast_step_concat_rec @bv_empty)      @bv_empty)
   (($bv_mk_bitblast_step_concat_rec (concat a1 a2)) (eo::list_concat @from_bools a1 ($bv_mk_bitblast_step_concat_rec a2)))
@@ -264,7 +262,7 @@
 ; return: the bitblasted version of a.
 (program $bv_mk_bitblast_step_bitwise ((T Type) (n Int) (m Int) (bf (-> (BitVec n) (BitVec n) (BitVec n))) 
                                        (f (-> T T Bool)) (a1 (BitVec m)) (a2 (BitVec m) :list) (ac (BitVec m)))
-  ((-> (BitVec n) (BitVec n) (BitVec n)) (-> T T Bool) (BitVec m) (BitVec m)) (BitVec m)
+  :signature ((-> (BitVec n) (BitVec n) (BitVec n)) (-> T T Bool) (BitVec m) (BitVec m)) (BitVec m)
   (
   (($bv_mk_bitblast_step_bitwise bf f (bf a1 a2) ac)    ($bv_mk_bitblast_step_bitwise bf f a2 ($bv_bitblast_apply_binary f ac a1)))
   (($bv_mk_bitblast_step_bitwise bf f a2 ac)            ac)
@@ -281,7 +279,7 @@
 ; - ac (BitVec m): The accumulated return value.
 ; return: a pair corresponding to the final carry bit and accumulated result.
 (program $bv_ripple_carry_adder_2 ((n Int) (m Int) (b1 Bool) (b2 Bool) (a1 (BitVec n) :list) (a2 (BitVec n) :list) (carry Bool) (res (BitVec m)))
-  ((BitVec n) (BitVec n) Bool (BitVec m)) (@Pair Bool (BitVec (eo::add n m)))
+  :signature ((BitVec n) (BitVec n) Bool (BitVec m)) (@Pair Bool (BitVec (eo::add n m)))
   (
   (($bv_ripple_carry_adder_2 (@from_bools b1 a1) (@from_bools b2 a2) carry res) ($bv_ripple_carry_adder_2 a1 a2 
                                                                                   (or (and b1 b2) (and (xor b1 b2) carry))
@@ -307,7 +305,7 @@
 ; - ac (BitVec n): The accumulated return value, a list of bits.
 ; return: the bitblasted term for a, given already processed arguments ac.
 (program $bv_mk_bitblast_step_add ((n Int) (a1 (BitVec n)) (a2 (BitVec n) :list) (ac (BitVec n)))
-  ((BitVec n) (BitVec n)) (BitVec n)
+  :signature ((BitVec n) (BitVec n)) (BitVec n)
   (
   (($bv_mk_bitblast_step_add (bvadd a1 a2) ac) ($bv_mk_bitblast_step_add a2 ($bv_ripple_carry_adder ac a1 false)))
   (($bv_mk_bitblast_step_add a2 ac)            ac)
@@ -328,7 +326,7 @@
 ; return: the bitblasted term for processing the multiplication at the current index.
 (program $bv_shift_add_multiplier_rec_step ((n Int) (np Int) (m Int) (k Int) (b1 Bool) (b2 Bool) (a2 (BitVec n) :list)
                                             (br Bool) (ar (BitVec m) :list) (carry Bool))
-  (Bool (BitVec n) Int (BitVec np) Bool) (BitVec np)
+  :signature (Bool (BitVec n) Int (BitVec np) Bool) (BitVec np)
   (
   (($bv_shift_add_multiplier_rec_step b1 a2 0 @bv_empty carry)                              @bv_empty)
   (($bv_shift_add_multiplier_rec_step b1 (@from_bools b2 a2) 0 (@from_bools br ar) carry)
@@ -348,7 +346,7 @@
 ; - res (BitVec n): The accumulated return value, a list of bits.
 ; return: the bitblasted term for processing the multiplication of a1 and a2.
 (program $bv_shift_add_multiplier_rec ((n Int) (m Int) (mm1 Int) (k Int) (b1 Bool) (a1 (BitVec mm1) :list) (a2 (BitVec n)) (res (BitVec n)))
-  ((BitVec m) (BitVec n) Int (BitVec n)) (BitVec n)
+  :signature ((BitVec m) (BitVec n) Int (BitVec n)) (BitVec n)
   (
   (($bv_shift_add_multiplier_rec @bv_empty a2 k res)            res)
   (($bv_shift_add_multiplier_rec (@from_bools b1 a1) a2 k res)
@@ -362,7 +360,7 @@
 ; - b (BitVec n): The second term to multiply, a lists of bits.
 ; return: the bitblasted term for (bvmul a b).
 (program $bv_shift_add_multiplier ((n Int) (m Int) (k Int) (b1 Bool) (a1 (BitVec k) :list) (a2 (BitVec n)))
-  ((BitVec n) (BitVec m)) (BitVec n)
+  :signature ((BitVec n) (BitVec m)) (BitVec n)
   (
   (($bv_shift_add_multiplier a2 (@from_bools b1 a1))
     (eo::define ((sz ($bv_bitwidth (eo::typeof a2))))
@@ -376,7 +374,7 @@
 ; - ac (BitVec n): The accumulated return value, a list of bits.
 ; return: the bitblasted term for a, given already processed arguments ac.
 (program $bv_mk_bitblast_step_mul ((n Int) (a1 (BitVec n)) (a2 (BitVec n) :list) (ac (BitVec n)))
-  ((BitVec n) (BitVec n)) (BitVec n)
+  :signature ((BitVec n) (BitVec n)) (BitVec n)
   (
   (($bv_mk_bitblast_step_mul (bvmul a1 a2) ac) ($bv_mk_bitblast_step_mul a2 ($bv_shift_add_multiplier ac a1)))
   (($bv_mk_bitblast_step_mul a2 ac)            ac)
@@ -394,7 +392,7 @@
 ; return:
 ;   A pair corresponding to the bitblasted form of the quotient/remainder of x and y.
 (program $bv_div_mod_impl ((n Int) (a1 (BitVec n)) (a2 (BitVec n)) (sz Int) (zero (BitVec n)))
-  ((BitVec n) (BitVec n) (BitVec n) Int) (@Pair (BitVec n) (BitVec n))
+  :signature ((BitVec n) (BitVec n) (BitVec n) Int) (@Pair (BitVec n) (BitVec n))
   (
   (($bv_div_mod_impl a1 a2 zero 0)    (@pair zero zero))
   (($bv_div_mod_impl zero a2 zero sz) (@pair zero zero))
@@ -456,7 +454,7 @@
 ; - y (BitVec n): The else branch, expected to be a list of bits.
 ; return: the bitblasted term for (bvite c x y).
 (program $bv_mk_bitblast_step_ite ((n Int) (b1 Bool) (a1 (BitVec n) :list) (b2 Bool) (a2 (BitVec n) :list) (bc Bool))
-  ((BitVec 1) (BitVec n) (BitVec n)) (BitVec n)
+  :signature ((BitVec 1) (BitVec n) (BitVec n)) (BitVec n)
   (
   (($bv_mk_bitblast_step_ite (@from_bools bc) (@from_bools b1 a1) (@from_bools b2 a2))
     (eo::cons @from_bools (and (or (not bc) b1) (or bc b2)) ($bv_mk_bitblast_step_ite (@from_bools bc) a1 a2)))
@@ -473,7 +471,7 @@
 ; - n Int: The bitwidth of c.
 ; return: the bitlist for a starting with index i.
 (program $bv_const_to_bitlist_rec ((n Int) (c (BitVec n)) (i Int))
-  ((BitVec n) Int Int) (BitVec (eo::add n (eo::neg i)))
+  :signature ((BitVec n) Int Int) (BitVec (eo::add n (eo::neg i)))
   (
     (($bv_const_to_bitlist_rec c n n)   @bv_empty)
     (($bv_const_to_bitlist_rec c i n)   (eo::cons @from_bools ($bv_bit_set c i) ($bv_const_to_bitlist_rec c (eo::add i 1) n)))
@@ -499,7 +497,7 @@
 (program $bv_mk_bitblast_step_shl_rec_step ((i Int) (n Int) (m Int) (mm1 Int)
                                              (b1 Bool) (a1 (BitVec mm1) :list)
                                              (b1c Bool) (a1c (BitVec n) :list) (b2 Bool))
-  ((BitVec m) (BitVec n) Int Bool) (BitVec m)
+  :signature ((BitVec m) (BitVec n) Int Bool) (BitVec m)
   (
   (($bv_mk_bitblast_step_shl_rec_step @bv_empty a1c i b2)                              @bv_empty)
   (($bv_mk_bitblast_step_shl_rec_step (@from_bools b1 a1) (@from_bools b1c a1c) 0 b2)
@@ -517,7 +515,7 @@
 ; - lsz Int: The bitwidth of a1.
 ; return: the bitblasted term for processing the left shift of a1 and a2.
 (program $bv_mk_bitblast_step_shl_rec ((s Int) (lsz Int) (n Int) (m Int) (a1 (BitVec n)) (b2 Bool) (a2 (BitVec m) :list))
-  ((BitVec n) (BitVec m) Int Int) (BitVec n)
+  :signature ((BitVec n) (BitVec m) Int Int) (BitVec n)
   (
   (($bv_mk_bitblast_step_shl_rec a1 a2 lsz lsz)                a1)
   (($bv_mk_bitblast_step_shl_rec a1 (@from_bools b2 a2) s lsz)
@@ -552,7 +550,7 @@
 (program $bv_mk_bitblast_step_shr_rec_step ((i Int) (n Int) (m Int) (mm1 Int)
                                              (b1 Bool) (a1 (BitVec mm1) :list)
                                              (b1c Bool) (a1c (BitVec n) :list) (b2 Bool) (sbit Bool))
-  ((BitVec m) (BitVec n) Int Bool Bool) (BitVec m)
+  :signature ((BitVec m) (BitVec n) Int Bool Bool) (BitVec m)
   (
   (($bv_mk_bitblast_step_shr_rec_step @bv_empty a1c i b2 sbit)                              @bv_empty)
   (($bv_mk_bitblast_step_shr_rec_step (@from_bools b1 a1) (@from_bools b1c a1c) 0 b2 sbit)
@@ -573,7 +571,7 @@
 ; - sbit Bool: The sign bit we are processing (the sign of first argument for bvashr, false otherwise).
 ; return: the bitblasted term for processing the left shift of a1 and a2.
 (program $bv_mk_bitblast_step_shr_rec ((s Int) (lsz Int) (n Int) (m Int) (a1 (BitVec n)) (b2 Bool) (a2 (BitVec m) :list) (sbit Bool))
-  ((BitVec n) (BitVec m) Int Int Bool) (BitVec n)
+  :signature ((BitVec n) (BitVec m) Int Int Bool) (BitVec n)
   (
   (($bv_mk_bitblast_step_shr_rec a1 a2 lsz lsz sbit)                a1)
   (($bv_mk_bitblast_step_shr_rec a1 (@from_bools b2 a2) s lsz sbit)
@@ -605,7 +603,7 @@
 ; - i Int: The index of the bit we are currently processing.
 ; return: the bitblasted term for variable a.
 (program $bv_mk_bitblast_step_var_rec ((n Int) (a (BitVec n)) (i Int) (Any Type))
-  ((BitVec n) Int) Any
+  :signature ((BitVec n) Int) Any
   (
     (($bv_mk_bitblast_step_var_rec a -1)  @bv_empty)
     (($bv_mk_bitblast_step_var_rec a i)   (eo::cons @from_bools (@bit i a) ($bv_mk_bitblast_step_var_rec a (eo::add i -1))))

--- a/proofs/eo/cpc/programs/Datatypes.eo
+++ b/proofs/eo/cpc/programs/Datatypes.eo
@@ -10,7 +10,7 @@
 ;   extract their constructors, which generates a list of *unannotated*
 ;   datatype constructors.
 (program $dt_get_constructors ((D Type) (T Type) (c T) (T1 Type) (T2 Type :list) (U Type) (DC (-> Type Type)))
-  (U) eo::List
+  :signature (U) eo::List
   (
     (($dt_get_constructors (Tuple T1 T2)) (eo::cons eo::List::cons tuple eo::List::nil))
     (($dt_get_constructors UnitTuple)     (eo::cons eo::List::cons tuple.unit eo::List::nil))
@@ -44,7 +44,7 @@
 ;   Tuples use a special selector tuple.select indexed by an integer, which is
 ;   why they require a special method here.
 (program $tuple_get_selectors_rec ((D Type) (T Type) (t T) (T1 Type) (T2 Type :list) (n Int))
-  (Type Int) eo::List
+  :signature (Type Int) eo::List
   (
     (($tuple_get_selectors_rec UnitTuple n)     eo::List::nil)
     (($tuple_get_selectors_rec (Tuple T1 T2) n) (eo::cons eo::List::cons (tuple.select n) ($tuple_get_selectors_rec T2 (eo::add n 1))))
@@ -60,7 +60,7 @@
 ;   (Unit) tuples are treated as a special case of datatypes whose selectors are
 ;   tuple.select indexed by an integer, which requires the above method.
 (program $dt_get_selectors ((D Type) (T Type) (c Type) (T1 Type) (T2 Type :list))
-  (Type T) eo::List
+  :signature (Type T) eo::List
   (
     (($dt_get_selectors (Tuple T1 T2) tuple)  ($tuple_get_selectors_rec (Tuple T1 T2) 0))
     (($dt_get_selectors UnitTuple tuple.unit) eo::List::nil)
@@ -74,7 +74,7 @@
 ; - t T: The constructor application of D.
 ; return: The list of selectors of the constructor of t, as a eo::List.
 (program $dt_get_selectors_of_app ((T Type) (U Type) (f (-> U T)) (a U))
-  (Type T) eo::List
+  :signature (Type T) eo::List
   (
     (($dt_get_selectors_of_app T (f a))  ($dt_get_selectors_of_app T f))
     (($dt_get_selectors_of_app T a)      ($dt_get_selectors T a))
@@ -96,7 +96,7 @@
 ; return: >
 ;   The list of arguments of the constructor application t.
 (program $dt_arg_list ((T Type) (U Type) (V Type) (W Type) (t T) (n Int) (t1 V) (t2 W :list))
-  (T) eo::List
+  :signature (T) eo::List
   (
     ; for tuples, we manually accumulate the list.
     (($dt_arg_list (tuple t1 t2))  (eo::cons @list t1 ($dt_arg_list t2)))
@@ -123,7 +123,7 @@
 ;   of t and s are different, and does not evaluate if at least one of t and s
 ;   is not an application of a constructor.
 (program $dt_eq_cons ((T Type) (U Type) (V Type) (W Type) (ct T) (cs V) (f (-> U W)) (a U))
-  (T V) Bool
+  :signature (T V) Bool
   (
     (($dt_eq_cons (f a) cs) ($dt_eq_cons f cs))
     (($dt_eq_cons ct (f a)) ($dt_eq_cons ct f))

--- a/proofs/eo/cpc/programs/DistinctValues.eo
+++ b/proofs/eo/cpc/programs/DistinctValues.eo
@@ -10,7 +10,7 @@
 (include "Datatypes.eo")
 
 ; note: This is a forward declaration of $are_distinct_terms_list below.
-(program $are_distinct_terms_list () (@List Type) Bool)
+(program $are_distinct_terms_list () :signature (@List Type) Bool)
 
 ; define: $are_distinct_terms
 ; args:
@@ -29,7 +29,7 @@
 ;   True if there is some term in ts and ss at the same position which can be shown to be semantically distinct.
 ;   This program expects ts and ss to be of the same length.
 (program $some_pairwise_distinct_term ((U Type) (t U) (s U) (ts @List :list) (ss @List :list))
-  (@List @List) Bool
+  :signature (@List @List) Bool
   (
   (($some_pairwise_distinct_term (@list t ts) (@list s ss))  (eo::ite ($are_distinct_terms t s)
                                                                 true
@@ -48,7 +48,7 @@
 ; return: >
 ;   True if we can show that t is not a subset of s based on reasoning about values.
 (program $set_is_not_subset ((T Type) (t (Set T)) (ts (Set T) :list) (s (Set T)) (ss (Set T) :list) (e1 T) (e2 T))
-  ((Set T) (Set T)) Bool
+  :signature ((Set T) (Set T)) Bool
   (
   (($set_is_not_subset (as set.empty (Set T)) s)                              false)
   (($set_is_not_subset (set.singleton e1) (as set.empty (Set T)))             true)
@@ -73,7 +73,7 @@
 ;   True if we can derive that t and s are distinct based on their length,
 ;   or by a character prefix that can be shown distinct.
 (program $seq_distinct_terms ((T Type) (t (Seq T)) (ts (Seq T) :list) (s (Seq T)) (ss (Seq T) :list) (e1 T) (e2 T))
-  ((Seq T) (Seq T)) Bool
+  :signature ((Seq T) (Seq T)) Bool
   (
   ; handle singleton cases
   (($seq_distinct_terms (seq.unit e1) s)                                     ($seq_distinct_terms (seq.++ (seq.unit e1)) s))
@@ -99,7 +99,7 @@
 ;   if t and s are distinct constructor applications, or are applications
 ;   of the same constructor and one of their arguments can be shown distinct.
 (program $dt_distinct_terms_rec ((T Type) (U Type) (V Type) (W Type) (ct T) (cs V) (f (-> U W)) (a U) (l1 @List) (l2 @List))
-  (T V @List @List) Bool
+  :signature (T V @List @List) Bool
   (
     (($dt_distinct_terms_rec (f a) cs l1 l2) ($dt_distinct_terms_rec f cs (eo::cons @list a l1) l2))
     (($dt_distinct_terms_rec ct (f a) l1 l2) ($dt_distinct_terms_rec ct f l1 (eo::cons @list a l2)))
@@ -134,9 +134,8 @@
 ; - T Type: The type of the arguments.
 ; return: >
 ;   True if we can shown that t and s are semantically distinct, e.g. (not (= t s)) holds.
-(program $are_distinct_terms_type
-  ((T Type) (t T) (s T) (U Type) (W Type) (n Int) (st (Set U)) (ss (Set U)) (sst (Seq U)) (sss (Seq U)))
-  (T T Type) Bool
+(program $are_distinct_terms_type ((T Type) (t T) (s T) (U Type) (W Type) (n Int) (st (Set U)) (ss (Set U)) (sst (Seq U)) (sss (Seq U)))
+  :signature (T T Type) Bool
   (
   (($are_distinct_terms_type t t T)           false)
   (($are_distinct_terms_type t s Int)         (eo::and (eo::is_z t) (eo::is_z s)))
@@ -158,7 +157,7 @@
 ; return: >
 ;   True if t can be shown to be disequal from all terms in xs.
 (program $are_distinct_terms_list_rec ((T Type) (t T) (s T) (xs @List :list))
-  (T @List Type) Bool
+  :signature (T @List Type) Bool
   (
   (($are_distinct_terms_list_rec t (@list s xs) T)  (eo::ite ($are_distinct_terms_type t s T)
                                                       ($are_distinct_terms_list_rec t xs T)
@@ -174,7 +173,7 @@
 ; return: >
 ;   True if each pair of terms in xs can be shown to be pairwise disequal.
 (program $are_distinct_terms_list ((T Type) (t T) (xs @List :list))
-  (@List Type) Bool
+  :signature (@List Type) Bool
   (
   (($are_distinct_terms_list @list.nil T)     true)
   (($are_distinct_terms_list (@list t xs) T)  (eo::ite ($are_distinct_terms_list_rec t xs T)

--- a/proofs/eo/cpc/programs/DistinctValues.eo
+++ b/proofs/eo/cpc/programs/DistinctValues.eo
@@ -134,7 +134,8 @@
 ; - T Type: The type of the arguments.
 ; return: >
 ;   True if we can shown that t and s are semantically distinct, e.g. (not (= t s)) holds.
-(program $are_distinct_terms_type ((T Type) (t T) (s T) (U Type) (W Type) (n Int) (st (Set U)) (ss (Set U)) (sst (Seq U)) (sss (Seq U)))
+(program $are_distinct_terms_type
+  ((T Type) (t T) (s T) (U Type) (W Type) (n Int) (st (Set U)) (ss (Set U)) (sst (Seq U)) (sss (Seq U)))
   :signature (T T Type) Bool
   (
   (($are_distinct_terms_type t t T)           false)

--- a/proofs/eo/cpc/programs/Nary.eo
+++ b/proofs/eo/cpc/programs/Nary.eo
@@ -19,7 +19,8 @@
 ; - c1 L: The first term, assumed to be a cons-list.
 ; - c2 L: The second term, assumed to be a cons-list.
 ; return: true if c1 is a prefix of c2, or c2 is a prefix of c1.
-(program $nary_is_compatible ((U Type) (L Type) (cons (-> L L L)) (nil U) (t U) (c1 U) (c2 U) (xs1 U :list) (xs2 U :list))
+(program $nary_is_compatible
+    ((U Type) (L Type) (cons (-> L L L)) (nil U) (t U) (c1 U) (c2 U) (xs1 U :list) (xs2 U :list))
     :signature ((-> L L L) U U U) Bool
     (
         (($nary_is_compatible cons nil nil t)                       true)

--- a/proofs/eo/cpc/programs/Nary.eo
+++ b/proofs/eo/cpc/programs/Nary.eo
@@ -19,9 +19,8 @@
 ; - c1 L: The first term, assumed to be a cons-list.
 ; - c2 L: The second term, assumed to be a cons-list.
 ; return: true if c1 is a prefix of c2, or c2 is a prefix of c1.
-(program $nary_is_compatible
-    ((U Type) (L Type) (cons (-> L L L)) (nil U) (t U) (c1 U) (c2 U) (xs1 U :list) (xs2 U :list))
-    ((-> L L L) U U U) Bool
+(program $nary_is_compatible ((U Type) (L Type) (cons (-> L L L)) (nil U) (t U) (c1 U) (c2 U) (xs1 U :list) (xs2 U :list))
+    :signature ((-> L L L) U U U) Bool
     (
         (($nary_is_compatible cons nil nil t)                       true)
         (($nary_is_compatible cons nil t nil)                       true)

--- a/proofs/eo/cpc/programs/PolyNorm.eo
+++ b/proofs/eo/cpc/programs/PolyNorm.eo
@@ -29,7 +29,7 @@
 ; - p @Polynomial: The polynomial to negate.
 ; return: the negation of the given polynomial.
 (program $poly_neg ((T Type) (c Real) (a T) (p @Polynomial :list))
-  (@Polynomial) @Polynomial
+  :signature (@Polynomial) @Polynomial
   (
     (($poly_neg @poly.zero)           @poly.zero)
     (($poly_neg (@poly (@mon a c) p)) (eo::cons @poly (@mon a (eo::neg c)) ($poly_neg p)))
@@ -41,7 +41,7 @@
 ; - w Int: The modulus to consider
 ; return: the given polynomial where all coefficient are taken mod w.
 (program $poly_mod_coeffs ((T Type) (c Real) (a T) (p @Polynomial :list) (w Int))
-  (@Polynomial Int) @Polynomial
+  :signature (@Polynomial Int) @Polynomial
   (
     (($poly_mod_coeffs @poly.zero w)           @poly.zero)
     (($poly_mod_coeffs (@poly (@mon a c) p) w) (eo::define ((newc (eo::zmod (eo::to_z c) w)))
@@ -58,7 +58,7 @@
 ; - p2 @Polynomial: The second polynomial to add.
 ; return: the addition of the given polynomials.
 (program $poly_add ((T Type) (U Type) (c1 Real) (a1 T) (c2 Real) (a2 U) (p @Polynomial) (p1 @Polynomial :list) (p2 @Polynomial :list))
-  (@Polynomial @Polynomial) @Polynomial
+  :signature (@Polynomial @Polynomial) @Polynomial
   (
     (($poly_add (@poly (@mon a1 c1) p1) (@poly (@mon a2 c2) p2)) (eo::ite (eo::eq a1 a2)
                                                                   (eo::define ((ca (eo::add c1 c2)) (pa ($poly_add p1 p2)))
@@ -80,7 +80,7 @@
 (program $mvar_mul_mvar ((T Type) (U Type) (V Type) (W Type) (X Type) (Y Type) (Z Type)
                          (a1 T) (a2 U :list) (c1 V) (c2 W :list)
                          (m Int)  (ba1 (BitVec m)) (ba2 (BitVec m) :list) (bc1 (BitVec m)) (bc2 (BitVec m) :list))
-  (X Y) ($typeunion X Y)
+  :signature (X Y) ($typeunion X Y)
   (
     (($mvar_mul_mvar (* a1 a2) (* c1 c2))  (eo::ite ($compare_var a1 c1)
                                              (eo::cons * a1 ($mvar_mul_mvar a2 (* c1 c2)))
@@ -103,7 +103,7 @@
 ; - b @Monomial: The second monomial to multiply.
 ; return: the multiplication of the given monomials.
 (program $mon_mul_mon ((T Type) (U Type) (a1 T) (a2 U) (c1 Real) (c2 Real))
-  (@Monomial @Monomial) @Monomial
+  :signature (@Monomial @Monomial) @Monomial
   (
     (($mon_mul_mon (@mon a1 c1) (@mon a2 c2))  (@mon ($mvar_mul_mvar a1 a2) (eo::mul c1 c2)))
   )
@@ -115,7 +115,7 @@
 ; - p @Polynomial: The polynomial to multiply.
 ; return: the multiplication of the polynomial by a monomial.
 (program $poly_mul_mon ((m1 @Monomial) (m2 @Monomial) (p2 @Polynomial :list))
-  (@Monomial @Polynomial) @Polynomial
+  :signature (@Monomial @Polynomial) @Polynomial
   (
     (($poly_mul_mon m1 (@poly m2 p2)) ($poly_add (@poly ($mon_mul_mon m1 m2)) ($poly_mul_mon m1 p2)))   ; NOTE: this amounts to an insertion sort
     (($poly_mul_mon m1 @poly.zero)    @poly.zero)
@@ -128,7 +128,7 @@
 ; - p2 @Polynomial: The second polynomial to multiply.
 ; return: the multiplication of the given polynomials.
 (program $poly_mul ((m @Monomial) (p1 @Polynomial :list) (p @Polynomial))
-  (@Polynomial @Polynomial) @Polynomial
+  :signature (@Polynomial @Polynomial) @Polynomial
   (
     (($poly_mul (@poly m p1) p) ($poly_add ($poly_mul_mon m p) ($poly_mul p1 p)))
     (($poly_mul @poly.zero p)   @poly.zero)
@@ -156,7 +156,7 @@
 ; - a T: The arithmetic term to process of type Int or Real.
 ; return: the polynomial corresponding to the (normalized) form of a.
 (program $get_arith_poly_norm ((T Type) (U Type) (V Type) (a T) (a1 U) (a2 V :list))
-  (T) @Polynomial
+  :signature (T) @Polynomial
   (
     (($get_arith_poly_norm (- a1))          ($poly_neg ($get_arith_poly_norm a1)))
     (($get_arith_poly_norm (+ a1 a2))       ($poly_add ($get_arith_poly_norm a1) ($get_arith_poly_norm a2)))
@@ -181,7 +181,7 @@
 ; - b (BitVec m): The bitvector term to process.
 ; return: the polynomial corresponding to the (normalized) form of b, prior to taking mod of its coefficients.
 (program $get_bv_poly_norm_rec ((m Int) (b (BitVec m)) (b1 (BitVec m)) (b2 (BitVec m) :list))
-  ((BitVec m)) @Polynomial
+  :signature ((BitVec m)) @Polynomial
   (
     (($get_bv_poly_norm_rec (bvneg b1))    ($poly_neg ($get_bv_poly_norm_rec b1)))
     (($get_bv_poly_norm_rec (bvadd b1 b2)) ($poly_add ($get_bv_poly_norm_rec b1) ($get_bv_poly_norm_rec b2)))
@@ -215,7 +215,7 @@
 ;       form, as 0/1 instead of 0 is used as the last element.
 ; note: This is a helper for $arith_poly_to_term below.
 (program $arith_poly_to_term_rec ((T Type) (p @Polynomial :list) (a T) (c Real))
-  (@Polynomial) Real
+  :signature (@Polynomial) Real
   (
     (($arith_poly_to_term_rec @poly.zero) 0/1)
     (($arith_poly_to_term_rec (@poly (@mon a c) p)) (+ (* c a) ($arith_poly_to_term_rec p)))

--- a/proofs/eo/cpc/programs/Quantifiers.eo
+++ b/proofs/eo/cpc/programs/Quantifiers.eo
@@ -7,9 +7,8 @@
 ; - arg2 S: The range of the substitution.
 ; - arg3 U: The term to process.
 ; return: the result of replacing all occurrences of arg1 with arg2 in arg3.
-(program $substitute
-  ((T Type) (U Type) (S Type) (x S) (y S) (f (-> T U)) (a T) (z U) (w T))
-  (S S U) U
+(program $substitute ((T Type) (U Type) (S Type) (x S) (y S) (f (-> T U)) (a T) (z U) (w T))
+  :signature (S S U) U
   (
   (($substitute x y (f a))         (_ ($substitute x y f) ($substitute x y a)))
   (($substitute x y x)             y)
@@ -22,9 +21,8 @@
 ; - arg1 S: The term to process.
 ; - arg2 U: The term to find.
 ; return: The result is true if arg2 is a subterm of arg1.
-(program $contains_subterm
-  ((T Type) (U Type) (S Type) (x U) (y S) (f (-> T S)) (a T))
-  (S U) Bool
+(program $contains_subterm ((T Type) (U Type) (S Type) (x U) (y S) (f (-> T S)) (a T))
+  :signature (S U) Bool
   (
   (($contains_subterm x x)      true)
   (($contains_subterm (f a) x)  (eo::ite ($contains_subterm f x) true ($contains_subterm a x)))
@@ -38,7 +36,7 @@
 ; - arg2 @List: The list of terms to find.
 ; return: true if any term in arg2 is a subterm of arg1.
 (program $contains_subterm_list ((T Type) (U Type) (t T) (x U) (xs @List :list))
-  (T @List) Bool
+  :signature (T @List) Bool
   (
     (($contains_subterm_list t (@list x xs)) (eo::ite ($contains_subterm t x) true ($contains_subterm_list t xs)))
     (($contains_subterm_list t @list.nil)    false)
@@ -51,7 +49,7 @@
 ; - xs @List: The list of terms to find.
 ; return: true if any atomic (0-ary) subterm of t is in xs.
 (program $contains_aterm_list ((T Type) (U Type) (S Type) (x U) (f (-> T S)) (a T) (xs @List))
-  (T @List) Bool
+  :signature (T @List) Bool
   (
     (($contains_aterm_list (f a) xs)  (eo::ite ($contains_aterm_list f xs) true ($contains_aterm_list a xs)))
     (($contains_aterm_list x xs)      (eo::not (eo::is_neg (eo::list_find @list xs x))))
@@ -64,9 +62,8 @@
 ; - xs @List: The list of variables to substitute.
 ; - ss @List: The terms to substitute.
 ; return: the result of simultaneously substituting xs to ss in t.
-(program $substitute_simul
-  ((T Type) (S Type) (x S) (f (-> T S)) (a T) (xs @List :list) (ss @List :list) (s S) (y S))
-  (S @List @List) S
+(program $substitute_simul ((T Type) (S Type) (x S) (f (-> T S)) (a T) (xs @List :list) (ss @List :list) (s S) (y S))
+  :signature (S @List @List) S
   (
   (($substitute_simul (f a) xs ss)                  (_ ($substitute_simul f xs ss) ($substitute_simul a xs ss)))
   (($substitute_simul x xs ss)                      (eo::define ((i (eo::list_find @list xs x)))
@@ -82,7 +79,7 @@
 ; - ss @List: The accumulated list of arguments to pass to the lambda.
 ; return: the result of beta reduction.
 (program $beta_reduce ((U Type) (T Type) (S Type) (f (-> T U)) (a T) (t S) (x T) (xs @List :list) (ss @List :list) (Any Type))
-  (U @List) Any
+  :signature (U @List) Any
   (
   ; handle higher-order case: if lambda is applied to one argument, it may be a partial application
   (($beta_reduce (_ (lambda (@list x xs) t) a) @list.nil)

--- a/proofs/eo/cpc/programs/Quantifiers.eo
+++ b/proofs/eo/cpc/programs/Quantifiers.eo
@@ -7,7 +7,8 @@
 ; - arg2 S: The range of the substitution.
 ; - arg3 U: The term to process.
 ; return: the result of replacing all occurrences of arg1 with arg2 in arg3.
-(program $substitute ((T Type) (U Type) (S Type) (x S) (y S) (f (-> T U)) (a T) (z U) (w T))
+(program $substitute
+  ((T Type) (U Type) (S Type) (x S) (y S) (f (-> T U)) (a T) (z U) (w T))
   :signature (S S U) U
   (
   (($substitute x y (f a))         (_ ($substitute x y f) ($substitute x y a)))
@@ -21,7 +22,8 @@
 ; - arg1 S: The term to process.
 ; - arg2 U: The term to find.
 ; return: The result is true if arg2 is a subterm of arg1.
-(program $contains_subterm ((T Type) (U Type) (S Type) (x U) (y S) (f (-> T S)) (a T))
+(program $contains_subterm
+  ((T Type) (U Type) (S Type) (x U) (y S) (f (-> T S)) (a T))
   :signature (S U) Bool
   (
   (($contains_subterm x x)      true)
@@ -62,7 +64,8 @@
 ; - xs @List: The list of variables to substitute.
 ; - ss @List: The terms to substitute.
 ; return: the result of simultaneously substituting xs to ss in t.
-(program $substitute_simul ((T Type) (S Type) (x S) (f (-> T S)) (a T) (xs @List :list) (ss @List :list) (s S) (y S))
+(program $substitute_simul
+  ((T Type) (S Type) (x S) (f (-> T S)) (a T) (xs @List :list) (ss @List :list) (s S) (y S))
   :signature (S @List @List) S
   (
   (($substitute_simul (f a) xs ss)                  (_ ($substitute_simul f xs ss) ($substitute_simul a xs ss)))

--- a/proofs/eo/cpc/programs/SeqToString.eo
+++ b/proofs/eo/cpc/programs/SeqToString.eo
@@ -37,7 +37,7 @@
 ;   A tuple containing the result of converting t, and the substitution
 ;   (units and chars) that was used to convert it.
 (program $seq_to_string_rec ((T Type) (t T) (ss (Seq T) :list) (s String) (units @List) (chars @List) (n Int))
-  ((Seq T) String @List @List Int) (Tuple String @List @List)
+  :signature ((Seq T) String @List @List Int) (Tuple String @List @List)
   (
     (($seq_to_string_rec (seq.unit t) s units chars n)              (eo::define ((u (seq.unit t)))
                                                                     ($seq_to_string_rec (eo::cons seq.++ u (as seq.empty (eo::typeof u))) s units chars n)))
@@ -87,7 +87,7 @@
 ;   A tuple containing the result of converting t, and the substitution
 ;   (units and chars) that was used to convert it.
 (program $seq_to_string_op_rec ((U Type) (T Type) (f (-> T U)) (b T) (units @List) (chars @List) (V Type) (u V) (ts (Seq V) :list))
-  (T @List @List) (Tuple String @List @List)
+  :signature (T @List @List) (Tuple String @List @List)
   (
   (($seq_to_string_op_rec (seq.unit u) units chars)             ($seq_to_string_rec (seq.unit u) "" units chars (eo::list_len @list units)))
   (($seq_to_string_op_rec (as seq.empty (Seq V)) units chars)   (tuple "" units chars))

--- a/proofs/eo/cpc/programs/Strings.eo
+++ b/proofs/eo/cpc/programs/Strings.eo
@@ -16,7 +16,7 @@
 ; - s U: a string term.
 ; return: true if s is the empty string or sequence.
 (program $str_is_empty ((U Type) (x (Seq U)))
-  ((Seq U)) Bool
+  :signature ((Seq U)) Bool
   (
     (($str_is_empty (as seq.empty (Seq U)))  true)
     (($str_is_empty "")                      true)
@@ -31,7 +31,7 @@
 ;   The length of s, if it denotes a "value-like" sequence, that
 ;   is, either a string literal or a concatentation of sequence units.
 (program $str_value_len ((T Type) (s (Seq T)) (e T) (ss (Seq T) :list))
-  ((Seq T)) Int
+  :signature ((Seq T)) Int
   (
     (($str_value_len (seq.++ (seq.unit e) ss))  (eo::add 1 ($str_value_len ss)))
     (($str_value_len (as seq.empty (Seq T)))    0)
@@ -117,7 +117,7 @@
 ;   The fixed length for the regular expression r if it can be inferred.
 ;   Otherwise results in an unevaluated term.
 (program $str_fixed_len_re ((r RegLan) (s1 String) (s2 String) (r1 RegLan :list))
-  (RegLan) Int
+  :signature (RegLan) Int
   (
   (($str_fixed_len_re (re.++ r r1))     (eo::add ($str_fixed_len_re r) ($str_fixed_len_re r1)))
   (($str_fixed_len_re re.allchar)       1)
@@ -165,7 +165,7 @@
 ;   This method has an exponential runtime. It is a placeholder for a
 ;   more efficient algorithm (via NFAs) to be written later.
 (program $str_eval_str_in_re_rec ((s String) (s1 String) (s2 String) (n Int) (r1 RegLan) (rr RegLan :list) (r2 RegLan) (sr String))
-  (String Int RegLan RegLan) Bool
+  :signature (String Int RegLan RegLan) Bool
   (
   (($str_eval_str_in_re_rec s 0 (re.++ r1 rr) @re.null)     ($str_eval_str_in_re_rec s 0 r1 rr))
   (($str_eval_str_in_re_rec s 0 (re.inter r1 rr) @re.null)  (eo::ite ($str_eval_str_in_re_rec s 0 r1 @re.null)
@@ -225,7 +225,7 @@
 ; return: >
 ;   The size of the smallest prefix of s that is contained in r.
 (program $str_first_match_rec_smallest ((s String) (r RegLan) (n Int) (m Int) (lens Int))
-  (String RegLan Int Int) Int
+  :signature (String RegLan Int Int) Int
   (
     (($str_first_match_rec_smallest s r m lens)   (eo::define ((ss (eo::extract s 0 (eo::add m -1))))
                                                   (eo::ite ($str_eval_str_in_re ss r)
@@ -247,7 +247,7 @@
 ;   at start position n' and end position m', or (-1, -1) if r does not match
 ;   any substring of s.
 (program $str_first_match_rec ((s String) (r RegLan) (rs RegLan) (n Int) (lens Int))
-  (String RegLan RegLan Int Int) (@Pair Int Int)
+  :signature (String RegLan RegLan Int Int) (@Pair Int Int)
   (
     (($str_first_match_rec s r rs n lens)  (eo::ite ($str_eval_str_in_re s rs)
                                             ; found (superstring) match, now find the smallest exact match
@@ -331,7 +331,7 @@
 ;   prefix (or suffix if rev is true) remainder of t (resp. s) in the case that
 ;   t (resp. s) is the longer string.
 (program $str_unify_split ((U Type) (t (Seq U)) (s (Seq U)) (rev Bool))
-  ((Seq U) (Seq U) Bool) (Seq U)
+  :signature ((Seq U) (Seq U) Bool) (Seq U)
   (
     (($str_unify_split t s true)  (ite (>= (str.len t) (str.len s))
                                     ($str_prefix t (- (str.len t) (str.len s)))
@@ -387,9 +387,8 @@
 ;   The result of ensuring that the input t is a str.++ list.
 ;   In particular, if it is not a str.++ and not the empty string, then we
 ;   return (str.++ t empty) where empty is the empty string for the type of t.
-(program $str_nary_intro
-    ((T Type) (t (Seq T)) (ss (Seq T) :list))
-    ((Seq T)) (Seq T)
+(program $str_nary_intro ((T Type) (t (Seq T)) (ss (Seq T) :list))
+    :signature ((Seq T)) (Seq T)
     (
         (($str_nary_intro (str.++ t ss)) (str.++ t ss))
         (($str_nary_intro t)             (eo::define ((nil ($seq_empty (eo::typeof t))))
@@ -405,7 +404,7 @@
 ;   to t that is a re.++ list. In particular, if t is not a re.++ and not the empty
 ;   regular expression, then we return (re.++ t @re.empty).
 (program $re_nary_intro ((t RegLan) (ss RegLan :list))
-    (RegLan) RegLan
+    :signature (RegLan) RegLan
     (
         (($re_nary_intro (re.++ t ss))    (re.++ t ss))
         (($re_nary_intro @re.empty)       @re.empty)
@@ -420,9 +419,8 @@
 ;   The result of ensuring that the input t is not a singleton str.++
 ;   application. In particular, if t is of the form (str.++ t1 empty) where
 ;   empty is the empty string for the type of t, we return t1.
-(program $str_nary_elim
-    ((T Type) (t (Seq T)) (ss (Seq T) :list))
-    ((Seq T)) (Seq T)
+(program $str_nary_elim ((T Type) (t (Seq T)) (ss (Seq T) :list))
+    :signature ((Seq T)) (Seq T)
     (
         (($str_nary_elim (str.++ t ss)) (eo::define ((nil ($seq_empty (eo::typeof t))))
                                            (eo::ite (eo::eq ss nil) t (str.++ t ss))))
@@ -438,7 +436,7 @@
 ;   singleton re.++ application. In particular, if t is of the form
 ;   (re.++ t1 @re.empty), we return t1.
 (program $re_nary_elim ((t RegLan) (ss RegLan :list))
-    (RegLan) RegLan
+    :signature (RegLan) RegLan
     (
         (($re_nary_elim (re.++ t ss)) (eo::ite (eo::eq ss @re.empty) t (re.++ t ss)))
         (($re_nary_elim t)            t)
@@ -473,7 +471,7 @@
 ; return: the reduction predicate for term t of sort s.
 (program $str_reduction_pred ((T Type) (U Type) (x (Seq U)) (y (Seq U)) (z (Seq U)) (n Int) (m Int)
                               (s String) (r RegLan) (t String))
-  (T) Bool
+  :signature (T) Bool
   (
     (($str_reduction_pred (str.contains x y))
       (eo::define ((k (@purify (str.contains x y))))
@@ -705,7 +703,7 @@
 ; - t U: The term to process.
 ; return: the eager reduction predicate of term t.
 (program $mk_str_eager_reduction ((U Type) (x (Seq U)) (y (Seq U)) (r RegLan) (n Int) (m Int) (s String))
-  (U) Bool
+  :signature (U) Bool
   (
     (($mk_str_eager_reduction (str.from_code n))
       (eo::define ((k (@purify (str.from_code n))))
@@ -759,7 +757,7 @@
 ;   application of the unfolding skolem program @re_unfold_pos_component.
 ; note: A helper method for computing the conclusion of ProofRule::RE_UNFOLD_POS.
 (program $re_unfold_pos_concat_rec ((t String) (r1 RegLan) (r2 RegLan :list) (ro RegLan) (i Int))
-  (String RegLan RegLan Int) (@Pair String Bool)
+  :signature (String RegLan RegLan Int) (@Pair String Bool)
   (
     (($re_unfold_pos_concat_rec t @re.empty ro i)       (@pair "" true))
     (($re_unfold_pos_concat_rec t (re.++ r1 r2) ro i)
@@ -835,7 +833,7 @@
 ;   The result of "flattening" t, for example given "AB", this returns the term
 ;   (str.++ "A" (str.++ "B" "")).
 (program $str_flatten_word ((U Type) (t (Seq U)))
-  ((Seq U)) (Seq U)  ; NOTE: this could be string, but leads to upstream type checking issues
+  :signature ((Seq U)) (Seq U)  ; NOTE: this could be string, but leads to upstream type checking issues
   (
     (($str_flatten_word "") "")
     (($str_flatten_word t)  ($str_cons (eo::extract t 0 0) ($str_flatten_word (eo::extract t 1 (eo::len t)))))
@@ -850,7 +848,7 @@
 ;   (str.++ "AB" x "CD"), this returns the term
 ;   (str.++ "A" (str.++ "B" (str.++ x (str.++ "C" (str.++ "D" ""))))).
 (program $str_flatten ((U Type) (t (Seq U)) (tail (Seq U) :list))
-  ((Seq U)) (Seq U)
+  :signature ((Seq U)) (Seq U)
   (
     (($str_flatten (str.++ t tail))
         ; otherwise, check whether t is a word constant of length greater than one
@@ -876,7 +874,7 @@
 ;   We return:
 ;     (@pair "AB" (str.++ x ""))
 (program $str_collect_acc ((U Type) (t (Seq U)) (tail (Seq U) :list))
-  ((Seq U)) (@Pair (Seq U) (Seq U))
+  :signature ((Seq U)) (@Pair (Seq U) (Seq U))
   (
     ; sequence not handled yet
     ; Check if t is a word constant
@@ -906,7 +904,7 @@
 ;   Notice that the collection of constants is done for all word constants in the
 ;   term s recursively.
 (program $str_collect ((U Type) (t (Seq U)) (s (Seq U) :list))
-  ((Seq U)) (Seq U)
+  :signature ((Seq U)) (Seq U)
   (
     (($str_collect (str.++ t s))
       (eo::match ((s1 (Seq U)) (s2 (Seq U)))
@@ -936,7 +934,7 @@
 ;     (pair (str.++ y (str.++ z "")) (str.++ w ""))
 ;   This side condition may fail if s or t is not a str.++ application.
 (program $str_strip_prefix ((U Type) (t (Seq U)) (s (Seq U)) (t2 (Seq U) :list) (s2 (Seq U) :list))
-  ((Seq U) (Seq U)) (@Pair (Seq U) (Seq U))
+  :signature ((Seq U) (Seq U)) (@Pair (Seq U) (Seq U))
   (
     (($str_strip_prefix (str.++ t t2) (str.++ t s2)) ($str_strip_prefix t2 s2))
     (($str_strip_prefix t s)                         (@pair t s))
@@ -956,7 +954,7 @@
 ;   We then decrement d until it is zero, while adding regular expressions
 ;   to a union, giving us (re.union r^n ... r^{n+d}).
 (program $str_mk_re_loop_elim_rec ((n Int) (d Int) (r RegLan) (rr RegLan :list))
-  (Int Int RegLan RegLan) RegLan
+  :signature (Int Int RegLan RegLan) RegLan
   (
     (($str_mk_re_loop_elim_rec 0 0 r rr) (eo::cons re.union ($singleton_elim rr) re.none))
     (($str_mk_re_loop_elim_rec 0 d r rr) (eo::cons re.union ($singleton_elim rr) ($str_mk_re_loop_elim_rec 0 (eo::add d -1) r (re.++ r rr))))
@@ -990,7 +988,7 @@
 ;   of one. Note that we do not require a singleton elimination step for and
 ;   since the original input should be a concatenation term.
 (program $str_mk_str_in_re_concat_star_char ((s1 String) (s2 String :list) (r RegLan))
-  (String RegLan) Bool
+  :signature (String RegLan) Bool
   (
     (($str_mk_str_in_re_concat_star_char (str.++ s1 s2) r) (eo::cons and (str.in_re s1 r) ($str_mk_str_in_re_concat_star_char s2 r)))
     (($str_mk_str_in_re_concat_star_char "" r)             true)
@@ -1007,7 +1005,7 @@
 ;   The conclusion used for ProofRewriteRule::STR_IN_RE_SIGMA on the membership
 ;   s in r, tracking information on the children of r we have already seen.
 (program $str_mk_str_in_re_sigma_rec ((s String) (r RegLan :list) (n Int) (b Bool))
-  (String RegLan Int Bool) Bool
+  :signature (String RegLan Int Bool) Bool
   (
     (($str_mk_str_in_re_sigma_rec s @re.empty n b)                    (eo::ite b (= (str.len s) n) (>= (str.len s) n)))
     (($str_mk_str_in_re_sigma_rec s (re.++ re.allchar r) n b)         ($str_mk_str_in_re_sigma_rec s r (eo::add n 1) b))
@@ -1033,7 +1031,7 @@
 ;   Calling $str_mk_str_in_re_sigma_star_rec s r n means we have s in r, we have
 ;   stripped off n re.allchar from r so far.
 (program $str_mk_str_in_re_sigma_star_rec ((s String) (r RegLan :list) (n Int))
-  (String RegLan Int) Bool
+  :signature (String RegLan Int) Bool
   (
     (($str_mk_str_in_re_sigma_star_rec s @re.empty n)                    (= (mod (str.len s) n) 0))
     (($str_mk_str_in_re_sigma_star_rec s (re.++ re.allchar r) n)         ($str_mk_str_in_re_sigma_star_rec s r (eo::add n 1)))
@@ -1085,7 +1083,7 @@
 ;   children (str.to_re s) of regular expression concatenation r to their flat
 ;   form, reversing if rev is true.
 (program $re_str_to_flat_form ((r1 RegLan) (r2 RegLan :list) (s String) (rev Bool))
-  (Bool RegLan) RegLan
+  :signature (Bool RegLan) RegLan
   (
     (($re_str_to_flat_form rev (re.++ (str.to_re s) r2))  (eo::cons re.++ (str.to_re ($str_to_flat_form s rev)) ($re_str_to_flat_form rev r2)))
     (($re_str_to_flat_form rev (re.++ r1 r2))             (eo::cons re.++ r1 ($re_str_to_flat_form rev r2)))
@@ -1145,7 +1143,7 @@
 ;   children (str.to_re s) of regular expression concatenation r from their flat
 ;   form, reversing if rev is true.
 (program $re_str_from_flat_form ((r1 RegLan) (r2 RegLan :list) (s String) (rev Bool))
-  (Bool RegLan) RegLan
+  :signature (Bool RegLan) RegLan
   (
     (($re_str_from_flat_form rev (re.++ (str.to_re s) r2))  (eo::cons re.++ (str.to_re ($str_from_flat_form s rev)) ($re_str_from_flat_form rev r2)))
     (($re_str_from_flat_form rev (re.++ r1 r2))             (eo::cons re.++ r1 ($re_str_from_flat_form rev r2)))
@@ -1169,7 +1167,7 @@
   ($re_nary_elim ($str_re_rev rev ($re_str_from_flat_form rev r))))
 
 ; note: This is a forward declaration of $str_re_includes below.
-(program $str_re_includes () (RegLan RegLan) Bool)
+(program $str_re_includes () :signature (RegLan RegLan) Bool)
 
 ; program: $str_re_includes_lhs_union
 ; args:
@@ -1179,7 +1177,7 @@
 ;   true if r is of the form (re.union r1 ... rn), and we can infer
 ;   that s is contained in some ri.
 (program $str_re_includes_lhs_union ((r1 RegLan) (r2 RegLan :list) (r3 RegLan))
-  (RegLan RegLan) Bool
+  :signature (RegLan RegLan) Bool
   (
   (($str_re_includes_lhs_union (re.union r1 r2) r3) (eo::ite ($str_re_includes r1 r3) true ($str_re_includes_lhs_union r2 r3)))
   (($str_re_includes_lhs_union r1 r3)               false)
@@ -1195,7 +1193,7 @@
 ;   true if s is of the form (re.inter s1 ... sn), and we can infer
 ;   that r is contained in some si.
 (program $str_re_includes_rhs_inter ((r1 RegLan) (r2 RegLan :list) (r3 RegLan))
-  (RegLan RegLan) Bool
+  :signature (RegLan RegLan) Bool
   (
   (($str_re_includes_rhs_inter r1 (re.inter r3 r2)) (eo::ite ($str_re_includes r1 r3) true ($str_re_includes_rhs_inter r1 r2)))
   (($str_re_includes_rhs_inter r1 r3)               false)
@@ -1212,7 +1210,7 @@
 ;   s is included in r1, or s1 is included in r1 where s is of the form
 ;   (re.* s1).
 (program $str_re_includes_lhs_star ((r1 RegLan) (r2 RegLan))
-  (RegLan RegLan) Bool
+  :signature (RegLan RegLan) Bool
   (
   (($str_re_includes_lhs_star (re.* r1) r2) (eo::ite (eo::eq r1 re.allchar)
                                               true
@@ -1238,7 +1236,7 @@
 ;   We also require that one of r1 or r2 is a concatenation, or else
 ;   we already checked for their inclusion directly.
 (program $str_re_includes_is_rec ((r1 RegLan) (r2 RegLan :list) (r3 RegLan))
-  (RegLan RegLan) Bool
+  :signature (RegLan RegLan) Bool
   (
   (($str_re_includes_is_rec r1 (re.inter r3 r2)) false)
   (($str_re_includes_is_rec (re.union r1 r2) r3) false)
@@ -1257,7 +1255,7 @@
 ;   This method is used for checking if there is no upper bound on the number of
 ;   arbitrary characters that can be consumed at the current position.
 (program $re_is_unbound_wildcard ((r1 RegLan) (r2 RegLan :list))
-  (RegLan) Bool
+  :signature (RegLan) Bool
   (
   (($re_is_unbound_wildcard (re.++ (re.* re.allchar) r2))  true)
   (($re_is_unbound_wildcard (re.++ re.allchar r2))         ($re_is_unbound_wildcard r2))
@@ -1273,7 +1271,7 @@
 ;   true if we can infer r2 is included in r1. We assume that r1 and r2
 ;   are re.++ lists that have been put into normal form with $re_to_flat_form.
 (program $str_re_includes_rec ((s1 String) (s2 String :list) (r1 RegLan) (r2 RegLan :list) (r3 RegLan) (r4 RegLan :list))
-  (RegLan RegLan) Bool
+  :signature (RegLan RegLan) Bool
   (
   ; true if equal, which includes if r1 is @re.empty
   (($str_re_includes_rec r1 r1)                                     true)
@@ -1310,7 +1308,7 @@
 ; return: >
 ;   true if we can infer that all strings in r2 are also in r1.
 (program $str_re_includes ((s1 String) (s2 String) (s3 String) (s4 String) (r1 RegLan) (r2 RegLan :list) (r3 RegLan))
-  (RegLan RegLan) Bool
+  :signature (RegLan RegLan) Bool
   (
   (($str_re_includes r1 r1)                               true)
   (($str_re_includes r1 (str.to_re s1))                   ($str_eval_str_in_re s1 r1)) ; requires constant s1/r1
@@ -1343,7 +1341,7 @@
 ;   true if we can show n is greater than or equal 0 using the fact that length
 ;   is non-negative and basic properties of arithmetic.
 (program $str_arith_entail_simple ((T Type) (s String) (n1 T) (n2 T :list))
-  (T) Bool
+  :signature (T) Bool
   (
     (($str_arith_entail_simple (str.len s)) true)
     (($str_arith_entail_simple (+ n1 n2))   (eo::ite ($str_arith_entail_simple n1) ($str_arith_entail_simple n2) false))
@@ -1361,7 +1359,7 @@
 ;   normalize the polynomial corresponding to F and check this
 ;   using the $str_arith_entail_simple program above.
 (program $str_arith_entail_simple_pred ((n Int) (m Int))
-  (Bool) Bool
+  :signature (Bool) Bool
   (
     (($str_arith_entail_simple_pred (>= n m))  ($str_arith_entail_simple ($arith_poly_to_term (- n m))))
     (($str_arith_entail_simple_pred (> n m))   ($str_arith_entail_simple ($arith_poly_to_term (- n (+ m 1)))))
@@ -1379,7 +1377,7 @@
 ;   in SMT", CAV 2019. When applicable, we also rely on calls that reason that string
 ;   length is non-negative and basic properties of arithmetic.
 (program $str_arith_entail_is_approx_len ((s String) (t String) (r String) (n1 Int) (n2 Int) (n Int) (isUnder Bool))
-  (String Int Bool) Bool
+  :signature (String Int Bool) Bool
   (
     (($str_arith_entail_is_approx_len (str.substr s n1 n2) n isUnder)
         (eo::define ((npm (+ n1 n2)))
@@ -1465,7 +1463,7 @@
 ;   as defined by Figure 2 of "High-Level Abstractions for Simplifying Extended String Constraints
 ;   in SMT", CAV 2019.
 (program $str_arith_entail_is_approx ((s String) (t String) (n1 Int) (n2 Int :list) (n3 Int) (n4 Int :list) (n5 Int) (isUnder Bool))
-  (Int Int Bool) Bool
+  :signature (Int Int Bool) Bool
   (
     (($str_arith_entail_is_approx n1 n1 isUnder)                    true)
     (($str_arith_entail_is_approx (str.len s) n1 isUnder)           ($str_arith_entail_is_approx_len s n1 isUnder))
@@ -1493,7 +1491,7 @@
 ; return: >
 ;   The result of implied consumption of string s in regular expression r.
 (program $str_re_consume_rec ((s1 String) (s2 String :list) (s String) (r1 RegLan) (r2 RegLan :list) (b Bool) (rev Bool))
-  (String RegLan Bool Bool) Bool
+  :signature (String RegLan Bool Bool) Bool
   (
     (($str_re_consume_rec (str.++ s1 s2) (re.++ r1 r2) @result.null rev)  
         (eo::match ((s3 String) (s4 String :list) (s5 String) (r3 RegLan))
@@ -1628,7 +1626,7 @@
 ;   about the body of re.*, succeeding if a conflict is found or we full
 ;   consume one copy.
 (program $str_re_consume ((s String) (r RegLan))
-  (String RegLan) Bool
+  :signature (String RegLan) Bool
   (
   (($str_re_consume s (re.* r))
     (eo::match ((s1 String))
@@ -1652,7 +1650,7 @@
 ;   The minimum number of characters that must be skipped in s before
 ;   string t can be compatible with it. See examples below.
 (program $str_overlap_rec ((s String) (s1 String :list) (t String))
-  (String String) Int
+  :signature (String String) Int
   (
   (($str_overlap_rec (str.++ s s1) t) (eo::ite ($nary_is_compatible str.++ "" (str.++ s s1) t)
                                         0
@@ -1708,7 +1706,7 @@
 ; returns: >
 ;   The result of evaluating `(str.from_int n)` given the current accumulated return value.
 (program $str_from_int_eval_rec ((s String) (n Int))
-  (Int String) Bool
+  :signature (Int String) Bool
   (
   (($str_from_int_eval_rec n s) (eo::ite (eo::eq n 0)
                                   (eo::ite (eo::eq s "") "0" s)
@@ -1740,7 +1738,7 @@
 ;   The result of evaluating `(str.to_int s)` given the current exponent and
 ;   accumulated return value.
 (program $str_to_int_eval_rec ((s1 String) (s2 String :list) (e Int) (n Int))
-  (String Int Int) Int
+  :signature (String Int Int) Int
   (
   (($str_to_int_eval_rec (str.++ s1 s2) e n)  (eo::define ((c (eo::add (eo::to_z s1) -48)))
                                               (eo::ite (eo::and (eo::gt 10 c) (eo::not (eo::is_neg c)))
@@ -1771,7 +1769,7 @@
 ; returns: >
 ;   The result of evaluating `(str.to_lower s)` (resp. `(str.to_upper s)`).
 (program $str_case_conv_rec ((s1 String) (s2 String :list) (isLower Bool))
-  (String Bool) String
+  :signature (String Bool) String
   (
   (($str_case_conv_rec (str.++ s1 s2) true)  (eo::define ((c (eo::to_z s1)))
                                               (eo::concat
@@ -1824,7 +1822,7 @@
 ; - t String: The second string to compare, expected to be a literal in flat form.
 ; returns: The result of evaluating `(str.<= s t)`.
 (program $str_leq_eval_rec ((s1 String) (s2 String :list) (t1 String) (t2 String :list) )
-  (String String) Bool
+  :signature (String String) Bool
   (
   (($str_leq_eval_rec (str.++ s1 s2) (str.++ t1 t2))  (eo::ite (eo::eq s1 t1)
                                                         ($str_leq_eval_rec s2 t2)
@@ -1857,7 +1855,7 @@
 ; return: >
 ;   The result of evaluating (str.replace_all s t u).
 (program $str_eval_replace_all_rec ((s String) (t String) (u String) (n Int) (lent Int))
-  (String String String Int Int) String
+  :signature (String String String Int Int) String
   (
   (($str_eval_replace_all_rec s t u -1 lent)  s)
   (($str_eval_replace_all_rec s t u n lent)   (eo::define ((snext (eo::extract s (eo::add n lent) (eo::len s))))

--- a/proofs/eo/cpc/programs/Strings.eo
+++ b/proofs/eo/cpc/programs/Strings.eo
@@ -387,7 +387,8 @@
 ;   The result of ensuring that the input t is a str.++ list.
 ;   In particular, if it is not a str.++ and not the empty string, then we
 ;   return (str.++ t empty) where empty is the empty string for the type of t.
-(program $str_nary_intro ((T Type) (t (Seq T)) (ss (Seq T) :list))
+(program $str_nary_intro
+    ((T Type) (t (Seq T)) (ss (Seq T) :list))
     :signature ((Seq T)) (Seq T)
     (
         (($str_nary_intro (str.++ t ss)) (str.++ t ss))
@@ -419,7 +420,8 @@
 ;   The result of ensuring that the input t is not a singleton str.++
 ;   application. In particular, if t is of the form (str.++ t1 empty) where
 ;   empty is the empty string for the type of t, we return t1.
-(program $str_nary_elim ((T Type) (t (Seq T)) (ss (Seq T) :list))
+(program $str_nary_elim
+    ((T Type) (t (Seq T)) (ss (Seq T) :list))
     :signature ((Seq T)) (Seq T)
     (
         (($str_nary_elim (str.++ t ss)) (eo::define ((nil ($seq_empty (eo::typeof t))))

--- a/proofs/eo/cpc/programs/Utils.eo
+++ b/proofs/eo/cpc/programs/Utils.eo
@@ -25,7 +25,7 @@
 (define @list () eo::List::cons)
 
 ; note: This is a forward declaration of $evaluate_list defined in Cpc.eo.
-(program $evaluate_list () (@List) @List)
+(program $evaluate_list () :signature (@List) @List)
 
 ; define: $evaluate
 ; args:
@@ -45,7 +45,7 @@
 ;   The list of arguments provided to the function at the head of t appended to
 ;   acc, or acc if t is not a function application.
 (program $get_arg_list_rec ((T Type) (S Type) (f (-> T S)) (x T) (y S) (acc @List))
-  (S @List) @List
+  :signature (S @List) @List
   (
     (($get_arg_list_rec (f x) acc)  ($get_arg_list_rec f (eo::cons @list x acc)))
     (($get_arg_list_rec y acc)      acc)
@@ -66,7 +66,7 @@
 ; - t S: The term to inspect.
 ; return: True if and only if t is an application of f.
 (program $is_app ((T Type) (S Type) (U Type) (f (-> T U)) (g (-> T S)) (x T) (y S))
-  ((-> T U) S) Bool
+  :signature ((-> T U) S) Bool
   (
     (($is_app f (g x))  ($is_app f g))
     (($is_app f x)      (eo::eq f x))
@@ -121,7 +121,7 @@
 ;   if s is of the form (f x1 x2) where x2 is the nil terminator of f, then we
 ;   return x1. Otherwise, we return s unchanged.
 (program $singleton_elim ((T Type) (S Type) (U Type) (f (-> T U S)) (x S) (x1 T) (x2 T :list))
-  (S) S
+  :signature (S) S
   (
     (($singleton_elim (f x1 x2))  (eo::ite (eo::eq x2 (eo::nil f (eo::typeof (f x1 x2)))) x1 (f x1 x2)))
     (($singleton_elim x)          x)
@@ -145,7 +145,7 @@
 ;   In summary, ($result_combine b1 ... ($result_combine bn @result.null)) returns
 ;   b1 if b1...bn are the same or @result.invalid otherwise.
 (program $result_combine ((b1 Bool) (b2 Bool))
-  (Bool Bool) Bool
+  :signature (Bool Bool) Bool
   (
     (($result_combine b1 @result.null) b1)
     (($result_combine b1 b1)           b1)
@@ -164,7 +164,7 @@
 ; - rem @List: The list of elements we have yet to process on the LHS.
 ; return: True if B is a pairwise application of f for the given arguments.
 (program $is_pairwise ((T Type) (U Type) (f (-> T T U)) (op (-> U U U)) (a T) (b T) (bs @List :list) (B U :list) (nil U) (rem @List :list))
-  ((-> T T U) (-> U U U) T @List U @List) Bool
+  :signature ((-> T T U) (-> U U U) T @List U @List) Bool
   (
   (($is_pairwise f op a (@list b bs) (op (f a b) B) rem) ($is_pairwise f op a bs B rem))
   (($is_pairwise f op a @list.nil B (@list b rem))       ($is_pairwise f op b rem B rem))
@@ -180,7 +180,7 @@
 ; - B U: The term that is potentially a pairwise application of f starting with a.
 ; return: The list of arguments that a is related to.
 (program $extract_pairwise_args_rec ((T Type) (U Type) (f (-> T T U)) (op (-> U U U)) (a T) (b T) (c T) (B U :list))
-  ((-> T T U) (-> U U U) T U) @List
+  :signature ((-> T T U) (-> U U U) T U) @List
   (
   (($extract_pairwise_args_rec f op a (op (f a c) B)) (eo::cons @list c ($extract_pairwise_args_rec f op a B)))
   (($extract_pairwise_args_rec f op a B)              @list.nil)  ; no further elements
@@ -200,7 +200,7 @@
 ;   its desugared version (and (distinct a b) (distinct a c) (distinct b c)) is
 ;   indeed obtained by desugaring distinct in the expected way.
 (program $extract_pairwise_args ((T Type) (U Type) (f (-> T T U)) (op (-> U U U)) (a T) (b T) (B U :list))
-  ((-> T T U) (-> U U U) U) @List
+  :signature ((-> T T U) (-> U U U) U) @List
   (
   (($extract_pairwise_args f op (op (f a b) B)) (eo::define ((D (op (f a b) B)))
                                                 (eo::define ((elems ($extract_pairwise_args_rec f op a D)))

--- a/proofs/eo/cpc/rules/Arith.eo
+++ b/proofs/eo/cpc/rules/Arith.eo
@@ -17,7 +17,7 @@
 ;   The relation that is implied when applications of the relations r1 and
 ;   r2 are added together for ProofRule::ARITH_SUM_UB and applied to a and b.
 (program $arith_rel_sum ((T Type) (U Type) (V Type) (W Type) (a V) (b W))
-  (T U V W) Bool
+  :signature (T U V W) Bool
   (
     (($arith_rel_sum < < a b) (< a b))
     (($arith_rel_sum < = a b) (< a b))
@@ -43,7 +43,7 @@
 ; - F Bool: A conjunction of arithmetic relations.
 ; return: the arithmetic relation that is implied by adding each of the relations in F together.
 (program $mk_arith_sum_ub ((T Type) (U Type) (r (-> T U Bool)) (a T) (b U) (tail Bool :list))
-    (Bool) Bool
+    :signature (Bool) Bool
     (
         (($mk_arith_sum_ub true)               (= 0 0))
         (($mk_arith_sum_ub (and (r a b) tail)) 
@@ -75,7 +75,7 @@
 ;   the result of multiply the atom by m. This is used to compute the
 ;   conclusion of the ProofRule::ARITH_MULT_POS rule.
 (program $mk_arith_mult_pos ((T Type) (U Type) (S Type) (r (-> T U Bool)) (a T) (b U) (m S))
-  (S Bool) Bool
+  :signature (S Bool) Bool
   (
     (($mk_arith_mult_pos m (r a b)) (r (* m a) (* m b)))
   )
@@ -106,7 +106,7 @@
 ;   This is used for determining the relation obtained when both sides are
 ;   multiplied by a negative term.
 (program $arith_rel_inv ((T Type) (U Type) (V Type) (a U) (b V))
-  (T U V) Bool
+  :signature (T U V) Bool
   (
     (($arith_rel_inv = a b) (= a b))
     (($arith_rel_inv < a b) (> a b))
@@ -124,7 +124,7 @@
 ;   the result of multiply the atom by m and invert its relation.
 ;   This is used to compute the conclusion of the ProofRule::ARITH_MULT_NEG rule.
 (program $mk_arith_mult_neg ((T Type) (U Type) (S Type) (r (-> T U Bool)) (a T) (b U) (m S))
-  (S Bool) Bool
+  :signature (S Bool) Bool
   (
     (($mk_arith_mult_neg m (r a b)) ($arith_rel_inv r (* m a) (* m b)))
   )
@@ -155,7 +155,7 @@
 ;   The relation that, along with r1 and r2, forms a trichotomy over
 ;   arithmetic values, applied to a and b.
 (program $arith_rel_trichotomy ((T Type) (U Type) (V Type) (W Type) (a V) (b W))
-  (T U V W) Bool
+  :signature (T U V W) Bool
   (
     (($arith_rel_trichotomy = < a b) (> a b))
     (($arith_rel_trichotomy = > a b) (< a b))
@@ -174,7 +174,7 @@
 ; return: >
 ;   The relation corresponding to the negation of r, applied to a and b.
 (program $arith_rel_neg ((T Type) (U Type) (V Type) (a U) (b V))
-  (T U V) Bool
+  :signature (T U V) Bool
   (
     (($arith_rel_neg < a b) (>= a b))
     (($arith_rel_neg <= a b) (> a b))
@@ -188,7 +188,7 @@
 ; - F Bool: An arithmetic literal, possibly negated or doubly negated.
 ; return: a literal equivalent to F that eliminates its negations, if any.
 (program $arith_normalize_lit ((T Type) (U Type) (r (-> T U Bool)) (a T) (b U))
-  (Bool) Bool
+  :signature (Bool) Bool
   (
     (($arith_normalize_lit (not (not (r a b)))) (r a b))
     (($arith_normalize_lit (not (r a b)))       ($arith_rel_neg r a b))
@@ -201,9 +201,8 @@
 ; - F1: The first arithmetic atom, which is an application of a binary arithmetic relation.
 ; - F2: The first arithmetic atom, which is an application of a binary arithmetic relation over the same terms as F1.
 ; return: The relation that along with F1 and F2 forms a trichotomy.
-(program $mk_arith_trichotomy
-  ((T Type) (U Type) (S Type) (r1 (-> T U Bool)) (r2 (-> T U Bool)) (a T) (b U))
-  (Bool Bool) Bool
+(program $mk_arith_trichotomy ((T Type) (U Type) (S Type) (r1 (-> T U Bool)) (r2 (-> T U Bool)) (a T) (b U))
+  :signature (Bool Bool) Bool
   (
     (($mk_arith_trichotomy (r1 a b) (r2 a b)) ($arith_rel_trichotomy r1 r2 a b))
   )
@@ -229,7 +228,7 @@
 ; - c R: A rational or integer value.
 ; return: the greatest integer less than (integer or real) c.
 (program $greatest_int_lt ((R Type) (c R))
-  (R) Int
+  :signature (R) Int
   (
     (($greatest_int_lt c) (eo::define ((ci (eo::to_z c)))
                                (eo::ite (eo::eq (eo::to_q c) (eo::to_q ci))
@@ -255,7 +254,7 @@
 ; - c R: A rational or integer value.
 ; return: the least integer greater than (integer or real) c.
 (program $least_int_gt ((R Type) (c R))
-  (R) Int
+  :signature (R) Int
   (
     (($least_int_gt c) (eo::add 1 (eo::to_z c)))
   )
@@ -301,7 +300,7 @@
 ; return: >
 ;   The result of stripping even exponent of t from the beginning of m.
 (program $strip_even_exponent ((T Type) (t T) (U Type) (V Type) (m V :list))
-  (T U) U
+  :signature (T U) U
   (
   (($strip_even_exponent t (* t t m)) ($strip_even_exponent t m))
   (($strip_even_exponent t m)         m)
@@ -316,7 +315,7 @@
 ; return: >
 ;   Whether the monomial we have processed is entailed to be positive (resp. negative).
 (program $mk_arith_mult_sign_sgn ((T Type) (U Type) (V Type) (F Bool :list) (l Bool) (t T) (z U) (m V :list) (sgn Bool))
-  (Bool Bool T) Bool
+  :signature (Bool Bool T) Bool
   (
   (($mk_arith_mult_sign_sgn sgn (and (not (= t z)) F) (* t t m))  ; ensures non-empty
       (eo::requires (eo::to_z z) 0
@@ -360,10 +359,9 @@
 ;   The literal proven by arith_mult_abs_comparison given C and the remaining
 ;   premises F.
 ; note: This program is a helper for $mk_arith_mult_abs_comparison.
-(program $mk_arith_mult_abs_comparison_rec
-  ((T Type) (U Type) (V Type) (W Type) (X Type)
+(program $mk_arith_mult_abs_comparison_rec ((T Type) (U Type) (V Type) (W Type) (X Type)
    (a W) (b X) (r (-> W X Bool)) (t T) (u U) (z V) (B Bool :list))
-  (Bool Bool) Bool
+  :signature (Bool Bool) Bool
   (
     (($mk_arith_mult_abs_comparison_rec (and (r (abs t) (abs u)) B) (r a b))
       ($mk_arith_mult_abs_comparison_rec B
@@ -382,9 +380,8 @@
 ; - F Bool: A conjunction of the remaining premises.
 ; return: >
 ;   The literal proven by arith_mult_abs_comparison given premises F.
-(program $mk_arith_mult_abs_comparison
-  ((T Type) (U Type) (V Type) (r T) (t T) (u U) (z V) (B Bool :list))
-  (Bool) Bool
+(program $mk_arith_mult_abs_comparison ((T Type) (U Type) (V Type) (r T) (t T) (u U) (z V) (B Bool :list))
+  :signature (Bool) Bool
   (
     (($mk_arith_mult_abs_comparison (and (> (abs t) (abs u)) B))
       ($mk_arith_mult_abs_comparison_rec B (> (* t) (* u))))
@@ -498,7 +495,7 @@
 ;   (= (* cx (- x1 x2)) (* cy (- y1 y2))). If r is any of <, <=, >=, or >, the
 ;   scaling factors must have the same sign. Returns false for any other relation.
 (program $is_poly_norm_rel_consts ((T Type) (U Type) (cx T) (cy U) (b Bool))
-  (Bool) Bool
+  :signature (Bool) Bool
   (
     (($is_poly_norm_rel_consts (< cx cy))  (eo::eq ($sgn cx) ($sgn cy)))
     (($is_poly_norm_rel_consts (<= cx cy)) (eo::eq ($sgn cx) ($sgn cy)))
@@ -517,7 +514,7 @@
 ;   True if x is syntactically equal to y, possibly removing an application of
 ;   to_real.
 (program $is_eq_maybe_to_real ((U Type) (x U) (T Type))
-  (U T) Bool
+  :signature (U T) Bool
   (
   (($is_eq_maybe_to_real x x)           true)
   (($is_eq_maybe_to_real (to_real x) x) true)

--- a/proofs/eo/cpc/rules/Arith.eo
+++ b/proofs/eo/cpc/rules/Arith.eo
@@ -201,7 +201,8 @@
 ; - F1: The first arithmetic atom, which is an application of a binary arithmetic relation.
 ; - F2: The first arithmetic atom, which is an application of a binary arithmetic relation over the same terms as F1.
 ; return: The relation that along with F1 and F2 forms a trichotomy.
-(program $mk_arith_trichotomy ((T Type) (U Type) (S Type) (r1 (-> T U Bool)) (r2 (-> T U Bool)) (a T) (b U))
+(program $mk_arith_trichotomy
+  ((T Type) (U Type) (S Type) (r1 (-> T U Bool)) (r2 (-> T U Bool)) (a T) (b U))
   :signature (Bool Bool) Bool
   (
     (($mk_arith_trichotomy (r1 a b) (r2 a b)) ($arith_rel_trichotomy r1 r2 a b))
@@ -359,7 +360,8 @@
 ;   The literal proven by arith_mult_abs_comparison given C and the remaining
 ;   premises F.
 ; note: This program is a helper for $mk_arith_mult_abs_comparison.
-(program $mk_arith_mult_abs_comparison_rec ((T Type) (U Type) (V Type) (W Type) (X Type)
+(program $mk_arith_mult_abs_comparison_rec
+  ((T Type) (U Type) (V Type) (W Type) (X Type)
    (a W) (b X) (r (-> W X Bool)) (t T) (u U) (z V) (B Bool :list))
   :signature (Bool Bool) Bool
   (
@@ -380,7 +382,8 @@
 ; - F Bool: A conjunction of the remaining premises.
 ; return: >
 ;   The literal proven by arith_mult_abs_comparison given premises F.
-(program $mk_arith_mult_abs_comparison ((T Type) (U Type) (V Type) (r T) (t T) (u U) (z V) (B Bool :list))
+(program $mk_arith_mult_abs_comparison
+  ((T Type) (U Type) (V Type) (r T) (t T) (u U) (z V) (B Bool :list))
   :signature (Bool) Bool
   (
     (($mk_arith_mult_abs_comparison (and (> (abs t) (abs u)) B))

--- a/proofs/eo/cpc/rules/ArithBvConv.eo
+++ b/proofs/eo/cpc/rules/ArithBvConv.eo
@@ -15,7 +15,7 @@
 ;   The result of the reduction for the remaining bits for (ubv_to_int b),
 ;   which is an arithmetic sum.
 (program $abconv_ubv_to_int_elim ((n Int) (b (BitVec n)) (i Int) (w Int) (p Int))
-  ((BitVec n) Int Int Int) Int
+  :signature ((BitVec n) Int Int Int) Int
   (
     (($abconv_ubv_to_int_elim b w w p) 0)
     (($abconv_ubv_to_int_elim b i w p) (eo::cons +
@@ -48,7 +48,7 @@
 ; return: >
 ;   The result of reducing (int2bv w n), which is a bitvector concatenation.
 (program $abconv_int_to_bv_elim ((n Int) (w Int) (p Int) (Any Type))
-  (Int Int Int) Any
+  :signature (Int Int Int) Any
   (
     (($abconv_int_to_bv_elim n 0 p) @bv_empty)
     (($abconv_int_to_bv_elim n w p) (eo::define ((wm1 (eo::add w -1)))

--- a/proofs/eo/cpc/rules/BitVectors.eo
+++ b/proofs/eo/cpc/rules/BitVectors.eo
@@ -32,7 +32,7 @@
 ;   A portion of the result of eliminating (bvsmulo a b).
 (program $bv_smulo_elim_rec ((n Int) (xa (BitVec n)) (xb (BitVec n))
                              (ppc (BitVec 1)) (res (BitVec 1)) (i Int) (nm2 Int))
-  ((BitVec n) (BitVec n) (BitVec 1) (BitVec 1) Int Int) (BitVec 1)
+  :signature ((BitVec n) (BitVec n) (BitVec 1) (BitVec 1) Int Int) (BitVec 1)
   (
   (($bv_smulo_elim_rec xa xb ppc res nm2 nm2)   res)
   (($bv_smulo_elim_rec xa xb ppc res i nm2)
@@ -92,7 +92,7 @@
 ;   A portion of the result of eliminating (bvsmulo a b).
 (program $bv_umulo_elim_rec ((n Int) (a (BitVec n)) (b (BitVec n))
                              (uppc (BitVec 1)) (res (BitVec 1)) (i Int))
-  ((BitVec n) (BitVec n) (BitVec 1) (BitVec 1) Int Int) (BitVec 1)
+  :signature ((BitVec n) (BitVec n) (BitVec 1) (BitVec 1) Int Int) (BitVec 1)
   (
   (($bv_umulo_elim_rec a b uppc res n n)   res)
   (($bv_umulo_elim_rec a b uppc res i n)
@@ -148,11 +148,10 @@
 ;   (concat (bvand ((_ extract 3 2) #b0011) ((_ extract 3 2) x))
 ;           (bvand ((_ extract 1 0) #b0011) ((_ extract 1 0) x)))
 ;   given input where f is bvand, c is #b0011, and a is x.
-(program $bv_mk_bitwise_slicing_rec
-  ((n Int) (m Int) (k Int)
+(program $bv_mk_bitwise_slicing_rec ((n Int) (m Int) (k Int)
    (f (-> (BitVec n) (BitVec n) (BitVec n))) (a (BitVec n)) (c (BitVec n))
    (b Bool) (bn Bool) (bs (BitVec m) :list) (start Int) (end Int))
-  ((-> (BitVec n) (BitVec n) (BitVec n)) (BitVec k) (BitVec k) (BitVec m) Bool Int Int) (BitVec k)
+  :signature ((-> (BitVec n) (BitVec n) (BitVec n)) (BitVec k) (BitVec k) (BitVec m) Bool Int Int) (BitVec k)
   (
   (($bv_mk_bitwise_slicing_rec f c a bs bn start -1)
       (eo::cons concat ($nary_app f (extract start 0 c) (extract start 0 a)) @bv_empty))

--- a/proofs/eo/cpc/rules/BitVectors.eo
+++ b/proofs/eo/cpc/rules/BitVectors.eo
@@ -148,7 +148,8 @@
 ;   (concat (bvand ((_ extract 3 2) #b0011) ((_ extract 3 2) x))
 ;           (bvand ((_ extract 1 0) #b0011) ((_ extract 1 0) x)))
 ;   given input where f is bvand, c is #b0011, and a is x.
-(program $bv_mk_bitwise_slicing_rec ((n Int) (m Int) (k Int)
+(program $bv_mk_bitwise_slicing_rec
+  ((n Int) (m Int) (k Int)
    (f (-> (BitVec n) (BitVec n) (BitVec n))) (a (BitVec n)) (c (BitVec n))
    (b Bool) (bn Bool) (bs (BitVec m) :list) (start Int) (end Int))
   :signature ((-> (BitVec n) (BitVec n) (BitVec n)) (BitVec k) (BitVec k) (BitVec m) Bool Int Int) (BitVec k)

--- a/proofs/eo/cpc/rules/Booleans.eo
+++ b/proofs/eo/cpc/rules/Booleans.eo
@@ -19,7 +19,7 @@
 ;   The result of converting F to a clause. In particular, if F is not
 ;   an or-list, we return (or F), otherwise F is unchanged.
 (program $to_clause ((F1 Bool) (F2 Bool :list))
-  (Bool) Bool
+  :signature (Bool) Bool
   (
     (($to_clause (or F1 F2)) (or F1 F2))
     (($to_clause false)      false)
@@ -36,7 +36,7 @@
 ;   The result of converting F to a normal formula. In particular, if F
 ;   is (or F), we return F, otherwise F is unchanged.
 (program $from_clause ((F1 Bool) (F2 Bool :list))
-  (Bool) Bool
+  :signature (Bool) Bool
   (
     (($from_clause (or F1 F2)) (eo::ite (eo::eq F2 false) F1 (or F1 F2)))
     (($from_clause F1)         F1)
@@ -108,7 +108,7 @@
 ;   This side condition applies multiple steps of resolution but leaves the
 ;   first argument in n-ary form as an optimization.
 (program $chain_resolve_rec ((C1 Bool) (C2 Bool) (Cs Bool :list) (pol Bool) (pols @List :list) (L Bool) (lits @List :list))
-    (Bool Bool @List @List) Bool
+    :signature (Bool Bool @List @List) Bool
     (
         (($chain_resolve_rec C1 true @list.nil @list.nil)         ($from_clause C1))
         (($chain_resolve_rec C1 (and C2 Cs) (@list pol pols) (@list L lits))
@@ -415,7 +415,7 @@
 ;   the result of negating F by turning it into a disjunction. For
 ;   example, we return (or (not l1) ... (not ln)) given input (and l1 .. ln).
 (program $lower_not_and ((l Bool) (ls Bool :list))
-    (Bool) Bool
+    :signature (Bool) Bool
     (
         (($lower_not_and true)       false) ; Terminator changes
         (($lower_not_and (and l ls)) (eo::cons or (not l) ($lower_not_and ls)))

--- a/proofs/eo/cpc/rules/Builtin.eo
+++ b/proofs/eo/cpc/rules/Builtin.eo
@@ -32,9 +32,8 @@
 ; return: >
 ;   The antecedant of F for conclusion C, e.g. this returns (and G1 G2) when F is
 ;   (=> G1 (=> G2 C)), or true if F is C. Otherwise, it does not evaluate.
-(program $extract_antec_rec
-   ((C Bool) (F1 Bool) (F2 Bool))
-   (Bool Bool) Bool
+(program $extract_antec_rec ((C Bool) (F1 Bool) (F2 Bool))
+   :signature (Bool Bool) Bool
    (
    (($extract_antec_rec C C)          true)
    (($extract_antec_rec (=> F1 F2) C) (eo::cons and F1 ($extract_antec_rec F2 C)))
@@ -49,9 +48,8 @@
 ;   The antecedant of F for conclusion C, calling $extract_antec_rec if necessary.
 ;   Note that the singleton case is handled here to avoid constructing an and term with
 ;   single child.
-(program $extract_antec
-   ((C Bool) (F Bool))
-   (Bool Bool) Bool
+(program $extract_antec ((C Bool) (F Bool))
+   :signature (Bool Bool) Bool
    (
    (($extract_antec (=> F C) C) F)
    (($extract_antec F C)        ($extract_antec_rec F C))
@@ -64,9 +62,8 @@
 ; - C Bool: The conclusion.
 ; return: >
 ;   The expected conclusion of a ProofRule::SCOPE.
-(program $run_process_scope
-   ((C Bool) (F Bool))
-   (Bool Bool) Bool
+(program $run_process_scope ((C Bool) (F Bool))
+   :signature (Bool Bool) Bool
    (
    (($run_process_scope F false)  (not ($extract_antec F false)))
    (($run_process_scope F C)      (=> ($extract_antec F C) C))

--- a/proofs/eo/cpc/rules/Builtin.eo
+++ b/proofs/eo/cpc/rules/Builtin.eo
@@ -32,7 +32,8 @@
 ; return: >
 ;   The antecedant of F for conclusion C, e.g. this returns (and G1 G2) when F is
 ;   (=> G1 (=> G2 C)), or true if F is C. Otherwise, it does not evaluate.
-(program $extract_antec_rec ((C Bool) (F1 Bool) (F2 Bool))
+(program $extract_antec_rec
+   ((C Bool) (F1 Bool) (F2 Bool))
    :signature (Bool Bool) Bool
    (
    (($extract_antec_rec C C)          true)
@@ -48,7 +49,8 @@
 ;   The antecedant of F for conclusion C, calling $extract_antec_rec if necessary.
 ;   Note that the singleton case is handled here to avoid constructing an and term with
 ;   single child.
-(program $extract_antec ((C Bool) (F Bool))
+(program $extract_antec
+   ((C Bool) (F Bool))
    :signature (Bool Bool) Bool
    (
    (($extract_antec (=> F C) C) F)
@@ -62,7 +64,8 @@
 ; - C Bool: The conclusion.
 ; return: >
 ;   The expected conclusion of a ProofRule::SCOPE.
-(program $run_process_scope ((C Bool) (F Bool))
+(program $run_process_scope
+   ((C Bool) (F Bool))
    :signature (Bool Bool) Bool
    (
    (($run_process_scope F false)  (not ($extract_antec F false)))

--- a/proofs/eo/cpc/rules/Datatypes.eo
+++ b/proofs/eo/cpc/rules/Datatypes.eo
@@ -356,7 +356,8 @@
 ; - c U: The result of updating t we have accumulated so far.
 ; return: >
 ;   The result of updating the argument specified by s in t.
-(program $dt_updater_elim_rhs ((D Type) (T Type) (U Type) (W Type) (X Type) (s (-> D T)) (s1 (-> D T)) (t D) (a T) (ss eo::List :list) (c (-> U W)) (cd D))
+(program $dt_updater_elim_rhs
+  ((D Type) (T Type) (U Type) (W Type) (X Type) (s (-> D T)) (s1 (-> D T)) (t D) (a T) (ss eo::List :list) (c (-> U W)) (cd D))
   :signature (D eo::List X) D
   (
     (($dt_updater_elim_rhs (update s t a) (eo::List::cons s ss) c)   ($dt_updater_elim_rhs (update s t a) ss (c a)))
@@ -371,7 +372,8 @@
 ; - ss eo::List: The remaining selector arguments to process.
 ; return: >
 ;   The result of updating the argument specified by s in t.
-(program $tuple_updater_elim_rhs ((D Type) (T Type) (U Type) (n Int) (s (-> D T)) (t D) (tu UnitTuple) (a T) (ss eo::List :list) (c U))
+(program $tuple_updater_elim_rhs
+  ((D Type) (T Type) (U Type) (n Int) (s (-> D T)) (t D) (tu UnitTuple) (a T) (ss eo::List :list) (c U))
   :signature (D eo::List) D
   (
     (($tuple_updater_elim_rhs (tuple.update n t a) (eo::List::cons (tuple.select n) ss))
@@ -389,7 +391,8 @@
 ; - ss eo::List: The list of selectors for the type of s.
 ; return: >
 ;   The right hand side is obtained by updating the proper argument of t.
-(program $mk_dt_updater_elim_rhs ((D Type) (T Type) (U Type) (s (-> D T)) (t D) (a T) (tr D) (c U) (n Int) (ss eo::List))
+(program $mk_dt_updater_elim_rhs
+  ((D Type) (T Type) (U Type) (s (-> D T)) (t D) (a T) (tr D) (c U) (n Int) (ss eo::List))
   :signature (D U eo::List) D
   (
     (($mk_dt_updater_elim_rhs (update s t a) c ss)

--- a/proofs/eo/cpc/rules/Datatypes.eo
+++ b/proofs/eo/cpc/rules/Datatypes.eo
@@ -9,7 +9,7 @@
 ; - x D: The datatype term we are splitting on.
 ; return: A disjunction of testers for the constructors in L, applied to x.
 (program $mk_dt_split ((D Type) (x D) (T Type) (c T) (xs eo::List :list))
-  (eo::List D) Bool
+  :signature (eo::List D) Bool
   (
     (($mk_dt_split eo::List::nil x)          false)
     (($mk_dt_split (eo::List::cons c xs) x)  (eo::cons or (is c x) ($mk_dt_split xs x)))
@@ -38,7 +38,7 @@
 ; - t T: The accumulated return value, which is a constructor applied to a list of testers applied to x.
 ; return: The result of dt-inst for x, given t and the remaining selectors in x.
 (program $mk_dt_inst_rec ((D Type) (x D) (T Type) (U Type) (t (-> T U)) (tb D) (s (-> D T)) (xs eo::List :list))
-  (eo::List D T) D
+  :signature (eo::List D T) D
   (
     (($mk_dt_inst_rec eo::List::nil x tb)         tb)
     (($mk_dt_inst_rec (eo::List::cons s xs) x t)  ($mk_dt_inst_rec xs x (t (s x))))
@@ -58,7 +58,7 @@
 ;   for an ordinary constructor C : (-> Int Int D) with selectors s1, s2,
 ;   $mk_dt_inst_rec above returns (C (s1 x) (s2 x)).
 (program $mk_dt_inst_tuple_rec ((D Type) (x D) (T Type) (t T) (T1 Type) (T2 Type :list) (n Int) (U Type) (Any Type))
-  (Type D Int) Any
+  :signature (Type D Int) Any
   (
     (($mk_dt_inst_tuple_rec UnitTuple x n)     tuple.unit)
     (($mk_dt_inst_tuple_rec (Tuple T1 T2) x n) (eo::cons tuple (tuple.select n x) ($mk_dt_inst_tuple_rec T2 x (eo::add n 1))))
@@ -72,7 +72,7 @@
 ; - x D: The datatype term of type D we are applying dt-inst to.
 ; return: An equality that is equivalent to (is c x).
 (program $mk_dt_inst ((C Type) (D Type) (x D) (c C) (T1 Type) (T2 Type :list) (DC (-> Type Type)) (xt (Tuple T1 T2)) (xu UnitTuple))
-  (Type C D) D
+  :signature (Type C D) D
   (
     (($mk_dt_inst (Tuple T1 T2) tuple xt)   ($mk_dt_inst_tuple_rec (Tuple T1 T2) xt 0))
     (($mk_dt_inst UnitTuple tuple.unit xu)  tuple.unit)
@@ -159,7 +159,7 @@
 ; return: >
 ;   The conjunction of equalities between the arguments of ts and ss.
 (program $mk_dt_cons_eq ((T Type) (t T) (s T) (ts @List :list) (ss @List :list))
-  (@List @List) Bool
+  :signature (@List @List) Bool
   (
   (($mk_dt_cons_eq (@list t ts) (@list s ss)) (eo::cons and (= t s) ($mk_dt_cons_eq ts ss)))
   (($mk_dt_cons_eq @list.nil @list.nil)       true)
@@ -217,7 +217,7 @@
 ; note: >
 ;   Since forward declarations must have a ground type signature, we wrap
 ;   the term to find (the s argument of dt-cycle) in a list.
-(program $dt_find_cycle_list () (@List @List) Bool)
+(program $dt_find_cycle_list () :signature (@List @List) Bool)
 
 
 ; define: $dt_find_cycle_rec
@@ -229,7 +229,7 @@
 ;   True iff t contains s as a strict subterm beneath constructor applications.
 ; note: This is a helper for $dt_find_cycle below.
 (program $dt_find_cycle_rec ((T Type) (U Type) (W Type) (c T) (f (-> U W)) (a U) (s @List) (l @List))
-  (T @List @List) Bool
+  :signature (T @List @List) Bool
   (
     (($dt_find_cycle_rec (f a) s l) ($dt_find_cycle_rec f s (eo::cons @list a l)))
     (($dt_find_cycle_rec c s l)
@@ -257,7 +257,7 @@
 ;   True iff a term in ts is s, or contains s as a strict subterm beneath
 ;   constructor applications.
 (program $dt_find_cycle_list ((U Type) (t U) (s U) (ts @List :list) (ss @List))
-  (@List @List) Bool
+  :signature (@List @List) Bool
   (
   (($dt_find_cycle_list (@list s ts) (@list s)) true)
   (($dt_find_cycle_list (@list t ts) ss)        (eo::ite ($dt_find_cycle t ss)
@@ -292,7 +292,7 @@
 ; return: >
 ;   The result of updating the n^th argument from the end in t.
 (program $dt_collapse_updater_rhs ((U Type) (T Type) (f (-> T U)) (x T) (a T) (n Int))
-  (U T Int) U
+  :signature (U T Int) U
   (
     (($dt_collapse_updater_rhs (f x) a 0)  (f a))
     (($dt_collapse_updater_rhs (f x) a n)  (_ ($dt_collapse_updater_rhs f a (eo::add n -1)) x))
@@ -307,7 +307,7 @@
 ; return: >
 ;   The result of updating the n^th argument in t.
 (program $tuple_collapse_updater_rhs ((U Type) (T Type) (W Type) (f (-> T U)) (x T) (a T) (b T) (n Int) (ts W :list))
-  (U T Int) U
+  :signature (U T Int) U
   (
   (($tuple_collapse_updater_rhs (tuple b ts) a 0)   (tuple a ts))
   (($tuple_collapse_updater_rhs (tuple b ts) a n)   (eo::cons tuple b ($tuple_collapse_updater_rhs ts a (eo::add n -1))))
@@ -321,7 +321,7 @@
 ; return: >
 ;   The result of collapsing the update term.
 (program $mk_dt_collapse_updater_rhs ((D Type) (T Type) (W Type) (U Type) (s (-> D T)) (t D) (a U) (tr D) (n Int))
-  (D) D
+  :signature (D) D
   (
   (($mk_dt_collapse_updater_rhs (update s t a))       (eo::define ((ss ($dt_get_selectors_of_app (eo::typeof t) t)))
                                                       (eo::define ((index (eo::list_find eo::List::cons ss s)))
@@ -356,9 +356,8 @@
 ; - c U: The result of updating t we have accumulated so far.
 ; return: >
 ;   The result of updating the argument specified by s in t.
-(program $dt_updater_elim_rhs
-  ((D Type) (T Type) (U Type) (W Type) (X Type) (s (-> D T)) (s1 (-> D T)) (t D) (a T) (ss eo::List :list) (c (-> U W)) (cd D))
-  (D eo::List X) D
+(program $dt_updater_elim_rhs ((D Type) (T Type) (U Type) (W Type) (X Type) (s (-> D T)) (s1 (-> D T)) (t D) (a T) (ss eo::List :list) (c (-> U W)) (cd D))
+  :signature (D eo::List X) D
   (
     (($dt_updater_elim_rhs (update s t a) (eo::List::cons s ss) c)   ($dt_updater_elim_rhs (update s t a) ss (c a)))
     (($dt_updater_elim_rhs (update s t a) (eo::List::cons s1 ss) c)  ($dt_updater_elim_rhs (update s t a) ss (c (s1 t))))
@@ -372,9 +371,8 @@
 ; - ss eo::List: The remaining selector arguments to process.
 ; return: >
 ;   The result of updating the argument specified by s in t.
-(program $tuple_updater_elim_rhs
-  ((D Type) (T Type) (U Type) (n Int) (s (-> D T)) (t D) (tu UnitTuple) (a T) (ss eo::List :list) (c U))
-  (D eo::List) D
+(program $tuple_updater_elim_rhs ((D Type) (T Type) (U Type) (n Int) (s (-> D T)) (t D) (tu UnitTuple) (a T) (ss eo::List :list) (c U))
+  :signature (D eo::List) D
   (
     (($tuple_updater_elim_rhs (tuple.update n t a) (eo::List::cons (tuple.select n) ss))
        (eo::cons tuple a ($tuple_updater_elim_rhs (tuple.update n t a) ss)))
@@ -391,9 +389,8 @@
 ; - ss eo::List: The list of selectors for the type of s.
 ; return: >
 ;   The right hand side is obtained by updating the proper argument of t.
-(program $mk_dt_updater_elim_rhs
-  ((D Type) (T Type) (U Type) (s (-> D T)) (t D) (a T) (tr D) (c U) (n Int) (ss eo::List))
-  (D U eo::List) D
+(program $mk_dt_updater_elim_rhs ((D Type) (T Type) (U Type) (s (-> D T)) (t D) (a T) (tr D) (c U) (n Int) (ss eo::List))
+  :signature (D U eo::List) D
   (
     (($mk_dt_updater_elim_rhs (update s t a) c ss)
        ($dt_updater_elim_rhs (update s t a) ss ($dt_inst_cons_of (eo::typeof t) c))) ; ensure the constructor is annotated

--- a/proofs/eo/cpc/rules/Quantifiers.eo
+++ b/proofs/eo/cpc/rules/Quantifiers.eo
@@ -24,7 +24,7 @@
 ;   The list of skolem variables for the quantified formula whose bound variable list
 ;   is arg1 and whose body is arg2.
 (program $mk_skolems ((x @List) (xs @List :list) (F Bool) (i Int))
-  (@List Bool Int) @List
+  :signature (@List Bool Int) @List
   (
     (($mk_skolems (@list x xs) F i) (eo::cons @list (@quantifiers_skolemize F i) ($mk_skolems xs F (eo::add i 1))))
     (($mk_skolems @list.nil F i)    @list.nil)
@@ -123,7 +123,7 @@
 ; - F Bool: The body of the quantified formula.
 ; return: the sublist of variables in x that should be quantified for F.
 (program $mk_quant_unused_vars_rec ((T Type) (xs @List :list) (x T) (F Bool))
-  (@List Bool) eo::List
+  :signature (@List Bool) eo::List
   (
   (($mk_quant_unused_vars_rec @list.nil F)    @list.nil)
   (($mk_quant_unused_vars_rec (@list x xs) F) (eo::define ((r ($mk_quant_unused_vars_rec xs F)))
@@ -169,7 +169,7 @@
 ; - F Bool: The formula for which we are merging prenexes.
 ; return: the result of merging all bound variables bound by Q in F.
 (program $mk_quant_merge_prenex ((Q (-> @List Bool Bool)) (x @List) (F Bool))
-  ((-> @List Bool Bool) Bool) Bool
+  :signature ((-> @List Bool Bool) Bool) Bool
   (
   (($mk_quant_merge_prenex Q (Q x F))  (eo::match ((R (-> @List Bool Bool)) (y @List) (G Bool))
                                          ($mk_quant_merge_prenex Q F)
@@ -202,7 +202,7 @@
 ; - F Bool: The body of the formula in question.
 ; return: The result of miniscoping (forall x F) based on conjunctions.
 (program $mk_quant_miniscope_and ((x @List) (f Bool) (fs Bool :list))
-  (@List Bool) Bool
+  :signature (@List Bool) Bool
   (
   (($mk_quant_miniscope_and x (and f fs)) (eo::cons and (forall x f) ($mk_quant_miniscope_and x fs)))
   (($mk_quant_miniscope_and x true)       true)
@@ -234,7 +234,7 @@
 ;    True if (forall x F) is equivalent to G based on miniscope reasoning with
 ;    free variables over OR.
 (program $is_quant_miniscope_or ((x @List) (xs @List :list) (ys @List :list) (f Bool) (fs Bool :list) (g Bool) (gs Bool :list))
-  (@List Bool Bool) Bool
+  :signature (@List Bool Bool) Bool
   (
   (($is_quant_miniscope_or x (or f fs) (or f gs))                     (eo::requires ($contains_aterm_list f x) false
                                                                         ($is_quant_miniscope_or x fs gs)))
@@ -298,7 +298,7 @@
 ;    is not a variable elimination, i.e. if F does not begin with a disequality
 ;    between x and a term not containing x.
 (program $mk_quant_var_elim_eq ((T Type) (x T) (t T) (F Bool :list))
-  (T Bool) Bool
+  :signature (T Bool) Bool
   (
   (($mk_quant_var_elim_eq x (not (= x t)))        ($mk_quant_var_elim_eq_subs x t false))
   (($mk_quant_var_elim_eq x (or (not (= x t)) F)) ($mk_quant_var_elim_eq_subs x t ($singleton_elim F)))
@@ -332,7 +332,7 @@
 ;    The true iff G corresponds to a conjunct expected in the rule
 ;    quant-dt-split for the current constructor.
 (program $is_quant_dt_split_conj ((T Type) (U Type) (C Type) (W Type) (x T) (cx T) (c (-> U W)) (y U) (ys @List :list) (zs @List :list) (F Bool) (G Bool))
-  (T C @List Bool Bool) Bool
+  :signature (T C @List Bool Bool) Bool
   (
     (($is_quant_dt_split_conj x c (@list y ys) F (forall (@list y zs) G)) (eo::requires ($contains_subterm zs y) false  ; ensure no shadowing
                                                                             ($is_quant_dt_split_conj x c ys F (forall zs G))))
@@ -354,7 +354,7 @@
 ;    The true iff splitting (forall (@list x ys) F) for the constructors
 ;    remaining in cs is equal to the remaining conjuncts in G.
 (program $is_quant_dt_split ((T Type) (x T) (C Type) (c C) (cs eo::List :list) (ys @List) (F Bool) (g Bool) (G Bool :list))
-  (T eo::List @List Bool Bool) Bool
+  :signature (T eo::List @List Bool Bool) Bool
   (
     (($is_quant_dt_split x (eo::List::cons c cs) ys F (and g G)) (eo::requires
                                                                     ($is_quant_dt_split_conj x c ys F g) true
@@ -391,7 +391,7 @@
 ; return: >
 ;    A disjunct used in the invertibility conditions for some shift operators.
 (program $mk_inv_cond_op_disj ((n Int) (f (-> (BitVec n) (BitVec n))) (w Int) (t (BitVec n)))
-  ((-> (BitVec n) (BitVec n)) (BitVec n) Int Int) Bool
+  :signature ((-> (BitVec n) (BitVec n)) (BitVec n) Int Int) Bool
   (
   (($mk_inv_cond_op_disj f t w w)  (eo::cons or (= (f (eo::to_bin w w)) t) false))
   (($mk_inv_cond_op_disj f t w n)  (eo::cons or (= (f (eo::to_bin w n)) t) ($mk_inv_cond_op_disj f t w (eo::add n 1))))
@@ -407,7 +407,7 @@
 ;    equivalent to (exists x. R).
 (program $mk_invertibility_condition ((n Int) (m Int) (x (BitVec n)) (s (BitVec n)) (ss (BitVec n) :list) (t (BitVec n))
                                       (k Int) (tk (BitVec k)) (nil (BitVec n) :list))
-  ((BitVec n) Bool) Bool
+  :signature ((BitVec n) Bool) Bool
   (
   (($mk_invertibility_condition x (= (bvmul x s nil) t))    (eo::requires (eo::to_z nil) 1
                                                               (= (bvand (bvor (bvneg s) s) t) t)))

--- a/proofs/eo/cpc/rules/Sets.eo
+++ b/proofs/eo/cpc/rules/Sets.eo
@@ -36,7 +36,7 @@
 ; return: >
 ;   A list of elements, whose union is equal to s.
 (program $set_union_to_list ((T Type) (t (Set T)) (e T))
-  ((Set T)) @List
+  :signature ((Set T)) @List
   (
     (($set_union_to_list (set.union (set.singleton e) t)) (eo::cons @list e ($set_union_to_list t)))
     (($set_union_to_list (as set.empty (Set T)))          @list.nil)
@@ -51,7 +51,7 @@
 ; return: >
 ;   The elements in the set resulting in the set intersection of the arguments.
 (program $eval_sets_inter ((T Type) (a T) (as @List :list) (bs @List))
-  (@List @List) @List
+  :signature (@List @List) @List
   (
     (($eval_sets_inter (@list a as) bs)  (eo::define ((r ($eval_sets_inter as bs)))
                                          (eo::ite (eo::is_neg (eo::list_find @list bs a))
@@ -68,7 +68,7 @@
 ; return: >
 ;   The elements in the set resulting in the set difference of the arguments.
 (program $eval_sets_minus ((T Type) (a T) (as @List :list) (bs @List))
-  (@List @List) @List
+  :signature (@List @List) @List
   (
     (($eval_sets_minus (@list a as) bs)  (eo::define ((r ($eval_sets_minus as bs)))
                                          (eo::ite (eo::is_neg (eo::list_find @list bs a))
@@ -85,7 +85,7 @@
 ; return: >
 ;   The result of evaluating the operator.
 (program $eval_sets_op ((T Type) (s (Set T)) (t (Set T)) (r (Set T)))
-  ((Set T)) @List
+  :signature ((Set T)) @List
   (
     (($eval_sets_op (set.union s t)) (eo::list_concat @list ($set_union_to_list s) ($set_union_to_list t)))
     (($eval_sets_op (set.inter s t)) ($eval_sets_inter ($set_union_to_list s) ($set_union_to_list t)))
@@ -117,7 +117,7 @@
 ; return: >
 ;   The union of elements in es with t.
 (program $set_eval_insert ((T Type) (x T) (xs @List :list) (t (Set T)))
-  (@List (Set T)) (Set T)
+  :signature (@List (Set T)) (Set T)
   (
     (($set_eval_insert (@list x xs) t) (set.union (set.singleton x) ($set_eval_insert xs t)))
     (($set_eval_insert @list.nil t)    t)

--- a/proofs/eo/cpc/rules/Strings.eo
+++ b/proofs/eo/cpc/rules/Strings.eo
@@ -275,7 +275,7 @@
 ;   The concatenation of the strings in E is in the concatenation of the regular
 ;   expressions in E.
 (program $mk_re_concat ((Es Bool :list) (s String) (r RegLan))
-  (Bool) Bool
+  :signature (Bool) Bool
   (
   (($mk_re_concat (and (str.in_re s r) Es)) (eo::match ((s1 String) (r1 RegLan))
                                               ($mk_re_concat Es)
@@ -586,7 +586,7 @@
 ;   In particular, note that all string literals are broken up into string
 ;   literals of size one.
 (program $str_multiset_overapprox ((T Type) (s (Seq T)) (ss (Seq T) :list) (t (Seq T)) (r (Seq T)) (n Int) (m Int))
-    ((Seq T)) @List
+    :signature ((Seq T)) @List
     (
       (($str_multiset_overapprox (str.++ s ss))        (eo::list_concat @list ($str_multiset_overapprox s) ($str_multiset_overapprox ss)))
       (($str_multiset_overapprox (str.substr s n m))   ($str_multiset_overapprox s))
@@ -612,7 +612,7 @@
 ;   approximated by t. We compute this by iteratively removing the components of
 ;   s from t, and then checking if a term in nr is provably distinct from the final xs.
 (program $str_is_multiset_subset_strict ((T Type) (emp (Seq T)) (s (Seq T)) (ss (Seq T) :list) (xs @List) (nr @List :list))
-    ((Seq T) @List @List) Bool
+    :signature ((Seq T) @List @List) Bool
     (
       (($str_is_multiset_subset_strict (str.++ s ss) xs nr) (eo::define ((xsr (eo::list_erase @list xs s)))
                                                             (eo::define ((nrem (eo::eq xs xsr)))
@@ -807,7 +807,7 @@
 ; return: >
 ;   The result of evaluating (str.replace_re_all s r t), which is a concatenation.
 (program $str_eval_replace_re_all_rec ((s String) (r RegLan) (t String) (sp Int) (ep Int))
-  (String RegLan String (@Pair Int Int)) String
+  :signature (String RegLan String (@Pair Int Int)) String
   (
   (($str_eval_replace_re_all_rec "" r t (@pair -1 -1))  "")
   (($str_eval_replace_re_all_rec s r t (@pair -1 -1))   (eo::cons str.++ s ""))
@@ -850,7 +850,7 @@
 ; - t T: the term to evaluate, expected to be an operator applied to values, including at least one sequence value.
 ; return: The result of evaluating t.
 (program $seq_eval ((T Type) (t (Seq T)) (n Int))
-  (T) T
+  :signature (T) T
   (
     ; handle sequence-specific operators here
     (($seq_eval (seq.nth t n))  (eo::match ((e T))

--- a/proofs/eo/cpc/rules/Uf.eo
+++ b/proofs/eo/cpc/rules/Uf.eo
@@ -43,7 +43,7 @@
 ;   hand side. Each additional equality checks that its left hand side matches
 ;   the current right hand side.
 (program $mk_trans ((U Type) (t1 U) (t2 U) (t3 U) (t4 U) (tail Bool :list))
-    (U U Bool) Bool
+    :signature (U U Bool) Bool
     (
         (($mk_trans t1 t2 (and (= t3 t4) tail))
             (eo::requires t2 t3 ($mk_trans t1 t4 tail)))
@@ -76,7 +76,7 @@
 ; return: >
 ;   The right hand side of the equality.
 (program $mk_cong_rhs ((T Type) (U Type) (f (-> T U)) (t1 U) (t2 U) (t3 U) (tail Bool :list))
-    (U Bool) U
+    :signature (U Bool) U
     (
         (($mk_cong_rhs (f t1) (and (= t1 t2) tail))  (_ ($mk_cong_rhs f tail) t2))
         (($mk_cong_rhs f true)                       f)
@@ -112,7 +112,7 @@
 ;   The right hand side of the equality proven by nary_cong for f and
 ;   the given premises E.
 (program $mk_nary_cong_rhs ((U Type) (f (-> U U U)) (s1 U) (s2 U) (t U :list) (tail Bool :list) (nil U))
-    (U Bool) U
+    :signature (U Bool) U
     (
         (($mk_nary_cong_rhs (f s1 t) (and (= s1 s2) tail))  (eo::cons f s2 ($mk_nary_cong_rhs t tail)))
         (($mk_nary_cong_rhs nil true)                       nil)
@@ -197,7 +197,7 @@
 ;   An equality where the original terms are applied to the left and
 ;   right hand sides of the equalities given by E.
 (program $mk_ho_cong ((T Type) (U Type) (f1 (-> T U)) (f2 (-> T U)) (t1 U) (t2 U) (tail Bool :list))
-    (U U Bool) Bool
+    :signature (U U Bool) Bool
     (
         (($mk_ho_cong f1 f2 (and (= t1 t2) tail)) ($mk_ho_cong (f1 t1) (f2 t2) tail))
         (($mk_ho_cong t1 t2 true)                 (= t1 t2))
@@ -233,7 +233,7 @@
 ;   The distinct function is already treated as pairwise, thus we only need to convert from
 ;   binary distinct to disequalities.
 (program $mk_distinct-elim ((T Type) (x T) (y T) (b Bool :list))
-  (Bool) Bool
+  :signature (Bool) Bool
   (
   (($mk_distinct-elim (and (distinct x y) b))   (eo::cons and (not (= x y)) ($mk_distinct-elim b)))
   (($mk_distinct-elim true)                     true)

--- a/proofs/eo/cpc/theories/Arith.eo
+++ b/proofs/eo/cpc/theories/Arith.eo
@@ -14,7 +14,7 @@
 ;   The "type union" of T and U. This method is used for the type rules
 ;   for operators that allow mixed arithmetic.
 (program $arith_typeunion ()
-    (Type Type) Type
+    :signature (Type Type) Type
     (
       (($arith_typeunion Int Int) Int)
       (($arith_typeunion Real Real) Real)
@@ -28,7 +28,7 @@
 ; - T Type: A type.
 ; return: true if T is Int or Real
 (program $is_arith_type ()
-    (Type) Bool
+    :signature (Type) Bool
     (
       (($is_arith_type Int) true)
       (($is_arith_type Real) true)

--- a/proofs/eo/cpc/theories/Builtin.eo
+++ b/proofs/eo/cpc/theories/Builtin.eo
@@ -31,7 +31,7 @@
 ;   The type of a lambda having the list of variables L and
 ;   body type B.
 (program $get_lambda_type ((x @List) (xs @List :list) (B Type))
-  (@List Type) Type
+  :signature (@List Type) Type
   (
     (($get_lambda_type (@list x xs) B) (-> (eo::typeof x) ($get_lambda_type xs B)))
     (($get_lambda_type @list.nil B)    B)

--- a/proofs/eo/cpc/theories/Datatypes.eo
+++ b/proofs/eo/cpc/theories/Datatypes.eo
@@ -40,7 +40,7 @@
 ;   consists of lifting each argument and return type T to
 ;   (Nullable T).
 (program $get_type_nullable_lift ((T Type) (U Type))
-    (Type) Type
+    :signature (Type) Type
     (
       (($get_type_nullable_lift (-> T U)) (-> (Nullable T) ($get_type_nullable_lift U)))
       (($get_type_nullable_lift U)        (Nullable U))

--- a/proofs/eo/cpc/theories/Quantifiers.eo
+++ b/proofs/eo/cpc/theories/Quantifiers.eo
@@ -21,7 +21,7 @@
 ; return: >
 ;   The i^th variable in the binder of F.
 (program $get_var_at_index ((Q (-> @List Bool Bool)) (xs @List) (G Bool) (i Int))
-  (Bool Int) Type
+  :signature (Bool Int) Type
   (
     (($get_var_at_index (Q xs G) i) (eo::list_nth @list xs i))
   )


### PR DESCRIPTION
Updates to new ethos version which supports `:signature` to clarify the i/o of programs.