### PR TITLE
Refactor CPC arithmetic signature to avoid eo::match, fix types

### DIFF
--- a/proofs/eo/cpc/programs/Arith.eo
+++ b/proofs/eo/cpc/programs/Arith.eo
@@ -2,6 +2,13 @@
 (include "../theories/Arith.eo")
 (include "../programs/Utils.eo")
 
+; define: $arith_mk_zero
+; args:
+; - u Type : The type of the zero, which should be Int or Real.
+; return: the zero for the given type.
+(define $arith_mk_zero ((T Type))
+  (eo::ite (eo::is_eq T Int) 0 (eo::requires T Real 0/1)))
+
 ; define: $arith_eval_add
 ; args:
 ; - x T: The first arithmetic term to add.
@@ -29,8 +36,7 @@
 ;   can each be integer or real. This method returns an integer value if x and y
 ;   are both integer, or a rational value otherwise.
 (define $arith_eval_sub ((U Type :implicit) (T Type :implicit) (x U) (y T))
-  ($arith_eval_add x (eo::neg y))
-)
+  ($arith_eval_add x (eo::neg y)))
 
 ; define: $arith_eval_mul
 ; args:
@@ -147,8 +153,8 @@
 ; - n Int: The number of times to multiply, expected to be a non-negative numeral.
 ; - a T: The term to muliply.
 ; return: The result of multiplying a, n times.
-(program $arith_unfold_pow_rec ((T Type) (n Int) (a T) (Any Type))
-  :signature (Int T) Any
+(program $arith_unfold_pow_rec ((T Type) (n Int) (a T))
+  :signature ((eo::quote n) T) (eo::ite (eo::eq n 0) Int T)
   (
     (($arith_unfold_pow_rec 0 a)  1)
     (($arith_unfold_pow_rec n a)  (eo::cons * a ($arith_unfold_pow_rec (eo::add n -1) a)))

--- a/proofs/eo/cpc/programs/Strings.eo
+++ b/proofs/eo/cpc/programs/Strings.eo
@@ -144,6 +144,28 @@
 (define $str_is_char_range ((s1 String) (s2 String))
   (eo::and (eo::is_eq (eo::len s1) 1) (eo::is_eq (eo::len s2) 1)))
 
+; program: $str_membership_str
+; args:
+; - B Bool: A predicate.
+; return: If B is of the form (str.in_re s r), this returns s.
+(program $str_membership_str ((s String) (r RegLan))
+  :signature (Bool) String
+  (
+  (($str_membership_str (str.in_re s r)) s)
+  )
+)
+
+; program: $str_membership_re
+; args:
+; - B Bool: A predicate.
+; return: If B is of the form (str.in_re s r), this returns r.
+(program $str_membership_re ((s String) (r RegLan))
+  :signature (Bool) RegLan
+  (
+  (($str_membership_re (str.in_re s r)) r)
+  )
+)
+
 ;;-------------------- RE evaluation
 
 ; note: used to represent an invalid regular expression below.
@@ -1492,89 +1514,78 @@
 ;   be reversed when we recurse on non-str.to_re children.
 ; return: >
 ;   The result of implied consumption of string s in regular expression r.
-(program $str_re_consume_rec ((s1 String) (s2 String :list) (s String) (r1 RegLan) (r2 RegLan :list) (b Bool) (rev Bool))
+(program $str_re_consume_rec
+  ((s1 String) (s2 String :list) (s String) (r1 RegLan) (r2 RegLan :list) (b Bool) (rev Bool)
+   (s3 String) (s4 String :list) (s5 String) (r3 RegLan))
   :signature (String RegLan Bool Bool) Bool
   (
-    (($str_re_consume_rec (str.++ s1 s2) (re.++ r1 r2) @result.null rev)  
-        (eo::match ((s3 String) (s4 String :list) (s5 String) (r3 RegLan))
-          r1
-          (
-          ((str.to_re (str.++ s3 s4)) (eo::ite (eo::eq s1 s3)
-                                        ($str_re_consume_rec s2 (re.++ (str.to_re s4) r2) @result.null rev)
-                                        (eo::ite (eo::and ($str_check_length_one s1) ($str_check_length_one s3))
-                                          false                                       ; conflicting characters
-                                          (str.in_re (str.++ s1 s2) (re.++ r1 r2))))) ; otherwise stuck
-          (@re.empty                  ($str_re_consume_rec (str.++ s1 s2) r2 @result.null rev)) ; finished current component
-          ((re.range s3 s5)           (eo::ite (eo::and ($str_check_length_one s1) ($str_is_char_range s3 s5))
-                                        (eo::ite ($str_eval_str_in_re s1 (re.range s3 s5))
-                                          ($str_re_consume_rec s2 r2 @result.null rev)
-                                          false)
-                                        (str.in_re (str.++ s1 s2) (re.++ r1 r2))))
-          (re.allchar                 (eo::ite ($str_check_length_one s1)
-                                        ($str_re_consume_rec s2 r2 @result.null rev)
-                                        (str.in_re (str.++ s1 s2) (re.++ r1 r2))))
-          ((re.* r3)                  ; see what happens if we unroll once
-                                      (eo::match ((sr String) (rr RegLan))
-                                        ($str_re_consume_rec (str.++ s1 s2) ($re_to_flat_form r3 rev) @result.null rev)
-                                        (
-                                          ; We can't unroll even once, thus we must skip it.
-                                          (false                     ($str_re_consume_rec (str.++ s1 s2) r2 @result.null rev))
-                                          ; If we fully consumed, now we go back and check if we get a conflict if we skip.
-                                          ((str.in_re sr @re.empty)  (eo::match ((br Bool))
-                                                                        ($str_re_consume_rec (str.++ s1 s2) r2 @result.null rev)
-                                                                        (
-                                                                          ; Skipping would give a conflict.
-                                                                          (false (eo::ite (eo::eq (str.++ s1 s2) sr)
-                                                                                    ; if we did not consume anything, we are stuck.
-                                                                                    (str.in_re (str.++ s1 s2) (re.++ r1 r2))
-                                                                                    ; otherwise, we continue with the RE consumed once.
-                                                                                    ($str_re_consume_rec sr (re.++ r1 r2) @result.null rev)
-                                                                                  ))
-                                                                          ; Otherwise we are stuck.
-                                                                          (br    (str.in_re (str.++ s1 s2) (re.++ r1 r2)))
-                                                                        )
-                                                                      ))
-                                          ; Otherwise we are stuck.
-                                          ((str.in_re sr rr)          (str.in_re (str.++ s1 s2) (re.++ r1 r2)))
-                                        )
-                                      ))
-          (r3                         ; likely intersection or union, process cases recursively
-                                      (eo::match ((sr String) (br Bool))
-                                        ($str_re_consume_rec (str.++ s1 s2) r3 @result.null rev)
-                                        (
-                                          ; conflict
-                                          (false                     false)
-                                          ; if all cases consumed the same, continue
-                                          ((str.in_re sr @re.empty)  ($str_re_consume_rec sr r2 @result.null rev))
-                                          ; otherwise we are stuck
-                                          (br                        (str.in_re (str.++ s1 s2) (re.++ r1 r2)))
-                                        )
-                                      ))
-          )
-        )
-    )
+    (($str_re_consume_rec (str.++ s1 s2) (re.++ (str.to_re (str.++ s3 s4)) r2) @result.null rev)
+      (eo::ite (eo::eq s1 s3)
+        ($str_re_consume_rec s2 (re.++ (str.to_re s4) r2) @result.null rev)
+        (eo::ite (eo::and ($str_check_length_one s1) ($str_check_length_one s3))
+          false                                       ; conflicting characters
+          (str.in_re (str.++ s1 s2) (re.++ (str.to_re (str.++ s3 s4)) r2))))) ; otherwise stuck
+    (($str_re_consume_rec (str.++ s1 s2) (re.++ @re.empty r2) @result.null rev)
+      ($str_re_consume_rec (str.++ s1 s2) r2 @result.null rev)) ; finished current component
+    (($str_re_consume_rec (str.++ s1 s2) (re.++ (re.range s3 s5) r2) @result.null rev)
+      (eo::ite (eo::and ($str_check_length_one s1) ($str_is_char_range s3 s5))
+        (eo::ite ($str_eval_str_in_re s1 (re.range s3 s5))
+          ($str_re_consume_rec s2 r2 @result.null rev)
+          false)
+        (str.in_re (str.++ s1 s2) (re.++ (re.range s3 s5) r2))))
+    (($str_re_consume_rec (str.++ s1 s2) (re.++ re.allchar r2) @result.null rev)
+      (eo::ite ($str_check_length_one s1)
+        ($str_re_consume_rec s2 r2 @result.null rev)
+        (str.in_re (str.++ s1 s2) (re.++ re.allchar r2))))
+    (($str_re_consume_rec (str.++ s1 s2) (re.++ (re.* r3) r2) @result.null rev)
+      (eo::define ((r1 (re.* r3)))
+      ; see what happens if we unroll once
+      (eo::define ((res ($str_re_consume_rec (str.++ s1 s2) ($re_to_flat_form r3 rev) @result.null rev)))
+      (eo::ite (eo::eq res false)
+        ; We can't unroll even once, thus we must skip it.
+        ($str_re_consume_rec (str.++ s1 s2) r2 @result.null rev)
+        (eo::ite (eo::eq ($str_membership_re res) @re.empty)
+          ; If we fully consumed, now we go back and check if we get a conflict if we skip.
+          (eo::define ((res2 ($str_re_consume_rec (str.++ s1 s2) r2 @result.null rev)))
+          (eo::ite (eo::is_eq res2 false)
+            ; Skipping would give a conflict.
+            (eo::define ((sr ($str_membership_str res)))
+            (eo::ite (eo::eq (str.++ s1 s2) sr)
+              ; if we did not consume anything, we are stuck.
+              (str.in_re (str.++ s1 s2) (re.++ r1 r2))
+              ; otherwise, we continue with the RE consumed once.
+              ($str_re_consume_rec sr (re.++ r1 r2) @result.null rev)))
+            ; Otherwise we are stuck.
+            (str.in_re (str.++ s1 s2) (re.++ r1 r2))))
+          ; Otherwise we are stuck.
+          (str.in_re (str.++ s1 s2) (re.++ r1 r2)))))))
+    (($str_re_consume_rec (str.++ s1 s2) (re.++ r1 r2) @result.null rev)
+      ; likely intersection or union, process cases recursively
+      (eo::define ((res ($str_re_consume_rec (str.++ s1 s2) r1 @result.null rev)))
+      (eo::ite (eo::is_eq res false)
+        ; conflict
+        false
+        (eo::ite (eo::is_eq ($str_membership_re res) @re.empty)
+          ; if all cases consumed the same, continue
+          ($str_re_consume_rec ($str_membership_str res) r2 @result.null rev)
+          ; otherwise we are stuck
+          (str.in_re (str.++ s1 s2) (re.++ r1 r2))))))
     (($str_re_consume_rec s1 (re.++ @re.empty r2) @result.null rev)
       ($str_re_consume_rec s1 r2 @result.null rev)) ; finished current component
     ; Intersection reports conflicts eagerly, and otherwise combines the results
     (($str_re_consume_rec s1 (re.inter r1 r2) b rev)   (eo::define ((r1r ($re_to_flat_form r1 rev)))
-                                                       (eo::match ((bb Bool))
-                                                          ($str_re_consume_rec s1 r1r @result.null rev)
-                                                          (
-                                                            (false  false)
-                                                            (bb     ($str_re_consume_rec s1 r2 ($result_combine bb b) rev))
-                                                          )
-                                                       )))
+                                                       (eo::define ((bb ($str_re_consume_rec s1 r1r @result.null rev)))
+                                                         (eo::ite (eo::eq bb false)
+                                                           false
+                                                           ($str_re_consume_rec s1 r2 ($result_combine bb b) rev)))))
     (($str_re_consume_rec s1 re.all @result.null rev)  (str.in_re "" @re.empty)) ; only used if re.all appears in unexpected position
     (($str_re_consume_rec s1 re.all b rev)             b)                        ; end of re.inter
     ; Union ignores conflicts, and otherwise combines the results. We report a conflict if all children give conflicts.
     (($str_re_consume_rec s1 (re.union r1 r2) b rev)   (eo::define ((r1r ($re_to_flat_form r1 rev)))
-                                                       (eo::match ((bb Bool))
-                                                          ($str_re_consume_rec s1 r1r @result.null rev)
-                                                          (
-                                                            (false  ($str_re_consume_rec s1 r2 b rev))
-                                                            (bb     ($str_re_consume_rec s1 r2 ($result_combine bb b) rev))
-                                                          )
-                                                       )))
+                                                       (eo::define ((bb ($str_re_consume_rec s1 r1r @result.null rev)))
+                                                         (eo::ite (eo::eq bb false)
+                                                           ($str_re_consume_rec s1 r2 b rev)
+                                                           ($str_re_consume_rec s1 r2 ($result_combine bb b) rev)))))
     (($str_re_consume_rec s1 re.none @result.null rev) false)     ; end of re.union, conflict, also used if re.none appears in unexpected position
     (($str_re_consume_rec s1 re.none b rev)            b)         ; end of re.union, no conflict
     (($str_re_consume_rec s1 r1 @result.null rev)      (str.in_re s1 r1))
@@ -1596,25 +1607,21 @@
 (define $str_re_consume_process ((s String) (r RegLan) (oneDir Bool))
   (eo::define ((ss ($str_to_flat_form s true)))  
   (eo::define ((rr ($re_to_flat_form r true)))
-  (eo::match ((s1 String) (r1 RegLan))
-      ($str_re_consume_rec ss rr @result.null true)
-      (
-        (false              false)
-        ((str.in_re s1 r1)  ; we revert if oneDir is true and we didn't fully consume
-                            (eo::define ((revert (eo::and oneDir (eo::not (eo::eq r1 @re.empty)))))
-                            (eo::define ((s1r ($str_rev true (eo::ite revert ss s1)))
-                                         (r1r ($re_to_flat_form (eo::ite revert rr r1) true)))
-                            (eo::match ((s2 String) (r2 RegLan))
-                              ($str_re_consume_rec s1r r1r @result.null false)
-                              (
-                                (false              false)
-                                ((str.in_re s2 r2)  (str.in_re ($str_from_flat_form s2 false) ($re_from_flat_form r2 false)))
-                              )
-                            )))
-        )
-      )
-  )))
-)
+  (eo::define ((resrev ($str_re_consume_rec ss rr @result.null true)))
+  (eo::ite (eo::eq resrev false)
+    false
+    (eo::define ((s1 ($str_membership_str resrev)))
+    (eo::define ((r1 ($str_membership_re resrev)))
+    ; we revert if oneDir is true and we didn't fully consume
+    (eo::define ((revert (eo::and oneDir (eo::not (eo::eq r1 @re.empty)))))
+    (eo::define ((s1r ($str_rev true (eo::ite revert ss s1)))
+                  (r1r ($re_to_flat_form (eo::ite revert rr r1) true)))
+    (eo::define ((resfwd ($str_re_consume_rec s1r r1r @result.null false)))
+    (eo::ite (eo::eq resfwd false)
+      false
+      (eo::define ((s2 ($str_membership_str resfwd)))
+      (eo::define ((r2 ($str_membership_re resfwd)))
+        (str.in_re ($str_from_flat_form s2 false) ($re_from_flat_form r2 false)))))))))))))))
 
 ; define: $str_re_consume
 ; args:
@@ -1631,13 +1638,11 @@
   :signature (String RegLan) Bool
   (
   (($str_re_consume s (re.* r))
-    (eo::match ((s1 String))
-        ($str_re_consume_process s r true)  ; only process in a single direction
-        (
-          (false                    false)  ; conflict
-          ((str.in_re s1 @re.empty) (str.in_re s1 (re.* r))) ; one full copy
-        )
-    ))
+    (eo::define ((res ($str_re_consume_process s r true)))  ; only process in a single direction
+    (eo::ite (eo::eq res false)
+      false
+      (eo::requires ($str_membership_re res) @re.empty      ; must have consumed one full copy
+        (str.in_re ($str_membership_str res) (re.* r))))))
   (($str_re_consume s r) ($str_re_consume_process s r false))
   )
 )

--- a/proofs/eo/cpc/rules/Arith.eo
+++ b/proofs/eo/cpc/rules/Arith.eo
@@ -146,8 +146,7 @@
 ; return: >
 ;   The relation that, along with r1 and r2, forms a trichotomy over
 ;   arithmetic values, applied to a and b.
-(program $arith_rel_trichotomy
-  ((T Type) (U Type) (V Type) (W Type) (a V) (b W))
+(program $arith_rel_trichotomy ((T Type) (U Type) (V Type) (W Type) (a V) (b W))
   :signature (T U V W) Bool
   (
     (($arith_rel_trichotomy = < a b) (> a b))
@@ -194,7 +193,8 @@
 ; - F1: The first arithmetic atom, which is an application of a binary arithmetic relation.
 ; - F2: The first arithmetic atom, which is an application of a binary arithmetic relation over the same terms as F1.
 ; return: The relation that along with F1 and F2 forms a trichotomy.
-(program $mk_arith_trichotomy ((T Type) (U Type) (S Type) (r1 (-> T U Bool)) (r2 (-> T U Bool)) (a T) (b U))
+(program $mk_arith_trichotomy
+  ((T Type) (U Type) (S Type) (r1 (-> T U Bool)) (r2 (-> T U Bool)) (a T) (b U))
   :signature (Bool Bool) Bool
   (
     (($mk_arith_trichotomy (r1 a b) (r2 a b)) ($arith_rel_trichotomy r1 r2 a b))

--- a/proofs/eo/cpc/rules/Arith.eo
+++ b/proofs/eo/cpc/rules/Arith.eo
@@ -34,6 +34,7 @@
 ; program: $mk_arith_sum_ub
 ; args:
 ; - F Bool: A conjunction of arithmetic relations.
+; - acc Bool: The current return value.
 ; return: the arithmetic relation that is implied by adding each of the relations in F together.
 (program $mk_arith_sum_ub ((T Type) (U Type) (r (-> T U Bool)) (a T) (b U) (tail Bool :list)
                            (S Type) (V Type) (r2 (-> S V Bool)) (a2 S :list) (b2 V :list) (acc Bool))

--- a/proofs/eo/cpc/rules/Arith.eo
+++ b/proofs/eo/cpc/rules/Arith.eo
@@ -31,26 +31,18 @@
   )
 )
 
-; define: $arith_mk_zero
-; args:
-; - u Type : The type of the zero, which should be Int or Real.
-; return: The zero for the given type.
-(define $arith_mk_zero ((T Type))
-  (eo::ite (eo::is_eq T Int) 0 (eo::requires T Real 0/1)))
-
 ; program: $mk_arith_sum_ub
 ; args:
 ; - F Bool: A conjunction of arithmetic relations.
 ; return: the arithmetic relation that is implied by adding each of the relations in F together.
-(program $mk_arith_sum_ub ((T Type) (U Type) (r (-> T U Bool)) (a T) (b U) (tail Bool :list))
-    :signature (Bool) Bool
-    (
-        (($mk_arith_sum_ub true)               (= 0 0))
-        (($mk_arith_sum_ub (and (r a b) tail)) 
-          (eo::match ((S Type) (V Type) (r2 (-> S V Bool)) (a2 S :list) (b2 V :list))
-            ($mk_arith_sum_ub tail)
-            (((r2 a2 b2) ($arith_rel_sum r r2 (+ a a2) (+ b b2))))))
-    )
+(program $mk_arith_sum_ub ((T Type) (U Type) (r (-> T U Bool)) (a T) (b U) (tail Bool :list)
+                           (S Type) (V Type) (r2 (-> S V Bool)) (a2 S :list) (b2 V :list) (acc Bool))
+  :signature (Bool Bool) Bool
+  (
+    (($mk_arith_sum_ub true acc)                      acc)
+    (($mk_arith_sum_ub (and (r a b) tail) (r2 a2 b2)) ($mk_arith_sum_ub tail ($arith_rel_sum r r2 (+ a a2) (+ b b2))))
+
+  )
 )
 
 ; rule: arith_sum_ub
@@ -62,7 +54,7 @@
 ;   relations in F together.
 (declare-rule arith_sum_ub ((F Bool))
   :premise-list F and
-  :conclusion ($mk_arith_sum_ub F)
+  :conclusion ($mk_arith_sum_ub (eo::list_rev and F) (= 0 0))
 )
 
 ;;;;; ProofRule::ARITH_MULT_POS
@@ -154,7 +146,8 @@
 ; return: >
 ;   The relation that, along with r1 and r2, forms a trichotomy over
 ;   arithmetic values, applied to a and b.
-(program $arith_rel_trichotomy ((T Type) (U Type) (V Type) (W Type) (a V) (b W))
+(program $arith_rel_trichotomy
+  ((T Type) (U Type) (V Type) (W Type) (a V) (b W))
   :signature (T U V W) Bool
   (
     (($arith_rel_trichotomy = < a b) (> a b))
@@ -201,8 +194,7 @@
 ; - F1: The first arithmetic atom, which is an application of a binary arithmetic relation.
 ; - F2: The first arithmetic atom, which is an application of a binary arithmetic relation over the same terms as F1.
 ; return: The relation that along with F1 and F2 forms a trichotomy.
-(program $mk_arith_trichotomy
-  ((T Type) (U Type) (S Type) (r1 (-> T U Bool)) (r2 (-> T U Bool)) (a T) (b U))
+(program $mk_arith_trichotomy ((T Type) (U Type) (S Type) (r1 (-> T U Bool)) (r2 (-> T U Bool)) (a T) (b U))
   :signature (Bool Bool) Bool
   (
     (($mk_arith_trichotomy (r1 a b) (r2 a b)) ($arith_rel_trichotomy r1 r2 a b))
@@ -432,30 +424,28 @@
       (=> (> v 0) (and lb (< u (* v (+ k 1)))))
       (=> (< v 0) (and lb (< u (* v (+ k -1))))))))))
 
-; define: $arith_reduction_pred
+; program: $arith_reduction_pred
 ; args:
 ; - t T: The term we are considering, which is expected to be an application of an extended arithmetic operator.
 ; return: the reduction predicate for term t.
-(define $arith_reduction_pred ((T Type :implicit) (t T))
-  (eo::match ((U Type) (V Type) (r Real) (a Int) (b Int) (u U) (v V))
-    t
-    (
-    ((is_int u)       (eo::define ((k (@purify (to_int u))))
-                        (and (= t (= (- u k) 0/1)) ($arith_to_int_reduction u))))
-    ((to_int u)       (eo::define ((k (@purify (to_int u))))
-                        (and (= t k) ($arith_to_int_reduction u))))
-    ((/ u v)          (eo::define ((ur (eo::ite (eo::eq (eo::typeof u) Int) (to_real u) u)))
-                        (= t (ite (= v ($arith_mk_zero (eo::typeof v))) (@div_by_zero ur) (/_total u v)))))
-    ((div a b)        (= t (ite (= b 0) (@int_div_by_zero a) (div_total a b))))
-    ((mod a b)        (= t (ite (= b 0) (@mod_by_zero a) (mod_total a b))))
-    ((/_total u v)    (eo::define ((k (@purify (/_total u v))))
-                        (and (= t k) (=> (not (= v ($arith_mk_zero (eo::typeof v)))) (= (* v k) u)))))
-    ((div_total a b)  (eo::define ((k (@purify (div_total a b))))
-                        (and (= t k) ($arith_int_div_total_reduction a b))))
-    ((mod_total a b)  (eo::define ((k (@purify (div_total a b))))
-                        (and (= t (- a (* b k))) ($arith_int_div_total_reduction a b))))
-    ((abs u)          (= t (ite (< u ($arith_mk_zero (eo::typeof u))) (- u) u)))
-    )
+(program $arith_reduction_pred ((T Type) (U Type) (V Type) (r Real) (a Int) (b Int) (u U) (v V))
+  :signature (T) Bool
+  (
+  (($arith_reduction_pred (is_int u))       (eo::define ((k (@purify (to_int u))))
+                                              (and (= (is_int u) (= (- u k) 0/1)) ($arith_to_int_reduction u))))
+  (($arith_reduction_pred (to_int u))       (eo::define ((k (@purify (to_int u))))
+                                              (and (= (to_int u) k) ($arith_to_int_reduction u))))
+  (($arith_reduction_pred (/ u v))          (eo::define ((ur (eo::ite (eo::eq (eo::typeof u) Int) (to_real u) u)))
+                                              (= (/ u v) (ite (= v ($arith_mk_zero (eo::typeof v))) (@div_by_zero ur) (/_total u v)))))
+  (($arith_reduction_pred (div a b))        (= (div a b) (ite (= b 0) (@int_div_by_zero a) (div_total a b))))
+  (($arith_reduction_pred (mod a b))        (= (mod a b) (ite (= b 0) (@mod_by_zero a) (mod_total a b))))
+  (($arith_reduction_pred (/_total u v))    (eo::define ((k (@purify (/_total u v))))
+                                              (and (= (/_total u v) k) (=> (not (= v ($arith_mk_zero (eo::typeof v)))) (= (* v k) u)))))
+  (($arith_reduction_pred (div_total a b))  (eo::define ((k (@purify (div_total a b))))
+                                              (and (= (div_total a b) k) ($arith_int_div_total_reduction a b))))
+  (($arith_reduction_pred (mod_total a b))  (eo::define ((k (@purify (div_total a b))))
+                                              (and (= (mod_total a b) (- a (* b k))) ($arith_int_div_total_reduction a b))))
+  (($arith_reduction_pred (abs u))          (= (abs u) (ite (< u ($arith_mk_zero (eo::typeof u))) (- u) u)))
   )
 )
 
@@ -538,8 +528,13 @@
 ;  equivalent to y1-y2.
 ; conclusion: >
 ;   An equivalence between relations specified by eqr and justified by eq.
+; note: >
+;   The parameter r is expected to be a binary predicate. We provide the type
+;   (-> R1 R2 R3) to acccount for the fact that its return type involves
+;   eo::requires and hence is not Bool.
 (declare-rule arith_poly_norm_rel
-  ((U Type) (U1 Type) (U2 Type) (V Type) (V1 Type) (V2 Type) (T Type) (r T)
+  ((U Type) (U1 Type) (U2 Type) (V Type) (V1 Type) (V2 Type)
+   (R1 Type) (R2 Type) (R3 Type) (r (-> R1 R2 R3))
    (x U) (y V) (cx U) (cy V) (x1 U1) (x2 U2) (y1 V1) (y2 V2))
   :premises ((= (* cx x) (* cy y)))
   :args ((= (r x1 x2) (r y1 y2)))


### PR DESCRIPTION
Note this uses `eo::quote` in one place as a mechanism to specify dependent types for programs, as described here: https://github.com/cvc5/ethos/blob/main/user_manual.md#dependently-typed-programs