### PR TITLE
Bump Pythonic API version and add Pythonic tests

### DIFF
--- a/cmake/FindCVC5PythonicAPI.cmake
+++ b/cmake/FindCVC5PythonicAPI.cmake
@@ -34,12 +34,12 @@ else()
     check_auto_download("CVC5PythonicAPI" "--no-python-bindings")
   endif()
 
-  set(CVC5PythonicAPI_VERSION "be54c2388b3271f657cad41cf5e3d6bc97cd51a1")
+  set(CVC5PythonicAPI_VERSION "27d50b6b23b59ef6661ef0b122daa8a51ba8e9d5")
   ExternalProject_Add(
     CVC5PythonicAPI
     ${COMMON_EP_CONFIG}
     URL https://github.com/cvc5/cvc5_pythonic_api/archive/${CVC5PythonicAPI_VERSION}.zip
-    URL_HASH SHA256=2bbee4592f7e01869a1512d11d57dcd88453f44076306c0d294877e81e2c0ca9
+    URL_HASH SHA256=ead4eac1788a5f48d6fcdc17132f2a8d9052e73b8f068af707260efc991216ba
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""

--- a/examples/api/python/CMakeLists.txt
+++ b/examples/api/python/CMakeLists.txt
@@ -34,6 +34,29 @@ set(EXAMPLES_API_PYTHON
   uf
 )
 
+# Examples that have a Pythonic version.
+# This list should include any such example,
+# even if it is only conditionally added (e.g.,
+# based on CVC5_USE_COCOA or NOT CVC5_SAFE_BUILD).
+set(EXAMPLES_API_PYTHON_PYTHONIC
+  bitvectors_and_arrays
+  bitvectors
+  combination
+  datatypes
+  exceptions
+  extract
+  floating_point
+  helloworld
+  id
+  linear_arith
+  quickstart
+  sequences
+  sets
+  strings
+  transcendentals
+  uf
+)
+
 find_package(Python ${CVC5_BINDINGS_PYTHON_VERSION} EXACT REQUIRED)
 
 # Check whether the cvc5 module is already installed
@@ -55,16 +78,29 @@ if(NOT (PYTHON_CVC5_RC EQUAL 0))
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()
 
-function(create_python_example example)
-  set(example_test example/api/python/${example})
+function(_add_python_test example subdir)
+  string(REPLACE "/" "_" subdir_name "${subdir}") # unique test name
+  set(test_name example/${subdir_name}/${example})
+
   add_test(
-    NAME ${example_test}
-    COMMAND
-      "${Python_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/api/python/${example}.py"
+    NAME     ${test_name}
+    COMMAND  "${Python_EXECUTABLE}"
+             "${CMAKE_SOURCE_DIR}/${subdir}/${example}.py"
   )
-  set_tests_properties(${example_test} PROPERTIES
-    LABELS "example"
-    ENVIRONMENT PYTHONPATH=${PYTHON_MODULE_PATH})
+  set_tests_properties(${test_name} PROPERTIES
+    LABELS      "example"
+    ENVIRONMENT "PYTHONPATH=${PYTHON_MODULE_PATH}"
+  )
+endfunction()
+
+function(create_python_example example)
+  # Base Python API example
+  _add_python_test(${example} "api/python")
+
+  # Only add the Pythonic version if it is in the list
+  if (example IN_LIST EXAMPLES_API_PYTHON_PYTHONIC)
+    _add_python_test(${example} "api/python/pythonic")
+  endif()
 endfunction()
 
 foreach(example ${EXAMPLES_API_PYTHON})


### PR DESCRIPTION
The new version of the Pythonic API ensures that each `Context` has its own `TermManager`, and that every object uses the correct `Context`. This fixes #11941.

Additionally, this PR adds tests for the Pythonic versions of the examples to ensure they continue to work correctly after future changes.