### PR TITLE
Remove deprecated table-based license key from pyproject.toml

### DIFF
--- a/.github/workflows/package_pypi.yml
+++ b/.github/workflows/package_pypi.yml
@@ -93,7 +93,6 @@ jobs:
           sed -e 's/^name="cvc5"$/name="cvc5-gpl"/' \
               -e 's/^\(description=".*\)"/\1 (GPL version)"/' \
               -e 's/^\(readme = {text = ".*\)\(", content-type = "text\/plain"\)/\1 (GPL version)\2/' \
-              -e 's/^license = {text = "/license = {text = "GPL-2.0-or-later AND GPL-3.0-or-later AND /' \
               ./src/api/python/pyproject.toml > ./build/src/api/python/pyproject.toml
         else
           sed -e 's/^\(description=".*\)"/\1 (BSD version)"/' \

--- a/src/api/python/pyproject.toml
+++ b/src/api/python/pyproject.toml
@@ -16,12 +16,6 @@ name="cvc5"
 description="Python bindings for cvc5"
 readme = {text = "Python bindings for cvc5", content-type = "text/plain"}
 dynamic = ["version"]
-license = {text = "BSD-3-Clause AND LGPL-3.0-or-later AND MIT"}
-# BSD-3-Clause      : cvc5 library and Python API
-# GPL-2.0-or-later  : CLN (only in GPL version)
-# GPL-3.0-or-later  : GLPK/glpk-cut-log and CoCoA (only in GPL version)
-# LGPL-3.0-or-later : LibPoly and GMP
-# MIT               : Pythonic API
 
 [project.urls]
 Homepage = "https://cvc5.github.io/"


### PR DESCRIPTION
Table-based license keys of the form `license = {text = "<license-string>"}` are deprecated in recent versions of Setuptools and will no longer be supported after 2026-02-18. According to PEP 639, the value for the license key must now be a simple string containing an SPDX expression.

However, this new format is only supported by Setuptools >= 77.0.0, which requires Python >= 3.9. To maintain compatibility with Python 3.7 and 3.8, as well as newer versions of Setuptools, this PR removes the optional license key entirely and relies solely on the license files included in the Python wheels to convey licensing information.

Refer to pypa/setuptools#4903 for a discussion of this change.