### PR TITLE
cmake: Always set --build option when building GMP, CLN, and GLPK

### DIFF
--- a/cmake/FindCLN.cmake
+++ b/cmake/FindCLN.cmake
@@ -112,6 +112,8 @@ if(NOT CLN_FOUND_SYSTEM)
         env "CFLAGS=--target=${TOOLCHAIN_PREFIX}"
         env "LDFLAGS=-arch ${CMAKE_OSX_ARCHITECTURES}")
     endif()
+  else()
+    set(CONFIGURE_OPTS --build=${BUILD_TRIPLET}) # Defined in Helpers
   endif()
 
   set(CLN_WITH_GMP)

--- a/cmake/FindGLPK.cmake
+++ b/cmake/FindGLPK.cmake
@@ -96,6 +96,8 @@ if(NOT GLPK_FOUND_SYSTEM)
         env "CFLAGS=--target=${TOOLCHAIN_PREFIX}"
         env "LDFLAGS=-arch ${CMAKE_OSX_ARCHITECTURES}")
     endif()
+  else()
+    set(CONFIGURE_OPTS --build=${BUILD_TRIPLET}) # Defined in Helpers
   endif()
 
   ExternalProject_Add(

--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -121,6 +121,8 @@ if(NOT GMP_FOUND_SYSTEM)
         env "LDFLAGS=-arch ${CMAKE_OSX_ARCHITECTURES}")
       set(GMP_CFLAGS "${GMP_CFLAGS} --target=${TOOLCHAIN_PREFIX}")
     endif()
+  else()
+    set(CONFIGURE_OPTS --build=${BUILD_TRIPLET}) # Defined in Helpers
   endif()
   set(CONFIGURE_ENV ${CONFIGURE_ENV} env "CFLAGS=${GMP_CFLAGS}")
 

--- a/cmake/Helpers.cmake
+++ b/cmake/Helpers.cmake
@@ -20,6 +20,30 @@ if(NOT WIN32)
   set(ResetColor "${Esc}[m")
 endif()
 
+# Build triplet used when compiling GMP, CLN, and GLPK to ensure that
+# optimizations using very specific CPU instructions are not enabled.
+# This makes the binary more portable.
+set(BUILD_TRIPLET "${CMAKE_HOST_SYSTEM_PROCESSOR}")
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+  if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    set(BUILD_TRIPLET "x86_64-linux-gnu")
+  elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
+    set(BUILD_TRIPLET "aarch64-linux-gnu")
+  endif()
+elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
+  if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    set(BUILD_TRIPLET "x86_64-apple-darwin")
+  elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
+    set(BUILD_TRIPLET "arm64-apple-darwin")
+  endif()
+elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+  if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    set(BUILD_TRIPLET "x86_64-w64-mingw32")
+  elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
+    set(BUILD_TRIPLET "aarch64-w64-mingw32")
+  endif()
+endif()
+
 # Add a C flag to the global list of C flags.
 macro(add_c_flag flag)
   if(CMAKE_C_FLAGS)


### PR DESCRIPTION
It always sets the `--build` option when compiling GMP, CLN, and GLPK to ensure that optimizations using very specific CPU instructions are not enabled. This makes the binary more portable.

Fixes #11858