### PR TITLE
Modify regression

### DIFF
--- a/test/regress/cli/regress0/proofs/issue8983-trust-subs.smt2
+++ b/test/regress/cli/regress0/proofs/issue8983-trust-subs.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE: --proof-granularity=theory-rewrite
 ; EXPECT: unsat
 (set-logic ALL)
 (assert (= 0 (div 0 0)))


### PR DESCRIPTION
We now enable dsl-proofs by default, the option set on this regression now weakens it, this reverts this.