### PR TITLE
Remove spurious assertion for HO models

### DIFF
--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -782,8 +782,8 @@ std::vector< Node > TheoryModel::getFunctionsToAssign() {
     {
       continue;
     }
-    // should not have been solved for in a substitution
-    Assert(d_env.getTopLevelSubstitutions().apply(n) == n);
+    // Note that d_env.getTopLevelSubstitutions().apply(n) may not be n
+    // if we are in incremenal mode.
     if (hasAssignedFunctionDefinition(n))
     {
       continue;

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1521,6 +1521,7 @@ set(regress_0_tests
   regress0/push-pop/inc-define.smt2
   regress0/push-pop/inc-double-u.smt2
   regress0/push-pop/incremental-subst-bug.cvc.smt2
+  regress0/push-pop/issue11934-ho-uf.smt2
   regress0/push-pop/issue1986.smt2
   regress0/push-pop/issue2137.min.smt2
   regress0/push-pop/issue6535-inc-solve.smt2

--- a/test/regress/cli/regress0/push-pop/issue11934-ho-uf.smt2
+++ b/test/regress/cli/regress0/push-pop/issue11934-ho-uf.smt2
@@ -1,0 +1,10 @@
+; COMMAND-LINE: -i
+; EXPECT: sat
+; EXPECT: sat
+(set-logic HO_ALL)
+(declare-fun a (Int Int) Int)
+(declare-fun d () Int)
+(assert (= (a d 0) (a 0 0)))
+(check-sat)
+(assert (= d 0))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/11934.  Removes an assertion for HO in incremental mode.

Substitutions in incremental mode may apply to nodes that appear in assertions, so the assertion was wrong.