### PR TITLE
Modify CPC definition of quantifiers rules to avoid eo::match

### DIFF
--- a/proofs/eo/cpc/rules/Quantifiers.eo
+++ b/proofs/eo/cpc/rules/Quantifiers.eo
@@ -167,6 +167,7 @@
 ; args:
 ; - Q (-> @List Bool Bool): The binding operator (forall or exists).
 ; - F Bool: The formula for which we are merging prenexes.
+; - y @List: The list of variables we have accumulated so far.
 ; return: the result of merging all bound variables bound by Q in F.
 (program $mk_quant_merge_prenex ((Q (-> @List Bool Bool)) (x @List) (y @List) (F Bool))
   :signature ((-> @List Bool Bool) Bool @List) Bool

--- a/proofs/eo/cpc/rules/Quantifiers.eo
+++ b/proofs/eo/cpc/rules/Quantifiers.eo
@@ -139,7 +139,7 @@
 ; - Q (-> @List Bool Bool): The quantifier, expected to be forall or exists.
 ; - x @List: The list of variables of the quantified formula.
 ; - F Bool: The body of the quantified formula.
-; return: The quantified formula (Q x F), or just F is x is the empty list.
+; return: The quantified formula (Q x F), or just F if x is the empty list.
 (program $mk_quant ((Q (-> @List Bool Bool)) (x @List) (F Bool))
   :signature ((-> @List Bool Bool) @List Bool) Bool
   (

--- a/proofs/eo/cpc/rules/Quantifiers.eo
+++ b/proofs/eo/cpc/rules/Quantifiers.eo
@@ -58,17 +58,17 @@
 ; rule: alpha_equiv
 ; implements: ProofRule::ALPHA_EQUIV.
 ; args:
-; - B Bool: The formula to apply to alpha equivalence to.
+; - t T: The term to apply to alpha equivalence to.
 ; - vs @List: The list of variables to substitute from.
 ; - ts @List: The list of (renamed) variables to substitute into.
-; requires: B does not contain any occurence of the range variables ts.
+; requires: t does not contain any occurence of the range variables ts.
 ; conclusion: >
 ;   The result of applying the substitution specified by vs and ts to
-;   B. The substitution is valid renaming due to the requirement check.
-(declare-rule alpha_equiv ((B Bool) (vs @List) (ts @List))
-  :args (B vs ts)
-  :requires ((($contains_aterm_list B ts) false))
-  :conclusion (= B ($substitute_simul B vs ts))
+;   t. The substitution is valid renaming due to the requirement check.
+(declare-rule alpha_equiv ((T Type) (t T) (vs @List) (ts @List))
+  :args (t vs ts)
+  :requires ((($contains_aterm_list t ts) false))
+  :conclusion (= t ($substitute_simul t vs ts))
 )
 
 ; rule: beta-reduce
@@ -134,19 +134,19 @@
   )
 )
 
-; program: $mk_quant_unused_vars
+; program: $mk_quant
 ; args:
 ; - Q (-> @List Bool Bool): The quantifier, expected to be forall or exists.
 ; - x @List: The list of variables of the quantified formula.
 ; - F Bool: The body of the quantified formula.
-; return: the result of removing duplicate and unused variables from x.
-(define $mk_quant_unused_vars ((Q (-> @List Bool Bool)) (x @List) (F Bool))
-  (eo::match ((y @List))
-    ($mk_quant_unused_vars_rec x F)
-    (
-      (@list.nil F)
-      (y (Q y F))
-    )))
+; return: The quantified formula (Q x F), or just F is x is the empty list.
+(program $mk_quant ((Q (-> @List Bool Bool)) (x @List) (F Bool))
+  :signature ((-> @List Bool Bool) @List Bool) Bool
+  (
+  (($mk_quant Q @list.nil F) F)
+  (($mk_quant Q x F) (Q x F))
+  )
+)
 
 ; rule: quant-unused-vars
 ; implements: ProofRewriteRule::QUANT_UNUSED_VARS
@@ -157,7 +157,7 @@
 ; conclusion: The given equality.
 (declare-rule quant-unused-vars ((Q (-> @List Bool Bool)) (x @List) (F Bool) (G Bool))
   :args ((= (Q x F) G))
-  :requires ((($mk_quant_unused_vars Q x F) G))
+  :requires ((($mk_quant Q ($mk_quant_unused_vars_rec x F) F) G))
   :conclusion (= (Q x F) G)
 )
 
@@ -168,14 +168,11 @@
 ; - Q (-> @List Bool Bool): The binding operator (forall or exists).
 ; - F Bool: The formula for which we are merging prenexes.
 ; return: the result of merging all bound variables bound by Q in F.
-(program $mk_quant_merge_prenex ((Q (-> @List Bool Bool)) (x @List) (F Bool))
-  :signature ((-> @List Bool Bool) Bool) Bool
+(program $mk_quant_merge_prenex ((Q (-> @List Bool Bool)) (x @List) (y @List) (F Bool))
+  :signature ((-> @List Bool Bool) Bool @List) Bool
   (
-  (($mk_quant_merge_prenex Q (Q x F))  (eo::match ((R (-> @List Bool Bool)) (y @List) (G Bool))
-                                         ($mk_quant_merge_prenex Q F)
-                                         ; note that since this method returns Q terms only, R is Q
-                                         (((R y G) (Q (eo::list_concat @list x y) G)))))
-  (($mk_quant_merge_prenex Q F)        (Q @list.nil F))
+  (($mk_quant_merge_prenex Q (Q x F) y)  ($mk_quant_merge_prenex Q F (eo::list_concat @list y x)))
+  (($mk_quant_merge_prenex Q F y)        (Q y F))
   )
 )
 
@@ -190,7 +187,7 @@
 (declare-rule quant-merge-prenex ((Q (-> @List Bool Bool)) (x @List) (F Bool) (G Bool))
   :args ((= (Q x F) G))
   :requires (((eo::or (eo::eq Q forall) (eo::eq Q exists)) true)
-             (($mk_quant_merge_prenex Q (Q x F)) G))
+             (($mk_quant_merge_prenex Q (Q x F) @list.nil) G))
   :conclusion (= (Q x F) G)
 )
 


### PR DESCRIPTION
Also fixes a minor fix to the types in the alpha equivalence rule.