### PR TITLE
ff: fix bitsum rewriter

### DIFF
--- a/src/theory/ff/theory_ff_rewriter.cpp
+++ b/src/theory/ff/theory_ff_rewriter.cpp
@@ -198,7 +198,7 @@ Node TheoryFiniteFieldsRewriter::postRewriteFfBitsum(TNode t)
   {
     if (child.isConst())
     {
-      acc = acc + child.getConst<FiniteFieldValue>();
+      acc = acc + multiplier * child.getConst<FiniteFieldValue>();
     }
     else
     {

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -844,6 +844,7 @@ set(regress_0_tests
   regress0/ff/as.smt2
   regress0/ff/bigff_is_zero_sound.smt2
   regress0/ff/bigff_is_zero_unsound.smt2
+  regress0/ff/bitsum_eval.smt2
   regress0/ff/bool_nary_or_sound.smt2
   regress0/ff/bool_nary_or_unsound.smt2
   regress0/ff/combination.smt2
@@ -860,6 +861,7 @@ set(regress_0_tests
   regress0/ff/issue10937.smt2
   regress0/ff/issue11107.smt2
   regress0/ff/issue11932.smt2
+  regress0/ff/issue11969.smt2
   regress0/ff/proj-issue705.smt2
   regress0/ff/proj-issue748-safe.smt2
   regress0/ff/randcompile-sound-3i-5t-circ.smt2

--- a/test/regress/cli/regress0/ff/bitsum_eval.smt2
+++ b/test/regress/cli/regress0/ff/bitsum_eval.smt2
@@ -1,0 +1,16 @@
+; Some test for the bitsum rewriter
+; REQUIRES: cocoa
+; EXPECT: sat
+; COMMAND-LINE: --ff-solver split
+; COMMAND-LINE: --ff-solver gb
+(set-logic QF_FF)
+(set-info :smt-lib-version 2.6)
+(set-info :category "crafted")
+(assert (= (ff.bitsum #f0m3 #f0m3 #f0m3) #f0m3))
+(assert (= (ff.bitsum #f1m3 #f0m3 #f0m3) #f1m3))
+(assert (= (ff.bitsum #f0m3 #f1m3 #f0m3) #f2m3))
+(assert (= (ff.bitsum #f0m3 #f0m3 #f1m3) #f1m3))
+(assert (= (ff.bitsum #f0m3 #f1m3 #f1m3) #f0m3))
+(assert (= (ff.bitsum #f1m3 #f2m3 #f0m3) #f2m3))
+(check-sat)
+

--- a/test/regress/cli/regress0/ff/issue11969.smt2
+++ b/test/regress/cli/regress0/ff/issue11969.smt2
@@ -1,0 +1,14 @@
+; This file is from Merlin Sun
+; REQUIRES: cocoa
+; EXPECT: sat
+; COMMAND-LINE: --ff-solver split
+; COMMAND-LINE: --ff-solver gb
+(set-logic QF_FF)
+(set-info :smt-lib-version 2.6)
+(set-info :category "crafted")
+(declare-const v (_ FiniteField 3))
+; v = v^2 + 2*(-1)
+(assert (= v (ff.bitsum (ff.mul v v) (as ff-1 (_ FiniteField 3)))))
+; 0 = v^2 - v - 2 = (v + 1)(v - 2)
+; models are 1 and 2
+(check-sat)


### PR DESCRIPTION
It was multiplying each term t_i by 1 instead of 2^i.

Credits to Merlin Sun for finding the problem. This bug was introduced by me in my last patch when I implemented the rewriter for ff.bitsum.

fixes #11969