### PR TITLE
Pin Cython to versions < 3.1.2

### DIFF
--- a/cmake/FindCython.cmake
+++ b/cmake/FindCython.cmake
@@ -64,7 +64,7 @@ if (Cython_VERSION_CHECK_RESULT EQUAL 0)
               if(ENABLE_AUTO_DOWNLOAD)
                 message(STATUS "Upgrading module Cython")
                 execute_process(COMMAND
-                  ${Python_EXECUTABLE} -m pip install Cython -U
+                  ${Python_EXECUTABLE} -m pip install "Cython<3.1.2" -U
                   RESULT_VARIABLE CYTHON_INSTALL_CMD_EXIT_CODE
                 )
                 if(CYTHON_INSTALL_CMD_EXIT_CODE)
@@ -86,7 +86,7 @@ else()
   if(ENABLE_AUTO_DOWNLOAD)
     message(STATUS "Installing module Cython")
     execute_process(
-      COMMAND ${Python_EXECUTABLE} -m pip install Cython
+      COMMAND ${Python_EXECUTABLE} -m pip install "Cython<3.1.2"
       RESULT_VARIABLE CYTHON_INSTALL_CMD_EXIT_CODE)
     if(CYTHON_INSTALL_CMD_EXIT_CODE)
       message(${Cython_FIND_MODE} "Could not install module Cython")

--- a/src/api/python/pyproject.toml
+++ b/src/api/python/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "setuptools!=70.2.0; os_name == 'nt'",
     # Avoid issue #283: https://github.com/pypa/distutils/issues/283
     "setuptools<72.2.0; implementation_name == 'pypy'",
-    "Cython>=3",
+    "Cython>=3,<3.1.2",
     # Avoid issue #6867: https://github.com/cython/cython/issues/6867
     "Cython<3.1.0; implementation_name == 'pypy' and python_version < '3.9'"
 ]


### PR DESCRIPTION
This is a temporary fix for a unit test in the Python API that fails with Cython 3.1.2.

It fixes CI and nightly builds.