### PR TITLE
Add .sy file referenced on the cvc5 website

### DIFF
--- a/examples/api/smtlib/sygus-grammar.sy
+++ b/examples/api/smtlib/sygus-grammar.sy
@@ -1,0 +1,16 @@
+; The printed output for this example should look like:
+; (
+;   (define-fun id1 ((x Int)) Int (+ x (+ x (- x))))
+;   (define-fun id2 ((x Int)) Int x)
+;   (define-fun id3 ((x Int)) Int (+ x 0))
+;   (define-fun id4 ((x Int)) Int (+ x (+ x (- x))))
+; )
+
+(set-logic LIA)
+(synth-fun id1 ((x Int)) Int ((Start Int)) ((Start Int ((- x) (+ x Start)))))
+(synth-fun id2 ((x Int)) Int ((Start Int)) ((Start Int ((Variable Int) (- x) (+ x Start)))))
+(synth-fun id3 ((x Int)) Int ((Start Int)) ((Start Int (0 (- x) (+ x Start)))))
+(synth-fun id4 ((x Int)) Int ((Start Int)) ((Start Int ((- x) (+ x Start)))))
+(declare-var x Int)
+(constraint (= (id1 x) (id2 x) (id3 x) (id4 x) x))
+(check-synth)


### PR DESCRIPTION
cvc5 website lists this example [here](https://cvc5.github.io/docs/cvc5-1.0.0/examples/sygus-grammar.html), but the link to the file is broken.