### PR TITLE
Add portfolio-dry-run option

### DIFF
--- a/src/options/main_options.toml
+++ b/src/options/main_options.toml
@@ -186,6 +186,14 @@ name   = "Driver"
   help       = "Use internal portfolio mode based on the logic"
 
 [[option]]
+  name       = "portfolioDryRun"
+  category   = "expert"
+  long       = "portfolio-dry-run"
+  type       = "bool"
+  default    = "false"
+  help       = "Print the strategies that would be run with --use-portfolio, without executing them"
+
+[[option]]
   name       = "portfolioJobs"
   category   = "expert"
   long       = "portfolio-jobs=n"


### PR DESCRIPTION
This PR introduces the `--portfolio-dry-run` boolean flag, which can be used alongside `--use-portfolio`. When enabled, it prints the list of strategies that would be executed with `--use-portfolio`, without actually running them.

For example, running cvc5 with `--use-portfolio --portfolio-dry-run` on an SMT-LIB problem with logic `QF_LRA` currently results in the following output:
```
(portfolio "--miplib-trick --miplib-trick-subs=4 --use-approx --lemmas-on-replay-failure --replay-early-close-depth=4 --replay-lemma-reject-cut=128 --replay-reject-cut=512 --unconstrained-simp --use-soi" :timeout 0.166667)
(portfolio "--no-restrict-pivots --use-soi --new-prop --unconstrained-simp" :timeout 0.583333)
(portfolio "" :timeout 0)
```