### PR TITLE
Minor simplification of BV rewriter for xor simplification

### DIFF
--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -1030,11 +1030,9 @@ bool RewriteDbProofCons::proveInternalBase(const Node& eqi,
   }
   // non-well-typed equalities cannot be proven
   // also, variables cannot be rewritten
-  if (eqi.getTypeOrNull().isNull()
-      || (eqi[0].isVar() && !eqi[0].getTypeOrNull().isBoolean()))
+  if (eqi.getTypeOrNull().isNull())
   {
-    Trace("rpc-debug2") << "...fail ("
-                        << (eqi[0].isVar() ? "variable" : "ill-typed") << ")"
+    Trace("rpc-debug2") << "...fail (ill-typed)"
                         << std::endl;
     ProvenInfo& pi = d_pcache[eqi];
     idb = RewriteProofStatus::FAIL;

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1406,12 +1406,14 @@ set(regress_0_tests
   regress0/proofs/dd_ada_open.smt2
   regress0/proofs/dd_alpha_eq_qpattern.smt2
   regress0/proofs/dd_bug787_beta_reduce.smt2
+  regress0/proofs/dd_check_cc_bvxor_xsimp.smt2
   regress0/proofs/dd_fv-bvl.smt2
   regress0/proofs/dd_ic_macro-elim-shadow.smt2
   regress0/proofs/dd_ic_pf_764.smt2
   regress0/proofs/dd_int_check_bvnot_lam_value_norm.smt2
   regress0/proofs/dd_int_check_rec_elim_shadow.smt2
   regress0/proofs/dd_issue3481_beta_red.smt2
+  regress0/proofs/dd_BitsTricks-scala-9-xsimp.smt2
   regress0/proofs/dd_M301_array_norm_op.smt2
   regress0/proofs/dd_N627_fun_const.smt2
   regress0/proofs/dd_pf_739.smt2

--- a/test/regress/cli/regress0/proofs/dd_BitsTricks-scala-9-xsimp.smt2
+++ b/test/regress/cli/regress0/proofs/dd_BitsTricks-scala-9-xsimp.smt2
@@ -1,2 +1,4 @@
+; EXPECT: unsat
+(set-logic ALL)
 (assert (exists ((!2 (_ BitVec 32))) (not (= !2 (bvxor !2 (bvxor !2 !2))))))
 (check-sat)

--- a/test/regress/cli/regress0/proofs/dd_BitsTricks-scala-9-xsimp.smt2
+++ b/test/regress/cli/regress0/proofs/dd_BitsTricks-scala-9-xsimp.smt2
@@ -1,0 +1,2 @@
+(assert (exists ((!2 (_ BitVec 32))) (not (= !2 (bvxor !2 (bvxor !2 !2))))))
+(check-sat)

--- a/test/regress/cli/regress0/proofs/dd_check_cc_bvxor_xsimp.smt2
+++ b/test/regress/cli/regress0/proofs/dd_check_cc_bvxor_xsimp.smt2
@@ -1,2 +1,4 @@
+; EXPECT: unsat
+(set-logic ALL)
 (assert (distinct true (exists ((x (_ BitVec 4)) (s (_ BitVec 4))) (= (bvxor x s) (_ bv0 4)))))
 (check-sat)

--- a/test/regress/cli/regress0/proofs/dd_check_cc_bvxor_xsimp.smt2
+++ b/test/regress/cli/regress0/proofs/dd_check_cc_bvxor_xsimp.smt2
@@ -1,0 +1,2 @@
+(assert (distinct true (exists ((x (_ BitVec 4)) (s (_ BitVec 4))) (= (bvxor x s) (_ bv0 4)))))
+(check-sat)

--- a/test/regress/cli/regress0/proofs/dd_check_cc_bvxor_xsimp.smt2
+++ b/test/regress/cli/regress0/proofs/dd_check_cc_bvxor_xsimp.smt2
@@ -1,4 +1,7 @@
 ; EXPECT: unsat
 (set-logic ALL)
-(assert (distinct true (exists ((x (_ BitVec 4)) (s (_ BitVec 4))) (= (bvxor x s) (_ bv0 4)))))
+(declare-const _x (_ BitVec 1))
+(declare-const s (_ BitVec 64))
+(declare-const t (_ BitVec 64))
+(assert (distinct (= (bvxor s t) (bvand (bvxor s t) ((_ zero_extend 63) _x))) (exists ((x (_ BitVec 64))) (and (= t (bvxor x s)) (= x (bvand x ((_ zero_extend 63) _x)))))))
 (check-sat)


### PR DESCRIPTION
The BV rewriter was rewriting e.g. `(bvxor x x x)` to `(bvxor x #b0000)`, whereas it is more direct to rewrite to `x`.

This was leading to proof holes during RARE reconstruction, which would be forced to prove steps `x = (bvxor x #b0000)`, which would be skipped since `x` is a variable.

Adds 2 regressions minimized from SMT-LIB that demonstrate the issue.