### PR TITLE
Add ProofRule::CHAIN_M_RESOLUTION, disabled by default

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -586,7 +586,9 @@ enum ENUM(ProofRule)
   EVALUE(MACRO_RESOLUTION_TRUST),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Boolean -- N-ary Resolution + Factoring + Reordering**
+   * **Boolean -- Chain multiset resolution**
+   *
+   * This rule combines Resolution + Factoring + Reordering.
    *
    * .. math::
    *   \inferrule{C_1 \dots C_n \mid C, (pol_1 \dots pol_{n-1}), (L_1 \dots L_{n-1})}{C}
@@ -605,7 +607,7 @@ enum ENUM(ProofRule)
    *   C_i'`
    *
    * The result of the chain resolution is :math:`C`, which is equal, in its set
-   * representation, to :math:`C_n'`
+   * representation, to :math:`C_n'`.
    * \endverbatim
    */
   EVALUE(CHAIN_M_RESOLUTION),

--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -584,6 +584,31 @@ enum ENUM(ProofRule)
    * \endverbatim
    */
   EVALUE(MACRO_RESOLUTION_TRUST),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Boolean -- N-ary Resolution + Factoring + Reordering**
+   *
+   * .. math::
+   *   \inferrule{C_1 \dots C_n \mid C, (pol_1 \dots pol_{n-1}), (L_1 \dots L_{n-1})}{C}
+   *
+   * where
+   *
+   * - let :math:`C_1 \dots C_n` be nodes viewed as clauses, as defined in
+   *   :cpp:enumerator:`RESOLUTION <cvc5::ProofRule::RESOLUTION>`
+   * - let :math:`C_1 \diamond_{L,\mathit{pol}} C_2` represent the resolution of
+   *   :math:`C_1` with :math:`C_2` with pivot :math:`L` and polarity
+   *   :math:`pol`, as defined in
+   *   :cpp:enumerator:`RESOLUTION <cvc5::ProofRule::RESOLUTION>`
+   * - let :math:`C_1'` be equal, in its set representation, to :math:`C_1`,
+   * - for each :math:`i > 1`, let :math:`C_i'` be equal, in its set
+   *   representation, to :math:`C_{i-1} \diamond_{L_{i-1},\mathit{pol}_{i-1}}
+   *   C_i'`
+   *
+   * The result of the chain resolution is :math:`C`, which is equal, in its set
+   * representation, to :math:`C_n'`
+   * \endverbatim
+   */
+  EVALUE(CHAIN_M_RESOLUTION),
 
   /**
    * \verbatim embed:rst:leading-asterisk

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -53,6 +53,7 @@ const char* toString(ProofRule rule)
     case ProofRule::REORDERING: return "REORDERING";
     case ProofRule::MACRO_RESOLUTION: return "MACRO_RESOLUTION";
     case ProofRule::MACRO_RESOLUTION_TRUST: return "MACRO_RESOLUTION_TRUST";
+    case ProofRule::CHAIN_M_RESOLUTION: return "CHAIN_M_RESOLUTION";
     case ProofRule::SPLIT: return "SPLIT";
     case ProofRule::EQ_RESOLVE: return "EQ_RESOLVE";
     case ProofRule::MODUS_PONENS: return "MODUS_PONENS";

--- a/src/options/proof_options.toml
+++ b/src/options/proof_options.toml
@@ -128,6 +128,14 @@ name   = "Proof"
   help       = "the matching recursion limit for reconstructing proofs of theory rewrites"
 
 [[option]]
+  name       = "proofChainMRes"
+  category   = "expert"
+  long       = "proof-chain-m-res"
+  type       = "bool"
+  default    = "false"
+  help       = "Use chain multiset resolution"
+
+[[option]]
   name       = "proofRewriteRconsStepLimit"
   category   = "regular"
   long       = "proof-rewrite-rcons-step-limit=N"

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -495,6 +495,13 @@ Node ProofPostprocessCallback::expandMacros(ProofRule id,
     std::vector<Node> chainResArgs;
     chainResArgs.push_back(nm->mkNode(Kind::SEXPR, pols));
     chainResArgs.push_back(nm->mkNode(Kind::SEXPR, lits));
+    if (options().proof.proofChainMRes)
+    {
+      chainResArgs.insert(chainResArgs.begin(), args[0]);
+      cdp->addStep(
+          args[0], ProofRule::CHAIN_M_RESOLUTION, children, chainResArgs);
+      return args[0];
+    }
     Node chainConclusion = d_pc->checkDebug(
         ProofRule::CHAIN_RESOLUTION, children, chainResArgs, Node::null(), "");
     Trace("smt-proof-pp-debug") << "Original conclusion: " << args[0] << "\n";

--- a/src/theory/booleans/proof_checker.cpp
+++ b/src/theory/booleans/proof_checker.cpp
@@ -33,6 +33,7 @@ void BoolProofRuleChecker::registerTo(ProofChecker* pc)
   pc->registerChecker(ProofRule::CHAIN_RESOLUTION, this);
   pc->registerTrustedChecker(ProofRule::MACRO_RESOLUTION_TRUST, this, 3);
   pc->registerChecker(ProofRule::MACRO_RESOLUTION, this);
+  pc->registerChecker(ProofRule::CHAIN_M_RESOLUTION, this);
   pc->registerChecker(ProofRule::FACTORING, this);
   pc->registerChecker(ProofRule::REORDERING, this);
   pc->registerChecker(ProofRule::EQ_RESOLVE, this);
@@ -303,10 +304,9 @@ Node BoolProofRuleChecker::checkInternal(ProofRule id,
     Assert(args.size() == 2 * (children.size() - 1) + 1);
     return args[0];
   }
-  if (id == ProofRule::MACRO_RESOLUTION)
+  if (id == ProofRule::MACRO_RESOLUTION || id == ProofRule::CHAIN_M_RESOLUTION)
   {
     Assert(children.size() > 1);
-    Assert(args.size() == 2 * (children.size() - 1) + 1);
     Trace("bool-pfcheck") << "macro_res: " << args[0] << "\n" << push;
     NodeManager* nm = nodeManager();
     Node trueNode = nm->mkConst(true);
@@ -314,12 +314,22 @@ Node BoolProofRuleChecker::checkInternal(ProofRule id,
     std::vector<Node> lhsClause, rhsClause;
     Node lhsElim, rhsElim;
     std::vector<Node> pols, lits;
-    for (size_t i = 1, nargs = args.size(); i < nargs; i = i + 2)
+    if (id == ProofRule::MACRO_RESOLUTION)
     {
-      pols.push_back(args[i]);
-      lits.push_back(args[i + 1]);
+      Assert(args.size() == 2 * (children.size() - 1) + 1);
+      for (size_t i = 1, nargs = args.size(); i < nargs; i = i + 2)
+      {
+        pols.push_back(args[i]);
+        lits.push_back(args[i + 1]);
+      }
     }
-
+    else
+    {
+      Assert(args.size() == 3);
+      Assert (id==ProofRule::CHAIN_M_RESOLUTION);
+      pols.insert(pols.end(), args[1].begin(), args[1].end());
+      lits.insert(lits.end(), args[2].begin(), args[2].end());
+    }
     if (children[0].getKind() != Kind::OR
         || (pols[0] == trueNode && children[0] == lits[0])
         || (pols[0] == falseNode && children[0] == lits[0].notNode()))


### PR DESCRIPTION
This adds the definition of a proposed addition to CPC which mimics the behavior of what is currently called `MACRO_RESOLTUION`.

In my initial tests, the use of this rule is significantly faster than an elaboration to chain resolution.

In a followup, we should eliminate MACRO_RESOLUTION / MACRO_RESOLUTION_TRUST in favor of this rule to avoid redundant work in the post processor.