### PR TITLE
Do not merge relevant domains of different type

### DIFF
--- a/src/theory/quantifiers/relevant_domain.cpp
+++ b/src/theory/quantifiers/relevant_domain.cpp
@@ -140,6 +140,7 @@ void RelevantDomain::compute(){
       unsigned sz = db->getNumGroundTerms( op );
       for( unsigned i=0; i<sz; i++ ){
         Node n = db->getGroundTerm(op, i);
+        Trace("rel-dom-debug") << "Consider " << n << std::endl;
         //if it is a non-redundant term
         if( db->isTermActive( n ) ){
           for( unsigned j=0; j<n.getNumChildren(); j++ ){
@@ -419,7 +420,7 @@ void RelevantDomain::computeRelevantDomainLit( Node q, bool hasPol, bool pol, No
             }
           }
         }
-        else if (!hasNonVar)
+        else if (!hasNonVar && var.getType()==var2.getType())
         {
           Assert(var2.hasAttribute(InstVarNumAttribute()));
           // merge the domains

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1598,6 +1598,7 @@ set(regress_0_tests
   regress0/quantifiers/issue11066-fresh-binders-err.smt2
   regress0/quantifiers/issue11751-prenex-norm.smt2
   regress0/quantifiers/issue11752-prenex-norm.smt2
+  regress0/quantifiers/issue11968-rd-typed.smt2
   regress0/quantifiers/issue2031-bv-var-elim.smt2
   regress0/quantifiers/issue2033-macro-arith.smt2
   regress0/quantifiers/issue2035.smt2

--- a/test/regress/cli/regress0/quantifiers/issue11968-rd-typed.smt2
+++ b/test/regress/cli/regress0/quantifiers/issue11968-rd-typed.smt2
@@ -1,0 +1,6 @@
+; COMMAND-LINE: --enum-inst --mbqi
+; EXPECT: unsat
+(set-logic ALL)
+(declare-fun r (Real) Int)
+(assert (forall ((x Real) (i Int)) (= (> x (to_real i)) (= 0 (r x)))))
+(check-sat)


### PR DESCRIPTION
Fixes #11968.

Adds `--mbqi` to the regression, which is necessary for solving it.