### PR TITLE
cadical: Do not notifySatLiteral on renotify_fixed.

### DIFF
--- a/src/prop/cadical.cpp
+++ b/src/prop/cadical.cpp
@@ -861,8 +861,6 @@ class CadicalPropagator : public CaDiCaL::ExternalPropagator,
     {
       Trace("cadical::propagator")
           << "re-enqueue (user pop): " << lit << std::endl;
-      // Make sure to pre-register the re-enqueued theory literal
-      d_proxy->notifySatLiteral(d_proxy->getNode(lit));
       // Re-enqueue fixed theory literal
       d_proxy->enqueueTheoryLiteral(lit);
       // We are notifying fixed literals at the current user level, update the

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1503,6 +1503,7 @@ set(regress_0_tests
   regress0/prop/cadical_bug5.smt2
   regress0/prop/cadical_bug6.smt2
   regress0/prop/cadical_bug7.smt2
+  regress0/prop/issue11867.smt2
   regress0/push-pop/boolean/fuzz_12.smt2
   regress0/push-pop/boolean/fuzz_13.smt2
   regress0/push-pop/boolean/fuzz_14.smt2

--- a/test/regress/cli/regress0/prop/issue11867.smt2
+++ b/test/regress/cli/regress0/prop/issue11867.smt2
@@ -1,0 +1,20 @@
+; COMMAND-LINE: -i --sat-solver=cadical
+; DISABLE-TESTER: proof
+; EXPECT: sat
+; EXPECT: sat
+(set-logic ALL)
+(declare-fun s () String)
+;
+(declare-fun a () Bool)
+(declare-fun b () Bool)
+(assert (or (not a) b))
+(assert (or (not b) a))
+(assert (or a b))
+; This part above is to force `a` to be a fixed assignment at user level 1,
+; so that the literal for `(= (str.len s) 0)` will be renotified and produce
+; the error
+(assert (or (not a) (= (str.len s) 0)))
+(push)
+(check-sat)
+(pop)
+(check-sat)


### PR DESCRIPTION
Fixes #11867.

When we get notified by CaDiCaL that a literal is fixed, it must already be preregistered (literals that are not introduced on user level 0 cannot be fixed). Thus, we don't have to notifySatLiteral() when renotifying the theory engine about fixed literals. This fix was tested on whole SMT-LIB, incremental and non-incremental.