### PR TITLE
ci: Tag latest as prerelease.

### DIFF
--- a/.github/actions/store-to-latest/action.yml
+++ b/.github/actions/store-to-latest/action.yml
@@ -37,7 +37,7 @@ runs:
           rel = repo.get_release('latest')
         except:
           print('New `latest` release')
-          rel = repo.create_git_release('latest', 'latest', 'Latest builds')
+          rel = repo.create_git_release('latest', 'latest', 'Latest builds', prerelease=True)
 
         # generate new filename
         package = os.getenv('PACKAGE')


### PR DESCRIPTION
We use a "latest" release that is updated with the assets of the latest commit on push to main. This "latest" release has been previously manually tagged as prerelease. This commit ensures that it is automatically tagged as prerelease if we ever delete the release and create it afresh.