### PR TITLE
OptionInfo: Revert change to field name.

### DIFF
--- a/include/cvc5/cvc5.h
+++ b/include/cvc5/cvc5.h
@@ -3356,7 +3356,7 @@ struct CVC5_EXPORT OptionInfo
    */
   [[deprecated(
       "Query cvc5::modes::OptionCategory category for EXPERT instead")]] bool
-      is_expert;
+      isExpert;
   /**
    * True if the option is a regular option
    * @warning This field is deprecated and replaced by `category`. It will be


### PR DESCRIPTION
Field `cvc5::OptionInfo::isExpert` was inadvertently renamed to `is_expert` in #11931. This reverts this change.