### PR TITLE
python: Suppress deprecation warnings related to OptionInfo

### DIFF
--- a/src/api/python/setup.py.in
+++ b/src/api/python/setup.py.in
@@ -67,7 +67,12 @@ else:
         'binding': False,
     }
 
-    extra_compile_args = ["-std=c++17", "-fno-var-tracking"]
+    extra_compile_args = [
+        "-std=c++17",
+        "-fno-var-tracking",
+        # Suppress deprecation warnings for deprecated members of OptionInfo
+        "-Wno-deprecated-declarations"
+    ]
 
     if sys.platform == 'win32':
         # Compile argument '-DMS_WIN64' fixes a division by zero error


### PR DESCRIPTION
PR #11931 introduced deprecation warnings for users of the cvc5 library. This PR suppresses those warnings when building the Python bindings for cvc5.