### PR TITLE
Do not filter output for the model-validation and unsat-cores tracks

### DIFF
--- a/contrib/competitions/smt-comp/run-script-smtcomp-current-model-validation
+++ b/contrib/competitions/smt-comp/run-script-smtcomp-current-model-validation
@@ -18,9 +18,5 @@ if [ -n "$2" ]; then
   out_file="$2/err.log"
 fi
 
-result="$({ $cvc5 -L smt2.6 --no-incremental --no-type-checking --no-interactive --fp-exp --use-portfolio $bench; } 2>&1)"
-case "$result" in
-  sat|unsat) echo "$result"; exit 0;;
-  *)         echo "$result" &> "$out_file";;
-esac
+$cvc5 -L smt2.6 --no-incremental --no-type-checking --no-interactive --fp-exp --use-portfolio $bench
 

--- a/contrib/competitions/smt-comp/run-script-smtcomp-current-unsat-cores
+++ b/contrib/competitions/smt-comp/run-script-smtcomp-current-unsat-cores
@@ -18,9 +18,5 @@ if [ -n "$2" ]; then
   out_file="$2/err.log"
 fi
 
-result="$({ $cvc5 -L smt2.6 --no-incremental --no-type-checking --no-interactive --fp-exp --use-portfolio $bench; } 2>&1)"
-case "$result" in
-  sat|unsat) echo "$result"; exit 0;;
-  *)         echo "$result" &> "$out_file";;
-esac
+$cvc5 -L smt2.6 --no-incremental --no-type-checking --no-interactive --fp-exp --use-portfolio $bench
 


### PR DESCRIPTION
We decided to use the same call to cvc5 for the single-query, model-validation, and unsat-cores tracks. PR #11882 implemented this by using a copy of the same script for all three tracks. However, we only want to filter the output for the single-query track. This PR updates the scripts for the model-validation and unsat-cores tracks to account for this difference.