### PR TITLE
Remove 'friend' declaration from Grammar class

### DIFF
--- a/include/cvc5/cvc5.h
+++ b/include/cvc5/cvc5.h
@@ -3120,7 +3120,6 @@ class CVC5_EXPORT Grammar
   friend class parser::Cmd;
   friend class Solver;
   friend struct std::hash<Grammar>;
-  friend std::ostream& operator<<(std::ostream& out, const Grammar& grammar);
 
  public:
   /**


### PR DESCRIPTION
The function `std::ostream& operator<<(std::ostream& out, const Grammar& grammar)` is currently declared twice:
- [Line 3123](https://github.com/cvc5/cvc5/blob/f38e07df08ce61358aa9a71df0ef5940fc1b1f3d/include/cvc5/cvc5.h#L3123): as a `friend` inside the `Grammar` class.
- [Line 3220](https://github.com/cvc5/cvc5/blob/f38e07df08ce61358aa9a71df0ef5940fc1b1f3d/include/cvc5/cvc5.h#L3220): as an external function with the `CVC5_EXPORT` attribute.

Since `operator<<` does not access any private or protected members of `Grammar`, the `friend` declaration is unnecessary. Moreover, declaring `operator<<` both with and without the `CVC5_EXPORT` attribute leads to compiler warnings in some versions of Clang on Windows.