### PR TITLE
More minor simplifications to declarations in Eunoia+CPC

### DIFF
--- a/proofs/eo/cpc/expert/CpcExpert.eo
+++ b/proofs/eo/cpc/expert/CpcExpert.eo
@@ -31,7 +31,7 @@
 (declare-const fmf.combined_card (-> Int Bool))
 
 ; Used in the --ho-elim preprocessing pass
-(declare-type @ho-elim-sort (Type))
+(declare-const @ho-elim-sort (-> Type Type))
 (declare-parameterized-const @fmf-fun-sort ((T Type :implicit)) (-> T Type))
 
 ; Dataypes shared selector

--- a/proofs/eo/cpc/expert/theories/Bags.eo
+++ b/proofs/eo/cpc/expert/theories/Bags.eo
@@ -6,7 +6,7 @@
 ; disclaimer: >
 ;   This sort is not in the SMT-LIB standard. All further
 ;   function symbols over this sort are also not part of the SMT-LIB standard.
-(declare-type Bag (Type))
+(declare-const Bag (-> Type Type))
 
 ; NOTE: permits non-set types
 (declare-parameterized-const bag.empty ((T Type :implicit)) (Bag T))

--- a/proofs/eo/cpc/expert/theories/FloatingPoints.eo
+++ b/proofs/eo/cpc/expert/theories/FloatingPoints.eo
@@ -3,10 +3,8 @@
 (include "../../theories/BitVectors.eo")
 
 ; note: We do not currently check whether the indices of this sort are positive.
-(declare-const FloatingPoint
-  (-> Int Int Type)
-)
-(declare-type RoundingMode ())
+(declare-const FloatingPoint (-> Int Int Type))
+(declare-const RoundingMode Type)
 
 ; A floating point constant is a term having 3 bitvector children.
 ; note: This is used for both FLOATINGPOINT_FP and CONST_FLOATINGPOINT.

--- a/proofs/eo/cpc/programs/PolyNorm.eo
+++ b/proofs/eo/cpc/programs/PolyNorm.eo
@@ -17,10 +17,10 @@
 ; Definitions of monomials and polynomials.
 ; A monomial is a list of terms that are ordered by `$compare_var` and a rational coefficient.
 ; A polynomial is a list of monomials whose monomials are ordered by `$compare_var`.
-(declare-type @Monomial ())
+(declare-const @Monomial Type)
 (declare-parameterized-const @mon ((T Type :implicit)) (-> T Real @Monomial))
 
-(declare-type @Polynomial ())
+(declare-const @Polynomial Type)
 (declare-const @poly.zero @Polynomial)
 (declare-const @poly (-> @Monomial @Polynomial @Polynomial) :right-assoc-nil @poly.zero)
 

--- a/proofs/eo/cpc/programs/Utils.eo
+++ b/proofs/eo/cpc/programs/Utils.eo
@@ -13,7 +13,7 @@
 (define $sgn ((T Type :implicit) (x T))
   (eo::ite (eo::is_neg x) -1 (eo::ite (eo::is_neg (eo::neg x)) 1 0)))
 
-(declare-type @Pair (Type Type))
+(declare-const @Pair (-> Type Type Type))
 (declare-parameterized-const @pair ((U Type :implicit) (T Type :implicit)) (-> U T (@Pair U T)))
 
 ; program: $pair_first

--- a/proofs/eo/cpc/theories/Arrays.eo
+++ b/proofs/eo/cpc/theories/Arrays.eo
@@ -1,6 +1,6 @@
 (include "../theories/Builtin.eo")
 
-(declare-type Array (Type Type))
+(declare-const Array (-> Type Type Type))
 
 ; Core operators.
 (declare-parameterized-const select ((U Type :implicit) (T Type :implicit))

--- a/proofs/eo/cpc/theories/BitVectors.eo
+++ b/proofs/eo/cpc/theories/BitVectors.eo
@@ -29,9 +29,7 @@
 
 (declare-parameterized-const extract ((n Int :implicit) (h Int) (l Int))
   (-> (BitVec n)
-      (BitVec (eo::requires (eo::gt (eo::add l 1) 0) true
-              (eo::requires (eo::gt n h) true
-                (eo::add h (eo::neg l) 1))))))
+      (BitVec (eo::add h (eo::neg l) 1))))
 
 (declare-parameterized-const repeat ((n Int :implicit) (i Int))
   (-> (BitVec n) (BitVec (eo::mul i n))))

--- a/proofs/eo/cpc/theories/Sets.eo
+++ b/proofs/eo/cpc/theories/Sets.eo
@@ -6,7 +6,7 @@
 ; disclaimer: >
 ;   This sort is not in the SMT-LIB standard. All further
 ;   function symbols over this sort are also not part of the SMT-LIB standard.
-(declare-type Set (Type))
+(declare-const Set (-> Type Type))
 
 ; Constants for the theory of sets.
 (declare-parameterized-const set.empty ((T Type :implicit)) (Set T))

--- a/proofs/eo/cpc/theories/Strings.eo
+++ b/proofs/eo/cpc/theories/Strings.eo
@@ -86,8 +86,6 @@
 ; disclaimer: This function is not in SMT-LIB.
 (declare-parameterized-const str.rev ((T Type :implicit)) (-> (Seq T) (Seq T)))
 ; disclaimer: This function is not in SMT-LIB.
-(declare-const str.unit (-> Int String))
-; disclaimer: This function is not in SMT-LIB.
 (declare-parameterized-const str.update ((T Type :implicit))
   (-> (Seq T) Int (Seq T) (Seq T)))
 ; disclaimer: This function is not in SMT-LIB.

--- a/proofs/eo/cpc/theories/Strings.eo
+++ b/proofs/eo/cpc/theories/Strings.eo
@@ -143,7 +143,7 @@
 (declare-parameterized-const seq.unit ((T Type :implicit)) (-> T (Seq T)))
 ; disclaimer: This function is not in SMT-LIB.
 (declare-parameterized-const seq.nth ((T Type :implicit))
-  (-> (Seq T) Int (eo::ite (eo::eq T Char) Int T)))
+  (-> (Seq T) Int T))
 
 ; Sequence operators are automatically translated to the string operators.
 ; disclaimer: This function is not in SMT-LIB.

--- a/proofs/eo/cpc/theories/Strings.eo
+++ b/proofs/eo/cpc/theories/Strings.eo
@@ -50,8 +50,13 @@
 ;   e.g. evaluation, strings require using string literals as their
 ;   values. In places where seq.empty can be used for a string or
 ;   sequence (e.g., RARE), we use this program to ensure this is the case.
-(define $seq_empty ((U Type))
-  (eo::ite (eo::is_eq U String) "" (as seq.empty U)))
+(program $seq_empty ((T Type))
+  :signature ((eo::quote T)) T
+  (
+  (($seq_empty String)  "")
+  (($seq_empty T)       (as seq.empty T))
+  )
+)
 
 ; Core functions of strings.
 (declare-parameterized-const str.len ((T Type :implicit)) (-> (Seq T) Int))


### PR DESCRIPTION
Cleans up constant definitions, including:
- eliminate remaining declare-type commands.
- eliminating eo::requires / eo::ite from types.  This includes reverting the change to the BV extract type rule (https://github.com/cvc5/cvc5/commit/bb321e300ef8547a4e4841521b841e2bc36abcbe).
- removing an unused (deprecated) const str.unit.