### PR TITLE
Java bindings: fix for performance bottleneck in Context

### DIFF
--- a/src/api/java/io/github/cvc5/AbstractPointer.java
+++ b/src/api/java/io/github/cvc5/AbstractPointer.java
@@ -30,6 +30,7 @@ abstract class AbstractPointer implements IPointer
   {
     if (pointer != 0)
     {
+      Context.removeAbstractPointer(this);
       deletePointer(pointer);
     }
     pointer = 0;

--- a/src/api/java/io/github/cvc5/Context.java
+++ b/src/api/java/io/github/cvc5/Context.java
@@ -45,8 +45,8 @@ public class Context
    */
   public static void deletePointers()
   {
-    var values = new LinkedList<AbstractPointer>(abstractPointers.values());
-    var i = values.descendingIterator();
+    LinkedList<AbstractPointer> values = new LinkedList<AbstractPointer>(abstractPointers.values());
+    Iterator<AbstractPointer> i = values.descendingIterator();
     while (i.hasNext()) {
       i.next().deletePointer();
     }

--- a/src/api/java/io/github/cvc5/Context.java
+++ b/src/api/java/io/github/cvc5/Context.java
@@ -15,19 +15,28 @@
 
 package io.github.cvc5;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Map;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.lang.Long;
 
 public class Context
 {
   // store pointers for terms, sorts, etc
-  private static List<AbstractPointer> abstractPointers = new ArrayList<>();
+
+  private static Map<Long, AbstractPointer> abstractPointers = new LinkedHashMap<>();
 
   static void addAbstractPointer(AbstractPointer pointer)
   {
-    if (!abstractPointers.contains(pointer))
-    {
-      abstractPointers.add(pointer);
+    abstractPointers.put(Long.valueOf(pointer.getPointer()), pointer);
+  }
+
+  /**
+   * Remove our record of a cpp pointer when it is deleted.
+   */
+  static void removeAbstractPointer(AbstractPointer pointer) {
+    if (pointer.getPointer() != 0) {
+      abstractPointers.remove(Long.valueOf(pointer.getPointer()));
     }
   }
 
@@ -36,10 +45,12 @@ public class Context
    */
   public static void deletePointers()
   {
-    for (int i = abstractPointers.size() - 1; i >= 0; i--)
-    {
-      abstractPointers.get(i).deletePointer();
+    var values = new LinkedList<AbstractPointer>(abstractPointers.values());
+    var i = values.descendingIterator();
+    while (i.hasNext()) {
+      i.next().deletePointer();
     }
+
     abstractPointers.clear();
   }
 }

--- a/src/api/java/io/github/cvc5/Context.java
+++ b/src/api/java/io/github/cvc5/Context.java
@@ -15,6 +15,7 @@
 
 package io.github.cvc5;
 
+import java.util.Iterator;
 import java.util.Map;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;


### PR DESCRIPTION
Replaces the AbstractPointer array with a LinkedHashMap, and removes elements when AbstractPointer.delete is called elsewhere to try to control the size of the map. 

Fix https://github.com/cvc5/cvc5/issues/12029