### PR TITLE
Introduce naming convention in CPC for internal data declarations

### DIFF
--- a/proofs/eo/cpc/Cpc.eo
+++ b/proofs/eo/cpc/Cpc.eo
@@ -355,7 +355,7 @@
 ;   particular, if t is an application of a known operator that has the property
 ;   of being either associative and commutative (resp. associative) we call
 ;   the method $get_ai_norm (resp. $get_a_norm), possibly wrapping the
-;   placeholder @aci_sorted.
+;   placeholder $aci_sorted.
 (program $get_aci_normal_form ((T Type) (x T)
                                (b1 Bool) (b2 Bool :list)
                                (r1 RegLan) (r2 RegLan :list)
@@ -363,13 +363,13 @@
                                (U Type) (xs1 (Seq U)) (xs2 (Seq U) :list))
   :signature (T) T
   (
-    (($get_aci_normal_form (or b1 b2))        (@aci_sorted or ($get_ai_norm (or b1 b2))))
-    (($get_aci_normal_form (and b1 b2))       (@aci_sorted and ($get_ai_norm (and b1 b2))))
-    (($get_aci_normal_form (re.union r1 r2))  (@aci_sorted re.union ($get_ai_norm (re.union r1 r2))))
-    (($get_aci_normal_form (re.inter r1 r2))  (@aci_sorted re.inter ($get_ai_norm (re.inter r1 r2))))
-    (($get_aci_normal_form (bvor xb1 xb2))    (@aci_sorted bvor ($get_ai_norm (bvor xb1 xb2))))
-    (($get_aci_normal_form (bvand xb1 xb2))   (@aci_sorted bvand ($get_ai_norm (bvand xb1 xb2))))
-    (($get_aci_normal_form (bvxor xb1 xb2))   (@aci_sorted bvxor ($get_a_norm (bvxor xb1 xb2))))
+    (($get_aci_normal_form (or b1 b2))        ($aci_sorted or ($get_ai_norm (or b1 b2))))
+    (($get_aci_normal_form (and b1 b2))       ($aci_sorted and ($get_ai_norm (and b1 b2))))
+    (($get_aci_normal_form (re.union r1 r2))  ($aci_sorted re.union ($get_ai_norm (re.union r1 r2))))
+    (($get_aci_normal_form (re.inter r1 r2))  ($aci_sorted re.inter ($get_ai_norm (re.inter r1 r2))))
+    (($get_aci_normal_form (bvor xb1 xb2))    ($aci_sorted bvor ($get_ai_norm (bvor xb1 xb2))))
+    (($get_aci_normal_form (bvand xb1 xb2))   ($aci_sorted bvand ($get_ai_norm (bvand xb1 xb2))))
+    (($get_aci_normal_form (bvxor xb1 xb2))   ($aci_sorted bvxor ($get_a_norm (bvxor xb1 xb2))))
     (($get_aci_normal_form (str.++ xs1 xs2))  ($get_a_norm (str.++ xs1 xs2)))
     (($get_aci_normal_form (re.++ r1 r2))     ($get_a_norm (re.++ r1 r2)))
     (($get_aci_normal_form (concat xb1 xb2))  ($get_a_norm (concat xb1 xb2)))

--- a/proofs/eo/cpc/Cpc.eo
+++ b/proofs/eo/cpc/Cpc.eo
@@ -82,10 +82,14 @@
 ;   All symbols prefixed by @ are not part of the SMT-LIB standard
 ;   and are used to model cvc5's internal symbols, including its skolems,
 ;   other internally introduced terms, and extensions.
+; disclaimer: >
+;   All symbols prefixed by @@ are furthermore used only internally to define
+;   this signature and will never appear in the conclusion of a proof.
 
 ; note: >
 ;   @const corresponds to generic abstract constants, which correspond to internally
 ;   introduced terms that do not have a formal definition in the signature.
+;   This symbol is intentionally unused in this signature.
 (declare-parameterized-const @const ((id Int :opaque) (T Type :opaque)) T)
 
 ; note: >

--- a/proofs/eo/cpc/Cpc.eo
+++ b/proofs/eo/cpc/Cpc.eo
@@ -60,6 +60,19 @@
 ; ./expert/CpcExpert.eo. This contains all definitions of theories and rules
 ; that are not supported by cvc5 when safe mode is enabled.
 ; 
+; Typically, we use $ as the prefix of symbols introduced by define and
+; program.  For clarity, we sometimes use @ as the prefix of symbols introduced
+; by simple define commands.
+;
+; All symbols introduced by declare-const and declare-parameterized-const that
+; are prefixed by @ are not part of the SMT-LIB standard and are used to model
+; cvc5's internal symbols, including its skolems, other internally introduced
+; terms, and extensions.
+;
+; Furthermote, all symbols prefixed by @@ are furthermore used only internally
+; to define this signature and will never appear in a formula that a proof
+; rule concludes, nor will it appear in a proof script.
+;
 ; =============================================================================
 
 (include "./rules/Builtin.eo")
@@ -82,9 +95,6 @@
 ;   All symbols prefixed by @ are not part of the SMT-LIB standard
 ;   and are used to model cvc5's internal symbols, including its skolems,
 ;   other internally introduced terms, and extensions.
-; disclaimer: >
-;   All symbols prefixed by @@ are furthermore used only internally to define
-;   this signature and will never appear in the conclusion of a proof.
 
 ; note: >
 ;   @const corresponds to generic abstract constants, which correspond to internally

--- a/proofs/eo/cpc/Cpc.eo
+++ b/proofs/eo/cpc/Cpc.eo
@@ -369,7 +369,7 @@
 ;   particular, if t is an application of a known operator that has the property
 ;   of being either associative and commutative (resp. associative) we call
 ;   the method $get_ai_norm (resp. $get_a_norm), possibly wrapping the
-;   placeholder $aci_sorted.
+;   placeholder @aci.sorted.
 (program $get_aci_normal_form ((T Type) (x T)
                                (b1 Bool) (b2 Bool :list)
                                (r1 RegLan) (r2 RegLan :list)
@@ -377,13 +377,13 @@
                                (U Type) (xs1 (Seq U)) (xs2 (Seq U) :list))
   :signature (T) T
   (
-    (($get_aci_normal_form (or b1 b2))        ($aci_sorted or ($get_ai_norm (or b1 b2))))
-    (($get_aci_normal_form (and b1 b2))       ($aci_sorted and ($get_ai_norm (and b1 b2))))
-    (($get_aci_normal_form (re.union r1 r2))  ($aci_sorted re.union ($get_ai_norm (re.union r1 r2))))
-    (($get_aci_normal_form (re.inter r1 r2))  ($aci_sorted re.inter ($get_ai_norm (re.inter r1 r2))))
-    (($get_aci_normal_form (bvor xb1 xb2))    ($aci_sorted bvor ($get_ai_norm (bvor xb1 xb2))))
-    (($get_aci_normal_form (bvand xb1 xb2))   ($aci_sorted bvand ($get_ai_norm (bvand xb1 xb2))))
-    (($get_aci_normal_form (bvxor xb1 xb2))   ($aci_sorted bvxor ($get_a_norm (bvxor xb1 xb2))))
+    (($get_aci_normal_form (or b1 b2))        (@aci.sorted or ($get_ai_norm (or b1 b2))))
+    (($get_aci_normal_form (and b1 b2))       (@aci.sorted and ($get_ai_norm (and b1 b2))))
+    (($get_aci_normal_form (re.union r1 r2))  (@aci.sorted re.union ($get_ai_norm (re.union r1 r2))))
+    (($get_aci_normal_form (re.inter r1 r2))  (@aci.sorted re.inter ($get_ai_norm (re.inter r1 r2))))
+    (($get_aci_normal_form (bvor xb1 xb2))    (@aci.sorted bvor ($get_ai_norm (bvor xb1 xb2))))
+    (($get_aci_normal_form (bvand xb1 xb2))   (@aci.sorted bvand ($get_ai_norm (bvand xb1 xb2))))
+    (($get_aci_normal_form (bvxor xb1 xb2))   (@aci.sorted bvxor ($get_a_norm (bvxor xb1 xb2))))
     (($get_aci_normal_form (str.++ xs1 xs2))  ($get_a_norm (str.++ xs1 xs2)))
     (($get_aci_normal_form (re.++ r1 r2))     ($get_a_norm (re.++ r1 r2)))
     (($get_aci_normal_form (concat xb1 xb2))  ($get_a_norm (concat xb1 xb2)))

--- a/proofs/eo/cpc/expert/CpcExpert.eo
+++ b/proofs/eo/cpc/expert/CpcExpert.eo
@@ -49,9 +49,9 @@
 (program $get_aci_normal_form_expert ((T Type) (x1 Bool) (x2 Bool :list) (m Int) (xf1 (FiniteField m)) (xf2 (FiniteField m) :list))
   :signature (T) T
   (
-    (($get_aci_normal_form_expert (sep x1 x2))       ($aci_sorted sep ($get_a_norm (sep x1 x2))))
-    (($get_aci_normal_form_expert (ff.add xf1 xf2))  ($aci_sorted ff.add ($get_a_norm (ff.add xf1 xf2))))
-    (($get_aci_normal_form_expert (ff.mul xf1 xf2))  ($aci_sorted ff.mul ($get_a_norm (ff.mul xf1 xf2))))
+    (($get_aci_normal_form_expert (sep x1 x2))       (@aci.sorted sep ($get_a_norm (sep x1 x2))))
+    (($get_aci_normal_form_expert (ff.add xf1 xf2))  (@aci.sorted ff.add ($get_a_norm (ff.add xf1 xf2))))
+    (($get_aci_normal_form_expert (ff.mul xf1 xf2))  (@aci.sorted ff.mul ($get_a_norm (ff.mul xf1 xf2))))
   )
 )
 

--- a/proofs/eo/cpc/expert/CpcExpert.eo
+++ b/proofs/eo/cpc/expert/CpcExpert.eo
@@ -49,9 +49,9 @@
 (program $get_aci_normal_form_expert ((T Type) (x1 Bool) (x2 Bool :list) (m Int) (xf1 (FiniteField m)) (xf2 (FiniteField m) :list))
   :signature (T) T
   (
-    (($get_aci_normal_form_expert (sep x1 x2))       (@aci_sorted sep ($get_a_norm (sep x1 x2))))
-    (($get_aci_normal_form_expert (ff.add xf1 xf2))  (@aci_sorted ff.add ($get_a_norm (ff.add xf1 xf2))))
-    (($get_aci_normal_form_expert (ff.mul xf1 xf2))  (@aci_sorted ff.mul ($get_a_norm (ff.mul xf1 xf2))))
+    (($get_aci_normal_form_expert (sep x1 x2))       ($aci_sorted sep ($get_a_norm (sep x1 x2))))
+    (($get_aci_normal_form_expert (ff.add xf1 xf2))  ($aci_sorted ff.add ($get_a_norm (ff.add xf1 xf2))))
+    (($get_aci_normal_form_expert (ff.mul xf1 xf2))  ($aci_sorted ff.mul ($get_a_norm (ff.mul xf1 xf2))))
   )
 )
 

--- a/proofs/eo/cpc/programs/AciNorm.eo
+++ b/proofs/eo/cpc/programs/AciNorm.eo
@@ -76,11 +76,11 @@
 )
 
 ; A placeholder that indicates that the given list can be sorted with respect
-; to operator f. For example, ($aci_sorted f t) indicates that t is an application
+; to operator f. For example, (@aci.sorted f t) indicates that t is an application
 ; of a commutative operator f. We show the equivalence of two applications marked
 ; in this way using the operator for multiset equality below.
 (declare-parameterized-const @@aci_sorted ((U Type :implicit) (T Type :implicit)) (-> U T T))
-(define $aci_sorted () @@aci_sorted)
+(define @aci.sorted () @@aci_sorted)
 
 ; program: $aci_norm_eq
 ; args:
@@ -91,8 +91,8 @@
   :signature (U U) Bool
   (
   (($aci_norm_eq t t) true)
-  (($aci_norm_eq ($aci_sorted f t) t) true)
-  (($aci_norm_eq ($aci_sorted f t) ($aci_sorted f s)) (eo::list_meq f t s))
+  (($aci_norm_eq (@aci.sorted f t) t) true)
+  (($aci_norm_eq (@aci.sorted f t) (@aci.sorted f s)) (eo::list_meq f t s))
   (($aci_norm_eq t s) false)
   )
 )

--- a/proofs/eo/cpc/programs/AciNorm.eo
+++ b/proofs/eo/cpc/programs/AciNorm.eo
@@ -76,10 +76,11 @@
 )
 
 ; A placeholder that indicates that the given list can be sorted with respect
-; to operator f. For example, (@aci_sorted f t) indicates that t is an application
+; to operator f. For example, ($aci_sorted f t) indicates that t is an application
 ; of a commutative operator f. We show the equivalence of two applications marked
 ; in this way using the operator for multiset equality below.
-(declare-parameterized-const @aci_sorted ((U Type :implicit) (T Type :implicit)) (-> U T T))
+(declare-parameterized-const @@aci_sorted ((U Type :implicit) (T Type :implicit)) (-> U T T))
+(define $aci_sorted () @@aci_sorted)
 
 ; program: $aci_norm_eq
 ; args:
@@ -90,8 +91,8 @@
   :signature (U U) Bool
   (
   (($aci_norm_eq t t) true)
-  (($aci_norm_eq (@aci_sorted f t) t) true)
-  (($aci_norm_eq (@aci_sorted f t) (@aci_sorted f s)) (eo::list_meq f t s))
+  (($aci_norm_eq ($aci_sorted f t) t) true)
+  (($aci_norm_eq ($aci_sorted f t) ($aci_sorted f s)) (eo::list_meq f t s))
   (($aci_norm_eq t s) false)
   )
 )

--- a/proofs/eo/cpc/programs/Nfa.eo
+++ b/proofs/eo/cpc/programs/Nfa.eo
@@ -2,68 +2,77 @@
 
 ; Declares a new sort which will be used to represent the states and transitions
 ; of the automaton.
-(declare-const @Nfa Type)
+(declare-const @@Nfa Type)
+(define $Nfa () @@Nfa)
 
 ; Declares a sort which represents a single character or a set of characters
 ; for an NFA transition.
-(define @nfa.char () String)
+(define $nfa_char () String)
 
 ; Declares the non-accepting trap state (also known as a sink state).
-(declare-const @nfa.decline @Nfa)
+(declare-const @@nfa_decline $Nfa)
+(define $nfa_decline () @@nfa_decline)
 
 ; This represents the terminal or final state of the NFA.
 ; A path in the NFA is accepting if it reaches this state.
-(declare-const @nfa.accept @Nfa)
+(declare-const @@nfa_accept $Nfa)
+(define $nfa_accept () @@nfa_accept)
 
 ; Declares a right-associative function to hold a list of states.
-(declare-const @nfa.list (-> @Nfa @Nfa @Nfa) :right-assoc-nil @nfa.decline)
+(declare-const @@nfa_list (-> $Nfa $Nfa $Nfa) :right-assoc-nil $nfa_decline)
+(define $nfa_list () @@nfa_list)
 
 ; Declares a function which takes a character condition and
 ; an NFA. This is the core construct for a state
 ; in the NFA. The first char argument specifies the character(s) for a transition
-; from this state. The second @Nfa argument is the next state upon a match.
-(declare-const @nfa.trans (-> @nfa.char @Nfa @Nfa))
+; from this state. The second $Nfa argument is the next state upon a match.
+(declare-const @@nfa_trans (-> $nfa_char $Nfa $Nfa))
+(define $nfa_trans () @@nfa_trans)
 
 ; Declares a transition that can be taken on any character.
-(declare-const @nfa.allchar @nfa.char)
+(declare-const @@nfa_allchar $nfa_char)
+(define $nfa_allchar () @@nfa_allchar)
 
 ; Creates a character set for a transition from a given range.
 ; The two Int arguments represent Unicode code points, allowing for ranges
 ; like 'a' to 'z' or any other character block.
-(declare-const @nfa.range (-> Int Int @nfa.char))
+(declare-const @@nfa_range (-> Int Int $nfa_char))
+(define $nfa_range () @@nfa_range)
 
 ; Represents a special epsilon transition that pushes the current state onto the stack.
 ; This is used to save the current position, for example, before entering a loop.
-(declare-const @nfa.push (-> @Nfa @Nfa))
+(declare-const @@nfa_push (-> $Nfa $Nfa))
+(define $nfa_push () @@nfa_push)
 
 ; Represents a special epsilon transition that pops a state from the stack.
 ; This is used to restore a saved state, for example, upon exiting a loop.
-(declare-const @nfa.pop (-> @Nfa @Nfa))
+(declare-const @@nfa_pop (-> $Nfa $Nfa))
+(define $nfa_pop () @@nfa_pop)
 
 ; This program recursively translates a regular expression (RegLan) into its
-; corresponding Nondeterministic Finite Automaton (@Nfa) representation.
+; corresponding Nondeterministic Finite Automaton ($Nfa) representation.
 ;
 ; program: $build_nfa
 ; args:
 ; - regex RegLan: The regular expression to translate.
-; - tail @Nfa: >
+; - tail $Nfa: >
 ; The tail represents the "rest of the automaton" that should be
 ; connected to the end of the NFA fragment currently being built. For example,
 ; when building the NFA for the regex "ab", the function first builds the NFA for "b"
 ; with the final accepting state as its tail. Then, it builds the NFA for "a", using 
 ; the just created NFA for "b" as its tail. This elegantly links the automaton parts together.
-; return: The @Nfa that was built from the regex.
-(program $build_nfa ((tail @Nfa) (s String) (r1 RegLan) (rr RegLan :list) (c0 String) (c1 String))
-  :signature (RegLan @Nfa) @Nfa
+; return: The $Nfa that was built from the regex.
+(program $build_nfa ((tail $Nfa) (s String) (r1 RegLan) (rr RegLan :list) (c0 String) (c1 String))
+  :signature (RegLan $Nfa) $Nfa
   (
-    (($build_nfa (re.* r1) tail) (eo::cons @nfa.list (@nfa.push ($build_nfa r1 (@nfa.list (@nfa.pop tail)))) tail))
-    (($build_nfa re.allchar tail) (@nfa.list (@nfa.trans @nfa.allchar tail)))
-    (($build_nfa re.none tail) (@nfa.list))
-    (($build_nfa (re.union r1 rr) tail) (eo::list_concat @nfa.list ($build_nfa r1 tail) ($build_nfa rr tail)))
+    (($build_nfa (re.* r1) tail) (eo::cons $nfa_list ($nfa_push ($build_nfa r1 ($nfa_list ($nfa_pop tail)))) tail))
+    (($build_nfa re.allchar tail) ($nfa_list ($nfa_trans $nfa_allchar tail)))
+    (($build_nfa re.none tail) ($nfa_list))
+    (($build_nfa (re.union r1 rr) tail) (eo::list_concat $nfa_list ($build_nfa r1 tail) ($build_nfa rr tail)))
     (($build_nfa (re.++ r1 rr) tail) ($build_nfa r1 ($build_nfa rr tail)))
     (($build_nfa @re.empty tail) tail)
-    (($build_nfa (re.range c0 c1) tail) (@nfa.list (@nfa.trans (@nfa.range (eo::to_z c0) (eo::to_z c1)) tail)))
-    (($build_nfa (str.to_re s) tail)  (@nfa.list (@nfa.trans (eo::extract s 0 0) ($build_nfa (str.to_re (eo::extract s 1 (eo::len s))) tail))))
+    (($build_nfa (re.range c0 c1) tail) ($nfa_list ($nfa_trans ($nfa_range (eo::to_z c0) (eo::to_z c1)) tail)))
+    (($build_nfa (str.to_re s) tail)  ($nfa_list ($nfa_trans (eo::extract s 0 0) ($build_nfa (str.to_re (eo::extract s 1 (eo::len s))) tail))))
     (($build_nfa re.all tail) ($build_nfa (re.* re.allchar) tail))
   )
 )
@@ -72,32 +81,32 @@
 ;
 ; This implementation extends the standard concept to handle special actions:
 ;  - It recursively follows all reachable states from the input states list.
-;  - It manages the @nfa.push and @nfa.pop actions by modifying the stack.
+;  - It manages the $nfa_push and $nfa_pop actions by modifying the stack.
 ;  - It avoids infinite loops by adding each unique state configuration to the
 ;    nexts set only once.
 ;
 ; program: $add_to_nexts
 ; args:
-; - states @Nfa:    The list of states to explore for epsilon transitions.
-; - stack @Nfa:     The current context stack, used for push and pop actions.
-; - nexts @Nfa:     The accumulating set of reachable states (the closure).
+; - states $Nfa:    The list of states to explore for epsilon transitions.
+; - stack $Nfa:     The current context stack, used for push and pop actions.
+; - nexts $Nfa:     The accumulating set of reachable states (the closure).
 ; return: The reachable states from the input states.
-(program $add_to_nexts ((t @Nfa) (st @Nfa) (tt @Nfa :list) (stt @Nfa :list) (nexts @Nfa))
-  :signature (@Nfa @Nfa @Nfa) @Nfa
+(program $add_to_nexts ((t $Nfa) (st $Nfa) (tt $Nfa :list) (stt $Nfa :list) (nexts $Nfa))
+  :signature ($Nfa $Nfa $Nfa) $Nfa
   (
-    (($add_to_nexts @nfa.decline st nexts) nexts)
-    (($add_to_nexts (@nfa.list (@nfa.push t) tt) st nexts) 
-      ($add_to_nexts tt st ($add_to_nexts t (eo::cons @nfa.list t st) nexts))
+    (($add_to_nexts $nfa_decline st nexts) nexts)
+    (($add_to_nexts ($nfa_list ($nfa_push t) tt) st nexts) 
+      ($add_to_nexts tt st ($add_to_nexts t (eo::cons $nfa_list t st) nexts))
     )
-    (($add_to_nexts (@nfa.list (@nfa.pop t) tt) (@nfa.list st stt) nexts)
-      (eo::ite (eo::is_neg (eo::list_find @nfa.list nexts (@nfa.list (@nfa.pop t) (@nfa.list st stt))))
-        ($add_to_nexts (eo::list_concat @nfa.list st tt) (@nfa.list st stt) (eo::cons @nfa.list (@nfa.list (@nfa.pop t) (@nfa.list st stt)) ($add_to_nexts t stt nexts)))
-        ($add_to_nexts tt (@nfa.list st stt) nexts)
+    (($add_to_nexts ($nfa_list ($nfa_pop t) tt) ($nfa_list st stt) nexts)
+      (eo::ite (eo::is_neg (eo::list_find $nfa_list nexts ($nfa_list ($nfa_pop t) ($nfa_list st stt))))
+        ($add_to_nexts (eo::list_concat $nfa_list st tt) ($nfa_list st stt) (eo::cons $nfa_list ($nfa_list ($nfa_pop t) ($nfa_list st stt)) ($add_to_nexts t stt nexts)))
+        ($add_to_nexts tt ($nfa_list st stt) nexts)
       )
     )
-    (($add_to_nexts (@nfa.list t tt) st nexts)
-      (eo::ite (eo::is_neg (eo::list_find @nfa.list nexts (@nfa.list t st)))
-        ($add_to_nexts tt st (eo::cons @nfa.list (@nfa.list t st) nexts))
+    (($add_to_nexts ($nfa_list t tt) st nexts)
+      (eo::ite (eo::is_neg (eo::list_find $nfa_list nexts ($nfa_list t st)))
+        ($add_to_nexts tt st (eo::cons $nfa_list ($nfa_list t st) nexts))
         ($add_to_nexts tt st nexts)
       )
     )
@@ -113,25 +122,25 @@
 ; args:
 ; - c String:              The character being evaluated in the current step.
 ; - s String:              The remaining part of the input string.
-; - current_states @Nfa:    The states the NFA is currently in. For each of these,
+; - current_states $Nfa:    The states the NFA is currently in. For each of these,
 ;                          the function checks for valid transitions based on the current character.
-; - next_states @Nfa:       An accumulating list of states the NFA will be in after the current character is processed.
+; - next_states $Nfa:       An accumulating list of states the NFA will be in after the current character is processed.
 ; return: True if the NFA accepts the string, false otherwise.
-(program $nfa_match ((c String) (s String) (nexts @Nfa) (tt @Nfa :list) (t @Nfa)
-                (st @Nfa) (z0 Int) (z1 Int))
-  :signature (@nfa.char String @Nfa @Nfa) Bool
+(program $nfa_match ((c String) (s String) (nexts $Nfa) (tt $Nfa :list) (t $Nfa)
+                (st $Nfa) (z0 Int) (z1 Int))
+  :signature ($nfa_char String $Nfa $Nfa) Bool
   (
-    (($nfa_match c s @nfa.decline @nfa.decline) false)
-    (($nfa_match c "" @nfa.decline nexts) (eo::not (eo::is_neg (eo::list_find @nfa.list nexts (@nfa.list @nfa.accept @nfa.decline)))))
-    (($nfa_match "" s t @nfa.decline) ($nfa_match "" s @nfa.decline ($add_to_nexts t @nfa.decline @nfa.decline)))
-    (($nfa_match c s @nfa.decline nexts) ($nfa_match (eo::extract s 0 0) (eo::extract s 1 (eo::len s)) nexts @nfa.decline))
-    (($nfa_match c s (@nfa.list (@nfa.list (@nfa.trans c t) st) tt) nexts)  ($nfa_match c s tt ($add_to_nexts t st nexts)))
-    (($nfa_match c s (@nfa.list (@nfa.list (@nfa.trans @nfa.allchar t) st) tt) nexts)  ($nfa_match c s tt ($add_to_nexts t st nexts)))
-    (($nfa_match c s (@nfa.list (@nfa.list (@nfa.trans (@nfa.range z0 z1) t) st) tt) nexts)
+    (($nfa_match c s $nfa_decline $nfa_decline) false)
+    (($nfa_match c "" $nfa_decline nexts) (eo::not (eo::is_neg (eo::list_find $nfa_list nexts ($nfa_list $nfa_accept $nfa_decline)))))
+    (($nfa_match "" s t $nfa_decline) ($nfa_match "" s $nfa_decline ($add_to_nexts t $nfa_decline $nfa_decline)))
+    (($nfa_match c s $nfa_decline nexts) ($nfa_match (eo::extract s 0 0) (eo::extract s 1 (eo::len s)) nexts $nfa_decline))
+    (($nfa_match c s ($nfa_list ($nfa_list ($nfa_trans c t) st) tt) nexts)  ($nfa_match c s tt ($add_to_nexts t st nexts)))
+    (($nfa_match c s ($nfa_list ($nfa_list ($nfa_trans $nfa_allchar t) st) tt) nexts)  ($nfa_match c s tt ($add_to_nexts t st nexts)))
+    (($nfa_match c s ($nfa_list ($nfa_list ($nfa_trans ($nfa_range z0 z1) t) st) tt) nexts)
       (eo::ite (eo::and ($compare_geq (eo::to_z c) z0) ($compare_geq z1 (eo::to_z c)))  
         ($nfa_match c s tt ($add_to_nexts t st nexts))
         ($nfa_match c s tt nexts))
     )
-    (($nfa_match c s (@nfa.list t tt) nexts)  ($nfa_match c s tt nexts))
+    (($nfa_match c s ($nfa_list t tt) nexts)  ($nfa_match c s tt nexts))
   )
 )

--- a/proofs/eo/cpc/programs/Nfa.eo
+++ b/proofs/eo/cpc/programs/Nfa.eo
@@ -3,76 +3,76 @@
 ; Declares a new sort which will be used to represent the states and transitions
 ; of the automaton.
 (declare-const @@Nfa Type)
-(define $Nfa () @@Nfa)
+(define @Nfa () @@Nfa)
 
 ; Declares a sort which represents a single character or a set of characters
 ; for an NFA transition.
-(define $nfa_char () String)
+(define @nfa.char () String)
 
 ; Declares the non-accepting trap state (also known as a sink state).
-(declare-const @@nfa_decline $Nfa)
-(define $nfa_decline () @@nfa_decline)
+(declare-const @@nfa_decline @Nfa)
+(define @nfa.decline () @@nfa_decline)
 
 ; This represents the terminal or final state of the NFA.
 ; A path in the NFA is accepting if it reaches this state.
-(declare-const @@nfa_accept $Nfa)
-(define $nfa_accept () @@nfa_accept)
+(declare-const @@nfa_accept @Nfa)
+(define @nfa.accept () @@nfa_accept)
 
 ; Declares a right-associative function to hold a list of states.
-(declare-const @@nfa_list (-> $Nfa $Nfa $Nfa) :right-assoc-nil $nfa_decline)
-(define $nfa_list () @@nfa_list)
+(declare-const @@nfa_list (-> @Nfa @Nfa @Nfa) :right-assoc-nil @nfa.decline)
+(define @nfa.list () @@nfa_list)
 
 ; Declares a function which takes a character condition and
 ; an NFA. This is the core construct for a state
 ; in the NFA. The first char argument specifies the character(s) for a transition
-; from this state. The second $Nfa argument is the next state upon a match.
-(declare-const @@nfa_trans (-> $nfa_char $Nfa $Nfa))
-(define $nfa_trans () @@nfa_trans)
+; from this state. The second @Nfa argument is the next state upon a match.
+(declare-const @@nfa_trans (-> @nfa.char @Nfa @Nfa))
+(define @nfa.trans () @@nfa_trans)
 
 ; Declares a transition that can be taken on any character.
-(declare-const @@nfa_allchar $nfa_char)
-(define $nfa_allchar () @@nfa_allchar)
+(declare-const @@nfa_allchar @nfa.char)
+(define @nfa.allchar () @@nfa_allchar)
 
 ; Creates a character set for a transition from a given range.
 ; The two Int arguments represent Unicode code points, allowing for ranges
 ; like 'a' to 'z' or any other character block.
-(declare-const @@nfa_range (-> Int Int $nfa_char))
-(define $nfa_range () @@nfa_range)
+(declare-const @@nfa_range (-> Int Int @nfa.char))
+(define @nfa.range () @@nfa_range)
 
 ; Represents a special epsilon transition that pushes the current state onto the stack.
 ; This is used to save the current position, for example, before entering a loop.
-(declare-const @@nfa_push (-> $Nfa $Nfa))
-(define $nfa_push () @@nfa_push)
+(declare-const @@nfa_push (-> @Nfa @Nfa))
+(define @nfa.push () @@nfa_push)
 
 ; Represents a special epsilon transition that pops a state from the stack.
 ; This is used to restore a saved state, for example, upon exiting a loop.
-(declare-const @@nfa_pop (-> $Nfa $Nfa))
-(define $nfa_pop () @@nfa_pop)
+(declare-const @@nfa_pop (-> @Nfa @Nfa))
+(define @nfa.pop () @@nfa_pop)
 
 ; This program recursively translates a regular expression (RegLan) into its
-; corresponding Nondeterministic Finite Automaton ($Nfa) representation.
+; corresponding Nondeterministic Finite Automaton (@Nfa) representation.
 ;
 ; program: $build_nfa
 ; args:
 ; - regex RegLan: The regular expression to translate.
-; - tail $Nfa: >
+; - tail @Nfa: >
 ; The tail represents the "rest of the automaton" that should be
 ; connected to the end of the NFA fragment currently being built. For example,
 ; when building the NFA for the regex "ab", the function first builds the NFA for "b"
 ; with the final accepting state as its tail. Then, it builds the NFA for "a", using 
 ; the just created NFA for "b" as its tail. This elegantly links the automaton parts together.
-; return: The $Nfa that was built from the regex.
-(program $build_nfa ((tail $Nfa) (s String) (r1 RegLan) (rr RegLan :list) (c0 String) (c1 String))
-  :signature (RegLan $Nfa) $Nfa
+; return: The @Nfa that was built from the regex.
+(program $build_nfa ((tail @Nfa) (s String) (r1 RegLan) (rr RegLan :list) (c0 String) (c1 String))
+  :signature (RegLan @Nfa) @Nfa
   (
-    (($build_nfa (re.* r1) tail) (eo::cons $nfa_list ($nfa_push ($build_nfa r1 ($nfa_list ($nfa_pop tail)))) tail))
-    (($build_nfa re.allchar tail) ($nfa_list ($nfa_trans $nfa_allchar tail)))
-    (($build_nfa re.none tail) ($nfa_list))
-    (($build_nfa (re.union r1 rr) tail) (eo::list_concat $nfa_list ($build_nfa r1 tail) ($build_nfa rr tail)))
+    (($build_nfa (re.* r1) tail) (eo::cons @nfa.list (@nfa.push ($build_nfa r1 (@nfa.list (@nfa.pop tail)))) tail))
+    (($build_nfa re.allchar tail) (@nfa.list (@nfa.trans @nfa.allchar tail)))
+    (($build_nfa re.none tail) (@nfa.list))
+    (($build_nfa (re.union r1 rr) tail) (eo::list_concat @nfa.list ($build_nfa r1 tail) ($build_nfa rr tail)))
     (($build_nfa (re.++ r1 rr) tail) ($build_nfa r1 ($build_nfa rr tail)))
     (($build_nfa @re.empty tail) tail)
-    (($build_nfa (re.range c0 c1) tail) ($nfa_list ($nfa_trans ($nfa_range (eo::to_z c0) (eo::to_z c1)) tail)))
-    (($build_nfa (str.to_re s) tail)  ($nfa_list ($nfa_trans (eo::extract s 0 0) ($build_nfa (str.to_re (eo::extract s 1 (eo::len s))) tail))))
+    (($build_nfa (re.range c0 c1) tail) (@nfa.list (@nfa.trans (@nfa.range (eo::to_z c0) (eo::to_z c1)) tail)))
+    (($build_nfa (str.to_re s) tail)  (@nfa.list (@nfa.trans (eo::extract s 0 0) ($build_nfa (str.to_re (eo::extract s 1 (eo::len s))) tail))))
     (($build_nfa re.all tail) ($build_nfa (re.* re.allchar) tail))
   )
 )
@@ -81,32 +81,32 @@
 ;
 ; This implementation extends the standard concept to handle special actions:
 ;  - It recursively follows all reachable states from the input states list.
-;  - It manages the $nfa_push and $nfa_pop actions by modifying the stack.
+;  - It manages the @nfa.push and @nfa.pop actions by modifying the stack.
 ;  - It avoids infinite loops by adding each unique state configuration to the
 ;    nexts set only once.
 ;
 ; program: $add_to_nexts
 ; args:
-; - states $Nfa:    The list of states to explore for epsilon transitions.
-; - stack $Nfa:     The current context stack, used for push and pop actions.
-; - nexts $Nfa:     The accumulating set of reachable states (the closure).
+; - states @Nfa:    The list of states to explore for epsilon transitions.
+; - stack @Nfa:     The current context stack, used for push and pop actions.
+; - nexts @Nfa:     The accumulating set of reachable states (the closure).
 ; return: The reachable states from the input states.
-(program $add_to_nexts ((t $Nfa) (st $Nfa) (tt $Nfa :list) (stt $Nfa :list) (nexts $Nfa))
-  :signature ($Nfa $Nfa $Nfa) $Nfa
+(program $add_to_nexts ((t @Nfa) (st @Nfa) (tt @Nfa :list) (stt @Nfa :list) (nexts @Nfa))
+  :signature (@Nfa @Nfa @Nfa) @Nfa
   (
-    (($add_to_nexts $nfa_decline st nexts) nexts)
-    (($add_to_nexts ($nfa_list ($nfa_push t) tt) st nexts) 
-      ($add_to_nexts tt st ($add_to_nexts t (eo::cons $nfa_list t st) nexts))
+    (($add_to_nexts @nfa.decline st nexts) nexts)
+    (($add_to_nexts (@nfa.list (@nfa.push t) tt) st nexts) 
+      ($add_to_nexts tt st ($add_to_nexts t (eo::cons @nfa.list t st) nexts))
     )
-    (($add_to_nexts ($nfa_list ($nfa_pop t) tt) ($nfa_list st stt) nexts)
-      (eo::ite (eo::is_neg (eo::list_find $nfa_list nexts ($nfa_list ($nfa_pop t) ($nfa_list st stt))))
-        ($add_to_nexts (eo::list_concat $nfa_list st tt) ($nfa_list st stt) (eo::cons $nfa_list ($nfa_list ($nfa_pop t) ($nfa_list st stt)) ($add_to_nexts t stt nexts)))
-        ($add_to_nexts tt ($nfa_list st stt) nexts)
+    (($add_to_nexts (@nfa.list (@nfa.pop t) tt) (@nfa.list st stt) nexts)
+      (eo::ite (eo::is_neg (eo::list_find @nfa.list nexts (@nfa.list (@nfa.pop t) (@nfa.list st stt))))
+        ($add_to_nexts (eo::list_concat @nfa.list st tt) (@nfa.list st stt) (eo::cons @nfa.list (@nfa.list (@nfa.pop t) (@nfa.list st stt)) ($add_to_nexts t stt nexts)))
+        ($add_to_nexts tt (@nfa.list st stt) nexts)
       )
     )
-    (($add_to_nexts ($nfa_list t tt) st nexts)
-      (eo::ite (eo::is_neg (eo::list_find $nfa_list nexts ($nfa_list t st)))
-        ($add_to_nexts tt st (eo::cons $nfa_list ($nfa_list t st) nexts))
+    (($add_to_nexts (@nfa.list t tt) st nexts)
+      (eo::ite (eo::is_neg (eo::list_find @nfa.list nexts (@nfa.list t st)))
+        ($add_to_nexts tt st (eo::cons @nfa.list (@nfa.list t st) nexts))
         ($add_to_nexts tt st nexts)
       )
     )
@@ -118,29 +118,29 @@
 ; The simulation moves character by character, with each step's next_states
 ; becoming the next step's current_states. The match is successful if an
 ; accepting state is reached at the end of the string.
-; program: $nfa_match
+; program: @nfa.match
 ; args:
 ; - c String:              The character being evaluated in the current step.
 ; - s String:              The remaining part of the input string.
-; - current_states $Nfa:    The states the NFA is currently in. For each of these,
+; - current_states @Nfa:    The states the NFA is currently in. For each of these,
 ;                          the function checks for valid transitions based on the current character.
-; - next_states $Nfa:       An accumulating list of states the NFA will be in after the current character is processed.
+; - next_states @Nfa:       An accumulating list of states the NFA will be in after the current character is processed.
 ; return: True if the NFA accepts the string, false otherwise.
-(program $nfa_match ((c String) (s String) (nexts $Nfa) (tt $Nfa :list) (t $Nfa)
-                (st $Nfa) (z0 Int) (z1 Int))
-  :signature ($nfa_char String $Nfa $Nfa) Bool
+(program @nfa.match ((c String) (s String) (nexts @Nfa) (tt @Nfa :list) (t @Nfa)
+                (st @Nfa) (z0 Int) (z1 Int))
+  :signature (@nfa.char String @Nfa @Nfa) Bool
   (
-    (($nfa_match c s $nfa_decline $nfa_decline) false)
-    (($nfa_match c "" $nfa_decline nexts) (eo::not (eo::is_neg (eo::list_find $nfa_list nexts ($nfa_list $nfa_accept $nfa_decline)))))
-    (($nfa_match "" s t $nfa_decline) ($nfa_match "" s $nfa_decline ($add_to_nexts t $nfa_decline $nfa_decline)))
-    (($nfa_match c s $nfa_decline nexts) ($nfa_match (eo::extract s 0 0) (eo::extract s 1 (eo::len s)) nexts $nfa_decline))
-    (($nfa_match c s ($nfa_list ($nfa_list ($nfa_trans c t) st) tt) nexts)  ($nfa_match c s tt ($add_to_nexts t st nexts)))
-    (($nfa_match c s ($nfa_list ($nfa_list ($nfa_trans $nfa_allchar t) st) tt) nexts)  ($nfa_match c s tt ($add_to_nexts t st nexts)))
-    (($nfa_match c s ($nfa_list ($nfa_list ($nfa_trans ($nfa_range z0 z1) t) st) tt) nexts)
+    ((@nfa.match c s @nfa.decline @nfa.decline) false)
+    ((@nfa.match c "" @nfa.decline nexts) (eo::not (eo::is_neg (eo::list_find @nfa.list nexts (@nfa.list @nfa.accept @nfa.decline)))))
+    ((@nfa.match "" s t @nfa.decline) (@nfa.match "" s @nfa.decline ($add_to_nexts t @nfa.decline @nfa.decline)))
+    ((@nfa.match c s @nfa.decline nexts) (@nfa.match (eo::extract s 0 0) (eo::extract s 1 (eo::len s)) nexts @nfa.decline))
+    ((@nfa.match c s (@nfa.list (@nfa.list (@nfa.trans c t) st) tt) nexts)  (@nfa.match c s tt ($add_to_nexts t st nexts)))
+    ((@nfa.match c s (@nfa.list (@nfa.list (@nfa.trans @nfa.allchar t) st) tt) nexts)  (@nfa.match c s tt ($add_to_nexts t st nexts)))
+    ((@nfa.match c s (@nfa.list (@nfa.list (@nfa.trans (@nfa.range z0 z1) t) st) tt) nexts)
       (eo::ite (eo::and ($compare_geq (eo::to_z c) z0) ($compare_geq z1 (eo::to_z c)))  
-        ($nfa_match c s tt ($add_to_nexts t st nexts))
-        ($nfa_match c s tt nexts))
+        (@nfa.match c s tt ($add_to_nexts t st nexts))
+        (@nfa.match c s tt nexts))
     )
-    (($nfa_match c s ($nfa_list t tt) nexts)  ($nfa_match c s tt nexts))
+    ((@nfa.match c s (@nfa.list t tt) nexts)  (@nfa.match c s tt nexts))
   )
 )

--- a/proofs/eo/cpc/programs/PolyNorm.eo
+++ b/proofs/eo/cpc/programs/PolyNorm.eo
@@ -17,58 +17,63 @@
 ; Definitions of monomials and polynomials.
 ; A monomial is a list of terms that are ordered by `$compare_var` and a rational coefficient.
 ; A polynomial is a list of monomials whose monomials are ordered by `$compare_var`.
-(declare-type @Monomial ())
-(declare-parameterized-const @mon ((T Type :implicit)) (-> T Real @Monomial))
+(declare-const @@Monomial Type)
+(define $Monomial () @@Monomial)
+(declare-parameterized-const @@mon ((T Type :implicit)) (-> T Real $Monomial))
+(define $mon () @@mon)
 
-(declare-type @Polynomial ())
-(declare-const @poly.zero @Polynomial)
-(declare-const @poly (-> @Monomial @Polynomial @Polynomial) :right-assoc-nil @poly.zero)
+(declare-const @@Polynomial Type)
+(define $Polynomial () @@Polynomial)
+(declare-const @@poly.zero $Polynomial)
+(define $poly_zero () @@Polynomial)
+(declare-const @@poly (-> $Monomial $Polynomial $Polynomial) :right-assoc-nil $poly_zero)
+(define $poly () @@poly)
 
 ; program: $poly_neg
 ; args:
-; - p @Polynomial: The polynomial to negate.
+; - p $Polynomial: The polynomial to negate.
 ; return: the negation of the given polynomial.
-(program $poly_neg ((T Type) (c Real) (a T) (p @Polynomial :list))
-  :signature (@Polynomial) @Polynomial
+(program $poly_neg ((T Type) (c Real) (a T) (p $Polynomial :list))
+  :signature ($Polynomial) $Polynomial
   (
-    (($poly_neg @poly.zero)           @poly.zero)
-    (($poly_neg (@poly (@mon a c) p)) (eo::cons @poly (@mon a (eo::neg c)) ($poly_neg p)))
+    (($poly_neg $poly_zero)           $poly_zero)
+    (($poly_neg ($poly ($mon a c) p)) (eo::cons $poly ($mon a (eo::neg c)) ($poly_neg p)))
   )
 )
 ; program: $poly_mod_coeffs
 ; args:
-; - p @Polynomial: The polynomial to modify.
+; - p $Polynomial: The polynomial to modify.
 ; - w Int: The modulus to consider
 ; return: the given polynomial where all coefficient are taken mod w.
-(program $poly_mod_coeffs ((T Type) (c Real) (a T) (p @Polynomial :list) (w Int))
-  :signature (@Polynomial Int) @Polynomial
+(program $poly_mod_coeffs ((T Type) (c Real) (a T) (p $Polynomial :list) (w Int))
+  :signature ($Polynomial Int) $Polynomial
   (
-    (($poly_mod_coeffs @poly.zero w)           @poly.zero)
-    (($poly_mod_coeffs (@poly (@mon a c) p) w) (eo::define ((newc (eo::zmod (eo::to_z c) w)))
+    (($poly_mod_coeffs $poly_zero w)           $poly_zero)
+    (($poly_mod_coeffs ($poly ($mon a c) p) w) (eo::define ((newc (eo::zmod (eo::to_z c) w)))
                                                (eo::ite (eo::eq newc 0)
                                                  ; if it becomes zero, it cancels
                                                  ($poly_mod_coeffs p w)
-                                                 (eo::cons @poly (@mon a (eo::to_q newc)) ($poly_mod_coeffs p w)))))
+                                                 (eo::cons $poly ($mon a (eo::to_q newc)) ($poly_mod_coeffs p w)))))
   )
 )
 
 ; program: $poly_add
 ; args:
-; - p1 @Polynomial: The first polynomial to add.
-; - p2 @Polynomial: The second polynomial to add.
+; - p1 $Polynomial: The first polynomial to add.
+; - p2 $Polynomial: The second polynomial to add.
 ; return: the addition of the given polynomials.
-(program $poly_add ((T Type) (U Type) (c1 Real) (a1 T) (c2 Real) (a2 U) (p @Polynomial) (p1 @Polynomial :list) (p2 @Polynomial :list))
-  :signature (@Polynomial @Polynomial) @Polynomial
+(program $poly_add ((T Type) (U Type) (c1 Real) (a1 T) (c2 Real) (a2 U) (p $Polynomial) (p1 $Polynomial :list) (p2 $Polynomial :list))
+  :signature ($Polynomial $Polynomial) $Polynomial
   (
-    (($poly_add (@poly (@mon a1 c1) p1) (@poly (@mon a2 c2) p2)) (eo::ite (eo::eq a1 a2)
+    (($poly_add ($poly ($mon a1 c1) p1) ($poly ($mon a2 c2) p2)) (eo::ite (eo::eq a1 a2)
                                                                   (eo::define ((ca (eo::add c1 c2)) (pa ($poly_add p1 p2)))
                                                                   ; check if cancels
-                                                                  (eo::ite (eo::eq ca 0/1) pa (eo::cons @poly (@mon a1 ca) pa)))
+                                                                  (eo::ite (eo::eq ca 0/1) pa (eo::cons $poly ($mon a1 ca) pa)))
                                                                 (eo::ite ($compare_var a1 a2)
-                                                                  (eo::cons @poly (@mon a1 c1) ($poly_add p1 (@poly (@mon a2 c2) p2)))
-                                                                  (eo::cons @poly (@mon a2 c2) ($poly_add (@poly (@mon a1 c1) p1) p2)))))
-    (($poly_add @poly.zero p)                                    p)
-    (($poly_add p @poly.zero)                                    p)
+                                                                  (eo::cons $poly ($mon a1 c1) ($poly_add p1 ($poly ($mon a2 c2) p2)))
+                                                                  (eo::cons $poly ($mon a2 c2) ($poly_add ($poly ($mon a1 c1) p1) p2)))))
+    (($poly_add $poly_zero p)                                    p)
+    (($poly_add p $poly_zero)                                    p)
   )
 )
 
@@ -99,64 +104,64 @@
 
 ; program: $mon_mul_mon
 ; args:
-; - a @Monomial: The first monomial to multiply.
-; - b @Monomial: The second monomial to multiply.
+; - a $Monomial: The first monomial to multiply.
+; - b $Monomial: The second monomial to multiply.
 ; return: the multiplication of the given monomials.
 (program $mon_mul_mon ((T Type) (U Type) (a1 T) (a2 U) (c1 Real) (c2 Real))
-  :signature (@Monomial @Monomial) @Monomial
+  :signature ($Monomial $Monomial) $Monomial
   (
-    (($mon_mul_mon (@mon a1 c1) (@mon a2 c2))  (@mon ($mvar_mul_mvar a1 a2) (eo::mul c1 c2)))
+    (($mon_mul_mon ($mon a1 c1) ($mon a2 c2))  ($mon ($mvar_mul_mvar a1 a2) (eo::mul c1 c2)))
   )
 )
 
 ; program: $poly_mul_mon
 ; args:
-; - a @Monomial: The monomial to multiply.
-; - p @Polynomial: The polynomial to multiply.
+; - a $Monomial: The monomial to multiply.
+; - p $Polynomial: The polynomial to multiply.
 ; return: the multiplication of the polynomial by a monomial.
-(program $poly_mul_mon ((m1 @Monomial) (m2 @Monomial) (p2 @Polynomial :list))
-  :signature (@Monomial @Polynomial) @Polynomial
+(program $poly_mul_mon ((m1 $Monomial) (m2 $Monomial) (p2 $Polynomial :list))
+  :signature ($Monomial $Polynomial) $Polynomial
   (
-    (($poly_mul_mon m1 (@poly m2 p2)) ($poly_add (@poly ($mon_mul_mon m1 m2)) ($poly_mul_mon m1 p2)))   ; NOTE: this amounts to an insertion sort
-    (($poly_mul_mon m1 @poly.zero)    @poly.zero)
+    (($poly_mul_mon m1 ($poly m2 p2)) ($poly_add ($poly ($mon_mul_mon m1 m2)) ($poly_mul_mon m1 p2)))   ; NOTE: this amounts to an insertion sort
+    (($poly_mul_mon m1 $poly_zero)    $poly_zero)
   )
 )
 
 ; program: $poly_mul
 ; args:
-; - p1 @Polynomial: The first polynomial to multiply.
-; - p2 @Polynomial: The second polynomial to multiply.
+; - p1 $Polynomial: The first polynomial to multiply.
+; - p2 $Polynomial: The second polynomial to multiply.
 ; return: the multiplication of the given polynomials.
-(program $poly_mul ((m @Monomial) (p1 @Polynomial :list) (p @Polynomial))
-  :signature (@Polynomial @Polynomial) @Polynomial
+(program $poly_mul ((m $Monomial) (p1 $Polynomial :list) (p $Polynomial))
+  :signature ($Polynomial $Polynomial) $Polynomial
   (
-    (($poly_mul (@poly m p1) p) ($poly_add ($poly_mul_mon m p) ($poly_mul p1 p)))
-    (($poly_mul @poly.zero p)   @poly.zero)
-    (($poly_mul p @poly.zero)   @poly.zero)
+    (($poly_mul ($poly m p1) p) ($poly_add ($poly_mul_mon m p) ($poly_mul p1 p)))
+    (($poly_mul $poly_zero p)   $poly_zero)
+    (($poly_mul p $poly_zero)   $poly_zero)
   )
 )
 
 ; program: $get_arith_poly_norm_div
 ; args:
 ; - a1 T: The numerator to process of type Int or Real.
-; - a1p @Polynomial: The normalization of a1.
+; - a1p $Polynomial: The normalization of a1.
 ; - a2 T: The denominator to process of type Int or Real.
 ; return: >
 ;   The polynomial corresponding to the (normalized) form of (/ a1 a2).
-(define $get_arith_poly_norm_div ((U Type :implicit) (V Type :implicit) (a1 U) (a1p @Polynomial) (a2 V))
+(define $get_arith_poly_norm_div ((U Type :implicit) (V Type :implicit) (a1 U) (a1p $Polynomial) (a2 V))
   (eo::define ((a2q (eo::to_q a2)))
   (eo::ite (eo::ite (eo::is_q a2q) (eo::not (eo::eq a2q 0/1)) false)
     ; if division by non-zero constant, we normalize
-    ($poly_mul_mon (@mon 1 (eo::qdiv 1/1 a2q)) a1p)
+    ($poly_mul_mon ($mon 1 (eo::qdiv 1/1 a2q)) a1p)
     ; otherwise it is treated as a variable
-    (@poly (@mon (* (/ a1 a2)) 1/1)))))
+    ($poly ($mon (* (/ a1 a2)) 1/1)))))
 
 ; program: $get_arith_poly_norm
 ; args:
 ; - a T: The arithmetic term to process of type Int or Real.
 ; return: the polynomial corresponding to the (normalized) form of a.
 (program $get_arith_poly_norm ((T Type) (U Type) (V Type) (a T) (a1 U) (a2 V :list))
-  :signature (T) @Polynomial
+  :signature (T) $Polynomial
   (
     (($get_arith_poly_norm (- a1))          ($poly_neg ($get_arith_poly_norm a1)))
     (($get_arith_poly_norm (+ a1 a2))       ($poly_add ($get_arith_poly_norm a1) ($get_arith_poly_norm a2)))
@@ -170,9 +175,9 @@
                                             (eo::ite (eo::is_q aq)
                                               ; if it is zero, it cancels, otherwise it is 1 with itself as coefficient
                                               (eo::ite (eo::is_eq aq 0/1)
-                                                @poly.zero
-                                                (@poly (@mon 1 aq)))
-                                            (@poly (@mon (* a) 1/1)))))    ; introduces list
+                                                $poly_zero
+                                                ($poly ($mon 1 aq)))
+                                            ($poly ($mon (* a) 1/1)))))    ; introduces list
   )
 )
 
@@ -181,7 +186,7 @@
 ; - b (BitVec m): The bitvector term to process.
 ; return: the polynomial corresponding to the (normalized) form of b, prior to taking mod of its coefficients.
 (program $get_bv_poly_norm_rec ((m Int) (b (BitVec m)) (b1 (BitVec m)) (b2 (BitVec m) :list))
-  :signature ((BitVec m)) @Polynomial
+  :signature ((BitVec m)) $Polynomial
   (
     (($get_bv_poly_norm_rec (bvneg b1))    ($poly_neg ($get_bv_poly_norm_rec b1)))
     (($get_bv_poly_norm_rec (bvadd b1 b2)) ($poly_add ($get_bv_poly_norm_rec b1) ($get_bv_poly_norm_rec b2)))
@@ -193,9 +198,9 @@
                                              (eo::define ((bz (eo::to_z b)))
                                              ; if it is zero, it cancels, otherwise it is 1 with itself as coefficient
                                              (eo::ite (eo::is_eq bz 0)
-                                               @poly.zero
-                                               (@poly (@mon one (eo::to_q bz)))))
-                                           (@poly (@mon (bvmul b) 1/1))))))    ; introduces list
+                                               $poly_zero
+                                               ($poly ($mon one (eo::to_q bz)))))
+                                           ($poly ($mon (bvmul b) 1/1))))))    ; introduces list
   )
 )
 
@@ -209,16 +214,16 @@
 
 ; program: $arith_poly_to_term_rec
 ; args:
-; - p @Polynomial: The polynomial to convert to a term.
+; - p $Polynomial: The polynomial to convert to a term.
 ; return: The term corresponding to the polynomial p.
 ; note: This method always returns a term of type Real and is not in n-ary
 ;       form, as 0/1 instead of 0 is used as the last element.
 ; note: This is a helper for $arith_poly_to_term below.
-(program $arith_poly_to_term_rec ((T Type) (p @Polynomial :list) (a T) (c Real))
-  :signature (@Polynomial) Real
+(program $arith_poly_to_term_rec ((T Type) (p $Polynomial :list) (a T) (c Real))
+  :signature ($Polynomial) Real
   (
-    (($arith_poly_to_term_rec @poly.zero) 0/1)
-    (($arith_poly_to_term_rec (@poly (@mon a c) p)) (+ (* c a) ($arith_poly_to_term_rec p)))
+    (($arith_poly_to_term_rec $poly_zero) 0/1)
+    (($arith_poly_to_term_rec ($poly ($mon a c) p)) (+ (* c a) ($arith_poly_to_term_rec p)))
   )
 )
 

--- a/proofs/eo/cpc/programs/PolyNorm.eo
+++ b/proofs/eo/cpc/programs/PolyNorm.eo
@@ -18,62 +18,62 @@
 ; A monomial is a list of terms that are ordered by `$compare_var` and a rational coefficient.
 ; A polynomial is a list of monomials whose monomials are ordered by `$compare_var`.
 (declare-const @@Monomial Type)
-(define $Monomial () @@Monomial)
-(declare-parameterized-const @@mon ((T Type :implicit)) (-> T Real $Monomial))
-(define $mon () @@mon)
+(define @Monomial () @@Monomial)
+(declare-parameterized-const @@mon ((T Type :implicit)) (-> T Real @Monomial))
+(define @mon () @@mon)
 
 (declare-const @@Polynomial Type)
-(define $Polynomial () @@Polynomial)
-(declare-const @@poly.zero $Polynomial)
-(define $poly_zero () @@Polynomial)
-(declare-const @@poly (-> $Monomial $Polynomial $Polynomial) :right-assoc-nil $poly_zero)
-(define $poly () @@poly)
+(define @Polynomial () @@Polynomial)
+(declare-const @@poly.zero @Polynomial)
+(define @poly.zero () @@Polynomial)
+(declare-const @@poly (-> @Monomial @Polynomial @Polynomial) :right-assoc-nil @poly.zero)
+(define @poly () @@poly)
 
 ; program: $poly_neg
 ; args:
-; - p $Polynomial: The polynomial to negate.
+; - p @Polynomial: The polynomial to negate.
 ; return: the negation of the given polynomial.
-(program $poly_neg ((T Type) (c Real) (a T) (p $Polynomial :list))
-  :signature ($Polynomial) $Polynomial
+(program $poly_neg ((T Type) (c Real) (a T) (p @Polynomial :list))
+  :signature (@Polynomial) @Polynomial
   (
-    (($poly_neg $poly_zero)           $poly_zero)
-    (($poly_neg ($poly ($mon a c) p)) (eo::cons $poly ($mon a (eo::neg c)) ($poly_neg p)))
+    (($poly_neg @poly.zero)           @poly.zero)
+    (($poly_neg (@poly (@mon a c) p)) (eo::cons @poly (@mon a (eo::neg c)) ($poly_neg p)))
   )
 )
 ; program: $poly_mod_coeffs
 ; args:
-; - p $Polynomial: The polynomial to modify.
+; - p @Polynomial: The polynomial to modify.
 ; - w Int: The modulus to consider
 ; return: the given polynomial where all coefficient are taken mod w.
-(program $poly_mod_coeffs ((T Type) (c Real) (a T) (p $Polynomial :list) (w Int))
-  :signature ($Polynomial Int) $Polynomial
+(program $poly_mod_coeffs ((T Type) (c Real) (a T) (p @Polynomial :list) (w Int))
+  :signature (@Polynomial Int) @Polynomial
   (
-    (($poly_mod_coeffs $poly_zero w)           $poly_zero)
-    (($poly_mod_coeffs ($poly ($mon a c) p) w) (eo::define ((newc (eo::zmod (eo::to_z c) w)))
+    (($poly_mod_coeffs @poly.zero w)           @poly.zero)
+    (($poly_mod_coeffs (@poly (@mon a c) p) w) (eo::define ((newc (eo::zmod (eo::to_z c) w)))
                                                (eo::ite (eo::eq newc 0)
                                                  ; if it becomes zero, it cancels
                                                  ($poly_mod_coeffs p w)
-                                                 (eo::cons $poly ($mon a (eo::to_q newc)) ($poly_mod_coeffs p w)))))
+                                                 (eo::cons @poly (@mon a (eo::to_q newc)) ($poly_mod_coeffs p w)))))
   )
 )
 
 ; program: $poly_add
 ; args:
-; - p1 $Polynomial: The first polynomial to add.
-; - p2 $Polynomial: The second polynomial to add.
+; - p1 @Polynomial: The first polynomial to add.
+; - p2 @Polynomial: The second polynomial to add.
 ; return: the addition of the given polynomials.
-(program $poly_add ((T Type) (U Type) (c1 Real) (a1 T) (c2 Real) (a2 U) (p $Polynomial) (p1 $Polynomial :list) (p2 $Polynomial :list))
-  :signature ($Polynomial $Polynomial) $Polynomial
+(program $poly_add ((T Type) (U Type) (c1 Real) (a1 T) (c2 Real) (a2 U) (p @Polynomial) (p1 @Polynomial :list) (p2 @Polynomial :list))
+  :signature (@Polynomial @Polynomial) @Polynomial
   (
-    (($poly_add ($poly ($mon a1 c1) p1) ($poly ($mon a2 c2) p2)) (eo::ite (eo::eq a1 a2)
+    (($poly_add (@poly (@mon a1 c1) p1) (@poly (@mon a2 c2) p2)) (eo::ite (eo::eq a1 a2)
                                                                   (eo::define ((ca (eo::add c1 c2)) (pa ($poly_add p1 p2)))
                                                                   ; check if cancels
-                                                                  (eo::ite (eo::eq ca 0/1) pa (eo::cons $poly ($mon a1 ca) pa)))
+                                                                  (eo::ite (eo::eq ca 0/1) pa (eo::cons @poly (@mon a1 ca) pa)))
                                                                 (eo::ite ($compare_var a1 a2)
-                                                                  (eo::cons $poly ($mon a1 c1) ($poly_add p1 ($poly ($mon a2 c2) p2)))
-                                                                  (eo::cons $poly ($mon a2 c2) ($poly_add ($poly ($mon a1 c1) p1) p2)))))
-    (($poly_add $poly_zero p)                                    p)
-    (($poly_add p $poly_zero)                                    p)
+                                                                  (eo::cons @poly (@mon a1 c1) ($poly_add p1 (@poly (@mon a2 c2) p2)))
+                                                                  (eo::cons @poly (@mon a2 c2) ($poly_add (@poly (@mon a1 c1) p1) p2)))))
+    (($poly_add @poly.zero p)                                    p)
+    (($poly_add p @poly.zero)                                    p)
   )
 )
 
@@ -104,64 +104,64 @@
 
 ; program: $mon_mul_mon
 ; args:
-; - a $Monomial: The first monomial to multiply.
-; - b $Monomial: The second monomial to multiply.
+; - a @Monomial: The first monomial to multiply.
+; - b @Monomial: The second monomial to multiply.
 ; return: the multiplication of the given monomials.
 (program $mon_mul_mon ((T Type) (U Type) (a1 T) (a2 U) (c1 Real) (c2 Real))
-  :signature ($Monomial $Monomial) $Monomial
+  :signature (@Monomial @Monomial) @Monomial
   (
-    (($mon_mul_mon ($mon a1 c1) ($mon a2 c2))  ($mon ($mvar_mul_mvar a1 a2) (eo::mul c1 c2)))
+    (($mon_mul_mon (@mon a1 c1) (@mon a2 c2))  (@mon ($mvar_mul_mvar a1 a2) (eo::mul c1 c2)))
   )
 )
 
 ; program: $poly_mul_mon
 ; args:
-; - a $Monomial: The monomial to multiply.
-; - p $Polynomial: The polynomial to multiply.
+; - a @Monomial: The monomial to multiply.
+; - p @Polynomial: The polynomial to multiply.
 ; return: the multiplication of the polynomial by a monomial.
-(program $poly_mul_mon ((m1 $Monomial) (m2 $Monomial) (p2 $Polynomial :list))
-  :signature ($Monomial $Polynomial) $Polynomial
+(program $poly_mul_mon ((m1 @Monomial) (m2 @Monomial) (p2 @Polynomial :list))
+  :signature (@Monomial @Polynomial) @Polynomial
   (
-    (($poly_mul_mon m1 ($poly m2 p2)) ($poly_add ($poly ($mon_mul_mon m1 m2)) ($poly_mul_mon m1 p2)))   ; NOTE: this amounts to an insertion sort
-    (($poly_mul_mon m1 $poly_zero)    $poly_zero)
+    (($poly_mul_mon m1 (@poly m2 p2)) ($poly_add (@poly ($mon_mul_mon m1 m2)) ($poly_mul_mon m1 p2)))   ; NOTE: this amounts to an insertion sort
+    (($poly_mul_mon m1 @poly.zero)    @poly.zero)
   )
 )
 
 ; program: $poly_mul
 ; args:
-; - p1 $Polynomial: The first polynomial to multiply.
-; - p2 $Polynomial: The second polynomial to multiply.
+; - p1 @Polynomial: The first polynomial to multiply.
+; - p2 @Polynomial: The second polynomial to multiply.
 ; return: the multiplication of the given polynomials.
-(program $poly_mul ((m $Monomial) (p1 $Polynomial :list) (p $Polynomial))
-  :signature ($Polynomial $Polynomial) $Polynomial
+(program $poly_mul ((m @Monomial) (p1 @Polynomial :list) (p @Polynomial))
+  :signature (@Polynomial @Polynomial) @Polynomial
   (
-    (($poly_mul ($poly m p1) p) ($poly_add ($poly_mul_mon m p) ($poly_mul p1 p)))
-    (($poly_mul $poly_zero p)   $poly_zero)
-    (($poly_mul p $poly_zero)   $poly_zero)
+    (($poly_mul (@poly m p1) p) ($poly_add ($poly_mul_mon m p) ($poly_mul p1 p)))
+    (($poly_mul @poly.zero p)   @poly.zero)
+    (($poly_mul p @poly.zero)   @poly.zero)
   )
 )
 
 ; program: $get_arith_poly_norm_div
 ; args:
 ; - a1 T: The numerator to process of type Int or Real.
-; - a1p $Polynomial: The normalization of a1.
+; - a1p @Polynomial: The normalization of a1.
 ; - a2 T: The denominator to process of type Int or Real.
 ; return: >
 ;   The polynomial corresponding to the (normalized) form of (/ a1 a2).
-(define $get_arith_poly_norm_div ((U Type :implicit) (V Type :implicit) (a1 U) (a1p $Polynomial) (a2 V))
+(define $get_arith_poly_norm_div ((U Type :implicit) (V Type :implicit) (a1 U) (a1p @Polynomial) (a2 V))
   (eo::define ((a2q (eo::to_q a2)))
   (eo::ite (eo::ite (eo::is_q a2q) (eo::not (eo::eq a2q 0/1)) false)
     ; if division by non-zero constant, we normalize
-    ($poly_mul_mon ($mon 1 (eo::qdiv 1/1 a2q)) a1p)
+    ($poly_mul_mon (@mon 1 (eo::qdiv 1/1 a2q)) a1p)
     ; otherwise it is treated as a variable
-    ($poly ($mon (* (/ a1 a2)) 1/1)))))
+    (@poly (@mon (* (/ a1 a2)) 1/1)))))
 
 ; program: $get_arith_poly_norm
 ; args:
 ; - a T: The arithmetic term to process of type Int or Real.
 ; return: the polynomial corresponding to the (normalized) form of a.
 (program $get_arith_poly_norm ((T Type) (U Type) (V Type) (a T) (a1 U) (a2 V :list))
-  :signature (T) $Polynomial
+  :signature (T) @Polynomial
   (
     (($get_arith_poly_norm (- a1))          ($poly_neg ($get_arith_poly_norm a1)))
     (($get_arith_poly_norm (+ a1 a2))       ($poly_add ($get_arith_poly_norm a1) ($get_arith_poly_norm a2)))
@@ -175,9 +175,9 @@
                                             (eo::ite (eo::is_q aq)
                                               ; if it is zero, it cancels, otherwise it is 1 with itself as coefficient
                                               (eo::ite (eo::is_eq aq 0/1)
-                                                $poly_zero
-                                                ($poly ($mon 1 aq)))
-                                            ($poly ($mon (* a) 1/1)))))    ; introduces list
+                                                @poly.zero
+                                                (@poly (@mon 1 aq)))
+                                            (@poly (@mon (* a) 1/1)))))    ; introduces list
   )
 )
 
@@ -186,7 +186,7 @@
 ; - b (BitVec m): The bitvector term to process.
 ; return: the polynomial corresponding to the (normalized) form of b, prior to taking mod of its coefficients.
 (program $get_bv_poly_norm_rec ((m Int) (b (BitVec m)) (b1 (BitVec m)) (b2 (BitVec m) :list))
-  :signature ((BitVec m)) $Polynomial
+  :signature ((BitVec m)) @Polynomial
   (
     (($get_bv_poly_norm_rec (bvneg b1))    ($poly_neg ($get_bv_poly_norm_rec b1)))
     (($get_bv_poly_norm_rec (bvadd b1 b2)) ($poly_add ($get_bv_poly_norm_rec b1) ($get_bv_poly_norm_rec b2)))
@@ -198,9 +198,9 @@
                                              (eo::define ((bz (eo::to_z b)))
                                              ; if it is zero, it cancels, otherwise it is 1 with itself as coefficient
                                              (eo::ite (eo::is_eq bz 0)
-                                               $poly_zero
-                                               ($poly ($mon one (eo::to_q bz)))))
-                                           ($poly ($mon (bvmul b) 1/1))))))    ; introduces list
+                                               @poly.zero
+                                               (@poly (@mon one (eo::to_q bz)))))
+                                           (@poly (@mon (bvmul b) 1/1))))))    ; introduces list
   )
 )
 
@@ -214,16 +214,16 @@
 
 ; program: $arith_poly_to_term_rec
 ; args:
-; - p $Polynomial: The polynomial to convert to a term.
+; - p @Polynomial: The polynomial to convert to a term.
 ; return: The term corresponding to the polynomial p.
 ; note: This method always returns a term of type Real and is not in n-ary
 ;       form, as 0/1 instead of 0 is used as the last element.
 ; note: This is a helper for $arith_poly_to_term below.
-(program $arith_poly_to_term_rec ((T Type) (p $Polynomial :list) (a T) (c Real))
-  :signature ($Polynomial) Real
+(program $arith_poly_to_term_rec ((T Type) (p @Polynomial :list) (a T) (c Real))
+  :signature (@Polynomial) Real
   (
-    (($arith_poly_to_term_rec $poly_zero) 0/1)
-    (($arith_poly_to_term_rec ($poly ($mon a c) p)) (+ (* c a) ($arith_poly_to_term_rec p)))
+    (($arith_poly_to_term_rec @poly.zero) 0/1)
+    (($arith_poly_to_term_rec (@poly (@mon a c) p)) (+ (* c a) ($arith_poly_to_term_rec p)))
   )
 )
 

--- a/proofs/eo/cpc/programs/Strings.eo
+++ b/proofs/eo/cpc/programs/Strings.eo
@@ -168,7 +168,7 @@
 
 ; note: used to represent an invalid regular expression below.
 (declare-const @@re.null RegLan)
-(define $re_null () @@re.null)
+(define @re.null () @@re.null)
 
 ; program: $str_eval_str_in_re_rec
 ; args:
@@ -177,7 +177,7 @@
 ; - r1 RegLan: The regular expression to inspect.
 ; - r2 RegLan: The remaining regular expression to be processed after r1, if it exists.
 ; return: >
-;   The call ($str_eval_str_in_re_rec s 0 r1 $re_null) returns true if s is in r1.
+;   The call ($str_eval_str_in_re_rec s 0 r1 @re.null) returns true if s is in r1.
 ;   The call ($str_eval_str_in_re_rec s n r1 r2) returns true if s = s1 ++ s2 for some s1, s2 such that:
 ;   - s1 in r1
 ;   - s2 in r2
@@ -188,33 +188,33 @@
 (program $str_eval_str_in_re_rec ((s String) (s1 String) (s2 String) (n Int) (r1 RegLan) (rr RegLan :list) (r2 RegLan) (sr String))
   :signature (String Int RegLan RegLan) Bool
   (
-  (($str_eval_str_in_re_rec s 0 (re.++ r1 rr) $re_null)     ($str_eval_str_in_re_rec s 0 r1 rr))
-  (($str_eval_str_in_re_rec s 0 (re.inter r1 rr) $re_null)  (eo::ite ($str_eval_str_in_re_rec s 0 r1 $re_null)
-                                                              ($str_eval_str_in_re_rec s 0 rr $re_null)
+  (($str_eval_str_in_re_rec s 0 (re.++ r1 rr) @re.null)     ($str_eval_str_in_re_rec s 0 r1 rr))
+  (($str_eval_str_in_re_rec s 0 (re.inter r1 rr) @re.null)  (eo::ite ($str_eval_str_in_re_rec s 0 r1 @re.null)
+                                                              ($str_eval_str_in_re_rec s 0 rr @re.null)
                                                               false))
-  (($str_eval_str_in_re_rec s 0 (re.union r1 rr) $re_null)  (eo::ite ($str_eval_str_in_re_rec s 0 r1 $re_null)
+  (($str_eval_str_in_re_rec s 0 (re.union r1 rr) @re.null)  (eo::ite ($str_eval_str_in_re_rec s 0 r1 @re.null)
                                                               true
-                                                              ($str_eval_str_in_re_rec s 0 rr $re_null)))
-  (($str_eval_str_in_re_rec s 0 (re.* r1) $re_null)         (eo::ite (eo::eq s "")
+                                                              ($str_eval_str_in_re_rec s 0 rr @re.null)))
+  (($str_eval_str_in_re_rec s 0 (re.* r1) @re.null)         (eo::ite (eo::eq s "")
                                                               true
                                                               ; to make progress, first component must be non-empty
                                                               ($str_eval_str_in_re_rec s 1 r1 (re.* r1))))
-  (($str_eval_str_in_re_rec s 0 (str.to_re sr) $re_null)    (eo::eq s sr))
-  (($str_eval_str_in_re_rec s 0 (re.range s1 s2) $re_null)  (eo::define ((cs (eo::to_z s)))
+  (($str_eval_str_in_re_rec s 0 (str.to_re sr) @re.null)    (eo::eq s sr))
+  (($str_eval_str_in_re_rec s 0 (re.range s1 s2) @re.null)  (eo::define ((cs (eo::to_z s)))
                                                             (eo::requires ($str_is_char_range s1 s2) true
                                                             (eo::ite (eo::eq (eo::len s) 1)
                                                                 (eo::and ($compare_geq cs (eo::to_z s1))
                                                                          ($compare_geq (eo::to_z s2) cs))
                                                                 false))))
-  (($str_eval_str_in_re_rec s 0 re.allchar $re_null)        (eo::eq (eo::len s) 1))
-  (($str_eval_str_in_re_rec s 0 re.all $re_null)            true)
-  (($str_eval_str_in_re_rec s 0 re.none $re_null)           false)
-  (($str_eval_str_in_re_rec s 0 (re.comp r1) $re_null)      (eo::not ($str_eval_str_in_re_rec s 0 r1 $re_null)))
+  (($str_eval_str_in_re_rec s 0 re.allchar @re.null)        (eo::eq (eo::len s) 1))
+  (($str_eval_str_in_re_rec s 0 re.all @re.null)            true)
+  (($str_eval_str_in_re_rec s 0 re.none @re.null)           false)
+  (($str_eval_str_in_re_rec s 0 (re.comp r1) @re.null)      (eo::not ($str_eval_str_in_re_rec s 0 r1 @re.null)))
   (($str_eval_str_in_re_rec s n r1 r2)                      (eo::define ((ls (eo::len s)))
                                                             (eo::define ((ss1 (eo::extract s 0 (eo::add n -1))))
                                                             (eo::define ((ss2 (eo::extract s n ls)))
-                                                            (eo::define ((res (eo::ite ($str_eval_str_in_re_rec ss1 0 r1 $re_null)
-                                                                       (eo::ite ($str_eval_str_in_re_rec ss2 0 r2 $re_null)
+                                                            (eo::define ((res (eo::ite ($str_eval_str_in_re_rec ss1 0 r1 @re.null)
+                                                                       (eo::ite ($str_eval_str_in_re_rec ss2 0 r2 @re.null)
                                                                          true false)
                                                                        false)))
                                                             (eo::ite res true
@@ -233,12 +233,12 @@
 ; note: This method attempts to use the NFA test whenever possible.
 (define $str_eval_str_in_re ((s String) (r RegLan))
   (eo::ite (eo::is_str s)
-    (eo::define ((nfa ($build_nfa r ($nfa_list $nfa_accept))))
+    (eo::define ((nfa ($build_nfa r (@nfa.list @nfa.accept))))
     (eo::ite (eo::is_ok nfa)
       ; if this is supported by the NFA signature, use the faster test
-      ($nfa_match "" s nfa $nfa_decline)
+      (@nfa.match "" s nfa @nfa.decline)
       ; otherwise, must use the backtracking method above.
-      ($str_eval_str_in_re_rec s 0 r $re_null)))
+      ($str_eval_str_in_re_rec s 0 r @re.null)))
     ; otherwise if s is not constant, we are unevaluated
     (str.in_re s r)))
 
@@ -1511,7 +1511,7 @@
 ; - r RegLan: The regular expression argument of the membership to rewrite.
 ; - b Bool: >
 ;   Stores temporary results when we are processing a union or intersection
-;   regular expression as argument r. Otherwise, this argument is $result_null.
+;   regular expression as argument r. Otherwise, this argument is @result.null.
 ; - rev Bool: >
 ;   Indicates whether s and r were reversed, in which case their components must
 ;   be reversed when we recurse on non-str.to_re children.
@@ -1522,34 +1522,34 @@
    (s3 String) (s4 String :list) (s5 String) (r3 RegLan))
   :signature (String RegLan Bool Bool) Bool
   (
-    (($str_re_consume_rec (str.++ s1 s2) (re.++ (str.to_re (str.++ s3 s4)) r2) $result_null rev)
+    (($str_re_consume_rec (str.++ s1 s2) (re.++ (str.to_re (str.++ s3 s4)) r2) @result.null rev)
       (eo::ite (eo::eq s1 s3)
-        ($str_re_consume_rec s2 (re.++ (str.to_re s4) r2) $result_null rev)
+        ($str_re_consume_rec s2 (re.++ (str.to_re s4) r2) @result.null rev)
         (eo::ite (eo::and ($str_check_length_one s1) ($str_check_length_one s3))
           false                                       ; conflicting characters
           (str.in_re (str.++ s1 s2) (re.++ (str.to_re (str.++ s3 s4)) r2))))) ; otherwise stuck
-    (($str_re_consume_rec (str.++ s1 s2) (re.++ @re.empty r2) $result_null rev)
-      ($str_re_consume_rec (str.++ s1 s2) r2 $result_null rev)) ; finished current component
-    (($str_re_consume_rec (str.++ s1 s2) (re.++ (re.range s3 s5) r2) $result_null rev)
+    (($str_re_consume_rec (str.++ s1 s2) (re.++ @re.empty r2) @result.null rev)
+      ($str_re_consume_rec (str.++ s1 s2) r2 @result.null rev)) ; finished current component
+    (($str_re_consume_rec (str.++ s1 s2) (re.++ (re.range s3 s5) r2) @result.null rev)
       (eo::ite (eo::and ($str_check_length_one s1) ($str_is_char_range s3 s5))
         (eo::ite ($str_eval_str_in_re s1 (re.range s3 s5))
-          ($str_re_consume_rec s2 r2 $result_null rev)
+          ($str_re_consume_rec s2 r2 @result.null rev)
           false)
         (str.in_re (str.++ s1 s2) (re.++ (re.range s3 s5) r2))))
-    (($str_re_consume_rec (str.++ s1 s2) (re.++ re.allchar r2) $result_null rev)
+    (($str_re_consume_rec (str.++ s1 s2) (re.++ re.allchar r2) @result.null rev)
       (eo::ite ($str_check_length_one s1)
-        ($str_re_consume_rec s2 r2 $result_null rev)
+        ($str_re_consume_rec s2 r2 @result.null rev)
         (str.in_re (str.++ s1 s2) (re.++ re.allchar r2))))
-    (($str_re_consume_rec (str.++ s1 s2) (re.++ (re.* r3) r2) $result_null rev)
+    (($str_re_consume_rec (str.++ s1 s2) (re.++ (re.* r3) r2) @result.null rev)
       (eo::define ((r1 (re.* r3)))
       ; see what happens if we unroll once
-      (eo::define ((res ($str_re_consume_rec (str.++ s1 s2) ($re_to_flat_form r3 rev) $result_null rev)))
+      (eo::define ((res ($str_re_consume_rec (str.++ s1 s2) ($re_to_flat_form r3 rev) @result.null rev)))
       (eo::ite (eo::eq res false)
         ; We can't unroll even once, thus we must skip it.
-        ($str_re_consume_rec (str.++ s1 s2) r2 $result_null rev)
+        ($str_re_consume_rec (str.++ s1 s2) r2 @result.null rev)
         (eo::ite (eo::eq ($str_membership_re res) @re.empty)
           ; If we fully consumed, now we go back and check if we get a conflict if we skip.
-          (eo::define ((res2 ($str_re_consume_rec (str.++ s1 s2) r2 $result_null rev)))
+          (eo::define ((res2 ($str_re_consume_rec (str.++ s1 s2) r2 @result.null rev)))
           (eo::ite (eo::is_eq res2 false)
             ; Skipping would give a conflict.
             (eo::define ((sr ($str_membership_str res)))
@@ -1557,41 +1557,41 @@
               ; if we did not consume anything, we are stuck.
               (str.in_re (str.++ s1 s2) (re.++ r1 r2))
               ; otherwise, we continue with the RE consumed once.
-              ($str_re_consume_rec sr (re.++ r1 r2) $result_null rev)))
+              ($str_re_consume_rec sr (re.++ r1 r2) @result.null rev)))
             ; Otherwise we are stuck.
             (str.in_re (str.++ s1 s2) (re.++ r1 r2))))
           ; Otherwise we are stuck.
           (str.in_re (str.++ s1 s2) (re.++ r1 r2)))))))
-    (($str_re_consume_rec (str.++ s1 s2) (re.++ r1 r2) $result_null rev)
+    (($str_re_consume_rec (str.++ s1 s2) (re.++ r1 r2) @result.null rev)
       ; likely intersection or union, process cases recursively
-      (eo::define ((res ($str_re_consume_rec (str.++ s1 s2) r1 $result_null rev)))
+      (eo::define ((res ($str_re_consume_rec (str.++ s1 s2) r1 @result.null rev)))
       (eo::ite (eo::is_eq res false)
         ; conflict
         false
         (eo::ite (eo::is_eq ($str_membership_re res) @re.empty)
           ; if all cases consumed the same, continue
-          ($str_re_consume_rec ($str_membership_str res) r2 $result_null rev)
+          ($str_re_consume_rec ($str_membership_str res) r2 @result.null rev)
           ; otherwise we are stuck
           (str.in_re (str.++ s1 s2) (re.++ r1 r2))))))
-    (($str_re_consume_rec s1 (re.++ @re.empty r2) $result_null rev)
-      ($str_re_consume_rec s1 r2 $result_null rev)) ; finished current component
+    (($str_re_consume_rec s1 (re.++ @re.empty r2) @result.null rev)
+      ($str_re_consume_rec s1 r2 @result.null rev)) ; finished current component
     ; Intersection reports conflicts eagerly, and otherwise combines the results
     (($str_re_consume_rec s1 (re.inter r1 r2) b rev)   (eo::define ((r1r ($re_to_flat_form r1 rev)))
-                                                       (eo::define ((bb ($str_re_consume_rec s1 r1r $result_null rev)))
+                                                       (eo::define ((bb ($str_re_consume_rec s1 r1r @result.null rev)))
                                                          (eo::ite (eo::eq bb false)
                                                            false
                                                            ($str_re_consume_rec s1 r2 ($result_combine bb b) rev)))))
-    (($str_re_consume_rec s1 re.all $result_null rev)  (str.in_re "" @re.empty)) ; only used if re.all appears in unexpected position
+    (($str_re_consume_rec s1 re.all @result.null rev)  (str.in_re "" @re.empty)) ; only used if re.all appears in unexpected position
     (($str_re_consume_rec s1 re.all b rev)             b)                        ; end of re.inter
     ; Union ignores conflicts, and otherwise combines the results. We report a conflict if all children give conflicts.
     (($str_re_consume_rec s1 (re.union r1 r2) b rev)   (eo::define ((r1r ($re_to_flat_form r1 rev)))
-                                                       (eo::define ((bb ($str_re_consume_rec s1 r1r $result_null rev)))
+                                                       (eo::define ((bb ($str_re_consume_rec s1 r1r @result.null rev)))
                                                          (eo::ite (eo::eq bb false)
                                                            ($str_re_consume_rec s1 r2 b rev)
                                                            ($str_re_consume_rec s1 r2 ($result_combine bb b) rev)))))
-    (($str_re_consume_rec s1 re.none $result_null rev) false)     ; end of re.union, conflict, also used if re.none appears in unexpected position
+    (($str_re_consume_rec s1 re.none @result.null rev) false)     ; end of re.union, conflict, also used if re.none appears in unexpected position
     (($str_re_consume_rec s1 re.none b rev)            b)         ; end of re.union, no conflict
-    (($str_re_consume_rec s1 r1 $result_null rev)      (str.in_re s1 r1))
+    (($str_re_consume_rec s1 r1 @result.null rev)      (str.in_re s1 r1))
   )
 )
 
@@ -1610,7 +1610,7 @@
 (define $str_re_consume_process ((s String) (r RegLan) (oneDir Bool))
   (eo::define ((ss ($str_to_flat_form s true)))  
   (eo::define ((rr ($re_to_flat_form r true)))
-  (eo::define ((resrev ($str_re_consume_rec ss rr $result_null true)))
+  (eo::define ((resrev ($str_re_consume_rec ss rr @result.null true)))
   (eo::ite (eo::eq resrev false)
     false
     (eo::define ((s1 ($str_membership_str resrev)))
@@ -1619,7 +1619,7 @@
     (eo::define ((revert (eo::and oneDir (eo::not (eo::eq r1 @re.empty)))))
     (eo::define ((s1r ($str_rev true (eo::ite revert ss s1)))
                   (r1r ($re_to_flat_form (eo::ite revert rr r1) true)))
-    (eo::define ((resfwd ($str_re_consume_rec s1r r1r $result_null false)))
+    (eo::define ((resfwd ($str_re_consume_rec s1r r1r @result.null false)))
     (eo::ite (eo::eq resfwd false)
       false
       (eo::define ((s2 ($str_membership_str resfwd)))

--- a/proofs/eo/cpc/programs/Strings.eo
+++ b/proofs/eo/cpc/programs/Strings.eo
@@ -1511,7 +1511,7 @@
 ; - r RegLan: The regular expression argument of the membership to rewrite.
 ; - b Bool: >
 ;   Stores temporary results when we are processing a union or intersection
-;   regular expression as argument r. Otherwise, this argument is @result.null.
+;   regular expression as argument r. Otherwise, this argument is $result_null.
 ; - rev Bool: >
 ;   Indicates whether s and r were reversed, in which case their components must
 ;   be reversed when we recurse on non-str.to_re children.
@@ -1522,34 +1522,34 @@
    (s3 String) (s4 String :list) (s5 String) (r3 RegLan))
   :signature (String RegLan Bool Bool) Bool
   (
-    (($str_re_consume_rec (str.++ s1 s2) (re.++ (str.to_re (str.++ s3 s4)) r2) @result.null rev)
+    (($str_re_consume_rec (str.++ s1 s2) (re.++ (str.to_re (str.++ s3 s4)) r2) $result_null rev)
       (eo::ite (eo::eq s1 s3)
-        ($str_re_consume_rec s2 (re.++ (str.to_re s4) r2) @result.null rev)
+        ($str_re_consume_rec s2 (re.++ (str.to_re s4) r2) $result_null rev)
         (eo::ite (eo::and ($str_check_length_one s1) ($str_check_length_one s3))
           false                                       ; conflicting characters
           (str.in_re (str.++ s1 s2) (re.++ (str.to_re (str.++ s3 s4)) r2))))) ; otherwise stuck
-    (($str_re_consume_rec (str.++ s1 s2) (re.++ @re.empty r2) @result.null rev)
-      ($str_re_consume_rec (str.++ s1 s2) r2 @result.null rev)) ; finished current component
-    (($str_re_consume_rec (str.++ s1 s2) (re.++ (re.range s3 s5) r2) @result.null rev)
+    (($str_re_consume_rec (str.++ s1 s2) (re.++ @re.empty r2) $result_null rev)
+      ($str_re_consume_rec (str.++ s1 s2) r2 $result_null rev)) ; finished current component
+    (($str_re_consume_rec (str.++ s1 s2) (re.++ (re.range s3 s5) r2) $result_null rev)
       (eo::ite (eo::and ($str_check_length_one s1) ($str_is_char_range s3 s5))
         (eo::ite ($str_eval_str_in_re s1 (re.range s3 s5))
-          ($str_re_consume_rec s2 r2 @result.null rev)
+          ($str_re_consume_rec s2 r2 $result_null rev)
           false)
         (str.in_re (str.++ s1 s2) (re.++ (re.range s3 s5) r2))))
-    (($str_re_consume_rec (str.++ s1 s2) (re.++ re.allchar r2) @result.null rev)
+    (($str_re_consume_rec (str.++ s1 s2) (re.++ re.allchar r2) $result_null rev)
       (eo::ite ($str_check_length_one s1)
-        ($str_re_consume_rec s2 r2 @result.null rev)
+        ($str_re_consume_rec s2 r2 $result_null rev)
         (str.in_re (str.++ s1 s2) (re.++ re.allchar r2))))
-    (($str_re_consume_rec (str.++ s1 s2) (re.++ (re.* r3) r2) @result.null rev)
+    (($str_re_consume_rec (str.++ s1 s2) (re.++ (re.* r3) r2) $result_null rev)
       (eo::define ((r1 (re.* r3)))
       ; see what happens if we unroll once
-      (eo::define ((res ($str_re_consume_rec (str.++ s1 s2) ($re_to_flat_form r3 rev) @result.null rev)))
+      (eo::define ((res ($str_re_consume_rec (str.++ s1 s2) ($re_to_flat_form r3 rev) $result_null rev)))
       (eo::ite (eo::eq res false)
         ; We can't unroll even once, thus we must skip it.
-        ($str_re_consume_rec (str.++ s1 s2) r2 @result.null rev)
+        ($str_re_consume_rec (str.++ s1 s2) r2 $result_null rev)
         (eo::ite (eo::eq ($str_membership_re res) @re.empty)
           ; If we fully consumed, now we go back and check if we get a conflict if we skip.
-          (eo::define ((res2 ($str_re_consume_rec (str.++ s1 s2) r2 @result.null rev)))
+          (eo::define ((res2 ($str_re_consume_rec (str.++ s1 s2) r2 $result_null rev)))
           (eo::ite (eo::is_eq res2 false)
             ; Skipping would give a conflict.
             (eo::define ((sr ($str_membership_str res)))
@@ -1557,41 +1557,41 @@
               ; if we did not consume anything, we are stuck.
               (str.in_re (str.++ s1 s2) (re.++ r1 r2))
               ; otherwise, we continue with the RE consumed once.
-              ($str_re_consume_rec sr (re.++ r1 r2) @result.null rev)))
+              ($str_re_consume_rec sr (re.++ r1 r2) $result_null rev)))
             ; Otherwise we are stuck.
             (str.in_re (str.++ s1 s2) (re.++ r1 r2))))
           ; Otherwise we are stuck.
           (str.in_re (str.++ s1 s2) (re.++ r1 r2)))))))
-    (($str_re_consume_rec (str.++ s1 s2) (re.++ r1 r2) @result.null rev)
+    (($str_re_consume_rec (str.++ s1 s2) (re.++ r1 r2) $result_null rev)
       ; likely intersection or union, process cases recursively
-      (eo::define ((res ($str_re_consume_rec (str.++ s1 s2) r1 @result.null rev)))
+      (eo::define ((res ($str_re_consume_rec (str.++ s1 s2) r1 $result_null rev)))
       (eo::ite (eo::is_eq res false)
         ; conflict
         false
         (eo::ite (eo::is_eq ($str_membership_re res) @re.empty)
           ; if all cases consumed the same, continue
-          ($str_re_consume_rec ($str_membership_str res) r2 @result.null rev)
+          ($str_re_consume_rec ($str_membership_str res) r2 $result_null rev)
           ; otherwise we are stuck
           (str.in_re (str.++ s1 s2) (re.++ r1 r2))))))
-    (($str_re_consume_rec s1 (re.++ @re.empty r2) @result.null rev)
-      ($str_re_consume_rec s1 r2 @result.null rev)) ; finished current component
+    (($str_re_consume_rec s1 (re.++ @re.empty r2) $result_null rev)
+      ($str_re_consume_rec s1 r2 $result_null rev)) ; finished current component
     ; Intersection reports conflicts eagerly, and otherwise combines the results
     (($str_re_consume_rec s1 (re.inter r1 r2) b rev)   (eo::define ((r1r ($re_to_flat_form r1 rev)))
-                                                       (eo::define ((bb ($str_re_consume_rec s1 r1r @result.null rev)))
+                                                       (eo::define ((bb ($str_re_consume_rec s1 r1r $result_null rev)))
                                                          (eo::ite (eo::eq bb false)
                                                            false
                                                            ($str_re_consume_rec s1 r2 ($result_combine bb b) rev)))))
-    (($str_re_consume_rec s1 re.all @result.null rev)  (str.in_re "" @re.empty)) ; only used if re.all appears in unexpected position
+    (($str_re_consume_rec s1 re.all $result_null rev)  (str.in_re "" @re.empty)) ; only used if re.all appears in unexpected position
     (($str_re_consume_rec s1 re.all b rev)             b)                        ; end of re.inter
     ; Union ignores conflicts, and otherwise combines the results. We report a conflict if all children give conflicts.
     (($str_re_consume_rec s1 (re.union r1 r2) b rev)   (eo::define ((r1r ($re_to_flat_form r1 rev)))
-                                                       (eo::define ((bb ($str_re_consume_rec s1 r1r @result.null rev)))
+                                                       (eo::define ((bb ($str_re_consume_rec s1 r1r $result_null rev)))
                                                          (eo::ite (eo::eq bb false)
                                                            ($str_re_consume_rec s1 r2 b rev)
                                                            ($str_re_consume_rec s1 r2 ($result_combine bb b) rev)))))
-    (($str_re_consume_rec s1 re.none @result.null rev) false)     ; end of re.union, conflict, also used if re.none appears in unexpected position
+    (($str_re_consume_rec s1 re.none $result_null rev) false)     ; end of re.union, conflict, also used if re.none appears in unexpected position
     (($str_re_consume_rec s1 re.none b rev)            b)         ; end of re.union, no conflict
-    (($str_re_consume_rec s1 r1 @result.null rev)      (str.in_re s1 r1))
+    (($str_re_consume_rec s1 r1 $result_null rev)      (str.in_re s1 r1))
   )
 )
 
@@ -1610,7 +1610,7 @@
 (define $str_re_consume_process ((s String) (r RegLan) (oneDir Bool))
   (eo::define ((ss ($str_to_flat_form s true)))  
   (eo::define ((rr ($re_to_flat_form r true)))
-  (eo::define ((resrev ($str_re_consume_rec ss rr @result.null true)))
+  (eo::define ((resrev ($str_re_consume_rec ss rr $result_null true)))
   (eo::ite (eo::eq resrev false)
     false
     (eo::define ((s1 ($str_membership_str resrev)))
@@ -1619,7 +1619,7 @@
     (eo::define ((revert (eo::and oneDir (eo::not (eo::eq r1 @re.empty)))))
     (eo::define ((s1r ($str_rev true (eo::ite revert ss s1)))
                   (r1r ($re_to_flat_form (eo::ite revert rr r1) true)))
-    (eo::define ((resfwd ($str_re_consume_rec s1r r1r @result.null false)))
+    (eo::define ((resfwd ($str_re_consume_rec s1r r1r $result_null false)))
     (eo::ite (eo::eq resfwd false)
       false
       (eo::define ((s2 ($str_membership_str resfwd)))

--- a/proofs/eo/cpc/programs/Strings.eo
+++ b/proofs/eo/cpc/programs/Strings.eo
@@ -167,7 +167,8 @@
 ;;-------------------- RE evaluation
 
 ; note: used to represent an invalid regular expression below.
-(declare-const @re.null RegLan)
+(declare-const @@re.null RegLan)
+(define $re_null () @@re.null)
 
 ; program: $str_eval_str_in_re_rec
 ; args:
@@ -176,7 +177,7 @@
 ; - r1 RegLan: The regular expression to inspect.
 ; - r2 RegLan: The remaining regular expression to be processed after r1, if it exists.
 ; return: >
-;   The call ($str_eval_str_in_re_rec s 0 r1 @re.null) returns true if s is in r1.
+;   The call ($str_eval_str_in_re_rec s 0 r1 $re_null) returns true if s is in r1.
 ;   The call ($str_eval_str_in_re_rec s n r1 r2) returns true if s = s1 ++ s2 for some s1, s2 such that:
 ;   - s1 in r1
 ;   - s2 in r2
@@ -187,33 +188,33 @@
 (program $str_eval_str_in_re_rec ((s String) (s1 String) (s2 String) (n Int) (r1 RegLan) (rr RegLan :list) (r2 RegLan) (sr String))
   :signature (String Int RegLan RegLan) Bool
   (
-  (($str_eval_str_in_re_rec s 0 (re.++ r1 rr) @re.null)     ($str_eval_str_in_re_rec s 0 r1 rr))
-  (($str_eval_str_in_re_rec s 0 (re.inter r1 rr) @re.null)  (eo::ite ($str_eval_str_in_re_rec s 0 r1 @re.null)
-                                                              ($str_eval_str_in_re_rec s 0 rr @re.null)
+  (($str_eval_str_in_re_rec s 0 (re.++ r1 rr) $re_null)     ($str_eval_str_in_re_rec s 0 r1 rr))
+  (($str_eval_str_in_re_rec s 0 (re.inter r1 rr) $re_null)  (eo::ite ($str_eval_str_in_re_rec s 0 r1 $re_null)
+                                                              ($str_eval_str_in_re_rec s 0 rr $re_null)
                                                               false))
-  (($str_eval_str_in_re_rec s 0 (re.union r1 rr) @re.null)  (eo::ite ($str_eval_str_in_re_rec s 0 r1 @re.null)
+  (($str_eval_str_in_re_rec s 0 (re.union r1 rr) $re_null)  (eo::ite ($str_eval_str_in_re_rec s 0 r1 $re_null)
                                                               true
-                                                              ($str_eval_str_in_re_rec s 0 rr @re.null)))
-  (($str_eval_str_in_re_rec s 0 (re.* r1) @re.null)         (eo::ite (eo::eq s "")
+                                                              ($str_eval_str_in_re_rec s 0 rr $re_null)))
+  (($str_eval_str_in_re_rec s 0 (re.* r1) $re_null)         (eo::ite (eo::eq s "")
                                                               true
                                                               ; to make progress, first component must be non-empty
                                                               ($str_eval_str_in_re_rec s 1 r1 (re.* r1))))
-  (($str_eval_str_in_re_rec s 0 (str.to_re sr) @re.null)    (eo::eq s sr))
-  (($str_eval_str_in_re_rec s 0 (re.range s1 s2) @re.null)  (eo::define ((cs (eo::to_z s)))
+  (($str_eval_str_in_re_rec s 0 (str.to_re sr) $re_null)    (eo::eq s sr))
+  (($str_eval_str_in_re_rec s 0 (re.range s1 s2) $re_null)  (eo::define ((cs (eo::to_z s)))
                                                             (eo::requires ($str_is_char_range s1 s2) true
                                                             (eo::ite (eo::eq (eo::len s) 1)
                                                                 (eo::and ($compare_geq cs (eo::to_z s1))
                                                                          ($compare_geq (eo::to_z s2) cs))
                                                                 false))))
-  (($str_eval_str_in_re_rec s 0 re.allchar @re.null)        (eo::eq (eo::len s) 1))
-  (($str_eval_str_in_re_rec s 0 re.all @re.null)            true)
-  (($str_eval_str_in_re_rec s 0 re.none @re.null)           false)
-  (($str_eval_str_in_re_rec s 0 (re.comp r1) @re.null)      (eo::not ($str_eval_str_in_re_rec s 0 r1 @re.null)))
+  (($str_eval_str_in_re_rec s 0 re.allchar $re_null)        (eo::eq (eo::len s) 1))
+  (($str_eval_str_in_re_rec s 0 re.all $re_null)            true)
+  (($str_eval_str_in_re_rec s 0 re.none $re_null)           false)
+  (($str_eval_str_in_re_rec s 0 (re.comp r1) $re_null)      (eo::not ($str_eval_str_in_re_rec s 0 r1 $re_null)))
   (($str_eval_str_in_re_rec s n r1 r2)                      (eo::define ((ls (eo::len s)))
                                                             (eo::define ((ss1 (eo::extract s 0 (eo::add n -1))))
                                                             (eo::define ((ss2 (eo::extract s n ls)))
-                                                            (eo::define ((res (eo::ite ($str_eval_str_in_re_rec ss1 0 r1 @re.null)
-                                                                       (eo::ite ($str_eval_str_in_re_rec ss2 0 r2 @re.null)
+                                                            (eo::define ((res (eo::ite ($str_eval_str_in_re_rec ss1 0 r1 $re_null)
+                                                                       (eo::ite ($str_eval_str_in_re_rec ss2 0 r2 $re_null)
                                                                          true false)
                                                                        false)))
                                                             (eo::ite res true
@@ -237,7 +238,7 @@
       ; if this is supported by the NFA signature, use the faster test
       ($nfa_match "" s nfa $nfa_decline)
       ; otherwise, must use the backtracking method above.
-      ($str_eval_str_in_re_rec s 0 r @re.null)))
+      ($str_eval_str_in_re_rec s 0 r $re_null)))
     ; otherwise if s is not constant, we are unevaluated
     (str.in_re s r)))
 

--- a/proofs/eo/cpc/programs/Strings.eo
+++ b/proofs/eo/cpc/programs/Strings.eo
@@ -232,10 +232,10 @@
 ; note: This method attempts to use the NFA test whenever possible.
 (define $str_eval_str_in_re ((s String) (r RegLan))
   (eo::ite (eo::is_str s)
-    (eo::define ((nfa ($build_nfa r (@nfa.list @nfa.accept))))
+    (eo::define ((nfa ($build_nfa r ($nfa_list $nfa_accept))))
     (eo::ite (eo::is_ok nfa)
       ; if this is supported by the NFA signature, use the faster test
-      ($nfa_match "" s nfa @nfa.decline)
+      ($nfa_match "" s nfa $nfa_decline)
       ; otherwise, must use the backtracking method above.
       ($str_eval_str_in_re_rec s 0 r @re.null)))
     ; otherwise if s is not constant, we are unevaluated

--- a/proofs/eo/cpc/programs/Utils.eo
+++ b/proofs/eo/cpc/programs/Utils.eo
@@ -13,8 +13,10 @@
 (define $sgn ((T Type :implicit) (x T))
   (eo::ite (eo::is_neg x) -1 (eo::ite (eo::is_neg (eo::neg x)) 1 0)))
 
-(declare-type @Pair (Type Type))
-(declare-parameterized-const @pair ((U Type :implicit) (T Type :implicit)) (-> U T (@Pair U T)))
+(declare-const @@Pair (-> Type Type Type))
+(define @Pair () @@Pair)
+(declare-parameterized-const @@pair ((U Type :implicit) (T Type :implicit)) (-> U T (@Pair U T)))
+(define @pair () @@pair)
 
 ; program: $pair_first
 ; args:
@@ -151,11 +153,11 @@
 ; - b1 Bool: The first Boolean result to combine.
 ; - b2 Bool: The second Boolean result to combine.
 ; return: >
-;   The result of combining the two results if they agree, where @result.null
-;   is treated as no result and $result_invalid is treated as an invalid result.
+;   The result of combining the two results if they agree, where $result_null
+;   is treated as no result and @result.invalid is treated as an invalid result.
 ; note: >
-;   In summary, ($result_combine b1 ... ($result_combine bn @result.null)) returns
-;   b1 if b1...bn are the same or $result_invalid otherwise.
+;   In summary, ($result_combine b1 ... ($result_combine bn $result_null)) returns
+;   b1 if b1...bn are the same or @result.invalid otherwise.
 (program $result_combine ((b1 Bool) (b2 Bool))
   :signature (Bool Bool) Bool
   (

--- a/proofs/eo/cpc/programs/Utils.eo
+++ b/proofs/eo/cpc/programs/Utils.eo
@@ -141,8 +141,10 @@
 ;; =============== for results
 
 ; Used for representing partial results of the method below.
-(declare-const @result.null Bool)
-(declare-const @result.invalid Bool)
+(declare-const @@result.null Bool)
+(define $result_null () @@result.null)
+(declare-const @@result.invalid Bool)
+(define $result_invalid () @@result.invalid)
 
 ; program: $result_combine
 ; args:
@@ -150,16 +152,16 @@
 ; - b2 Bool: The second Boolean result to combine.
 ; return: >
 ;   The result of combining the two results if they agree, where @result.null
-;   is treated as no result and @result.invalid is treated as an invalid result.
+;   is treated as no result and $result_invalid is treated as an invalid result.
 ; note: >
 ;   In summary, ($result_combine b1 ... ($result_combine bn @result.null)) returns
-;   b1 if b1...bn are the same or @result.invalid otherwise.
+;   b1 if b1...bn are the same or $result_invalid otherwise.
 (program $result_combine ((b1 Bool) (b2 Bool))
   :signature (Bool Bool) Bool
   (
-    (($result_combine b1 @result.null) b1)
+    (($result_combine b1 $result_null) b1)
     (($result_combine b1 b1)           b1)
-    (($result_combine b1 b2)           @result.invalid)
+    (($result_combine b1 b2)           $result_invalid)
   )
 )
 ;; =============== for pairwise

--- a/proofs/eo/cpc/programs/Utils.eo
+++ b/proofs/eo/cpc/programs/Utils.eo
@@ -144,26 +144,26 @@
 
 ; Used for representing partial results of the method below.
 (declare-const @@result.null Bool)
-(define $result_null () @@result.null)
+(define @result.null () @@result.null)
 (declare-const @@result.invalid Bool)
-(define $result_invalid () @@result.invalid)
+(define @result.invalid () @@result.invalid)
 
 ; program: $result_combine
 ; args:
 ; - b1 Bool: The first Boolean result to combine.
 ; - b2 Bool: The second Boolean result to combine.
 ; return: >
-;   The result of combining the two results if they agree, where $result_null
+;   The result of combining the two results if they agree, where @result.null
 ;   is treated as no result and @result.invalid is treated as an invalid result.
 ; note: >
-;   In summary, ($result_combine b1 ... ($result_combine bn $result_null)) returns
+;   In summary, ($result_combine b1 ... ($result_combine bn @result.null)) returns
 ;   b1 if b1...bn are the same or @result.invalid otherwise.
 (program $result_combine ((b1 Bool) (b2 Bool))
   :signature (Bool Bool) Bool
   (
-    (($result_combine b1 $result_null) b1)
+    (($result_combine b1 @result.null) b1)
     (($result_combine b1 b1)           b1)
-    (($result_combine b1 b2)           $result_invalid)
+    (($result_combine b1 b2)           @result.invalid)
   )
 )
 ;; =============== for pairwise


### PR DESCRIPTION
This is work towards a meta-formalization of CPC.

It renames constants that are used solely for the definition of the signature to prefix `@@`.  This distinguishes them from symbols like `@arrays_deq_diff`, where the latter requires a model semantics.