### PR TITLE
Add missing Java API docs for the Op, Sort, and Term classes

### DIFF
--- a/src/api/java/io/github/cvc5/Op.java
+++ b/src/api/java/io/github/cvc5/Op.java
@@ -63,6 +63,8 @@ public class Op extends AbstractPointer
   private native boolean equals(long pointer1, long pointer2);
 
   /**
+   * Get the kind of this operator.
+   *
    * @return The kind of this operator.
    */
   public Kind getKind()
@@ -82,6 +84,8 @@ public class Op extends AbstractPointer
   private native int getKind(long pointer);
 
   /**
+   * Determine if this operator is a null term.
+   *
    * @return True if this operator is a null term.
    */
   public boolean isNull()
@@ -92,6 +96,8 @@ public class Op extends AbstractPointer
   private native boolean isNull(long pointer);
 
   /**
+   * Determine if this operator is indexed.
+   * 
    * @return True iff this operator is indexed.
    */
   public boolean isIndexed()
@@ -102,6 +108,8 @@ public class Op extends AbstractPointer
   private native boolean isIndexed(long pointer);
 
   /**
+   * Get the number of indices of this op.
+   *
    * @return The number of indices of this op.
    */
   public int getNumIndices()

--- a/src/api/java/io/github/cvc5/Sort.java
+++ b/src/api/java/io/github/cvc5/Sort.java
@@ -83,6 +83,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   private native int compareTo(long pointer1, long pointer2);
 
   /**
+   * Get the kind of this sort.
+   *
    * @return The kind of this sort.
    * @api.note This method is experimental and may change in future versions.
    * @throws CVC5ApiException on error
@@ -96,6 +98,7 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   private native int getKind(long pointer);
 
   /**
+   * Determine if the sort has a symbol.
    * @return True if the sort has a symbol.
    */
   public boolean hasSymbol()
@@ -106,6 +109,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   private native boolean hasSymbol(long pointer);
 
   /**
+   * Get the raw symbol of the symbol.
+   * 
    * @api.note Asserts hasSymbol().
    * @return The raw symbol of the symbol.
    */
@@ -457,6 +462,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   private native long getUninterpretedSortConstructor(long pointer);
 
   /**
+   * Get the underlying datatype of a datatype sort.
+   * 
    * @return The underlying datatype of a datatype sort.
    */
   public Datatype getDatatype()
@@ -561,6 +568,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   /* Constructor sort ------------------------------------------------------- */
 
   /**
+   * Get the arity of a datatype constructor sort.
+   * 
    * @return The arity of a datatype constructor sort.
    */
   public int getDatatypeConstructorArity()
@@ -571,6 +580,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   private native int getDatatypeConstructorArity(long pointer);
 
   /**
+   * Get the domain sorts of a datatype constructor sort.
+   * 
    * @return The domain sorts of a datatype constructor sort.
    */
   public Sort[] getDatatypeConstructorDomainSorts()
@@ -582,6 +593,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   private native long[] getDatatypeConstructorDomainSorts(long pointer);
 
   /**
+   * Get the codomain sort of a datatype constructor sort.
+   * 
    * @return The codomain sort of a datatype constructor sort.
    */
   public Sort getDatatypeConstructorCodomainSort()
@@ -595,6 +608,7 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   /* Selector sort ------------------------------------------------------- */
 
   /**
+   * Get the domain sort of a datatype selector sort.
    * @return The domain sort of a datatype selector sort.
    */
   public Sort getDatatypeSelectorDomainSort()
@@ -606,6 +620,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   private native long getDatatypeSelectorDomainSort(long pointer);
 
   /**
+   * Get the codomain sort of a datatype selector sort.
+   * 
    * @return The codomain sort of a datatype selector sort.
    */
   public Sort getDatatypeSelectorCodomainSort()
@@ -619,6 +635,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   /* Tester sort ------------------------------------------------------- */
 
   /**
+   * Get the domain sort of a datatype tester sort.
+   * 
    * @return The domain sort of a datatype tester sort.
    */
   public Sort getDatatypeTesterDomainSort()
@@ -630,6 +648,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   private native long getDatatypeTesterDomainSort(long pointer);
 
   /**
+   * Get the codomain sort of a datatype tester sort, which is the Boolean sort.
+   * 
    * @return The codomain sort of a datatype tester sort, which is the Boolean
    *         sort.
    */
@@ -644,6 +664,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   /* Function sort ------------------------------------------------------- */
 
   /**
+   * Get the arity of a function sort.
+   * 
    * @return The arity of a function sort.
    */
   public int getFunctionArity()
@@ -654,6 +676,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   private native int getFunctionArity(long pointer);
 
   /**
+   * Get the domain sorts of a function sort.
+   * 
    * @return The domain sorts of a function sort.
    */
   public Sort[] getFunctionDomainSorts()
@@ -665,6 +689,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   private native long[] getFunctionDomainSorts(long pointer);
 
   /**
+   * Get the codomain sort of a function sort.
+   * 
    * @return The codomain sort of a function sort.
    */
   public Sort getFunctionCodomainSort()
@@ -678,6 +704,7 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   /* Array sort ---------------------------------------------------------- */
 
   /**
+   * Get the array index sort of an array sort.
    * @return The array index sort of an array sort.
    */
   public Sort getArrayIndexSort()
@@ -689,6 +716,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   private native long getArrayIndexSort(long pointer);
 
   /**
+   * Get the array element sort of an array element sort.
+   * 
    * @return The array element sort of an array element sort.
    */
   public Sort getArrayElementSort()
@@ -702,6 +731,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   /* Set sort ------------------------------------------------------------ */
 
   /**
+   * Get the element sort of a set sort.
+   * 
    * @return The element sort of a set sort.
    */
   public Sort getSetElementSort()
@@ -715,6 +746,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   /* Bag sort ------------------------------------------------------------ */
 
   /**
+   * Get the element sort of a bag sort.
+   * 
    * @return The element sort of a bag sort.
    */
   public Sort getBagElementSort()
@@ -728,6 +761,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   /* Sequence sort ------------------------------------------------------- */
 
   /**
+   * Get the element sort of a sequence sort.
+   * 
    * @return The element sort of a sequence sort.
    */
   public Sort getSequenceElementSort()
@@ -741,6 +776,9 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   /* Abstract sort ------------------------------------------------------- */
 
   /**
+   * Get the sort kind of an abstract sort, which denotes the kind of
+   * sorts that this abstract sort denotes.
+   * 
    * @return The sort kind of an abstract sort, which denotes the kind of
    * sorts that this abstract sort denotes.
    * @throws CVC5ApiException on error
@@ -758,6 +796,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   /* Sort constructor sort ----------------------------------------------- */
 
   /**
+   * Get the arity of an uninterpreted sort constructor sort.
+   * 
    * @return The arity of an uninterpreted sort constructor sort.
    */
   public int getUninterpretedSortConstructorArity()
@@ -770,6 +810,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   /* Bit-vector sort ----------------------------------------------------- */
 
   /**
+   * Get the bit-width of the bit-vector sort.
+   * 
    * @return The bit-width of the bit-vector sort.
    */
   public int getBitVectorSize()
@@ -782,6 +824,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   /* Finite field sort --------------------------------------------------- */
 
   /**
+   * Get the bit-width of the bit-vector sort.
+   * 
    * @return The bit-width of the bit-vector sort.
    */
   public String getFiniteFieldSize()
@@ -794,6 +838,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   /* Floating-point sort ------------------------------------------------- */
 
   /**
+   * Get the bit-width of the exponent of the floating-point sort.
+   * 
    * @return The bit-width of the exponent of the floating-point sort.
    */
   public int getFloatingPointExponentSize()
@@ -804,6 +850,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   private native int getFloatingPointExponentSize(long pointer);
 
   /**
+   * Get the width of the significand of the floating-point sort.
+   * 
    * @return The width of the significand of the floating-point sort.
    */
   public int getFloatingPointSignificandSize()
@@ -816,6 +864,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   /* Datatype sort ------------------------------------------------------- */
 
   /**
+   * Get the arity of a datatype sort.
+   * 
    * @return The arity of a datatype sort.
    */
   public int getDatatypeArity()
@@ -828,6 +878,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   /* Tuple sort ---------------------------------------------------------- */
 
   /**
+   * Get the length of a tuple sort.
+   * 
    * @return The length of a tuple sort.
    */
   public int getTupleLength()
@@ -838,6 +890,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   private native int getTupleLength(long pointer);
 
   /**
+   * Get the element sorts of a tuple sort.
+   * 
    * @return The element sorts of a tuple sort.
    */
   public Sort[] getTupleSorts()
@@ -849,6 +903,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   private native long[] getTupleSorts(long pointer);
 
   /**
+   * Get the element sort of a nullable sort.
+   * 
    * @return The element sort of a nullable sort.
    */
   public Sort getNullableElementSort()

--- a/src/api/java/io/github/cvc5/Term.java
+++ b/src/api/java/io/github/cvc5/Term.java
@@ -85,6 +85,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native int compareTo(long pointer1, long pointer2);
 
   /**
+   * Get the number of children of this term.
+   *
    * @return The number of children of this term.
    */
   public int getNumChildren()
@@ -111,6 +113,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native long getChild(long pointer, int index);
 
   /**
+   * Get the id of this term.
+   * 
    * @return The id of this term.
    */
   public long getId()
@@ -121,6 +125,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native long getId(long pointer);
 
   /**
+   * Get the kind of this term.
+   * 
    * @return The kind of this term.
    * @throws CVC5ApiException on error
    */
@@ -133,6 +139,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native int getKind(long pointer);
 
   /**
+   * Get the sort of this term.
+   * 
    * @return The sort of this term.
    */
   public Sort getSort()
@@ -200,6 +208,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native long substitute(long pointer, long[] termPointers, long[] replacementPointers);
 
   /**
+   * Determine if this term has an operator.
+   * 
    * @return True iff this term has an operator.
    */
   public boolean hasOp()
@@ -210,6 +220,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native boolean hasOp(long pointer);
 
   /**
+   * Get the Op used to create this term.
+   * 
    * @return The Op used to create this term.
    * @api.note This is safe to call when {@link Term#hasOp()} returns true.
    */
@@ -222,6 +234,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native long getOp(long pointer);
 
   /**
+   * Determine if the term has a symbol.
+   * 
    * @return True if the term has a symbol.
    */
   public boolean hasSymbol()
@@ -243,6 +257,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native String getSymbol(long pointer);
 
   /**
+   * Determine if this term is a null term.
+   * 
    * @return True if this Term is a null term.
    */
   public boolean isNull()
@@ -369,6 +385,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native int getRealOrIntegerValueSign(long pointer);
 
   /**
+   * Determine if the term is an integer value.
+   * 
    * @return True if the term is an integer value.
    */
   public boolean isIntegerValue()
@@ -390,6 +408,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native String getIntegerValue(long pointer);
 
   /**
+   * Determine if the term is a string constant.
+   * 
    * @return True if the term is a string constant.
    */
   public boolean isStringValue()
@@ -400,6 +420,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native boolean isStringValue(long pointer);
 
   /**
+   * Get the stored string constant.
+   *
    * @return The stored string constant.
    *
    * Asserts isString().
@@ -416,6 +438,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native String getStringValue(long pointer);
 
   /**
+   * Determine if the term is a rational value.
+   * 
    * @return True if the term is a rational value.
    */
   public boolean isRealValue()
@@ -439,6 +463,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native String getRealValue(long pointer);
 
   /**
+   * Determine if the term is a constant array.
+   * 
    * @return True if the term is a constant array.
    */
   public boolean isConstArray()
@@ -461,6 +487,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native long getConstArrayBase(long pointer);
 
   /**
+   * Determine if the term is a Boolean value.
+   * 
    * @return True if the term is a Boolean value.
    */
   public boolean isBooleanValue()
@@ -481,6 +509,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native boolean getBooleanValue(long pointer);
 
   /**
+   * Determine if the term is a bit-vector value.
+   * 
    * @return True if the term is a bit-vector value.
    */
   public boolean isBitVectorValue()
@@ -523,6 +553,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native String getBitVectorValue(long pointer, int base);
 
   /**
+   * Determine if the term is a finite field value.
+   * 
    * @return True if the term is a finite field value.
    */
   public boolean isFiniteFieldValue()
@@ -548,6 +580,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native String getFiniteFieldValue(long pointer);
 
   /**
+   * Determine if the term is an uninterpreted sort value.
+   * 
    * @return True if the term is an uninterpreted sort value.
    */
   public boolean isUninterpretedSortValue()
@@ -569,6 +603,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native String getUninterpretedSortValue(long pointer);
 
   /**
+   * Determine if the term is a floating-point rounding mode value.
+   * 
    * @return True if the term is a floating-point rounding mode value.
    */
   public boolean isRoundingModeValue()
@@ -592,6 +628,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native int getRoundingModeValue(long pointer);
 
   /**
+   * Determine if the term is a tuple value.
+   * 
    * @return True if the term is a tuple value.
    */
   public boolean isTupleValue()
@@ -614,6 +652,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native long[] getTupleValue(long pointer);
 
   /**
+   * Determine if the term is the floating-point value for positive zero.
+   * 
    * @return True if the term is the floating-point value for positive zero.
    */
   public boolean isFloatingPointPosZero()
@@ -622,7 +662,10 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   }
 
   private native boolean isFloatingPointPosZero(long pointer);
+
   /**
+   * Determine if the term is the floating-point value for negative zero.
+   * 
    * @return True if the term is the floating-point value for negative zero.
    */
   public boolean isFloatingPointNegZero()
@@ -632,6 +675,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
 
   private native boolean isFloatingPointNegZero(long pointer);
   /**
+   * Determine if the term is the floating-point value for positive.
+   *
    * @return True if the term is the floating-point value for positive.
    * infinity.
    */
@@ -641,7 +686,11 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   }
 
   private native boolean isFloatingPointPosInf(long pointer);
+
   /**
+   * Determine if the term is the floating-point value for negative.
+   * infinity.
+   * 
    * @return True if the term is the floating-point value for negative.
    * infinity.
    */
@@ -652,6 +701,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
 
   private native boolean isFloatingPointNegInf(long pointer);
   /**
+   * Determine if the term is the floating-point value for not a number.
+   * 
    * @return True if the term is the floating-point value for not a number.
    */
   public boolean isFloatingPointNaN()
@@ -661,6 +712,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
 
   private native boolean isFloatingPointNaN(long pointer);
   /**
+   * Determine if the term is a floating-point value.
+   * 
    * @return True if the term is a floating-point value.
    */
   public boolean isFloatingPointValue()
@@ -685,6 +738,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native Triplet<String, String, Long> getFloatingPointValue(long pointer);
 
   /**
+   * Determine if the term is a set value.
+   * 
    * @return True if the term is a set value.
    */
   public boolean isSetValue()
@@ -707,6 +762,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native long[] getSetValue(long pointer);
 
   /**
+   * Determine if the term is a sequence value.
+   * 
    * @return True if the term is a sequence value.
    */
   public boolean isSequenceValue()
@@ -733,6 +790,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native long[] getSequenceValue(long pointer);
 
   /**
+   * Determine if the term is a cardinality constraint.
+   * 
    * @return True if the term is a cardinality constraint.
    */
   public boolean isCardinalityConstraint()
@@ -756,6 +815,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native Pair<Long, BigInteger> getCardinalityConstraint(long pointer);
 
   /**
+   * Determine if the term is a real algebraic number.
+   * 
    * @return True if the term is a real algebraic number.
    */
   public boolean isRealAlgebraicNumber()
@@ -803,6 +864,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native long getRealAlgebraicNumberUpperBound(long pointer);
 
   /**
+   * Determine if this term is a skolem function.
+   * 
    * @api.note This method is experimental and may change in future versions.
    * @return True if this term is a skolem function.
    */
@@ -844,11 +907,18 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
 
   private native long[] getSkolemIndices(long pointer);
 
+  /**
+   * ConstIterator is an implementation of the {@link Iterator} interface for iterating over
+   * a collection of {@code Term} objects. It provides read-only access to the elements.
+   */
   public class ConstIterator implements Iterator<Term>
   {
     private int currentIndex;
     private int size;
 
+    /**
+     * Constructs a new ConstIterator.
+     */
     public ConstIterator()
     {
       currentIndex = -1;


### PR DESCRIPTION
This PR addresses several warnings reported by Javadoc 21.