### PR TITLE
Fix (unused) incorrect bound inference in strings arith entail

### DIFF
--- a/src/theory/strings/arith_entail.cpp
+++ b/src/theory/strings/arith_entail.cpp
@@ -1012,7 +1012,6 @@ Node ArithEntail::getConstantBound(TNode a, bool isLower)
       Node ac = getConstantBound(a[i], isLower);
       if (ac.isNull())
       {
-        ret = ac;
         success = false;
         break;
       }
@@ -1022,7 +1021,6 @@ Node ArithEntail::getConstantBound(TNode a, bool isLower)
         {
           if (a.getKind() == Kind::MULT)
           {
-            ret = Node::null();
             success = false;
             break;
           }
@@ -1033,7 +1031,6 @@ Node ArithEntail::getConstantBound(TNode a, bool isLower)
           {
             if ((ac.getConst<Rational>().sgn() > 0) != isLower)
             {
-              ret = Node::null();
               success = false;
               break;
             }

--- a/src/theory/strings/arith_entail.cpp
+++ b/src/theory/strings/arith_entail.cpp
@@ -1022,7 +1022,7 @@ Node ArithEntail::getConstantBound(TNode a, bool isLower)
         {
           if (a.getKind() == Kind::MULT)
           {
-            ret = ac;
+            ret = Node::null();
             success = false;
             break;
           }

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2016,6 +2016,7 @@ set(regress_0_tests
   regress0/strings/issue11703-re-uf.smt2
   regress0/strings/issue11710-numeric-max.smt2
   regress0/strings/issue11890-eec-model.smt2
+  regress0/strings/issue12027-str-ae.smt2
   regress0/strings/issue1189.smt2
   regress0/strings/issue2958.smt2
   regress0/strings/issue3440.smt2

--- a/test/regress/cli/regress0/strings/issue12027-str-ae.smt2
+++ b/test/regress/cli/regress0/strings/issue12027-str-ae.smt2
@@ -1,0 +1,7 @@
+; EXPECT: sat
+(set-logic ALL)
+(declare-fun i () Int)
+(declare-fun t () String)
+(declare-fun r () String)
+(assert (distinct 0 (str.indexof (str.++ r r) (str.++ t t) (* (abs i) (str.len (str.++ t t))))))
+(check-sat)


### PR DESCRIPTION
This utility would incorrectly say that zero was a lower bound e.g. for (* (str.len s) n) where n could be negative.

This utility is only used in a single place: https://github.com/cvc5/cvc5/blob/main/src/theory/strings/strings_entail.cpp#L137,
where it is used to strip >=1 constants.  Incorrectly returning 0 had no effect in this case.

Fixes #12027.