### PR TITLE
Fix resource limit setup in get-value

### DIFF
--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -1184,11 +1184,6 @@ Node SolverEngine::simplify(const Node& t, bool applySubs)
 
 Node SolverEngine::getValue(const Node& t, bool fromUser)
 {
-  // can invoke satisfiability check below
-  if (fromUser)
-  {
-    beginCall(true);
-  }
   ensureWellFormedTerm(t, "get value");
   Trace("smt") << "SMT getValue(" << t << ")" << endl;
   TypeNode expectedType = t.getType();
@@ -1246,6 +1241,9 @@ Node SolverEngine::getValue(const Node& t, bool fromUser)
       // given in an assertion.
       if (NonClosedNodeConverter::isClosed(*d_env.get(), resultNode))
       {
+        // set up a resource limit
+        ResourceManager* rm = getResourceManager();
+        rm->beginCall();
         TypeNode rtn = resultNode.getType();
         SkolemManager* skm = d_env->getNodeManager()->getSkolemManager();
         Node k = skm->mkInternalSkolemFunction(
@@ -1274,6 +1272,8 @@ Node SolverEngine::getValue(const Node& t, bool fromUser)
           resultNode = getValueChecker->getValue(k);
           subSuccess = m->isValue(resultNode);
         }
+        // end resource limit
+        rm->refresh();
       }
     }
     if (!subSuccess)
@@ -1301,10 +1301,6 @@ Node SolverEngine::getValue(const Node& t, bool fromUser)
       resultNode = a;
       Trace("smt") << "--- abstract value >> " << resultNode << endl;
     }
-  }
-  if (fromUser)
-  {
-    endCall();
   }
   return resultNode;
 }

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1040,6 +1040,7 @@ set(regress_0_tests
   regress0/issue1063-overloading-dt-fun.smt2
   regress0/issue1063-overloading-dt-sel.smt2
   regress0/issue11198-real-as-int.smt2
+  regress0/issue12038-model-get-value.smt2
   regress0/issue2832-qualId.smt2
   regress0/issue4010-sort-inf-var.smt2
   regress0/issue4469-unc-no-reuse-var.smt2

--- a/test/regress/cli/regress0/issue12038-model-get-value.smt2
+++ b/test/regress/cli/regress0/issue12038-model-get-value.smt2
@@ -1,3 +1,4 @@
+; COMMAND-LINE: --produce-models
 ; EXPECT: sat
 ; EXPECT: ((A true))
 (set-logic ALL)

--- a/test/regress/cli/regress0/issue12038-model-get-value.smt2
+++ b/test/regress/cli/regress0/issue12038-model-get-value.smt2
@@ -1,0 +1,8 @@
+; EXPECT: sat
+; EXPECT: ((A true))
+(set-logic ALL)
+(declare-const A Bool)
+(declare-const b (_ BitVec 4))
+(assert (or (and A (= b #b0001)) (and A (= b #b0000))))
+(check-sat)
+(get-value (A))


### PR DESCRIPTION
Fixes #12038.

We were mistakenly popping the context, thus discarding the current model.