### PR TITLE
Add missing Java API docs for Datatype* classes

### DIFF
--- a/src/api/java/io/github/cvc5/Datatype.java
+++ b/src/api/java/io/github/cvc5/Datatype.java
@@ -103,7 +103,11 @@ public class Datatype extends AbstractPointer implements Iterable<DatatypeConstr
 
   private native long getSelector(long pointer, String name);
 
-  /** @return The name of this Datatype. */
+  /**
+   * Get the name of this Datatype.
+   *
+   * @return The name of this Datatype.
+   */
   public String getName()
   {
     return getName(pointer);
@@ -111,7 +115,11 @@ public class Datatype extends AbstractPointer implements Iterable<DatatypeConstr
 
   private native String getName(long pointer);
 
-  /** @return The number of constructors for this Datatype. */
+  /**
+   * Get the number of constructors for this Datatype.
+   *
+   * @return The number of constructors for this Datatype.
+   */
   public int getNumConstructors()
   {
     return getNumConstructors(pointer);
@@ -120,6 +128,8 @@ public class Datatype extends AbstractPointer implements Iterable<DatatypeConstr
   private native int getNumConstructors(long pointer);
 
   /**
+   * Get the parameters of this datatype.
+   *
    * @api.note This method is experimental and may change in future versions.
    *
    * @return The parameters of this datatype, if it is parametric. An exception.
@@ -135,6 +145,8 @@ public class Datatype extends AbstractPointer implements Iterable<DatatypeConstr
   private native long[] getParameters(long pointer);
 
   /**
+   * Determine if this datatype is parametric.
+   *
    * @api.note This method is experimental and may change in future versions.
    *
    * @return True if this datatype is parametric.
@@ -146,7 +158,11 @@ public class Datatype extends AbstractPointer implements Iterable<DatatypeConstr
 
   private native boolean isParametric(long pointer);
 
-  /** @return True if this datatype corresponds to a co-datatype */
+  /**
+   * Determine if this datatype corresponds to a co-datatype.
+   *
+   * @return True if this datatype corresponds to a co-datatype.
+   */
   public boolean isCodatatype()
   {
     return isCodatatype(pointer);
@@ -154,7 +170,11 @@ public class Datatype extends AbstractPointer implements Iterable<DatatypeConstr
 
   private native boolean isCodatatype(long pointer);
 
-  /** @return True if this datatype corresponds to a tuple */
+  /**
+   * Determine if this datatype corresponds to a tuple.
+   *
+   * @return True if this datatype corresponds to a tuple.
+   */
   public boolean isTuple()
   {
     return isTuple(pointer);
@@ -163,6 +183,8 @@ public class Datatype extends AbstractPointer implements Iterable<DatatypeConstr
   private native boolean isTuple(long pointer);
 
   /**
+   * Determine if this datatype corresponds to a record.
+   *
    * @api.note This method is experimental and may change in future versions.
    *
    * @return True if this datatype corresponds to a record.
@@ -174,7 +196,11 @@ public class Datatype extends AbstractPointer implements Iterable<DatatypeConstr
 
   private native boolean isRecord(long pointer);
 
-  /** @return True if this datatype is finite */
+  /**
+   * Determine if this datatype is finite.
+   *
+   * @return True if this datatype is finite
+   */
   public boolean isFinite()
   {
     return isFinite(pointer);
@@ -197,6 +223,8 @@ public class Datatype extends AbstractPointer implements Iterable<DatatypeConstr
   private native boolean isWellFounded(long pointer);
 
   /**
+   * Determine if this Datatype is a null object.
+   *
    * @return True if this Datatype is a null object.
    */
   public boolean isNull()
@@ -207,15 +235,26 @@ public class Datatype extends AbstractPointer implements Iterable<DatatypeConstr
   private native boolean isNull(long pointer);
 
   /**
+   * Provide a string representation of the native datatype.
+   * 
+   * @param pointer The native memory address pointing to the datatype. 
    * @return A string representation of this datatype.
    */
   protected native String toString(long pointer);
 
+  /**
+   * ConstIterator is an implementation of the {@link Iterator} interface for iterating over
+   * a collection of {@code DatatypeConstructor} objects.
+   * It provides read-only access to the elements.
+   */
   public class ConstIterator implements Iterator<DatatypeConstructor>
   {
     private int currentIndex;
     private int size;
 
+    /**
+     * Constructs a new ConstIterator.
+     */
     public ConstIterator()
     {
       currentIndex = -1;

--- a/src/api/java/io/github/cvc5/DatatypeConstructor.java
+++ b/src/api/java/io/github/cvc5/DatatypeConstructor.java
@@ -60,7 +60,11 @@ public class DatatypeConstructor extends AbstractPointer implements Iterable<Dat
 
   private native boolean equals(long pointer1, long pointer2);
 
-  /** @return The name of this Datatype constructor. */
+  /**
+   * Get the name of this Datatype constructor.
+   *
+   * @return The name of this Datatype constructor.
+   */
   public String getName()
   {
     return getName(pointer);
@@ -146,6 +150,8 @@ public class DatatypeConstructor extends AbstractPointer implements Iterable<Dat
   private native long getTesterTerm(long pointer);
 
   /**
+   * Get the number of selectors (so far) of this Datatype constructor.
+   *
    * @return The number of selectors (so far) of this Datatype constructor.
    */
   public int getNumSelectors()
@@ -181,6 +187,8 @@ public class DatatypeConstructor extends AbstractPointer implements Iterable<Dat
   private native long getSelector(long pointer, String name);
 
   /**
+   * Determine if this DatatypeConstructor is a null object.
+   *
    * @return True if this DatatypeConstructor is a null object.
    */
   public boolean isNull()
@@ -191,15 +199,26 @@ public class DatatypeConstructor extends AbstractPointer implements Iterable<Dat
   private native boolean isNull(long pointer);
 
   /**
+   * Provide a string representation of the native datatype constructor.
+   * 
+   * @param pointer The native memory address pointing to the datatype constructor. 
    * @return A string representation of this datatype constructor.
    */
   protected native String toString(long pointer);
 
+  /**
+   * ConstIterator is an implementation of the {@link Iterator} interface for iterating over
+   * a collection of {@code DatatypeSelector} objects.
+   * It provides read-only access to the elements.
+   */
   public class ConstIterator implements Iterator<DatatypeSelector>
   {
     private int currentIndex;
     private int size;
 
+    /**
+     * Constructs a new ConstIterator.
+     */
     public ConstIterator()
     {
       currentIndex = -1;

--- a/src/api/java/io/github/cvc5/DatatypeConstructorDecl.java
+++ b/src/api/java/io/github/cvc5/DatatypeConstructorDecl.java
@@ -98,6 +98,8 @@ public class DatatypeConstructorDecl extends AbstractPointer
   private native void addSelectorUnresolved(long pointer, String name, String unresDataypeName);
 
   /**
+   * Determine if this DatatypeConstructorDecl is a null declaration.
+   *
    * @return True If this DatatypeConstructorDecl is a null declaration.
    */
   public boolean isNull()

--- a/src/api/java/io/github/cvc5/DatatypeDecl.java
+++ b/src/api/java/io/github/cvc5/DatatypeDecl.java
@@ -109,6 +109,8 @@ public class DatatypeDecl extends AbstractPointer
   private native boolean isParametric(long pointer);
 
   /**
+   * Determine if this DatatypeDecl is a null object.
+   *
    * @return True if this DatatypeDecl is a null object.
    */
   public boolean isNull()
@@ -123,7 +125,11 @@ public class DatatypeDecl extends AbstractPointer
    */
   protected native String toString(long pointer);
 
-  /** @return The name of this datatype declaration. */
+  /**
+   * Get the name of this datatype declaration.
+   *
+   * @return The name of this datatype declaration.
+   */
   public String getName()
   {
     return getName(pointer);

--- a/src/api/java/io/github/cvc5/DatatypeSelector.java
+++ b/src/api/java/io/github/cvc5/DatatypeSelector.java
@@ -57,7 +57,11 @@ public class DatatypeSelector extends AbstractPointer
 
   private native boolean equals(long pointer1, long pointer2);
 
-  /** @return The Name of this Datatype selector. */
+  /**
+   * Get the Name of this Datatype selector.
+   *
+   * @return The Name of this Datatype selector.
+   */
   public String getName()
   {
     return getName(pointer);
@@ -99,7 +103,11 @@ public class DatatypeSelector extends AbstractPointer
 
   private native long getUpdaterTerm(long pointer);
 
-  /** @return The Codomain sort of this selector. */
+  /**
+   * Get the Codomain sort of this selector.
+   *
+   * @return The Codomain sort of this selector.
+   */
   public Sort getCodomainSort()
   {
     long sortPointer = getCodomainSort(pointer);
@@ -109,6 +117,8 @@ public class DatatypeSelector extends AbstractPointer
   private native long getCodomainSort(long pointer);
 
   /**
+   * Determine if this DatatypeSelector is a null object.
+   *
    * @return True If this DatatypeSelector is a null object.
    */
   public boolean isNull()


### PR DESCRIPTION
This PR addresses several warnings reported by Javadoc 21.