### PR TITLE
Fix unsound proof rule str-indexof-eq-irr

### DIFF
--- a/proofs/eo/cpc/rules/Rewrites.eo
+++ b/proofs/eo/cpc/rules/Rewrites.eo
@@ -1410,7 +1410,7 @@
   :conclusion (= (seq.indexof t1 emp1 n1) n1)
 )
 (declare-rule str-indexof-eq-irr ((@T0 Type) (@T1 Type) (@T2 Type) (t1 (Seq @T0)) (s1 (Seq @T1)) (r1 (Seq @T2)) (n1 Int))
-  :premises ((= (seq.extract t1 n1 (seq.len t1)) (seq.extract r1 n1 (seq.len r1))))
+  :premises ((= (<= n1 (seq.len t1)) true) (= (<= n1 (seq.len r1)) true) (= (seq.extract t1 n1 (seq.len t1)) (seq.extract r1 n1 (seq.len r1))))
   :args (t1 s1 r1 n1)
   :conclusion (= (= (seq.indexof t1 s1 n1) (seq.indexof r1 s1 n1)) true)
 )

--- a/src/theory/strings/rewrites
+++ b/src/theory/strings/rewrites
@@ -344,7 +344,7 @@
   n)
 
 (define-cond-rule str-indexof-eq-irr ((t ?Seq) (s ?Seq) (r ?Seq) (n Int))
-  (= (str.substr t n (str.len t)) (str.substr r n (str.len r)))
+  (and (<= n (str.len t)) (<= n (str.len r)) (= (str.substr t n (str.len t)) (str.substr r n (str.len r))))
   (= (str.indexof t s n) (str.indexof r s n))
   true)
 


### PR DESCRIPTION
Found by Eunoia+SMT-LIB formalization.

This was wrong for the corner case where the position was equal to one but not both of the end positions of the strings.