### PR TITLE
ci: Treat all Javadoc warnings as errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,24 +15,25 @@ jobs:
         build:
           - name: ubuntu:production
             os: ubuntu-22.04
-            config: production --auto-download --all-bindings --editline --docs --docs-ga -DBUILD_GMP=1
+            config: production --auto-download --all-bindings --editline -DBUILD_GMP=1
             cache-key: production
             strip-bin: strip
             python-bindings: true
             java-bindings: true
-            build-documentation: true
             check-examples: true
             package-name: cvc5-Linux-x86_64
             exclude_regress: 3-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
           - name: ubuntu:safe-mode
-            os: ubuntu-22.04
-            config: safe-mode --auto-download --all-bindings --editline -DBUILD_GMP=1
+            os: ubuntu-24.04
+            config: safe-mode --auto-download --all-bindings --editline --docs --docs-ga -DBUILD_GMP=1
             cache-key: production-safe
             strip-bin: strip
             python-bindings: true
             java-bindings: true
+            java-version: 21
+            build-documentation: true
             check-examples: true
             exclude_regress: 3-4
             run_regression_args: --tester base --tester proof --tester cpc --tester model --tester synth --tester abduct --tester dump

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,8 @@ option(ENABLE_COVERAGE         "Enable support for gcov coverage testing")
 option(ENABLE_DEBUG_CONTEXT_MM "Enable the debug context memory manager")
 option(ENABLE_PROFILING        "Enable support for gprof profiling")
 
+option(TREAT_WARNING_AS_ERROR  "Treat warnings on building as errors")
+
 # Optional dependencies
 #
 # >> 2-valued: ON OFF

--- a/configure.sh
+++ b/configure.sh
@@ -362,6 +362,7 @@ done
 if [ $werror != default ]; then
   export CFLAGS=-Werror
   export CXXFLAGS=-Werror
+  cmake_opts="$cmake_opts -DTREAT_WARNING_AS_ERROR=$werror"
 fi
 
 [ $buildtype != default ] \

--- a/docs/api/java/CMakeLists.txt
+++ b/docs/api/java/CMakeLists.txt
@@ -53,11 +53,18 @@ if(BUILD_BINDINGS_JAVA)
   string(REPLACE "\n" " " JAVADOC_MATHJAX ${JAVADOC_MATHJAX})
   string(REPLACE " " ";" JAVADOC_MATHJAX ${JAVADOC_MATHJAX})
 
+set(Java_DOCLINT -Xdoclint:all)
+if(TREAT_WARNING_AS_ERROR)
+  list(APPEND Java_DOCLINT -Werror)
+endif()
+
   get_target_property(CVC5_JAR_FILE cvc5jar JAR_FILE)
   add_custom_command(
     OUTPUT ${JAVADOC_INDEX_FILE}
     COMMAND
       ${Java_JAVADOC_EXECUTABLE} io.github.cvc5
+      ${Java_DOCLINT}
+      -Xmaxwarns 1000
       -sourcepath ${CMAKE_SOURCE_DIR}/src/api/java/:${CMAKE_BINARY_DIR}/src/api/java/
       -d ${JAVADOC_OUTPUT_DIR}
       -cp ${CVC5_JAR_FILE}

--- a/src/api/java/io/github/cvc5/AbstractPlugin.java
+++ b/src/api/java/io/github/cvc5/AbstractPlugin.java
@@ -15,6 +15,9 @@
 
 package io.github.cvc5;
 
+/**
+ * A cvc5 plugin abstract class.
+ */
 public abstract class AbstractPlugin
 {
   /**
@@ -26,6 +29,7 @@ public abstract class AbstractPlugin
     this.termManager = tm;
   }
 
+  /** The associated term manager. */
   protected final TermManager termManager;
 
   /**

--- a/src/api/java/io/github/cvc5/CVC5ApiException.java
+++ b/src/api/java/io/github/cvc5/CVC5ApiException.java
@@ -15,8 +15,17 @@
 
 package io.github.cvc5;
 
+/**
+ * Base class for all API exceptions.
+ * If thrown, all API objects may be in an unsafe state.
+ */
 public class CVC5ApiException extends Exception
 {
+  /**
+   * Construct with message from a string.
+   *
+   * @param message The error message.
+   */
   public CVC5ApiException(String message)
   {
     super(message);

--- a/src/api/java/io/github/cvc5/CVC5ApiOptionException.java
+++ b/src/api/java/io/github/cvc5/CVC5ApiOptionException.java
@@ -15,8 +15,17 @@
 
 package io.github.cvc5;
 
+/**
+ * An option-related API exception.
+ * If thrown, API objects can still be used.
+ */
 public class CVC5ApiOptionException extends CVC5ApiRecoverableException
 {
+  /**
+   * Construct with message from a string.
+   *
+   * @param message The error message.
+   */
   public CVC5ApiOptionException(String message)
   {
     super(message);

--- a/src/api/java/io/github/cvc5/CVC5ApiRecoverableException.java
+++ b/src/api/java/io/github/cvc5/CVC5ApiRecoverableException.java
@@ -15,8 +15,17 @@
 
 package io.github.cvc5;
 
+/**
+ * A recoverable API exception.
+ * If thrown, API objects can still be used.
+ */
 public class CVC5ApiRecoverableException extends CVC5ApiException
 {
+  /**
+   * Construct with message from a string.
+   *
+   * @param message The error message.
+   */
   public CVC5ApiRecoverableException(String message)
   {
     super(message);

--- a/src/api/java/io/github/cvc5/CVC5ParserException.java
+++ b/src/api/java/io/github/cvc5/CVC5ParserException.java
@@ -15,8 +15,16 @@
 
 package io.github.cvc5;
 
+/**
+ * A parser-related API exception.
+ */
 public class CVC5ParserException extends Exception
 {
+  /**
+   * Construct with message from a string.
+   *
+   * @param message The error message.
+   */
   public CVC5ParserException(String message)
   {
     super(message);

--- a/src/api/java/io/github/cvc5/Command.java
+++ b/src/api/java/io/github/cvc5/Command.java
@@ -14,6 +14,12 @@
  */
 package io.github.cvc5;
 
+/**
+ * Encapsulation of a command.
+ *
+ * Commands are constructed by the input parser and can be invoked on
+ * the solver and symbol manager.
+ */
 public class Command extends AbstractPointer
 {
   /**
@@ -61,6 +67,7 @@ public class Command extends AbstractPointer
   private native String getCommandName(long pointer);
 
   /**
+   * Determine if this command is null.
    * @return True if this command is null.
    */
   public boolean isNull()

--- a/src/api/java/io/github/cvc5/Grammar.java
+++ b/src/api/java/io/github/cvc5/Grammar.java
@@ -30,6 +30,12 @@ public class Grammar extends AbstractPointer
     super(pointer);
   }
 
+  /**
+   * Constructs a new {@code Grammar} instance by creating a deep copy of
+   * the specified {@code Grammar}.
+   *
+   * @param grammar the {@code Grammar} instance to copy
+   */
   public Grammar(Grammar grammar)
   {
     super(copyGrammar(grammar.pointer));
@@ -102,7 +108,7 @@ public class Grammar extends AbstractPointer
     addRules(pointer, ntSymbol.getPointer(), pointers);
   }
 
-  public native void addRules(long pointer, long ntSymbolPointer, long[] rulePointers);
+  private native void addRules(long pointer, long ntSymbolPointer, long[] rulePointers);
 
   /**
    * Allow {@code ntSymbol} to be an arbitrary constant.

--- a/src/api/java/io/github/cvc5/IOracle.java
+++ b/src/api/java/io/github/cvc5/IOracle.java
@@ -17,7 +17,18 @@
 
 package io.github.cvc5;
 
+/**
+ * Functional interface representing an oracle function that operates on an array of
+ * {@link Term} objects and produces a single {@link Term} as output.
+ */
 @FunctionalInterface
 public interface IOracle {
+  /**
+   * Applies the oracle to the given array of {@link Term} arguments.
+   *
+   * @param terms An array of {@link Term} objects to be used as input to the oracle.
+   * @return a {@link Term} representing the result of the oracle computation.
+   * @throws CVC5ApiException if an error occurs during term processing or oracle computation.
+   */
   Term apply(Term[] terms) throws CVC5ApiException;
 }

--- a/src/api/java/io/github/cvc5/InputParser.java
+++ b/src/api/java/io/github/cvc5/InputParser.java
@@ -84,6 +84,8 @@ public class InputParser extends AbstractPointer
   }
 
   /**
+   * Get the underlying solver of this input parser.
+   *
    * @return The underlying solver of this input parser
    */
   public Solver getSolver()
@@ -94,6 +96,8 @@ public class InputParser extends AbstractPointer
   private native long getSolver(long pointer);
 
   /**
+   * Get the underlying symbol manager of this input parser.
+   *
    * @return The underlying symbol manager of this input parser.
    */
   public SymbolManager getSymbolManager()
@@ -183,7 +187,11 @@ public class InputParser extends AbstractPointer
 
   private native long nextTerm(long pointer);
 
-  /** @return True if this parser done reading input. */
+  /**
+   * Determine if this parser done reading input.
+   *
+   * @return True if this parser done reading input.
+   */
   public boolean done()
   {
     return done(pointer);

--- a/src/api/java/io/github/cvc5/OptionInfo.java
+++ b/src/api/java/io/github/cvc5/OptionInfo.java
@@ -78,37 +78,79 @@ public class OptionInfo extends AbstractPointer
   /** Abstract class for OptionInfo values */
   public abstract class BaseInfo
   {
+    /**
+     * Construct a new BaseInfo.
+     */
+    public BaseInfo() {}
   }
 
-  /** Has the current and the default value */
+  /**
+   * Has the current and the default value
+   *
+   * @param <T> the type of the value
+   */
   public class ValueInfo<T> extends BaseInfo
   {
     private final T defaultValue;
     private final T currentValue;
+
+    /**
+     * Construct a new {@code ValueInfo} instance with the given default and current values.
+     *
+     * @param defaultValue the default value
+     * @param currentValue the current value
+     */
     public ValueInfo(T defaultValue, T currentValue)
     {
       this.defaultValue = defaultValue;
       this.currentValue = currentValue;
     }
+    /**
+     * Get the default value.
+     *
+     * @return the default value
+     */
     public T getDefaultValue()
     {
       return defaultValue;
     }
+    /**
+     * Get the current value.
+     *
+     * @return the current value
+     */
     public T getCurrentValue()
     {
       return currentValue;
     }
   }
 
+  /**
+   * Information for mode option values.
+   */
   public class ModeInfo extends ValueInfo<String>
   {
     private final String[] modes;
 
+    /**
+     * Constructs a {@code ModeInfo} instance with the specified default value,
+     * current value, and available mode options.
+     *
+     * @param defaultValue The default value
+     * @param currentValue The current value
+     * @param modes The possible mode values
+     */
     public ModeInfo(String defaultValue, String currentValue, String[] modes)
     {
       super(defaultValue, currentValue);
       this.modes = modes;
     }
+
+    /**
+     * Get the list of valid mode values.
+     *
+     * @return an array of available mode options
+     */
     public String[] getModes()
     {
       return modes;
@@ -118,23 +160,53 @@ public class OptionInfo extends AbstractPointer
   /** Has no value information */
   public class VoidInfo extends BaseInfo
   {
+    /**
+     * Construct a new VoidInfo.
+     */
+    public VoidInfo() {}
   }
 
-  /** Default value, current value, minimum and maximum of a numeric value */
+  /**
+   * Default value, current value, minimum and maximum of a numeric value
+   *
+   * @param <T> the type of the numeric value
+   */
   public class NumberInfo<T> extends ValueInfo<T>
   {
     private final T minimum;
     private final T maximum;
+
+    /**
+     * Construct a {@code NumberInfo} instance with specified default value,
+     * current value, minimum, and maximum.
+     *
+     * @param defaultValue the default value
+     * @param currentValue the current value
+     * @param minimum the minimum value
+     * @param maximum the maximum value
+     */
     public NumberInfo(T defaultValue, T currentValue, T minimum, T maximum)
     {
       super(defaultValue, currentValue);
       this.minimum = minimum;
       this.maximum = maximum;
     }
+
+    /**
+     * Get the minimum value.
+     *
+     * @return the minimum value
+     */
     public T getMinimum()
     {
       return minimum;
     }
+
+    /**
+     * Get the maximum value.
+     *
+     * @return the maximum value
+     */
     public T getMaximum()
     {
       return maximum;
@@ -151,18 +223,37 @@ public class OptionInfo extends AbstractPointer
 
   /** The option name */
   private final String name;
+
+  /**
+   * Get the name of the option.
+   *
+   * @return the option name
+   */
   public String getName()
   {
     return name;
   }
+
   /** The option name aliases */
   private final String[] aliases;
+  /**
+   * Get the option name aliases.
+   *
+   * @return an array of alias strings associated with the option
+   */
   public String[] getAliases()
   {
     return aliases;
   }
+
   /** Whether the option was explicitly set by the user */
   private final boolean setByUser;
+
+  /**
+   * Determine if the option was set by the user.
+   *
+   * @return True if the option was set by the user.
+   */
   public boolean getSetByUser()
   {
     return setByUser;
@@ -170,6 +261,11 @@ public class OptionInfo extends AbstractPointer
 
   /** The option variant information */
   private final BaseInfo baseInfo;
+  /**
+   * Get base info.
+   *
+   * @return The base info.
+   */
   public BaseInfo getBaseInfo()
   {
     return baseInfo;

--- a/src/api/java/io/github/cvc5/Result.java
+++ b/src/api/java/io/github/cvc5/Result.java
@@ -41,6 +41,9 @@ public class Result extends AbstractPointer
   protected native void deletePointer(long pointer);
 
   /**
+   * Determine if Result is empty, i.e., a nullary Result, and not an actual
+   * result returned from a checkSat() (and friends) query.
+   *
    * @return True if Result is empty, i.e., a nullary Result, and not an actual
    * result returned from a checkSat() (and friends) query.
    */
@@ -52,6 +55,9 @@ public class Result extends AbstractPointer
   private native boolean isNull(long pointer);
 
   /**
+   * Determine if query was a satisfiable checkSat() or checkSatAssuming()
+   * query.
+   *
    * @return True if query was a satisfiable checkSat() or checkSatAssuming()
    * query.
    */
@@ -63,6 +69,9 @@ public class Result extends AbstractPointer
   private native boolean isSat(long pointer);
 
   /**
+   * Determine if if query was an unsatisfiable checkSat() or
+   * checkSatAssuming() query.
+   *
    * @return True if query was an unsatisfiable checkSat() or
    * checkSatAssuming() query.
    */
@@ -74,6 +83,9 @@ public class Result extends AbstractPointer
   private native boolean isUnsat(long pointer);
 
   /**
+   * Determine if query was a checkSat() or checkSatAssuming() query and
+   * cvc5 was not able to determine (un)satisfiability.
+   *
    * @return True if query was a checkSat() or checkSatAssuming() query and
    * cvc5 was not able to determine (un)satisfiability.
    */

--- a/src/api/java/io/github/cvc5/Statistics.java
+++ b/src/api/java/io/github/cvc5/Statistics.java
@@ -20,6 +20,9 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+/**
+ * Represents a snapshot of the solver statistics.
+ */
 public class Statistics extends AbstractPointer implements Iterable<Map.Entry<String, Stat>>
 {
   // region construction and destruction
@@ -72,14 +75,29 @@ public class Statistics extends AbstractPointer implements Iterable<Map.Entry<St
 
   private native void deleteIteratorPointer(long iteratorPointer);
 
+  /**
+   * An iterator over the statistics entries maintained by the {@code Statistics} class.
+   * This is a constant (read-only) iterator that returns immutable key-value pairs,
+   * where the key is a {@code String} and the value is a {@code Stat}.
+   */
   public class ConstIterator implements Iterator<Map.Entry<String, Stat>>
   {
     private long iteratorPointer = 0;
 
+    /**
+     * Constructs a new iterator over the statistics with specific filtering options.
+     *
+     * @param internal If {@code true}, internal statistics are included in the iteration.
+     * @param defaulted If {@code true}, statistics that have default values are included.
+     */
     public ConstIterator(boolean internal, boolean defaulted)
     {
       iteratorPointer = getIteratorOpts(pointer, internal, defaulted);
     }
+    /**
+     * Constructs a new iterator over the statistics using default visibility options.
+     * By default, only public (non-internal) and explicitly set statistics are shown.
+     */
     public ConstIterator()
     {
       iteratorPointer = getIterator(pointer);
@@ -108,6 +126,15 @@ public class Statistics extends AbstractPointer implements Iterable<Map.Entry<St
     }
   }
 
+  /**
+   * Begin iteration over the statistics values.
+   * By default, only entries that are public (non-internal) and have been set
+   * are visible while the others are skipped.
+   *
+   * @param internal If set to {@code true}, internal statistics are shown as well.
+   * @param defaulted If set to {@code true}, defaulted statistics are shown as well.
+   * @return A {@code ConstIterator} over the matching statistics entries.
+   */
   public ConstIterator iterator(boolean internal, boolean defaulted)
   {
     return new ConstIterator(internal, defaulted);

--- a/src/api/java/io/github/cvc5/SymbolManager.java
+++ b/src/api/java/io/github/cvc5/SymbolManager.java
@@ -17,6 +17,19 @@ package io.github.cvc5;
 
 import java.util.*;
 
+/**
+ * Symbol manager. Internally, this class manages a symbol table and other
+ * meta-information pertaining to SMT2 file inputs (e.g. named assertions,
+ * declared functions, etc.).
+ *
+ * A symbol manager can be modified by invoking commands, see
+ * {@link Command#invoke(Solver, SymbolManager)}.
+ *
+ * A symbol manager can be provided when constructing an InputParser, in which
+ * case that InputParser has symbols of this symbol manager preloaded.
+ *
+ * The symbol manager's interface is otherwise not publicly available.
+ */
 public class SymbolManager extends AbstractPointer
 {
   /**
@@ -81,6 +94,8 @@ public class SymbolManager extends AbstractPointer
   }
 
   /**
+   * Determine if the logic of this symbol manager has been set.
+   *
    * @return True if the logic of this symbol manager has been set.
    */
   public boolean isLogicSet()
@@ -91,8 +106,9 @@ public class SymbolManager extends AbstractPointer
   private native boolean isLogicSet(long pointer);
 
   /**
-   * @api.note Asserts isLogicSet().
+   * Get the logic used by this symbol manager.
    *
+   * @api.note Asserts isLogicSet().
    * @return The logic used by this symbol manager.
    */
   public String getLogic()

--- a/src/api/java/io/github/cvc5/SynthResult.java
+++ b/src/api/java/io/github/cvc5/SynthResult.java
@@ -71,6 +71,9 @@ public class SynthResult extends AbstractPointer
   private native boolean equals(long pointer1, long pointer2);
 
   /**
+   * Determine if SynthResult is empty, i.e., a nullary SynthResult, and not
+   * an actual result returned from a synthesis query.
+   *
    * @return True if SynthResult is empty, i.e., a nullary SynthResult, and not
    * an actual result returned from a synthesis query.
    */
@@ -82,6 +85,8 @@ public class SynthResult extends AbstractPointer
   private native boolean isNull(long pointer);
 
   /**
+   * Determine if the synthesis query has a solution.
+   *
    * @return True if the synthesis query has a solution.
    */
   public boolean hasSolution()
@@ -92,6 +97,8 @@ public class SynthResult extends AbstractPointer
   private native boolean hasSolution(long pointer);
 
   /**
+   * Determine if the synthesis query has no solution.
+   *
    * @return True if the synthesis query has no solution. In this case, it was
    * determined there was no solution.
    */
@@ -103,6 +110,8 @@ public class SynthResult extends AbstractPointer
   private native boolean hasNoSolution(long pointer);
 
   /**
+   * Determine if the result of the synthesis query could not be determined.
+   *
    * @return True if the result of the synthesis query could not be determined.
    */
   public boolean isUnknown()

--- a/src/api/java/io/github/cvc5/TermManager.java
+++ b/src/api/java/io/github/cvc5/TermManager.java
@@ -119,7 +119,7 @@ public class TermManager extends AbstractPointer
     return new Sort(sortPointer);
   }
 
-  public native long getIntegerSort(long pointer);
+  private native long getIntegerSort(long pointer);
   /**
    * Get the real sort.
    * @return Sort Real.


### PR DESCRIPTION
This PR raises the quality standard for the cvc5 Java API documentation by treating all warnings reported by Javadoc (in Java 21) as errors and by addressing the remaining warnings in the source code. Since newer versions of Javadoc catch more issues than older ones, this PR uses the current Long-Term Support (LTS) release of Java (version 21) to generate the documentation. However, it continues to use Java 8 in the workflow jobs that build the JAR files for releases in order to maintain backward compatibility with the older Java version.