### PR TITLE
cadical: Update to fixed CaDiCaL version.

### DIFF
--- a/cmake/FindCaDiCaL.cmake
+++ b/cmake/FindCaDiCaL.cmake
@@ -87,8 +87,8 @@ if(NOT CaDiCaL_FOUND_SYSTEM)
   include(CheckSymbolExists)
   include(ExternalProject)
 
-  set(CaDiCaL_VERSION "rel-2.1.3")
-  set(CaDiCaL_CHECKSUM "abfe890aa4ccda7b8449c7ad41acb113cfb8e7e8fbf5e49369075f9b00d70465")
+  set(CaDiCaL_VERSION "rel-2.1.3-elevate")
+  set(CaDiCaL_CHECKSUM "15e1e82f7f9a9da0e97070cb8ac41d5b32139f65d54f72d2ff84849b0466ef92")
 
   # avoid configure script and instantiate the makefile manually the configure
   # scripts unnecessarily fails for cross compilation thus we do the bare

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1506,6 +1506,7 @@ set(regress_0_tests
   regress0/prop/cadical_bug6.smt2
   regress0/prop/cadical_bug7.smt2
   regress0/prop/issue11867.smt2
+  regress0/prop/red-psyco-134.smt2
   regress0/push-pop/boolean/fuzz_12.smt2
   regress0/push-pop/boolean/fuzz_13.smt2
   regress0/push-pop/boolean/fuzz_14.smt2

--- a/test/regress/cli/regress0/prop/red-psyco-134.smt2
+++ b/test/regress/cli/regress0/prop/red-psyco-134.smt2
@@ -1,0 +1,9 @@
+; COMMAND-LINE: --sat-solver=cadical
+; DISABLE-TESTER: proof
+; EXPECT: sat
+(set-logic LIA)
+(declare-const x Bool)
+(declare-const x1 Bool)
+(declare-fun R () Bool)
+(assert (and (or R x1) (forall ((V Int)) (or (not R) (and x1 (or (not R) (= 1 V))) (and x1 x (or (not R) (= 1 V)))))))
+(check-sat)


### PR DESCRIPTION
CaDiCaL version 2.1.3 via IPASIR-UP missed propagations in very rare corner cases. In fact, this only triggered erroneous behavior on our side on a single benchmark. This updates to the CaDiCaL version that incorporates the fix for this issue.