### PR TITLE
Fix unsound proof rule str-indexof-find-emp

### DIFF
--- a/proofs/eo/cpc/rules/Rewrites.eo
+++ b/proofs/eo/cpc/rules/Rewrites.eo
@@ -1405,7 +1405,7 @@
   :conclusion (= (seq.indexof (seq.++ t1 t2) s1 n1) (seq.indexof t1 s1 n1))
 )
 (declare-rule str-indexof-find-emp ((@T0 Type) (@T1 Type) (t1 (Seq @T0)) (emp1 (Seq @T1)) (n1 Int))
-  :premises ((= emp1 ($seq_empty (Seq @T0))) (= (>= (seq.len t1) n1) true))
+  :premises ((= emp1 ($seq_empty (Seq @T0))) (= (>= (seq.len t1) n1) true) (= (>= n1 0) true))
   :args (t1 emp1 n1 (Seq @T0))
   :conclusion (= (seq.indexof t1 emp1 n1) n1)
 )

--- a/src/theory/strings/rewrites
+++ b/src/theory/strings/rewrites
@@ -339,7 +339,7 @@
   (str.indexof t1 s n))
 
 (define-cond-rule str-indexof-find-emp ((t ?Seq) (emp ?Seq) (n Int))
-  (and (= emp (@seq.empty_of_type (@type_of t))) (>= (str.len t) n))
+  (and (= emp (@seq.empty_of_type (@type_of t))) (>= (str.len t) n) (>= n 0))
   (str.indexof t emp n)
   n)
 


### PR DESCRIPTION
Found by Eunoia+SMT-LIB formalization.

This also needed a guard that n is non-negative.