### PR TITLE
ci: Continue if setup-cmake fails

### DIFF
--- a/.github/actions/setup-cmake/action.yml
+++ b/.github/actions/setup-cmake/action.yml
@@ -20,6 +20,10 @@ runs:
         echo "::endgroup::"
 
     - name: Setup CMake
+      # This GH Action has been a bit flaky lately.
+      # Since testing with an old CMake version is not critical,
+      # let's continue even if it fails.
+      continue-on-error: true
       uses: jwlawson/actions-setup-cmake@v2
       with:
         cmake-version: '${{ steps.cmake.outputs.version }}.x'


### PR DESCRIPTION
The `setup-cmake` GitHub action has been a bit flaky lately. Since testing with an old CMake version is not critical, this change allows the process to continue even if it fails.