### PR TITLE
doc: Fix invalid escape sequences in Sphinx config files

### DIFF
--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -139,10 +139,10 @@ mathjax3_config = {
       '[+]': ['ams', 'bussproofs'],
     },
     'macros': {
-      'xor': '\\mathbin{xor}',
-      'ite': ['#1 \\mathbin{?} #2 \\mathbin{:} #3', 3],
-      'inferrule': ['\\begin{prooftree}\AxiomC{$#1$}\\UnaryInfC{$#2$}\\end{prooftree}', 2],
-      'inferruleSC': ['\\begin{prooftree}\AxiomC{$#1$}\RightLabel{ #3}\\UnaryInfC{$#2$}\\end{prooftree}', 3],
+      'xor': r'\mathbin{xor}',
+      'ite': [r'#1 \mathbin{?} #2 \mathbin{:} #3', 3],
+      'inferrule': [r'\begin{prooftree}\AxiomC{$#1$}\UnaryInfC{$#2$}\end{prooftree}', 2],
+      'inferruleSC': [r'\begin{prooftree}\AxiomC{$#1$}\RightLabel{ #3}\UnaryInfC{$#2$}\end{prooftree}', 3],
     }
   }
 }
@@ -166,47 +166,47 @@ googleanalytics_enabled = ${GOOGLE_ANALYTICS_ENABLE}
 
 # Configuration for tabs: title, language and group for detecting missing files
 examples_types = {
-        '\.cpp$': {
+        r'\.cpp$': {
                 'title': 'C++',
                 'lang': 'c++',
                 'group': 'c++'
         },
-        '\.c$': {
+        r'\.c$': {
                 'title': 'C',
                 'lang': 'c',
                 'group': 'c'
         },
-        '\.h$': {
+        r'\.h$': {
                 'title': 'C++ (header)',
                 'lang': 'c++',
                 'group': 'c++'
         },
-        '\.java$': {
+        r'\.java$': {
                 'title': 'Java',
                 'lang': 'java',
                 'group': 'java'
         },
-        '^<examples>.*pythonic.*\.py$': {
+        r'^<examples>.*pythonic.*\.py$': {
                 'title': 'Python (pythonic)',
                 'lang': 'python',
                 'group': 'py-pythonicapi'
         },
-        '^<examples>.*\.py$': {
+        r'^<examples>.*\.py$': {
                 'title': 'Python (base)',
                 'lang': 'python',
                 'group': 'py-regular'
         },
-        '^<pythonicapi>.*\.py$': {
+        r'^<pythonicapi>.*\.py$': {
                 'title': 'Python (pythonic)',
                 'lang': 'python',
                 'group': 'py-pythonicapi'
         },
-        '\.smt2$': {
+        r'\.smt2$': {
                 'title': 'SMT-LIBv2',
                 'lang': 'smtlib',
                 'group': 'smt2'
         },
-        '\.sy$': {
+        r'\.sy$': {
                 'title': 'SyGuS',
                 'lang': 'smtlib',
                 'group': 'smt2'
@@ -214,12 +214,12 @@ examples_types = {
 }
 # Special file patterns
 examples_file_patterns = {
-        '^<examples>(.*)': {
+        r'^<examples>(.*)': {
                 'local': '/../examples{}',
                 'url': 'https://github.com/cvc5/cvc5/tree/main/examples{}',
                 'urlname': 'examples{}',
         },
-        '<pythonicapi>(.*)': {
+        r'<pythonicapi>(.*)': {
                 'local': '/' + os.path.relpath('${CMAKE_BINARY_DIR}/deps/src/CVC5PythonicAPI', '${CMAKE_CURRENT_SOURCE_DIR}') + '{}',
                 'url': 'https://github.com/cvc5/cvc5_pythonic_api/tree/main{}',
                 'urlname': 'cvc5_pythonic_api:{}',

--- a/docs/ext/smtliblexer.py
+++ b/docs/ext/smtliblexer.py
@@ -24,7 +24,7 @@ class SmtLibLexer(RegexLexer):
     directly in the root state, as well as the commands, sorts and operators.
     Note that commands, sorts and operators are used to build regular
     expressions and, thus, can contain character classes (e.g. "[0-9]+"), but
-    also need to escape certain characters (e.g. "\." or "\+").
+    also need to escape certain characters (e.g. "\\." or "\\+").
     """
 
     name = 'smtlib'
@@ -63,41 +63,41 @@ class SmtLibLexer(RegexLexer):
         '=>', '=', 'true', 'false', 'not', 'and', 'or', 'xor', 'distinct',
         'ite',
         # datatypes
-        'tuple', 'tuple\.project', 'tuple\.select', 'tuple\.update',
+        'tuple', 'tuple\\.project', 'tuple\\.select', 'tuple\\.update',
         # fp
-        'RNE', 'RNA', 'RTP', 'RTN', 'RTZ', 'fp', 'NaN', 'fp\.abs', 'fp\.neg',
-        'fp\.add', 'fp\.sub', 'fp\.mul', 'fp\.div', 'fp\.fma', 'fp\.sqrt',
-        'fp\.rem', 'fp\.roundToIntegral', 'fp\.min', 'fp\.max', 'fp\.leq',
-        'fp\.lt', 'fp\.geq', 'fp\.gt', 'fp\.eq', 'fp\.isNormal',
-        'fp\.isSubnormal', 'fp\.isZero', 'fp\.isInfinite', 'fp\.isNaN',
-        'fp\.isNegative', 'fp\.isPositive', 'to_fp', 'to_fp_unsigned',
-        'fp\.to_ubv', 'fp\.to_sbv', 'fp\.to_real', '\+oo', '-oo', '\+zero',
+        'RNE', 'RNA', 'RTP', 'RTN', 'RTZ', 'fp', 'NaN', 'fp\\.abs', 'fp\\.neg',
+        'fp\\.add', 'fp\\.sub', 'fp\\.mul', 'fp\\.div', 'fp\\.fma', 'fp\\.sqrt',
+        'fp\\.rem', 'fp\\.roundToIntegral', 'fp\\.min', 'fp\\.max', 'fp\\.leq',
+        'fp\\.lt', 'fp\\.geq', 'fp\\.gt', 'fp\\.eq', 'fp\\.isNormal',
+        'fp\\.isSubnormal', 'fp\\.isZero', 'fp\\.isInfinite', 'fp\\.isNaN',
+        'fp\\.isNegative', 'fp\\.isPositive', 'to_fp', 'to_fp_unsigned',
+        'fp\\.to_ubv', 'fp\\.to_sbv', 'fp\\.to_real', '\\+oo', '-oo', '\\+zero',
         '-zero',
         # int / real
-        '<', '>', '<=', '>=', '!=', '\+', '-', '\*', '/', 'div', 'mod', 'abs',
+        '<', '>', '<=', '>=', '!=', '\\+', '-', '\\*', '/', 'div', 'mod', 'abs',
         'divisible', 'to_real', 'to_int', 'is_int', 'iand', 'int2bv',
         'int_to_bv', 'ubv_to_int', 'sbv_to_int',
         # separation logic
-        'sep\.emp', 'pto', 'sep', 'wand', 'sep\.nil',
+        'sep\\.emp', 'pto', 'sep', 'wand', 'sep\\.nil',
         # sets / relations
-        'set\.union', 'set\.minus', 'set\.member', 'set\.subset', 'set\.empty',
-        'set\.singleton', 'set\.card', 'set\.insert', 'set\.complement',
-        'set\.universe', 'rel\.transpose', 'rel\.tclosure', 'rel\.join',
-        'rel\.product', 'set\.inter',
+        'set\\.union', 'set\\.minus', 'set\\.member', 'set\\.subset', 'set\\.empty',
+        'set\\.singleton', 'set\\.card', 'set\\.insert', 'set\\.complement',
+        'set\\.universe', 'rel\\.transpose', 'rel\\.tclosure', 'rel\\.join',
+        'rel\\.product', 'set\\.inter',
         # string
-        'char', 'str\.\+\+', 'str\.len', 'str\.<', 'str\.<=', 'str\.to_re',
-        'str\.in_re', 're\.none', 're\.all', 're\.allchar', 're\.\+\+',
-        're\.union', 're\.inter', 're\.*', 'str\.<=', 'str\.at', 'str\.substr',
-        'str\.prefixof', 'str\.suffixof', 'str\.contains', 'str\.indexof',
-        'str\.replace', 'str\.replace_all', 'str\.replace_re',
-        'str\.replace_re_all', 're\.comp', 're\.diff', 're\.\+', 're\.opt',
-        're\.range', 're\.^', 're\.loop', 'str\.is_digit', 'str\.to_code',
-        'str\.from_code', 'str\.to_int', 'str\.from_int',
+        'char', 'str\\.\\+\\+', 'str\\.len', 'str\\.<', 'str\\.<=', 'str\\.to_re',
+        'str\\.in_re', 're\\.none', 're\\.all', 're\\.allchar', 're\\.\\+\\+',
+        're\\.union', 're\\.inter', 're\\.*', 'str\\.<=', 'str\\.at', 'str\\.substr',
+        'str\\.prefixof', 'str\\.suffixof', 'str\\.contains', 'str\\.indexof',
+        'str\\.replace', 'str\\.replace_all', 'str\\.replace_re',
+        'str\\.replace_re_all', 're\\.comp', 're\\.diff', 're\\.\\+', 're\\.opt',
+        're\\.range', 're\\.^', 're\\.loop', 'str\\.is_digit', 'str\\.to_code',
+        'str\\.from_code', 'str\\.to_int', 'str\\.from_int',
         # sequences
-        'seq\.\+\+', 'seq\.len', 'seq\.extract', 'seq\.update', 'seq\.at',
-        'seq\.contains', 'seq\.indexof', 'seq\.replace', 'seq\.prefixof',
-        'seq\.suffixof', 'seq\.rev', 'seq\.replace_all', 'seq\.unit',
-        'seq\.nth', 'seq\.empty',
+        'seq\\.\\+\\+', 'seq\\.len', 'seq\\.extract', 'seq\\.update', 'seq\\.at',
+        'seq\\.contains', 'seq\\.indexof', 'seq\\.replace', 'seq\\.prefixof',
+        'seq\\.suffixof', 'seq\\.rev', 'seq\\.replace_all', 'seq\\.unit',
+        'seq\\.nth', 'seq\\.empty',
         # others
         'witness',
     ]
@@ -128,11 +128,11 @@ class SmtLibLexer(RegexLexer):
             (r'\{', token.Text),
             (r'\}', token.Text),
             # commands (terminated by whitespace or ")")
-            ('(' + '|'.join(COMMANDS) + ')(?=(\s|\)))', token.Keyword),
+            ('(' + '|'.join(COMMANDS) + r')(?=(\s|\)))', token.Keyword),
             # sorts (terminated by whitespace or ")")
-            ('(' + '|'.join(SORTS) + ')(?=(\s|\)))', token.Name.Attribute),
+            ('(' + '|'.join(SORTS) + r')(?=(\s|\)))', token.Name.Attribute),
             # operators (terminated by whitespace or ")")
-            ('(' + '|'.join(OPERATORS) + ')(?=(\s|\)))', token.Operator),
+            ('(' + '|'.join(OPERATORS) + r')(?=(\s|\)))', token.Operator),
             # symbols (regular and quoted, see lexicon)
             (r'[a-zA-Z~!@$%^&*_+=<>.?/-][a-zA-Z0-9~!@$%^&*_+=<>.?/-]*', token.Name),
             (r'\|[^|\\]*\|', token.Name),


### PR DESCRIPTION
This PR addresses the `SyntaxWarning: invalid escape sequence` warnings reported by recent versions of Python.