### PR TITLE
Track has term incrementally for term db relevant

### DIFF
--- a/src/theory/quantifiers/master_eq_notify.cpp
+++ b/src/theory/quantifiers/master_eq_notify.cpp
@@ -32,7 +32,6 @@ void MasterNotifyClass::eqNotifyMerge(TNode t1, TNode t2)
   d_quantEngine->eqNotifyMerge(t1, t2);
 }
 
-
 }  // namespace quantifiers
 }  // namespace theory
 }  // namespace cvc5::internal

--- a/src/theory/quantifiers/master_eq_notify.cpp
+++ b/src/theory/quantifiers/master_eq_notify.cpp
@@ -29,7 +29,7 @@ void MasterNotifyClass::eqNotifyNewClass(TNode t)
 }
 void MasterNotifyClass::eqNotifyMerge(TNode t1, TNode t2)
 {
-  d_quantEngine->eqNotifyMerge(t);
+  d_quantEngine->eqNotifyMerge(t1, t2);
 }
 
 

--- a/src/theory/quantifiers/master_eq_notify.cpp
+++ b/src/theory/quantifiers/master_eq_notify.cpp
@@ -27,6 +27,10 @@ void MasterNotifyClass::eqNotifyNewClass(TNode t)
 {
   d_quantEngine->eqNotifyNewClass(t);
 }
+void MasterNotifyClass::eqNotifyMerge(TNode t1, TNode t2)
+{
+  d_quantEngine->eqNotifyMerge(t);
+}
 
 
 }  // namespace quantifiers

--- a/src/theory/quantifiers/master_eq_notify.h
+++ b/src/theory/quantifiers/master_eq_notify.h
@@ -52,7 +52,7 @@ class MasterNotifyClass : public theory::eq::EqualityEngineNotify
     return true;
   }
   void eqNotifyConstantTermMerge(TNode t1, TNode t2) override {}
-  void eqNotifyMerge(TNode t1, TNode t2) override {}
+  void eqNotifyMerge(TNode t1, TNode t2) override;
   void eqNotifyDisequal(TNode t1, TNode t2, TNode reason) override {}
 
   private:

--- a/src/theory/quantifiers/term_database.cpp
+++ b/src/theory/quantifiers/term_database.cpp
@@ -648,16 +648,18 @@ void TermDb::getOperatorsFor(TNode f, std::vector<TNode>& ops)
   ops.push_back(f);
 }
 
-void TermDb::setHasTerm( Node n ) 
+void TermDb::setHasTerm(Node n)
 {
   Trace("term-db-debug2") << "hasTerm : " << n  << std::endl;
   std::vector<TNode> visit;
   TNode cur;
   visit.push_back(n);
-  do {
+  do
+  {
     cur = visit.back();
     visit.pop_back();
-    if (d_has_map.find(cur) == d_has_map.end()) {
+    if (d_has_map.find(cur) == d_has_map.end())
+    {
       d_has_map.insert(cur);
       visit.insert(visit.end(), cur.begin(), cur.end());
     }

--- a/src/theory/quantifiers/term_database.cpp
+++ b/src/theory/quantifiers/term_database.cpp
@@ -439,22 +439,7 @@ void TermDb::computeUfTerms( TNode f ) {
 
       computeArgReps(n);
       std::vector<TNode>& reps = d_arg_reps[n];
-      Trace("term-db-debug") << "Adding term " << n << " with arg reps : ";
-      std::vector<std::vector<TNode> >& frds = d_fmapRelDom[f];
-      size_t rsize = reps.size();
-      // ensure the relevant domain vector has been allocated
-      frds.resize(rsize);
-      for (size_t i = 0; i < rsize; i++)
-      {
-        TNode r = reps[i];
-        Trace("term-db-debug") << r << " ";
-        std::vector<TNode>& frd = frds[i];
-        if (std::find(frd.begin(), frd.end(), r) == frd.end())
-        {
-          frd.push_back(r);
-        }
-      }
-      Trace("term-db-debug") << std::endl;
+      Trace("term-db-debug") << "Adding term " << n << " with arg reps : " << reps << std::endl;
       Assert(d_qstate.hasTerm(n));
       Trace("term-db-debug")
           << "  and value : " << d_qstate.getRepresentative(n) << std::endl;
@@ -499,6 +484,20 @@ void TermDb::computeUfTerms( TNode f ) {
                                d_dcproof.get());
         d_qstate.notifyInConflict();
         return;
+      }
+      // also populate relevant domain
+      std::vector<std::vector<TNode> >& frds = d_fmapRelDom[f];
+      size_t rsize = reps.size();
+      // ensure the relevant domain vector has been allocated
+      frds.resize(rsize);
+      for (size_t i = 0; i < rsize; i++)
+      {
+        TNode r = reps[i];
+        std::vector<TNode>& frd = frds[i];
+        if (std::find(frd.begin(), frd.end(), r) == frd.end())
+        {
+          frd.push_back(r);
+        }
       }
       nonCongruentCount++;
       d_op_nonred_count[f]++;

--- a/src/theory/quantifiers/term_database.cpp
+++ b/src/theory/quantifiers/term_database.cpp
@@ -648,7 +648,8 @@ void TermDb::getOperatorsFor(TNode f, std::vector<TNode>& ops)
   ops.push_back(f);
 }
 
-void TermDb::setHasTerm( Node n ) {
+void TermDb::setHasTerm( Node n ) 
+{
   Trace("term-db-debug2") << "hasTerm : " << n  << std::endl;
   std::vector<TNode> visit;
   TNode cur;
@@ -671,8 +672,6 @@ bool TermDb::reset( Theory::Effort effort ){
   d_func_map_trie.clear();
   d_func_map_eqc_trie.clear();
   d_fmapRelDom.clear();
-
-  eq::EqualityEngine* ee = d_qstate.getEqualityEngine();
 
   Assert(ee->consistent());
 

--- a/src/theory/quantifiers/term_database.h
+++ b/src/theory/quantifiers/term_database.h
@@ -126,6 +126,8 @@ class TermDb : public QuantifiersUtil {
    * matched with via E-matching, and can be used in entailment tests below.
    */
   void addTerm(Node n);
+  /** notification when master equality engine merges two classes*/
+  void eqNotifyMerge(TNode t1, TNode t2);
   /** Get the currently added ground terms of the given type */
   DbList* getOrMkDbListForType(TypeNode tn);
   /** Get the currently added ground terms for the given operator */
@@ -256,7 +258,7 @@ class TermDb : public QuantifiersUtil {
    */
   std::map<Node, std::vector<std::vector<TNode>>> d_fmapRelDom;
   /** has map */
-  std::map< Node, bool > d_has_map;
+  context::CDHashSet<Node> d_has_map;
   /** map from reps to a term in eqc in d_has_map */
   std::map<Node, Node> d_term_elig_eqc;
   /**

--- a/src/theory/quantifiers/term_registry.cpp
+++ b/src/theory/quantifiers/term_registry.cpp
@@ -80,7 +80,7 @@ void TermRegistry::addQuantifierBody(TNode n)
 
 void TermRegistry::eqNotifyNewClass(TNode t)
 {
-  addTermInternal(n, false);
+  addTermInternal(t, false);
 }
 
 void TermRegistry::eqNotifyMerge(TNode t1, TNode t2)

--- a/src/theory/quantifiers/term_registry.cpp
+++ b/src/theory/quantifiers/term_registry.cpp
@@ -73,15 +73,9 @@ void TermRegistry::finishInit(FirstOrderModel* fm,
   }
 }
 
-void TermRegistry::addQuantifierBody(TNode n)
-{
-  addTermInternal(n, true);
-}
+void TermRegistry::addQuantifierBody(TNode n) { addTermInternal(n, true); }
 
-void TermRegistry::eqNotifyNewClass(TNode t)
-{
-  addTermInternal(t, false);
-}
+void TermRegistry::eqNotifyNewClass(TNode t) { addTermInternal(t, false); }
 
 void TermRegistry::eqNotifyMerge(TNode t1, TNode t2)
 {

--- a/src/theory/quantifiers/term_registry.cpp
+++ b/src/theory/quantifiers/term_registry.cpp
@@ -73,7 +73,23 @@ void TermRegistry::finishInit(FirstOrderModel* fm,
   }
 }
 
-void TermRegistry::addTerm(TNode n, bool withinQuant)
+void TermRegistry::addQuantifierBody(TNode n)
+{
+  addTermInternal(n, true);
+}
+
+void TermRegistry::eqNotifyNewClass(TNode t)
+{
+  addTermInternal(n, false);
+}
+
+void TermRegistry::eqNotifyMerge(TNode t1, TNode t2)
+{
+  // notify the term database
+  d_termDb->eqNotifyMerge(t1, t2);
+}
+
+void TermRegistry::addTermInternal(TNode n, bool withinQuant)
 {
   // don't add terms in quantifier bodies
   if (withinQuant && !options().quantifiers.registerQuantBodyTerms)

--- a/src/theory/quantifiers/term_registry.h
+++ b/src/theory/quantifiers/term_registry.h
@@ -50,14 +50,12 @@ class TermRegistry : protected EnvObj
   /** Finish init, which sets the inference manager on modules of this class */
   void finishInit(FirstOrderModel* fm, QuantifiersInferenceManager* qim);
 
-  /**
-   * Add term n, which notifies the term database that the ground term n
-   * exists in the current context.
-   *
-   * @param n the term to add
-   * @param withinQuant whether n occurs within a quantified formula body
-   */
-  void addTerm(TNode n, bool withinQuant = false);
+  /** Add quantified formula body, which may impact term registration */
+  void addQuantifierBody(TNode n);
+  /** notification when master equality engine is updated */
+  void eqNotifyNewClass(TNode t);
+  /** notification when master equality engine merges two classes*/
+  void eqNotifyMerge(TNode t1, TNode t2);
 
   /** get term for type
    *
@@ -128,6 +126,14 @@ class TermRegistry : protected EnvObj
   FirstOrderModel* getModel() const;
 
  private:
+  /**
+   * Add term n, which notifies the term database that the ground term n
+   * exists in the current context.
+   *
+   * @param n the term to add
+   * @param withinQuant whether n occurs within a quantified formula body
+   */
+  void addTermInternal(TNode n, bool withinQuant = false);
   /** Whether we are using the fmc model */
   bool d_useFmcModel;
   /** term enumeration utility */

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -648,10 +648,10 @@ void QuantifiersEngine::assertQuantifier( Node f, bool pol ){
     mdl->assertNode(f);
   }
   // add term to the registry
-  d_treg.addTerm(d_qreg.getInstConstantBody(f), true);
+  d_treg.addQuantifierBody(d_qreg.getInstConstantBody(f));
 }
 
-void QuantifiersEngine::eqNotifyNewClass(TNode t) { d_treg.addTerm(t); }
+void QuantifiersEngine::eqNotifyNewClass(TNode t) { d_treg.eqNotifyNewClass(t); }
 
 void QuantifiersEngine::eqNotifyMerge(TNode t1, TNode t2)
 {

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -651,7 +651,10 @@ void QuantifiersEngine::assertQuantifier( Node f, bool pol ){
   d_treg.addQuantifierBody(d_qreg.getInstConstantBody(f));
 }
 
-void QuantifiersEngine::eqNotifyNewClass(TNode t) { d_treg.eqNotifyNewClass(t); }
+void QuantifiersEngine::eqNotifyNewClass(TNode t)
+{
+  d_treg.eqNotifyNewClass(t);
+}
 
 void QuantifiersEngine::eqNotifyMerge(TNode t1, TNode t2)
 {

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -653,6 +653,11 @@ void QuantifiersEngine::assertQuantifier( Node f, bool pol ){
 
 void QuantifiersEngine::eqNotifyNewClass(TNode t) { d_treg.addTerm(t); }
 
+void QuantifiersEngine::eqNotifyMerge(TNode t1, TNode t2)
+{
+  d_treg.eqNotifyMerge(t1, t2);
+}
+
 void QuantifiersEngine::markRelevant( Node q ) {
   d_model->markRelevant( q );
 }

--- a/src/theory/quantifiers_engine.h
+++ b/src/theory/quantifiers_engine.h
@@ -95,6 +95,8 @@ class QuantifiersEngine : protected EnvObj
   void assertQuantifier( Node q, bool pol );
   /** notification when master equality engine is updated */
   void eqNotifyNewClass(TNode t);
+  /** notification when master equality engine merges two classes*/
+  void eqNotifyMerge(TNode t1, TNode t2);
   /** mark relevant quantified formula, this will indicate it should be checked
    * before the others */
   void markRelevant(Node q);


### PR DESCRIPTION
This makes quantifiers roughly 10% faster on large industrial problems in my initial tests.

In detail, we recently switched to `--term-db=relevant`, which requires tracking which terms are relevant in the current SAT context. This makes this computation maintained incrementally, instead of recomputed at each full check.

This PR also includes a minor optimization to only update the relevant domain when a ground term is non-congruent.