### PR TITLE
doc: Copy references.bib to build directory

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -31,6 +31,7 @@ else()
 endif()
 
 configure_file(conf.py.in ${CMAKE_CURRENT_BINARY_DIR}/conf.py)
+configure_file(references.bib ${CMAKE_CURRENT_BINARY_DIR}/references.bib COPYONLY)
 
 add_custom_target(
   docs


### PR DESCRIPTION
This lets Sphinx find the `references.bib` file again.