### PR TITLE
doc: Fix toctree consistency issues

### DIFF
--- a/docs/api/c/c.rst
+++ b/docs/api/c/c.rst
@@ -88,7 +88,6 @@ The C API offers **two modes** of memory management:
    structs/cvc5optioninfo.rst
    structs/cvc5plugin
    enums/cvc5kind
-   enums/cvc5proofrule
    enums/cvc5sortkind
    enums/cvc5roundingmode
    enums/cvc5unknownexplanation
@@ -137,8 +136,6 @@ Enums
 - enum :doc:`enums/cvc5kind`
 - enum :doc:`enums/cvc5sortkind`
 - enum :cpp:enum:`Cvc5OptionInfoKind`
-- enum :cpp:enum:`Cvc5ProofRule`
-- enum :cpp:enum:`Cvc5ProofRewriteRule`
 - enum :doc:`enums/cvc5roundingmode`
 - enum :doc:`enums/cvc5unknownexplanation`
 
@@ -150,3 +147,8 @@ Enums
   - enum :cpp:enum:`Cvc5OptionCategory`
   - enum :cpp:enum:`Cvc5ProofComponent`
   - enum :cpp:enum:`Cvc5ProofFormat`
+
+- enums classes for :doc:`proof rules <enums/cvc5proofrule>`
+
+  - enum :cpp:enum:`Cvc5ProofRule`
+  - enum :cpp:enum:`Cvc5ProofRewriteRule`

--- a/docs/api/cpp/cpp.rst
+++ b/docs/api/cpp/cpp.rst
@@ -32,7 +32,6 @@ entry point to cvc5.
     classes/optioninfo
     classes/plugin
     classes/proof
-    enums/proofrule
     classes/result
     enums/roundingmode
     classes/solver
@@ -85,8 +84,11 @@ Class hierarchy
   * enum class :doc:`enums/sortkind`
   * enum class :doc:`enums/roundingmode`
   * enum class :doc:`enums/unknownexplanation`
-  * enum class :cpp:enum:`ProofRule <cvc5::ProofRule>`
-  * enum class :cpp:enum:`ProofRewriteRule <cvc5::ProofRewriteRule>`
+
+  * enum classes for :doc:`proof rules <enums/proofrule>`
+
+    * enum class :cpp:enum:`ProofRule <cvc5::ProofRule>`
+    * enum class :cpp:enum:`ProofRewriteRule <cvc5::ProofRewriteRule>`
 
 ``namespace modes {``
   * enum classes for :doc:`configuration modes <enums/modes>`

--- a/docs/api/python/base/python.rst
+++ b/docs/api/python/base/python.rst
@@ -31,10 +31,10 @@ For a higher-level, more pythonic programming experience, cvc5 provides the
     grammar
     inputparser
     kind
+    modes
     op
     plugin
     proof
-    proofrule
     result
     roundingmode
     solver


### PR DESCRIPTION
This PR addresses two issues reported by Sphinx. First, the `docs/api/python/base/modes.rst` document was not included in any toctree. Second, the `proofrule.rst` and `cvc5proofrule.rst` documents were included in multiple toctrees. The latter is resolved by including each document in only one toctree and referencing it elsewhere in the documentation using cross-references.