### PR TITLE
Optimize care graph for higher-order

### DIFF
--- a/src/theory/uf/ho_extension.cpp
+++ b/src/theory/uf/ho_extension.cpp
@@ -478,8 +478,6 @@ unsigned HoExtension::applyAppCompletion(TNode n)
 unsigned HoExtension::checkAppCompletion()
 {
   Trace("uf-ho") << "HoExtension::checkApplyCompletion..." << std::endl;
-  // compute the operators that are relevant (those for which an HO_APPLY exist)
-  std::set<TNode> rlvOp;
   eq::EqualityEngine* ee = d_state.getEqualityEngine();
   eq::EqClassesIterator eqcs_i = eq::EqClassesIterator(ee);
   std::map<TNode, std::vector<Node> > apply_uf;
@@ -499,59 +497,11 @@ unsigned HoExtension::checkAppCompletion()
         if (n.getKind() == Kind::APPLY_UF)
         {
           TNode rop = ee->getRepresentative(n.getOperator());
-          if (true || rlvOp.find(rop) != rlvOp.end())
+          // always apply app completion
+          curr_sum = applyAppCompletion(n);
+          if (curr_sum > 0)
           {
-            // try if its operator is relevant
-            curr_sum = applyAppCompletion(n);
-            if (curr_sum > 0)
-            {
-              return curr_sum;
-            }
-          }
-          else
-          {
-            // add to pending list
-            apply_uf[rop].push_back(n);
-          }
-          // Arguments are also relevant operators.
-          // It might be possible include fewer terms here, see #1115.
-          for (unsigned k = 0; k < n.getNumChildren(); k++)
-          {
-            if (n[k].getType().isFunction())
-            {
-              TNode rop2 = ee->getRepresentative(n[k]);
-              curr_rops[rop2] = true;
-            }
-          }
-        }
-        else
-        {
-          Assert(n.getKind() == Kind::HO_APPLY);
-          TNode rop = ee->getRepresentative(n[0]);
-          curr_rops[rop] = true;
-        }
-        for (std::map<TNode, bool>::iterator itc = curr_rops.begin();
-             itc != curr_rops.end();
-             ++itc)
-        {
-          TNode rop = itc->first;
-          if (rlvOp.find(rop) == rlvOp.end())
-          {
-            rlvOp.insert(rop);
-            // now, try each pending APPLY_UF for this operator
-            std::map<TNode, std::vector<Node> >::iterator itu =
-                apply_uf.find(rop);
-            if (itu != apply_uf.end())
-            {
-              for (unsigned j = 0, size = itu->second.size(); j < size; j++)
-              {
-                curr_sum = applyAppCompletion(itu->second[j]);
-                if (curr_sum > 0)
-                {
-                  return curr_sum;
-                }
-              }
-            }
+            return curr_sum;
           }
         }
       }

--- a/src/theory/uf/ho_extension.h
+++ b/src/theory/uf/ho_extension.h
@@ -121,7 +121,8 @@ class HoExtension : protected EnvObj
   bool collectModelInfoHo(TheoryModel* m, const std::set<Node>& termSet);
 
   /**
-   * Compute relevant terms. Used in higher-order.
+   * Compute relevant terms. For each (f a b) in termSet, we add terms
+   * e.g. (@ f a), (@ (@ f a) b) to termSet.
    */
   void computeRelevantTerms(std::set<Node>& termSet);
   

--- a/src/theory/uf/ho_extension.h
+++ b/src/theory/uf/ho_extension.h
@@ -120,6 +120,11 @@ class HoExtension : protected EnvObj
    */
   bool collectModelInfoHo(TheoryModel* m, const std::set<Node>& termSet);
 
+  /**
+   * Compute relevant terms. Used in higher-order.
+   */
+  void computeRelevantTerms(std::set<Node>& termSet);
+  
  protected:
   /** get apply uf for ho apply
    *
@@ -196,7 +201,6 @@ class HoExtension : protected EnvObj
    * true if the model m is consistent after this call.
    */
   bool collectModelInfoHoTerm(Node n, TheoryModel* m);
-
  private:
   /** Cache lemma lem, return true if it does not already exist */
   bool cacheLemma(TNode lem);

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -612,13 +612,17 @@ void TheoryUF::computeCareGraph() {
           {
             Node happ = nm->mkNode(Kind::HO_APPLY, curr, c);
             Assert(curr.getType().isFunction());
-            typeIndex[curr.getType()].addTerm(happ, {curr, c});
+            //typeIndex[curr.getType()].addTerm(happ, {curr, c});
             curr = happ;
             keep.push_back(happ);
           }
         }
       }
-      else if (k == Kind::HO_APPLY || k == Kind::BITVECTOR_UBV_TO_INT)
+      else if (k == Kind::HO_APPLY)
+      {
+        // skip
+      }
+      else if (k == Kind::BITVECTOR_UBV_TO_INT)
       {
         // add it to the typeIndex for the function type if HO_APPLY, or the
         // bitvector type if bv2nat. The latter ensures that we compute

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -579,6 +579,10 @@ void TheoryUF::computeCareGraph() {
   std::vector<Node> keep;
   std::map<Node, TNodeTrie> index;
   std::map<TypeNode, TNodeTrie> typeIndex;
+  // For HO_APPLY, we only consider care pairs of the form (= a b) where
+  // (@ f a) and (@ g b) exist and f = g. Conversely, we do not consider
+  // pairs (= f h) where (@ f a) and (@ h c) exist, as equality between f and
+  // h is managed by our policy for extensionality.
   std::map<Node, TNodeTrie> hoIndex;
   std::map<Node, size_t> arity;
   for (TNode app : d_functionsTerms)

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -555,6 +555,14 @@ void TheoryUF::processCarePairArgs(TNode a, TNode b)
   }
 }
 
+void TheoryUF::computeRelevantTerms(std::set<Node>& termSet)
+{
+  if (d_ho!=nullptr)
+  {
+    d_ho->computeRelevantTerms(termSet);
+  }
+}
+
 void TheoryUF::computeCareGraph() {
   if (d_state.getSharedTerms().empty())
   {
@@ -571,6 +579,7 @@ void TheoryUF::computeCareGraph() {
   std::vector<Node> keep;
   std::map<Node, TNodeTrie> index;
   std::map<TypeNode, TNodeTrie> typeIndex;
+  std::map<Node, TNodeTrie> hoIndex;
   std::map<Node, size_t> arity;
   for (TNode app : d_functionsTerms)
   {
@@ -597,30 +606,11 @@ void TheoryUF::computeCareGraph() {
         Node op = app.getOperator();
         index[op].addTerm(app, reps);
         arity[op] = reps.size();
-        if (isHigherOrder && d_equalityEngine->hasTerm(op))
-        {
-          // Since we use a lazy app-completion scheme for equating fully
-          // and partially applied versions of terms, we must add all
-          // sub-chains to the HO index if the operator of this term occurs
-          // in a higher-order context in the equality engine.  In other words,
-          // for (f a b c), this will add the terms:
-          // (HO_APPLY f a), (HO_APPLY (HO_APPLY f a) b),
-          // (HO_APPLY (HO_APPLY (HO_APPLY f a) b) c) to the higher-order
-          // term index for consideration when computing care pairs.
-          Node curr = op;
-          for (const Node& c : app)
-          {
-            Node happ = nm->mkNode(Kind::HO_APPLY, curr, c);
-            Assert(curr.getType().isFunction());
-            //typeIndex[curr.getType()].addTerm(happ, {curr, c});
-            curr = happ;
-            keep.push_back(happ);
-          }
-        }
       }
       else if (k == Kind::HO_APPLY)
       {
-        // skip
+        Node f = d_equalityEngine->getRepresentative(app[0]);
+        hoIndex[f].addTerm(app, {app[1]});
       }
       else if (k == Kind::BITVECTOR_UBV_TO_INT)
       {
@@ -646,12 +636,18 @@ void TheoryUF::computeCareGraph() {
     Assert(arity.find(tt.first) != arity.end());
     nodeTriePathPairProcess(&tt.second, arity[tt.first], d_cpacb);
   }
+  for (std::pair<const Node, TNodeTrie>& tt : hoIndex)
+  {
+    Trace("uf::sharing") << "TheoryUf::computeCareGraph(): Process index "
+                         << tt.first << "..." << std::endl;
+    nodeTriePathPairProcess(&tt.second, 1, d_cpacb);
+  }
   for (std::pair<const TypeNode, TNodeTrie>& tt : typeIndex)
   {
     // functions for HO_APPLY which has arity 2, bitvectors for bv2nat which
     // has arity one
     size_t a = tt.first.isFunction() ? 2 : 1;
-    Trace("uf::sharing") << "TheoryUf::computeCareGraph(): Process ho index "
+    Trace("uf::sharing") << "TheoryUf::computeCareGraph(): Process type index "
                          << tt.first << "..." << std::endl;
     // the arity of HO_APPLY is always two
     nodeTriePathPairProcess(&tt.second, a, d_cpacb);

--- a/src/theory/uf/theory_uf.h
+++ b/src/theory/uf/theory_uf.h
@@ -167,6 +167,10 @@ private:
    */
   void processCarePairArgs(TNode a, TNode b) override;
   /**
+   * Compute relevant terms. Used in higher-order.
+   */
+  void computeRelevantTerms(std::set<Node>& termSet) override;
+  /**
    * Is t a higher order type? A higher-order type is a function type having
    * an argument type that is also a function type. This is used for checking
    * logic exceptions.


### PR DESCRIPTION
This makes several changes to our handling of higher-order:
(1) Apply completion (which equates APPLY_UF to HO_APPLY chains) is applied more eagerly,
(2) Model construction for HO is made more standard by marking more terms as relevant.
(3) The care graph for HO_APPLY terms is optimized by only considering arguments of HO_APPLY, not functions.