### PR TITLE
Minor fixes to model construction for theory of datatypes

### DIFF
--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -1843,13 +1843,18 @@ void TheoryDatatypes::computeRelevantTerms(std::set<Node>& termSet)
     }
     // scan the equivalence class
     bool foundCons = false;
+    bool hasRlv = false;
     eq::EqClassIterator eqc_i = eq::EqClassIterator(r, d_equalityEngine);
     while (!eqc_i.isFinished())
     {
       TNode n = *eqc_i;
       ++eqc_i;
-      if (n.getKind() == Kind::APPLY_CONSTRUCTOR
-          && termSet.find(n) != termSet.end())
+      if (termSet.find(n) == termSet.end())
+      {
+        continue;
+      }
+      hasRlv = true;
+      if (n.getKind() == Kind::APPLY_CONSTRUCTOR)
       {
         // change the recorded constructor to be a relevant one
         ei->d_constructor = n;
@@ -1857,11 +1862,22 @@ void TheoryDatatypes::computeRelevantTerms(std::set<Node>& termSet)
         break;
       }
     }
+    // if no relevant terms whatsoever, we skip
+    if (!hasRlv)
+    {
+      continue;
+    }
     // If there are no constructors that are relevant, we consider the
     // recorded constructor to be relevant.
     if (!foundCons)
     {
-      termSet.insert(ei->d_constructor.get());
+      Node cons = ei->d_constructor.get();
+      termSet.insert(cons);
+      // its arguments are also relevant
+      for (const Node& nc : cons)
+      {
+        termSet.insert(nc);
+      }
     }
   }
 }


### PR DESCRIPTION
This corrects the corner case of model construction for the theory of datatypes.

In rare cases, an "instantiatied" constructor will be necessary to add to the model, despite not being an asserted term.

For example, if `t = (cons (head t) (tail t))` where this fact did not need to be shared, say, if `(head t)` is a term also belonging to theory of datatypes.

This corrects the model construction in two ways: 
(1) `(head t)` and `(tail t)` need also be marked as relevant.  
(2) Constructor terms that are preregistered but not asserted should *not* be marked as relevant.

The former ensures that doing congruence over selectors in the model equality engine is not necessary.

This is in preparation for making our model construction more intuitive (see https://github.com/cvc5/cvc5/pull/12093).