### PR TITLE
ci: Update code to clean up artifacts from latest

### DIFF
--- a/.github/actions/store-to-latest/action.yml
+++ b/.github/actions/store-to-latest/action.yml
@@ -46,25 +46,5 @@ runs:
         samedayprefix = '{}-{}-'.format(name, curtime)
         filename = '{}-{}-{}{}'.format(name, curtime, sha[:7], ext)
 
-        # prune old commits
-        assets = list(rel.get_assets())
-        assets.sort(key=lambda x: x.created_at, reverse=True)
-
-        for cnt,asset in enumerate(assets):
-          delete = False
-          # We generate 10 packages per build:
-          # {Linux-x86_64, Linux-arm64, macOS-x86_64, macOS-arm64, Win64-x86_64} * {static, shared}
-          # and 5 JARS {Linux-x86_64, Linux-arm64, macOS-x86_64, macOS-arm64, Win64-x86_64}
-          if cnt >= 30: # Keep at most 2 builds
-            delete = True
-          if asset.name.startswith(samedayprefix):
-            delete = True
-          # convert to timezone-aware datetime
-          age = datetime.datetime.now().replace(tzinfo=datetime.timezone.utc) - asset.created_at
-          if age.days > 7:
-            delete = True
-          if delete:
-            asset.delete_asset()
-
         # upload as asset with proper name
         rel.upload_asset(package, name=filename)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,3 +332,93 @@ jobs:
         github-token-latest: ${{ secrets.GITHUB_TOKEN }}
         github-token-release: ${{ secrets.ACTION_USER_TOKEN }}
         shell: ${{ matrix.build.shell }}
+
+
+  cleanup-artifacts:
+    name: Clean up artifacts from latest
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: [builds]
+    concurrency:
+      group: cleanup-artifacts
+      cancel-in-progress: false
+    steps:
+    - name: Prune old assets
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: 'python3 {0}'
+      run: |
+        import subprocess
+        import json
+        from datetime import datetime, timezone, timedelta
+        import re
+        import os
+
+        repo = os.environ["GITHUB_REPOSITORY"]
+
+        # Fetch latest release info
+        release_json = subprocess.run(
+            ["gh", "api", f"repos/{repo}/releases/tags/latest"],
+            capture_output=True,
+            text=True,
+            check=True
+        ).stdout
+        release = json.loads(release_json)
+
+        assets = release.get("assets", [])
+        now = datetime.now(timezone.utc)
+        seven_days_ago = now - timedelta(days=7)
+
+        # Set of assets to delete
+        delete_ids = set()
+
+        # Dictionary to group assets by prefix and date
+        # for filenames like "prefix-date-sha.ext"
+        # Structure: { prefix: { date: [asset1, asset2, ...] } }
+        prefix_date_assets = {}
+
+        # Group assets by prefix and date (excluding assets older than 7 days)
+        for asset in assets:
+            name = asset["name"]
+            created_at = datetime.fromisoformat(asset["created_at"].replace("Z", "+00:00"))
+
+            # Mark for deletion assets older than 7 days
+            if created_at < seven_days_ago:
+                delete_ids.add((asset["id"], asset["name"]))
+                continue
+
+            # Extract prefix and date from filenames like:
+            # "prefix-YYYY-MM-DD-sha.ext"
+            m = re.match(r"^(.+)-(\d{4}-\d{2}-\d{2})-.*$", name)
+            if not m:
+                continue
+
+            prefix, date_str = m.group(1), m.group(2)
+            # Append asset to the relevant prefix/date group
+            prefix_date_assets.setdefault(prefix, {}).setdefault(date_str, []).append(asset)
+
+        keep_ids = set()
+        # For each prefix, keep only:
+        # - The 2 most recent dates
+        # - The newest asset for each date
+        for prefix, date_assets in prefix_date_assets.items():
+            sorted_dates = sorted(date_assets.keys(), reverse=True)
+            top_two_dates = sorted_dates[:2]
+
+            for date in top_two_dates:
+                newest_asset = max(date_assets[date], key=lambda a: a["created_at"])
+                keep_ids.add(newest_asset["id"])
+
+        # Mark for deletion all assets not in keep_ids
+        for asset in assets:
+            if asset["id"] not in keep_ids:
+                delete_ids.add((asset["id"], asset["name"]))
+
+        # Delete old assets
+        for asset_id, asset_name in delete_ids:
+            print(f"Deleting asset {asset_name} ({asset_id})")
+            subprocess.run([
+                "gh", "api",
+                "--method", "DELETE",
+                f"repos/{repo}/releases/assets/{asset_id}"
+            ], check=True)


### PR DESCRIPTION
This PR updates the current code to address two issues:
1. CI sometimes spuriously fails when one job tries to remove an asset marked for deletion, but another job has already deleted it.
2. The code uses a hard-coded value and a counter to enforce that at most two builds per platform are kept. Now that the number and variety of artifacts has grown, this simple approach no longer guarantees that the correct set of artifacts is deleted.

This PR resolves the issues above by:
- Running the cleanup code in a single job after all jobs that build and upload artifacts have finished. Moreover, the new job uses a GitHub concurrency group to ensure that only one cleanup job runs at a time across concurrent workflows.
- Grouping assets by prefix and date to ensure that only the two most recent artifacts for each prefix and the newest asset for each date are kept.

The new code preserves the previous behavior of deleting any asset older than 7 days. It also removes the dependency on PyGithub, so no additional installation is required in the new job.