### PR TITLE
doc: Avoid duplicate indexing of cvc5.pythonic.Length

### DIFF
--- a/docs/api/python/pythonic/string.rst
+++ b/docs/api/python/pythonic/string.rst
@@ -14,6 +14,7 @@ String Operators
 -------------------
 
 .. autofunction:: cvc5.pythonic.Length
+   :noindex:
 .. autofunction:: cvc5.pythonic.SubString
 .. autofunction:: cvc5.pythonic.Contains
 .. autofunction:: cvc5.pythonic.PrefixOf


### PR DESCRIPTION
The `Length` function in the Pythonic API applies to both strings and sequences, so its documentation appears in `strings.rst` and `sequences.rst`. To avoid duplicate entries in the index, one occurrence is marked with `:noindex:`.