### PR TITLE
Add support for compilation on Windows ARM64

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -43,14 +43,22 @@ Compilation on Windows
 ^^^^^^^^^^^^^^^^^^^^^^
 
 Install `MSYS2 <https://www.msys2.org/>`_ and `Python <https://www.python.org/downloads/windows/>`_ on your system.
-Launch a `MINGW64 environment <https://www.msys2.org/docs/environments/>`_ and
-install the required packages for building cvc5:
+Then, launch the appropriate `MSYS2 environment <https://www.msys2.org/docs/environments/>`_ and
+install the required dependencies:
+
+- On x86_64 machines, open a `MINGW64` shell and run:
 
 .. code:: bash
 
   pacman -S git make mingw-w64-x86_64-cmake mingw-w64-x86_64-gcc mingw-w64-x86_64-gmp zip
 
-Clone the cvc5 repository and follow the general build steps above.
+- On ARM64 machines, open a `CLANGARM64` shell and run:
+
+.. code:: bash
+
+  pacman -S git make mingw-w64-clang-aarch64-cmake mingw-w64-clang-aarch64-clang mingw-w64-clang-aarch64-gmp zip
+
+After that, clone the cvc5 repository and follow the general build steps above.
 The built binary ``cvc5.exe`` and the DLL libraries are located in
 ``<build_dir>/bin``. The import libraries and the static libraries
 can be found in ``<build_dir>/lib``.

--- a/docs/api/python/python.rst
+++ b/docs/api/python/python.rst
@@ -68,7 +68,9 @@ command instead of ``make install``:
 
   cmake --install . --component python-api
 
-For Windows, the steps above must be executed on a MINGW64 environment
+For Windows, the steps above must be executed in
+a MINGW64 or CLANGARM64 environment with the required
+dependencies installed
 (see the :doc:`installation instructions <../../installation/installation>`).
 
 Finally, you can make sure that it works by running:

--- a/examples/api/c/quickstart.c
+++ b/examples/api/c/quickstart.c
@@ -256,7 +256,7 @@ int main()
   //! [docs-c-quickstart-18 start]
   size_t size;
   const Cvc5Term* unsat_core = cvc5_get_unsat_core(slv, &size);
-  printf("unsat core size: %lu\n", size);
+  printf("unsat core size: %zu\n", size);
   printf("unsat core: \n");
   for (size_t i = 0; i < size; i++)
   {

--- a/include/cvc5/cvc5_parser.h
+++ b/include/cvc5/cvc5_parser.h
@@ -185,7 +185,7 @@ class CVC5_EXPORT Command
   std::shared_ptr<Cmd> d_cmd;
 }; /* class Command */
 
-std::ostream& operator<<(std::ostream&, const Command&) CVC5_EXPORT;
+ CVC5_EXPORT std::ostream& operator<<(std::ostream&, const Command&);
 
 /**
  * This class is the main interface for retrieving commands and expressions

--- a/src/api/c/cvc5.cpp
+++ b/src/api/c/cvc5.cpp
@@ -4869,6 +4869,8 @@ const char** cvc5_get_option_names(Cvc5* cvc5, size_t* size)
   return res.data();
 }
 
+static thread_local std::vector<const char*> c_modes;
+
 template <class... Ts>
 struct overloaded : Ts...
 {
@@ -4998,7 +5000,6 @@ void cvc5_get_option_info(Cvc5* cvc5, const char* option, Cvc5OptionInfo* info)
             info->info_mode.num_modes =
                 std::get<cvc5::OptionInfo::ModeInfo>(cpp_info.valueInfo)
                     .modes.size();
-            static thread_local std::vector<const char*> c_modes;
             c_modes.clear();
             for (const auto& m :
                  std::get<cvc5::OptionInfo::ModeInfo>(cpp_info.valueInfo).modes)

--- a/src/api/python/setup.py.in
+++ b/src/api/python/setup.py.in
@@ -21,6 +21,7 @@
 
 import os
 import sysconfig
+import platform
 from setuptools import setup
 
 ext_filename = 'cvc5_python_base' + sysconfig.get_config_var('EXT_SUFFIX')
@@ -78,8 +79,9 @@ else:
         # Compile argument '-DMS_WIN64' fixes a division by zero error
         # See https://stackoverflow.com/q/64898146
         extra_compile_args += ["-DMS_WIN64"]
-        # Add default MSYS2 installation path for local development
-        os.environ['PATH'] += r';C:\msys64\mingw64\bin'
+        machine = platform.machine().lower()
+        if machine in ["arm64", "aarch64"]:
+            os.environ['CXX'] = r'aarch64-w64-mingw32-clang++'
 
     ext_options = {
         "libraries" : ["cvc5", "cvc5parser"],

--- a/src/base/exception.h
+++ b/src/base/exception.h
@@ -137,7 +137,7 @@ inline void CheckArgument(bool cond, const T& arg CVC5_UNUSED)
   }
 }
 
-class CVC5_EXPORT LastExceptionBuffer
+class LastExceptionBuffer
 {
  public:
   LastExceptionBuffer();

--- a/src/expr/metakind_template.h
+++ b/src/expr/metakind_template.h
@@ -94,7 +94,7 @@ typedef cvc5::internal::kind::metakind::MetaKind_t MetaKind;
 /**
  * Get the metakind for a particular kind.
  */
-MetaKind metaKindOf(Kind k);
+CVC5_EXPORT MetaKind metaKindOf(Kind k);
 
 /**
  * Map a kind of the operator to the kind of the enclosing expression. For

--- a/src/expr/type_node.cpp
+++ b/src/expr/type_node.cpp
@@ -204,6 +204,27 @@ CardinalityClass TypeNode::getCardinalityClass()
   return ret;
 }
 
+bool TypeNode::isBoolean() const {
+  return (getKind() == Kind::TYPE_CONSTANT
+          && getConst<TypeConstant>() == BOOLEAN_TYPE);
+}
+
+bool TypeNode::isString() const {
+  return getKind() == Kind::TYPE_CONSTANT
+         && getConst<TypeConstant>() == STRING_TYPE;
+}
+
+/** Is this a regexp type */
+bool TypeNode::isRegExp() const {
+  return getKind() == Kind::TYPE_CONSTANT
+         && getConst<TypeConstant>() == REGEXP_TYPE;
+ }
+
+bool TypeNode::isRoundingMode() const {
+  return getKind() == Kind::TYPE_CONSTANT
+         && getConst<TypeConstant>() == ROUNDINGMODE_TYPE;
+}
+
 bool TypeNode::isCardinalityLessThan(size_t n)
 {
   if (isBoolean())

--- a/src/expr/type_node.h
+++ b/src/expr/type_node.h
@@ -933,27 +933,6 @@ inline void TypeNode::printAst(std::ostream& out, int indent) const {
   d_nv->printAst(out, indent);
 }
 
-inline bool TypeNode::isBoolean() const {
-  return (getKind() == Kind::TYPE_CONSTANT
-          && getConst<TypeConstant>() == BOOLEAN_TYPE);
-}
-
-inline bool TypeNode::isString() const {
-  return getKind() == Kind::TYPE_CONSTANT
-         && getConst<TypeConstant>() == STRING_TYPE;
-}
-
-/** Is this a regexp type */
-inline bool TypeNode::isRegExp() const {
-  return getKind() == Kind::TYPE_CONSTANT
-         && getConst<TypeConstant>() == REGEXP_TYPE;
- }
-
-inline bool TypeNode::isRoundingMode() const {
-  return getKind() == Kind::TYPE_CONSTANT
-         && getConst<TypeConstant>() == ROUNDINGMODE_TYPE;
-}
-
 inline bool TypeNode::isArray() const { return getKind() == Kind::ARRAY_TYPE; }
 
 inline bool TypeNode::isFiniteField() const

--- a/src/printer/printer.cpp
+++ b/src/printer/printer.cpp
@@ -33,8 +33,8 @@ using namespace std;
 
 namespace cvc5::internal {
 
-thread_local unique_ptr<Printer>
-    Printer::d_printers[static_cast<size_t>(Language::LANG_MAX)];
+static thread_local unique_ptr<Printer>
+    global_printers[static_cast<size_t>(Language::LANG_MAX)];
 
 unique_ptr<Printer> Printer::makePrinter(Language lang)
 {
@@ -149,11 +149,11 @@ Printer* Printer::getPrinter(Language lang)
   {
     lang = Language::LANG_SMTLIB_V2_6;  // default
   }
-  if (d_printers[static_cast<size_t>(lang)] == nullptr)
+  if (global_printers[static_cast<size_t>(lang)] == nullptr)
   {
-    d_printers[static_cast<size_t>(lang)] = makePrinter(lang);
+    global_printers[static_cast<size_t>(lang)] = makePrinter(lang);
   }
-  return d_printers[static_cast<size_t>(lang)].get();
+  return global_printers[static_cast<size_t>(lang)].get();
 }
 
 void Printer::printUnknownCommandStatus(std::ostream& out,

--- a/src/printer/printer.h
+++ b/src/printer/printer.h
@@ -389,10 +389,6 @@ class CVC5_EXPORT Printer
   /** Make a Printer for a given Language */
   static std::unique_ptr<Printer> makePrinter(Language lang);
 
-  /** Printers for each Language */
-  static thread_local std::unique_ptr<Printer>
-      d_printers[static_cast<size_t>(Language::LANG_MAX)];
-
 }; /* class Printer */
 
 }  // namespace cvc5::internal


### PR DESCRIPTION
This PR applies several changes required to compile cvc5 on Windows ARM64 using MSYS2 CLANGARM64. In particular, `thread_local` class fields and local function variables in classes and functions exported in the API are not allowed, so they have been converted into global variables within the compilation unit. Moreover, some functions in the cvc5 parser library were using non-exported functions from the cvc5 base library. This PR exports these functions and converts the ones that were inlined into non-inlined functions to make them exportable.

Here is a summary of the results of running the cvc5 version in main and in this branch:
```
config   status   total  solved     sat   unsat    best  timeout  memout  error  uniq  dis    time_cpu      memory 
main     ee      450474  385375  173928  211447  256627    57617     719      5    36    0  18909500.3  42742499.9 
pr       ee      450474  385370  173923  211447  192564    57621     720      5    31    0  18914388.1  42779989.7 
``` 
It seems that the Windows ARM64 changes do not significantly affect solver performance compared to the main branch.