### PR TITLE
Ensure secant planes for exp don't cross zero

### DIFF
--- a/src/theory/arith/nl/transcendental/exponential_solver.cpp
+++ b/src/theory/arith/nl/transcendental/exponential_solver.cpp
@@ -290,7 +290,7 @@ std::pair<Node, Node> ExponentialSolver::getSecantBounds(TNode e,
     // ensure we don't cross zero
     if (bounds.first.getConst<Rational>().sgn() != csign)
     {
-      bounds.first = center;
+      bounds.first = nm->mkConstReal(Rational(0));
     }
   }
   if (bounds.second.isNull())
@@ -302,7 +302,7 @@ std::pair<Node, Node> ExponentialSolver::getSecantBounds(TNode e,
     // ensure we don't cross zero
     if (bounds.second.getConst<Rational>().sgn() != csign)
     {
-      bounds.second = center;
+      bounds.second = nm->mkConstReal(Rational(0));
     }
   }
   return bounds;

--- a/src/theory/arith/nl/transcendental/exponential_solver.cpp
+++ b/src/theory/arith/nl/transcendental/exponential_solver.cpp
@@ -288,7 +288,7 @@ std::pair<Node, Node> ExponentialSolver::getSecantBounds(TNode e,
     // pick c-1
     bounds.first = rewrite(nm->mkNode(Kind::SUB, center, one));
     // ensure we don't cross zero
-    if (bounds.first.getConst<Rational>().sgn()!=csign)
+    if (bounds.first.getConst<Rational>().sgn() != csign)
     {
       bounds.first = center;
     }
@@ -300,7 +300,7 @@ std::pair<Node, Node> ExponentialSolver::getSecantBounds(TNode e,
     // pick c+1
     bounds.second = rewrite(nm->mkNode(Kind::ADD, center, one));
     // ensure we don't cross zero
-    if (bounds.second.getConst<Rational>().sgn()!=csign)
+    if (bounds.second.getConst<Rational>().sgn() != csign)
     {
       bounds.second = center;
     }

--- a/src/theory/arith/nl/transcendental/exponential_solver.cpp
+++ b/src/theory/arith/nl/transcendental/exponential_solver.cpp
@@ -279,6 +279,7 @@ std::pair<Node, Node> ExponentialSolver::getSecantBounds(TNode e,
 {
   std::pair<Node, Node> bounds = d_data->getClosestSecantPoints(e, center, d);
 
+  int csign = center.getConst<Rational>().sgn();
   // Check if we already have neighboring secant points
   if (bounds.first.isNull())
   {
@@ -286,6 +287,11 @@ std::pair<Node, Node> ExponentialSolver::getSecantBounds(TNode e,
     Node one = nm->mkConstInt(Rational(1));
     // pick c-1
     bounds.first = rewrite(nm->mkNode(Kind::SUB, center, one));
+    // ensure we don't cross zero
+    if (bounds.first.getConst<Rational>().sgn()!=csign)
+    {
+      bounds.first = center;
+    }
   }
   if (bounds.second.isNull())
   {
@@ -293,6 +299,11 @@ std::pair<Node, Node> ExponentialSolver::getSecantBounds(TNode e,
     Node one = nm->mkConstInt(Rational(1));
     // pick c+1
     bounds.second = rewrite(nm->mkNode(Kind::ADD, center, one));
+    // ensure we don't cross zero
+    if (bounds.second.getConst<Rational>().sgn()!=csign)
+    {
+      bounds.second = center;
+    }
   }
   return bounds;
 }

--- a/src/theory/arith/nl/transcendental/proof_checker.cpp
+++ b/src/theory/arith/nl/transcendental/proof_checker.cpp
@@ -153,7 +153,8 @@ Node TranscendentalProofRuleChecker::checkInternal(
     Node t = args[1];
     Node l = args[2];
     Node u = args[3];
-    if (l.getConst<Rational>().sgn()<0 || l.getConst<Rational>()>u.getConst<Rational>())
+    if (l.getConst<Rational>().sgn() < 0
+        || l.getConst<Rational>() > u.getConst<Rational>())
     {
       return Node::null();
     }
@@ -183,7 +184,8 @@ Node TranscendentalProofRuleChecker::checkInternal(
     Node t = args[1];
     Node l = args[2];
     Node u = args[3];
-    if (u.getConst<Rational>().sgn()>0 || l.getConst<Rational>()>u.getConst<Rational>())
+    if (u.getConst<Rational>().sgn() > 0
+        || l.getConst<Rational>() > u.getConst<Rational>())
     {
       return Node::null();
     }

--- a/src/theory/arith/nl/transcendental/proof_checker.cpp
+++ b/src/theory/arith/nl/transcendental/proof_checker.cpp
@@ -153,6 +153,10 @@ Node TranscendentalProofRuleChecker::checkInternal(
     Node t = args[1];
     Node l = args[2];
     Node u = args[3];
+    if (l.getConst<Rational>().sgn()<0 || l.getConst<Rational>()>u.getConst<Rational>())
+    {
+      return Node::null();
+    }
     TaylorGenerator tg(nm);
     TaylorGenerator::ApproximationBounds bounds;
     tg.getPolynomialApproximationBounds(Kind::EXPONENTIAL, d / 2, bounds);
@@ -179,6 +183,10 @@ Node TranscendentalProofRuleChecker::checkInternal(
     Node t = args[1];
     Node l = args[2];
     Node u = args[3];
+    if (u.getConst<Rational>().sgn()>0 || l.getConst<Rational>()>u.getConst<Rational>())
+    {
+      return Node::null();
+    }
     TaylorGenerator tg(nm);
     TaylorGenerator::ApproximationBounds bounds;
     tg.getPolynomialApproximationBounds(Kind::EXPONENTIAL, d / 2, bounds);


### PR DESCRIPTION
Also adds some checks to the internal proof checker.

This behavior was already broken on the regression `regress1/nl/exp-4.5-lt.smt2`.