### PR TITLE
ci: Add Windows ARM64 build job

### DIFF
--- a/.github/actions/add-package/action.yml
+++ b/.github/actions/add-package/action.yml
@@ -30,13 +30,21 @@ runs:
         rm -rf ${{ inputs.build-dir }}/install/lib/python*
         rm -rf ${{ inputs.build-dir }}/install/lib/site-packages
 
-        if [[ "$RUNNER_OS" == "Windows" ]]; then
+        if [[ "$MSYSTEM" == "MINGW64" ]]; then
           if [ -f ${{ inputs.build-dir }}/install/bin/libcvc5.dll ]; then
             cp /mingw64/bin/libgcc_s_seh-1.dll ${{ inputs.build-dir }}/install/bin/
             cp /mingw64/bin/libstdc++-6.dll ${{ inputs.build-dir }}/install/bin/
             cp /mingw64/bin/libwinpthread-1.dll ${{ inputs.build-dir }}/install/bin/
           else
             cp /mingw64/lib/libgmp.a ${{ inputs.build-dir }}/install/lib/
+          fi
+        fi
+
+        if [[ "$MSYSTEM" == "CLANGARM64" ]]; then
+          if [ -f ${{ inputs.build-dir }}/install/bin/libcvc5.dll ]; then
+            cp /clangarm64/bin/libc++.dll ${{ inputs.build-dir }}/install/bin/
+          else
+            cp /clangarm64/lib/libgmp.a ${{ inputs.build-dir }}/install/bin/
           fi
         fi
 

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -43,7 +43,7 @@ runs:
           g++-aarch64-linux-gnu
         echo "::endgroup::"
 
-    - name: Install software for cross-compiling for Windows
+    - name: Install software for cross-compiling for Windows x86_64
       # Boolean inputs are actually strings:
       # https://github.com/actions/runner/issues/1483
       if: runner.os == 'Linux' && inputs.windows-build == 'true'
@@ -75,8 +75,8 @@ runs:
         echo "$(pwd)" >> $GITHUB_PATH
         echo "$(pwd)/upstream/emscripten" >> $GITHUB_PATH
 
-    - name: Install Windows software
-      if: runner.os == 'Windows' && inputs.windows-build == 'true'
+    - name: Install Windows x86_64 software
+      if: runner.os == 'Windows' && runner.arch == 'X64' && inputs.windows-build == 'true'
       uses: msys2/setup-msys2@v2
       with:
         update: true
@@ -89,6 +89,22 @@ runs:
           mingw-w64-x86_64-cmake
           mingw-w64-x86_64-gcc
           mingw-w64-x86_64-gmp
+          zip
+
+    - name: Install Windows arm64 software
+      if: runner.os == 'Windows' && runner.arch == 'ARM64' && inputs.windows-build == 'true'
+      uses: msys2/setup-msys2@v2
+      with:
+        update: true
+        msystem: CLANGARM64
+        path-type: inherit
+        install: |
+          make
+          mingw-w64-clang-aarch64-autotools
+          mingw-w64-clang-aarch64-ccache
+          mingw-w64-clang-aarch64-clang
+          mingw-w64-clang-aarch64-cmake
+          mingw-w64-clang-aarch64-gmp
           zip
 
     - name: Set up num_proc variable for Linux and Windows

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -40,7 +40,7 @@ runs:
         echo "#include <cvc5/cvc5.h>" > /tmp/test.cpp
         echo "using namespace cvc5;" >> /tmp/test.cpp
         echo "int main() { TermManager tm; Solver s(tm); return 0; }" >> /tmp/test.cpp
-        g++ -std=c++17 /tmp/test.cpp -I install/include -L install/lib -lcvc5
+        c++ -std=c++17 /tmp/test.cpp -I install/include -L install/lib -lcvc5
 
     - name: Python Install Check
       shell: ${{ inputs.shell }}
@@ -52,7 +52,7 @@ runs:
         else
           export PYTHONPATH="$PYTHONPATH:$PYTHON_MODULE_PATH"
         fi
-        python3 -c "import cvc5"
+        python3 examples/api/python/quickstart.py
 
     - name: Check Examples
       shell: ${{ inputs.shell }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,21 @@ jobs:
             exclude_regress: 1-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
+          - name: win64:production-arm64
+            os: windows-11-arm
+            config: production --auto-download --all-bindings
+            cache-key: production-win64-native-arm64
+            strip-bin: strip
+            python-bindings: true
+            java-bindings: true
+            java-version: 21
+            windows-build: true
+            shell: 'msys2 {0}'
+            check-examples: true
+            package-name: cvc5-Win64-arm64
+            exclude_regress: 1-4
+            run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
+
           - name: win64:production-cross
             os: ubuntu-latest
             config: production --auto-download --win64

--- a/.github/workflows/package_pypi.yml
+++ b/.github/workflows/package_pypi.yml
@@ -32,6 +32,7 @@ jobs:
           - macos-x86_64
           - macos-arm64
           - windows-x86_64
+          - windows-arm64
         gpl: [false, true]
         include:
           - name: manylinux-x86_64
@@ -53,8 +54,13 @@ jobs:
           - name: windows-x86_64
             os: windows-latest
             shell: 'msys2 {0}'
+          - name: windows-arm64
+            os: windows-11-arm
+            shell: 'msys2 {0}'
         exclude:
           - name: windows-x86_64
+            gpl: true
+          - name: windows-arm64
             gpl: true
     defaults:
       run:
@@ -74,7 +80,7 @@ jobs:
         echo "$HOME/.venv/bin" >> $GITHUB_PATH
 
     - uses: msys2/setup-msys2@v2
-      if: runner.os == 'Windows'
+      if: runner.os == 'Windows' && runner.arch == 'X64'
       with:
         msystem: mingw64
         path-type: inherit
@@ -83,6 +89,17 @@ jobs:
           mingw-w64-x86_64-cmake
           mingw-w64-x86_64-gcc
           mingw-w64-x86_64-gmp
+
+    - uses: msys2/setup-msys2@v2
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      with:
+        msystem: clangarm64
+        path-type: inherit
+        install: |
+          make
+          mingw-w64-clang-aarch64-cmake
+          mingw-w64-clang-aarch64-clang
+          mingw-w64-clang-aarch64-gmp
 
     # cibuildwheel requires pyproject.toml to be present from the beginning
     - name: Create pyproject.toml
@@ -105,7 +122,7 @@ jobs:
       if: runner.os == 'Windows'
       id: mingw64-path
       shell: msys2 {0}
-      run: echo "bin=$(cygpath -m $(dirname $(which gcc)))" >> $GITHUB_OUTPUT
+      run: echo "bin=$(cygpath -m $(dirname $(which cc)))" >> $GITHUB_OUTPUT
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.23.3
@@ -129,6 +146,8 @@ jobs:
         CIBW_ENVIRONMENT_MACOS: >
           DYLD_LIBRARY_PATH="$(pwd)/install/lib:$DYLD_LIBRARY_PATH"
           MACOSX_DEPLOYMENT_TARGET=${{ matrix.macos-target }}
+        CIBW_ENVIRONMENT_WINDOWS: >
+          PATH="${{ steps.mingw64-path.outputs.bin }};$PATH"
         CIBW_TEST_COMMAND: python {project}/examples/api/python/quickstart.py
         CIBW_TEST_SKIP: "cp38-macosx_arm64" # Silence warning. See: https://github.com/pypa/cibuildwheel/pull/1171
 


### PR DESCRIPTION
This PR adds a Windows ARM64 job to both the CI and package_pypi workflows.