### PR TITLE
cmake: Use valid version id as specified in PEP 440

### DIFF
--- a/cmake/version-base.cmake
+++ b/cmake/version-base.cmake
@@ -7,6 +7,7 @@ set(CVC5_IS_RELEASE "false")
 set(GIT_BUILD "false")
 set(CVC5_VERSION "${CVC5_LAST_RELEASE}")
 set(CVC5_FULL_VERSION "${CVC5_LAST_RELEASE}")
+set(CVC5_WHEEL_VERSION "${CVC5_LAST_RELEASE}")
 set(CVC5_GIT_INFO "")
 
 # Shared library versioning. Increment SOVERSION for every new cvc5 release.

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -60,8 +60,10 @@ if(CVC5_IS_RELEASE STREQUAL "false")
     list(LENGTH VERSION_LIST VERSION_LIST_LENGTH)
   endwhile()
 
-  set(CVC5_VERSION "${NEXT_CVC5_VERSION}-dev")
-  set(CVC5_FULL_VERSION "${NEXT_CVC5_VERSION}-dev")
+  set(CVC5_VERSION "${NEXT_CVC5_VERSION}.dev")
+  set(CVC5_FULL_VERSION "${NEXT_CVC5_VERSION}.dev")
+  # Development segment MUST follow the format devN, where N is a sequence of digits.
+  set(CVC5_WHEEL_VERSION "${NEXT_CVC5_VERSION}.dev0")
 endif()
 
 # now use git to retrieve additional version information
@@ -97,7 +99,9 @@ if(GIT_FOUND)
     )
 
     if(CVC5_IS_RELEASE STREQUAL "false")
-      set(CVC5_FULL_VERSION "${CVC5_FULL_VERSION}-${GIT_BRANCH}@${GIT_COMMIT}")
+      set(CVC5_FULL_VERSION "${CVC5_FULL_VERSION}+${GIT_BRANCH}@${GIT_COMMIT}")
+      # A local version id MUST start with + and contain only ASCII letters, digits, and periods.
+      set(CVC5_WHEEL_VERSION "${CVC5_WHEEL_VERSION}+${GIT_COMMIT}")
     endif()
 
     # result is != 0 if worktree is dirty

--- a/src/api/python/__init__.py.in
+++ b/src/api/python/__init__.py.in
@@ -1,4 +1,4 @@
 import sys
 from .cvc5_python_base import *
 __file__ = cvc5_python_base.__file__
-__version__ = "${CVC5_VERSION}"
+__version__ = "${CVC5_WHEEL_VERSION}"


### PR DESCRIPTION
Versioning for development cvc5 builds was not working before merging PR #12116, so Python wheels always used the simple `X.Y.Z` version format. Now that Python wheels use development versioning, the wheel builds started to fail because the version identifiers were not valid according to [PEP 440](https://peps.python.org/pep-0440/). This PR specifies a valid version format for Python wheels and slightly modifies the cvc5 version scheme to make the two more consistent.