### PR TITLE
Introduce 3 new proof rules for handling distinct

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -1232,9 +1232,8 @@ enum ENUM(ProofRule)
    *   \inferrule{t_1=s_1,\dots,t_n=s_n\mid f(t_1,\dots, t_n)}{f(t_1,\dots, t_n) = f(s_1,\dots, s_n)}
    *
    * This rule is used for terms :math:`f(t_1,\dots, t_n)` whose kinds
-   * :math:`k` have variadic arity and are treated as right associative
-   * with a nil terminator, such as ``cvc5::Kind::AND``, ``cvc5::Kind::PLUS``
-   * and so on.
+   * :math:`k` have variadic arity and are treated as associative,
+   * such as ``cvc5::Kind::AND``, ``cvc5::Kind::PLUS`` and so on.
    * \endverbatim
    */
   EVALUE(NARY_CONG),
@@ -2777,9 +2776,9 @@ enum ENUM(ProofRewriteRule)
    *
    * .. math::
    *
-   *   (distinct \ t_1 \ldots t_n) = \bot
+   *   \mathit{distinct}(t_1, \ldots, t_n) = \bot
    *
-   * where :math:`t_i` is :math:`t_j` for some distinct :math:`i`, `j`.
+   * where :math:`t_i` is :math:`t_j` for some distinct :math:`i`, :math:`j`.
    *
    * \endverbatim
    */
@@ -2790,7 +2789,7 @@ enum ENUM(ProofRewriteRule)
    *
    * .. math::
    *
-   *   (distinct \ t_1 \ldots t_n) = \top
+   *   \mathit{distinct}(t_1, \ldots, t_n) = \top
    *
    * where :math:`t_1, \ldots, t_n` are distinct values.
    *

--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -1232,11 +1232,27 @@ enum ENUM(ProofRule)
    *   \inferrule{t_1=s_1,\dots,t_n=s_n\mid f(t_1,\dots, t_n)}{f(t_1,\dots, t_n) = f(s_1,\dots, s_n)}
    *
    * This rule is used for terms :math:`f(t_1,\dots, t_n)` whose kinds
-   * :math:`k` have variadic arity, such as ``cvc5::Kind::AND``,
-   * ``cvc5::Kind::PLUS`` and so on.
+   * :math:`k` have variadic arity and are treated as right associative
+   * with a nil terminator, such as ``cvc5::Kind::AND``, ``cvc5::Kind::PLUS``
+   * and so on.
    * \endverbatim
    */
   EVALUE(NARY_CONG),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Equality -- Argument list Congruence**
+   *
+   * .. math::
+   *
+   *   \inferrule{t_1=s_1,\dots,t_n=s_n\mid f(t_1,\dots, t_n)}{f(t_1,\dots, t_n) = f(s_1,\dots, s_n)}
+   *
+   * This rule is used for terms :math:`f(t_1,\dots, t_n)` whose kinds
+   * :math:`k` have variadic arity and are treated as taking an argument list.
+   * Currently, this rule is used only for congruence of terms whose kind is
+   * ``cvc5::Kind::DISTINCT``.
+   * \endverbatim
+   */
+  EVALUE(ARG_LIST_CONG),
   /**
    * \verbatim embed:rst:leading-asterisk
    * **Equality -- True intro**
@@ -2755,6 +2771,32 @@ enum ENUM(ProofRewriteRule)
    * \endverbatim
    */
   EVALUE(ARITH_POW_ELIM),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Equality -- Distinct conflict**
+   *
+   * .. math::
+   *
+   *   (distinct \ t_1 \ldots t_n) = \bot
+   *
+   * where :math:`t_i` is :math:`t_j` for some distinct :math:`i`, `j`.
+   *
+   * \endverbatim
+   */
+  EVALUE(DISTINCT_FALSE),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Equality -- Distinct conflict**
+   *
+   * .. math::
+   *
+   *   (distinct \ t_1 \ldots t_n) = \top
+   *
+   * where :math:`t_1, \ldots, t_n` are distinct values.
+   *
+   * \endverbatim
+   */
+  EVALUE(DISTINCT_TRUE),
   /**
    * \verbatim embed:rst:leading-asterisk
    * **Equality -- Beta reduction**

--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -1240,19 +1240,19 @@ enum ENUM(ProofRule)
   EVALUE(NARY_CONG),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Equality -- Argument list Congruence**
+   * **Equality -- Pairwise Congruence**
    *
    * .. math::
    *
    *   \inferrule{t_1=s_1,\dots,t_n=s_n\mid f(t_1,\dots, t_n)}{f(t_1,\dots, t_n) = f(s_1,\dots, s_n)}
    *
    * This rule is used for terms :math:`f(t_1,\dots, t_n)` whose kinds
-   * :math:`k` have variadic arity and are treated as taking an argument list.
+   * :math:`k` have variadic arity and are pairwise.
    * Currently, this rule is used only for congruence of terms whose kind is
    * ``cvc5::Kind::DISTINCT``.
    * \endverbatim
    */
-  EVALUE(ARG_LIST_CONG),
+  EVALUE(PAIRWISE_CONG),
   /**
    * \verbatim embed:rst:leading-asterisk
    * **Equality -- True intro**

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -106,6 +106,7 @@ const char* toString(ProofRule rule)
     case ProofRule::TRANS: return "TRANS";
     case ProofRule::CONG: return "CONG";
     case ProofRule::NARY_CONG: return "NARY_CONG";
+    case ProofRule::ARG_LIST_CONG: return "ARG_LIST_CONG";
     case ProofRule::TRUE_INTRO: return "TRUE_INTRO";
     case ProofRule::TRUE_ELIM: return "TRUE_ELIM";
     case ProofRule::FALSE_INTRO: return "FALSE_INTRO";
@@ -243,6 +244,8 @@ const char* toString(cvc5::ProofRewriteRule rule)
     case ProofRewriteRule::MACRO_ARITH_STRING_PRED_ENTAIL:
       return "macro-arith-string-pred-entail";
     case ProofRewriteRule::ARITH_POW_ELIM: return "arith-pow-elim";
+    case ProofRewriteRule::DISTINCT_FALSE: return "distinct-false";
+    case ProofRewriteRule::DISTINCT_TRUE: return "distinct-true";
     case ProofRewriteRule::BETA_REDUCE: return "beta-reduce";
     case ProofRewriteRule::LAMBDA_ELIM: return "lambda-elim";
     case ProofRewriteRule::MACRO_LAMBDA_CAPTURE_AVOID:

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -106,7 +106,7 @@ const char* toString(ProofRule rule)
     case ProofRule::TRANS: return "TRANS";
     case ProofRule::CONG: return "CONG";
     case ProofRule::NARY_CONG: return "NARY_CONG";
-    case ProofRule::ARG_LIST_CONG: return "ARG_LIST_CONG";
+    case ProofRule::PAIRWISE_CONG: return "PAIRWISE_CONG";
     case ProofRule::TRUE_INTRO: return "TRUE_INTRO";
     case ProofRule::TRUE_ELIM: return "TRUE_ELIM";
     case ProofRule::FALSE_INTRO: return "FALSE_INTRO";

--- a/src/theory/uf/proof_checker.cpp
+++ b/src/theory/uf/proof_checker.cpp
@@ -31,7 +31,7 @@ void UfProofRuleChecker::registerTo(ProofChecker* pc)
   pc->registerChecker(ProofRule::TRANS, this);
   pc->registerChecker(ProofRule::CONG, this);
   pc->registerChecker(ProofRule::NARY_CONG, this);
-  pc->registerChecker(ProofRule::ARG_LIST_CONG, this);
+  pc->registerChecker(ProofRule::PAIRWISE_CONG, this);
   pc->registerChecker(ProofRule::TRUE_INTRO, this);
   pc->registerChecker(ProofRule::TRUE_ELIM, this);
   pc->registerChecker(ProofRule::FALSE_INTRO, this);
@@ -91,7 +91,7 @@ Node UfProofRuleChecker::checkInternal(ProofRule id,
     return first.eqNode(curr);
   }
   else if (id == ProofRule::CONG || id == ProofRule::NARY_CONG
-           || id == ProofRule::ARG_LIST_CONG)
+           || id == ProofRule::PAIRWISE_CONG)
   {
     Assert(children.size() > 0);
     if (args.size() != 1)

--- a/src/theory/uf/proof_checker.cpp
+++ b/src/theory/uf/proof_checker.cpp
@@ -31,6 +31,7 @@ void UfProofRuleChecker::registerTo(ProofChecker* pc)
   pc->registerChecker(ProofRule::TRANS, this);
   pc->registerChecker(ProofRule::CONG, this);
   pc->registerChecker(ProofRule::NARY_CONG, this);
+  pc->registerChecker(ProofRule::ARG_LIST_CONG, this);
   pc->registerChecker(ProofRule::TRUE_INTRO, this);
   pc->registerChecker(ProofRule::TRUE_ELIM, this);
   pc->registerChecker(ProofRule::FALSE_INTRO, this);
@@ -89,7 +90,8 @@ Node UfProofRuleChecker::checkInternal(ProofRule id,
     }
     return first.eqNode(curr);
   }
-  else if (id == ProofRule::CONG || id == ProofRule::NARY_CONG)
+  else if (id == ProofRule::CONG || id == ProofRule::NARY_CONG
+           || id == ProofRule::ARG_LIST_CONG)
   {
     Assert(children.size() > 0);
     if (args.size() != 1)

--- a/src/theory/uf/theory_uf_rewriter.cpp
+++ b/src/theory/uf/theory_uf_rewriter.cpp
@@ -41,6 +41,14 @@ TheoryUfRewriter::TheoryUfRewriter(NodeManager* nm) : TheoryRewriter(nm)
                            TheoryRewriteCtx::PRE_DSL);
   registerProofRewriteRule(ProofRewriteRule::MACRO_LAMBDA_CAPTURE_AVOID,
                            TheoryRewriteCtx::PRE_DSL);
+  registerProofRewriteRule(ProofRewriteRule::DISTINCT_CARD_CONFLICT,
+                           TheoryRewriteCtx::PRE_DSL);
+  registerProofRewriteRule(ProofRewriteRule::DISTINCT_ELIM,
+                           TheoryRewriteCtx::PRE_DSL);
+  registerProofRewriteRule(ProofRewriteRule::DISTINCT_FALSE,
+                           TheoryRewriteCtx::PRE_DSL);
+  registerProofRewriteRule(ProofRewriteRule::DISTINCT_TRUE,
+                           TheoryRewriteCtx::PRE_DSL);
 }
 
 RewriteResponse TheoryUfRewriter::postRewrite(TNode node)
@@ -160,12 +168,17 @@ RewriteResponse TheoryUfRewriter::postRewrite(TNode node)
     Node rite = nm->mkNode(Kind::ITE, cond, r, nm->mkNode(Kind::SUB, r, ttm));
     return RewriteResponse(REWRITE_AGAIN_FULL, rite);
   }
+  else if (k == Kind::DISTINCT)
+  {
+    return rewriteDistinct(node);
+  }
   return RewriteResponse(REWRITE_DONE, node);
 }
 
 RewriteResponse TheoryUfRewriter::preRewrite(TNode node)
 {
-  if (node.getKind() == Kind::EQUAL)
+  Kind k = node.getKind();
+  if (k == Kind::EQUAL)
   {
     if (node[0] == node[1])
     {
@@ -176,6 +189,10 @@ RewriteResponse TheoryUfRewriter::preRewrite(TNode node)
       // uninterpreted constants are all distinct
       return RewriteResponse(REWRITE_DONE, nodeManager()->mkConst(false));
     }
+  }
+  else if (k == Kind::DISTINCT)
+  {
+    return rewriteDistinct(node);
   }
   return RewriteResponse(REWRITE_DONE, node);
 }
@@ -370,6 +387,60 @@ Node TheoryUfRewriter::rewriteViaRule(ProofRewriteRule id, const Node& n)
       }
     }
     break;
+    case ProofRewriteRule::DISTINCT_CARD_CONFLICT:
+      if (n.getKind() == Kind::DISTINCT)
+      {
+        TypeNode tn = n[0].getType();
+        // we intentionally only handle booleans and bitvectors here
+        // for the sake of simplicity.
+        if (tn.isBoolean() || tn.isBitVector())
+        {
+          if (tn.isCardinalityLessThan(n.getNumChildren()))
+          {
+            return nodeManager()->mkConst(false);
+          }
+        }
+      }
+      break;
+    case ProofRewriteRule::DISTINCT_FALSE:
+      if (n.getKind() == Kind::DISTINCT)
+      {
+        std::unordered_set<Node> children;
+        for (const Node& c : n)
+        {
+          if (!children.insert(c).second)
+          {
+            // distinct with duplicate child
+            return nodeManager()->mkConst(false);
+          }
+        }
+      }
+      break;
+    case ProofRewriteRule::DISTINCT_TRUE:
+      if (n.getKind() == Kind::DISTINCT)
+      {
+        bool allDistinctConst = true;
+        std::unordered_set<Node> children;
+        for (const Node& c : n)
+        {
+          if (!c.isConst() || !children.insert(c).second)
+          {
+            allDistinctConst = false;
+            break;
+          }
+        }
+        if (allDistinctConst)
+        {
+          return nodeManager()->mkConst(true);
+        }
+      }
+      break;
+    case ProofRewriteRule::DISTINCT_ELIM:
+      if (n.getKind() == Kind::DISTINCT)
+      {
+        return blastDistinct(nodeManager(), n);
+      }
+      break;
     default: break;
   }
   return Node::null();
@@ -567,6 +638,64 @@ Node TheoryUfRewriter::canEliminateLambda(NodeManager* nm, const Node& node)
     }
   }
   return Node::null();
+}
+
+RewriteResponse TheoryUfRewriter::rewriteDistinct(TNode node)
+{
+  Node ret = rewriteViaRule(ProofRewriteRule::DISTINCT_CARD_CONFLICT, node);
+  if (!ret.isNull())
+  {
+    // Cardinality of type does not allow to find distinct values for all
+    // children of this node.
+    return RewriteResponse(REWRITE_DONE, nodeManager()->mkConst<bool>(false));
+  }
+  // if all constant, rewrites to true/false
+  bool allConst = true;
+  std::unordered_set<Node> children;
+  for (const Node& c : node)
+  {
+    allConst = allConst && c.isConst();
+    if (!children.insert(c).second)
+    {
+      // distinct with duplicate child
+      return RewriteResponse(REWRITE_DONE, nodeManager()->mkConst<bool>(false));
+    }
+  }
+  if (allConst)
+  {
+    return RewriteResponse(REWRITE_DONE, nodeManager()->mkConst<bool>(true));
+  }
+  if (node.getNumChildren() <= 5)
+  {
+    return RewriteResponse(REWRITE_DONE, blastDistinct(nodeManager(), node));
+  }
+  return RewriteResponse(REWRITE_DONE, node);
+}
+
+Node TheoryUfRewriter::blastDistinct(NodeManager* nm, TNode in)
+{
+  Assert(in.getKind() == Kind::DISTINCT);
+
+  if (in.getNumChildren() == 2)
+  {
+    // if this is the case exactly 1 != pair will be generated so the
+    // AND is not required
+    return nm->mkNode(Kind::NOT, nm->mkNode(Kind::EQUAL, in[0], in[1]));
+  }
+
+  // assume that in.getNumChildren() > 2 => diseqs.size() > 1
+  std::vector<Node> diseqs;
+  for (TNode::iterator i = in.begin(); i != in.end(); ++i)
+  {
+    TNode::iterator j = i;
+    while (++j != in.end())
+    {
+      Node eq = nm->mkNode(Kind::EQUAL, *i, *j);
+      Node neq = nm->mkNode(Kind::NOT, eq);
+      diseqs.push_back(neq);
+    }
+  }
+  return nm->mkNode(Kind::AND, diseqs);
 }
 
 }  // namespace uf

--- a/src/theory/uf/theory_uf_rewriter.cpp
+++ b/src/theory/uf/theory_uf_rewriter.cpp
@@ -649,27 +649,8 @@ RewriteResponse TheoryUfRewriter::rewriteDistinct(TNode node)
     // children of this node.
     return RewriteResponse(REWRITE_DONE, nodeManager()->mkConst<bool>(false));
   }
-  // if all constant, rewrites to true/false
-  bool allConst = true;
-  std::unordered_set<Node> children;
-  for (const Node& c : node)
-  {
-    allConst = allConst && c.isConst();
-    if (!children.insert(c).second)
-    {
-      // distinct with duplicate child
-      return RewriteResponse(REWRITE_DONE, nodeManager()->mkConst<bool>(false));
-    }
-  }
-  if (allConst)
-  {
-    return RewriteResponse(REWRITE_DONE, nodeManager()->mkConst<bool>(true));
-  }
-  if (node.getNumChildren() <= 5)
-  {
-    return RewriteResponse(REWRITE_DONE, blastDistinct(nodeManager(), node));
-  }
-  return RewriteResponse(REWRITE_DONE, node);
+  // otherwise, eagerly expand
+  return RewriteResponse(REWRITE_DONE, blastDistinct(nodeManager(), node));
 }
 
 Node TheoryUfRewriter::blastDistinct(NodeManager* nm, TNode in)

--- a/src/theory/uf/theory_uf_rewriter.h
+++ b/src/theory/uf/theory_uf_rewriter.h
@@ -84,6 +84,10 @@ class TheoryUfRewriter : public TheoryRewriter
    * @return the result of eliminating n, if possible, or null otherwise.
    */
   static Node canEliminateLambda(NodeManager* nm, const Node& n);
+  /**
+   * Blast distinct, which eliminates the distinct operator.
+   */
+  static Node blastDistinct(NodeManager* nm, TNode node);
 
  private:
   /** Entry point for rewriting lambdas */
@@ -92,6 +96,8 @@ class TheoryUfRewriter : public TheoryRewriter
   RewriteResponse rewriteBVToInt(TNode node);
   /** rewrite int_to_bv */
   RewriteResponse rewriteIntToBV(TNode node);
+  /** rewrite distinct */
+  RewriteResponse rewriteDistinct(TNode node);
 }; /* class TheoryUfRewriter */
 
 }  // namespace uf


### PR DESCRIPTION
This is work towards having cvc5 handle `distinct` lazily. It introduces 3 new CPC rules for distinct. The first is to handle congruence over distinct, which no current congruence rule fits.

The second are 2 new proof rewrite rules for more fine grained (non-reduction) rewrites for distinct.