### PR TITLE
ci: Update cibuildwheel to v3.1.4

### DIFF
--- a/.github/workflows/package_pypi.yml
+++ b/.github/workflows/package_pypi.yml
@@ -125,14 +125,18 @@ jobs:
       run: echo "bin=$(cygpath -m $(dirname $(which cc)))" >> $GITHUB_OUTPUT
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23.3
+      uses: pypa/cibuildwheel@v3.1.4
       with:
         package-dir: ./build/src/api/python/
       env:
         CIBW_ALLOW_EMPTY: True
         CIBW_BUILD: "${{ github.event.inputs.python_versions || '*' }}"
-        CIBW_SKIP: "cp36-* pp*-win* *-win32 *-manylinux_i686 *-musllinux_*"
-        CIBW_ENABLE: pypy
+        CIBW_SKIP: "pp*-win* *-win32 *-manylinux_i686 *-musllinux_* cp31?t-*"
+        CIBW_ENABLE: pypy pypy-eol
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+        CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+        CIBW_MANYLINUX_PYPY_X86_64_IMAGE: manylinux2014
+        CIBW_MANYLINUX_PYPY_AARCH64_IMAGE: manylinux2014
         CIBW_ARCHS_LINUX: "${{ matrix.arch }}"
         CIBW_BEFORE_ALL_LINUX: bash ./contrib/cibw/before_all_linux.sh ${{ matrix.gpl }}
         CIBW_BEFORE_ALL_MACOS: bash ./contrib/cibw/before_all_macos.sh ${{ matrix.gpl }}


### PR DESCRIPTION
This PR adds support for CPython 3.14 (scheduled for release on 2025-10-07) and drops support for CPython 3.7 and PyPy 3.7. It continues to use the `manylinux2014` image to maintain compatibility with glibc >= 2.17 and older Linux distributions such as Amazon Linux 2.