### PR TITLE
Fix type in macro elaboration of var-elim-ineq

### DIFF
--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1505,6 +1505,7 @@ set(regress_0_tests
   regress0/proofs/t1-difficulty-filter.smt2
   regress0/proofs/tricky-sat-assumption-incremental-bookeeping.smt2
   regress0/proofs/trust-subs-eq-open.smt2
+  regress0/proofs/typeerror.smt2
   regress0/proofs/unused-def1.smt2
   regress0/proofs/unused-def2.smt2
   regress0/proofs/var-eq-elim-tester-simple.smt2

--- a/test/regress/cli/regress0/proofs/typeerror.smt2
+++ b/test/regress/cli/regress0/proofs/typeerror.smt2
@@ -1,3 +1,4 @@
+; COMMAND-LINE: --proof-elim-subtypes
 ; EXPECT: unsat
 (set-logic AUFLIRA)
 (assert (! (not (exists ((?v0 Int)) (forall ((?v1 Int) (?v2 Real)) (=> (and (< 0 ?v1) (< 0.0 ?v2)) (< (- 1) ?v1))))) :named a0))

--- a/test/regress/cli/regress0/proofs/typeerror.smt2
+++ b/test/regress/cli/regress0/proofs/typeerror.smt2
@@ -1,0 +1,5 @@
+; EXPECT: unsat
+(set-logic AUFLIRA)
+(assert (! (not (exists ((?v0 Int)) (forall ((?v1 Int) (?v2 Real)) (=> (and (< 0 ?v1) (< 0.0 ?v2)) (< (- 1) ?v1))))) :named a0))
+(check-sat)
+(get-proof)

--- a/test/regress/cli/regress0/proofs/typeerror.smt2
+++ b/test/regress/cli/regress0/proofs/typeerror.smt2
@@ -2,4 +2,3 @@
 (set-logic AUFLIRA)
 (assert (! (not (exists ((?v0 Int)) (forall ((?v1 Int) (?v2 Real)) (=> (and (< 0 ?v1) (< 0.0 ?v2)) (< (- 1) ?v1))))) :named a0))
 (check-sat)
-(get-proof)


### PR DESCRIPTION
Fixes mixed arithmetic that may be introduced by macro expansion, which occurs after subtype elimination. 
