### PR TITLE
Set default value for stable_mode in configure.sh

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -151,6 +151,7 @@ java_bindings=default
 editline=default
 build_shared=ON
 safe_mode=default
+stable_mode=default
 static_binary=default
 statistics=default
 tracing=default


### PR DESCRIPTION
It fixes the following error: `./configure.sh: line 434: [: !=: unary operator expected`