### PR TITLE
cmake: Reintroduce variable CVC5_WHEEL_VERSION

### DIFF
--- a/cmake/version-base.cmake
+++ b/cmake/version-base.cmake
@@ -7,6 +7,7 @@ set(CVC5_IS_RELEASE "false")
 set(GIT_BUILD "false")
 set(CVC5_VERSION "${CVC5_LAST_RELEASE}")
 set(CVC5_FULL_VERSION "${CVC5_LAST_RELEASE}")
+set(CVC5_WHEEL_VERSION "${CVC5_LAST_RELEASE}")
 set(CVC5_GIT_INFO "")
 
 # Shared library versioning. Increment SOVERSION for every new cvc5 release.

--- a/cmake/version-base.cmake.template
+++ b/cmake/version-base.cmake.template
@@ -7,6 +7,7 @@ set(CVC5_IS_RELEASE "{{IS_RELEASE}}")
 set(GIT_BUILD "false")
 set(CVC5_VERSION "${CVC5_LAST_RELEASE}")
 set(CVC5_FULL_VERSION "${CVC5_LAST_RELEASE}")
+set(CVC5_WHEEL_VERSION "${CVC5_LAST_RELEASE}")
 set(CVC5_GIT_INFO "")
 
 # Shared library versioning. Increment SOVERSION for every new cvc5 release.


### PR DESCRIPTION
The variable was introduced in PR #12120, but only in the `version-base.cmake` file. This PR includes it in the `version-base.cmake.template` file too to ensure it is preserved.