### PR TITLE
[alethe] Update names of proof-specific BV operators

### DIFF
--- a/contrib/get-carcara-checker
+++ b/contrib/get-carcara-checker
@@ -26,7 +26,7 @@ CARCARA_DIR="$BASE_DIR/carcara"
 mkdir -p $CARCARA_DIR
 
 # download and unpack Carcara
-CARCARA_VERSION="6ccf94d0704a20c8c3ffdd3f6d68dfe6079b8dc0"
+CARCARA_VERSION="e6920442ee95a7dd4a8a58a02a62e9425541acbc"
 download "https://github.com/hanielb/carcara/archive/$CARCARA_VERSION.tar.gz" $BASE_DIR/tmp/carcara.tgz
 tar --strip 1 -xzf $BASE_DIR/tmp/carcara.tgz -C $CARCARA_DIR
 rm $BASE_DIR/tmp/carcara.tgz

--- a/src/proof/alethe/alethe_node_converter.cpp
+++ b/src/proof/alethe/alethe_node_converter.cpp
@@ -84,7 +84,7 @@ Node AletheNodeConverter::postConvert(Node n)
     case Kind::BITVECTOR_BIT:
     {
       std::stringstream ss;
-      ss << "(_ @bitOf " << n.getOperator().getConst<BitVectorBit>().d_bitIndex
+      ss << "(_ @bit_of " << n.getOperator().getConst<BitVectorBit>().d_bitIndex
          << ")";
       TypeNode fType = d_nm->mkFunctionType(n[0].getType(), n.getType());
       Node op = mkInternalSymbol(ss.str(), fType, true);
@@ -101,7 +101,7 @@ Node AletheNodeConverter::postConvert(Node n)
         children.push_back(c);
       }
       TypeNode fType = d_nm->mkFunctionType(childrenTypes, n.getType());
-      Node op = mkInternalSymbol("@bbT", fType, true);
+      Node op = mkInternalSymbol("@bbterm", fType, true);
       children.insert(children.begin(), op);
       Node converted = d_nm->mkNode(Kind::APPLY_UF, children);
       return converted;


### PR DESCRIPTION
To reflect changes in Alethe (and in Carcara).