### PR TITLE
Make the semantics of symbolic bitvector constants strict

### DIFF
--- a/proofs/eo/cpc/Cpc.eo
+++ b/proofs/eo/cpc/Cpc.eo
@@ -307,7 +307,9 @@
                                               (eo::concat ($run_evaluate ($bv_unfold_repeat ($run_evaluate n) ($bv_sign_bit ex))) ex)))
       (($run_evaluate (zero_extend n xb))  (eo::define ((ex ($run_evaluate xb)))
                                               (eo::concat ($run_evaluate ($bv_unfold_repeat ($run_evaluate n) #b0)) ex)))
-      (($run_evaluate (@bv n m))           (eo::to_bin ($run_evaluate m) ($run_evaluate n)))
+      (($run_evaluate (@bv n m))           (eo::define ((val ($run_evaluate n)))
+                                           (eo::define ((res (eo::to_bin ($run_evaluate m) val)))
+                                              (eo::requires (eo::to_z res) val res)))) ; should not have overflowed
       (($run_evaluate (@bvsize xb))        ($bv_bitwidth (eo::typeof xb)))
 
       ; arith bv conversions

--- a/proofs/eo/cpc/Cpc.eo
+++ b/proofs/eo/cpc/Cpc.eo
@@ -163,9 +163,9 @@
       (($run_evaluate (to_int x))          (eo::to_z ($run_evaluate x)))
       (($run_evaluate (is_int x))          (eo::define ((ex ($run_evaluate x))) (eo::eq (eo::to_q (eo::to_z ex)) (eo::to_q ex))))
       (($run_evaluate (abs x))             (eo::define ((ex ($run_evaluate x))) (eo::ite (eo::is_neg ex) (eo::neg ex) ex)))
-      (($run_evaluate (int.log2 i1))       ($arith_eval_int_log_2 ($run_evaluate i1)))
+      (($run_evaluate (int.log2 i1))       ($run_evaluate (ite (< i1 0) 0 (div i1 (int.pow2 i1)))))
       (($run_evaluate (int.pow2 i1))       ($arith_eval_int_pow_2 ($run_evaluate i1)))
-      (($run_evaluate (int.ispow2 i1))     ($arith_eval_int_is_pow_2 ($run_evaluate i1)))
+      (($run_evaluate (int.ispow2 i1))     ($run_evaluate (and (>= i1 0) (= i1 (int.pow2 (int.log2 i1))))))
 
       ; strings
       (($run_evaluate (str.++ sx sys))      (eo::concat ($run_evaluate sx) ($run_evaluate sys)))

--- a/proofs/eo/cpc/Cpc.eo
+++ b/proofs/eo/cpc/Cpc.eo
@@ -163,9 +163,9 @@
       (($run_evaluate (to_int x))          (eo::to_z ($run_evaluate x)))
       (($run_evaluate (is_int x))          (eo::define ((ex ($run_evaluate x))) (eo::eq (eo::to_q (eo::to_z ex)) (eo::to_q ex))))
       (($run_evaluate (abs x))             (eo::define ((ex ($run_evaluate x))) (eo::ite (eo::is_neg ex) (eo::neg ex) ex)))
-      (($run_evaluate (int.log2 i1))       ($run_evaluate (ite (< i1 0) 0 (div i1 (int.pow2 i1)))))
+      (($run_evaluate (int.log2 i1))       ($arith_eval_int_log_2 ($run_evaluate i1)))
       (($run_evaluate (int.pow2 i1))       ($arith_eval_int_pow_2 ($run_evaluate i1)))
-      (($run_evaluate (int.ispow2 i1))     ($run_evaluate (and (>= i1 0) (= i1 (int.pow2 (int.log2 i1))))))
+      (($run_evaluate (int.ispow2 i1))     ($arith_eval_int_is_pow_2 ($run_evaluate i1)))
 
       ; strings
       (($run_evaluate (str.++ sx sys))      (eo::concat ($run_evaluate sx) ($run_evaluate sys)))

--- a/proofs/eo/cpc/programs/Arith.eo
+++ b/proofs/eo/cpc/programs/Arith.eo
@@ -75,28 +75,6 @@
 ;   arguments cannot be statically computed.
 (define $arith_mk_binary_minus ((T Type :implicit) (U Type :implicit) (x T) (y U)) (- x y))
 
-; program: $arith_eval_int_log_2_rec
-; args:
-; - x  Int: The term to compute the log (base 2) of, assumed to be a positive numeral value.
-; return: The log base 2 of x.
-; note: Helper method for $arith_eval_int_log_2 below.
-(program $arith_eval_int_log_2_rec ((x Int))
-  :signature (Int) Int
-  (
-  (($arith_eval_int_log_2_rec 1) 0)
-  (($arith_eval_int_log_2_rec x) (eo::add 1 ($arith_eval_int_log_2_rec (eo::zdiv x 2))))
-  )
-)
-
-; define: $arith_eval_int_log_2
-; args:
-; - x Int: The term to compute the log (base 2) of.
-; return: >
-;   the log base 2 of x. If x is not strictly positive, we return
-;   the term (int.log2 x).
-(define $arith_eval_int_log_2 ((x Int))
-  (eo::ite (eo::is_neg (eo::neg x)) ($arith_eval_int_log_2_rec x) (int.log2 x)))
-
 ; program: $arith_eval_int_pow_2_rec
 ; args:
 ; - x  Int: The term to compute 2 to the power of, assumed to be a positive numeral value.
@@ -120,29 +98,3 @@
   (eo::ite (eo::is_z x)
     (eo::ite (eo::is_neg x) 0 ($arith_eval_int_pow_2_rec x))
     (int.pow2 x)))
-
-; program: $arith_eval_int_is_pow_2_rec
-; args:
-; - x  Int: The term to compute whether it is a power of two, assumed to be a positive numeral value.
-; return: true iff x is a power of two.
-; note: Helper method for $arith_eval_is_pow_2 below.
-(program $arith_eval_int_is_pow_2_rec ((x Int))
-  :signature (Int) Bool
-  (
-  (($arith_eval_int_is_pow_2_rec 1) true)
-  (($arith_eval_int_is_pow_2_rec x) (eo::ite (eo::eq (eo::zmod x 2) 0)
-                                      ($arith_eval_int_is_pow_2_rec (eo::zdiv x 2))
-                                      false))
-  )
-)
-
-; define: $arith_eval_is_pow_2
-; args:
-; - x Int: The term to compute whether it is a power of two.
-; return: >
-;   true iff x is a power of two. If x is not a numeral value, we return
-;   the term (int.ispow2 x).
-(define $arith_eval_int_is_pow_2 ((x Int))
-  (eo::ite (eo::is_z x) 
-    (eo::ite (eo::is_neg x) false ($arith_eval_int_is_pow_2_rec x))
-    (int.ispow2 x)))

--- a/proofs/eo/cpc/programs/Arith.eo
+++ b/proofs/eo/cpc/programs/Arith.eo
@@ -75,6 +75,28 @@
 ;   arguments cannot be statically computed.
 (define $arith_mk_binary_minus ((T Type :implicit) (U Type :implicit) (x T) (y U)) (- x y))
 
+; program: $arith_eval_int_log_2_rec
+; args:
+; - x  Int: The term to compute the log (base 2) of, assumed to be a positive numeral value.
+; return: The log base 2 of x.
+; note: Helper method for $arith_eval_int_log_2 below.
+(program $arith_eval_int_log_2_rec ((x Int))
+  :signature (Int) Int
+  (
+  (($arith_eval_int_log_2_rec 1) 0)
+  (($arith_eval_int_log_2_rec x) (eo::add 1 ($arith_eval_int_log_2_rec (eo::zdiv x 2))))
+  )
+)
+
+; define: $arith_eval_int_log_2
+; args:
+; - x Int: The term to compute the log (base 2) of.
+; return: >
+;   the log base 2 of x. If x is not strictly positive, we return
+;   the term (int.log2 x).
+(define $arith_eval_int_log_2 ((x Int))
+  (eo::ite (eo::is_neg (eo::neg x)) ($arith_eval_int_log_2_rec x) (int.log2 x)))
+
 ; program: $arith_eval_int_pow_2_rec
 ; args:
 ; - x  Int: The term to compute 2 to the power of, assumed to be a positive numeral value.
@@ -98,3 +120,16 @@
   (eo::ite (eo::is_z x)
     (eo::ite (eo::is_neg x) 0 ($arith_eval_int_pow_2_rec x))
     (int.pow2 x)))
+
+; define: $arith_eval_is_pow_2
+; args:
+; - x Int: The term to compute whether it is a power of two.
+; return: >
+;   true iff x is a power of two. If x is not a numeral value, we return
+;   the term (int.ispow2 x).
+(define $arith_eval_int_is_pow_2 ((x Int))
+  (eo::ite (eo::is_z x) 
+    (eo::ite (eo::is_neg x)
+      false
+      (eo::eq x ($arith_eval_int_pow_2 ($arith_eval_int_log_2 x))))
+    (int.ispow2 x)))

--- a/proofs/eo/cpc/programs/Arith.eo
+++ b/proofs/eo/cpc/programs/Arith.eo
@@ -121,6 +121,21 @@
     (eo::ite (eo::is_neg x) 0 ($arith_eval_int_pow_2_rec x))
     (int.pow2 x)))
 
+; program: $arith_eval_int_is_pow_2_rec
+; args:
+; - x  Int: The term to compute whether it is a power of two, assumed to be a positive numeral value.
+; return: true iff x is a power of two.
+; note: Helper method for $arith_eval_is_pow_2 below.
+(program $arith_eval_int_is_pow_2_rec ((x Int))
+  :signature (Int) Bool
+  (
+  (($arith_eval_int_is_pow_2_rec 1) true)
+  (($arith_eval_int_is_pow_2_rec x) (eo::ite (eo::eq (eo::zmod x 2) 0)
+                                      ($arith_eval_int_is_pow_2_rec (eo::zdiv x 2))
+                                      false))
+  )
+)
+
 ; define: $arith_eval_is_pow_2
 ; args:
 ; - x Int: The term to compute whether it is a power of two.
@@ -129,7 +144,5 @@
 ;   the term (int.ispow2 x).
 (define $arith_eval_int_is_pow_2 ((x Int))
   (eo::ite (eo::is_z x) 
-    (eo::ite (eo::is_neg x)
-      false
-      (eo::eq x ($arith_eval_int_pow_2 ($arith_eval_int_log_2 x))))
+    (eo::ite (eo::is_neg x) false ($arith_eval_int_is_pow_2_rec x))
     (int.ispow2 x)))

--- a/src/theory/bv/theory_bv_rewrite_rules_constant_evaluation.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_constant_evaluation.h
@@ -506,7 +506,13 @@ inline Node RewriteRule<EvalConstBvSym>::apply(TNode node)
                       << std::endl;
   Integer a = node[0].getConst<Rational>().getNumerator();
   Integer b = node[1].getConst<Rational>().getNumerator();
-  return utils::mkConst(node.getNodeManager(), b.toUnsignedInt(), a);
+  BitVector val(b.toUnsignedInt(), a);
+  // only rewrites if no overflow
+  if (val.getValue()==a)
+  {
+    return node.getNodeManager()->mkConst(val);
+  }
+  return node;
 }
 
 template <>

--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -1292,13 +1292,20 @@ EvalResult Evaluator::evalInternal(
         {
           Integer i = results[currNode[0]].d_rat.getNumerator();
           Integer w = results[currNode[1]].d_rat.getNumerator();
+          bool handled = false;
           if (w.fitsUnsignedInt())
           {
-            Trace("evaluator") << currNode << " evalutes to "
-                               << BitVector(w.toUnsignedInt(), i) << std::endl;
-            results[currNode] = EvalResult(BitVector(w.toUnsignedInt(), i));
+            BitVector res(w.toUnsignedInt(), i);
+            // should not have overflowed
+            if (res.getValue()==i)
+            {
+              handled = true;
+              Trace("evaluator") << currNode << " evalutes to "
+                                << res << std::endl;
+              results[currNode] = EvalResult(res);
+            }
           }
-          else
+          if (!handled)
           {
             processUnhandled(
                 currNode, currNodeVal, evalAsNode, results, needsReconstruct);

--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -1297,11 +1297,11 @@ EvalResult Evaluator::evalInternal(
           {
             BitVector res(w.toUnsignedInt(), i);
             // should not have overflowed
-            if (res.getValue()==i)
+            if (res.getValue() == i)
             {
               handled = true;
-              Trace("evaluator") << currNode << " evalutes to "
-                                << res << std::endl;
+              Trace("evaluator")
+                  << currNode << " evalutes to " << res << std::endl;
               results[currNode] = EvalResult(res);
             }
           }


### PR DESCRIPTION
This updates symbolic bitvector constants (used in RARE rules) to have a strict semantics that does not permit overflow.

In detail `(@bv n w)` represents a bitvector constant of width w and value n.  

Currently `(@bv n w)` evaluates to the bitvector constant of width `w` and value `(n mod 2^w)` when `w` is a 32 bit unsigned integer value.

After this PR, `(@bv n w)` evaluates to the bitvector constant of width `w` and value `n` when `w` is a 32 bit unsigned integer value and `0 <= n < 2^w`.

This change fixes an inconsistency between our evaluator and the required semantics for bitvector constants. Otherwise with the previous semantics, several of our RARE rules are unsound.