### PR TITLE
Remove proof rule MACRO_RESOLUTION(_TRUST)

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -583,42 +583,6 @@ enum ENUM(ProofRule)
   EVALUE(REORDERING),
   /**
    * \verbatim embed:rst:leading-asterisk
-   * **Boolean -- N-ary Resolution + Factoring + Reordering**
-   *
-   * .. math::
-   *
-   *   \inferrule{C_1 \dots C_n \mid C, pol_1,L_1 \dots pol_{n-1},L_{n-1}}{C}
-   *
-   * where
-   *
-   * - let :math:`C_1 \dots C_n` be nodes viewed as clauses, as defined in
-   *   :cpp:enumerator:`RESOLUTION <cvc5::ProofRule::RESOLUTION>`
-   * - let :math:`C_1 \diamond_{L,\mathit{pol}} C_2` represent the resolution of
-   *   :math:`C_1` with :math:`C_2` with pivot :math:`L` and polarity
-   *   :math:`pol`, as defined in
-   *   :cpp:enumerator:`RESOLUTION <cvc5::ProofRule::RESOLUTION>`
-   * - let :math:`C_1'` be equal, in its set representation, to :math:`C_1`,
-   * - for each :math:`i > 1`, let :math:`C_i'` be equal, in its set
-   *   representation, to :math:`C_{i-1} \diamond_{L_{i-1},\mathit{pol}_{i-1}}
-   *   C_i'`
-   *
-   * The result of the chain resolution is :math:`C`, which is equal, in its set
-   * representation, to :math:`C_n'`
-   * \endverbatim
-   */
-  EVALUE(MACRO_RESOLUTION),
-  /**
-   * \verbatim embed:rst:leading-asterisk
-   * **Boolean -- N-ary Resolution + Factoring + Reordering unchecked**
-   *
-   * Same as
-   * :cpp:enumerator:`MACRO_RESOLUTION <cvc5::ProofRule::MACRO_RESOLUTION>`, but
-   * not checked by the internal proof checker.
-   * \endverbatim
-   */
-  EVALUE(MACRO_RESOLUTION_TRUST),
-  /**
-   * \verbatim embed:rst:leading-asterisk
    * **Boolean -- Chain multiset resolution**
    *
    * This rule combines Resolution + Factoring + Reordering.

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -51,8 +51,6 @@ const char* toString(ProofRule rule)
     case ProofRule::CHAIN_RESOLUTION: return "CHAIN_RESOLUTION";
     case ProofRule::FACTORING: return "FACTORING";
     case ProofRule::REORDERING: return "REORDERING";
-    case ProofRule::MACRO_RESOLUTION: return "MACRO_RESOLUTION";
-    case ProofRule::MACRO_RESOLUTION_TRUST: return "MACRO_RESOLUTION_TRUST";
     case ProofRule::CHAIN_M_RESOLUTION: return "CHAIN_M_RESOLUTION";
     case ProofRule::SPLIT: return "SPLIT";
     case ProofRule::EQ_RESOLVE: return "EQ_RESOLVE";

--- a/src/proof/alethe/alethe_post_processor.cpp
+++ b/src/proof/alethe/alethe_post_processor.cpp
@@ -691,8 +691,7 @@ bool AletheProofPostprocessCallback::update(Node res,
     //  * the corresponding proof node is C
     case ProofRule::RESOLUTION:
     case ProofRule::CHAIN_RESOLUTION:
-    case ProofRule::MACRO_RESOLUTION:
-    case ProofRule::MACRO_RESOLUTION_TRUST:
+    case ProofRule::CHAIN_M_RESOLUTION:
     {
       std::vector<Node> cargs;
       if (id == ProofRule::CHAIN_RESOLUTION)
@@ -703,10 +702,15 @@ bool AletheProofPostprocessCallback::update(Node res,
           cargs.push_back(args[1][i]);
         }
       }
-      else if (id == ProofRule::MACRO_RESOLUTION
-               || id == ProofRule::MACRO_RESOLUTION_TRUST)
+      else if (id == ProofRule::CHAIN_M_RESOLUTION)
       {
-        cargs.insert(cargs.end(), args.begin() + 1, args.end());
+        Assert (args.size()==3 && args[1].getNumChildren()==args[2].getNumChildren());
+        //cargs.insert(cargs.end(), args.begin() + 1, args.end());
+        for (size_t i=0, nsteps=args[1].getNumChildren(); i<nsteps; i++)
+        {
+          cargs.push_back(args[1][i]);
+          cargs.push_back(args[2][i]);
+        }
       }
       else
       {

--- a/src/proof/alethe/alethe_post_processor.cpp
+++ b/src/proof/alethe/alethe_post_processor.cpp
@@ -706,7 +706,7 @@ bool AletheProofPostprocessCallback::update(Node res,
       {
         Assert(args.size() == 3
                && args[1].getNumChildren() == args[2].getNumChildren());
-        // cargs.insert(cargs.end(), args.begin() + 1, args.end());
+        // Alethe expects the polarity/literals to be interleaved
         for (size_t i = 0, nsteps = args[1].getNumChildren(); i < nsteps; i++)
         {
           cargs.push_back(args[1][i]);

--- a/src/proof/alethe/alethe_post_processor.cpp
+++ b/src/proof/alethe/alethe_post_processor.cpp
@@ -704,9 +704,10 @@ bool AletheProofPostprocessCallback::update(Node res,
       }
       else if (id == ProofRule::CHAIN_M_RESOLUTION)
       {
-        Assert (args.size()==3 && args[1].getNumChildren()==args[2].getNumChildren());
-        //cargs.insert(cargs.end(), args.begin() + 1, args.end());
-        for (size_t i=0, nsteps=args[1].getNumChildren(); i<nsteps; i++)
+        Assert(args.size() == 3
+               && args[1].getNumChildren() == args[2].getNumChildren());
+        // cargs.insert(cargs.end(), args.begin() + 1, args.end());
+        for (size_t i = 0, nsteps = args[1].getNumChildren(); i < nsteps; i++)
         {
           cargs.push_back(args[1][i]);
           cargs.push_back(args[2][i]);

--- a/src/proof/dot/dot_printer.cpp
+++ b/src/proof/dot/dot_printer.cpp
@@ -450,7 +450,7 @@ inline bool DotPrinter::isInput(const ProofNode* pn)
 inline bool DotPrinter::isSat(const ProofRule& rule)
 {
   return ProofRule::CHAIN_RESOLUTION <= rule
-         && rule <= ProofRule::MACRO_RESOLUTION_TRUST;
+         && rule <= ProofRule::CHAIN_M_RESOLUTION;
 }
 
 inline bool DotPrinter::isCNF(const ProofRule& rule)

--- a/src/proof/dot/dot_printer.h
+++ b/src/proof/dot/dot_printer.h
@@ -40,8 +40,8 @@ enum class ProofNodeClusterType : uint8_t
   FIRST_SCOPE = 0,
   // ======== SAT
   // Type of proof node cluster that is between FIRST_SCOPE and CNF.
-  // The rules are: CHAIN_RESOLUTION, FACTORING, REORDERING, MACRO_RESOLUTION
-  // and MACRO_RESOLUTION_TRUST.
+  // The rules are: CHAIN_RESOLUTION, FACTORING, REORDERING and
+  // CHAIN_M_RESOLUTION.
   SAT,
   // ======== CNF
   // Type of proof node cluster that is below SAT and above THEORY_LEMMA or
@@ -168,8 +168,7 @@ class DotPrinter : protected EnvObj
   inline bool isInput(const ProofNode* pn);
 
   /** Verify if the rule is in the SAT range (i.e. a ProofRule that is
-   * CHAIN_RESOLUTION, FACTORING, REORDERING, MACRO_RESOLUTION or
-   * MACRO_RESOLUTION_TRUST).
+   * CHAIN_RESOLUTION, FACTORING, REORDERING or CHAIN_M_RESOLUTION).
    * @param rule The rule to be verified.
    * @return The bool indicating if the rule is or not in the SAT range.
    */

--- a/src/proof/resolution_proofs_util.cpp
+++ b/src/proof/resolution_proofs_util.cpp
@@ -22,7 +22,7 @@
 namespace cvc5::internal {
 namespace proof {
 
-/** The information relevant for converting MACRO_RESOLUTION steps into
+/** The information relevant for converting CHAIN_M_RESOLUTION steps into
  * CHAIN_RESOLUTION+FACTORING steps when "crowding literals" are present. See
  * `ProofPostprocessCallback::eliminateCrowdingLits` for more information. */
 struct CrowdingLitInfo
@@ -351,7 +351,7 @@ Node eliminateCrowdingLits(NodeManager* nm,
                   newArgs.begin() + (2 * maxSafeMove) - 1);
       // Being pedantic here we should assert that the rotated
       // newChildren/newArgs still yield the same conclusion with a
-      // MACRO_RESOLUTION step. However this can be very expensive to check, so
+      // CHAIN_M_RESOLUTION step. However this can be very expensive to check, so
       // we don't do this. Only if one is debugging this code this test should
       // be added.
 

--- a/src/proof/resolution_proofs_util.cpp
+++ b/src/proof/resolution_proofs_util.cpp
@@ -351,9 +351,9 @@ Node eliminateCrowdingLits(NodeManager* nm,
                   newArgs.begin() + (2 * maxSafeMove) - 1);
       // Being pedantic here we should assert that the rotated
       // newChildren/newArgs still yield the same conclusion with a
-      // CHAIN_M_RESOLUTION step. However this can be very expensive to check, so
-      // we don't do this. Only if one is debugging this code this test should
-      // be added.
+      // CHAIN_M_RESOLUTION step. However this can be very expensive to check,
+      // so we don't do this. Only if one is debugging this code this test
+      // should be added.
 
       // Now we need to update the indices, since we have changed newChildren.
       // For every crowding literal whose information indices are in the

--- a/src/proof/resolution_proofs_util.h
+++ b/src/proof/resolution_proofs_util.h
@@ -37,7 +37,7 @@ namespace proof {
  * literals removed implicitly by macro resolution. For example
  *
  *      l0 v l0 v l0 v l1 v l2    ~l0 v l1   ~l1
- * (1)  ----------------------------------------- MACRO_RES
+ * (1)  ----------------------------------------- CHAIN_M_RES
  *                 l2
  *
  * but
@@ -48,8 +48,8 @@ namespace proof {
  *
  * where l0 and l1 are crowding literals in the second proof.
  *
- * There are two views for how MACRO_RES implicitly removes the crowding
- * literal, i.e., how MACRO_RES can be expanded into CHAIN_RES so that
+ * There are two views for how CHAIN_M_RES implicitly removes the crowding
+ * literal, i.e., how CHAIN_M_RES can be expanded into CHAIN_RES so that
  * crowding literals are removed. The first is that (1) becomes
  *
  *  l0 v l0 v l0 v l1 v l2  ~l0 v l1  ~l0 v l1  ~l0 v l1  ~l1  ~l1  ~l1  ~l1
@@ -67,7 +67,7 @@ namespace proof {
  * chains going from dozens to thousands of premises. Such examples do occur
  * in practice, even in our regressions.
  *
- * The second way of expanding MACRO_RES, which avoids this exponential
+ * The second way of expanding CHAIN_M_RES, which avoids this exponential
  * behavior, is so that (1) becomes
  *
  *      l0 v l0 v l0 v l1 v l2
@@ -82,7 +82,7 @@ namespace proof {
  *
  * This method first determines what are the crowding literals by checking
  * what literals occur in clauseLits that do not occur in targetClauseLits
- * (the latter contains the literals from the original MACRO_RES conclusion
+ * (the latter contains the literals from the original CHAIN_M_RES conclusion
  * while the former the literals from a direct application of CHAIN_RES). Then
  * it builds a proof such as (4) and adds the steps to cdp. The final
  * conclusion is returned.
@@ -99,12 +99,12 @@ namespace proof {
  * @param reorderPremises Whether to optimize elemination by reordering premises
  * @param clauseLits literals in the conclusion of a CHAIN_RESOLUTION step
  * with children and args[1:]
- * @param clauseLits literals in the conclusion of a MACRO_RESOLUTION step
+ * @param clauseLits literals in the conclusion of a CHAIN_M_RESOLUTION step
  * with children and args
  * @param children a list of clauses
- * @param args a list of arguments to a MACRO_RESOLUTION step
+ * @param args a list of arguments to a CHAIN_M_RESOLUTION step
  * @param cdp a CDProof
- * @return The resulting node of transforming MACRO_RESOLUTION into
+ * @return The resulting node of transforming CHAIN_M_RESOLUTION into
  * CHAIN_RESOLUTION according to the above idea.
  */
 Node eliminateCrowdingLits(NodeManager* nm,

--- a/src/prop/minisat/sat_proof_manager.cpp
+++ b/src/prop/minisat/sat_proof_manager.cpp
@@ -482,8 +482,7 @@ void SatProofManager::explainLit(SatLiteral lit,
       Trace("sat-proof") << "SatProofManager::explainLit:   " << children[i];
       if (i > 0)
       {
-        Trace("sat-proof") << " [" << lits[i] << ", "
-                           << pols[i] << "]";
+        Trace("sat-proof") << " [" << lits[i] << ", " << pols[i] << "]";
       }
       Trace("sat-proof") << "\n";
     }

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -132,11 +132,10 @@ PfManager::PfManager(Env& env)
     d_pfpp->setEliminateRule(ProofRule::MACRO_SR_PRED_INTRO);
     d_pfpp->setEliminateRule(ProofRule::MACRO_SR_PRED_ELIM);
     d_pfpp->setEliminateRule(ProofRule::MACRO_SR_PRED_TRANSFORM);
-    // Alethe does not require macro resolution to be expanded
-    if (options().proof.proofFormatMode != options::ProofFormatMode::ALETHE)
+    // Alethe does not require chain multiset resolution to be expanded
+    if (options().proof.proofFormatMode != options::ProofFormatMode::ALETHE && !options().proof.proofChainMRes)
     {
-      d_pfpp->setEliminateRule(ProofRule::MACRO_RESOLUTION_TRUST);
-      d_pfpp->setEliminateRule(ProofRule::MACRO_RESOLUTION);
+      d_pfpp->setEliminateRule(ProofRule::CHAIN_M_RESOLUTION);
     }
     d_pfpp->setEliminateRule(ProofRule::MACRO_ARITH_SCALE_SUM_UB);
     if (options().proof.proofGranularityMode

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -133,7 +133,8 @@ PfManager::PfManager(Env& env)
     d_pfpp->setEliminateRule(ProofRule::MACRO_SR_PRED_ELIM);
     d_pfpp->setEliminateRule(ProofRule::MACRO_SR_PRED_TRANSFORM);
     // Alethe does not require chain multiset resolution to be expanded
-    if (options().proof.proofFormatMode != options::ProofFormatMode::ALETHE && !options().proof.proofChainMRes)
+    if (options().proof.proofFormatMode != options::ProofFormatMode::ALETHE
+        && !options().proof.proofChainMRes)
     {
       d_pfpp->setEliminateRule(ProofRule::CHAIN_M_RESOLUTION);
     }

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -483,7 +483,7 @@ Node ProofPostprocessCallback::expandMacros(ProofRule id,
     // first generate the naive chain_resolution
     std::vector<Node> pols;
     std::vector<Node> lits;
-    Assert(args.size()==3);
+    Assert(args.size() == 3);
     for (size_t i = 1, nargs = args.size(); i < nargs; i = i + 2)
     {
       pols.push_back(args[1][i]);
@@ -507,10 +507,10 @@ Node ProofPostprocessCallback::expandMacros(ProofRule id,
     //   FACTORING step
     // - if the order is not the same, add a REORDERING step
     // - if there are literals in chainConclusion that are not in the original
-    //   conclusion, we need to transform the CHAIN_M_RESOLUTION into a series of
-    //   CHAIN_RESOLUTION + FACTORING steps, so that we explicitly eliminate all
-    //   these "crowding" literals. We do this via FACTORING so we avoid adding
-    //   an exponential number of premises, which would happen if we just
+    //   conclusion, we need to transform the CHAIN_M_RESOLUTION into a series
+    //   of CHAIN_RESOLUTION + FACTORING steps, so that we explicitly eliminate
+    //   all these "crowding" literals. We do this via FACTORING so we avoid
+    //   adding an exponential number of premises, which would happen if we just
     //   repeated in the premises the clauses needed for eliminating crowding
     //   literals, which could themselves add crowding literals.
     if (chainConclusion == args[0])

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -484,10 +484,10 @@ Node ProofPostprocessCallback::expandMacros(ProofRule id,
     Assert(args.size() == 3);
     std::vector<Node> pols(args[1].begin(), args[1].end());
     std::vector<Node> lits(args[2].begin(), args[2].end());
-    Assert (lits.size()==pols.size());
+    Assert(lits.size() == pols.size());
     Assert(pols.size() == children.size() - 1);
     NodeManager* nm = nodeManager();
-    std::vector<Node> chainResArgs(args.begin()+1, args.end());
+    std::vector<Node> chainResArgs(args.begin() + 1, args.end());
     Node chainConclusion = d_pc->checkDebug(
         ProofRule::CHAIN_RESOLUTION, children, chainResArgs, Node::null(), "");
     Trace("smt-proof-pp-debug") << "Original conclusion: " << args[0] << "\n";

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -477,31 +477,23 @@ Node ProofPostprocessCallback::expandMacros(ProofRule id,
     cdp->addStep(eq[1], ProofRule::EQ_RESOLVE, {children[0], eq}, {});
     return args[0];
   }
-  else if (id == ProofRule::MACRO_RESOLUTION
-           || id == ProofRule::MACRO_RESOLUTION_TRUST)
+  else if (id == ProofRule::CHAIN_M_RESOLUTION)
   {
     ProofNodeManager* pnm = d_env.getProofNodeManager();
     // first generate the naive chain_resolution
     std::vector<Node> pols;
     std::vector<Node> lits;
-    Assert((args.size() + 1) % 2 == 0);
+    Assert(args.size()==3);
     for (size_t i = 1, nargs = args.size(); i < nargs; i = i + 2)
     {
-      pols.push_back(args[i]);
-      lits.push_back(args[i + 1]);
+      pols.push_back(args[1][i]);
+      lits.push_back(args[2][i]);
     }
     Assert(pols.size() == children.size() - 1);
     NodeManager* nm = nodeManager();
     std::vector<Node> chainResArgs;
     chainResArgs.push_back(nm->mkNode(Kind::SEXPR, pols));
     chainResArgs.push_back(nm->mkNode(Kind::SEXPR, lits));
-    if (options().proof.proofChainMRes)
-    {
-      chainResArgs.insert(chainResArgs.begin(), args[0]);
-      cdp->addStep(
-          args[0], ProofRule::CHAIN_M_RESOLUTION, children, chainResArgs);
-      return args[0];
-    }
     Node chainConclusion = d_pc->checkDebug(
         ProofRule::CHAIN_RESOLUTION, children, chainResArgs, Node::null(), "");
     Trace("smt-proof-pp-debug") << "Original conclusion: " << args[0] << "\n";
@@ -515,7 +507,7 @@ Node ProofPostprocessCallback::expandMacros(ProofRule id,
     //   FACTORING step
     // - if the order is not the same, add a REORDERING step
     // - if there are literals in chainConclusion that are not in the original
-    //   conclusion, we need to transform the MACRO_RESOLUTION into a series of
+    //   conclusion, we need to transform the CHAIN_M_RESOLUTION into a series of
     //   CHAIN_RESOLUTION + FACTORING steps, so that we explicitly eliminate all
     //   these "crowding" literals. We do this via FACTORING so we avoid adding
     //   an exponential number of premises, which would happen if we just

--- a/src/theory/booleans/proof_checker.cpp
+++ b/src/theory/booleans/proof_checker.cpp
@@ -31,8 +31,6 @@ void BoolProofRuleChecker::registerTo(ProofChecker* pc)
   pc->registerChecker(ProofRule::SPLIT, this);
   pc->registerChecker(ProofRule::RESOLUTION, this);
   pc->registerChecker(ProofRule::CHAIN_RESOLUTION, this);
-  pc->registerTrustedChecker(ProofRule::MACRO_RESOLUTION_TRUST, this, 3);
-  pc->registerChecker(ProofRule::MACRO_RESOLUTION, this);
   pc->registerChecker(ProofRule::CHAIN_M_RESOLUTION, this);
   pc->registerChecker(ProofRule::FACTORING, this);
   pc->registerChecker(ProofRule::REORDERING, this);
@@ -298,13 +296,7 @@ Node BoolProofRuleChecker::checkInternal(ProofRule id,
                           << pop;
     return nm->mkOr(lhsClause);
   }
-  if (id == ProofRule::MACRO_RESOLUTION_TRUST)
-  {
-    Assert(children.size() > 1);
-    Assert(args.size() == 2 * (children.size() - 1) + 1);
-    return args[0];
-  }
-  if (id == ProofRule::MACRO_RESOLUTION || id == ProofRule::CHAIN_M_RESOLUTION)
+  if (id == ProofRule::CHAIN_M_RESOLUTION)
   {
     Assert(children.size() > 1);
     Trace("bool-pfcheck") << "macro_res: " << args[0] << "\n" << push;
@@ -314,22 +306,9 @@ Node BoolProofRuleChecker::checkInternal(ProofRule id,
     std::vector<Node> lhsClause, rhsClause;
     Node lhsElim, rhsElim;
     std::vector<Node> pols, lits;
-    if (id == ProofRule::MACRO_RESOLUTION)
-    {
-      Assert(args.size() == 2 * (children.size() - 1) + 1);
-      for (size_t i = 1, nargs = args.size(); i < nargs; i = i + 2)
-      {
-        pols.push_back(args[i]);
-        lits.push_back(args[i + 1]);
-      }
-    }
-    else
-    {
-      Assert(args.size() == 3);
-      Assert(id == ProofRule::CHAIN_M_RESOLUTION);
-      pols.insert(pols.end(), args[1].begin(), args[1].end());
-      lits.insert(lits.end(), args[2].begin(), args[2].end());
-    }
+    Assert(args.size() == 3);
+    pols.insert(pols.end(), args[1].begin(), args[1].end());
+    lits.insert(lits.end(), args[2].begin(), args[2].end());
     if (children[0].getKind() != Kind::OR
         || (pols[0] == trueNode && children[0] == lits[0])
         || (pols[0] == falseNode && children[0] == lits[0].notNode()))


### PR DESCRIPTION
We now use `CHAIN_M_RESOLUTION` throughout.

This PR does not fundamentally change the behavior of cvc5 (yet). We still expand CHAIN_M_RESOLUTION to CHAIN_RESOLUTION by default.

Will performance test this change.