### PR TITLE
python: Allow None for tm argument in _term function

### DIFF
--- a/cmake/FindCython.cmake
+++ b/cmake/FindCython.cmake
@@ -64,7 +64,7 @@ if (Cython_VERSION_CHECK_RESULT EQUAL 0)
               if(ENABLE_AUTO_DOWNLOAD)
                 message(STATUS "Upgrading module Cython")
                 execute_process(COMMAND
-                  ${Python_EXECUTABLE} -m pip install "Cython<3.1.2" -U
+                  ${Python_EXECUTABLE} -m pip install Cython -U
                   RESULT_VARIABLE CYTHON_INSTALL_CMD_EXIT_CODE
                 )
                 if(CYTHON_INSTALL_CMD_EXIT_CODE)
@@ -86,7 +86,7 @@ else()
   if(ENABLE_AUTO_DOWNLOAD)
     message(STATUS "Installing module Cython")
     execute_process(
-      COMMAND ${Python_EXECUTABLE} -m pip install "Cython<3.1.2"
+      COMMAND ${Python_EXECUTABLE} -m pip install Cython
       RESULT_VARIABLE CYTHON_INSTALL_CMD_EXIT_CODE)
     if(CYTHON_INSTALL_CMD_EXIT_CODE)
       message(${Cython_FIND_MODE} "Could not install module Cython")

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -93,7 +93,7 @@ cdef Op _op(tm: TermManager, op: c_Op):
   o.tm = tm
   return o
 
-cdef Term _term(tm: TermManager, term: c_Term):
+cdef Term _term(TermManager tm, const c_Term& term):
   t = Term()
   t.cterm = term
   t.tm = tm

--- a/src/api/python/pyproject.toml
+++ b/src/api/python/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "setuptools!=70.2.0; os_name == 'nt'",
     # Avoid issue #283: https://github.com/pypa/distutils/issues/283
     "setuptools<72.2.0; implementation_name == 'pypy'",
-    "Cython>=3,<3.1.2",
+    "Cython>=3",
     # Avoid issue #6867: https://github.com/cython/cython/issues/6867
     "Cython<3.1.0; implementation_name == 'pypy' and python_version < '3.9'"
 ]


### PR DESCRIPTION
This PR changes the signature of `_term` from `cdef Term _term(tm: TermManager, term: c_Term)`, which uses Python type annotations and assumes `None` is invalid for `TermManager`, to `cdef Term _term(TermManager tm, const c_Term& term)`, which uses Cython type annotations and allows `None` as a valid value. This change enables the creation of terms without an associated term manager, which is necessary for null terms. The problem was detected when running the cvc5 Python bindings tests compiled with Cython 3.1.2, which introduced runtime `None` checks for functions using Python syntax. Specifically, `unit/api/python/test_proof.py::test_null_proof` failed.

The PR also removes the previous Cython version upper-bound that was used as a temporary workaround. 