### PR TITLE
python: Define explicit __init__ constructors for Cython classes

### DIFF
--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -270,6 +270,9 @@ cdef class Command:
     """
     cdef c_Command cc
 
+    def __init__(self):
+        pass
+
     def __str__(self):
         return self.cc.toString().decode()
 
@@ -445,6 +448,9 @@ cdef class Datatype:
     cdef c_Datatype cdt
     cdef TermManager tm
 
+    def __init__(self):
+        pass
+
     def __getitem__(self, index):
         """
             Get the datatype constructor with the given index, where index can
@@ -574,6 +580,9 @@ cdef class DatatypeConstructor:
     """
     cdef c_DatatypeConstructor cdtcons
     cdef TermManager tm
+
+    def __init__(self):
+        pass
 
     def __getitem__(self, index):
         """
@@ -722,6 +731,9 @@ cdef class DatatypeConstructorDecl:
     cdef c_DatatypeConstructorDecl cdtconsdecl
     cdef TermManager tm
 
+    def __init__(self):
+        pass
+
     def addSelector(self, str name, Sort sort):
         """
             Add datatype selector declaration.
@@ -788,6 +800,9 @@ cdef class DatatypeDecl:
     cdef c_DatatypeDecl cdtdecl
     cdef TermManager tm
 
+    def __init__(self):
+        pass
+
     def addConstructor(self, DatatypeConstructorDecl ctor):
         """
             Add a datatype constructor declaration.
@@ -840,6 +855,9 @@ cdef class DatatypeSelector:
     """
     cdef c_DatatypeSelector cdtsel
     cdef TermManager tm
+
+    def __init__(self):
+        pass
 
     def getName(self):
         """
@@ -910,6 +928,9 @@ cdef class Op:
     cdef c_Op cop
     cdef TermManager tm
 
+    def __init__(self):
+        pass
+
     def __eq__(self, Op other):
         return self.cop == other.cop
 
@@ -974,6 +995,9 @@ cdef class Grammar:
     cdef c_Grammar  cgrammar
     cdef TermManager tm
 
+    def __init__(self):
+        pass
+
     def __str__(self):
         return self.cgrammar.toString().decode()
 
@@ -1031,10 +1055,10 @@ cdef class Result:
 
         Wrapper class for :cpp:class:`cvc5::Result`.
     """
-    cdef c_Result cr
-    def __cinit__(self):
-        # gets populated by solver
-        self.cr = c_Result()
+    cdef c_Result cr # gets populated by solver
+
+    def __init__(self):
+        pass
 
     def isNull(self):
         """
@@ -1098,10 +1122,10 @@ cdef class SynthResult:
       which we call synthesis queries. This class indicates whether the
       synthesis query has a solution, has no solution, or is unknown.
     """
-    cdef c_SynthResult cr
-    def __cinit__(self):
-        # gets populated by solver
-        self.cr = c_SynthResult()
+    cdef c_SynthResult cr # gets populated by solver
+
+    def __init__(self):
+        pass
 
     def __eq__(self, SynthResult other):
         return self.cr == other.cr
@@ -1168,6 +1192,9 @@ cdef class TermManager:
         res = Statistics()
         res.cstats = self.ctm.getStatistics()
         return res
+
+    def __init__(self):
+        pass
 
     def __cinit__(self):
         self.ctm = new c_TermManager()
@@ -1477,7 +1504,6 @@ cdef class TermManager:
             :param symbol: The name of the sort.
             :return: The uninterpreted sort.
         """
-        cdef Sort sort = Sort(self)
         if name is None:
           return _sort(self, self.ctm.mkUninterpretedSort())
         return _sort(self, self.ctm.mkUninterpretedSort(name.encode()))
@@ -1508,7 +1534,6 @@ cdef class TermManager:
             :param arity: The arity of the sort (must be > 0).
             :return: The sort constructor sort.
         """
-        cdef Sort sort = Sort(self)
         if symbol is None:
           return _sort(self, self.ctm.mkUninterpretedSortConstructorSort(arity))
         return _sort(
@@ -4765,6 +4790,9 @@ cdef class Sort:
     cdef c_Sort csort
     cdef TermManager tm
 
+    def __init__(self):
+        pass
+
     def __eq__(self, Sort other):
         return self.csort == other.csort
 
@@ -5424,6 +5452,9 @@ cdef class Term:
     cdef c_Term cterm
     cdef TermManager tm
 
+    def __init__(self):
+        pass
+
     def __eq__(self, Term other):
         return self.cterm == other.cterm
 
@@ -5550,9 +5581,7 @@ cdef class Term:
 
                 This is safe to call when :py:meth:`hasOp()` returns True.
         """
-        cdef Op op = Op(self.tm)
-        op.cop = self.cterm.getOp()
-        return op
+        return _op(self.tm, self.cterm.getOp())
 
     def hasSymbol(self):
         """
@@ -6114,6 +6143,9 @@ cdef class Proof:
     """
     cdef c_Proof cproof
     cdef TermManager tm
+
+    def __init__(self):
+        pass
 
     def __eq__(self, Proof other):
         return self.cproof == other.cproof

--- a/test/unit/api/python/test_datatype_api.py
+++ b/test/unit/api/python/test_datatype_api.py
@@ -44,11 +44,11 @@ def test_mk_datatype_sort(tm):
 
 def test_is_null(tm):
     # creating empty (null) objects.
-    dtypeSpec = DatatypeDecl(tm)
-    cons = DatatypeConstructorDecl(tm)
-    d = Datatype(tm)
-    consConstr = DatatypeConstructor(tm)
-    sel = DatatypeSelector(tm)
+    dtypeSpec = DatatypeDecl()
+    cons = DatatypeConstructorDecl()
+    d = Datatype()
+    consConstr = DatatypeConstructor()
+    sel = DatatypeSelector()
 
     # verifying that the objects are considered null.
     assert dtypeSpec.isNull()
@@ -196,7 +196,7 @@ def test_datatype_structs(tm):
     cons = tm.mkDatatypeConstructorDecl("cons")
     cons.addSelector("head", intSort)
     cons.addSelectorSelf("tail")
-    nullSort = Sort(tm)
+    nullSort = Sort()
     with pytest.raises(RuntimeError):
         cons.addSelector("null", nullSort)
     dtypeSpec.addConstructor(cons)
@@ -303,7 +303,7 @@ def test_datatype_names(tm):
 
     # possible to construct null datatype declarations if not using mkDatatypeDecl
     with pytest.raises(RuntimeError):
-        DatatypeDecl(tm).getName()
+        DatatypeDecl().getName()
 
 
 def test_parametric_datatype(tm):
@@ -565,7 +565,6 @@ def test_datatype_specialized_cons(tm):
     iargs = [isort]
     listInt = dtsorts[0].instantiate(iargs)
 
-    testConsTerm = Term(tm)
     # get the specialized constructor term for list[Int]
     testConsTerm = nilc.getInstantiatedTerm(listInt)
     assert testConsTerm != nilc.getTerm()

--- a/test/unit/api/python/test_op.py
+++ b/test/unit/api/python/test_op.py
@@ -36,7 +36,7 @@ def test_get_kind(tm):
 
 
 def test_is_null(tm):
-    x = Op(tm)
+    x = Op()
     assert x.isNull()
     y = tm.mkOp(Kind.BITVECTOR_EXTRACT, 31, 1)
     assert not y.isNull()

--- a/test/unit/api/python/test_proof.py
+++ b/test/unit/api/python/test_proof.py
@@ -72,7 +72,7 @@ def create_rewrite_proof(tm, solver):
 
 
 def test_null_proof(solver):
-  proof = cvc5.Proof(solver)
+  proof = cvc5.Proof()
   assert proof.getRule() == ProofRule.UNKNOWN
   assert hash(ProofRule.UNKNOWN) == hash(ProofRule.UNKNOWN)
   assert proof.getResult().isNull()
@@ -119,7 +119,7 @@ def test_get_arguments(tm, solver):
 def test_eq(tm, solver):
     x = create_proof(tm, solver)
     y = x.getChildren()[0]
-    z = cvc5.Proof(solver)
+    z = cvc5.Proof()
 
     assert x == x
     assert not x != x

--- a/test/unit/api/python/test_result.py
+++ b/test/unit/api/python/test_result.py
@@ -30,7 +30,7 @@ def solver(tm):
 
 
 def test_is_null(tm, solver):
-    res_null = Result(solver)
+    res_null = Result()
     assert res_null.isNull()
     assert not res_null.isSat()
     assert not res_null.isUnsat()

--- a/test/unit/api/python/test_synth_result.py
+++ b/test/unit/api/python/test_synth_result.py
@@ -29,7 +29,7 @@ def solver(tm):
 
 
 def test_is_null(solver):
-    res_null = SynthResult(solver)
+    res_null = SynthResult()
     assert res_null.isNull()
     assert not res_null.hasSolution()
     assert not res_null.hasNoSolution()
@@ -64,7 +64,7 @@ def test_has_solution(tm, solver):
 
 
 def test_has_no_solution(solver):
-    res_null = SynthResult(solver)
+    res_null = SynthResult()
     assert not res_null.hasNoSolution()
 
 


### PR DESCRIPTION
Cython `cdef` classes without an explicit `__init__` constructor have an implicit `__init__` that accepts any number of arguments. (Python classes, by contrast, default to an `__init__` that takes no arguments.) This can lead to confusing situations where arguments appear to be accepted but are discarded. This PR fixes the issue by adding explicit `__init__` methods to the Cython classes.

Additionally, this PR removes some unnecessary field initializations in the Cython classes.