### PR TITLE
cmake: Avoid building GMP demo programs

### DIFF
--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -143,6 +143,7 @@ if(NOT GMP_FOUND_SYSTEM)
           --with-pic
           --enable-cxx
           ${CONFIGURE_OPTS}
+    BUILD_COMMAND ${MAKE_CMD}
     BUILD_BYPRODUCTS ${GMP_LIBRARIES}
   )
 endif()


### PR DESCRIPTION
The default CMake build command for external projects targets *all* components, including those that are not enabled by default. This PR explicitly specifies the build command for the GMP library to avoid building the demo programs, which require Bison.