### PR TITLE
Avoid mixed arithmetic in ARITH_REDUCTION

### DIFF
--- a/proofs/eo/cpc/rules/Arith.eo
+++ b/proofs/eo/cpc/rules/Arith.eo
@@ -405,7 +405,7 @@
 ; return: the reduction predicate for (to_int r).
 (define $arith_to_int_reduction ((r Real))
   (eo::define ((k (@purify (to_int r))))
-    (and (<= 0/1 (- r k)) (< (- r k) 1/1))))
+    (and (<= 0/1 (- r (to_real k))) (< (- r (to_real k)) 1/1))))
 
 ; define: $arith_int_div_total_reduction
 ; args:
@@ -433,7 +433,7 @@
   :signature (T) Bool
   (
   (($arith_reduction_pred (is_int u))       (eo::define ((k (@purify (to_int u))))
-                                              (and (= (is_int u) (= (- u k) 0/1)) ($arith_to_int_reduction u))))
+                                              (and (= (is_int u) (= u (to_real k))) ($arith_to_int_reduction u))))
   (($arith_reduction_pred (to_int u))       (eo::define ((k (@purify (to_int u))))
                                               (and (= (to_int u) k) ($arith_to_int_reduction u))))
   (($arith_reduction_pred (/ u v))          (eo::define ((ur (eo::ite (eo::eq (eo::typeof u) Int) (to_real u) u)))

--- a/src/theory/arith/operator_elim.cpp
+++ b/src/theory/arith/operator_elim.cpp
@@ -106,14 +106,15 @@ Node OperatorElim::eliminateOperators(NodeManager* nm,
       // 0 <= node[0] - toIntSkolem < 1
       Node pterm = nm->mkNode(Kind::TO_INTEGER, node[0]);
       Node v = sm->mkPurifySkolem(pterm);
+      Node vr = nm->mkNode(Kind::TO_REAL, v);
       Node one = nm->mkConstReal(Rational(1));
       Node zero = nm->mkConstReal(Rational(0));
-      Node diff = nm->mkNode(Kind::SUB, node[0], v);
+      Node diff = nm->mkNode(Kind::SUB, node[0], vr);
       Node lem = mkInRange(diff, zero, one);
       lems.emplace_back(lem, v);
       if (k == Kind::IS_INTEGER)
       {
-        return mkEquality(node[0], v);
+        return nm->mkNode(Kind::EQUAL, node[0], vr);
       }
       Assert(k == Kind::TO_INTEGER);
       return v;


### PR DESCRIPTION
Work towards enabling `--proof-elim-subtypes` by default.

Makes a minor change to the reduction of `to_int/is_int` to avoid introduction of mixed arithmetic.