### PR TITLE
Fixes warnings in GMP build

### DIFF
--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -80,6 +80,7 @@ if(NOT GMP_FOUND_SYSTEM)
   # only supports C17. To also support older compiler versions, we fix the
   # standard for GMP to C99.
   set(GMP_CFLAGS "-std=gnu99")
+  set(GMP_CXXFLAGS "")
 
   if(BUILD_SHARED_LIBS)
     set(LINK_OPTS --enable-shared --disable-static)
@@ -120,11 +121,12 @@ if(NOT GMP_FOUND_SYSTEM)
         ${CONFIGURE_ENV}
         env "LDFLAGS=-arch ${CMAKE_OSX_ARCHITECTURES}")
       set(GMP_CFLAGS "${GMP_CFLAGS} --target=${TOOLCHAIN_PREFIX}")
+      set(GMP_CXXFLAGS "${GMP_CXXFLAGS} --target=${TOOLCHAIN_PREFIX}")
     endif()
   else()
     set(CONFIGURE_OPTS --build=${BUILD_TRIPLET}) # Defined in Helpers
   endif()
-  set(CONFIGURE_ENV ${CONFIGURE_ENV} env "CFLAGS=${GMP_CFLAGS}")
+  set(CONFIGURE_ENV ${CONFIGURE_ENV} env "CXXFLAGS=${GMP_CXXFLAGS}" env "CFLAGS=${GMP_CFLAGS}")
 
   # `CC_FOR_BUILD`, `--host`, and `--build` are passed to `configure` to ensure
   # that cross-compilation works (as suggested in the GMP documentation).


### PR DESCRIPTION
Removes -std=gnu99 in g++ compiler invoation to avoid warnings.