### PR TITLE
cmake: Use correct source directory for GMP install

### DIFF
--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -181,7 +181,7 @@ else()
   # On Windows, this installs the import libraries (LIB) and
   # the DLL libraries (BIN)
   install(
-    DIRECTORY ${DEPS_BASE}/${CMAKE_INSTALL_LIBDIR}/
+    DIRECTORY ${DEPS_BASE}/lib/
     TYPE LIB
     FILES_MATCHING PATTERN libgmp* PATTERN gmp*.pc
   )


### PR DESCRIPTION
When GMP is built from sources, the static library is always in `${DEPS_BASE}/lib/`, even on systems using the `lib64` convention.

Fixes #12144