### PR TITLE
ci: Upgrade macOS runners to macOS 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
             strip-bin: aarch64-linux-gnu-strip
 
           - name: macos:production
-            os: macos-13
+            os: macos-15-intel
             config: production --auto-download --all-bindings --editline -DBUILD_GMP=1
             cache-key: production
             strip-bin: strip
@@ -104,7 +104,7 @@ jobs:
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
           - name: macos:production-arm64
-            os: macos-14
+            os: macos-15
             config: production --auto-download --all-bindings --editline -DBUILD_GMP=1
             cache-key: production-arm64
             strip-bin: strip
@@ -118,7 +118,7 @@ jobs:
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
           - name: macos:production-arm64-cross
-            os: macos-13
+            os: macos-15-intel
             config: production --auto-download --all-bindings --editline --arm64
             cache-key: production-arm64-cross
             strip-bin: strip
@@ -217,7 +217,7 @@ jobs:
             gpl-tag: -gpl
 
           - name: macos:production-gpl
-            os: macos-13
+            os: macos-15-intel
             config: production --auto-download --editline --gpl --cln --glpk --cocoa -DBUILD_GMP=1 -DBUILD_CLN=1
             cache-key: production-gpl
             strip-bin: strip
@@ -226,7 +226,7 @@ jobs:
             gpl-tag: -gpl
 
           - name: macos:production-arm64-gpl
-            os: macos-14
+            os: macos-15
             config: production --auto-download --editline --gpl --cln --glpk --cocoa -DBUILD_GMP=1 -DBUILD_CLN=1
             cache-key: production-arm64-gpl
             strip-bin: strip

--- a/.github/workflows/package_pypi.yml
+++ b/.github/workflows/package_pypi.yml
@@ -44,11 +44,11 @@ jobs:
             arch: aarch64
             shell: bash
           - name: macos-x86_64
-            os: macos-13
+            os: macos-15-intel
             macos-target: 10.13
             shell: bash
           - name: macos-arm64
-            os: macos-14
+            os: macos-15
             macos-target: 11
             shell: bash
           - name: windows-x86_64

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -330,7 +330,7 @@ Dependencies for Language Bindings
   - `Cython <https://cython.org/>`_ >= 3.0.0
   - `pip <https://pip.pypa.io/>`_ >= 23.0
   - `pytest <https://docs.pytest.org/en/6.2.x/>`_
-  - `repairwheel <https://github.com/jvolkman/repairwheel>`_ >= 0.3.1
+  - `repairwheel <https://github.com/jvolkman/repairwheel>`_ >= 0.3.2
   - `setuptools <https://setuptools.pypa.io/>`_ >= 66.1.0
   - The source for the `pythonic API <https://github.com/cvc5/cvc5_pythonic_api>`_
 

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -25,7 +25,7 @@ if(NOT ONLY_PYTHON_EXT_SRC)
   # a directory within the Python wheel package so that
   # the package is self-contained. It works on Linux,
   # macOS, and Windows.
-  find_package(Repairwheel 0.3.1 REQUIRED)
+  find_package(Repairwheel 0.3.2 REQUIRED)
 endif()
 
 configure_file(genenums.py.in genenums.py)


### PR DESCRIPTION
The macOS 13 runner images are [deprecated](https://github.com/actions/runner-images/issues/13046) and will no longer be supported after December 4.

In order to make the Python wheels work on Intel macOS 15, it was necessary to use repairwheel 0.3.2, which includes a bug fix related to the `__LINKEDIT` segment size.