### PR TITLE
Add the no-supports field in the output of --help-option-categories

### DIFF
--- a/src/main/options_template.cpp
+++ b/src/main/options_template.cpp
@@ -100,7 +100,6 @@ void printUsageCategories(cvc5::Solver& solver, std::ostream& os)
   std::stringstream ssRegular;
   std::stringstream ssRegularNoSupport;
   std::stringstream ssExpert;
-  std::stringstream ssUndocumented;
   for (const auto& name : options::getNames())
   {
     auto info = solver.getOptionInfo(name);
@@ -137,7 +136,6 @@ void printUsageCategories(cvc5::Solver& solver, std::ostream& os)
     else
     {
       Assert(info.category == cvc5::modes::OptionCategory::UNDOCUMENTED);
-      ssUndocumented << "- " << name << std::endl;
     }
   }
   os << "Common options:" << std::endl;
@@ -148,8 +146,6 @@ void printUsageCategories(cvc5::Solver& solver, std::ostream& os)
   os << ssRegularNoSupport.str();
   os << "Expert options:" << std::endl;
   os << ssExpert.str();
-  os << "Undocumented options:" << std::endl;
-  os << ssUndocumented.str();
 }
 
 /**


### PR DESCRIPTION
For instance:
```
Regular options with a no-support restriction:
- bv-solver [proofs]
- cegqi-bv [proofs]
- cegqi-midpoint [proofs]
- cegqi-nested-qe [proofs]
- ext-rewrite-quant [proofs]
- learned-rewrite [proofs, unsat-cores]
- macros-quant [proofs]
- nl-cov [proofs]
- re-elim [proofs]
- solve-bv-as-int [proofs]
- strings-lazy-pp [proofs]
- sub-cbqi [proofs]
- symmetry-breaker [proofs]
```
Also removes the undocumented category from this output, which should not be given to the user.