### PR TITLE
Add beta reduction infra

### DIFF
--- a/src/smt/beta_reduce_converter.cpp
+++ b/src/smt/beta_reduce_converter.cpp
@@ -1,0 +1,39 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2023 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Implementation of beta reduction node conversion
+ */
+
+#include "expr/beta_reduce_converter.h"
+
+namespace cvc5::internal {
+
+/** convert node n as described above during post-order traversal */
+Node BetaReduceNodeConverter::postConvert(Node n)
+{
+  if (n.getKind() == Kind::APPLY_UF
+      && n.getOperator().getKind() == Kind::LAMBDA)
+  {
+    Node lam = n.getOperator();
+    std::vector<Node> vars(lam[0].begin(), lam[0].end());
+    std::vector<Node> subs(n.begin(), n.end());
+    // only reduce if arity is correct
+    if (vars.size() == subs.size())
+    {
+      return lam[1].substitute(
+          vars.begin(), vars.end(), subs.begin(), subs.end());
+    }
+  }
+  return n;
+}
+
+}  // namespace cvc5::internal

--- a/src/smt/beta_reduce_converter.h
+++ b/src/smt/beta_reduce_converter.h
@@ -1,0 +1,43 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Andrew Reynolds
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2023 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Implementation of beta reduction node conversion
+ */
+#include "cvc5_private.h"
+
+#ifndef CVC4__PROOF__EXPR__BETA_REDUCE_NODE_CONVERTER_H
+#define CVC4__PROOF__EXPR__BETA_REDUCE_NODE_CONVERTER_H
+
+#include <iostream>
+#include <map>
+
+#include "expr/node.h"
+#include "expr/node_converter.h"
+#include "expr/type_node.h"
+
+namespace cvc5::internal {
+
+/**
+ * Applies beta-reduction to all subterms
+ */
+class BetaReduceNodeConverter : public NodeConverter
+{
+ public:
+  BetaReduceNodeConverter(NodeManager * nm) : NodeConverter(nm) {}
+  ~BetaReduceNodeConverter() {}
+  /** convert node n as described above during post-order traversal */
+  Node postConvert(Node n) override;
+};
+
+}  // namespace cvc5::internal
+
+#endif


### PR DESCRIPTION
This PR introduces the beta reduction infrastructure to the cvc5 codebase. It adds`beta_reduce_converter.cpp` and `beta_reduce_converter.h` which implements the `BetaReduceNodeConverter` class.

This infrastructure will be used in an upcoming PR for SMT query normalization.

