### PR TITLE
Building GMP in source directory

### DIFF
--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -137,6 +137,7 @@ if(NOT GMP_FOUND_SYSTEM)
     ${COMMON_EP_CONFIG}
     URL https://github.com/cvc5/cvc5-deps/blob/main/gmp-${GMP_VERSION}.tar.bz2?raw=true
     URL_HASH SHA256=ac28211a7cfb609bae2e2c8d6058d66c8fe96434f740cf6fe2e47b000d1c20cb
+    BUILD_IN_SOURCE ON
     CONFIGURE_COMMAND
       ${CONFIGURE_ENV}
           ${CONFIGURE_CMD_WRAPPER} ${SHELL} <SOURCE_DIR>/configure


### PR DESCRIPTION
Some scripts in the GMP build system require to have certain files in the build directory. Otherwise, bison is invoced to regenerte them which causes errors when bison is not installed.