### PR TITLE
Fix fairness issue with inst-when mode

### DIFF
--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -399,6 +399,8 @@ void QuantifiersEngine::check( Theory::Effort e ){
       }else{
         if (quant_e == QuantifiersModule::QEFFORT_CONFLICT)
         {
+          // increment the instantiation round counter only if we did not find a
+          // conflict or lemma at QEFFORT_CONFLICT above.
           d_qstate.incrementInstRoundCounters(e);
         }
         else if (quant_e == QuantifiersModule::QEFFORT_MODEL)
@@ -492,6 +494,8 @@ void QuantifiersEngine::check( Theory::Effort e ){
     Trace("quant-engine-debug2") << "Finished quantifiers engine check." << std::endl;
   }else{
     Trace("quant-engine-debug2") << "Quantifiers Engine does not need check." << std::endl;
+    // increment counter
+    d_qstate.incrementInstRoundCounters(e);
   }
 
   //SAT case


### PR DESCRIPTION
When using `--no-cbqi`, we would never enter a full effort quantifiers check with `--inst-when=full-last-call` (which says to alternate FULL/LAST_CALL) and instead always defer to last call effort.

This ensures we increment the instantiation round counter even if no module asked to check for that effort.

This issue seems to only occur with `--no-cbqi` (where otherwise conflict-based instantiation always runs at full effort).