### PR TITLE
Improvement to get-ethos-checker script

### DIFF
--- a/contrib/get-ethos-checker
+++ b/contrib/get-ethos-checker
@@ -27,7 +27,7 @@ EO_DIR="$BASE_DIR/ethos-checker"
 mkdir -p $EO_DIR
 
 # download and unpack ethos
-ETHOS_VERSION="f69def2dfdbf4e44c1de89798bf4fbf88a8863f2"
+ETHOS_VERSION="ca81b652c9d3a7fef994f4a544ddb01c534ebe30"
 download "https://github.com/cvc5/ethos/archive/$ETHOS_VERSION.tar.gz" $BASE_DIR/tmp/ethos.tgz
 tar --strip 1 -xzf $BASE_DIR/tmp/ethos.tgz -C $EO_DIR
 


### PR DESCRIPTION
Currently, we must run `contrib/get-ethos-checker` from the main `cvc5` directory.
For example, we cannot `cd` into `contrib` and then run `get-ethos-checker` from there.
This PR adds flexibility by allowing the user to run the script from wherever they want.