### PR TITLE
cpc proofs for log2

### DIFF
--- a/proofs/lfsc/signatures/theory_def.plf
+++ b/proofs/lfsc/signatures/theory_def.plf
@@ -125,6 +125,8 @@
 (define iand (# x mpz (# y term (# z term (apply (apply (f_iand x) y) z)))))
 (declare f_int.pow2 term)
 (define int.pow2 (# x term (apply f_int.pow2 x)))
+(declare f_int.log2 term)
+(define int.log2 (# x term (apply f_int.log2 x)))
 
 ;; ---- Arrays
 (declare f_select term)

--- a/src/theory/quantifiers/inst_strategy_mbqi.cpp
+++ b/src/theory/quantifiers/inst_strategy_mbqi.cpp
@@ -18,16 +18,17 @@
 #include "expr/node_algorithm.h"
 #include "expr/skolem_manager.h"
 #include "expr/subs.h"
+#include "options/arrays_options.h"
 #include "printer/smt2/smt2_printer.h"
-#include "theory/quantifiers/mbqi_enum.h"
+#include "smt/set_defaults.h"
 #include "theory/quantifiers/first_order_model.h"
 #include "theory/quantifiers/instantiate.h"
+#include "theory/quantifiers/mbqi_enum.h"
 #include "theory/quantifiers/quantifiers_rewriter.h"
 #include "theory/quantifiers/skolemize.h"
 #include "theory/quantifiers/term_util.h"
 #include "theory/strings/theory_strings_utils.h"
 #include "theory/uf/function_const.h"
-#include "smt/set_defaults.h"
 
 using namespace std;
 using namespace cvc5::internal::kind;
@@ -44,7 +45,11 @@ InstStrategyMbqi::InstStrategyMbqi(Env& env,
     : QuantifiersModule(env, qs, qim, qr, tr), d_globalSyms(userContext())
 {
   // some kinds may appear in model values that cannot be asserted
-  d_nonClosedKinds.insert(Kind::STORE_ALL);
+  // if arraysExp is enabled, we allow STORE_ALL terms in assertions.
+  if (!options().arrays.arraysExp)
+  {
+    d_nonClosedKinds.insert(Kind::STORE_ALL);
+  }
   d_nonClosedKinds.insert(Kind::CODATATYPE_BOUND_VARIABLE);
   d_nonClosedKinds.insert(Kind::UNINTERPRETED_SORT_VALUE);
   // may appear in certain models e.g. strings of excessive length

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1571,6 +1571,7 @@ set(regress_0_tests
   regress0/push-pop/test.01.cvc.smt2
   regress0/push-pop/tiny_bug.smt2
   regress0/push-pop/units.cvc.smt2
+  regress0/quantifiers/abv-const-array-inst.smt2
   regress0/quantifiers/agg-rew-test-cf.smt2
   regress0/quantifiers/agg-rew-test.smt2
   regress0/quantifiers/alpha-eq-var-reorder.smt2

--- a/test/regress/cli/regress0/quantifiers/abv-const-array-inst.smt2
+++ b/test/regress/cli/regress0/quantifiers/abv-const-array-inst.smt2
@@ -1,0 +1,9 @@
+; COMMAND-LINE: --arrays-exp --mbqi
+; EXPECT: unsat
+(set-logic ABV)
+(assert
+  (forall ((x (Array (_ BitVec 32) (_ BitVec 32))) (i (_ BitVec 32)))
+    (= (select x i) (_ bv0 32))
+  )
+)
+(check-sat)


### PR DESCRIPTION
This PR adds cpc proof support for the new log2 operator.