### PR TITLE
Build Javadoc and sources JARs for IDE docs and navigation

### DIFF
--- a/docs/api/java/CMakeLists.txt
+++ b/docs/api/java/CMakeLists.txt
@@ -53,10 +53,10 @@ if(BUILD_BINDINGS_JAVA)
   string(REPLACE "\n" " " JAVADOC_MATHJAX ${JAVADOC_MATHJAX})
   string(REPLACE " " ";" JAVADOC_MATHJAX ${JAVADOC_MATHJAX})
 
-set(Java_DOCLINT -Xdoclint:all)
-if(TREAT_WARNING_AS_ERROR)
-  list(APPEND Java_DOCLINT -Werror)
-endif()
+  set(Java_DOCLINT -Xdoclint:all)
+  if(TREAT_WARNING_AS_ERROR)
+    list(APPEND Java_DOCLINT -Werror)
+  endif()
 
   get_target_property(CVC5_JAR_FILE cvc5jar JAR_FILE)
   add_custom_command(
@@ -80,6 +80,18 @@ endif()
   )
 
   add_custom_target(docs-java-javadoc DEPENDS ${JAVADOC_INDEX_FILE})
-  add_dependencies(docs-java docs-java-javadoc)
+
+  # Build cvc5-javadoc.jar to enable IDE tooltips and API documentation
+  set(JAVADOC_JAR ${CMAKE_CURRENT_BINARY_DIR}/cvc5-javadoc.jar)
+  add_custom_command(
+    OUTPUT ${JAVADOC_JAR}
+    COMMAND ${Java_JAR_EXECUTABLE} cf ${JAVADOC_JAR} -C ${JAVADOC_OUTPUT_DIR} .
+    DEPENDS ${JAVADOC_INDEX_FILE}
+    COMMENT "Generating javadoc JAR"
+  )
+
+  add_custom_target(javadoc-jar ALL DEPENDS ${JAVADOC_JAR})
+
+  add_dependencies(docs-java docs-java-javadoc javadoc-jar)
 endif()
 

--- a/src/api/java/CMakeLists.txt
+++ b/src/api/java/CMakeLists.txt
@@ -346,6 +346,21 @@ endif()
 
 add_dependencies(cvc5jar generate-java-kinds cvc5jni cvc5 cvc5parser)
 
+if(BUILD_DOCS)
+  # Build cvc5-sources.jar to enable viewing, navigation, and debugging of the library source code
+  set(SOURCES_JAR ${CMAKE_CURRENT_BINARY_DIR}/cvc5-sources.jar)
+
+  add_custom_command(
+      OUTPUT ${SOURCES_JAR}
+      COMMAND ${Java_JAR_EXECUTABLE} cf ${SOURCES_JAR}
+              -C ${CMAKE_CURRENT_LIST_DIR} io/github/cvc5
+              -C ${CMAKE_CURRENT_BINARY_DIR} io/github/cvc5
+      DEPENDS ${JAVA_FILES}
+      COMMENT "Generating sources JAR"
+  )
+  add_custom_target(cvc5-sources-jar ALL DEPENDS ${SOURCES_JAR})
+endif()
+
 # Install in the same directory of cvc5-targets.
 # On Windows, CMake's default install action places
 # DLLs into the runtime path (by default "bin")


### PR DESCRIPTION
Enabled only when the `--docs` option is used. Providing these JAR files is one of the requirements for publishing in Maven Central.