### PR TITLE
java: Store JNI library by OS and CPU architecture

### DIFF
--- a/.github/actions/add-jar/action.yml
+++ b/.github/actions/add-jar/action.yml
@@ -3,10 +3,8 @@ description: |
   Creates a JAR that includes the cvc5 Java bindings
   along with the necessary native libraries.
 inputs:
-  install-path:
-    description: path to the directory with installed artifacts
-  jar-libs-dir:
-    description: name of the directory that will contain the libraries within the JAR
+  build-dir:
+    description: path to the build directory
   jar-name:
     description: target name of the JAR
   shell:
@@ -14,42 +12,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Create JAR contents (Linux)
-      if: runner.os == 'Linux'
-      shell: ${{ inputs.shell }}
-      run: |
-        echo "::group::Create JAR contents (Linux)"
-        mkdir ${{ inputs.jar-libs-dir }}
-        cd ${{ inputs.jar-libs-dir }}
-        cp ${{ inputs.install-path }}/lib/libcvc5jni.so .
-        echo "::endgroup::"
-
-    - name: Create JAR contents (macOS)
-      if: runner.os == 'macOS'
-      shell: ${{ inputs.shell }}
-      run: |
-        echo "::group::Create JAR contents (macOS)"
-        mkdir ${{ inputs.jar-libs-dir }}
-        cd ${{ inputs.jar-libs-dir }}
-        cp ${{ inputs.install-path }}/lib/libcvc5jni.dylib .
-        echo "::endgroup::"
-
-    - name: Create JAR contents (Windows)
-      if: runner.os == 'Windows'
-      shell: ${{ inputs.shell }}
-      run: |
-        echo "::group::Create JAR contents (Windows)"
-        mkdir ${{ inputs.jar-libs-dir }}
-        cd ${{ inputs.jar-libs-dir }}
-        cp ${{ inputs.install-path }}/bin/cvc5jni.dll .
-        echo "::endgroup::"
-
     - name: Create JAR
       shell: ${{ inputs.shell }}
       run: |
         echo "::group::Create JAR"
-        unzip ${{ inputs.install-path }}/share/java/cvc5.jar
-        jar cf ${{ inputs.jar-name }}.jar AUTHORS COPYING licenses io ${{ inputs.jar-libs-dir }}
+        unzip ${{ inputs.build-dir }}/src/api/java/cvc5.jar
+        jar cf ${{ inputs.jar-name }}.jar AUTHORS COPYING licenses io \
+            -C ${{ inputs.build-dir }}/src/api/java/ cvc5-libs
         echo "::endgroup::"
 
     - name: Test JAR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,8 +362,7 @@ jobs:
       if: matrix.build.java-bindings && matrix.build.package-name && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
       uses: ./.github/actions/add-jar
       with:
-        install-path: ${{ steps.create-static-package.outputs.install-path }}
-        jar-libs-dir: cvc5-libs
+        build-dir: ${{ steps.configure-and-build.outputs.static-build-dir }}
         jar-name: ${{ matrix.build.package-name }}${{ matrix.build.gpl-tag }}-java-api
         shell: ${{ matrix.build.shell }}
 

--- a/src/api/java/CMakeLists.txt
+++ b/src/api/java/CMakeLists.txt
@@ -310,6 +310,34 @@ target_include_directories(cvc5jni PUBLIC ${CMAKE_BINARY_DIR}/src/)
 target_include_directories(cvc5jni PUBLIC ${JNI_DIR})
 target_link_libraries(cvc5jni PRIVATE cvc5 cvc5parser)
 
+# Normalize the system name and CPU architecture according to the conventions of
+# the os-maven-plugin, so that the JNI library is built under the path
+# ${JNI_PREFIX}/${SYS_NAME}/${CPU_ARCH}. This enables the creation of
+# a single JAR that can contain native JNI libraries for multiple OSes and
+# CPU architectures simultaneously.
+# Additionally, it prevents file collisions when multiple JARs containing
+# a native JNI library for the same OS but different architectures are added to
+# the classpath at the same time.
+set(JNI_PREFIX "cvc5-libs")
+string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" CPU_ARCH)
+# Normalize supported CPU architectures
+if(CPU_ARCH MATCHES "x86_64|amd64")
+  set(CPU_ARCH "x86_64")
+elseif(CPU_ARCH MATCHES "aarch64|arm64")
+  set(CPU_ARCH "aarch_64")
+endif()
+# Normalize supported system names
+string(TOLOWER "${CMAKE_SYSTEM_NAME}" SYS_NAME)
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(SYS_NAME "osx")
+endif()
+
+set(JNI_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/${JNI_PREFIX}/${SYS_NAME}/${CPU_ARCH}")
+set_target_properties(cvc5jni PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY "${JNI_OUTPUT_DIR}"
+  RUNTIME_OUTPUT_DIRECTORY "${JNI_OUTPUT_DIR}"
+)
+
 if (WIN32 AND NOT BUILD_SHARED_LIBS)
   # Statically link all libraries, including MinGW-w64 libraries
   set_target_properties(cvc5jni PROPERTIES LINK_FLAGS -static)

--- a/test/api/java/CMakeLists.txt
+++ b/test/api/java/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(Java REQUIRED)
 include(UseJava)
 
 get_target_property(CVC5_JAR_PATH cvc5jar JAR_FILE)
-get_filename_component(CVC5_JNI_PATH ${CVC5_JAR_PATH} DIRECTORY)
+get_target_property(CVC5_JNI_LIBDIR cvc5jni LIBRARY_OUTPUT_DIRECTORY)
 
 add_custom_target(build-japitests)
 add_dependencies(build-apitests build-japitests)
@@ -48,7 +48,7 @@ macro(cvc5_add_java_api_test name dir)
   add_test(${testname}
       ${ENV_PATH_CMD}
       ${Java_JAVA_EXECUTABLE}
-        -Djava.library.path=${CVC5_JNI_PATH}
+        -Djava.library.path=${CVC5_JNI_LIBDIR}
         -cp "${CVC5_JAR_PATH}${PATH_SEP}${test_bin_dir}/${name}.jar" ${name}
     )
   set_tests_properties(${testname} PROPERTIES LABELS "api japi")

--- a/test/unit/api/java/CMakeLists.txt
+++ b/test/unit/api/java/CMakeLists.txt
@@ -18,7 +18,7 @@ include(UseJava)
 find_package(JUnit REQUIRED)
 
 get_target_property(CVC5_JAR_PATH cvc5jar JAR_FILE)
-get_filename_component(CVC5_JNI_PATH ${CVC5_JAR_PATH} DIRECTORY)
+get_target_property(CVC5_JNI_LIBDIR cvc5jni LIBRARY_OUTPUT_DIRECTORY)
 
 # specify source files for junit tests
 set(java_test_src_files
@@ -66,7 +66,7 @@ macro(cvc5_add_java_api_test name)
     COMMAND
       ${ENV_PATH_CMD}
       ${Java_JAVA_EXECUTABLE}
-      -Djava.library.path=${CVC5_JNI_PATH}
+      -Djava.library.path=${CVC5_JNI_LIBDIR}
       -jar ${JUnit_JAR}
       -cp "${JUnit_JAR}${PATH_SEP}${CVC5_JAR_PATH}${PATH_SEP}."
       -select-package tests


### PR DESCRIPTION
This PR builds and stores the JNI library in a directory structured according to the OS and CPU architecture. This allows a single JAR to contain native JNI libraries for multiple OSes and CPU architectures simultaneously, and prevents file collisions when multiple JARs containing a native JNI library for the same OS but different architectures are added to the classpath.