### PR TITLE
[proofs] Fix cyclic proof issue in EqProof conversion

### DIFF
--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1473,6 +1473,7 @@ set(regress_0_tests
   regress0/proofs/issue9669-clause-level-opt-incremental.smt2
   regress0/proofs/issue9770-open-sat-proof.smt2
   regress0/proofs/issue9927.smt2
+  regress0/proofs/issue12240-cyclic-proof.smt2
   regress0/proofs/lfsc-test-1.smt2
   regress0/proofs/macro-quant-prenex-simple.smt2
   regress0/proofs/nomerge-alethe-pf.smt2

--- a/test/regress/cli/regress0/proofs/issue12240-cyclic-proof.smt2
+++ b/test/regress/cli/regress0/proofs/issue12240-cyclic-proof.smt2
@@ -1,0 +1,10 @@
+; COMMAND-LINE: --check-proofs --proof-check=eager
+; EXPECT: sat
+(set-logic ALL)
+(declare-fun x () Int)
+(declare-fun y () Int)
+(declare-fun z () Int)
+(assert (and (or (= (* (* (- x (* x y)) (- z 1)) (* (- x (* x y)) (- z 1)))
+(div (- (* z (- x)) 2) 2)) (= (* (* (- x (* x y)) (- z 1)) (* (- x (* x y))
+(- z 1))) (div (- (* z (- x)) 2) 2)))))
+(check-sat)


### PR DESCRIPTION
Sometimes the equality engine proof is silly in that an equality is derived having itself as an assumption. While silly, this is not wrong, but when building the proof, given the overwrite policy of assumptions, this would lead to a cyclic proof.

A thorough way to avoid this issue is to not override assumptions, since in this module assumptions are never supposed to be generated during proof conversion other than original assumptions given to the module. So this commit makes the construction of the proof more careful.

An alternative solution would be to guard the conversion in different points to short-circuit cases in which you are rederiving something. But this is error-prone and can be done in post-processing anyway.

Fixes #12240