### PR TITLE
Update Eunoia+CPC to ensure substitutions have no variable capture

### DIFF
--- a/proofs/eo/cpc/programs/Quantifiers.eo
+++ b/proofs/eo/cpc/programs/Quantifiers.eo
@@ -1,34 +1,34 @@
 (include "../theories/Builtin.eo")
 (include "../theories/Quantifiers.eo")
 
-; program: $contains_aterm
+; program: $contains_atomic_term
 ; args:
 ; - arg1 S: The term to process.
-; - arg2 U: The (0-ary) term to find.
+; - arg2 U: The atomic (0-ary) term to find.
 ; return: The result is true if arg2 is a subterm of arg1.
-(program $contains_aterm
+(program $contains_atomic_term
   ((T Type) (U Type) (S Type) (x U) (y S) (f (-> T S)) (a T))
   :signature (S U) Bool
   (
-  (($contains_aterm (f a) x)  (eo::ite ($contains_aterm f x) true ($contains_aterm a x)))
-  (($contains_aterm x y)      (eo::eq x y))
+  (($contains_atomic_term (f a) x)  (eo::ite ($contains_atomic_term f x) true ($contains_atomic_term a x)))
+  (($contains_atomic_term x y)      (eo::eq x y))
   )
 )
 
-; program: $contains_aterm_list
+; program: $contains_atomic_term_list
 ; args:
 ; - t T: The term to process.
 ; - xs @List: The list of terms to find.
 ; return: true if any atomic (0-ary) subterm of t is in xs.
-(program $contains_aterm_list ((T Type) (U Type) (S Type) (x U) (f (-> T S)) (a T) (xs @List))
+(program $contains_atomic_term_list ((T Type) (U Type) (S Type) (x U) (f (-> T S)) (a T) (xs @List))
   :signature (T @List) Bool
   (
-    (($contains_aterm_list (f a) xs)  (eo::ite ($contains_aterm_list f xs) true ($contains_aterm_list a xs)))
-    (($contains_aterm_list x xs)      (eo::not (eo::is_neg (eo::list_find @list xs x))))
+    (($contains_atomic_term_list (f a) xs)  (eo::ite ($contains_atomic_term_list f xs) true ($contains_atomic_term_list a xs)))
+    (($contains_atomic_term_list x xs)      (eo::not (eo::is_neg (eo::list_find @list xs x))))
   )
 )
 
-; program: $contains_aterm_list_free_rec
+; program: $contains_atomic_term_list_free_rec
 ; args:
 ; - t T: The term to process.
 ; - xs @List: The list of terms to find.
@@ -36,33 +36,35 @@
 ; return: >
 ;   true if any atomic (0-ary) subterm of t is in xs and is not a bound variable
 ;   of t at that position or in the set of already bound variables bvs.
-(program $contains_aterm_list_free_rec 
+; note: Assumes applications with lists as their first argument are binders.
+(program $contains_atomic_term_list_free_rec
   ((T Type) (U Type) (S Type) (x U) (q (-> @List T S)) (f (-> T S)) (a T) (xs @List) (bvs @List) (x U) (ys @List :list))
   :signature (T @List @List) Bool
   (
     ; we assume that any function taking a list as a first argument is a binder
-    (($contains_aterm_list_free_rec (q (@list x ys) a) xs bvs)
+    (($contains_atomic_term_list_free_rec (q (@list x ys) a) xs bvs)
       ; concatenate these variables to the list of bound variables
-      ($contains_aterm_list_free_rec a xs (eo::list_concat @list (@list x ys) bvs)))
+      ($contains_atomic_term_list_free_rec a xs (eo::list_concat @list (@list x ys) bvs)))
     ; otherwise normal recursion
-    (($contains_aterm_list_free_rec (f a) xs bvs)
-      (eo::ite ($contains_aterm_list_free_rec f xs bvs) true ($contains_aterm_list_free_rec a xs bvs)))
-    (($contains_aterm_list_free_rec x xs bvs)
+    (($contains_atomic_term_list_free_rec (f a) xs bvs)
+      (eo::ite ($contains_atomic_term_list_free_rec f xs bvs) true ($contains_atomic_term_list_free_rec a xs bvs)))
+    (($contains_atomic_term_list_free_rec x xs bvs)
       (eo::ite (eo::is_neg (eo::list_find @list xs x)) 
         false
         (eo::is_neg (eo::list_find @list bvs x))))
   )
 )
 
-; define: $contains_aterm_list_free
+; define: $contains_atomic_term_list_free
 ; args:
 ; - t T: The term to process.
 ; - xs @List: The list of terms to find.
 ; return: >
 ;   true if any atomic (0-ary) subterm of t is in xs and is not a bound
 ;   variable of t at that position.
-(define $contains_aterm_list_free ((T Type :implicit) (x T) (xs @List))
-  ($contains_aterm_list_free_rec x xs @list.nil))
+; note: Assumes applications with lists as their first argument are binders.
+(define $contains_atomic_term_list_free ((T Type :implicit) (x T) (xs @List))
+  ($contains_atomic_term_list_free_rec x xs @list.nil))
 
 
 ; program: $substitute
@@ -71,6 +73,7 @@
 ; - arg2 S: The range of the substitution.
 ; - arg3 U: The term to process.
 ; return: the result of replacing all occurrences of arg1 with arg2 in arg3.
+; note: Assumes applications with lists as their first argument are binders.
 ; note: This method does not evaluate if variable capture is encountered.
 (program $substitute
   ((T Type) (U Type) (S Type) (x S) (y S) (f (-> T U)) (a T) (z U)
@@ -80,7 +83,7 @@
   ; we assume that any function taking a list as a first argument is a binder
   ; for binders, we ensure no variable capture, get stuck otherwise.
   (($substitute x y (q (@list v vs) a))
-    (eo::requires ($contains_aterm_list_free y (@list v vs)) false
+    (eo::requires ($contains_atomic_term_list_free y (@list v vs)) false
       (q ($substitute x y (@list v vs)) ($substitute x y a))))
   (($substitute x y (f a))              (_ ($substitute x y f) ($substitute x y a)))
   (($substitute x y x)                  y)
@@ -94,6 +97,7 @@
 ; - xs @List: The list of variables to substitute.
 ; - ss @List: The terms to substitute.
 ; return: the result of simultaneously substituting xs to ss in t.
+; note: Assumes applications with lists as their first argument are binders.
 ; note: This method does not evaluate if variable capture is encountered.
 (program $substitute_simul
   ((T Type) (S Type) (x S) (f (-> T S)) (a T) (xs @List :list) (ss @List :list) (s S) (y S)
@@ -103,7 +107,7 @@
   ; we assume that any function taking a list as a first argument is a binder
   ; for binders, we ensure no variable capture, get stuck otherwise.
   (($substitute_simul (q (@list v vs) a) xs ss)
-    (eo::requires ($contains_aterm_list_free ss (@list v vs)) false
+    (eo::requires ($contains_atomic_term_list_free ss (@list v vs)) false
       (q ($substitute_simul (@list v vs) xs ss) ($substitute_simul a xs ss))))
   (($substitute_simul (f a) xs ss)                  (_ ($substitute_simul f xs ss) ($substitute_simul a xs ss)))
   (($substitute_simul x xs ss)                      (eo::define ((i (eo::list_find @list xs x)))

--- a/proofs/eo/cpc/rules/Quantifiers.eo
+++ b/proofs/eo/cpc/rules/Quantifiers.eo
@@ -74,8 +74,8 @@
   :args (t vs ts)
   :requires ((($is_var_list vs) true)
              (($is_var_list ts) true)
-             (($contains_aterm_list_free t vs) false)
-             (($contains_aterm_list t ts) false))
+             (($contains_atomic_term_list_free t vs) false)
+             (($contains_atomic_term_list t ts) false))
   :conclusion (= t ($substitute_simul t vs ts))
 )
 
@@ -137,7 +137,7 @@
   (
   (($mk_quant_unused_vars_rec @list.nil F)    @list.nil)
   (($mk_quant_unused_vars_rec (@list x xs) F) (eo::define ((r ($mk_quant_unused_vars_rec xs F)))
-                                              (eo::ite ($contains_aterm F x)
+                                              (eo::ite ($contains_atomic_term F x)
                                                 ; remove the duplicate of x in r if it exists
                                                 (eo::cons @list x (eo::list_erase @list r x))
                                                 r)))
@@ -244,12 +244,12 @@
 (program $is_quant_miniscope_or ((x @List) (xs @List :list) (ys @List :list) (f Bool) (fs Bool :list) (g Bool) (gs Bool :list))
   :signature (@List Bool Bool) Bool
   (
-  (($is_quant_miniscope_or x (or f fs) (or f gs))                     (eo::requires ($contains_aterm_list f x) false
+  (($is_quant_miniscope_or x (or f fs) (or f gs))                     (eo::requires ($contains_atomic_term_list f x) false
                                                                         ($is_quant_miniscope_or x fs gs)))
-  (($is_quant_miniscope_or x (or f fs) (or (forall @list.nil f) gs))  (eo::requires ($contains_aterm_list f x) false
+  (($is_quant_miniscope_or x (or f fs) (or (forall @list.nil f) gs))  (eo::requires ($contains_atomic_term_list f x) false
                                                                         ($is_quant_miniscope_or x fs gs)))
   (($is_quant_miniscope_or (@list x xs) (or f fs) (or (forall (@list x ys) f) gs))  
-                                                                      (eo::requires ($contains_aterm gs x) false
+                                                                      (eo::requires ($contains_atomic_term gs x) false
                                                                         ($is_quant_miniscope_or xs (or f fs) (or (forall ys f) gs))))
   (($is_quant_miniscope_or @list.nil false false)                     true)
   (($is_quant_miniscope_or x f g)                                     false)
@@ -282,7 +282,7 @@
 ; conclusion: The given equality.
 (declare-rule quant-miniscope-ite ((x @List) (A Bool) (F1 Bool) (F2 Bool) (G Bool))
   :args ((= (forall x (ite A F1 F2)) (ite A (forall x F1) (forall x F2))))
-  :requires ((($contains_aterm_list A x) false))
+  :requires ((($contains_atomic_term_list A x) false))
   :conclusion (= (forall x (ite A F1 F2)) (ite A (forall x F1) (forall x F2)))
 )
 
@@ -295,7 +295,7 @@
 ; return: >
 ;    The result of eliminating x from F. This method does not evaluate if t contains x.
 (define $mk_quant_var_elim_eq_subs ((T Type :implicit) (x T) (t T) (F Bool))
-  (eo::requires ($contains_aterm t x) false ($substitute x t F)))
+  (eo::requires ($contains_atomic_term t x) false ($substitute x t F)))
 
 ; program: $mk_quant_var_elim_eq
 ; args:
@@ -342,9 +342,9 @@
 (program $is_quant_dt_split_conj ((T Type) (U Type) (C Type) (W Type) (x T) (cx T) (c (-> U W)) (y U) (ys @List :list) (zs @List :list) (F Bool) (G Bool))
   :signature (T C @List Bool Bool) Bool
   (
-    (($is_quant_dt_split_conj x c (@list y ys) F (forall (@list y zs) G)) (eo::requires ($contains_aterm zs y) false  ; ensure no shadowing
+    (($is_quant_dt_split_conj x c (@list y ys) F (forall (@list y zs) G)) (eo::requires ($contains_atomic_term zs y) false  ; ensure no shadowing
                                                                             ($is_quant_dt_split_conj x c ys F (forall zs G))))
-    (($is_quant_dt_split_conj x c @list.nil F (forall (@list y zs) G))    (eo::requires ($contains_aterm zs y) false  ; ensure no shadowing
+    (($is_quant_dt_split_conj x c @list.nil F (forall (@list y zs) G))    (eo::requires ($contains_atomic_term zs y) false  ; ensure no shadowing
                                                                             ($is_quant_dt_split_conj x (c y) @list.nil F (forall zs G))))
     (($is_quant_dt_split_conj x c @list.nil F (forall @list.nil G))       ($is_quant_dt_split_conj x c @list.nil F G))
     (($is_quant_dt_split_conj x cx @list.nil F G)                         (eo::eq ($substitute x cx F) G))


### PR DESCRIPTION
This would have prevented ethos from accepting the proof from https://github.com/cvc5/cvc5/issues/12252.

We now only use substitute methods that fail if variable capture is discovered.

This PR also simplifies the quantifiers signature slightly to use more consistent side conditions.