### PR TITLE
smt: ModelBlocker: Fix refcount issues of TNode vs Node handling.

### DIFF
--- a/src/smt/model_blocker.cpp
+++ b/src/smt/model_blocker.cpp
@@ -79,11 +79,11 @@ Node ModelBlocker::getModelBlocker(const std::vector<Node>& assertions,
         blockers.insert(cur);
       }
     }
-    std::unordered_set<TNode> visited;
-    std::unordered_set<TNode>::iterator it;
-    std::vector<TNode> visit;
+    std::unordered_set<Node> visited;
+    std::unordered_set<Node>::iterator it;
+    std::vector<Node> visit;
     visit.insert(visit.end(), asserts.begin(), asserts.end());
-    TNode cur;
+    Node cur;
     while (!visit.empty())
     {
       cur = visit.back();


### PR DESCRIPTION
This is the reason why #12285 was failing. `visit` is a vector of `TNode`, however, `impl` are nodes created while traversing and pushed on the `visit` stack, which can go out of scope while `visit` not holding a reference due to `TNode`.