### PR TITLE
ci: Bump GitHub Actions versions

### DIFF
--- a/.github/actions/build-documentation/action.yml
+++ b/.github/actions/build-documentation/action.yml
@@ -16,7 +16,7 @@ runs:
       working-directory: ${{ inputs.build-dir }}
     
     - name: Store Documentation
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: documentation
         path: ${{ inputs.build-dir }}/docs/sphinx-gh/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout code
         if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up latest page
         if: github.ref == 'refs/heads/main'
@@ -261,11 +261,11 @@ jobs:
       cancel-in-progress: ${{ github.repository != 'cvc5/cvc5' || startsWith(github.ref, 'refs/pull/') }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     # Ensure that the Java bindings, Java API tests, and Java examples are compatible
     # with the minimum required Java version (currently Java 8).
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.build.java-version || '8' }}

--- a/.github/workflows/cmake-version.yml
+++ b/.github/workflows/cmake-version.yml
@@ -15,11 +15,11 @@ jobs:
 
     steps:
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v1.9
+      uses: jwlawson/actions-setup-cmake@v2
       with:
         cmake-version: ${{ matrix.cmake_version }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
 
     - name: Adapt cmake version checks
       run: |

--- a/.github/workflows/docs_upload.yml
+++ b/.github/workflows/docs_upload.yml
@@ -19,7 +19,7 @@ jobs:
           git config --global user.name "DocBot"
 
       - name: Download artifact
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({

--- a/.github/workflows/package_pypi.yml
+++ b/.github/workflows/package_pypi.yml
@@ -67,7 +67,7 @@ jobs:
         shell: ${{ matrix.shell }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         ref: ${{ github.event.inputs.release_tag }}
@@ -125,7 +125,7 @@ jobs:
       run: echo "bin=$(cygpath -m $(dirname $(which cc)))" >> $GITHUB_OUTPUT
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v3.1.4
+      uses: pypa/cibuildwheel@v3.3.0
       with:
         package-dir: ./build/src/api/python/
       env:
@@ -155,7 +155,7 @@ jobs:
         CIBW_TEST_COMMAND: python {project}/examples/api/python/quickstart.py
         CIBW_TEST_SKIP: "cp38-macosx_arm64" # Silence warning. See: https://github.com/pypa/cibuildwheel/pull/1171
 
-    # - uses: actions/upload-artifact@v4
+    # - uses: actions/upload-artifact@v5
     #   with:
     #     name: wheels-${{ matrix.name }}
     #     path: ./wheelhouse/*.whl


### PR DESCRIPTION
The new version of the `cibuildwheel` action uses the final CPython 3.14.0 release to build wheels for that version, rather than a release candidate, although using the candidate release should still produce ABI-compatible wheels.