### PR TITLE
ci: Build and release Linux artifacts compiled with libc++

### DIFF
--- a/.github/actions/configure-and-build/action.yml
+++ b/.github/actions/configure-and-build/action.yml
@@ -1,8 +1,6 @@
 name: Configure and build
 description: Run configure script and build
 inputs:
-  configure-env:
-    default: ""
   configure-config:
     default: ""
   macos-target:
@@ -40,7 +38,7 @@ runs:
       shell: ${{ inputs.shell }}
       run: |
         echo "::group::Shared build"
-        ${{ inputs.configure-env }} ./configure.sh ${{ inputs.configure-config }} \
+        ./configure.sh ${{ inputs.configure-config }} \
           --prefix=$(pwd)/build-shared/install --werror --name=build-shared \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
         
@@ -60,7 +58,7 @@ runs:
       shell: ${{ inputs.shell }}
       run: |
         echo "::group::Static build"
-        ${{ inputs.configure-env }} ./configure.sh ${{ inputs.configure-config }} \
+        ./configure.sh ${{ inputs.configure-config }} \
           --prefix=$(pwd)/build-static/install --werror --static --name=build-static \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
 

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -3,6 +3,12 @@ description: Install necessary dependencies on the target system
 inputs:
   with-documentation:
     default: false
+  use-clang:
+    default: false
+    type: boolean
+  use-libcxx:
+    default: false
+    type: boolean
   windows-build:
     default: false
     type: boolean
@@ -32,6 +38,22 @@ runs:
           libfl-dev
         echo "SED=sed" >> $GITHUB_ENV
         echo "::endgroup::"
+
+    - name: Set Clang as the compiler
+      if: inputs.use-clang
+      shell: ${{ inputs.shell }}
+      run: |
+        echo "CC=clang" >> $GITHUB_ENV
+        echo "CXX=clang++" >> $GITHUB_ENV
+
+    - name: Install and set up libc++ as the standard C++ library
+      if: inputs.use-libcxx
+      shell: ${{ inputs.shell }}
+      run: |
+        sudo apt-get install -y libc++-dev libc++abi-dev
+        CLANG_DIR="$(dirname $(realpath $(which clang++)))"
+        echo "-stdlib=libc++ -lc++abi" > clang++.cfg
+        sudo cp clang++.cfg $CLANG_DIR/
 
     - name: Install software for cross-compiling for arm64 Linux
       if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,18 @@ jobs:
             exclude_regress: 3-4
             run_regression_args: --tester base --tester proof --tester cpc --tester model --tester dump
 
+          - name: ubuntu:production-libc++
+            os: ubuntu-24.04
+            use-clang: true
+            use-libcxx: true
+            config: production --auto-download -DBUILD_GMP=1
+            cache-key: production-libcxx
+            strip-bin: strip
+            check-examples: true
+            package-name: cvc5-Linux-x86_64-libcxx
+            exclude_regress: 3-4
+            run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
+
           - name: ubuntu:production-arm64
             os: ubuntu-22.04-arm
             config: production --auto-download --all-bindings --editline -DBUILD_GMP=1
@@ -82,6 +94,18 @@ jobs:
             java-bindings: true
             check-examples: true
             package-name: cvc5-Linux-arm64
+            exclude_regress: 3-4
+            run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
+
+          - name: ubuntu:production-arm64-libc++
+            os: ubuntu-24.04-arm
+            use-clang: true
+            use-libcxx: true
+            config: production --auto-download -DBUILD_GMP=1
+            cache-key: production-arm64-libcxx
+            strip-bin: strip
+            check-examples: true
+            package-name: cvc5-Linux-arm64-libcxx
             exclude_regress: 3-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
@@ -172,7 +196,7 @@ jobs:
 
           - name: ubuntu:production-clang
             os: ubuntu-22.04
-            env: CC=clang CXX=clang++
+            use-clang: true
             config: production --auto-download --no-poly
             cache-key: productionclang
             check-examples: true
@@ -195,7 +219,7 @@ jobs:
 
           - name: ubuntu:production-dbg-clang
             os: ubuntu-22.04
-            env: CC=clang CXX=clang++
+            use-clang: true
             config: production --auto-download --assertions --tracing --cln --gpl
             cache-key: dbgclang
             exclude_regress: 3-4
@@ -281,6 +305,8 @@ jobs:
       uses: ./.github/actions/install-dependencies
       with:
         with-documentation: ${{ matrix.build.build-documentation }}
+        use-clang: ${{ matrix.build.use-clang }}
+        use-libcxx: ${{ matrix.build.use-libcxx }}
         windows-build: ${{ matrix.build.windows-build }}
         wasm-build: ${{ matrix.build.wasm-build }}
         shell: ${{ matrix.build.shell }}
@@ -297,7 +323,6 @@ jobs:
       id: configure-and-build
       uses: ./.github/actions/configure-and-build
       with:
-        configure-env: ${{ matrix.build.env }}
         configure-config: ${{ matrix.build.config }}
         macos-target: ${{ matrix.build.macos-target }}
         build-shared: ${{ matrix.build.build-shared }}


### PR DESCRIPTION
The new artifacts simplify integrating the cvc5 library into [lean-cvc5](https://github.com/abdoo8080/lean-cvc5), which requires cvc5 to be compiled with libc++.