### PR TITLE
ci: Move cross-compilation jobs to a new workflow

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -40,14 +40,14 @@ runs:
         echo "::endgroup::"
 
     - name: Set Clang as the compiler
-      if: inputs.use-clang
+      if: inputs.use-clang == 'true'
       shell: ${{ inputs.shell }}
       run: |
         echo "CC=clang" >> $GITHUB_ENV
         echo "CXX=clang++" >> $GITHUB_ENV
 
     - name: Install and set up libc++ as the standard C++ library
-      if: inputs.use-libcxx
+      if: inputs.use-libcxx == 'true'
       shell: ${{ inputs.shell }}
       run: |
         sudo apt-get install -y libc++-dev libc++abi-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,12 +109,6 @@ jobs:
             exclude_regress: 3-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
-          - name: ubuntu:production-arm64-cross
-            os: ubuntu-latest
-            config: production --auto-download --arm64
-            cache-key: production-arm64-cross
-            strip-bin: aarch64-linux-gnu-strip
-
           - name: macos:production
             os: macos-15-intel
             config: production --auto-download --all-bindings --editline -DBUILD_GMP=1
@@ -141,13 +135,6 @@ jobs:
             macos-target: 11.0
             exclude_regress: 3-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
-
-          - name: macos:production-arm64-cross
-            os: macos-15-intel
-            config: production --auto-download --all-bindings --editline --arm64
-            cache-key: production-arm64-cross
-            strip-bin: strip
-            python-bindings: true
 
           - name: win64:production
             os: windows-latest
@@ -177,13 +164,6 @@ jobs:
             package-name: cvc5-Win64-arm64
             exclude_regress: 1-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
-
-          - name: win64:production-cross
-            os: ubuntu-latest
-            config: production --auto-download --win64
-            cache-key: production-win64-cross
-            strip-bin: x86_64-w64-mingw32-strip
-            windows-build: true
 
           - name: wasm:production
             os: ubuntu-22.04

--- a/.github/workflows/cross_compilation.yml
+++ b/.github/workflows/cross_compilation.yml
@@ -1,0 +1,49 @@
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+name: Cross-compilation
+
+jobs:
+  cross-compile:
+    name: ${{ matrix.name }}
+    if: (github.repository == 'cvc5/cvc5') || (github.event_name != 'schedule')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: ubuntu:production-arm64-cross
+            os: ubuntu-latest
+            config: production --auto-download --arm64
+            strip-bin: aarch64-linux-gnu-strip
+
+          - name: macos:production-arm64-cross
+            os: macos-15-intel
+            config: production --auto-download --all-bindings --editline --arm64
+            strip-bin: strip
+            python-bindings: true
+            macos-target: 11.0
+
+          - name: win64:production-cross
+            os: ubuntu-latest
+            config: production --auto-download --win64
+            strip-bin: x86_64-w64-mingw32-strip
+            windows-build: true
+          
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install dependencies
+      uses: ./.github/actions/install-dependencies
+      with:
+        windows-build: ${{ matrix.windows-build }}
+
+    - name: Configure and build
+      id: configure-and-build
+      uses: ./.github/actions/configure-and-build
+      with:
+        configure-config: ${{ matrix.config }}
+        macos-target: ${{ matrix.macos-target }}
+        strip-bin: ${{ matrix.strip-bin }}
+


### PR DESCRIPTION
This PR moves the cross-compilation CI jobs out of the main workflow and into a nightly scheduled one. Since native builds now cover all supported platforms, cross-compilation testing is less critical. This change streamlines CI and reduces cache contention.