### PR TITLE
ci: Remove unneeded pip-related step

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -168,14 +168,6 @@ runs:
         python3 -m venv ~/.venv
         echo "$HOME/.venv/bin" >> $GITHUB_PATH
         echo "::endgroup::"
-    
-    # Required for the installation of Python bindings
-    - name: Upgrade Python pip
-      shell: ${{ inputs.shell }}
-      run: |
-        echo "::group::Upgrade Python pip"
-        python3 -m pip install --upgrade pip
-        echo "::endgroup::"
 
     - name: Install software for documentation
       if: inputs.with-documentation == 'true'


### PR DESCRIPTION
The step was necessary for installing the Python bindings on Ubuntu 20.04 runners that used an old version of pip (< 20.3), but all current Linux runners run Ubuntu 22.04 or later.