### PR TITLE
Fix deployment of Maven artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,7 +407,10 @@ jobs:
       continue-on-error: true
       run: |
         cd ./maven
-        mvn deploy --batch-mode -Prelease -Dartifacts.dir=./ -Djavadoc.dir=./
+        mkdir -p ./src/api/java ./docs/api/java
+        mv cvc5-javadoc.jar ./docs/api/java/
+        mv *.jar ./src/api/java/
+        mvn deploy --batch-mode -Prelease
       env:
         MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
         MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}

--- a/docs/api/java/java.rst
+++ b/docs/api/java/java.rst
@@ -27,8 +27,10 @@ Using the cvc5 Java API in a Maven project
 
 .. note::
 
-   As of version 1.3.1, a stable release has not yet been published to Maven Central.
-   Only snapshot builds are available in the Central Portal Snapshots repository.
+   As of version 1.3.2, a release that includes the native JNI libraries has not yet
+   been published to Maven Central. Only snapshot builds, available in 
+   the Central Portal Snapshots repository, provide both the Java API and 
+   the JNI library.
 
 To use the library in your Maven project, add the following
 repository and dependency settings:
@@ -67,7 +69,7 @@ repository and dependency settings:
   </dependencies>
 
 Here, ``${cvc5.version}`` refers to the version following the latest stable release
-(e.g., use ``1.3.2`` if the latest stable version is ``1.3.1``).
+(e.g., use ``1.3.3`` if the latest stable version is ``1.3.2``).
 The ``${os.classifier}`` variable specifies the operating system and CPU architecture
 (e.g., ``linux-x86_64`` or ``osx-aarch_64``).
 


### PR DESCRIPTION
The `pom.xml` file conditionally attaches platform-specific and documentation artifacts only if they are generated during a build. This is achieved by activating Maven profiles only when the corresponding files are present in a directory determined by the `artifacts.dir` and `javadoc.dir` properties. This is convenient for publishing only the generated artifacts to a local Maven repository.

Unfortunately, when alternative values for these properties are specified as command-line arguments, as we currently do in CI to publish artifacts for all platforms, the new values are not taken into account for Maven profile activation. This PR addresses the issue by reproducing the expected directory configuration instead of providing alternative paths.