### PR TITLE
Alethe backend: update theory rewrite proof rewrite rule

### DIFF
--- a/src/proof/alethe/alethe_post_processor.cpp
+++ b/src/proof/alethe/alethe_post_processor.cpp
@@ -601,35 +601,23 @@ bool AletheProofPostprocessCallback::update(Node res,
     case ProofRule::THEORY_REWRITE:
     {
       ProofRewriteRule di;
-      bool success = true;
 
       if (rewriter::getRewriteRule(args[0], di))
       {
+        if (updateTheoryRewriteProofRewriteRule(res, children, args, cdp, di))
+        {
+          return true;
+        }
         std::stringstream ss;
         ss << "\"" << di << "\"";
-        Node rule = NodeManager::mkRawSymbol(ss.str(), nm->sExprType());
-
-        if (!updateTheoryRewriteProofRewriteRule(res, children, args, cdp, di))
-        {
-          success = false;
-          new_args.push_back(rule);
-        }
+        new_args.push_back(NodeManager::mkRawSymbol(ss.str(), nm->sExprType()));
       }
-      else
-      {
-        success = false;
-      }
-
-      if (!success)
-      {
-        return addAletheStep(AletheRule::HOLE,
-                             res,
-                             nm->mkNode(Kind::SEXPR, d_cl, res),
-                             children,
-                             new_args,
-                             *cdp);
-      }
-      return true;
+      return addAletheStep(AletheRule::HOLE,
+                           res,
+                           nm->mkNode(Kind::SEXPR, d_cl, res),
+                           children,
+                           new_args,
+                           *cdp);
     }
     // Both ARITH_POLY_NORM and EVALUATE, which are used by the Rare
     // elaboration, are captured by the "rare_rewrite" rule.


### PR DESCRIPTION
Add the case that  no information which ProofRewriteRule was applied. Merge its handling with the case that the ProofRewriteRule could not be translated into Alethe and output a hole in these cases. If known add the rule name as an argument.

Co-authored-by: Haniel Barbosa <hbarbosa@dcc.ufmg.br>