### PR TITLE
Fix assertion for nl-ext-flatten-mon

### DIFF
--- a/src/theory/arith/nl/ext/flatten_monomial_check.cpp
+++ b/src/theory/arith/nl/ext/flatten_monomial_check.cpp
@@ -15,6 +15,7 @@
 
 #include "theory/arith/nl/ext/flatten_monomial_check.h"
 
+#include "expr/node_algorithm.h"
 #include "proof/conv_proof_generator.h"
 #include "proof/proof.h"
 #include "proof/proof_node.h"


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/12321.

The benchmark on that issue times out.