### PR TITLE
Require k to be positive in (_ iand k)

### DIFF
--- a/src/theory/arith/theory_arith_type_rules.cpp
+++ b/src/theory/arith/theory_arith_type_rules.cpp
@@ -15,6 +15,7 @@
 
 #include "theory/arith/theory_arith_type_rules.h"
 
+#include "util/iand.h"
 #include "util/rational.h"
 
 namespace cvc5::internal {
@@ -216,6 +217,17 @@ TypeNode IAndTypeRule::computeType(NodeManager* nodeManager,
   {
     TypeNode arg1 = n[0].getTypeOrNull();
     TypeNode arg2 = n[1].getTypeOrNull();
+    Node op = n.getOperator();
+    uint32_t bsize = op.getConst<IntAnd>().d_size;
+    if (bsize <= 0)
+    {
+      if (errOut)
+      {
+        (*errOut) << "iand must be indexed by a positive integer. Index is: "
+                  << bsize;
+      }
+      return TypeNode::null();
+    }
     if (!isMaybeInteger(arg1) || !isMaybeInteger(arg2))
     {
       if (errOut)

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1124,6 +1124,7 @@ set(regress_0_tests
   regress0/nl/dd.polypaver-bench-exp-3d-chunk-0067.smt2
   regress0/nl/dd.sin-cos-346-b-chunk-0210.smt2
   regress0/nl/dd.sin-cos-346-b-chunk-0210_unsat.smt2
+  regress0/nl/iand0.smt2
   regress0/nl/iand-no-init.smt2
   regress0/nl/issue10145-ir-pow.smt2
   regress0/nl/issue10140-nl-tc.smt2

--- a/test/regress/cli/regress0/nl/iand0.smt2
+++ b/test/regress/cli/regress0/nl/iand0.smt2
@@ -1,0 +1,19 @@
+; DISABLE-TESTER: dump
+; EXPECT:
+; SCRUBBER: grep -v "iand.must.be"
+; EXIT: 1
+(set-logic QF_ANIA)
+(declare-const x Bool)
+(declare-const x2 Bool)
+(declare-fun x_ () Int)
+(declare-fun _5 () (Array Int Int))
+(declare-fun _6 () (Array Int Int))
+(declare-fun _7 () (Array Int Int))
+(declare-fun _73 () (Array Int Int))
+(declare-fun _76 () Int)
+(assert (or x2 x))
+(assert (= 0 (select _6 ((_ iand 0) 1 x_))))
+(assert (or (= _73 _6) (and x2 (= _73 (store _6 _76 1))) (= _7 (store _5 0 0))))
+(assert (or x (and (= _6 _5) (= _76 (select _7 0)))))
+(assert (or x (= _73 (store _5 0 0))))
+(check-sat)


### PR DESCRIPTION
We now throw a parsing error when k is non-positive. 
Fixes #11393 .
The first benchmark on that issue now times out (in particular, the error is not given).
The second benchmark is added in this PR as a regression.