### PR TITLE
Enable -Wtype-limits and fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,7 @@ add_check_cxx_flag("-Wsuggest-override")
 add_check_cxx_flag("-Wnon-virtual-dtor")
 add_check_c_cxx_flag("-Wimplicit-fallthrough")
 add_check_c_cxx_flag("-Wshadow")
+add_check_c_cxx_flag("-Wtype-limits")
 add_check_c_cxx_flag("-fno-operator-names")
 
 # Assume no dynamic initialization of thread-local variables in non-defining

--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -2921,7 +2921,6 @@ Term Term::const_iterator::operator*() const
       Assert(idx > 0);
       --idx;
     }
-    Assert(idx >= 0);
     return Term(d_tm, (*d_origNode)[idx]);
   }
 }

--- a/src/expr/sequence.cpp
+++ b/src/expr/sequence.cpp
@@ -323,7 +323,6 @@ Sequence Sequence::replace(const Sequence& s, const Sequence& t) const
 
 Sequence Sequence::substr(size_t i) const
 {
-  Assert(i >= 0);
   Assert(i <= size());
   std::vector<Node> retVec(d_seq.begin() + i, d_seq.end());
   return Sequence(getType(), retVec);
@@ -331,8 +330,6 @@ Sequence Sequence::substr(size_t i) const
 
 Sequence Sequence::substr(size_t i, size_t j) const
 {
-  Assert(i >= 0);
-  Assert(j >= 0);
   Assert(i + j <= size());
   std::vector<Node>::const_iterator itr = d_seq.begin() + i;
   std::vector<Node> retVec(itr, itr + j);

--- a/src/parser/smt2/smt2_term_parser.cpp
+++ b/src/parser/smt2/smt2_term_parser.cpp
@@ -1160,7 +1160,7 @@ std::vector<DatatypeDecl> Smt2TermParser::parseDatatypesDef(
       // if the arity is not yet fixed, declare it as an unresolved type
       d_state.mkUnresolvedType(dnames[i], params.size());
     }
-    else if (arities[i] >= 0 && params.size() != arities[i])
+    else if (params.size() != arities[i])
     {
       // if the arity was fixed by prelude and is not equal to the number of
       // parameters

--- a/src/prop/minisat/mtl/Alloc.h
+++ b/src/prop/minisat/mtl/Alloc.h
@@ -64,23 +64,23 @@ class RegionAllocator
     // Deref, Load Effective Address (LEA), Inverse of LEA (AEL):
     T& operator[](Ref r)
     {
-      Assert(r >= 0 && r < sz);
+      Assert(r < sz);
       return memory[r];
     }
     const T& operator[](Ref r) const
     {
-      Assert(r >= 0 && r < sz);
+      Assert(r < sz);
       return memory[r];
     }
 
     T* lea(Ref r)
     {
-      Assert(r >= 0 && r < sz);
+      Assert(r < sz);
       return &memory[r];
     }
     const T* lea(Ref r) const
     {
-      Assert(r >= 0 && r < sz);
+      Assert(r < sz);
       return &memory[r];
     }
     Ref ael(const T* t)

--- a/src/prop/minisat/sat_proof_manager.cpp
+++ b/src/prop/minisat/sat_proof_manager.cpp
@@ -325,7 +325,7 @@ void SatProofManager::processRedundantLit(
                        !negated);
     return;
   }
-  Assert(reasonRef >= 0 && reasonRef < d_solver->ca.size())
+  Assert(reasonRef < d_solver->ca.size())
       << "reasonRef " << reasonRef << " and d_satSolver->ca.size() "
       << d_solver->ca.size() << "\n";
   const Minisat::Clause& reason = d_solver->ca[reasonRef];
@@ -410,7 +410,7 @@ void SatProofManager::explainLit(SatLiteral lit,
     Trace("sat-proof") << "SatProofManager::explainLit: no SAT reason\n" << pop;
     return;
   }
-  Assert(reasonRef >= 0 && reasonRef < d_solver->ca.size())
+  Assert(reasonRef < d_solver->ca.size())
       << "reasonRef " << reasonRef << " and d_satSolver->ca.size() "
       << d_solver->ca.size() << "\n";
   const Minisat::Clause& reason = d_solver->ca[reasonRef];

--- a/src/theory/arith/nl/iand_utils.cpp
+++ b/src/theory/arith/nl/iand_utils.cpp
@@ -39,7 +39,6 @@ static Rational intpow2(uint32_t b)
 
 Node pow2(NodeManager* nm, uint32_t k)
 {
-  Assert(k >= 0);
   return nm->mkConstInt(Rational(intpow2(k)));
 }
 

--- a/src/theory/bv/int_blaster.cpp
+++ b/src/theory/bv/int_blaster.cpp
@@ -127,7 +127,6 @@ Node IntBlaster::maxInt(uint32_t k)
 
 Node IntBlaster::pow2(uint32_t k)
 {
-  Assert(k >= 0);
   return d_nm->mkConstInt(intpow2(k));
 }
 

--- a/src/theory/quantifiers/sygus/cegis_unif.cpp
+++ b/src/theory/quantifiers/sygus/cegis_unif.cpp
@@ -315,7 +315,7 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
         Assert(std::find(enums.begin(), enums.end(), hd) != enums.end());
         unsigned i = std::distance(enums.begin(),
                                    std::find(enums.begin(), enums.end(), hd));
-        Assert(i >= 0 && i < enum_values.size());
+        Assert(i < enum_values.size());
         TermDbSygus::toStreamSygus("cegis-unif", enum_values[i]);
         Trace("cegis-unif") << "\n";
       }

--- a/src/theory/rep_set_iterator.cpp
+++ b/src/theory/rep_set_iterator.cpp
@@ -287,7 +287,7 @@ Node RepSetIterator::getCurrentTerm(size_t i, bool valTerm) const
                      << ", index order = " << d_index_order[i] << std::endl;
   Trace("rsi-debug") << "rsi : curr = " << curr << " / "
                      << d_domain_elements[i].size() << std::endl;
-  Assert(0 <= curr && curr < d_domain_elements[i].size());
+  Assert(curr < d_domain_elements[i].size());
   Node t = d_domain_elements[i][curr];
   Trace("rsi-debug") << "rsi : term = " << t << std::endl;
   if (valTerm)

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -985,12 +985,12 @@ void CoreSolver::getNormalForms(Node eqc,
           }
           // Now that we are finished with the loop, we convert forward indices
           // to reverse indices in the explanation dependency information
-          int total_size = nf_curr.d_nf.size();
+          size_t total_size = nf_curr.d_nf.size();
           for (std::pair<const Node, std::map<bool, unsigned> >& ed :
                nf_curr.d_expDep)
           {
+            Assert(total_size >= ed.second[true]);
             ed.second[true] = total_size - ed.second[true];
-            Assert(ed.second[true] >= 0);
           }
         }
         //if not equal to self

--- a/src/theory/strings/normal_form.cpp
+++ b/src/theory/strings/normal_form.cpp
@@ -66,7 +66,7 @@ void NormalForm::splitConstant(unsigned index, Node c1, Node c2)
     {
       // See if this can be incremented: it can if this literal is not relevant
       // to the current index, and hence it is not relevant for both c1 and c2.
-      Assert(pep.second >= 0 && pep.second <= d_nf.size());
+      Assert(pep.second <= d_nf.size());
       bool increment = (pep.first == d_isRev)
                            ? pep.second > index
                            : (d_nf.size() - 1 - pep.second) < index;


### PR DESCRIPTION
Address warning: `Comparison of unsigned expression in ‘>= 0’ is always true`