### PR TITLE
Disable an iand test in competition build

### DIFF
--- a/test/regress/cli/regress0/nl/iand0.smt2
+++ b/test/regress/cli/regress0/nl/iand0.smt2
@@ -1,6 +1,7 @@
 ; DISABLE-TESTER: dump
 ; EXPECT:
 ; SCRUBBER: grep -v "iand.must.be"
+; REQUIRES: no-competition
 ; EXIT: 1
 (set-logic QF_ANIA)
 (declare-const x Bool)


### PR DESCRIPTION
Some tests are disabled in competition build, such as [this](https://github.com/cvc5/cvc5/blob/main/test/regress/cli/regress0/bv/issue-4075.smt2) one.
The recently added iand test is similar, and thus we disable it as well.