### PR TITLE
context,decision,prop: Annotate unused parameters with CVC5_UNUSED

### DIFF
--- a/src/context/cdhashmap.h
+++ b/src/context/cdhashmap.h
@@ -273,14 +273,14 @@ class CDHashMap : public ContextObj
   Context* d_context;
 
   // Nothing to save; the elements take care of themselves
-  ContextObj* save(ContextMemoryManager* pCMM) override
+  ContextObj* save(CVC5_UNUSED ContextMemoryManager* pCMM) override
   {
     Unreachable();
     SuppressWrongNoReturnWarning;
   }
 
   // Similarly, nothing to restore
-  void restore(ContextObj* data) override { Unreachable(); }
+  void restore(CVC5_UNUSED ContextObj* data) override { Unreachable(); }
 
   // no copy or assignment
   CDHashMap(const CDHashMap&) = delete;

--- a/src/context/cdhashset.h
+++ b/src/context/cdhashset.h
@@ -48,7 +48,8 @@ public:
     this->ContextObj::deleteSelf();
   }
 
-  static void operator delete(void* pMem) {
+  static void operator delete(CVC5_UNUSED void* pMem)
+  {
     AlwaysAssert(false) << "It is not allowed to delete a ContextObj this way!";
   }
 

--- a/src/context/context.h
+++ b/src/context/context.h
@@ -328,8 +328,11 @@ class Scope {
    * called.  Include both placement and standard delete for
    * completeness.
    */
-  static void operator delete(void* pMem, ContextMemoryManager* pCMM) {}
-  static void operator delete(void* pMem) {}
+  static void operator delete(CVC5_UNUSED void* pMem,
+                              CVC5_UNUSED ContextMemoryManager* pCMM)
+  {
+  }
+  static void operator delete(CVC5_UNUSED void* pMem) {}
 
   //FIXME:  //! Check for memory leaks
   //  void check();
@@ -562,7 +565,8 @@ class CVC5_EXPORT ContextObj
    * never be deleted.  Objects allocated with new(bool) should be deleted by
    * calling deleteSelf().
    */
-  static void operator delete(void* pMem) {
+  static void operator delete(CVC5_UNUSED void* pMem)
+  {
     AlwaysAssert(false) << "It is not allowed to delete a ContextObj this way!";
   }
 
@@ -585,7 +589,10 @@ class CVC5_EXPORT ContextObj
    * ContextObj constructor throws an exception after a successful
    * call to the above new operator.
    */
-  static void operator delete(void* pMem, ContextMemoryManager* pCMM) {}
+  static void operator delete(CVC5_UNUSED void* pMem,
+                              CVC5_UNUSED ContextMemoryManager* pCMM)
+  {
+  }
 
   /**
    * Create a new ContextObj.  The initial scope is set to the bottom

--- a/src/decision/decision_engine.cpp
+++ b/src/decision/decision_engine.cpp
@@ -37,8 +37,12 @@ DecisionEngineEmpty::DecisionEngineEmpty(Env& env)
 {
 }
 bool DecisionEngineEmpty::isDone() { return false; }
-void DecisionEngineEmpty::addAssertions(const std::vector<TNode>& lems) {}
-prop::SatLiteral DecisionEngineEmpty::getNextInternal(bool& stopSearch)
+void DecisionEngineEmpty::addAssertions(
+    CVC5_UNUSED const std::vector<TNode>& lems)
+{
+}
+prop::SatLiteral DecisionEngineEmpty::getNextInternal(
+    CVC5_UNUSED bool& stopSearch)
 {
   return prop::undefSatLiteral;
 }

--- a/src/decision/decision_engine.h
+++ b/src/decision/decision_engine.h
@@ -58,7 +58,7 @@ class DecisionEngine : protected EnvObj
    * this call.
    * @param lems The lemmas to add.
    */
-  virtual void addLocalAssertions(const std::vector<TNode>& lems) {}
+  virtual void addLocalAssertions(CVC5_UNUSED const std::vector<TNode>& lems) {}
 
  protected:
   /** Get next internal, the engine-specific implementation of getNext */

--- a/src/prop/cadical/cadical.cpp
+++ b/src/prop/cadical/cadical.cpp
@@ -260,15 +260,15 @@ ClauseId CadicalSolver::addClause(SatClause& clause, bool removable)
   return ClauseIdError;
 }
 
-ClauseId CadicalSolver::addXorClause(SatClause& clause,
-                                     bool rhs,
-                                     bool removable)
+ClauseId CadicalSolver::addXorClause(CVC5_UNUSED SatClause& clause,
+                                     CVC5_UNUSED bool rhs,
+                                     CVC5_UNUSED bool removable)
 {
   Unreachable() << "CaDiCaL does not support adding XOR clauses.";
   return 0;
 }
 
-SatVariable CadicalSolver::newVar(bool isTheoryAtom, bool canErase)
+SatVariable CadicalSolver::newVar(bool isTheoryAtom, CVC5_UNUSED bool canErase)
 {
   ++d_statistics.d_numVariables;
   if (d_propagator)
@@ -343,7 +343,7 @@ CadicalSolver::Statistics::Statistics(StatisticsRegistry& registry,
 /* CDCLTSatSolver Interface ------------------------------------------------- */
 
 void CadicalSolver::initialize(prop::TheoryProxy* theoryProxy,
-                               PropPfManager* ppm)
+                               CVC5_UNUSED PropPfManager* ppm)
 {
   d_proxy = theoryProxy;
   d_propagator.reset(new CadicalPropagator(

--- a/src/prop/cadical/cdclt_propagator.cpp
+++ b/src/prop/cadical/cdclt_propagator.cpp
@@ -176,7 +176,8 @@ void CadicalPropagator::notify_backtrack(size_t level)
   Trace("cadical::propagator") << "notif::backtrack end" << std::endl;
 }
 
-bool CadicalPropagator::cb_check_found_model(const std::vector<int>& model)
+bool CadicalPropagator::cb_check_found_model(
+    CVC5_UNUSED const std::vector<int>& model)
 {
   Trace("cadical::propagator") << "cb::check_found_model" << std::endl;
   bool recheck = false;

--- a/src/prop/cadical/proof_tracer.cpp
+++ b/src/prop/cadical/proof_tracer.cpp
@@ -32,9 +32,9 @@ ProofTracer::ProofTracer(const CadicalPropagator& propagator)
 }
 
 void ProofTracer::add_original_clause(uint64_t clause_id,
-                                      bool redundant,
+                                      CVC5_UNUSED bool redundant,
                                       const std::vector<int>& clause,
-                                      bool restored)
+                                      CVC5_UNUSED bool restored)
 {
   Assert(d_antecedents.size() == clause_id);
   d_antecedents.emplace_back();  // no antecedents
@@ -90,7 +90,7 @@ void ProofTracer::add_assumption_clause(
   }
 }
 
-void ProofTracer::conclude_unsat(CaDiCaL::ConclusionType type,
+void ProofTracer::conclude_unsat(CVC5_UNUSED CaDiCaL::ConclusionType type,
                                  const std::vector<uint64_t>& clause_ids)
 {
   // Store final clause ids that concluded unsat.

--- a/src/prop/minisat/minisat.h
+++ b/src/prop/minisat/minisat.h
@@ -51,7 +51,9 @@ class MinisatSatSolver : public CDCLTSatSolver, protected EnvObj
   void initialize(TheoryProxy* theoryProxy, PropPfManager* ppm) override;
 
   ClauseId addClause(SatClause& clause, bool removable) override;
-  ClauseId addXorClause(SatClause& clause, bool rhs, bool removable) override
+  ClauseId addXorClause(CVC5_UNUSED SatClause& clause,
+                        CVC5_UNUSED bool rhs,
+                        CVC5_UNUSED bool removable) override
   {
     Unreachable() << "Minisat does not support native XOR reasoning";
   }

--- a/src/prop/proof_post_processor.cpp
+++ b/src/prop/proof_post_processor.cpp
@@ -29,9 +29,10 @@ ProofPostprocessCallback::ProofPostprocessCallback(
 
 void ProofPostprocessCallback::initializeUpdate() { d_assumpToProof.clear(); }
 
-bool ProofPostprocessCallback::shouldUpdate(std::shared_ptr<ProofNode> pn,
-                                            const std::vector<Node>& fa,
-                                            bool& continueUpdate)
+bool ProofPostprocessCallback::shouldUpdate(
+    std::shared_ptr<ProofNode> pn,
+    CVC5_UNUSED const std::vector<Node>& fa,
+    bool& continueUpdate)
 {
   bool result =
       pn->getRule() == ProofRule::ASSUME && d_pg->hasProofFor(pn->getResult());

--- a/src/prop/registrar.h
+++ b/src/prop/registrar.h
@@ -41,7 +41,7 @@ public:
 
 class NullRegistrar : public Registrar {
 public:
- void notifySatLiteral(Node n) override {}
+ void notifySatLiteral(CVC5_UNUSED Node n) override {}
 
 };/* class NullRegistrar */
 

--- a/src/prop/sat_solver.h
+++ b/src/prop/sat_solver.h
@@ -86,7 +86,7 @@ public:
   virtual SatValue solve(long unsigned int&) = 0;
 
   /** Check satisfiability under assumptions */
-  virtual SatValue solve(const std::vector<SatLiteral>& assumptions)
+  virtual SatValue solve(CVC5_UNUSED const std::vector<SatLiteral>& assumptions)
   {
     Unimplemented() << "Solving under assumptions not implemented";
     return SAT_VALUE_UNKNOWN;
@@ -122,7 +122,8 @@ public:
    * Can only be called if satisfiability check under assumptions was used and
    * if it returned SAT_VALUE_FALSE.
    */
-  virtual void getUnsatAssumptions(std::vector<SatLiteral>& unsat_assumptions)
+  virtual void getUnsatAssumptions(
+      CVC5_UNUSED std::vector<SatLiteral>& unsat_assumptions)
   {
     Unimplemented() << "getUnsatAssumptions not implemented";
   }

--- a/src/prop/sat_solver_factory.cpp
+++ b/src/prop/sat_solver_factory.cpp
@@ -29,9 +29,10 @@ CDCLTSatSolver* SatSolverFactory::createCDCLTMinisat(
   return new MinisatSatSolver(env, registry);
 }
 
-SatSolver* SatSolverFactory::createCryptoMinisat(StatisticsRegistry& registry,
-                                                 ResourceManager* resmgr,
-                                                 const std::string& name)
+SatSolver* SatSolverFactory::createCryptoMinisat(
+    CVC5_UNUSED StatisticsRegistry& registry,
+    CVC5_UNUSED ResourceManager* resmgr,
+    CVC5_UNUSED const std::string& name)
 {
 #ifdef CVC5_USE_CRYPTOMINISAT
   CryptoMinisatSolver* res = new CryptoMinisatSolver(registry, name);
@@ -69,8 +70,9 @@ CDCLTSatSolver* SatSolverFactory::createCadicalCDCLT(
   return res;
 }
 
-SatSolver* SatSolverFactory::createKissat(StatisticsRegistry& registry,
-                                          const std::string& name)
+SatSolver* SatSolverFactory::createKissat(
+    CVC5_UNUSED StatisticsRegistry& registry,
+    CVC5_UNUSED const std::string& name)
 {
 #ifdef CVC5_USE_KISSAT
   KissatSolver* res = new KissatSolver(registry, name);


### PR DESCRIPTION
These are acceptable cases, such as defining default implementations for virtual functions and overriding them, as well as conditional code.