### PR TITLE
parser: Annotate unused parameters with CVC5_UNUSED

### DIFF
--- a/src/parser/commands.cpp
+++ b/src/parser/commands.cpp
@@ -235,7 +235,8 @@ std::ostream& operator<<(std::ostream& out, const Cmd* c)
 
 EmptyCommand::EmptyCommand(std::string name) : d_name(name) {}
 std::string EmptyCommand::getName() const { return d_name; }
-void EmptyCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void EmptyCommand::invoke(CVC5_UNUSED cvc5::Solver* solver,
+                          CVC5_UNUSED SymManager* sm)
 {
   /* empty commands have no implementation */
   d_commandStatus = CommandSuccess::instance();
@@ -256,12 +257,14 @@ EchoCommand::EchoCommand(std::string output) : d_output(output) {}
 
 std::string EchoCommand::getOutput() const { return d_output; }
 
-void EchoCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void EchoCommand::invoke(CVC5_UNUSED cvc5::Solver* solver,
+                         CVC5_UNUSED SymManager* sm)
 {
   d_commandStatus = CommandSuccess::instance();
 }
 
-void EchoCommand::printResult(cvc5::Solver* solver, std::ostream& out) const
+void EchoCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
+                              std::ostream& out) const
 {
   Trace("dtview::command") << "* ~COMMAND: echo |" << d_output << "|~"
                            << std::endl;
@@ -282,7 +285,7 @@ void EchoCommand::toStream(std::ostream& out) const
 AssertCommand::AssertCommand(const cvc5::Term& t) : d_term(t) {}
 
 cvc5::Term AssertCommand::getTerm() const { return d_term; }
-void AssertCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void AssertCommand::invoke(cvc5::Solver* solver, CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -309,7 +312,7 @@ void AssertCommand::toStream(std::ostream& out) const
 
 PushCommand::PushCommand(uint32_t nscopes) : d_nscopes(nscopes) {}
 
-void PushCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void PushCommand::invoke(cvc5::Solver* solver, CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -335,7 +338,7 @@ void PushCommand::toStream(std::ostream& out) const
 
 PopCommand::PopCommand(uint32_t nscopes) : d_nscopes(nscopes) {}
 
-void PopCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void PopCommand::invoke(cvc5::Solver* solver, CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -361,7 +364,7 @@ void PopCommand::toStream(std::ostream& out) const
 
 CheckSatCommand::CheckSatCommand() {}
 
-void CheckSatCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void CheckSatCommand::invoke(cvc5::Solver* solver, CVC5_UNUSED SymManager* sm)
 {
   Trace("dtview::command") << "* ~COMMAND: " << getCommandName() << "~"
                            << std::endl;
@@ -378,7 +381,8 @@ void CheckSatCommand::invoke(cvc5::Solver* solver, SymManager* sm)
 
 cvc5::Result CheckSatCommand::getResult() const { return d_result; }
 
-void CheckSatCommand::printResult(cvc5::Solver* solver, std::ostream& out) const
+void CheckSatCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
+                                  std::ostream& out) const
 {
   out << d_result << endl;
 }
@@ -410,7 +414,8 @@ const std::vector<cvc5::Term>& CheckSatAssumingCommand::getTerms() const
   return d_terms;
 }
 
-void CheckSatAssumingCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void CheckSatAssumingCommand::invoke(cvc5::Solver* solver,
+                                     CVC5_UNUSED SymManager* sm)
 {
   Trace("dtview::command") << "* ~COMMAND: (check-sat-assuming ( " << d_terms
                            << " )~" << std::endl;
@@ -431,7 +436,7 @@ cvc5::Result CheckSatAssumingCommand::getResult() const
   return d_result;
 }
 
-void CheckSatAssumingCommand::printResult(cvc5::Solver* solver,
+void CheckSatAssumingCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
                                           std::ostream& out) const
 {
   out << d_result << endl;
@@ -545,7 +550,8 @@ SygusConstraintCommand::SygusConstraintCommand(const cvc5::Term& t,
 {
 }
 
-void SygusConstraintCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void SygusConstraintCommand::invoke(cvc5::Solver* solver,
+                                    CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -604,7 +610,8 @@ SygusInvConstraintCommand::SygusInvConstraintCommand(const cvc5::Term& inv,
 {
 }
 
-void SygusInvConstraintCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void SygusInvConstraintCommand::invoke(cvc5::Solver* solver,
+                                       CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -707,7 +714,7 @@ void CheckSynthCommand::invoke(cvc5::Solver* solver, SymManager* sm)
 }
 
 cvc5::SynthResult CheckSynthCommand::getResult() const { return d_result; }
-void CheckSynthCommand::printResult(cvc5::Solver* solver,
+void CheckSynthCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
                                     std::ostream& out) const
 {
   out << d_solution.str();
@@ -734,7 +741,7 @@ void CheckSynthCommand::toStream(std::ostream& out) const
 /* class FindSynthCommand                                                    */
 /* -------------------------------------------------------------------------- */
 
-void FindSynthCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void FindSynthCommand::invoke(cvc5::Solver* solver, CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -754,7 +761,7 @@ void FindSynthCommand::invoke(cvc5::Solver* solver, SymManager* sm)
 }
 
 Term FindSynthCommand::getResult() const { return d_result; }
-void FindSynthCommand::printResult(cvc5::Solver* solver,
+void FindSynthCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
                                    std::ostream& out) const
 {
   if (d_result.isNull())
@@ -784,7 +791,8 @@ void FindSynthCommand::toStream(std::ostream& out) const
 
 cvc5::Term FindSynthNextCommand::getResult() const { return d_result; }
 
-void FindSynthNextCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void FindSynthNextCommand::invoke(cvc5::Solver* solver,
+                                  CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -798,7 +806,7 @@ void FindSynthNextCommand::invoke(cvc5::Solver* solver, SymManager* sm)
   }
 }
 
-void FindSynthNextCommand::printResult(cvc5::Solver* solver,
+void FindSynthNextCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
                                        std::ostream& out) const
 {
   if (d_result.isNull())
@@ -878,7 +886,8 @@ void ResetAssertionsCommand::toStream(std::ostream& out) const
 /* class QuitCommand                                                          */
 /* -------------------------------------------------------------------------- */
 
-void QuitCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void QuitCommand::invoke(CVC5_UNUSED cvc5::Solver* solver,
+                         CVC5_UNUSED SymManager* sm)
 {
   d_commandStatus = CommandSuccess::instance();
 }
@@ -1050,7 +1059,8 @@ const std::string& DeclareOracleFunCommand::getBinaryName() const
   return d_binName;
 }
 
-void DeclareOracleFunCommand::invoke(Solver* solver, SymManager* sm)
+void DeclareOracleFunCommand::invoke(CVC5_UNUSED Solver* solver,
+                                     CVC5_UNUSED SymManager* sm)
 {
   std::vector<Sort> args;
   Sort ret;
@@ -1147,7 +1157,7 @@ const std::vector<cvc5::Sort>& DefineSortCommand::getParameters() const
 }
 
 cvc5::Sort DefineSortCommand::getSort() const { return d_sort; }
-void DefineSortCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void DefineSortCommand::invoke(CVC5_UNUSED cvc5::Solver* solver, SymManager* sm)
 {
   // This name is not its own distinct sort, it's an alias.
   if (!sm->bindType(d_symbol, d_params, d_sort, true))
@@ -1329,7 +1339,8 @@ DeclareHeapCommand::DeclareHeapCommand(cvc5::Sort locSort, cvc5::Sort dataSort)
 cvc5::Sort DeclareHeapCommand::getLocationSort() const { return d_locSort; }
 cvc5::Sort DeclareHeapCommand::getDataSort() const { return d_dataSort; }
 
-void DeclareHeapCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void DeclareHeapCommand::invoke(cvc5::Solver* solver,
+                                CVC5_UNUSED SymManager* sm)
 {
   solver->declareSepHeap(d_locSort, d_dataSort);
 }
@@ -1351,7 +1362,7 @@ void DeclareHeapCommand::toStream(std::ostream& out) const
 
 SimplifyCommand::SimplifyCommand(cvc5::Term term) : d_term(term) {}
 cvc5::Term SimplifyCommand::getTerm() const { return d_term; }
-void SimplifyCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void SimplifyCommand::invoke(cvc5::Solver* solver, CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -1365,7 +1376,8 @@ void SimplifyCommand::invoke(cvc5::Solver* solver, SymManager* sm)
 }
 
 cvc5::Term SimplifyCommand::getResult() const { return d_result; }
-void SimplifyCommand::printResult(cvc5::Solver* solver, std::ostream& out) const
+void SimplifyCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
+                                  std::ostream& out) const
 {
   out << d_result << endl;
 }
@@ -1397,7 +1409,7 @@ const std::vector<cvc5::Term>& GetValueCommand::getTerms() const
 {
   return d_terms;
 }
-void GetValueCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void GetValueCommand::invoke(cvc5::Solver* solver, CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -1419,7 +1431,8 @@ const std::vector<cvc5::Term>& GetValueCommand::getResult() const
 {
   return d_result;
 }
-void GetValueCommand::printResult(cvc5::Solver* solver, std::ostream& out) const
+void GetValueCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
+                                  std::ostream& out) const
 {
   Assert(d_result.size() == d_terms.size());
   // we print each of the values separately since we do not want
@@ -1460,7 +1473,8 @@ GetModelDomainElementsCommand::GetModelDomainElementsCommand(cvc5::Sort sort)
 
 cvc5::Sort GetModelDomainElementsCommand::getSort() const { return d_sort; }
 
-void GetModelDomainElementsCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void GetModelDomainElementsCommand::invoke(cvc5::Solver* solver,
+                                           CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -1482,8 +1496,8 @@ const std::vector<cvc5::Term>& GetModelDomainElementsCommand::getResult() const
   return d_result;
 }
 
-void GetModelDomainElementsCommand::printResult(cvc5::Solver* solver,
-                                                std::ostream& out) const
+void GetModelDomainElementsCommand::printResult(
+    CVC5_UNUSED cvc5::Solver* solver, std::ostream& out) const
 {
   out << "(";
   bool firstTime = true;
@@ -1557,7 +1571,7 @@ void GetAssignmentCommand::invoke(cvc5::Solver* solver, SymManager* sm)
 }
 
 cvc5::Term GetAssignmentCommand::getResult() const { return d_result; }
-void GetAssignmentCommand::printResult(cvc5::Solver* solver,
+void GetAssignmentCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
                                        std::ostream& out) const
 {
   out << d_result << endl;
@@ -1597,7 +1611,8 @@ void GetModelCommand::invoke(cvc5::Solver* solver, SymManager* sm)
   }
 }
 
-void GetModelCommand::printResult(cvc5::Solver* solver, std::ostream& out) const
+void GetModelCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
+                                  std::ostream& out) const
 {
   out << d_result;
 }
@@ -1616,7 +1631,7 @@ void GetModelCommand::toStream(std::ostream& out) const
 BlockModelCommand::BlockModelCommand(modes::BlockModelsMode mode) : d_mode(mode)
 {
 }
-void BlockModelCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void BlockModelCommand::invoke(cvc5::Solver* solver, CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -1656,7 +1671,8 @@ const std::vector<cvc5::Term>& BlockModelValuesCommand::getTerms() const
 {
   return d_terms;
 }
-void BlockModelValuesCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void BlockModelValuesCommand::invoke(cvc5::Solver* solver,
+                                     CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -1741,7 +1757,8 @@ void GetProofCommand::invoke(cvc5::Solver* solver, SymManager* sm)
   }
 }
 
-void GetProofCommand::printResult(cvc5::Solver* solver, std::ostream& out) const
+void GetProofCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
+                                  std::ostream& out) const
 {
   out << d_result;
 }
@@ -1758,7 +1775,7 @@ void GetProofCommand::toStream(std::ostream& out) const
 /* -------------------------------------------------------------------------- */
 
 GetInstantiationsCommand::GetInstantiationsCommand() : d_solver(nullptr) {}
-bool GetInstantiationsCommand::isEnabled(cvc5::Solver* solver,
+bool GetInstantiationsCommand::isEnabled(CVC5_UNUSED cvc5::Solver* solver,
                                          const cvc5::Result& res)
 {
   return (res.isSat()
@@ -1767,7 +1784,8 @@ bool GetInstantiationsCommand::isEnabled(cvc5::Solver* solver,
                      == cvc5::UnknownExplanation::INCOMPLETE))
          || res.isUnsat();
 }
-void GetInstantiationsCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void GetInstantiationsCommand::invoke(cvc5::Solver* solver,
+                                      CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -1780,7 +1798,7 @@ void GetInstantiationsCommand::invoke(cvc5::Solver* solver, SymManager* sm)
   }
 }
 
-void GetInstantiationsCommand::printResult(cvc5::Solver* solver,
+void GetInstantiationsCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
                                            std::ostream& out) const
 {
   out << d_solver->getInstantiations();
@@ -1843,7 +1861,7 @@ void GetInterpolantCommand::invoke(Solver* solver, SymManager* sm)
   }
 }
 
-void GetInterpolantCommand::printResult(cvc5::Solver* solver,
+void GetInterpolantCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
                                         std::ostream& out) const
 {
   if (!d_result.isNull())
@@ -1891,7 +1909,7 @@ void GetInterpolantNextCommand::invoke(Solver* solver, SymManager* sm)
   }
 }
 
-void GetInterpolantNextCommand::printResult(cvc5::Solver* solver,
+void GetInterpolantNextCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
                                             std::ostream& out) const
 {
   if (!d_result.isNull())
@@ -1963,7 +1981,7 @@ void GetAbductCommand::invoke(cvc5::Solver* solver, SymManager* sm)
   }
 }
 
-void GetAbductCommand::printResult(cvc5::Solver* solver,
+void GetAbductCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
                                    std::ostream& out) const
 {
   if (!d_result.isNull())
@@ -2008,7 +2026,7 @@ void GetAbductNextCommand::invoke(cvc5::Solver* solver, SymManager* sm)
   }
 }
 
-void GetAbductNextCommand::printResult(cvc5::Solver* solver,
+void GetAbductNextCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
                                        std::ostream& out) const
 {
   if (!d_result.isNull())
@@ -2049,7 +2067,7 @@ GetQuantifierEliminationCommand::GetQuantifierEliminationCommand(
 cvc5::Term GetQuantifierEliminationCommand::getTerm() const { return d_term; }
 bool GetQuantifierEliminationCommand::getDoFull() const { return d_doFull; }
 void GetQuantifierEliminationCommand::invoke(cvc5::Solver* solver,
-                                             SymManager* sm)
+                                             CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -2073,8 +2091,8 @@ cvc5::Term GetQuantifierEliminationCommand::getResult() const
 {
   return d_result;
 }
-void GetQuantifierEliminationCommand::printResult(cvc5::Solver* solver,
-                                                  std::ostream& out) const
+void GetQuantifierEliminationCommand::printResult(
+    CVC5_UNUSED cvc5::Solver* solver, std::ostream& out) const
 {
   out << d_result << endl;
 }
@@ -2096,7 +2114,8 @@ void GetQuantifierEliminationCommand::toStream(std::ostream& out) const
 
 GetUnsatAssumptionsCommand::GetUnsatAssumptionsCommand() {}
 
-void GetUnsatAssumptionsCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void GetUnsatAssumptionsCommand::invoke(cvc5::Solver* solver,
+                                        CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -2118,7 +2137,7 @@ std::vector<cvc5::Term> GetUnsatAssumptionsCommand::getResult() const
   return d_result;
 }
 
-void GetUnsatAssumptionsCommand::printResult(cvc5::Solver* solver,
+void GetUnsatAssumptionsCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
                                              std::ostream& out) const
 {
   internal::container_to_stream(out, d_result, "(", ")\n", " ");
@@ -2159,7 +2178,7 @@ void GetUnsatCoreCommand::invoke(cvc5::Solver* solver, SymManager* sm)
   }
 }
 
-void GetUnsatCoreCommand::printResult(cvc5::Solver* solver,
+void GetUnsatCoreCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
                                       std::ostream& out) const
 {
   if (d_solver->getOption("print-cores-full") == "true")
@@ -2200,7 +2219,8 @@ void GetUnsatCoreCommand::toStream(std::ostream& out) const
 /* -------------------------------------------------------------------------- */
 
 GetUnsatCoreLemmasCommand::GetUnsatCoreLemmasCommand() : d_solver(nullptr) {}
-void GetUnsatCoreLemmasCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void GetUnsatCoreLemmasCommand::invoke(cvc5::Solver* solver,
+                                       CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -2219,7 +2239,7 @@ void GetUnsatCoreLemmasCommand::invoke(cvc5::Solver* solver, SymManager* sm)
   }
 }
 
-void GetUnsatCoreLemmasCommand::printResult(cvc5::Solver* solver,
+void GetUnsatCoreLemmasCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
                                             std::ostream& out) const
 {
   // use the assertions
@@ -2261,7 +2281,7 @@ void GetDifficultyCommand::invoke(cvc5::Solver* solver, SymManager* sm)
   }
 }
 
-void GetDifficultyCommand::printResult(cvc5::Solver* solver,
+void GetDifficultyCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
                                        std::ostream& out) const
 {
   out << "(" << std::endl;
@@ -2341,7 +2361,7 @@ void GetTimeoutCoreCommand::invoke(cvc5::Solver* solver, SymManager* sm)
   }
 }
 
-void GetTimeoutCoreCommand::printResult(cvc5::Solver* solver,
+void GetTimeoutCoreCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
                                         std::ostream& out) const
 {
   cvc5::Result res = d_result.first;
@@ -2399,7 +2419,8 @@ GetLearnedLiteralsCommand::GetLearnedLiteralsCommand(modes::LearnedLitType t)
     : d_type(t)
 {
 }
-void GetLearnedLiteralsCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void GetLearnedLiteralsCommand::invoke(cvc5::Solver* solver,
+                                       CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -2417,7 +2438,7 @@ void GetLearnedLiteralsCommand::invoke(cvc5::Solver* solver, SymManager* sm)
   }
 }
 
-void GetLearnedLiteralsCommand::printResult(cvc5::Solver* solver,
+void GetLearnedLiteralsCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
                                             std::ostream& out) const
 {
   out << "(" << std::endl;
@@ -2450,7 +2471,8 @@ void GetLearnedLiteralsCommand::toStream(std::ostream& out) const
 /* -------------------------------------------------------------------------- */
 
 GetAssertionsCommand::GetAssertionsCommand() {}
-void GetAssertionsCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void GetAssertionsCommand::invoke(cvc5::Solver* solver,
+                                  CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -2469,7 +2491,7 @@ void GetAssertionsCommand::invoke(cvc5::Solver* solver, SymManager* sm)
 }
 
 std::string GetAssertionsCommand::getResult() const { return d_result; }
-void GetAssertionsCommand::printResult(cvc5::Solver* solver,
+void GetAssertionsCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
                                        std::ostream& out) const
 {
   out << d_result;
@@ -2532,7 +2554,7 @@ SetInfoCommand::SetInfoCommand(const std::string& flag,
 
 const std::string& SetInfoCommand::getFlag() const { return d_flag; }
 const std::string& SetInfoCommand::getValue() const { return d_value; }
-void SetInfoCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void SetInfoCommand::invoke(cvc5::Solver* solver, CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -2567,7 +2589,7 @@ void SetInfoCommand::toStream(std::ostream& out) const
 
 GetInfoCommand::GetInfoCommand(std::string flag) : d_flag(flag) {}
 std::string GetInfoCommand::getFlag() const { return d_flag; }
-void GetInfoCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void GetInfoCommand::invoke(cvc5::Solver* solver, CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -2594,7 +2616,8 @@ void GetInfoCommand::invoke(cvc5::Solver* solver, SymManager* sm)
 }
 
 std::string GetInfoCommand::getResult() const { return d_result; }
-void GetInfoCommand::printResult(cvc5::Solver* solver, std::ostream& out) const
+void GetInfoCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
+                                 std::ostream& out) const
 {
   if (d_result != "")
   {
@@ -2621,7 +2644,7 @@ SetOptionCommand::SetOptionCommand(const std::string& flag,
 
 const std::string& SetOptionCommand::getFlag() const { return d_flag; }
 const std::string& SetOptionCommand::getValue() const { return d_value; }
-void SetOptionCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void SetOptionCommand::invoke(cvc5::Solver* solver, CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -2656,7 +2679,7 @@ void SetOptionCommand::toStream(std::ostream& out) const
 
 GetOptionCommand::GetOptionCommand(std::string flag) : d_flag(flag) {}
 std::string GetOptionCommand::getFlag() const { return d_flag; }
-void GetOptionCommand::invoke(cvc5::Solver* solver, SymManager* sm)
+void GetOptionCommand::invoke(cvc5::Solver* solver, CVC5_UNUSED SymManager* sm)
 {
   try
   {
@@ -2674,7 +2697,7 @@ void GetOptionCommand::invoke(cvc5::Solver* solver, SymManager* sm)
 }
 
 std::string GetOptionCommand::getResult() const { return d_result; }
-void GetOptionCommand::printResult(cvc5::Solver* solver,
+void GetOptionCommand::printResult(CVC5_UNUSED cvc5::Solver* solver,
                                    std::ostream& out) const
 {
   if (d_result != "")

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -30,7 +30,7 @@ Parser::Parser(Solver* solver, SymManager* sm)
 {
 }
 
-void Parser::setLogic(const std::string& name) {}
+void Parser::setLogic(CVC5_UNUSED const std::string& name) {}
 
 void Parser::setFileInput(const std::string& filename)
 {

--- a/src/parser/parser_state.cpp
+++ b/src/parser/parser_state.cpp
@@ -91,7 +91,11 @@ Term ParserState::getExpressionForNameAndType(const std::string& name, Sort t)
   return expr;
 }
 
-bool ParserState::getTesterName(Term cons, std::string& name) { return false; }
+bool ParserState::getTesterName(CVC5_UNUSED Term cons,
+                                CVC5_UNUSED std::string& name)
+{
+  return false;
+}
 
 Kind ParserState::getKindForFunction(Term fun)
 {


### PR DESCRIPTION
These are acceptable cases, such as defining default implementations for virtual functions and overriding them.