### PR TITLE
context,prop: Remove unused parameters

### DIFF
--- a/src/context/cdqueue.h
+++ b/src/context/cdqueue.h
@@ -87,8 +87,7 @@ public:
   /** Creates a new CDQueue associated with the current context. */
  CDQueue(Context* context,
          bool callCleanup = true,
-         const CleanUp& cleanup = CleanUp(),
-         const Allocator& alloc = Allocator())
+         const CleanUp& cleanup = CleanUp())
      : ParentType(context, callCleanup, cleanup), d_iter(0), d_lastsave(0)
  {
  }

--- a/src/prop/minisat/core/Solver.cc
+++ b/src/prop/minisat/core/Solver.cc
@@ -134,7 +134,6 @@ class ScopedBool
 Solver::Solver(Env& env,
                cvc5::internal::prop::TheoryProxy* proxy,
                context::Context* context,
-               context::UserContext* userContext,
                PropPfManager* ppm,
                bool enableIncremental)
     : EnvObj(env),
@@ -236,7 +235,7 @@ Solver::~Solver()
 // Creates a new SAT variable in the solver. If 'decision_var' is cleared, variable will not be
 // used as a decision variable (NOTE! This has effects on the meaning of a SATISFIABLE result).
 //
-Var Solver::newVar(bool sign, bool dvar, bool isTheoryAtom, bool canErase)
+Var Solver::newVar(bool sign, bool dvar, bool isTheoryAtom)
 {
     int v = nVars();
 
@@ -1812,18 +1811,16 @@ void Solver::toDimacs(FILE* f, Clause& c, vec<Var>& map, Var& max)
     fprintf(f, "0\n");
 }
 
-
-void Solver::toDimacs(const char *file, const vec<Lit>& assumps)
+void Solver::toDimacs(const char* file)
 {
     FILE* f = fopen(file, "wr");
     if (f == NULL)
         fprintf(stderr, "could not open file %s\n", file), exit(1);
-    toDimacs(f, assumps);
+    toDimacs(f);
     fclose(f);
 }
 
-
-void Solver::toDimacs(FILE* f, const vec<Lit>& assumps)
+void Solver::toDimacs(FILE* f)
 {
     // Handle case when solver is in contradictory state:
     if (!ok){

--- a/src/prop/minisat/core/Solver.h
+++ b/src/prop/minisat/core/Solver.h
@@ -123,7 +123,6 @@ public:
  Solver(Env& env,
         cvc5::internal::prop::TheoryProxy* proxy,
         context::Context* context,
-        context::UserContext* userContext,
         prop::PropPfManager* ppm,
         bool enableIncremental = false);
  virtual ~Solver();
@@ -132,9 +131,8 @@ public:
  //
  Var newVar(bool polarity = true,
             bool dvar = true,
-            bool isTheoryAtom = false,
-            bool canErase = true);  // Add a new variable with parameters
-                                    // specifying variable mode.
+            bool isTheoryAtom = false);  // Add a new variable with parameters
+                                         // specifying variable mode.
  Var trueVar() const { return varTrue; }
  Var falseVar() const { return varFalse; }
 
@@ -253,16 +251,9 @@ public:
  bool okay() const;   // FALSE means solver is in a conflicting state
 
  void toDimacs();
- void toDimacs(FILE* f,
-               const vec<Lit>& assumps);  // Write CNF to file in DIMACS-format.
- void toDimacs(const char* file, const vec<Lit>& assumps);
- void toDimacs(FILE* f, Clause& c, vec<Var>& map, Var& max);
-
- // Convenience versions of 'toDimacs()':
+ void toDimacs(FILE* f);  // Write CNF to file in DIMACS-format.
  void toDimacs(const char* file);
- void toDimacs(const char* file, Lit p);
- void toDimacs(const char* file, Lit p, Lit q);
- void toDimacs(const char* file, Lit p, Lit q, Lit r);
+ void toDimacs(FILE* f, Clause& c, vec<Var>& map, Var& max);
 
  // Variable mode:
  //
@@ -709,13 +700,7 @@ inline lbool     Solver::solve         (const vec<Lit>& assumps){ budgetOff(); a
 inline lbool    Solver::solveLimited  (const vec<Lit>& assumps){ assumps.copyTo(assumptions); return solve_(); }
 inline bool     Solver::okay          ()      const   { return ok; }
 
-inline void     Solver::toDimacs     () { vec<Lit> as; toDimacs(stdout, as); }
-inline void     Solver::toDimacs     (const char* file){ vec<Lit> as; toDimacs(file, as); }
-inline void     Solver::toDimacs     (const char* file, Lit p){ vec<Lit> as; as.push(p); toDimacs(file, as); }
-inline void     Solver::toDimacs     (const char* file, Lit p, Lit q){ vec<Lit> as; as.push(p); as.push(q); toDimacs(file, as); }
-inline void     Solver::toDimacs     (const char* file, Lit p, Lit q, Lit r){ vec<Lit> as; as.push(p); as.push(q); as.push(r); toDimacs(file, as); }
-
-
+inline void Solver::toDimacs() { toDimacs(stdout); }
 
 //=================================================================================================
 // Debug etc:

--- a/src/prop/minisat/minisat.cpp
+++ b/src/prop/minisat/minisat.cpp
@@ -120,7 +120,6 @@ void MinisatSatSolver::initialize(TheoryProxy* theoryProxy, PropPfManager* ppm)
       new Minisat::SimpSolver(d_env,
                               theoryProxy,
                               context(),
-                              userContext(),
                               ppm,
                               options().base.incrementalSolving
                                   || options().decision.decisionMode

--- a/src/prop/minisat/simp/SimpSolver.cc
+++ b/src/prop/minisat/simp/SimpSolver.cc
@@ -50,10 +50,9 @@ static DoubleOption opt_simp_garbage_frac(_cat, "simp-gc-frac", "The fraction of
 SimpSolver::SimpSolver(Env& env,
                        prop::TheoryProxy* proxy,
                        context::Context* context,
-                       context::UserContext* userContext,
                        prop::PropPfManager* ppm,
                        bool enableIncremental)
-    : Solver(env, proxy, context, userContext, ppm, enableIncremental),
+    : Solver(env, proxy, context, ppm, enableIncremental),
       grow(opt_grow),
       clause_lim(opt_clause_lim),
       subsumption_lim(opt_subsumption_lim),
@@ -99,7 +98,7 @@ SimpSolver::~SimpSolver()
 
 Var SimpSolver::newVar(bool sign, bool dvar, bool isTheoryAtom, bool canErase)
 {
-  Var v = Solver::newVar(sign, dvar, isTheoryAtom, canErase);
+  Var v = Solver::newVar(sign, dvar, isTheoryAtom);
 
   if (use_simplification)
   {

--- a/src/prop/minisat/simp/SimpSolver.h
+++ b/src/prop/minisat/simp/SimpSolver.h
@@ -46,7 +46,6 @@ class SimpSolver : public Solver {
   SimpSolver(Env& env,
              prop::TheoryProxy* proxy,
              context::Context* context,
-             context::UserContext* userContext,
              prop::PropPfManager* ppm,
              bool enableIncremental = false);
   ~SimpSolver();

--- a/src/prop/theory_preregistrar.cpp
+++ b/src/prop/theory_preregistrar.cpp
@@ -50,8 +50,8 @@ class TheoryPreregistrarNotify : public context::ContextNotifyObj
 
 TheoryPreregistrar::TheoryPreregistrar(Env& env,
                                        TheoryEngine* te,
-                                       CDCLTSatSolver* ss,
-                                       CnfStream* cs)
+                                       CVC5_UNUSED CDCLTSatSolver* ss,
+                                       CVC5_UNUSED CnfStream* cs)
     : EnvObj(env),
       d_theoryEngine(te),
       d_notify(new TheoryPreregistrarNotify(env, *this))
@@ -64,9 +64,16 @@ bool TheoryPreregistrar::needsActiveSkolemDefs() const { return false; }
 
 void TheoryPreregistrar::check() {}
 
-void TheoryPreregistrar::addAssertion(TNode n, TNode skolem, bool isLemma) {}
+void TheoryPreregistrar::addAssertion(CVC5_UNUSED TNode n,
+                                      CVC5_UNUSED TNode skolem,
+                                      CVC5_UNUSED bool isLemma)
+{
+}
 
-void TheoryPreregistrar::notifyActiveSkolemDefs(std::vector<TNode>& defs) {}
+void TheoryPreregistrar::notifyActiveSkolemDefs(
+    CVC5_UNUSED std::vector<TNode>& defs)
+{
+}
 
 void TheoryPreregistrar::notifySatLiteral(TNode n)
 {

--- a/src/prop/theory_preregistrar.h
+++ b/src/prop/theory_preregistrar.h
@@ -46,24 +46,24 @@ class TheoryPreregistrar : protected EnvObj
                      TheoryEngine* te,
                      CDCLTSatSolver* ss,
                      CnfStream* cs);
-  ~TheoryPreregistrar();
+  virtual ~TheoryPreregistrar();
   /** Do we need to be informed of activated skolem definitions? */
-  bool needsActiveSkolemDefs() const;
+  virtual bool needsActiveSkolemDefs() const;
   /** theory check */
-  void check();
+  virtual void check();
   /** Notify assertion */
-  void addAssertion(TNode n, TNode skolem, bool isLemma);
+  virtual void addAssertion(TNode n, TNode skolem, bool isLemma);
   /** Notify that skolem definitions have become active */
-  void notifyActiveSkolemDefs(std::vector<TNode>& defs);
+  virtual void notifyActiveSkolemDefs(std::vector<TNode>& defs);
   /**
    * Notify that a SAT literal for atom n has been allocated in the SAT solver.
    * @param n The node to preregister.
    */
-  void notifySatLiteral(TNode n);
+  virtual void notifySatLiteral(TNode n);
   /**
    * Callback to notify that the SAT solver backtracked.
    */
-  void notifyBacktrack();
+  virtual void notifyBacktrack();
   /**
    * Notify that n is asserted from SAT solver, return true if we should
    * assert n to the theory engine.
@@ -74,7 +74,7 @@ class TheoryPreregistrar : protected EnvObj
    * call this method for such terms when the TRACK_AND_NOTIFY(_VAR) policy
    * is used in the CNF stream.
    */
-  bool notifyAsserted(TNode n);
+  virtual bool notifyAsserted(TNode n);
 
  private:
   /** pre-register to theory */


### PR DESCRIPTION
One of the unused parameters was `assumps` in `void toDimacs(FILE* f, const vec<Lit>& assumps)`. I deleted all functions relying on this parameter, since they could not work properly.

I also marked the methods of `TheoryPreregistrar` as virtual, since the only way the unused parameters could make sense is if other classes extend this class in the future.