### PR TITLE
Fix get-assertions to not reset the model

### DIFF
--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -2118,7 +2118,8 @@ std::vector<Node> SolverEngine::getAssertions()
 void SolverEngine::getDifficultyMap(std::map<Node, Node>& dmap)
 {
   Trace("smt") << "SMT getDifficultyMap()\n";
-  beginCall();
+  // ensure this solver engine has been initialized
+  finishInit();
   if (!d_env->getOptions().smt.produceDifficulty)
   {
     throw ModalException(

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1064,6 +1064,7 @@ set(regress_0_tests
   regress0/issue1063-overloading-dt-sel.smt2
   regress0/issue11198-real-as-int.smt2
   regress0/issue12038-model-get-value.smt2
+  regress0/issue12386-get-assertions.smt2
   regress0/issue2832-qualId.smt2
   regress0/issue4010-sort-inf-var.smt2
   regress0/issue4469-unc-no-reuse-var.smt2

--- a/test/regress/cli/regress0/issue12386-get-assertions.smt2
+++ b/test/regress/cli/regress0/issue12386-get-assertions.smt2
@@ -1,0 +1,13 @@
+; EXPECT: sat
+; EXPECT: (
+; EXPECT: (distinct x 0)
+; EXPECT: true
+; EXPECT: )
+; EXPECT: ((x (- 1)))
+(set-option :produce-models true)
+(set-logic QF_LIA)
+(declare-const x Int)
+(assert (distinct x 0))
+(check-sat-assuming (true))
+(get-assertions)
+(get-value (x))


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/12386.

When calling `get-assertions`, we were incorrectly popping the context (which resets the model). However SMT-LIB indicates `get-assertions` does not impact the state of the solver (Figure 4.1 of https://smt-lib.org/papers/smt-lib-reference-v2.7-r2025-07-07.pdf).

A similar issue occurs with the non-standard command `getDifficultyMap`, which is also changed to this behavior.