### PR TITLE
Modify strategy for non-linear arithmetic to ensure nl-cov has chance to answer sat

### DIFF
--- a/src/theory/arith/nl/strategy.cpp
+++ b/src/theory/arith/nl/strategy.cpp
@@ -169,10 +169,11 @@ void Strategy::initializeStrategy(const Options& options)
     one << InferStep::COVERINGS_INIT << InferStep::BREAK;
     one << InferStep::COVERINGS_FULL << InferStep::BREAK;
   }
-  else if (options.arith.nlExt == options::NlExtMode::FULL)
+  if (options.arith.nlExt == options::NlExtMode::FULL &&
+      (!options.arith.nlCov || options.arith.nlCovForce))
   {
-    // if nl-cov is not enabled, then we use heuristic non-terminating
-    // techniques as a last resort
+    // if nl-cov is not enabled or we forced it to be enabled, then we use
+    // heuristic non-terminating techniques as a last resort
     one << InferStep::FLUSH_WAITING_LEMMAS << InferStep::BREAK;
     if (options.arith.nlExtFactor)
     {


### PR DESCRIPTION
Makes a change to the strategy for non-linear arithmetic such that non-terminating lemma schemas do not preempt nl-cov from running.

This is +15-14 on QF_NRA SMT-LIB but significantly helps a benchmark set of interest.