### PR TITLE
Two minor fixes to options

### DIFF
--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -1774,6 +1774,7 @@ name   = "Quantifiers"
   long       = "macros-quant-mode=MODE"
   type       = "MacrosQuantMode"
   default    = "GROUND_UF"
+  no_support = ["proofs"]
   help       = "mode for quantifiers macro expansion"
   help_mode  = "Modes for quantifiers macro expansion."
 [[option.mode.ALL]]

--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -209,7 +209,7 @@ name   = "SMT Layer"
 
 [[option]]
   name       = "unsatAssumptions"
-  category   = "regular"
+  category   = "common"
   long       = "produce-unsat-assumptions"
   type       = "bool"
   default    = "false"


### PR DESCRIPTION
First, `produce-unsat-assumptions` analogous to produce-unsat-cores should be a common option.

Second, `macros-quant-mode` should be marked as not supporting proofs, since it automatically enables `macros-quant`.