### PR TITLE
Alethe Fix Bug in Translation of QUANT_MERGE_PRENEX

### DIFF
--- a/src/proof/alethe/alethe_post_processor.cpp
+++ b/src/proof/alethe/alethe_post_processor.cpp
@@ -181,7 +181,8 @@ bool AletheProofPostprocessCallback::updateTheoryRewriteProofRewriteRule(
     // (cl (= (Q Y_i. Q X_i+2. ... Q X_n. F) (Q Y_i+1. Q X_i+3. ... Q X_n. F))),
     // for i>0 where Y_i = Y_i-1 u X_i, Y_0 = X_1
     //
-    // Finally,
+    // Finally, if there are duplicates we remove them otherwise, VP_b_n is
+    // already equal to res.
     //
     //   VP_b_n
     // ---------- QNT_REMOVE_UNUSED
@@ -245,13 +246,16 @@ bool AletheProofPostprocessCallback::updateTheoryRewriteProofRewriteRule(
         curr_vp_b = next_vp_b;
       }
 
-      return success
-             && addAletheStep(AletheRule::QNT_RM_UNUSED,
-                              res,
-                              nm->mkNode(Kind::SEXPR, d_cl, res),
-                              {curr_vp_b},
-                              {},
-                              *cdp);
+      if (curr_vp_b != res)
+      {
+        success &= addAletheStep(AletheRule::QNT_RM_UNUSED,
+                                 res,
+                                 nm->mkNode(Kind::SEXPR, d_cl, res),
+                                 {curr_vp_b},
+                                 {},
+                                 *cdp);
+      }
+      return success;
     }
     // ======== QUANT_MINISCOPE_AND
     // This rule is translated according to the clause pattern.


### PR DESCRIPTION
The QUANT_MERGE_PRENEX was translated to QNT_JOIN but that only works for the n=2 case (if there are two nested quantifiers). The case n>2 was not addressed. The translation did also not account for duplicate removal.

This PR fixes this.

- I found that it is easiest to understand the code when doing the same thing done in the loop in the "base" case (i.e., for `VP_b_1`) but of course that could be simplified. There also some other lines of code that could be simplified if preferred.
- I tried to be consistent with variable names in the comment using underscores since i+1 is hard to read otherwise but happy to change that.
- I thought that adding comment such as `// Yi` to the code would be helpful (note that clang-format decided to format that specific comment the way it is)



