### PR TITLE
Fix WASM configure failure with custom EXPORTED_FUNCTIONS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -645,6 +645,11 @@ else()
   endif()
 endif()
 
+# Re-apply EXPORTED_FUNCTIONS after configure checks complete
+if(NOT "${WASM_EXPORTED_FUNCTIONS_FLAG}" STREQUAL "")
+  string(APPEND CMAKE_EXE_LINKER_FLAGS " ${WASM_EXPORTED_FUNCTIONS_FLAG}")
+endif()
+
 #-----------------------------------------------------------------------------#
 # Add subdirectories
 


### PR DESCRIPTION
Fixes #12349 by extracting EXPORTED_FUNCTIONS during configure phase to prevent try_compile failures