### PR TITLE
Address dangling reference warnings in CoCoA-related code

### DIFF
--- a/src/theory/ff/multi_roots.cpp
+++ b/src/theory/ff/multi_roots.cpp
@@ -163,7 +163,7 @@ bool allVarsAssigned(const CoCoA::ideal& ideal)
 
 std::unique_ptr<AssignmentEnumerator> applyRule(const CoCoA::ideal& ideal)
 {
-  CoCoA::ring polyRing = ideal->myRing();
+  CoCoA::PolyRing polyRing(ideal->myRing());
   Assert(!isUnsat(ideal));
   // first, we look for super-linear univariate polynomials.
   Assert(CoCoA::HasGBasis(ideal));

--- a/src/theory/ff/sub_theory.cpp
+++ b/src/theory/ff/sub_theory.cpp
@@ -113,7 +113,8 @@ Result SubTheory::postCheck(Theory::Effort e)
                           enc.bitsumPolys().end());
         if (options().ff.ffFieldPolys)
         {
-          for (const auto& var : CoCoA::indets(enc.polyRing()))
+          CoCoA::PolyRing polyRing(enc.polyRing());
+          for (const auto& var : CoCoA::indets(polyRing))
           {
             CoCoA::BigInt characteristic = CoCoA::characteristic(coeffRing());
             const long power = CoCoA::LogCardinality(coeffRing());


### PR DESCRIPTION
When `-Wdangling-reference` is enabled in GCC 14 or later, the compiler issues a warning about a potential dangling reference when executing `for (const auto& var : CoCoA::indets(x))`, where `x` is a temporary object. Although the implementation details of `CoCoA::ring`, `CoCoA::PolyRing`, and `CoCoA::indets()` prevent the dangling reference issue, this PR ensures that an lvalue is passed, making the code safe regardless of the concrete implementation.