### PR TITLE
Fix Eunoia definition of concat_csplit

### DIFF
--- a/proofs/eo/cpc/rules/Strings.eo
+++ b/proofs/eo/cpc/rules/Strings.eo
@@ -87,11 +87,12 @@
   :conclusion
     (eo::define ((t1 ($str_head ($str_to_nary_form t rev))))
     (eo::define ((s1 ($str_head ($str_to_nary_form s rev))))
+      (eo::requires t1 u
       (eo::requires ($str_check_length_one s1) true    ; checks if char
         (= u
           (eo::ite rev
             (str.++ (@purify ($str_prefix u (- (str.len u) 1))) s1)
-            (str.++ s1 (@purify ($str_suffix_rem u 1))))))))
+            (str.++ s1 (@purify ($str_suffix_rem u 1)))))))))
 )
 
 ; rule: concat_split


### PR DESCRIPTION
Found by sygus-based fuzzing over the Eunoia -> SMT2 translation on a new version of SMT-LIB model semantics.

The missing guard was accidentally dropped in https://github.com/cvc5/cvc5/commit/69ba034479e9d7e1a8e0af0b76984bd4f91657d3, this readds it.