### PR TITLE
Disable some flattening rewrite rules

### DIFF
--- a/src/theory/bv/theory_bv_rewriter.cpp
+++ b/src/theory/bv/theory_bv_rewriter.cpp
@@ -423,7 +423,6 @@ RewriteResponse TheoryBVRewriter::RewriteConcat(TNode node,
 
 RewriteResponse TheoryBVRewriter::RewriteAnd(TNode node, bool prerewrite)
 {
-  TRY_REWRITE(FlattenAssocCommutNoDuplicates)
   TRY_REWRITE(AndSimplify)
   TRY_REWRITE(AndOrXorConcatPullUp)
   if (!prerewrite)
@@ -435,7 +434,6 @@ RewriteResponse TheoryBVRewriter::RewriteAnd(TNode node, bool prerewrite)
 
 RewriteResponse TheoryBVRewriter::RewriteOr(TNode node, bool prerewrite)
 {
-  TRY_REWRITE(FlattenAssocCommutNoDuplicates)
   TRY_REWRITE(OrSimplify)
   TRY_REWRITE(AndOrXorConcatPullUp)
   if (!prerewrite)
@@ -447,7 +445,6 @@ RewriteResponse TheoryBVRewriter::RewriteOr(TNode node, bool prerewrite)
 
 RewriteResponse TheoryBVRewriter::RewriteXor(TNode node, bool prerewrite)
 {
-  TRY_REWRITE(FlattenAssocCommut) // flatten the expression
   TRY_REWRITE(XorSimplify) // simplify duplicates and constants
   TRY_REWRITE(XorZero) // checks if the constant part is zero and eliminates it
   TRY_REWRITE(AndOrXorConcatPullUp)


### PR DESCRIPTION
The BV plugin performs a rewriting rule that flattens chains of binary bv operations (bvand, bvor, bvxor, bvadd, bvmul) into a n-ary operation. This hinders boolean variable sharing in the SAT solver for bitblasting.
Turning them off, allows for an additional 21 instances of QF_BV solved within 5 min (loosing 4).