### PR TITLE
Fix small bug in FF split solver

### DIFF
--- a/src/theory/ff/split_gb.cpp
+++ b/src/theory/ff/split_gb.cpp
@@ -406,21 +406,23 @@ Polys BitProp::getBitEqualities(const SplitGb& splitBasis)
       Poly normal = b.reduce(d_enc->getTermEncoding(bitsum));
       if (CoCoA::IsConstant(normal))
       {
-        // this basis b knows that bitsum is a constant
-        Integer val =
-            d_enc->cocoaFfToFfVal(CoCoA::ConstantCoeff(normal)).getValue();
-        if (val >= Integer(2).pow(bitsum.getNumChildren()))
-        {
-          output.clear();
-          output.push_back(CoCoA::one(d_enc->polyRing()));
-          return output;
-        }
-
+      
         // check that all inputs are bit-constrained
         if (std::all_of(bitsum.begin(), bitsum.end(), [&](const Node& bit) {
               return isBit(bit, splitBasis);
             }))
         {
+          // this basis b knows that bitsum is a constant
+          Integer val =
+              d_enc->cocoaFfToFfVal(CoCoA::ConstantCoeff(normal)).getValue();
+
+          if (val >= Integer(2).pow(bitsum.getNumChildren()))
+          {
+            output.clear();
+            output.push_back(CoCoA::one(d_enc->polyRing()));
+            return output;
+          }
+
           // propagate `bits(bitsum) = bits(k)`
           for (size_t i = 0, n = bitsum.getNumChildren(); i < n; ++i)
           {

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -858,6 +858,7 @@ set(regress_0_tests
   regress0/ff/bigff_is_zero_sound.smt2
   regress0/ff/bigff_is_zero_unsound.smt2
   regress0/ff/bitsum_eval.smt2
+  regress0/ff/bitsum_overflow.smt2
   regress0/ff/bool_nary_or_sound.smt2
   regress0/ff/bool_nary_or_unsound.smt2
   regress0/ff/combination.smt2

--- a/test/regress/cli/regress0/ff/bitsum_overflow.smt2
+++ b/test/regress/cli/regress0/ff/bitsum_overflow.smt2
@@ -1,0 +1,12 @@
+; REQUIRES: cocoa
+; EXPECT: sat
+; COMMAND-LINE: --ff-solver split
+; COMMAND-LINE: --ff-solver gb
+(set-info :smt-lib-version 2.6)
+(set-info :category "crafted")
+(set-logic QF_FF)
+(define-sort FF () (_ FiniteField 21888242871839275222246405745257275088548364400416034343698204186575808495617))
+(declare-const _0 FF)
+(declare-const _1 FF)
+(assert (= (ff.add (ff.mul (as ff-2 FF) _0) (ff.mul (as ff-1 FF) _1) (as ff4 FF)) (as ff0 FF)))
+(check-sat)


### PR DESCRIPTION
The overflow check for constant bitsum under
analysis in BitProp::getBitEqualities was not
ensuring that the bitsum elements involved where
constrained to be 0 or 1. A regression test
has been added to demonstrate the issue.