### PR TITLE
ci: Schedule nightly CI run including GPL builds

### DIFF
--- a/.github/actions/add-jar/action.yml
+++ b/.github/actions/add-jar/action.yml
@@ -9,6 +9,8 @@ inputs:
     description: target name of the JAR
   shell:
     default: bash
+  dry-run:
+    default: false
 runs:
   using: composite
   steps:
@@ -33,14 +35,14 @@ runs:
         rm QuickStart.class
 
     - name: Store to latest
-      if: github.ref == 'refs/heads/main'
+      if: ${{ github.ref == 'refs/heads/main' && inputs.dry-run != 'true' }}
       uses: ./.github/actions/store-to-latest
       with:
         asset-filename: ${{ inputs.jar-name }}.jar
         shell: ${{ inputs.shell }}
 
     - name: Store to release
-      if: startsWith(github.ref, 'refs/tags/')
+      if: ${{ startsWith(github.ref, 'refs/tags/') && inputs.dry-run != 'true' }}
       shell: ${{ inputs.shell }}
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/actions/add-package/action.yml
+++ b/.github/actions/add-package/action.yml
@@ -7,6 +7,8 @@ inputs:
     description: target name of the package
   shell:
     default: bash
+  dry-run:
+    default: false
 outputs:
   install-path:
     description: path to the installation directory
@@ -62,14 +64,14 @@ runs:
         echo "::endgroup::"
 
     - name: Store to latest
-      if: github.ref == 'refs/heads/main'
+      if: ${{ github.ref == 'refs/heads/main' && inputs.dry-run != 'true' }}
       uses: ./.github/actions/store-to-latest
       with:
         asset-filename: ${{ inputs.package-name }}.zip
         shell: ${{ inputs.shell }}
 
     - name: Store to release
-      if: startsWith(github.ref, 'refs/tags/')
+      if: ${{ startsWith(github.ref, 'refs/tags/') && inputs.dry-run != 'true' }}
       shell: ${{ inputs.shell }}
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/actions/add-wasm/action.yml
+++ b/.github/actions/add-wasm/action.yml
@@ -11,6 +11,8 @@ inputs:
   shell:
     description: shell to use for commands
     default: bash
+  dry-run:
+    default: false
 runs:
   using: composite
   steps:
@@ -27,14 +29,14 @@ runs:
         echo "::endgroup::"
 
     - name: Store WASM package to latest
-      if: github.ref == 'refs/heads/main'
+      if: ${{ github.ref == 'refs/heads/main' && inputs.dry-run != 'true' }}
       uses: ./.github/actions/store-to-latest
       with:
         asset-filename: ${{ inputs.wasm-name }}.zip
         shell: ${{ inputs.shell }}
 
     - name: Store WASM package to release
-      if: startsWith(github.ref, 'refs/tags/')
+      if: ${{ startsWith(github.ref, 'refs/tags/') && inputs.dry-run != 'true' }}
       shell: ${{ inputs.shell }}
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 5 * * *'
 
 name: CI
 
@@ -35,8 +39,8 @@ jobs:
     needs: [setup-release-pages]
     strategy:
       matrix:
-        has-tag:
-          - ${{ startsWith(github.ref, 'refs/tags/') }}
+        gpl-build:
+          - ${{ startsWith(github.ref, 'refs/tags/') || (github.event_name == 'schedule') }}
         build:
           - name: ubuntu:production
             os: ubuntu-22.04
@@ -234,16 +238,16 @@ jobs:
             gpl-tag: -gpl
 
         exclude:
-          - has-tag: false
+          - gpl-build: false
             build:
               name: ubuntu:production-gpl
-          - has-tag: false
+          - gpl-build: false
             build:
               name: ubuntu:production-arm64-gpl
-          - has-tag: false
+          - gpl-build: false
             build:
               name: macos:production-gpl
-          - has-tag: false
+          - gpl-build: false
             build:
               name: macos:production-arm64-gpl
 
@@ -326,7 +330,7 @@ jobs:
         shell: ${{ matrix.build.shell }}
 
     - name: Build documentation
-      if: matrix.build.build-documentation
+      if: matrix.build.build-documentation && (github.event_name != 'schedule')
       uses: ./.github/actions/build-documentation
       with:
         build-dir: ${{ steps.configure-and-build.outputs.shared-build-dir }}
@@ -339,6 +343,7 @@ jobs:
         build-dir: ${{ steps.configure-and-build.outputs.shared-build-dir }}
         package-name: ${{ matrix.build.package-name }}-shared${{ matrix.build.gpl-tag }}
         shell: ${{ matrix.build.shell }}
+        dry-run: ${{ github.event_name == 'schedule' }}
 
     - name: Create and add static package to latest and release
       id: create-static-package
@@ -348,6 +353,7 @@ jobs:
         build-dir: ${{ steps.configure-and-build.outputs.static-build-dir }}
         package-name: ${{ matrix.build.package-name }}-static${{ matrix.build.gpl-tag }}
         shell: ${{ matrix.build.shell }}
+        dry-run: ${{ github.event_name == 'schedule' }}
 
     - name: Create and add WASM to latest and release
       if: matrix.build.wasm-pkg-name && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
@@ -356,6 +362,7 @@ jobs:
         build-dir: ${{ steps.configure-and-build.outputs.static-build-dir }}
         wasm-name: ${{ matrix.build.wasm-pkg-name }}${{ matrix.build.gpl-tag }}
         shell: ${{ matrix.build.shell }}
+        dry-run: ${{ github.event_name == 'schedule' }}
 
     - name: Create and add JAR to latest and release
       if: matrix.build.java-bindings && matrix.build.package-name && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
@@ -364,10 +371,11 @@ jobs:
         build-dir: ${{ steps.configure-and-build.outputs.static-build-dir }}
         jar-name: ${{ matrix.build.package-name }}${{ matrix.build.gpl-tag }}-java-api
         shell: ${{ matrix.build.shell }}
+        dry-run: ${{ github.event_name == 'schedule' }}
 
     - name: Upload Maven artifacts
       if: >
-        github.repository == 'cvc5/cvc5' &&
+        github.repository == 'cvc5/cvc5' && github.event_name != 'schedule' &&
         (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) &&
         (matrix.build.upload-maven-doc ||
          (matrix.build.java-bindings && matrix.build.package-name))
@@ -381,7 +389,7 @@ jobs:
 
   publish-to-maven-central:
     name: Publish to Maven central
-    if: github.repository == 'cvc5/cvc5' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    if: github.repository == 'cvc5/cvc5' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && github.event_name != 'schedule'
     runs-on: ubuntu-latest
     continue-on-error: true
     needs: [builds]
@@ -431,7 +439,7 @@ jobs:
 
   cleanup-artifacts:
     name: Clean up artifacts from latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && github.event_name != 'schedule'
     runs-on: ubuntu-latest
     needs: [builds]
     concurrency:


### PR DESCRIPTION
Currently, GPL builds are only compiled in CI when a new release is published to avoid cache congestion and slow runtimes. This can lead to surprises on release day. This PR schedules a nightly CI run that includes GPL builds but does not upload any artifacts.