### PR TITLE
Update about

### DIFF
--- a/src/base/configuration.cpp
+++ b/src/base/configuration.cpp
@@ -185,7 +185,8 @@ std::string Configuration::about()
   return ss.str();
 }
 
-std::string Configuration::aboutAndCopyright() {
+std::string Configuration::aboutAndCopyright()
+{
   std::stringstream ss;
   ss << about();
   ss << std::endl << std::endl;
@@ -211,6 +212,7 @@ bool Configuration::isBuiltWithKissat() { return IS_KISSAT_BUILD; }
 bool Configuration::isBuiltWithEditline() { return IS_EDITLINE_BUILD; }
 
 bool Configuration::isBuiltWithPoly() { return IS_POLY_BUILD; }
+
 bool Configuration::isBuiltWithCoCoA() { return IS_COCOA_BUILD; }
 
 bool Configuration::isBuiltWithPortfolio() { return IS_PORTFOLIO_BUILD; }

--- a/src/base/configuration.cpp
+++ b/src/base/configuration.cpp
@@ -12,9 +12,6 @@
  */
 #include "base/configuration.h"
 
-#include <stdlib.h>
-#include <string.h>
-
 #include <algorithm>
 #include <sstream>
 #include <string>
@@ -179,13 +176,20 @@ std::string Configuration::about()
 {
   std::stringstream ss;
   ss << "This is cvc5 version " << getVersionString();
-  if (Configuration::isGitBuild())
+  if (isGitBuild())
   {
-    ss << " [" << Configuration::getGitInfo() << "]";
+    ss << " [" << getGitInfo() << "]";
   }
-  ss << "\ncompiled with " << Configuration::getCompiler() << "\non "
-     << Configuration::getCompiledDateTime() << "\n\n";
-  ss << Configuration::copyright();
+  ss << std::endl << "compiled with " << getCompiler();
+  ss << std::endl << "on " << getCompiledDateTime();
+  return ss.str();
+}
+
+std::string Configuration::aboutAndCopyright() {
+  std::stringstream ss;
+  ss << about();
+  ss << std::endl << std::endl;
+  ss << copyright();
   return ss.str();
 }
 

--- a/src/base/configuration.cpp
+++ b/src/base/configuration.cpp
@@ -175,13 +175,13 @@ std::string Configuration::copyright()
 std::string Configuration::about()
 {
   std::stringstream ss;
-  ss << "This is cvc5 version " << getVersionString();
+  ss << "cvc5 " << getVersionString();
   if (isGitBuild())
   {
     ss << " [" << getGitInfo() << "]";
   }
-  ss << std::endl << "compiled with " << getCompiler();
-  ss << std::endl << "on " << getCompiledDateTime();
+  ss << std::endl;
+  ss << "compiled with " << getCompiler() << " on " << getCompiledDateTime();
   return ss.str();
 }
 

--- a/src/base/configuration.cpp
+++ b/src/base/configuration.cpp
@@ -62,7 +62,7 @@ std::string Configuration::copyright()
   ss << "Copyright (c) 2009-2026 by the authors and their institutional\n"
      << "affiliations listed at https://cvc5.github.io/people.html\n\n";
 
-  if (Configuration::licenseIsGpl())
+  if (licenseIsGpl())
   {
     ss << "This build of cvc5 uses GPLed libraries, and is thus covered by\n"
        << "the GNU General Public License (GPL) version 3.  Versions of cvc5\n"
@@ -86,23 +86,22 @@ std::string Configuration::copyright()
      << "  See https://github.com/arminbiere/cadical for copyright "
      << "information.\n\n";
 
-  if (Configuration::isBuiltWithCryptominisat()
-      || Configuration::isBuiltWithKissat()
-      || Configuration::isBuiltWithEditline())
+  if (isBuiltWithCryptominisat() || isBuiltWithKissat()
+      || isBuiltWithEditline())
   {
-    if (Configuration::isBuiltWithCryptominisat())
+    if (isBuiltWithCryptominisat())
     {
       ss << "  CryptoMiniSat - An Advanced SAT Solver\n"
          << "  See https://github.com/msoos/cryptominisat for copyright "
          << "information.\n\n";
     }
-    if (Configuration::isBuiltWithKissat())
+    if (isBuiltWithKissat())
     {
       ss << "  Kissat - Simplified Satisfiability Solver\n"
          << "  See https://fmv.jku.at/kissat for copyright "
          << "information.\n\n";
     }
-    if (Configuration::isBuiltWithEditline())
+    if (isBuiltWithEditline())
     {
       ss << "  Editline Library\n"
          << "  See https://thrysoee.dk/editline\n"
@@ -114,23 +113,23 @@ std::string Configuration::copyright()
      << "  See https://github.com/martin-cs/symfpu/tree/CVC4 for copyright "
      << "information.\n\n";
 
-  if (Configuration::isBuiltWithGmp() || Configuration::isBuiltWithPoly())
+  if (isBuiltWithGmp() || isBuiltWithPoly())
   {
     ss << "This version of cvc5 is linked against the following third party\n"
        << "libraries covered by the LGPLv3 license.\n"
        << "See licenses/lgpl-3.0.txt for more information.\n\n";
-    if (Configuration::isBuiltWithGmp())
+    if (isBuiltWithGmp())
     {
       ss << "  GMP - Gnu Multi Precision Arithmetic Library\n"
          << "  See http://gmplib.org for copyright information.\n\n";
     }
-    if (Configuration::isBuiltWithPoly())
+    if (isBuiltWithPoly())
     {
       ss << "  LibPoly polynomial library\n"
          << "  See https://github.com/SRI-CSL/libpoly for copyright and\n"
          << "  licensing information.\n\n";
     }
-    if (Configuration::isStaticBuild())
+    if (isStaticBuild())
     {
       ss << "cvc5 is statically linked against these libraries. To recompile\n"
             "this version of cvc5 with different versions of these libraries\n"
@@ -139,25 +138,24 @@ std::string Configuration::copyright()
     }
   }
 
-  if (Configuration::isBuiltWithCln() || Configuration::isBuiltWithGlpk()
-      || Configuration::isBuiltWithCoCoA())
+  if (isBuiltWithCln() || isBuiltWithGlpk() || isBuiltWithCoCoA())
   {
     ss << "This version of cvc5 is linked against the following third party\n"
        << "libraries covered by the GPLv3 license.\n"
        << "See licenses/gpl-3.0.txt for more information.\n\n";
-    if (Configuration::isBuiltWithCln())
+    if (isBuiltWithCln())
     {
       ss << "  CLN - Class Library for Numbers\n"
          << "  See http://www.ginac.de/CLN for copyright information.\n\n";
     }
-    if (Configuration::isBuiltWithGlpk())
+    if (isBuiltWithGlpk())
     {
       ss << "  glpk-cut-log - a modified version of GPLK, "
          << "the GNU Linear Programming Kit\n"
          << "  See http://github.com/timothy-king/glpk-cut-log for copyright"
          << " information\n\n";
     }
-    if (Configuration::isBuiltWithCoCoA())
+    if (isBuiltWithCoCoA())
     {
       ss << "  CoCoALib - a computer algebra library\n"
          << "  See https://cocoa.dima.unige.it/cocoa/cocoalib/index.shtml for "

--- a/src/base/configuration.h
+++ b/src/base/configuration.h
@@ -91,6 +91,8 @@ class CVC5_EXPORT Configuration
 
   static std::string about();
 
+  static std::string aboutAndCopyright();
+
   static bool licenseIsGpl();
 
   static bool isBuiltWithGmp();

--- a/src/base/configuration.h
+++ b/src/base/configuration.h
@@ -41,12 +41,13 @@ static constexpr bool isStatisticsBuild()
 /**
  * Represents the (static) configuration of cvc5.
  */
-class CVC5_EXPORT Configuration
+class CVC5_EXPORT Configuration final
 {
- private:
-  /** Private default ctor: Disallow construction of this class */
-  Configuration();
+ public:
+  /** Delete default ctor: Disallow construction of this class. */
+  Configuration() = delete;
 
+ private:
   // these constants are filled in by the build system
   static const bool GIT_BUILD;
   static const bool CVC5_IS_RELEASE;

--- a/src/main/driver_unified.cpp
+++ b/src/main/driver_unified.cpp
@@ -201,16 +201,7 @@ int runCvc5(int argc, char* argv[], std::unique_ptr<cvc5::Solver>& solver)
       if (isInteractive)
       {
         auto& out = solver->getDriverOptions().out();
-        out << Configuration::getPackageName() << " "
-            << Configuration::getVersionString();
-        if (Configuration::isGitBuild())
-        {
-          out << " [" << Configuration::getGitInfo() << "]";
-        }
-        out << (Configuration::isDebugBuild() ? " DEBUG" : "") << " assertions:"
-            << (Configuration::isAssertionBuild() ? "on" : "off") << std::endl
-            << std::endl
-            << Configuration::copyright() << std::endl;
+        out << Configuration::aboutAndCopyright();
       }
 
       while (true)

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -349,8 +349,7 @@ void OptionsHandler::showConfiguration(CVC5_UNUSED const std::string& flag,
 {
   if (!value) return;
   std::ostream& o = d_options->base.out;
-  o << Configuration::about() << std::endl;
-
+  print_config(o, "package", Configuration::getPackageName());
   print_config(o, "version", Configuration::getVersionString());
   if (Configuration::isGitBuild())
   {
@@ -360,12 +359,6 @@ void OptionsHandler::showConfiguration(CVC5_UNUSED const std::string& flag,
   {
     print_config_cond(o, "scm", false);
   }
-
-  o << std::endl;
-
-  std::stringstream ss;
-  ss << Configuration::getVersionString();
-  print_config(o, "library", ss.str());
 
   o << std::endl;
 
@@ -388,8 +381,8 @@ void OptionsHandler::showConfiguration(CVC5_UNUSED const std::string& flag,
 
   print_config_cond(o, "cln", Configuration::isBuiltWithCln());
   print_config_cond(o, "glpk", Configuration::isBuiltWithGlpk());
-  print_config_cond(
-      o, "cryptominisat", Configuration::isBuiltWithCryptominisat());
+  print_config_cond(o, "cryptominisat",
+    Configuration::isBuiltWithCryptominisat());
   print_config_cond(o, "gmp", Configuration::isBuiltWithGmp());
   print_config_cond(o, "kissat", Configuration::isBuiltWithKissat());
   print_config_cond(o, "poly", Configuration::isBuiltWithPoly());
@@ -408,7 +401,7 @@ void OptionsHandler::showVersion(CVC5_UNUSED const std::string& flag,
                                  bool value)
 {
   if (!value) return;
-  d_options->base.out << Configuration::about() << std::endl;
+  d_options->base.out << Configuration::aboutAndCopyright() << std::endl;
 }
 
 void OptionsHandler::showTraceTags(CVC5_UNUSED const std::string& flag,

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -54,7 +54,7 @@ void printTags(std::ostream& out, const std::vector<std::string>& tags)
 }
 
 std::string suggestTags(const std::vector<std::string>& validTags,
-                        std::string inputTag,
+                        const std::string& inputTag,
                         const std::vector<std::string>& additionalTags)
 {
   DidYouMean didYouMean;
@@ -146,7 +146,7 @@ Languages currently supported as arguments to the --output-lang option:
 }
 
 void OptionsHandler::setInputLanguage(const std::string& flag,
-                                      Language lang) const
+                                      const Language lang) const
 {
   if (lang == Language::LANG_AST)
   {
@@ -160,7 +160,7 @@ void OptionsHandler::setInputLanguage(const std::string& flag,
 }
 
 void OptionsHandler::setVerbosity(CVC5_UNUSED const std::string& flag,
-                                  int value) const
+                                  const int value) const
 {
   if (Configuration::isMuzzledBuild())
   {
@@ -194,7 +194,8 @@ void OptionsHandler::increaseVerbosity(CVC5_UNUSED const std::string& flag,
   setVerbosity(flag, d_options->base.verbosity);
 }
 
-void OptionsHandler::setStats(CVC5_UNUSED const std::string& flag, bool value) const
+void OptionsHandler::setStats(CVC5_UNUSED const std::string& flag,
+                              const bool value) const
 {
 #ifndef CVC5_STATISTICS_ON
   if (value)
@@ -215,7 +216,7 @@ void OptionsHandler::setStats(CVC5_UNUSED const std::string& flag, bool value) c
 }
 
 void OptionsHandler::setStatsDetail(CVC5_UNUSED const std::string& flag,
-                                    bool value) const
+                                    const bool value) const
 {
 #ifndef CVC5_STATISTICS_ON
   if (value)
@@ -240,7 +241,7 @@ void OptionsHandler::enableTraceTag(CVC5_UNUSED const std::string& flag,
   {
     throw OptionException("trace tags not available in non-tracing builds");
   }
-  auto tags = selectTags(Configuration::getTraceTags(), optarg);
+  const auto tags = selectTags(Configuration::getTraceTags(), optarg);
   if (tags.empty())
   {
     if (optarg == "help")
@@ -262,9 +263,9 @@ void OptionsHandler::enableTraceTag(CVC5_UNUSED const std::string& flag,
 }
 
 void OptionsHandler::enableOutputTag(CVC5_UNUSED const std::string& flag,
-                                     OutputTag optarg) const
+                                     const OutputTag optarg) const
 {
-  size_t tagid = static_cast<size_t>(optarg);
+  const size_t tagid = static_cast<size_t>(optarg);
   Assert(d_options->base.outputTagHolder.size() > tagid)
       << "Output tag is larger than the bitset that holds it.";
   d_options->write_base().outputTagHolder.set(tagid);
@@ -277,7 +278,7 @@ void OptionsHandler::setResourceWeight(CVC5_UNUSED const std::string& flag,
 }
 
 void OptionsHandler::checkBvSatSolver(const std::string& flag,
-                                      BvSatSolverMode m) const
+                                      const BvSatSolverMode m) const
 {
   if (m == BvSatSolverMode::CRYPTOMINISAT
       && !Configuration::isBuiltWithCryptominisat())
@@ -305,23 +306,10 @@ void OptionsHandler::checkBvSatSolver(const std::string& flag,
     if (d_options->bv.bitblastMode == options::BitblastMode::LAZY
         && d_options->bv.bitblastModeWasSetByUser)
     {
-      std::string sat_solver;
-      if (m == options::BvSatSolverMode::CADICAL)
-      {
-        sat_solver = "CaDiCaL";
-      }
-      else if (m == options::BvSatSolverMode::KISSAT)
-      {
-        sat_solver = "Kissat";
-      }
-      else
-      {
-        Assert(m == options::BvSatSolverMode::CRYPTOMINISAT);
-        sat_solver = "CryptoMiniSat";
-      }
-      throw OptionException(sat_solver
-                            + " does not support lazy bit-blasting.\n"
-                            + "Try --bv-sat-solver=minisat");
+      std::stringstream ss;
+      ss << m << " does not support lazy bit-blasting." << std::endl
+         << "Try --bv-sat-solver=minisat";
+      throw OptionException(ss.str());
     }
     if (!d_options->bv.bitvectorToBoolWasSetByUser)
     {
@@ -346,7 +334,7 @@ void print_config_cond(std::ostream& out, const char* str, bool cond = false)
 }  // namespace
 
 void OptionsHandler::showConfiguration(CVC5_UNUSED const std::string& flag,
-                                       bool value) const
+                                       const bool value) const
 {
   if (!value) return;
   std::ostream& o = d_options->base.out;
@@ -392,21 +380,21 @@ void OptionsHandler::showConfiguration(CVC5_UNUSED const std::string& flag,
 }
 
 void OptionsHandler::showCopyright(CVC5_UNUSED const std::string& flag,
-                                   bool value) const
+                                   const bool value) const
 {
   if (!value) return;
   d_options->base.out << Configuration::copyright() << std::endl;
 }
 
 void OptionsHandler::showVersion(CVC5_UNUSED const std::string& flag,
-                                 bool value) const
+                                 const bool value) const
 {
   if (!value) return;
   d_options->base.out << Configuration::aboutAndCopyright() << std::endl;
 }
 
 void OptionsHandler::showTraceTags(CVC5_UNUSED const std::string& flag,
-                                   bool value) const
+                                   const bool value) const
 {
   if (!value) return;
   if (!Configuration::isTracingBuild())
@@ -417,7 +405,7 @@ void OptionsHandler::showTraceTags(CVC5_UNUSED const std::string& flag,
 }
 
 void OptionsHandler::strictParsing(CVC5_UNUSED const std::string& flag,
-                                   bool value) const
+                                   const bool value) const
 {
   if (value)
   {

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -105,14 +105,14 @@ std::vector<std::string> selectTags(const std::vector<std::string>& validTags,
 OptionsHandler::OptionsHandler(Options* options) : d_options(options) {}
 
 void OptionsHandler::setErrStream(CVC5_UNUSED const std::string& flag,
-                                  const ManagedErr& me)
+                                  const ManagedErr& me) const
 {
   Warning.setStream(me);
   TraceChannel.setStream(me);
 }
 
 Language OptionsHandler::stringToLanguage(const std::string& flag,
-                                          const std::string& optarg)
+                                          const std::string& optarg) const
 {
   if (optarg == "help")
   {
@@ -145,7 +145,8 @@ Languages currently supported as arguments to the --output-lang option:
   Unreachable();
 }
 
-void OptionsHandler::setInputLanguage(const std::string& flag, Language lang)
+void OptionsHandler::setInputLanguage(const std::string& flag,
+                                      Language lang) const
 {
   if (lang == Language::LANG_AST)
   {
@@ -159,7 +160,7 @@ void OptionsHandler::setInputLanguage(const std::string& flag, Language lang)
 }
 
 void OptionsHandler::setVerbosity(CVC5_UNUSED const std::string& flag,
-                                  int value)
+                                  int value) const
 {
   if (Configuration::isMuzzledBuild())
   {
@@ -193,7 +194,7 @@ void OptionsHandler::increaseVerbosity(CVC5_UNUSED const std::string& flag,
   setVerbosity(flag, d_options->base.verbosity);
 }
 
-void OptionsHandler::setStats(CVC5_UNUSED const std::string& flag, bool value)
+void OptionsHandler::setStats(CVC5_UNUSED const std::string& flag, bool value) const
 {
 #ifndef CVC5_STATISTICS_ON
   if (value)
@@ -214,7 +215,7 @@ void OptionsHandler::setStats(CVC5_UNUSED const std::string& flag, bool value)
 }
 
 void OptionsHandler::setStatsDetail(CVC5_UNUSED const std::string& flag,
-                                    bool value)
+                                    bool value) const
 {
 #ifndef CVC5_STATISTICS_ON
   if (value)
@@ -233,7 +234,7 @@ void OptionsHandler::setStatsDetail(CVC5_UNUSED const std::string& flag,
 }
 
 void OptionsHandler::enableTraceTag(CVC5_UNUSED const std::string& flag,
-                                    const std::string& optarg)
+                                    const std::string& optarg) const
 {
   if (!Configuration::isTracingBuild())
   {
@@ -261,7 +262,7 @@ void OptionsHandler::enableTraceTag(CVC5_UNUSED const std::string& flag,
 }
 
 void OptionsHandler::enableOutputTag(CVC5_UNUSED const std::string& flag,
-                                     OutputTag optarg)
+                                     OutputTag optarg) const
 {
   size_t tagid = static_cast<size_t>(optarg);
   Assert(d_options->base.outputTagHolder.size() > tagid)
@@ -270,13 +271,13 @@ void OptionsHandler::enableOutputTag(CVC5_UNUSED const std::string& flag,
 }
 
 void OptionsHandler::setResourceWeight(CVC5_UNUSED const std::string& flag,
-                                       const std::string& optarg)
+                                       const std::string& optarg) const
 {
   d_options->write_base().resourceWeightHolder.emplace_back(optarg);
 }
 
 void OptionsHandler::checkBvSatSolver(const std::string& flag,
-                                      BvSatSolverMode m)
+                                      BvSatSolverMode m) const
 {
   if (m == BvSatSolverMode::CRYPTOMINISAT
       && !Configuration::isBuiltWithCryptominisat())
@@ -345,7 +346,7 @@ void print_config_cond(std::ostream& out, const char* str, bool cond = false)
 }  // namespace
 
 void OptionsHandler::showConfiguration(CVC5_UNUSED const std::string& flag,
-                                       bool value)
+                                       bool value) const
 {
   if (!value) return;
   std::ostream& o = d_options->base.out;
@@ -391,21 +392,21 @@ void OptionsHandler::showConfiguration(CVC5_UNUSED const std::string& flag,
 }
 
 void OptionsHandler::showCopyright(CVC5_UNUSED const std::string& flag,
-                                   bool value)
+                                   bool value) const
 {
   if (!value) return;
   d_options->base.out << Configuration::copyright() << std::endl;
 }
 
 void OptionsHandler::showVersion(CVC5_UNUSED const std::string& flag,
-                                 bool value)
+                                 bool value) const
 {
   if (!value) return;
   d_options->base.out << Configuration::aboutAndCopyright() << std::endl;
 }
 
 void OptionsHandler::showTraceTags(CVC5_UNUSED const std::string& flag,
-                                   bool value)
+                                   bool value) const
 {
   if (!value) return;
   if (!Configuration::isTracingBuild())
@@ -416,7 +417,7 @@ void OptionsHandler::showTraceTags(CVC5_UNUSED const std::string& flag,
 }
 
 void OptionsHandler::strictParsing(CVC5_UNUSED const std::string& flag,
-                                   bool value)
+                                   bool value) const
 {
   if (value)
   {

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -329,20 +329,20 @@ void OptionsHandler::checkBvSatSolver(const std::string& flag,
   }
 }
 
-static void print_config(std::ostream& out, const char* str, std::string config)
+namespace {
+void print_config(std::ostream& out, const char* str, const std::string& config)
 {
   std::string s(str);
-  unsigned sz = 14;
+  constexpr unsigned sz = 14;
   if (s.size() < sz) s.resize(sz, ' ');
   out << s << ": " << config << std::endl;
 }
 
-static void print_config_cond(std::ostream& out,
-                              const char* str,
-                              bool cond = false)
+void print_config_cond(std::ostream& out, const char* str, bool cond = false)
 {
   print_config(out, str, cond ? "yes" : "no");
 }
+}  // namespace
 
 void OptionsHandler::showConfiguration(CVC5_UNUSED const std::string& flag,
                                        bool value)

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -370,8 +370,8 @@ void OptionsHandler::showConfiguration(CVC5_UNUSED const std::string& flag,
 
   print_config_cond(o, "cln", Configuration::isBuiltWithCln());
   print_config_cond(o, "glpk", Configuration::isBuiltWithGlpk());
-  print_config_cond(o, "cryptominisat",
-    Configuration::isBuiltWithCryptominisat());
+  print_config_cond(
+      o, "cryptominisat", Configuration::isBuiltWithCryptominisat());
   print_config_cond(o, "gmp", Configuration::isBuiltWithGmp());
   print_config_cond(o, "kissat", Configuration::isBuiltWithKissat());
   print_config_cond(o, "poly", Configuration::isBuiltWithPoly());

--- a/src/options/options_handler.h
+++ b/src/options/options_handler.h
@@ -73,7 +73,8 @@ class OptionsHandler
   void setErrStream(const std::string& flag, const ManagedErr& me) const;
 
   /** Convert option value to Language enum */
-  Language stringToLanguage(const std::string& flag, const std::string& optarg) const;
+  Language stringToLanguage(const std::string& flag,
+                            const std::string& optarg) const;
   /** Set the input language. Check that lang is not LANG_AST */
   void setInputLanguage(const std::string& flag, Language lang) const;
   /** Apply verbosity to the different output channels */
@@ -91,7 +92,8 @@ class OptionsHandler
   /** Enable a particular output tag */
   void enableOutputTag(const std::string& flag, OutputTag optarg) const;
   /** Pass the resource weight specification to the resource manager */
-  void setResourceWeight(const std::string& flag, const std::string& optarg) const;
+  void setResourceWeight(const std::string& flag,
+                         const std::string& optarg) const;
 
   /******************************* bv options *******************************/
 

--- a/src/options/options_handler.h
+++ b/src/options/options_handler.h
@@ -41,10 +41,10 @@ namespace options {
 class OptionsHandler
 {
  public:
-  OptionsHandler(Options* options);
+  explicit OptionsHandler(Options* options);
 
   template <typename T>
-  void checkMinimum(const std::string& flag, T value, T minimum) const
+  static void checkMinimum(const std::string& flag, T value, T minimum)
   {
     if (value < minimum)
     {
@@ -56,7 +56,7 @@ class OptionsHandler
     }
   }
   template <typename T>
-  void checkMaximum(const std::string& flag, T value, T maximum) const
+  static void checkMaximum(const std::string& flag, T value, T maximum)
   {
     if (value > maximum)
     {
@@ -70,50 +70,50 @@ class OptionsHandler
 
   /******************************* base options *******************************/
   /** Apply the error output stream to the different output channels */
-  void setErrStream(const std::string& flag, const ManagedErr& me);
+  void setErrStream(const std::string& flag, const ManagedErr& me) const;
 
   /** Convert option value to Language enum */
-  Language stringToLanguage(const std::string& flag, const std::string& optarg);
+  Language stringToLanguage(const std::string& flag, const std::string& optarg) const;
   /** Set the input language. Check that lang is not LANG_AST */
-  void setInputLanguage(const std::string& flag, Language lang);
+  void setInputLanguage(const std::string& flag, Language lang) const;
   /** Apply verbosity to the different output channels */
-  void setVerbosity(const std::string& flag, int value);
+  void setVerbosity(const std::string& flag, int value) const;
   /** Decrease verbosity and call setVerbosity */
   void decreaseVerbosity(const std::string& flag, bool value);
   /** Increase verbosity and call setVerbosity */
   void increaseVerbosity(const std::string& flag, bool value);
   /** If statistics are disabled, disable statistics sub-options */
-  void setStats(const std::string& flag, bool value);
+  void setStats(const std::string& flag, bool value) const;
   /** If statistics sub-option is disabled, enable statistics */
-  void setStatsDetail(const std::string& flag, bool value);
+  void setStatsDetail(const std::string& flag, bool value) const;
   /** Enable a particular trace tag */
-  void enableTraceTag(const std::string& flag, const std::string& optarg);
+  void enableTraceTag(const std::string& flag, const std::string& optarg) const;
   /** Enable a particular output tag */
-  void enableOutputTag(const std::string& flag, OutputTag optarg);
+  void enableOutputTag(const std::string& flag, OutputTag optarg) const;
   /** Pass the resource weight specification to the resource manager */
-  void setResourceWeight(const std::string& flag, const std::string& optarg);
+  void setResourceWeight(const std::string& flag, const std::string& optarg) const;
 
   /******************************* bv options *******************************/
 
   /** Check that the sat solver mode is compatible with other bv options */
-  void checkBvSatSolver(const std::string& flag, BvSatSolverMode m);
+  void checkBvSatSolver(const std::string& flag, BvSatSolverMode m) const;
 
   /******************************* main options *******************************/
   /** Show the solver build configuration and exit */
-  void showConfiguration(const std::string& flag, bool value);
+  void showConfiguration(const std::string& flag, bool value) const;
   /** Show copyright information and exit */
-  void showCopyright(const std::string& flag, bool value);
+  void showCopyright(const std::string& flag, bool value) const;
   /** Show version information and exit */
-  void showVersion(const std::string& flag, bool value);
+  void showVersion(const std::string& flag, bool value) const;
   /** Show all trace tags and exit */
-  void showTraceTags(const std::string& flag, bool value);
+  void showTraceTags(const std::string& flag, bool value) const;
 
   /***************************** parser options *******************************/
-  void strictParsing(const std::string& flag, bool value);
+  void strictParsing(const std::string& flag, bool value) const;
 
  private:
   /** Pointer to the containing Options object.*/
-  Options* d_options;
+  Options* const d_options;
 }; /* class OptionHandler */
 
 }  // namespace options

--- a/test/regress/cli/regress0/options/version.smt2
+++ b/test/regress/cli/regress0/options/version.smt2
@@ -1,3 +1,3 @@
 ; COMMAND-LINE: --version
-; EXPECT: This is cvc5 version
-; SCRUBBER: grep -o "This is cvc5 version"
+; EXPECT: 1
+; SCRUBBER: grep -E "^cvc5 [0-9]+\.[0-9]+\.[0-9]+" | wc -l

--- a/test/unit/util/configuration_black.cpp
+++ b/test/unit/util/configuration_black.cpp
@@ -85,8 +85,10 @@ TEST_F(TestUtilBlackConfiguration, versions)
 
 TEST_F(TestUtilBlackConfiguration, about)
 {
-  // just test that the function exists
+  // just test that the functions exists
   Configuration::about();
+  Configuration::copyright();
+  Configuration::aboutAndCopyright();
 }
 }  // namespace test
 }  // namespace cvc5::internal


### PR DESCRIPTION
Aligns the about printing for both `--version` and `-v`.
Also updates `--show-config` to avoid printing the copyright and removed duplicated version printing.
Add const to `OptionsHandler`.