### PR TITLE
Enable all default clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,14 +1,7 @@
 Checks: >
-  -*,
-  clang-analyzer-core.CallAndMessage,
-  clang-analyzer-core.uninitialized.Assign,
-  clang-analyzer-core.uninitialized.UndefReturn,
-  clang-analyzer-cplusplus.Move,
-  clang-analyzer-deadcode.*,
-  clang-analyzer-optin.cplusplus.UninitializedObject,
-  clang-analyzer-optin.cplusplus.VirtualCall,
-  clang-analyzer-optin.performance.*,
-  clang-analyzer-unix.*
+  # Default checks enabled by clang-tidy (explicitly listed):
+  clang-diagnostic-*,
+  clang-analyzer-*
 HeaderFilterRegex: '.*'
 # Use .clang-format for formatting changes
 FormatStyle: file


### PR DESCRIPTION
This enables all default clang-tidy checks, covering all previously enabled checks plus some additional ones for which no issues were detected.