### PR TITLE
Use __clang_analyzer__ to define DebugUnhandled macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,10 +501,6 @@ else()
   add_definitions(-DNDEBUG)
 endif()
 
-if(ENABLE_CLANG_TIDY)
-  add_definitions(-DCVC5_STATIC_ANALYSIS)
-endif()
-
 if(ENABLE_COVERAGE)
   include(CodeCoverage)
   append_coverage_compiler_flags()

--- a/src/base/check.h
+++ b/src/base/check.h
@@ -125,11 +125,11 @@ class OstreamVoider
   CVC5_FATAL_IF(false, __PRETTY_FUNCTION__, __FILE__, __LINE__)
 #endif
 
-// DebugUnhandled() logs an error and aborts if CVC5_ASSERTIONS is set but
-// CVC5_STATIC_ANALYSIS is not. Otherwise, it does nothing.
-// Allows static analyzers to follow production control flow but
-// fail during debugging.
-#ifdef CVC5_STATIC_ANALYSIS
+// DebugUnhandled() triggers an assertion failure (when CVC5_ASSERTIONS is
+// enabled) to flag potential unhandled code paths. When running under
+// the Clang Static Analyzer, it becomes a no-op so the analyzer can continue
+// exploring the production control flow.
+#if defined(__clang_analyzer__)
 #define DebugUnhandled() Assert(true)
 #else
 #define DebugUnhandled() Assert(false)


### PR DESCRIPTION
Using the preprocessor macro `__clang_analyzer__` is a more robust solution because it allows `clang-tidy` to be run on the codebase not only during the build (by passing `--clang-tidy` to `./configure.sh`) but also after the code has been built without that option.