### PR TITLE
[proofs] [alethe] Fixes to ABSORB translation

### DIFF
--- a/src/proof/alethe/alethe_post_processor.cpp
+++ b/src/proof/alethe/alethe_post_processor.cpp
@@ -556,10 +556,11 @@ bool AletheProofPostprocessCallback::update(Node res,
       std::map<Node, Node> emptyMap;
       Node t = res[0];
       Node tf = applyAcSimp(d_env, emptyMap, t);
-      Kind k = res.getKind();
+      Kind k = t.getKind();
       // if the simplification did not result in a term that would simplify to
       // the expected constant, abort. For this the kind of tf must be the same
-      // as of t and one of its arguments must be res[1].
+      // as of t and one of its arguments must be res[1] (the absorbing
+      // constant).
       bool success = false;
       for (const Node& ch : tf)
       {
@@ -569,19 +570,20 @@ bool AletheProofPostprocessCallback::update(Node res,
           break;
         }
       }
-      if (!success || k != tf.getKind())
+      if (!success || k != tf.getKind() || (k != Kind::OR && k != Kind::AND))
       {
-        return addAletheStep(AletheRule::HOLE,
-                             res,
-                             nm->mkNode(Kind::SEXPR, d_cl, res),
-                             {},
-                             {},
-                             *cdp);
+        return addAletheStep(
+            AletheRule::HOLE,
+            res,
+            nm->mkNode(Kind::SEXPR, d_cl, res),
+            {},
+            {nm->mkRawSymbol("\"failed absorb\"", nm->sExprType())},
+            *cdp);
       }
       Node vp1 = nm->mkNode(Kind::EQUAL, t, tf);
       Node vp2 = nm->mkNode(Kind::EQUAL, tf, res[1]);
       // if the kind was not one of these, the simplification above would have failed
-      Assert(k == Kind::OR || k == Kind::AND);
+      Assert(k == Kind::OR || k == Kind::AND) << "Kind is " << k;
       AletheRule rule =
           k == Kind::OR ? AletheRule::OR_SIMPLIFY : AletheRule::AND_SIMPLIFY;
       return addAletheStep(AletheRule::AC_SIMP,

--- a/src/proof/alethe/alethe_post_processor_algorithm.cpp
+++ b/src/proof/alethe/alethe_post_processor_algorithm.cpp
@@ -36,16 +36,6 @@ Node applyAcSimp(Env& env, std::map<Node, Node>& cache, Node term)
   {
     return term;
   }
-  if (term.getMetaKind() == metakind::PARAMETERIZED)
-  {
-    // not supported
-    Trace("alethe-proof") << "... reached a parameterized operator during "
-                             "flattening the term which is not supported. Will "
-                             "not flatten any subterm of the current term "
-                          << term << "\n";
-    return term;
-  }
-
   Kind k = term.getKind();
   Node ac_term;
   std::vector<Node> ac_children;
@@ -86,13 +76,13 @@ Node applyAcSimp(Env& env, std::map<Node, Node>& cache, Node term)
   }
   else
   {
+    if (term.getMetaKind() == metakind::PARAMETERIZED)
+    {
+      ac_children.push_back(applyAcSimp(env, cache, term.getOperator()));
+    }
     for (const Node& child : term)
     {
       ac_children.push_back(applyAcSimp(env, cache, child));
-    }
-    if (k == Kind::APPLY_UF)
-    {
-      ac_children.insert(ac_children.begin(), term.getOperator());
     }
     ac_term = nm->mkNode(k, ac_children);
   }


### PR DESCRIPTION
Previously the translation was not considering cases where subterms were applications of parameterized operators, which was not a needed restriction.

There was also a bug with the term to get kind from.

These changes were tested on a branch where cvc5 is expected to produce non-holey Alethe proofs from non-holey CPC proofs for UFLIRA and in the cvc5 regressions no issues were found.