### PR TITLE
[proofs] [alethe] Translate ACI_NORM

### DIFF
--- a/src/proof/alethe/alethe_post_processor.cpp
+++ b/src/proof/alethe/alethe_post_processor.cpp
@@ -2557,6 +2557,15 @@ bool AletheProofPostprocessCallback::update(Node res,
       }
       return success;
     }
+    case ProofRule::ACI_NORM:
+    {
+      return addAletheStep(AletheRule::ACI_SIMP,
+                           res,
+                           nm->mkNode(Kind::SEXPR, d_cl, res),
+                           {},
+                           {},
+                           *cdp);
+    }
     default:
     {
       Trace("alethe-proof")

--- a/src/proof/alethe/alethe_proof_rule.cpp
+++ b/src/proof/alethe/alethe_proof_rule.cpp
@@ -119,6 +119,7 @@ const char* aletheRuleToString(AletheRule id)
     case AletheRule::SKO_EX: return "sko_ex";
     case AletheRule::SKO_FORALL: return "sko_forall";
     case AletheRule::ALL_SIMPLIFY: return "all_simplify";
+    case AletheRule::ACI_SIMP: return "aci_simp";
     case AletheRule::RARE_REWRITE: return "rare_rewrite";
     case AletheRule::SYMM: return "symm";
     case AletheRule::NOT_SYMM: return "not_symm";

--- a/src/proof/alethe/alethe_proof_rule.h
+++ b/src/proof/alethe/alethe_proof_rule.h
@@ -394,6 +394,8 @@ enum class AletheRule : uint32_t
   NARY_ELIM,
   QNT_SIMPLIFY,
   ALL_SIMPLIFY,
+  // Simplifications based on AC, identity, duplicates
+  ACI_SIMP,
   RARE_REWRITE,
   // ======== let
   // G,x1->F1,...,xn->Fn > j. (= G G')


### PR DESCRIPTION
Uses the new Alethe rule `aci_simp`.

These changes were tested on a branch where cvc5 is expected to produce non-holey Alethe proofs from non-holey CPC proofs for UFLIRA and in the cvc5 regressions no issues were found.