### PR TITLE
bv-to-int: allow quantifiers and UFs as long as the output sort of the UF is not a bit-vector

### DIFF
--- a/src/theory/bv/int_blaster.cpp
+++ b/src/theory/bv/int_blaster.cpp
@@ -1060,8 +1060,13 @@ Node IntBlaster::translateQuantifiedFormula(Node quantifiedNode)
   // that involve quantified variables
   std::unordered_set<Node> applys;
   expr::getKindSubterms(quantifiedNode[1], Kind::APPLY_UF, true, applys);
-  if (applys.size() > 0) {
-     throw LogicException("bv-to-int does not support the combination of quantifiers and uninterpreted functions");
+  for (const Node& apply : applys) {
+    Node f = apply.getOperator();
+    TypeNode range = f.getType().getRangeType();
+    if (range.isBitVector())
+    {
+      throw LogicException("bv-to-int does not support the combination of quantifiers and uninterpreted functions that return bit-vectors");
+    }
   }
 
   // the body of the quantifier

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2688,6 +2688,8 @@ set(regress_1_tests
   regress1/bv/bug_extract_mult_leading_bit.smt2
   regress1/bv/bv_to_int_10084.smt2
   regress1/bv/bv_to_int_10084_forall.smt2
+  regress1/bv/bv_to_int_quant_uf_bv.smt2
+  regress1/bv/bv_to_int_quant_uf_nobv.smt2
   regress1/bv/bv-int-collapse2-sat.smt2
   regress1/bv/bv-proof00.smtv1.smt2
   regress1/bv/bv2nat-ground.smt2

--- a/test/regress/cli/regress1/bv/bv_to_int_10084_forall.smt2
+++ b/test/regress/cli/regress1/bv/bv_to_int_10084_forall.smt2
@@ -1,7 +1,5 @@
 ; COMMAND-LINE: --solve-bv-as-int=iand
-; EXPECT:
-; SCRUBBER: grep -v "uninterpreted"
-; EXIT: 1
+; EXPECT: unsat
 
 ;; produced by cvc4_16.drv ;;
 (set-logic AUFBVFPDTNIRA)

--- a/test/regress/cli/regress1/bv/bv_to_int_quant_uf_bv.smt2
+++ b/test/regress/cli/regress1/bv/bv_to_int_quant_uf_bv.smt2
@@ -1,0 +1,9 @@
+; COMMAND-LINE: --solve-bv-as-int=iand --finite-model-find
+; EXPECT:
+; SCRUBBER: grep -v "uninterpreted"
+; EXIT: 1
+(set-logic UFBV)
+(declare-sort S 0)
+(declare-fun f (S) (_ BitVec 16))
+(assert (forall ((x S) (y S)) (= (f x) (f y))))
+(check-sat)

--- a/test/regress/cli/regress1/bv/bv_to_int_quant_uf_nobv.smt2
+++ b/test/regress/cli/regress1/bv/bv_to_int_quant_uf_nobv.smt2
@@ -1,0 +1,7 @@
+; COMMAND-LINE: --solve-bv-as-int=iand --finite-model-find
+; EXPECT: sat
+(set-logic UFBV)
+(declare-sort S 0)
+(declare-fun f ((_ BitVec 16)) S)
+(assert (forall ((x (_ BitVec 16)) (y (_ BitVec 16))) (= (f x) (f y))))
+(check-sat)


### PR DESCRIPTION
Int-blasting currently does not support quantified variables under UF applications (see #12346).
However, this restriction can be relaxed, by allowing quantified variables under UF applications, as long as the output sort of the UF is not a BV sort.
This PR performs this relaxation, and includes two tests that clarify the difference between the cases.