### PR TITLE
Promote conflict-based instantiation to common option

### DIFF
--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -786,7 +786,7 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "conflictBasedInst"
-  category   = "regular"
+  category   = "common"
   long       = "cbqi"
   type       = "bool"
   default    = "true"


### PR DESCRIPTION
A number of large use cases of cvc5 require `--no-cbqi`.