### PR TITLE
Set SOVERSION to cvc5 major version number

### DIFF
--- a/cmake/version-base.cmake
+++ b/cmake/version-base.cmake
@@ -6,10 +6,13 @@ set(CVC5_IS_RELEASE "false")
 # If possible, they are updated by version.cmake
 set(GIT_BUILD "false")
 set(CVC5_VERSION "${CVC5_LAST_RELEASE}")
+set(CVC5_VERSION_NUMBER "${CVC5_LAST_RELEASE}")
 set(CVC5_FULL_VERSION "${CVC5_LAST_RELEASE}")
 set(CVC5_WHEEL_VERSION "${CVC5_LAST_RELEASE}")
 set(CVC5_MAVEN_VERSION "${CVC5_LAST_RELEASE}")
 set(CVC5_GIT_INFO "")
 
-# Shared library versioning. Increment SOVERSION for every new cvc5 release.
-set(CVC5_SOVERSION 1)
+# Shared library versioning: extract and use the major version.
+# This assumes the cvc5 major version is incremented whenever
+# API/ABI compatibility is broken.
+string(REGEX MATCH "^[0-9]+" CVC5_SOVERSION "${CVC5_LAST_RELEASE}")

--- a/cmake/version-base.cmake.template
+++ b/cmake/version-base.cmake.template
@@ -6,10 +6,13 @@ set(CVC5_IS_RELEASE "{{IS_RELEASE}}")
 # If possible, they are updated by version.cmake
 set(GIT_BUILD "false")
 set(CVC5_VERSION "${CVC5_LAST_RELEASE}")
+set(CVC5_VERSION_NUMBER "${CVC5_LAST_RELEASE}")
 set(CVC5_FULL_VERSION "${CVC5_LAST_RELEASE}")
 set(CVC5_WHEEL_VERSION "${CVC5_LAST_RELEASE}")
 set(CVC5_MAVEN_VERSION "${CVC5_LAST_RELEASE}")
 set(CVC5_GIT_INFO "")
 
-# Shared library versioning. Increment SOVERSION for every new cvc5 release.
-set(CVC5_SOVERSION 1)
+# Shared library versioning: extract and use the major version.
+# This assumes the cvc5 major version is incremented whenever
+# API/ABI compatibility is broken.
+string(REGEX MATCH "^[0-9]+" CVC5_SOVERSION "${CVC5_LAST_RELEASE}")

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -58,6 +58,9 @@ if(CVC5_IS_RELEASE STREQUAL "false")
   endwhile()
 
   set(CVC5_VERSION "${NEXT_CVC5_VERSION}.dev")
+  set(CVC5_VERSION_NUMBER "${NEXT_CVC5_VERSION}")
+  # Set SOVERSION to cvc5 major version number
+  string(REGEX MATCH "^[0-9]+" CVC5_SOVERSION "${NEXT_CVC5_VERSION}")
   set(CVC5_FULL_VERSION "${NEXT_CVC5_VERSION}.dev")
   # Python: Development segment MUST follow the format devN, where N is a sequence of digits.
   set(CVC5_WHEEL_VERSION "${NEXT_CVC5_VERSION}.dev0")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1525,7 +1525,8 @@ if(NOT SKIP_SET_RPATH AND BUILD_SHARED_LIBS AND APPLE)
 endif()
 
 if(BUILD_SHARED_LIBS)
-  set_target_properties(cvc5 PROPERTIES SOVERSION ${CVC5_SOVERSION})
+  set_target_properties(cvc5 PROPERTIES
+    VERSION ${CVC5_VERSION_NUMBER} SOVERSION ${CVC5_SOVERSION})
 endif()
 
 include(GenerateExportHeader)

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -81,7 +81,8 @@ add_library(cvc5parser
   $<TARGET_OBJECTS:cvc5parserapi-objs>
 )
 if(BUILD_SHARED_LIBS)
-  set_target_properties(cvc5parser PROPERTIES SOVERSION ${CVC5_SOVERSION})
+  set_target_properties(cvc5parser PROPERTIES
+    VERSION ${CVC5_VERSION_NUMBER} SOVERSION ${CVC5_SOVERSION})
 endif()
 
 set_target_properties(cvc5parser PROPERTIES OUTPUT_NAME cvc5parser)


### PR DESCRIPTION
This change modifies the CMake file to automatically set SOVERSION to the cvc5 major version number instead of updating it manually. This aligns with the convention of incrementing the project's major version whenever breaking API/ABI changes are introduced.

It also sets the VERSION property of the shared library targets to ensure that versioned shared libraries are generated on Unix systems.