### PR TITLE
Updating the documentation of --arrays-exp

### DIFF
--- a/src/options/arrays_options.toml
+++ b/src/options/arrays_options.toml
@@ -55,5 +55,5 @@ name   = "Arrays Theory"
   long       = "arrays-exp"
   type       = "bool"
   default    = "false"
-  help       = "enable experimental features in the theory of arrays"
+  help       = "use a theory of arrays that includes constant arrays, and other experimental features"
 


### PR DESCRIPTION
Making explicit the fact that it changes the underlying theory to a theory in which constant arrays exist.