### PR TITLE
Accept option values with quotes

### DIFF
--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -926,16 +926,7 @@ cdef class DatatypeSelector:
 # ----------------------------------------------------------------------------
 
 cdef class Op:
-    """
-        A cvc5 operator.
-
-        An operator is a term that represents certain operators,
-        instantiated with its required parameters, e.g.,
-        a term of kind
-        :py:obj:`BITVECTOR_EXTRACT <Kind.BITVECTOR_EXTRACT>`.
-
-        Wrapper class for :cpp:class:`cvc5::Op`.
-    """
+    """Wrapper class for :cpp:class:`cvc5::api::Op`."""
     cdef c_Op cop
     cdef TermManager tm
 
@@ -959,10 +950,10 @@ cdef class Op:
 
     def getKind(self):
         """
-            :return: The kind of this operator.
+            :return: the kind of this operator.
         """
-        return Kind(<int> self.cop.getKind())
-
+        return kind(<int> self.cop.getKind())
+    
     def isIndexed(self):
         """
             :return: True iff this operator is indexed.

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -926,7 +926,16 @@ cdef class DatatypeSelector:
 # ----------------------------------------------------------------------------
 
 cdef class Op:
-    """Wrapper class for :cpp:class:`cvc5::api::Op`."""
+    """
+        A cvc5 operator.
+
+        An operator is a term that represents certain operators,
+        instantiated with its required parameters, e.g.,
+        a term of kind
+        :py:obj:`BITVECTOR_EXTRACT <Kind.BITVECTOR_EXTRACT>`.
+
+        Wrapper class for :cpp:class:`cvc5::Op`.
+    """
     cdef c_Op cop
     cdef TermManager tm
 
@@ -950,10 +959,10 @@ cdef class Op:
 
     def getKind(self):
         """
-            :return: the kind of this operator.
+            :return: The kind of this operator.
         """
-        return kind(<int> self.cop.getKind())
-    
+        return Kind(<int> self.cop.getKind())
+
     def isIndexed(self):
         """
             :return: True iff this operator is indexed.

--- a/src/parser/smt2/smt2_cmd_parser.cpp
+++ b/src/parser/smt2/smt2_cmd_parser.cpp
@@ -877,7 +877,7 @@ std::unique_ptr<Cmd> Smt2CmdParser::parseNextCommand()
       std::string key = d_tparser.parseKeyword();
       Term sexpr = d_tparser.parseSymbolicExpr();
       std::string ss = sexprToString(sexpr);
-      // If the value is a quoted string, strip the quotes. 
+      // If the value is a quoted string, strip the quotes.
       if (ss.size() >= 2 && ss[0] == '"' && ss[ss.size() - 1] == '"')
       {
         ss = d_state.stripQuotes(ss);

--- a/src/parser/smt2/smt2_cmd_parser.cpp
+++ b/src/parser/smt2/smt2_cmd_parser.cpp
@@ -877,8 +877,7 @@ std::unique_ptr<Cmd> Smt2CmdParser::parseNextCommand()
       std::string key = d_tparser.parseKeyword();
       Term sexpr = d_tparser.parseSymbolicExpr();
       std::string ss = sexprToString(sexpr);
-      // If the value is a quoted string, strip the quotes. This allows e.g.
-      // `(set-option :solve-bv-as-int "sum")` to be treated as `sum`.
+      // If the value is a quoted string, strip the quotes. 
       if (ss.size() >= 2 && ss[0] == '"' && ss[ss.size() - 1] == '"')
       {
         ss = d_state.stripQuotes(ss);

--- a/src/parser/smt2/smt2_cmd_parser.cpp
+++ b/src/parser/smt2/smt2_cmd_parser.cpp
@@ -877,16 +877,13 @@ std::unique_ptr<Cmd> Smt2CmdParser::parseNextCommand()
       std::string key = d_tparser.parseKeyword();
       Term sexpr = d_tparser.parseSymbolicExpr();
       std::string ss = sexprToString(sexpr);
-      // special case: for channel settings, we are expected to parse e.g.
-      // `"stdin"` which should be treated as `stdin`
-      // Note we could consider a more general solution where knowing whether
-      // this special case holds can be queried via OptionInfo.
-      if (key == "diagnostic-output-channel" || key == "regular-output-channel"
-          || key == "in" || key == "out")
+      // If the value is a quoted string, strip the quotes. This allows e.g.
+      // `(set-option :solve-bv-as-int "sum")` to be treated as `sum`.
+      if (ss.size() >= 2 && ss[0] == '"' && ss[ss.size() - 1] == '"')
       {
         ss = d_state.stripQuotes(ss);
       }
-      else if (key=="use-portfolio")
+      if (key=="use-portfolio")
       {
         // we don't allow setting portfolio via the command line
         d_lex.parseError("Can only enable use-portfolio via the command line");

--- a/src/parser/smt2/smt2_cmd_parser.cpp
+++ b/src/parser/smt2/smt2_cmd_parser.cpp
@@ -880,7 +880,7 @@ std::unique_ptr<Cmd> Smt2CmdParser::parseNextCommand()
       // If the value is a quoted string, strip the quotes. 
       if (ss.size() >= 2 && ss[0] == '"' && ss[ss.size() - 1] == '"')
       {
-        ss = ss.substr(1, ss.size() - 2);
+        ss = d_state.stripQuotes(ss);
       }
       if (key=="use-portfolio")
       {

--- a/src/parser/smt2/smt2_cmd_parser.cpp
+++ b/src/parser/smt2/smt2_cmd_parser.cpp
@@ -880,7 +880,7 @@ std::unique_ptr<Cmd> Smt2CmdParser::parseNextCommand()
       // If the value is a quoted string, strip the quotes. 
       if (ss.size() >= 2 && ss[0] == '"' && ss[ss.size() - 1] == '"')
       {
-        ss = d_state.stripQuotes(ss);
+        ss = ss.substr(1, ss.size() - 2);
       }
       if (key=="use-portfolio")
       {

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1260,6 +1260,7 @@ set(regress_0_tests
   regress0/nl/very-easy-sat.smt2
   regress0/nl/very-simple-unsat.smt2
   regress0/opt-abd-no-use.smt2
+  regress0/options_quotes.smt2
   regress0/options/ast-and-sexpr.smt2
   regress0/options/didyoumean.smt2
   regress0/options/help.smt2

--- a/test/regress/cli/regress0/options_quotes.smt2
+++ b/test/regress/cli/regress0/options_quotes.smt2
@@ -1,0 +1,4 @@
+; EXPECT:
+; EXIT: 0
+(set-logic ALL)
+(set-option :solve-bv-as-int "sum")


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

According to the SMT-LIB standard, the user can wrap `val` in quotes here:
`(set-option :key val)`.

This PR makes cvc5 accept such commands.


# Explanation:
-------------

## `<option>` can be an `<attribute`>:
----------

<img width="770" height="222" alt="image" src="https://github.com/user-attachments/assets/de153f0f-7ec9-4446-b152-87cd2e08edc4" />

<img width="1148" height="736" alt="image" src="https://github.com/user-attachments/assets/1fa2aa2e-c5ba-44a9-8ce6-92defbca9b5e" />

-------------

## `<attribute-value>` can be a `<spec_constant>`, which can be any `<string>`:

----------------

<img width="1608" height="576" alt="image" src="https://github.com/user-attachments/assets/4ecff425-c279-4418-b83b-a937cadf04bf" />

<img width="840" height="264" alt="image" src="https://github.com/user-attachments/assets/f4862992-cd56-4f72-aea0-1c903fc38cf3" />

<img width="840" height="227" alt="image" src="https://github.com/user-attachments/assets/6eed83e1-ee07-4fd1-a00f-bb80ce8bec1d" />


