### PR TITLE
Give a warning if not in safe/stable mode by default

### DIFF
--- a/src/options/base_options.toml
+++ b/src/options/base_options.toml
@@ -72,9 +72,8 @@ name   = "Base"
   help       = "decrease verbosity (may be repeated)"
 
 [[option]]
-  name       = "quiteSafe"
+  name       = "quietSafe"
   category   = "common"
-  short      = "qsafe"
   long       = "quiet-safe"
   type       = "bool"
   default    = "false"

--- a/src/options/base_options.toml
+++ b/src/options/base_options.toml
@@ -72,6 +72,15 @@ name   = "Base"
   help       = "decrease verbosity (may be repeated)"
 
 [[option]]
+  name       = "quiteSafe"
+  category   = "common"
+  short      = "qsafe"
+  long       = "quiet-safe"
+  type       = "bool"
+  default    = "false"
+  help       = "do not give warnings related to safe modes"
+
+[[option]]
   name       = "incrementalSolving"
   category   = "common"
   short      = "i"

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -137,8 +137,9 @@ void SetDefaults::setDefaultsPre(Options& opts)
     if (!options().base.quietSafe)
     {
       Warning() << "This is an unrestricted build of cvc5, use at your own risk." << std::endl;
-      Warning() << "To avoid this warning, cvc5 can be built in safe or stable modes (see ./configure.sh --help)." << std::endl;
-      Warning() << "Use -q or -qsafe to silence this warning." << std::endl;
+      Warning() << "To avoid this warning, cvc5 can be built in safe or stable modes" << std::endl;
+      Warning() << "(see ./configure.sh --help), which restricts the set of available" << std::endl;
+      Warning() << "features. Use -q or --quiet-safe to silence this warning." << std::endl;
     }
   }
   else

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -132,7 +132,16 @@ void SetDefaults::setDefaults(LogicInfo& logic, Options& opts)
 void SetDefaults::setDefaultsPre(Options& opts)
 {
   // safe options
-  if (options().base.safeMode != options::SafeMode::UNRESTRICTED)
+  if (options().base.safeMode == options::SafeMode::UNRESTRICTED)
+  {
+    if (!options().base.quietSafe)
+    {
+      Warning() << "This is an unrestricted build of cvc5, use at your own risk." << std::endl;
+      Warning() << "To avoid this warning, cvc5 can be built in safe or stable modes (see ./configure.sh --help)." << std::endl;
+      Warning() << "Use -q or -qsafe to silence this warning." << std::endl;
+    }
+  }
+  else
   {
     // all "experimental" theories that are enabled by default should be
     // disabled here

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -134,7 +134,7 @@ void SetDefaults::setDefaultsPre(Options& opts)
   // safe options
   if (options().base.safeMode == options::SafeMode::UNRESTRICTED)
   {
-    if (!options().base.quietSafe)
+    if (!d_isInternalSubsolver && !options().base.quietSafe)
     {
       Warning() << "This is an unrestricted build of cvc5, use at your own risk." << std::endl;
       Warning() << "To avoid this warning, cvc5 can be built in safe or stable modes" << std::endl;

--- a/test/binary/interactive_shell_define_fun_rec_multiline.py
+++ b/test/binary/interactive_shell_define_fun_rec_multiline.py
@@ -37,6 +37,8 @@ def check_iteractive_shell_define_fun_rec_multiline():
     child = pexpect.spawn("bin/cvc5", timeout=1)
     # We expect to see the cvc5 prompt
     child.expect("cvc5> ")
+    sendline(child, "(set-option :quiet-safe true)")
+    expect_exact(child, "cvc5> ")
     sendline(child, "(set-logic ALL)")
     expect_exact(child, "cvc5> ")
     sendline(child, "(define-fun-rec")

--- a/test/binary/interactive_shell_parser_inc.py
+++ b/test/binary/interactive_shell_parser_inc.py
@@ -38,6 +38,8 @@ def check_iteractive_shell_parser_inc():
 
     # We expect to see the cvc5 prompt
     child.expect("cvc5> ")
+    sendline(child, "(set-option :quiet-safe true)")
+    expect_exact(child, "cvc5> ")
     sendline(child, "(set-logic ALL)")
     expect_exact(child, "cvc5> ")
     sendline(child,"(set-option :incremental true)")

--- a/test/regress/cli/run_regression.py
+++ b/test/regress/cli/run_regression.py
@@ -85,6 +85,10 @@ class Tester:
 
         print()
         print_info(self.name)
+        # Always disable warnings involving safe mode in all regression testers.
+        benchmark_info = benchmark_info._replace(
+            command_line_args=benchmark_info.command_line_args + ["--quiet-safe"]
+        )
         print("  Flags: {}".format(benchmark_info.command_line_args))
         return self.run_internal(benchmark_info)
 


### PR DESCRIPTION
To discuss.

Makes cvc5 give a warning if we are in an unrestricted build. This can be disabled specifically by `--quiet-safe` or more broadly via `-q`.