### PR TITLE
fixes issue with mbqi-enum + non-first class types

### DIFF
--- a/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
@@ -119,6 +119,10 @@ SygusGrammar SygusGrammarCons::mkDefaultGrammar(const Env& env,
   for (const Node& r : trulesAll)
   {
     TypeNode rt = r.getType();
+    if (!rt.isFirstClass())
+    {
+      continue;
+    }
     it = typeToNtSym.find(rt);
     if (it != typeToNtSym.end())
     {
@@ -185,10 +189,14 @@ SygusGrammar SygusGrammarCons::mkEmptyGrammar(const Env& env,
   std::unordered_set<TypeNode> types;
   for (const Node& r : trules)
   {
-    // constants don't contribute anything by themselves
-    if (!r.isConst())
+    TypeNode rt = r.getType();
+    // constants don't contribute anything by themselves. Non-first-class
+    // operators like datatype constructors/selectors/testers are added by the
+    // default grammar rules directly and should not induce their own
+    // non-terminals.
+    if (!r.isConst() && rt.isFirstClass())
     {
-      collectTypes(nm, r.getType(), types);
+      collectTypes(nm, rt, types);
     }
   }
   collectTypes(nm, range, types);

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -3164,6 +3164,7 @@ set(regress_1_tests
   regress1/quantifiers/ho-seu-sygus-inst.smt2
   regress1/quantifiers/horn-simple.smt2
   regress1/quantifiers/inst-ground-term.smt2
+  regress1/quantifiers/mbqi-enum-dtype-ops.smt2
   regress1/quantifiers/inst-max-level-segf.smt2
   regress1/quantifiers/inst-prop-simp.smt2
   regress1/quantifiers/intersection-example-onelane.proof-node22337.smt2

--- a/test/regress/cli/regress1/quantifiers/mbqi-enum-dtype-ops.smt2
+++ b/test/regress/cli/regress1/quantifiers/mbqi-enum-dtype-ops.smt2
@@ -1,0 +1,31 @@
+; COMMAND-LINE: --mbqi --mbqi-enum
+; EXPECT: unsat
+(set-logic ALL)
+
+(declare-datatypes ((struct.0 0))
+  (((mk-struct.0 (struct.0.coeffs (Array (_ BitVec 64) (_ BitVec 16)))))))
+(declare-datatypes ((struct.2 0))
+  (((mk-struct.2 (struct.2.vec (Array (_ BitVec 64) struct.0))))))
+
+(declare-fun arr () (Array (_ BitVec 64) struct.0))
+(declare-fun s2 () struct.2)
+
+(assert
+  (forall ((j (_ BitVec 32)))
+    (and
+      (= (select arr ((_ zero_extend 32) j))
+         (mk-struct.0 (struct.0.coeffs (select arr ((_ zero_extend 32) j)))))
+      (= (select (struct.2.vec s2) (_ bv0 64))
+         (select arr ((_ zero_extend 32) j)))
+      (bvsge
+        ((_ sign_extend 16)
+          (select (struct.0.coeffs (select arr ((_ zero_extend 32) j)))
+                  (_ bv0 64)))
+        (_ bv0 32)))))
+
+(assert
+  (not (bvsge ((_ sign_extend 16)
+                (select (struct.0.coeffs (select arr (_ bv0 64))) (_ bv0 64)))
+              (_ bv0 32))))
+
+(check-sat)


### PR DESCRIPTION
Fixes the issue with --mbqi-enum on #12508 by filtering non-first-class terminal types out of default SyGuS grammar construction, so --mbqi-enum no longer tries to build grammars for internal datatype selector/constructor sorts. Adds a regression for MBQI enum on datatype constructor/selector terms.