### PR TITLE
Fix assertion failure caused by bv-to-bool

### DIFF
--- a/src/preprocessing/passes/bv_to_bool.cpp
+++ b/src/preprocessing/passes/bv_to_bool.cpp
@@ -51,11 +51,11 @@ PreprocessingPassResult BVToBool::applyInternal(
   {
     assertionsToPreprocess->replace(
         i, new_assertions[i], nullptr, TrustId::PREPROCESS_BV_TO_BOOL);
-    assertionsToPreprocess->ensureRewritten(i);
     if (assertionsToPreprocess->isInConflict())
     {
       return PreprocessingPassResult::CONFLICT;
     }
+    assertionsToPreprocess->ensureRewritten(i);
   }
   return PreprocessingPassResult::NO_CONFLICT;
 }

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -345,6 +345,7 @@ set(regress_0_tests
   regress0/bv/bv_to_int_int1.smt2
   regress0/bv/bv_to_int_proj_417.smt2
   regress0/bv/bv_to_int_zext.smt2
+  regress0/bv/bv_to_bool_conflict.smt2
   regress0/bv/bvcomp.cvc.smt2
   regress0/bv/bvmul-pow2-only.smt2
   regress0/bv/bvproof1.smt2

--- a/test/regress/cli/regress0/bv/bv_to_bool_conflict.smt2
+++ b/test/regress/cli/regress0/bv/bv_to_bool_conflict.smt2
@@ -1,0 +1,7 @@
+; COMMAND-LINE: --bv-to-bool
+; EXPECT: unsat
+(set-logic ALL)
+(declare-const x (_ BitVec 1))
+(assert true)
+(assert (distinct (bvor x (bvashr (_ bv1 1) x)) (bvor x (bvor x (bvashr (_ bv1 1) x)))))
+(check-sat)


### PR DESCRIPTION
Fucntion `AssertionPipeline::replace` may delete all assertions if a conflict is discovered. This broke a check made by bv-to-bool. The fix is to move the check to after conflicts are checked for.

Bug found by murxla.