### PR TITLE
ci: Bump GH action versions for Node.js 24 compatibility

### DIFF
--- a/.github/actions/build-documentation/action.yml
+++ b/.github/actions/build-documentation/action.yml
@@ -16,7 +16,7 @@ runs:
       working-directory: ${{ inputs.build-dir }}
     
     - name: Store Documentation
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: documentation
         path: ${{ inputs.build-dir }}/docs/sphinx-gh/

--- a/.github/actions/setup-cache/action.yml
+++ b/.github/actions/setup-cache/action.yml
@@ -39,7 +39,7 @@ runs:
   using: composite
   steps:
     - name: Setup ccache cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ccache-dir
         key: ${{ inputs.cache-key }}-${{ runner.os }}-ccache-${{ github.sha }}
@@ -56,7 +56,7 @@ runs:
 
     - name: Setup contrib dependencies cache
       id: contrib-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: deps/bin
         key: ${{ inputs.cache-key }}-${{ runner.os }}-contrib-${{ hashFiles('contrib/get-**') }}-${{ hashFiles('.github/**') }}
@@ -74,7 +74,7 @@ runs:
         fi
 
     - name: Setup dependencies cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           build-shared/deps

--- a/.github/actions/upload-mvn-files/action.yml
+++ b/.github/actions/upload-mvn-files/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: Upload main Maven JAR and POM file
       if: ${{ inputs.upload-main }}
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: mvn-main
         retention-days: 1
@@ -44,7 +44,7 @@ runs:
 
     - name: Upload sources and javadoc Maven JARs
       if: ${{ inputs.artifact-suffix == 'docs' }}
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: mvn-docs
         retention-days: 1
@@ -60,7 +60,7 @@ runs:
 
     - name: Upload architecture-specific Mave JARs
       if: ${{ inputs.artifact-suffix != 'docs' }}
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: mvn-${{ inputs.artifact-suffix }}
         retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,7 +406,7 @@ jobs:
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
     - name: Download Maven JAR artifacts
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v7
       with:
         path: ./maven
         pattern: mvn-*

--- a/.github/workflows/package_pypi.yml
+++ b/.github/workflows/package_pypi.yml
@@ -155,7 +155,7 @@ jobs:
         CIBW_TEST_COMMAND: python {project}/examples/api/python/quickstart.py
         CIBW_TEST_SKIP: "cp38-macosx_arm64" # Silence warning. See: https://github.com/pypa/cibuildwheel/pull/1171
 
-    # - uses: actions/upload-artifact@v5
+    # - uses: actions/upload-artifact@v6
     #   with:
     #     name: wheels-${{ matrix.name }}
     #     path: ./wheelhouse/*.whl


### PR DESCRIPTION
Node.js 20 support in GitHub Actions is being deprecated. Starting June 2, 2026, workflows using actions that depend on Node.js 20 may begin to fail unless those actions are updated to versions that support Node.js 24.

This PR updates our actions to versions compatible with Node.js 24. The only exception is `msys2/setup-msys2`, which is currently pinned to an older version to use Clang 19.1.4 (required by lean-cvc5). We will need to investigate whether this dependency will cause issues once Node.js 20 is fully deprecated, and how to address it if necessary.