### PR TITLE
ci: Remove old homebrew workaround

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -145,9 +145,6 @@ runs:
       shell: ${{ inputs.shell }}
       run: |
         echo "::group::Install macOS software"
-        brew config
-        brew untap homebrew/core homebrew/cask
-        brew config
         if [[ $RUNNER_ARCH == "ARM64" ]]; then
           AUTOTOOLS="autoconf libtool"
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,6 @@ on:
 
 name: CI
 
-# Prevents github from relying on clones of homebrew-core or homebrew-cask.
-# https://github.com/orgs/Homebrew/discussions/4612
-env:
-    HOMEBREW_NO_INSTALL_FROM_API: ""
-
 jobs:
   setup-release-pages:
     name: Set up release pages


### PR DESCRIPTION
Removes manual 'untap' of homebrew/core and homebrew/cask. These are no longer required on modern GitHub runners as Homebrew now uses the API by default.