### PR TITLE
Return unknown instead of sat for fmf-mbqi trust

### DIFF
--- a/src/theory/quantifiers/fmf/model_engine.cpp
+++ b/src/theory/quantifiers/fmf/model_engine.cpp
@@ -212,11 +212,13 @@ int ModelEngine::checkModel(){
   }
 
   Trace("model-engine-debug") << "Do exhaustive instantiation..." << std::endl;
-  // FMC uses two sub-effort levels
+  // FMC uses two sub-effort levels. In trust mode, we intentionally skip
+  // exhaustive instantiation, which means any active quantifier we would have
+  // processed here must force an unknown answer instead of sat.
   options::FmfMbqiMode mode = options().quantifiers.fmfMbqiMode;
   int e_max = mode == options::FmfMbqiMode::FMC
                   ? 2
-                  : (mode == options::FmfMbqiMode::TRUST ? 0 : 1);
+                  : 1;
   for( int e=0; e<e_max; e++) {
     d_incompleteQuants.clear();
     for( unsigned i=0; i<fm->getNumAssertedQuantifiers(); i++ ){
@@ -231,6 +233,14 @@ int ModelEngine::checkModel(){
       if (!shouldProcess(q))
       {
         Trace("fmf-exh-inst") << "-> Not processed : " << q << std::endl;
+        d_incompleteQuants.insert(q);
+        continue;
+      }
+      if (mode == options::FmfMbqiMode::TRUST)
+      {
+        Trace("fmf-exh-inst")
+            << "-> Trust mode skips exhaustive instantiation." << std::endl;
+        d_incomplete_check = true;
         d_incompleteQuants.insert(q);
         continue;
       }

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -917,6 +917,7 @@ set(regress_0_tests
   regress0/fmf/get-model-domain-elements.smt2
   regress0/fmf/get-model.smt2
   regress0/fmf/issue3661-ccard-dec.smt2
+  regress0/fmf/issue12528-fmf-mbqi-trust-unknown.smt2
   regress0/fmf/issue4850-force-card.smt2
   regress0/fmf/issue4872-qf_ufc.smt2
   regress0/fmf/issue5239-uf-ss-tot.smt2

--- a/test/regress/cli/regress0/fmf/issue12528-fmf-mbqi-trust-unknown.smt2
+++ b/test/regress/cli/regress0/fmf/issue12528-fmf-mbqi-trust-unknown.smt2
@@ -1,0 +1,14 @@
+; COMMAND-LINE: --finite-model-find --fmf-mbqi=trust -o incomplete
+; EXPECT: (incomplete INCOMPLETE QUANTIFIERS_FMF)
+; EXPECT: unknown
+; EXPECT: (:reason-unknown incomplete)
+(set-logic UF)
+(declare-sort A 0)
+(declare-fun le (A A) Bool)
+(declare-fun p (A) Bool)
+(declare-const w A)
+(assert (forall ((x A)) (le x x)))
+(assert (forall ((x A)) (=> (le x x) (not (p x)))))
+(assert (p w))
+(check-sat)
+(get-info :reason-unknown)


### PR DESCRIPTION
Co-authored by ChatGPT 5.4.

Fixes https://github.com/cvc5/cvc5/issues/12528.

We should avoid options that change smt-lib semantics, even if they are expert.

Instead, "sat" is now replaced by "unknown" with a specific reason.