### PR TITLE
feat: Add atomic refcount flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,8 @@ option(BUILD_DOCS_GA "Build API documentation with Google Analytics")
 option(BUILD_GMP "Build GMP from source")
 option(BUILD_CLN "Build CLN from source")
 
+option(ATOMIC_REFCOUNT "Enable Atomic Reference Counts")
+
 # Link against static system libraries
 cvc5_option(STATIC_BINARY "Link against static system libraries \
 (enabled by default for static builds)")

--- a/configure.sh
+++ b/configure.sh
@@ -150,6 +150,7 @@ python_bindings=default
 python_only_src=default
 pyvenv=default
 java_bindings=default
+atomic_refcount=default
 editline=default
 build_shared=ON
 safe_mode=default
@@ -321,6 +322,8 @@ do
       python_bindings=ON
       java_bindings=ON;;
 
+    --atomic-refcount) atomic_refcount=ON;;
+
     --valgrind) valgrind=ON;;
     --no-valgrind) valgrind=OFF;;
 
@@ -479,6 +482,8 @@ fi
   && cmake_opts="$cmake_opts -DONLY_PYTHON_EXT_SRC=$python_only_src"
 [ $java_bindings != default ] \
   && cmake_opts="$cmake_opts -DBUILD_BINDINGS_JAVA=$java_bindings"
+[ $atomic_refcount != default ] \
+  && cmake_opts="$cmake_opts -DATOMIC_REFCOUNT=$atomic_refcount"
 [ $valgrind != default ] \
   && cmake_opts="$cmake_opts -DENABLE_VALGRIND=$valgrind"
 [ $profiling != default ] \

--- a/src/expr/node_manager_template.cpp
+++ b/src/expr/node_manager_template.cpp
@@ -341,6 +341,9 @@ const DType& NodeManager::getDTypeForIndex(size_t index) const
 
 void NodeManager::reclaimZombies()
 {
+#if CVC5_ATOMIC_REFCOUNT
+	std::lock_guard<std::mutex> _guard(reclaim_mutex);
+#endif
   Assert(!d_attrManager->inGarbageCollection());
 
   Trace("gc") << "reclaiming " << d_zombies.size() << " zombie(s)!\n";

--- a/src/expr/node_manager_template.h
+++ b/src/expr/node_manager_template.h
@@ -16,6 +16,10 @@
 #include <poly/polyxx.h>
 #endif
 
+#if CVC5_ATOMIC_REFCOUNT
+#include <mutex>
+#endif
+
 /* circular dependency; force node.h first */
 #include "expr/node.h"
 #include "expr/type_node.h"
@@ -1049,6 +1053,10 @@ class NodeManager
    * we also need to avoid processing a zombie twice.
    */
   NodeValueIDSet d_zombies;
+
+#if CVC5_ATOMIC_REFCOUNT
+	std::mutex reclaim_mutex;
+#endif
 
   /**
    * NodeValues with maxed out reference counts. These live as long as the

--- a/src/expr/node_value.h
+++ b/src/expr/node_value.h
@@ -344,11 +344,19 @@ class CVC5_EXPORT NodeValue
     }
   }
 
+
+#if CVC5_ATOMIC_REFCOUNT
+  /** The expression's reference count. */
+  std::atomic_uint32_t d_rc;
+#endif
+
   /** The ID (0 is reserved for the null value) */
   uint64_t d_id : NBITS_ID;
 
+#if !(CVC5_ATOMIC_REFCOUNT)
   /** The expression's reference count. */
   uint32_t d_rc : NBITS_REFCOUNT;
+#endif
 
   /** Kind of the expression */
   uint32_t d_kind : NBITS_KIND;


### PR DESCRIPTION
This is an experiment to see if we can make the node manager thread safe. It adds a `ATOMIC_REFCOUNT` flag, when turned on, replaces reference counts on nodes with `std::atomic_uint32_t`.

In Rust terminology, `NodeManager` could be `Send` but not `Sync`, which is fine. `Node` could be `Send` and `Sync`.

This allows multiple threads to call into cvc5 `NodeManager`s and makes `lean-cvc5` safe.