### PR TITLE
Remove null op/term check when getting number of children/indices.

### DIFF
--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -2202,7 +2202,6 @@ bool Op::isIndexed() const
 size_t Op::getNumIndices() const
 {
   CVC5_API_TRY_CATCH_BEGIN;
-  CVC5_API_CHECK_NOT_NULL;
   //////// all checks before this line
   return getNumIndicesHelper();
   ////////
@@ -2557,7 +2556,6 @@ bool Term::operator>=(const Term& t) const
 size_t Term::getNumChildren() const
 {
   CVC5_API_TRY_CATCH_BEGIN;
-  CVC5_API_CHECK_NOT_NULL;
   //////// all checks before this line
 
   // special case for apply kinds

--- a/test/unit/api/cpp/api_term_black.cpp
+++ b/test/unit/api/cpp/api_term_black.cpp
@@ -674,7 +674,7 @@ TEST_F(TestApiBlackTerm, termChildren)
   ASSERT_EQ(t1[0], two);
   ASSERT_EQ(t1.getNumChildren(), 2);
   Term tnull;
-  ASSERT_THROW(tnull.getNumChildren(), CVC5ApiException);
+  ASSERT_EQ(tnull.getNumChildren(), 0);
 
   Term::const_iterator it;
   it = t1.begin();

--- a/test/unit/api/java/TermTest.java
+++ b/test/unit/api/java/TermTest.java
@@ -699,7 +699,7 @@ class TermTest
     assertEquals(t1.getChild(0), two);
     assertEquals(t1.getNumChildren(), 2);
     Term tnull = new Term();
-    assertThrows(CVC5ApiException.class, () -> tnull.getNumChildren());
+    assertEquals(tnull.getNumChildren(), 0);
 
     // apply term f(2)
     Sort intSort = d_tm.getIntegerSort();


### PR DESCRIPTION
This PR removes null-node checks in `Op::getNumIndices` and `Term::getNumChildren`. Lean's indexing API (i.e., `operator[]` syntax) assumes that out‑of‑bounds checks do not throw, and `Term::getChildren` already returns an empty vector when the term is null, so the explicit check in `Term::getNumChildren` is redundant.

Note: The C and Python API term tests do not perform these checks, so no updates were needed there.