### PR TITLE
Fix strings arithmetic entailment proof utility for parameteric operators 

### DIFF
--- a/src/theory/strings/arith_entail.cpp
+++ b/src/theory/strings/arith_entail.cpp
@@ -162,6 +162,10 @@ Node ArithEntail::rewriteLengthIntro(const Node& n,
       Kind k = cur.getKind();
       bool childChanged = false;
       std::vector<Node> children;
+      if (cur.getMetaKind() == kind::metakind::PARAMETERIZED)
+      {
+        children.push_back(cur.getOperator());
+      }
       for (const Node& cn : cur)
       {
         it = visited.find(cn);

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1516,6 +1516,7 @@ set(regress_0_tests
   regress0/proofs/issue11750.smt2
   regress0/proofs/issue12254-pf-arith-cm.smt2
   regress0/proofs/issue12255-cyclic-arith-rcons.smt2
+  regress0/proofs/issue12574-check-proofs-int-to-bv.smt2
   regress0/proofs/issue8983-trust-subs.smt2
   regress0/proofs/issue9156-doublePropProof.smt2
   regress0/proofs/issue9172-doublePropProof.smt2

--- a/test/regress/cli/regress0/proofs/issue12574-check-proofs-int-to-bv.smt2
+++ b/test/regress/cli/regress0/proofs/issue12574-check-proofs-int-to-bv.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE: --check-proofs
 ; EXPECT: unsat
 (set-logic UFBVSLIA)
 (declare-fun s (String String Int) String)

--- a/test/regress/cli/regress0/proofs/issue12574-check-proofs-int-to-bv.smt2
+++ b/test/regress/cli/regress0/proofs/issue12574-check-proofs-int-to-bv.smt2
@@ -1,0 +1,22 @@
+; COMMAND-LINE: --check-proofs
+; EXPECT: unsat
+(set-logic UFBVSLIA)
+(declare-fun s (String String Int) String)
+(declare-const e String)
+(assert (= 1
+  (ite (str.in_re (s (str.from_int 0) (str.from_int 0) 0) re.allchar)
+       0
+       (ubv_to_int ((_ int_to_bv 1) 1)))))
+(assert (forall ((b String))
+  (= (= 1
+        (+ 0
+           (ubv_to_int
+             (bvand ((_ int_to_bv 2) 1)
+                    ((_ int_to_bv 2)
+                     (str.indexof
+                       (ite (str.in_re e re.allchar) e (str.from_int 0))
+                       "."
+                       0))))))
+     (= 1 (str.len b)))))
+(assert (= e ""))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/12574.

Co-Authored-By: ChatGPT 5.4 <noreply@openai.com>