### PR TITLE
Re-enable Python test with debug options

### DIFF
--- a/examples/api/python/CMakeLists.txt
+++ b/examples/api/python/CMakeLists.txt
@@ -11,8 +11,7 @@
 ##
 
 set(EXAMPLES_API_PYTHON
-# disabled due to failures on windows builds
-#  bitvectors_and_arrays
+  bitvectors_and_arrays
   bitvectors
   combination
   datatypes
@@ -37,8 +36,7 @@ set(EXAMPLES_API_PYTHON
 # even if it is only conditionally added (e.g.,
 # based on CVC5_USE_COCOA or NOT CVC5_SAFE_BUILD).
 set(EXAMPLES_API_PYTHON_PYTHONIC
-# disabled due to failures on windows builds
-#  bitvectors_and_arrays
+  bitvectors_and_arrays
   bitvectors
   combination
   datatypes
@@ -83,7 +81,7 @@ function(_add_python_test example subdir)
 
   add_test(
     NAME     ${test_name}
-    COMMAND  "${Python_EXECUTABLE}"
+    COMMAND  "${Python_EXECUTABLE}" ${ARGN}
              "${CMAKE_SOURCE_DIR}/${subdir}/${example}.py"
   )
   set_tests_properties(${test_name} PROPERTIES
@@ -98,7 +96,16 @@ function(create_python_example example)
 
   # Only add the Pythonic version if it is in the list
   if (example IN_LIST EXAMPLES_API_PYTHON_PYTHONIC)
-    _add_python_test(${example} "api/python/pythonic")
+    # The Pythonic version of the bitvectors_and_arrays example is known to
+    # cause a SEGFAULT on ARM64 Windows but it eludes any attempt to debug it.
+    # We run it with debbugging options to get more information if it fails.
+    if(example STREQUAL "bitvectors_and_arrays" AND
+       WIN32 AND
+       CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|arm64|aarch64)$")
+      _add_python_test(${example} "api/python/pythonic" -X dev -X faulthandler)
+    else()
+      _add_python_test(${example} "api/python/pythonic")
+    endif()
   endif()
 endfunction()
 


### PR DESCRIPTION
The test was disabled due to intermittent failures in #12449. The failure only occurs on the Windows ARM64 CI runner, and our attempts to debug it so far have been unsuccessful. This PR re-enables the test and runs it with Python debug options in the hope that it will fail again and provide additional diagnostic information.