### PR TITLE
Add CMake FetchContent support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -460,7 +460,7 @@ endmacro()
 if(ENABLE_AUTO_DOWNLOAD)
   if(USE_PYTHON_VENV)
     # Set up Python venv if one doesn't exist already
-    set(VENV_PATH "${CMAKE_BINARY_DIR}/venv-${Python_VERSION}")
+    set(VENV_PATH "${PROJECT_BINARY_DIR}/venv-${Python_VERSION}")
     if(NOT EXISTS ${VENV_PATH})
       create_venv()
     endif()
@@ -520,7 +520,7 @@ if(ENABLE_COVERAGE)
   setup_code_coverage_fastcov(
     NAME coverage
     PATH "${PROJECT_SOURCE_DIR}"
-    EXCLUDE "${CMAKE_BINARY_DIR}/deps/*"
+    EXCLUDE "${PROJECT_BINARY_DIR}/deps/*"
     DEPENDENCIES cvc5-bin
   )
 endif()
@@ -679,7 +679,7 @@ endif()
 
 # Include public headers
 include_directories(include)
-include_directories(${CMAKE_BINARY_DIR}/include)
+include_directories(${PROJECT_BINARY_DIR}/include)
 
 # Install public headers
 install(DIRECTORY include/cvc5 DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
@@ -766,8 +766,8 @@ install(EXPORT cvc5-targets
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cvc5)
 
 configure_package_config_file(
-  ${CMAKE_SOURCE_DIR}/cmake/cvc5Config.cmake.in
-  ${CMAKE_BINARY_DIR}/cmake/cvc5Config.cmake
+  ${PROJECT_SOURCE_DIR}/cmake/cvc5Config.cmake.in
+  ${PROJECT_BINARY_DIR}/cmake/cvc5Config.cmake
   INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cvc5
   PATH_VARS CMAKE_INSTALL_LIBDIR
 )
@@ -779,8 +779,8 @@ write_basic_package_version_file(
 )
 
 install(FILES
-  ${CMAKE_BINARY_DIR}/cmake/cvc5Config.cmake
-  ${CMAKE_BINARY_DIR}/cvc5ConfigVersion.cmake
+  ${PROJECT_BINARY_DIR}/cmake/cvc5Config.cmake
+  ${PROJECT_BINARY_DIR}/cvc5ConfigVersion.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cvc5
 )
 

--- a/cmake/CMakeGraphVizOptions.cmake.in
+++ b/cmake/CMakeGraphVizOptions.cmake.in
@@ -10,8 +10,8 @@
 # targets.
 ##
 
-set(CTX "@CMAKE_BINARY_DIR@/src/context/CMakeFiles/cvc5base.dir/")
-set(BASE "@CMAKE_BINARY_DIR@/src/base/CMakeFiles/cvc5base.dir/")
+set(CTX "@PROJECT_BINARY_DIR@/src/context/CMakeFiles/cvc5base.dir/")
+set(BASE "@PROJECT_BINARY_DIR@/src/base/CMakeFiles/cvc5base.dir/")
 
 # ignore targets that do not actually help the understanding or are (usually)
 # not interesting: tests and object files.

--- a/cmake/FindCaDiCaL.cmake
+++ b/cmake/FindCaDiCaL.cmake
@@ -21,8 +21,8 @@ find_library(CaDiCaL_LIBRARIES NAMES cadical)
 set(CaDiCaL_FOUND_SYSTEM FALSE)
 if(CaDiCaL_INCLUDE_DIR AND CaDiCaL_LIBRARIES)
 
-  # Generate our version check file in CMAKE_BINARY_DIR
-  set(CaDiCaL_version_src "${CMAKE_BINARY_DIR}/CaDiCaL_version.cpp")
+  # Generate our version check file in PROJECT_BINARY_DIR
+  set(CaDiCaL_version_src "${PROJECT_BINARY_DIR}/CaDiCaL_version.cpp")
   file(WRITE ${CaDiCaL_version_src}
     "
     #include <cadical/cadical.hpp>
@@ -48,7 +48,7 @@ if(CaDiCaL_INCLUDE_DIR AND CaDiCaL_LIBRARIES)
   # Try to compile and run our version file
   try_run(RUN_RESULT_VAR
     COMPILE_RESULT_VAR
-    ${CMAKE_BINARY_DIR}
+    ${PROJECT_BINARY_DIR}
     ${CaDiCaL_version_src}
     LINK_LIBRARIES ${CaDiCaL_LIBRARIES}
     RUN_OUTPUT_VARIABLE CaDiCaL_VERSION

--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -199,7 +199,7 @@ else()
           -DINSTALL_NAME_TOOL=${CMAKE_INSTALL_NAME_TOOL}
           -DDYLIB_PATH=\${GMP_DYLIB}
           -DDEPS_BASE=${DEPS_BASE}
-          -P ${CMAKE_SOURCE_DIR}/cmake/update_rpath_macos.cmake)
+          -P ${PROJECT_SOURCE_DIR}/cmake/update_rpath_macos.cmake)
       endforeach()
     ")
   endif()

--- a/cmake/FindLFSC.cmake
+++ b/cmake/FindLFSC.cmake
@@ -15,15 +15,15 @@
 
 find_program(LFSC_BINARY
     NAMES lfscc
-    PATHS ${CMAKE_SOURCE_DIR}/deps/bin
+    PATHS ${PROJECT_SOURCE_DIR}/deps/bin
 )
 find_path(LFSC_INCLUDE_DIR
     NAMES lfscc.h
-    PATHS ${CMAKE_SOURCE_DIR}/deps/include
+    PATHS ${PROJECT_SOURCE_DIR}/deps/include
 )
 find_library(LFSC_LIBRARIES
     NAMES lfscc
-    PATHS ${CMAKE_SOURCE_DIR}/deps/lib
+    PATHS ${PROJECT_SOURCE_DIR}/deps/lib
 )
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/FindPoly.cmake
+++ b/cmake/FindPoly.cmake
@@ -67,7 +67,7 @@ if(NOT Poly_FOUND_SYSTEM)
   if(CCWIN)
     set(POLY_PATCH_CMD
       ${POLY_PATCH_KWD}
-        ${CMAKE_SOURCE_DIR}/cmake/deps-utils/Poly-windows-patch.sh <SOURCE_DIR>
+        ${PROJECT_SOURCE_DIR}/cmake/deps-utils/Poly-windows-patch.sh <SOURCE_DIR>
     )
     set(POLY_PATCH_KWD COMMAND)
   endif()

--- a/cmake/Helpers.cmake
+++ b/cmake/Helpers.cmake
@@ -328,5 +328,5 @@ macro(update_rpath_macos dylibname)
     -DINSTALL_NAME_TOOL=${CMAKE_INSTALL_NAME_TOOL}
     -DDYLIB_PATH=\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${dylibname}
     -DDEPS_BASE=${DEPS_BASE}
-    -P ${CMAKE_SOURCE_DIR}/cmake/update_rpath_macos.cmake)")
+    -P ${PROJECT_SOURCE_DIR}/cmake/update_rpath_macos.cmake)")
 endmacro()

--- a/cmake/deps-helper.cmake
+++ b/cmake/deps-helper.cmake
@@ -13,9 +13,9 @@
 ##
 
 # where to build dependencies
-set(DEPS_PREFIX "${CMAKE_BINARY_DIR}/deps")
+set(DEPS_PREFIX "${PROJECT_BINARY_DIR}/deps")
 # base path to installed dependencies
-set(DEPS_BASE "${CMAKE_BINARY_DIR}/deps")
+set(DEPS_BASE "${PROJECT_BINARY_DIR}/deps")
 # CMake wants directories specified via INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
 # (and similar) to exist when target property is set.
 file(MAKE_DIRECTORY "${DEPS_BASE}/include/")

--- a/cmake/fuzzing-murxla.cmake
+++ b/cmake/fuzzing-murxla.cmake
@@ -26,9 +26,9 @@ ExternalProject_Add(
   ${COMMON_EP_CONFIG}
   URL https://github.com/murxla/murxla/archive/${Murxla_COMMIT}.tar.gz
   URL_HASH SHA256=b3ae1042ff9887d91db1eee990c32be5cbebe809e0350f8b3b3e334a4c6bd0d9
-  SOURCE_DIR ${CMAKE_BINARY_DIR}/murxla
+  SOURCE_DIR ${PROJECT_BINARY_DIR}/murxla
   CMAKE_ARGS
-    -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}/murxla-install/usr/local/
+    -DCMAKE_PREFIX_PATH=${PROJECT_BINARY_DIR}/murxla-install/usr/local/
     -DENABLE_BITWUZLA=OFF
     -DENABLE_BOOLECTOR=OFF
     -DENABLE_YICES=OFF
@@ -42,8 +42,8 @@ set(MURXLA_BINARY "deps/bin/murxla")
 add_custom_target(fuzz-murxla
   COMMAND echo ""
   COMMAND echo "Run Murxla as follows:"
-  COMMAND echo "  LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/murxla-install/usr/local/lib/ ${MURXLA_BINARY} -t 1 -d --cvc5"
+  COMMAND echo "  LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/murxla-install/usr/local/lib/ ${MURXLA_BINARY} -t 1 -d --cvc5"
   COMMAND echo "Convert traces to SMT-LIB as follows:"
-  COMMAND echo "  LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/murxla-install/usr/local/lib/ ${MURXLA_BINARY} --smt2 -u \\<filename\\>"
+  COMMAND echo "  LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/murxla-install/usr/local/lib/ ${MURXLA_BINARY} --smt2 -u \\<filename\\>"
   DEPENDS Murxla-EP
 )

--- a/cmake/target-graphs.cmake
+++ b/cmake/target-graphs.cmake
@@ -15,15 +15,15 @@ string(REPLACE ";" " " APITESTS "${APITESTS}")
 
 configure_file(
     cmake/CMakeGraphVizOptions.cmake.in 
-    ${CMAKE_BINARY_DIR}/CMakeGraphVizOptions.cmake
+    ${PROJECT_BINARY_DIR}/CMakeGraphVizOptions.cmake
     @ONLY
 )
 
 add_custom_target(target-graphs
     COMMAND
-        ${CMAKE_COMMAND} --graphviz=target-graphs/graph.dot ${CMAKE_SOURCE_DIR}
+        ${CMAKE_COMMAND} --graphviz=target-graphs/graph.dot ${PROJECT_SOURCE_DIR}
     COMMAND
         find target-graphs/ -iname "graph.dot*" -and \! -iname "*.png"
         -exec dot -Tpng -O {} +
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
 )

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -25,7 +25,7 @@ else()
   add_custom_target(gen-versioninfo
     COMMAND ${CMAKE_COMMAND}
       -DPROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}
-      -DCMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}
+      -DPROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}
       -P ${PROJECT_SOURCE_DIR}/cmake/version.cmake
   )
 endif()
@@ -126,4 +126,4 @@ endif()
 
 # actually configure versioninfo.cpp
 configure_file(
-    ${PROJECT_SOURCE_DIR}/src/base/versioninfo.cpp.in ${CMAKE_BINARY_DIR}/src/base/versioninfo.cpp)
+    ${PROJECT_SOURCE_DIR}/src/base/versioninfo.cpp.in ${PROJECT_BINARY_DIR}/src/base/versioninfo.cpp)

--- a/docs/api/java/CMakeLists.txt
+++ b/docs/api/java/CMakeLists.txt
@@ -62,7 +62,7 @@ if(BUILD_BINDINGS_JAVA)
       ${Java_JAVADOC_EXECUTABLE} io.github.cvc5
       ${Java_DOCLINT}
       -Xmaxwarns 1000
-      -sourcepath ${CMAKE_SOURCE_DIR}/src/api/java/:${CMAKE_BINARY_DIR}/src/api/java/
+      -sourcepath ${PROJECT_SOURCE_DIR}/src/api/java/:${PROJECT_BINARY_DIR}/src/api/java/
       -d ${JAVADOC_OUTPUT_DIR}
       -cp ${CVC5_JAR_FILE}
       -tag "api.note:a:Note:"

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -29,7 +29,7 @@ import datetime
 sys.path.insert(0, '${CMAKE_CURRENT_SOURCE_DIR}/ext/')
 
 # path to python api
-sys.path.insert(0, '${CMAKE_BINARY_DIR}/src/api/python')
+sys.path.insert(0, '${PROJECT_BINARY_DIR}/src/api/python')
 
 if("${BUILD_BINDINGS_PYTHON}" == "ON"):
         tags.add('bindings_python')
@@ -105,7 +105,7 @@ lexers['smtlib'] = SmtLibLexer()
 
 # -- Java configuration ------------------------------------------------------
 if tags.has('bindings_java'):
-        html_extra_path.append('${CMAKE_BINARY_DIR}/docs/api/java/build/')
+        html_extra_path.append('${PROJECT_BINARY_DIR}/docs/api/java/build/')
 
 
 # -- core extension:: sphinx.ext.autosectionlabel ----------------------------
@@ -217,7 +217,7 @@ examples_file_patterns = {
                 'urlname': 'examples{}',
         },
         r'<pythonicapi>(.*)': {
-                'local': '/' + os.path.relpath('${CMAKE_BINARY_DIR}/deps/src/CVC5PythonicAPI', '${CMAKE_CURRENT_SOURCE_DIR}') + '{}',
+                'local': '/' + os.path.relpath('${PROJECT_BINARY_DIR}/deps/src/CVC5PythonicAPI', '${CMAKE_CURRENT_SOURCE_DIR}') + '{}',
                 'url': 'https://github.com/cvc5/cvc5_pythonic_api/tree/main{}',
                 'urlname': 'cvc5_pythonic_api:{}',
         }
@@ -232,4 +232,4 @@ ibf_folders = ['${CMAKE_CURRENT_BINARY_DIR}']
 
 # -- custom extension:: run_command ------------------------------------------
 
-runcmd_build = '/' + os.path.relpath('${CMAKE_BINARY_DIR}', '${CMAKE_CURRENT_SOURCE_DIR}')
+runcmd_build = '/' + os.path.relpath('${PROJECT_BINARY_DIR}', '${CMAKE_CURRENT_SOURCE_DIR}')

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -23,7 +23,7 @@ enable_testing()
 # of cvc5Config.cmake.
 find_package(cvc5)
 
-set(EXAMPLES_BIN_DIR ${CMAKE_BINARY_DIR}/bin)
+set(EXAMPLES_BIN_DIR ${PROJECT_BINARY_DIR}/bin)
 
 # Add example target and create test to run example with ctest.
 #
@@ -94,7 +94,7 @@ if(TARGET cvc5::cvc5jar)
     NAME java/SimpleVC
     COMMAND
       ${Java_JAVA_EXECUTABLE}
-        -cp "${CVC5_JAR}${PATH_SEP}${CMAKE_BINARY_DIR}/SimpleVC.jar"
+        -cp "${CVC5_JAR}${PATH_SEP}${PROJECT_BINARY_DIR}/SimpleVC.jar"
         -Djava.library.path=${CVC5_JNI_PATH}
         SimpleVC
   )

--- a/examples/api/java/CMakeLists.txt
+++ b/examples/api/java/CMakeLists.txt
@@ -33,7 +33,7 @@ set(EXAMPLES_API_JAVA
 function(add_java_example example)
   add_jar(${example} ${example}.java
           INCLUDE_JARS "${CVC5_JAR}"
-          OUTPUT_DIR "${CMAKE_BINARY_DIR}/bin/api/java")
+          OUTPUT_DIR "${PROJECT_BINARY_DIR}/bin/api/java")
 
   set(EXAMPLE_TEST_NAME api/java/${example})
 
@@ -47,7 +47,7 @@ function(add_java_example example)
     NAME ${EXAMPLE_TEST_NAME}
     COMMAND
       ${Java_JAVA_EXECUTABLE}
-        -cp "${CVC5_JAR}${PATH_SEP}${CMAKE_BINARY_DIR}/bin/api/java/${example}.jar"
+        -cp "${CVC5_JAR}${PATH_SEP}${PROJECT_BINARY_DIR}/bin/api/java/${example}.jar"
         -Djava.library.path=${CVC5_JNI_PATH}
         ${example}
   )

--- a/examples/api/python/CMakeLists.txt
+++ b/examples/api/python/CMakeLists.txt
@@ -82,7 +82,7 @@ function(_add_python_test example subdir)
   add_test(
     NAME     ${test_name}
     COMMAND  "${Python_EXECUTABLE}" ${ARGN}
-             "${CMAKE_SOURCE_DIR}/${subdir}/${example}.py"
+             "${PROJECT_SOURCE_DIR}/${subdir}/${example}.py"
   )
   set_tests_properties(${test_name} PROPERTIES
     LABELS      "example"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1512,7 +1512,8 @@ set_target_properties(cvc5 PROPERTIES OUTPUT_NAME cvc5)
 # Link the shared library
 target_include_directories(cvc5
   PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include:${PROJECT_BINARY_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
 # On Windows, CMake's default install action places

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1391,7 +1391,7 @@ if (BUILD_DOCS)
   list(
     APPEND
       options_gen_doc_files
-      "${CMAKE_BINARY_DIR}/docs/options_generated.rst"
+      "${PROJECT_BINARY_DIR}/docs/options_generated.rst"
   )
 endif()
 
@@ -1414,7 +1414,7 @@ add_custom_command(
     ${Python_EXECUTABLE}
     ${CMAKE_CURRENT_LIST_DIR}/options/mkoptions.py
     ${CMAKE_CURRENT_LIST_DIR}
-    ${CMAKE_BINARY_DIR}
+    ${PROJECT_BINARY_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
     ${abs_toml_files}
   BYPRODUCTS
@@ -1512,7 +1512,7 @@ set_target_properties(cvc5 PROPERTIES OUTPUT_NAME cvc5)
 # Link the shared library
 target_include_directories(cvc5
   PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include:${CMAKE_BINARY_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include:${PROJECT_BINARY_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
 # On Windows, CMake's default install action places
@@ -1532,10 +1532,10 @@ endif()
 include(GenerateExportHeader)
 generate_export_header(cvc5-obj
   BASE_NAME cvc5
-  EXPORT_FILE_NAME ${CMAKE_BINARY_DIR}/include/cvc5/cvc5_export.h
+  EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/cvc5/cvc5_export.h
 )
 install(FILES
-  ${CMAKE_BINARY_DIR}/include/cvc5/cvc5_export.h
+  ${PROJECT_BINARY_DIR}/include/cvc5/cvc5_export.h
   DESTINATION
     ${CMAKE_INSTALL_INCLUDEDIR}/cvc5/
 )

--- a/src/api/java/CMakeLists.txt
+++ b/src/api/java/CMakeLists.txt
@@ -303,7 +303,7 @@ endif()
 
 target_include_directories(cvc5jni PUBLIC ${JNI_INCLUDE_DIRS})
 target_include_directories(cvc5jni PUBLIC ${PROJECT_SOURCE_DIR}/src)
-target_include_directories(cvc5jni PUBLIC ${CMAKE_BINARY_DIR}/src/)
+target_include_directories(cvc5jni PUBLIC ${PROJECT_BINARY_DIR}/src/)
 target_include_directories(cvc5jni PUBLIC ${JNI_DIR})
 target_link_libraries(cvc5jni PRIVATE cvc5 cvc5parser)
 
@@ -397,7 +397,7 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 # POM file for publishing cvc5 Java bindings to Maven Central
-configure_file(pom.xml.in ${CMAKE_BINARY_DIR}/pom.xml @ONLY)
+configure_file(pom.xml.in ${PROJECT_BINARY_DIR}/pom.xml @ONLY)
 
 # Install in the same directory of cvc5-targets.
 # On Windows, CMake's default install action places

--- a/src/api/java/genenums.py.in
+++ b/src/api/java/genenums.py.in
@@ -20,7 +20,7 @@ import re
 import textwrap
 
 # get access to cvc5/src/api/parseenums.py
-SOURCE_DIR = '${CMAKE_SOURCE_DIR}/src'
+SOURCE_DIR = '${PROJECT_SOURCE_DIR}/src'
 sys.path.insert(0, os.path.abspath(f'{SOURCE_DIR}/api'))
 
 from parseenums import *

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -123,14 +123,14 @@ execute_process(COMMAND
 
 # Set include_dirs and library_dirs variables that are used in setup.cfg.in
 if (WIN32)
-  set(SETUP_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include;${CMAKE_BINARY_DIR}/include")
-  set(SETUP_LIBRARY_DIRS "${CMAKE_BINARY_DIR}/src;${CMAKE_BINARY_DIR}/src/parser")
+  set(SETUP_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include;${PROJECT_BINARY_DIR}/include")
+  set(SETUP_LIBRARY_DIRS "${PROJECT_BINARY_DIR}/src;${PROJECT_BINARY_DIR}/src/parser")
   set(SETUP_COMPILER "[build]\ncompiler=mingw32")
 else()
-  set(SETUP_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include:${CMAKE_BINARY_DIR}/include")
-  set(SETUP_LIBRARY_DIRS "${CMAKE_BINARY_DIR}/src:${CMAKE_BINARY_DIR}/src/parser")
+  set(SETUP_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include:${PROJECT_BINARY_DIR}/include")
+  set(SETUP_LIBRARY_DIRS "${PROJECT_BINARY_DIR}/src:${PROJECT_BINARY_DIR}/src/parser")
   # On Linux and macOS, set rpath variable too
-  set(SETUP_RPATH "rpath=${CMAKE_BINARY_DIR}/src:${CMAKE_BINARY_DIR}/src/parser")
+  set(SETUP_RPATH "rpath=${PROJECT_BINARY_DIR}/src:${PROJECT_BINARY_DIR}/src/parser")
 endif()
 
 # Set MACOS_ARCH variable that is used in setup.py.in
@@ -264,10 +264,10 @@ else()
   install(CODE "execute_process(COMMAND \${CMAKE_COMMAND}
     -DPython_EXECUTABLE=${Python_EXECUTABLE}
     -DRepairwheel_EXECUTABLE=${Repairwheel_EXECUTABLE}
-    -DBUILD_DIR=${CMAKE_BINARY_DIR}
+    -DBUILD_DIR=${PROJECT_BINARY_DIR}
     -DDEPS_BASE=${DEPS_BASE}
     -DINSTALL_CMD=\"${INSTALL_CMD}\"
-    -P ${CMAKE_SOURCE_DIR}/cmake/install_python_wheel.cmake)"
+    -P ${PROJECT_SOURCE_DIR}/cmake/install_python_wheel.cmake)"
     COMPONENT python-api)
 
 endif()

--- a/src/api/python/genenums.py.in
+++ b/src/api/python/genenums.py.in
@@ -24,7 +24,7 @@ import re
 import sys
 
 # get access to cvc5/src/api/parseenums.py
-SOURCE_DIR = '${CMAKE_SOURCE_DIR}'
+SOURCE_DIR = '${PROJECT_SOURCE_DIR}'
 INCLUDE_DIR = f'{SOURCE_DIR}/include'
 sys.path.insert(0, os.path.abspath(f'{SOURCE_DIR}/src/api'))
 

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -60,7 +60,7 @@ target_compile_definitions(cvc5-bin PRIVATE -D__BUILDING_CVC5DRIVER -Dcvc5_obj_E
 set_target_properties(cvc5-bin
   PROPERTIES
     OUTPUT_NAME cvc5
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+    RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 if(PROGRAM_PREFIX)
   install(PROGRAMS
     $<TARGET_FILE:cvc5-bin>

--- a/src/rewriter/CMakeLists.txt
+++ b/src/rewriter/CMakeLists.txt
@@ -48,14 +48,14 @@ libcvc5_add_sources(GENERATED
 )
 
 list(APPEND REWRITE_OUTPUT_FILES
-  ${CMAKE_BINARY_DIR}/src/api/cpp/cvc5_proof_rule.cpp
-  ${CMAKE_BINARY_DIR}/include/cvc5/cvc5_proof_rule.h
+  ${PROJECT_BINARY_DIR}/src/api/cpp/cvc5_proof_rule.cpp
+  ${PROJECT_BINARY_DIR}/include/cvc5/cvc5_proof_rule.h
 )
 
 # If the generated header differs from the source header, it should be copied to
 # the source directory manually for compilation to succeed.
 list(APPEND LIBCVC5_GEN_SRCS
-  ${CMAKE_BINARY_DIR}/src/api/cpp/cvc5_proof_rule.cpp
+  ${PROJECT_BINARY_DIR}/src/api/cpp/cvc5_proof_rule.cpp
 )
 
 set(LIBCVC5_GEN_SRCS ${LIBCVC5_GEN_SRCS} PARENT_SCOPE)
@@ -67,8 +67,8 @@ add_custom_command(
       ${Python_EXECUTABLE}
       ${mkrewrites_script}
       rewrite-db
-      --src ${CMAKE_SOURCE_DIR}
-      --bin ${CMAKE_BINARY_DIR}
+      --src ${PROJECT_SOURCE_DIR}
+      --bin ${PROJECT_BINARY_DIR}
       --rewrites_files ${REWRITES_FILES}
       --rewrites_files_expert ${REWRITES_FILES_EXPERT}
     DEPENDS
@@ -77,8 +77,8 @@ add_custom_command(
       ${REWRITES_FILES_EXPERT}
       ${CMAKE_CURRENT_LIST_DIR}/theory_rewrites_template.cpp
       ${CMAKE_CURRENT_LIST_DIR}/rewrites_template.cpp
-      ${CMAKE_SOURCE_DIR}/src/api/cpp/cvc5_proof_rule_template.cpp
-      ${CMAKE_SOURCE_DIR}/include/cvc5/cvc5_proof_rule.h
+      ${PROJECT_SOURCE_DIR}/src/api/cpp/cvc5_proof_rule_template.cpp
+      ${PROJECT_SOURCE_DIR}/include/cvc5/cvc5_proof_rule.h
     COMMENT
       "Generating rewrites.{h,cpp}"
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,8 +19,8 @@ set(ENV_PATH_CMD )
 if(WIN32)
   # Set up a command to add DLL library paths to PATH
   set(ENV_PATH )
-  list(APPEND ENV_PATH ${CMAKE_BINARY_DIR}\\src)
-  list(APPEND ENV_PATH ${CMAKE_BINARY_DIR}\\src\\parser)
+  list(APPEND ENV_PATH ${PROJECT_BINARY_DIR}\\src)
+  list(APPEND ENV_PATH ${PROJECT_BINARY_DIR}\\src\\parser)
   list(APPEND ENV_PATH ${DEPS_BASE}\\bin)
   list(APPEND ENV_PATH $ENV{PATH})
   # Escape semicolons and backslashes

--- a/test/api/c/CMakeLists.txt
+++ b/test/api/c/CMakeLists.txt
@@ -19,7 +19,7 @@ add_dependencies(build-apitests build-capitests)
 
 # Disabled temporarily due to problems in the nightly builds
 # # See the comment about 'make test' in test/regress/cli/CMakeLists.txt
-# add_test(build_capitests_test "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --config "$<CONFIG>" --target build-capitests)
+# add_test(build_capitests_test "${CMAKE_COMMAND}" --build "${PROJECT_BINARY_DIR}" --config "$<CONFIG>" --target build-capitests)
 # set_tests_properties(build_capitests_test PROPERTIES FIXTURES_SETUP build_capitests_fixture)
 
 add_custom_target(capitests
@@ -29,7 +29,7 @@ add_custom_target(capitests
 set(CVC5_API_TEST_FLAGS -D__BUILDING_CVC5_API_TEST -Dcvc5_obj_EXPORTS)
 
 macro(cvc5_add_capi_test name dir)
-  set(test_bin_dir ${CMAKE_BINARY_DIR}/bin/test/api/c/${dir})
+  set(test_bin_dir ${PROJECT_BINARY_DIR}/bin/test/api/c/${dir})
   set(cname capi_${name})
   add_executable(${cname} ${name}.c)
   target_link_libraries(${cname} PUBLIC main-test)

--- a/test/api/cpp/CMakeLists.txt
+++ b/test/api/cpp/CMakeLists.txt
@@ -22,7 +22,7 @@ add_dependencies(build-apitests build-cppapitests)
 
 # Disabled temporarily due to problems in the nightly builds
 # # See the comment about 'make test' in test/regress/cli/CMakeLists.txt
-# add_test(build_apitests_test "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --config "$<CONFIG>" --target build-apitests)
+# add_test(build_apitests_test "${CMAKE_COMMAND}" --build "${PROJECT_BINARY_DIR}" --config "$<CONFIG>" --target build-apitests)
 # set_tests_properties(build_apitests_test PROPERTIES FIXTURES_SETUP build_apitests_fixture)
 
 add_custom_target(cppapitests
@@ -32,7 +32,7 @@ add_custom_target(cppapitests
 set(CVC5_API_TEST_FLAGS -D__BUILDING_CVC5_API_TEST -Dcvc5_obj_EXPORTS)
 
 macro(cvc5_add_api_test name dir)
-  set(test_bin_dir ${CMAKE_BINARY_DIR}/bin/test/api/cpp/${dir})
+  set(test_bin_dir ${PROJECT_BINARY_DIR}/bin/test/api/cpp/${dir})
   add_executable(${name} ${name}.cpp)
   target_link_libraries(${name} PUBLIC main-test)
   target_compile_definitions(${name} PRIVATE ${CVC5_API_TEST_FLAGS})

--- a/test/api/java/CMakeLists.txt
+++ b/test/api/java/CMakeLists.txt
@@ -30,7 +30,7 @@ else()
 endif()
 
 macro(cvc5_add_java_api_test name dir)
-  set(test_bin_dir ${CMAKE_BINARY_DIR}/bin/test/api/java/${dir})
+  set(test_bin_dir ${PROJECT_BINARY_DIR}/bin/test/api/java/${dir})
   add_jar(${name}
     SOURCES ${name}.java
     INCLUDE_JARS ${CVC5_JAR_PATH}

--- a/test/api/python/CMakeLists.txt
+++ b/test/api/python/CMakeLists.txt
@@ -18,7 +18,7 @@ add_custom_target(pyapitests
   DEPENDS build-pyapitests)
 
 if(WIN32)
-  set(CVC5_PYAPI_TEST_DIR ${CMAKE_BINARY_DIR}/cvc5-pyapi-test)
+  set(CVC5_PYAPI_TEST_DIR ${PROJECT_BINARY_DIR}/cvc5-pyapi-test)
 
   set(WHEEL_INSTALL_CMD
        "${Python_EXECUTABLE} -m pip install --prefix ${CVC5_PYAPI_TEST_DIR}")
@@ -36,10 +36,10 @@ if(WIN32)
       ${CMAKE_COMMAND}
         -DPython_EXECUTABLE=${Python_EXECUTABLE}
         -DRepairwheel_EXECUTABLE=${Repairwheel_EXECUTABLE}
-        -DBUILD_DIR=${CMAKE_BINARY_DIR}
+        -DBUILD_DIR=${PROJECT_BINARY_DIR}
         -DDEPS_BASE=${DEPS_BASE}
         -DINSTALL_CMD="${WHEEL_INSTALL_CMD}"
-        -P ${CMAKE_SOURCE_DIR}/cmake/install_python_wheel.cmake
+        -P ${PROJECT_SOURCE_DIR}/cmake/install_python_wheel.cmake
     DEPENDS cvc5_python_api
   )
 
@@ -56,7 +56,7 @@ if(WIN32)
     OUTPUT_VARIABLE PYTHON_MODULE_PATH
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 else()
-  set(PYTHON_MODULE_PATH ${CMAKE_BINARY_DIR}/src/api/python)
+  set(PYTHON_MODULE_PATH ${PROJECT_BINARY_DIR}/src/api/python)
   add_dependencies(build-pyapitests cvc5_python_api)
 endif()
 

--- a/test/binary/CMakeLists.txt
+++ b/test/binary/CMakeLists.txt
@@ -12,7 +12,7 @@
 include_directories(.)
 include_directories(${PROJECT_SOURCE_DIR}/src)
 include_directories(${PROJECT_SOURCE_DIR}/src/include)
-include_directories(${CMAKE_BINARY_DIR}/src)
+include_directories(${PROJECT_BINARY_DIR}/src)
 
 # if we've built using libedit, (--editline) then we want the interactive shell tests
 if (USE_EDITLINE)
@@ -24,29 +24,29 @@ if (USE_EDITLINE)
   add_test(
     NAME interactive_shell
     COMMAND
-    "${Python_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/test/binary/interactive_shell.py"
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+    "${Python_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/test/binary/interactive_shell.py"
+    WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
   )
   set_tests_properties(interactive_shell PROPERTIES LABELS "binary")
   add_test(
     NAME interactive_shell_parser_inc
     COMMAND
-    "${Python_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/test/binary/interactive_shell_parser_inc.py"
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+    "${Python_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/test/binary/interactive_shell_parser_inc.py"
+    WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
   )
   set_tests_properties(interactive_shell_parser_inc PROPERTIES LABELS "binary")
   add_test(
     NAME interactive_shell_define_fun_rec_multiline
     COMMAND
-    "${Python_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/test/binary/interactive_shell_define_fun_rec_multiline.py"
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+    "${Python_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/test/binary/interactive_shell_define_fun_rec_multiline.py"
+    WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
   )
   set_tests_properties(interactive_shell_define_fun_rec_multiline PROPERTIES LABELS "binary")
   add_test(
     NAME issue_10258
     COMMAND
-    "${Python_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/test/binary/issue_10258.py"
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+    "${Python_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/test/binary/issue_10258.py"
+    WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
   )
   set_tests_properties(issue_10258 PROPERTIES LABELS "binary")
 endif()

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -4465,7 +4465,7 @@ endforeach()
 # we use a Cmake feature called FIXTURES to add 'build_regress' as the first test
 # which builds the 'build_regress' target.
 # Disabled temporarily due to problems in the nightly builds
-# add_test(build_regress_test "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --config "$<CONFIG>" --target build-regress)
+# add_test(build_regress_test "${CMAKE_COMMAND}" --build "${PROJECT_BINARY_DIR}" --config "$<CONFIG>" --target build-regress)
 # set_tests_properties(build_regress_test PROPERTIES FIXTURES_SETUP build_regress_fixture)
 
 macro(cvc5_add_regression_test level file)
@@ -4481,11 +4481,11 @@ macro(cvc5_add_regression_test level file)
     ${Python_EXECUTABLE}
     ${run_regress_script}
     ${RUN_REGRESSION_ARGS}
-    --lfsc-binary ${CMAKE_SOURCE_DIR}/deps/bin/lfscc
-    --lfsc-sig-dir ${CMAKE_SOURCE_DIR}/proofs/lfsc/signatures
-    --carcara-binary ${CMAKE_SOURCE_DIR}/deps/bin/carcara
-    --ethos-binary ${CMAKE_SOURCE_DIR}/deps/bin/ethos
-    --cpc-sig-dir ${CMAKE_SOURCE_DIR}/proofs/eo
+    --lfsc-binary ${PROJECT_SOURCE_DIR}/deps/bin/lfscc
+    --lfsc-sig-dir ${PROJECT_SOURCE_DIR}/proofs/lfsc/signatures
+    --carcara-binary ${PROJECT_SOURCE_DIR}/deps/bin/carcara
+    --ethos-binary ${PROJECT_SOURCE_DIR}/deps/bin/ethos
+    --cpc-sig-dir ${PROJECT_SOURCE_DIR}/proofs/eo
     ${wrapper}
     ${path_to_cvc5}/cvc5${CMAKE_EXECUTABLE_SUFFIX}
     ${CMAKE_CURRENT_LIST_DIR}/${file})

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(GTest REQUIRED)
 include_directories(.)
 include_directories(${PROJECT_SOURCE_DIR}/src)
 include_directories(${PROJECT_SOURCE_DIR}/src/include)
-include_directories(${CMAKE_BINARY_DIR}/src)
+include_directories(${PROJECT_BINARY_DIR}/src)
 
 #-----------------------------------------------------------------------------#
 # Add target 'units', builds and runs
@@ -27,7 +27,7 @@ add_dependencies(build-tests build-units)
 
 # See the comment about 'make test' in test/regress/cli/CMakeLists.txt
 # Disabled temporarily due to problems in the nightly builds
-# add_test(build_units_test "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --config "$<CONFIG>" --target build-units)
+# add_test(build_units_test "${CMAKE_COMMAND}" --build "${PROJECT_BINARY_DIR}" --config "$<CONFIG>" --target build-units)
 # set_tests_properties(build_units_test PROPERTIES FIXTURES_SETUP build_units_fixture)
 
 add_custom_target(units
@@ -67,7 +67,7 @@ macro(cvc5_add_unit_test is_white name output_dir)
     endif()
     add_dependencies(build-units ${name})
     # Generate into bin/test/unit/<output_dir>.
-    set(test_bin_dir ${CMAKE_BINARY_DIR}/bin/test/unit/${output_dir})
+    set(test_bin_dir ${PROJECT_BINARY_DIR}/bin/test/unit/${output_dir})
     set_target_properties(${name}
       PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${test_bin_dir})
     # The test target is prefixed with test identifier 'unit/' and the path,

--- a/test/unit/api/python/CMakeLists.txt
+++ b/test/unit/api/python/CMakeLists.txt
@@ -22,7 +22,7 @@ macro(cvc5_add_python_api_unit_test name)
     COMMAND ${Python_EXECUTABLE}
             -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/${name}.py
     # directory for importing the python bindings
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src/api/python)
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src/api/python)
     set_tests_properties(${test_name} PROPERTIES LABELS "unit;python")
 endmacro()
 


### PR DESCRIPTION
Replace `CMAKE_SOURCE_DIR`/`CMAKE_BINARY_DIR` with `PROJECT_SOURCE_DIR`/`PROJECT_BINARY_DIR` in CMakeLists.txt files to ensure correct path resolution when cvc5 is used via `FetchContent`. Also, fix include path separation in `target_include_directories`.

Resolve #12061