### PR TITLE
Fix DT_INST reconstruction in datatypes infer proof cons

### DIFF
--- a/src/theory/datatypes/infer_proof_cons.cpp
+++ b/src/theory/datatypes/infer_proof_cons.cpp
@@ -274,7 +274,7 @@ void InferProofCons::convert(InferenceId infer,
           for (size_t i = 0; i < 2; i++)
           {
             Node t = i == 0 ? tester1 : tester1c;
-            Node inst = rr->rewriteViaRule(ProofRewriteRule::DT_INST, tester1);
+            Node inst = rr->rewriteViaRule(ProofRewriteRule::DT_INST, t);
             Assert(!inst.isNull());
             Assert(inst.getKind() == Kind::EQUAL);
             Node eq = t.eqNode(inst);
@@ -290,8 +290,8 @@ void InferProofCons::convert(InferenceId infer,
           }
           Node ceq = insts[0][0].eqNode(insts[1][1]);
           cdp->addStep(ceq, ProofRule::TRANS, insts, {});
+          tryRewriteRule(ceq, fn, ProofRewriteRule::MACRO_DT_CONS_EQ, cdp);
           Node ceqf = ceq.eqNode(fn);
-          tryRewriteRule(ceqf, conc, ProofRewriteRule::MACRO_DT_CONS_EQ, cdp);
           cdp->addStep(fn, ProofRule::EQ_RESOLVE, {ceq, ceqf}, {});
         }
         success = true;

--- a/test/regress/cli/regress0/proofs/issue12604-dt-tester-merge.smt2
+++ b/test/regress/cli/regress0/proofs/issue12604-dt-tester-merge.smt2
@@ -2,7 +2,7 @@
 ; EXPECT: unknown
 (set-logic ALL)
 (declare-const x Bool)
-(declare-datatypes ((F 0)) (((N) (A) (O (l F) (l2 F)) (a (d (_ BitVec 1)))))))
+(declare-datatypes ((F 0)) (((N) (A) (O (l F) (l2 F)) (a (d (_ BitVec 1))))))
 (declare-fun r () F)
 (declare-fun e (F) Bool)
 (declare-fun n (F) F)

--- a/test/regress/cli/regress0/proofs/issue12604-dt-tester-merge.smt2
+++ b/test/regress/cli/regress0/proofs/issue12604-dt-tester-merge.smt2
@@ -1,0 +1,12 @@
+; COMMAND-LINE: --check-proofs
+; EXPECT: unknown
+(set-logic ALL)
+(declare-const x Bool)
+(declare-datatypes ((F 0)) (((N) (A) (O (l F) (l2 F)) (a (d (_ BitVec 1)))))))
+(declare-fun r () F)
+(declare-fun e (F) Bool)
+(declare-fun n (F) F)
+(assert (forall ((o F)) (= ((_ is O) o) (ite ((_ is A) o) (or (e (n o))) (ite ((_ is N) r) false (ite false ((_ is A) N) true))))))
+(assert (forall ((o F)) (= (n o) (ite ((_ is A) o) A (ite ((_ is a) r) r (O N (n r)))))))
+(assert (exists ((f F)) (and (or ((_ is a) f) x) (distinct (e r) (e (n f))))))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/12604.

Note this block was missing from our code coverage.

Co-authored-by: ChatGPT 5.4 [noreply@openai.com](mailto:noreply@openai.com)