### PR TITLE
Ensure factors of shared multiplication terms are preregistered

### DIFF
--- a/src/theory/arith/nl/nonlinear_extension.cpp
+++ b/src/theory/arith/nl/nonlinear_extension.cpp
@@ -344,7 +344,8 @@ void NonlinearExtension::checkFullEffort(std::map<Node, Node>& arithModel,
       {
         for (const Node& stf : st)
         {
-          if (arithModel.find(stf) == arithModel.end() && factorsSplit.insert(stf).second)
+          if (arithModel.find(stf) == arithModel.end()
+              && factorsSplit.insert(stf).second)
           {
             Trace("nl-model-final") << "*** Identified multiplication term "
                                        "with factor that is not preregistered: "

--- a/src/theory/arith/nl/nonlinear_extension.cpp
+++ b/src/theory/arith/nl/nonlinear_extension.cpp
@@ -336,6 +336,26 @@ void NonlinearExtension::checkFullEffort(std::map<Node, Node>& arithModel,
       Trace("nl-model-final")
           << "- shared term value (post) " << st << " = " << stv << std::endl;
       sharedTermsPost[stv].emplace_back(st);
+      // Corner case: if a multiplication term, need to ensure that each of
+      // our variables are assigned in the model. If not, to force this to be
+      // the case, we split on that variable and zero.
+      if (st.getKind()==Kind::NONLINEAR_MULT)
+      {
+        for (const Node& stf : st)
+        {
+          if (arithModel.find(stf)==arithModel.end())
+          {
+            Trace("nl-model-final")
+                << "*** Identified multiplication term with factor that is not preregistered: " << st
+                << " " << stf << std::endl;
+            Node zero = nodeManager()->mkConstRealOrInt(stf.getType(), Rational(0));
+            Node eq = stf.eqNode(zero);
+            Node split = eq.orNode(eq.negate());
+            NlLemma nlem(InferenceId::ARITH_NL_SHARED_TERM_FACTOR_SPLIT, split);
+            d_im.addPendingLemma(nlem);
+          }
+        }
+      }
     }
     std::unordered_map<TNode, Node>::iterator itrs;
     for (const std::pair<const TNode, std::vector<Node>>& stp : sharedTermsPost)

--- a/src/theory/arith/nl/nonlinear_extension.cpp
+++ b/src/theory/arith/nl/nonlinear_extension.cpp
@@ -330,6 +330,7 @@ void NonlinearExtension::checkFullEffort(std::map<Node, Node>& arithModel,
     // prior to modifying the model. If we did so for two terms t and s, then we
     // must split on t = s.
     std::unordered_map<TNode, std::vector<Node>> sharedTermsPost;
+    std::unordered_set<Node> factorsSplit;
     for (TNode st : sts)
     {
       Node stv = d_model.computeAbstractModelValue(st);
@@ -343,7 +344,7 @@ void NonlinearExtension::checkFullEffort(std::map<Node, Node>& arithModel,
       {
         for (const Node& stf : st)
         {
-          if (arithModel.find(stf) == arithModel.end())
+          if (arithModel.find(stf) == arithModel.end() && factorsSplit.insert(stf).second)
           {
             Trace("nl-model-final") << "*** Identified multiplication term "
                                        "with factor that is not preregistered: "

--- a/src/theory/arith/nl/nonlinear_extension.cpp
+++ b/src/theory/arith/nl/nonlinear_extension.cpp
@@ -339,16 +339,17 @@ void NonlinearExtension::checkFullEffort(std::map<Node, Node>& arithModel,
       // Corner case: if a multiplication term, need to ensure that each of
       // our variables are assigned in the model. If not, to force this to be
       // the case, we split on that variable and zero.
-      if (st.getKind()==Kind::NONLINEAR_MULT)
+      if (st.getKind() == Kind::NONLINEAR_MULT)
       {
         for (const Node& stf : st)
         {
-          if (arithModel.find(stf)==arithModel.end())
+          if (arithModel.find(stf) == arithModel.end())
           {
-            Trace("nl-model-final")
-                << "*** Identified multiplication term with factor that is not preregistered: " << st
-                << " " << stf << std::endl;
-            Node zero = nodeManager()->mkConstRealOrInt(stf.getType(), Rational(0));
+            Trace("nl-model-final") << "*** Identified multiplication term "
+                                       "with factor that is not preregistered: "
+                                    << st << " " << stf << std::endl;
+            Node zero =
+                nodeManager()->mkConstRealOrInt(stf.getType(), Rational(0));
             Node eq = stf.eqNode(zero);
             Node split = eq.orNode(eq.negate());
             NlLemma nlem(InferenceId::ARITH_NL_SHARED_TERM_FACTOR_SPLIT, split);

--- a/src/theory/inference_id.cpp
+++ b/src/theory/inference_id.cpp
@@ -67,6 +67,8 @@ const char* toString(InferenceId i)
     case InferenceId::ARITH_NL_CONGRUENCE: return "ARITH_NL_CONGRUENCE";
     case InferenceId::ARITH_NL_SHARED_TERM_SPLIT:
       return "ARITH_NL_SHARED_TERM_SPLIT";
+    case InferenceId::ARITH_NL_SHARED_TERM_FACTOR_SPLIT:
+      return "ARITH_NL_SHARED_TERM_FACTOR_SPLIT";
     case InferenceId::ARITH_NL_CM_QUADRATIC_EQ:
       return "ARITH_NL_CM_QUADRATIC_EQ";
     case InferenceId::ARITH_NL_SPLIT_ZERO: return "ARITH_NL_SPLIT_ZERO";

--- a/src/theory/inference_id.h
+++ b/src/theory/inference_id.h
@@ -112,6 +112,9 @@ enum class InferenceId
   ARITH_NL_CONGRUENCE,
   // for theory combination when NL model construction identifies shared terms
   ARITH_NL_SHARED_TERM_SPLIT,
+  // for theory combination when NL has a muliplication term with factors that
+  // are not preregistered.
+  ARITH_NL_SHARED_TERM_FACTOR_SPLIT,
   // checkModel found a conflict with a quadratic equality
   ARITH_NL_CM_QUADRATIC_EQ,
   //-------------------- nonlinear incremental linearization solver

--- a/src/theory/inference_id.h
+++ b/src/theory/inference_id.h
@@ -112,7 +112,7 @@ enum class InferenceId
   ARITH_NL_CONGRUENCE,
   // for theory combination when NL model construction identifies shared terms
   ARITH_NL_SHARED_TERM_SPLIT,
-  // for theory combination when NL has a muliplication term with factors that
+  // for theory combination when NL has a multiplication term with factors that
   // are not preregistered.
   ARITH_NL_SHARED_TERM_FACTOR_SPLIT,
   // checkModel found a conflict with a quadratic equality

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1146,6 +1146,7 @@ set(regress_0_tests
   regress0/nl/issue11901-pow-rewrite-type.smt2
   regress0/nl/issue12239-subtype-elim.smt2
   regress0/nl/issue12408-nl-fm.smt2
+  regress0/nl/issue12607-shared-term-factor.smt2
   regress0/nl/issue3003.smt2
   regress0/nl/issue3407.smt2
   regress0/nl/issue3411.smt2

--- a/test/regress/cli/regress0/nl/issue12607-shared-term-factor.smt2
+++ b/test/regress/cli/regress0/nl/issue12607-shared-term-factor.smt2
@@ -1,0 +1,7 @@
+; EXPECT: sat
+(set-logic ALL)
+(declare-fun b () Real)
+(declare-fun r () (Array Real Real))
+(assert (= 0.0 (select r (* b b))))
+(assert (= 1.0 (select r 1.0)))
+(check-sat)


### PR DESCRIPTION
Fixes https://github.com/cvc5/cvc5/issues/12607.

Note this corner case happens quite rarely, it happens on only 1 previous regression and the added regression.