### PR TITLE
Integer: Fix off-by-one in mkRandom() with CLN.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
           - name: ubuntu:production-dbg-clang
             os: ubuntu-22.04
             use-clang: true
-            config: production --auto-download --assertions --tracing --cln --gpl -DNO_GLOBAL_POLY_CTX=1
+            config: production --auto-download --assertions --tracing --cln --gpl --unit-testing -DNO_GLOBAL_POLY_CTX=1
             cache-key: dbgclang
             exclude_regress: 3-4
             run_regression_args: --tester cpc --tester alethe --tester base --tester model --tester synth --tester abduct --tester unsat-core --tester dump

--- a/src/util/integer_cln_imp.cpp
+++ b/src/util/integer_cln_imp.cpp
@@ -601,7 +601,7 @@ Integer Integer::mkRandom(uint32_t nbits)
   Assert(nbits > 0);
   Random& rnd = Random::getRandom();
   cln::cl_I max(2);
-  max = cln::expt_pos(max, nbits) - 1;
+  max = cln::expt_pos(max, nbits);
   cln::cl_I res = cln::random_I(*rnd.getCLNRandstate(), max);
   return Integer(res);
 }


### PR DESCRIPTION
cln::random_I(random_state, n) picks a random number >= 0 but < n. This fixes an off-by-one in Integer::mkRandom() (which takes the number of bits the random Integer should be representable in) where, previously, `n` was considered to be an inclusive bound.

This was not caught in CI since the CLN build was run without unit testing. This commit enables unit testing for
the CLN build.

This fixes the failure in the nightlies.