### PR TITLE
Update ethos, fixes chain_m_resolution. Preparation for release.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@ cvc5 1.3.4 prerelease
   quantified variables occur under UFs.
 - Fixes an issue where the parser would abort prematurely when `get-value` was
   called after an unsat response when uninterpreted sorts are present.
+- Fixes issues related to theory combination with arrays and non-linear
+  arithmetic.
 
 cvc5 1.3.3
 ==========

--- a/contrib/get-ethos-checker
+++ b/contrib/get-ethos-checker
@@ -27,7 +27,7 @@ EO_DIR="$BASE_DIR/ethos-checker"
 mkdir -p $EO_DIR
 
 # download and unpack ethos
-ETHOS_VERSION="72ce6374a4e3436895b0754445c2f3900ffec06d"
+ETHOS_VERSION="26e6c62d0f5fe462d5477a2487b5e2fd6fde8642"
 download "https://github.com/cvc5/ethos/archive/$ETHOS_VERSION.tar.gz" $BASE_DIR/tmp/ethos.tgz
 tar --strip 1 -xzf $BASE_DIR/tmp/ethos.tgz -C $EO_DIR
 

--- a/proofs/eo/cpc/rules/Booleans.eo
+++ b/proofs/eo/cpc/rules/Booleans.eo
@@ -257,7 +257,7 @@
 (declare-rule reordering ((C1 Bool) (C2 Bool))
     :premises (C1)
     :args (C2)
-    :requires (((eo::list_minclude or C1 C2) true))
+    :requires (((eo::list_minclude or C2 C1) true))
     :conclusion C2
 )
 

--- a/proofs/eo/cpc/rules/Datatypes.eo
+++ b/proofs/eo/cpc/rules/Datatypes.eo
@@ -163,7 +163,7 @@
   (
   (($mk_dt_cons_eq (tuple a as) (tuple b bs)) (_ and (= a b) ($mk_dt_cons_eq as bs)))
   (($mk_dt_cons_eq (f a) (g b))               (eo::list_concat and ($mk_dt_cons_eq f g) (and (= a b))))
-  (($mk_dt_cons_eq c c)                       (eo::requires ($dt_is_cons c) true true))
+  (($mk_dt_cons_eq c c)                       true)
   )
 )
 

--- a/proofs/eo/cpc/rules/Datatypes.eo
+++ b/proofs/eo/cpc/rules/Datatypes.eo
@@ -163,7 +163,7 @@
   (
   (($mk_dt_cons_eq (tuple a as) (tuple b bs)) (_ and (= a b) ($mk_dt_cons_eq as bs)))
   (($mk_dt_cons_eq (f a) (g b))               (eo::list_concat and ($mk_dt_cons_eq f g) (and (= a b))))
-  (($mk_dt_cons_eq c c)                       true)
+  (($mk_dt_cons_eq c c)                       (eo::requires ($dt_is_cons c) true true))
   )
 )
 


### PR DESCRIPTION
This updates Ethos to a version in which `eo::list_minclude` matches the user manual. This effectively fixes an unsoundness in CHAIN_M_RESOLUTION, which was checking multi-set inclusion in the opposite way that than Ethos implemented. Given the swapped order, this changes REORDERING to match the new order (it was already correct).

This issues was discovered in Logos verification in Lean.