### PR TITLE
[alethe] Require valid Alethe proofs in CI

### DIFF
--- a/contrib/get-carcara-checker
+++ b/contrib/get-carcara-checker
@@ -26,7 +26,7 @@ CARCARA_DIR="$BASE_DIR/carcara"
 mkdir -p $CARCARA_DIR
 
 # download and unpack Carcara
-CARCARA_VERSION="5f9f77bf83c52748dccc12829ce5e80903de0c99"
+CARCARA_VERSION="394edbb15ba95c47893f1d821fddde7e016af178"
 download "https://github.com/hanielb/carcara/archive/$CARCARA_VERSION.tar.gz" $BASE_DIR/tmp/carcara.tgz
 tar --strip 1 -xzf $BASE_DIR/tmp/carcara.tgz -C $CARCARA_DIR
 rm $BASE_DIR/tmp/carcara.tgz

--- a/src/options/proof_options.toml
+++ b/src/options/proof_options.toml
@@ -176,6 +176,14 @@ name   = "Proof"
   help       = "Add pivots to Alethe resolution steps"
 
 [[option]]
+  name       = "proofAletheTesting"
+  category   = "expert"
+  long       = "proof-alethe-testing"
+  type       = "bool"
+  default    = "false"
+  help       = "If testing, do not support experimental features such as BV, Strings, Datatypes, and print holes coming from the CPC proof with an \"undefined\" rule to help identify it."
+
+[[option]]
   name       = "printDotAsDAG"
   category   = "expert"
   long       = "proof-dot-dag"

--- a/src/proof/alethe/alethe_node_converter.cpp
+++ b/src/proof/alethe/alethe_node_converter.cpp
@@ -72,6 +72,15 @@ void collectTypes(std::vector<TypeNode>& allTypesVec,
   }
 }
 
+Node AletheNodeConverter::recordUnsupportedKind(Kind k)
+{
+  Trace("alethe-conv") << "AletheNodeConverter: ...unsupported kind\n";
+  std::stringstream ss;
+  ss << "\"Proof unsupported by Alethe: contains operator " << k << "\"";
+  d_error = ss.str();
+  return Node::null();
+}
+
 Node AletheNodeConverter::postConvert(Node n)
 {
   Kind k = n.getKind();
@@ -81,6 +90,10 @@ Node AletheNodeConverter::postConvert(Node n)
   {
     case Kind::BITVECTOR_BIT:
     {
+      if (d_isTesting)
+      {
+        return recordUnsupportedKind(k);
+      }
       std::stringstream ss;
       ss << "(_ @bit_of " << n.getOperator().getConst<BitVectorBit>().d_bitIndex
          << ")";
@@ -93,6 +106,10 @@ Node AletheNodeConverter::postConvert(Node n)
     }
     case Kind::BITVECTOR_FROM_BOOLS:
     {
+      if (d_isTesting)
+      {
+        return recordUnsupportedKind(k);
+      }
       std::vector<Node> children;
       std::vector<TypeNode> childrenTypes;
       for (const Node& c : n)
@@ -108,6 +125,10 @@ Node AletheNodeConverter::postConvert(Node n)
     }
     case Kind::BITVECTOR_EAGER_ATOM:
     {
+      if (d_isTesting)
+      {
+        return recordUnsupportedKind(k);
+      }
       return n[0];
     }
     case Kind::DIVISION_TOTAL:
@@ -327,9 +348,6 @@ Node AletheNodeConverter::postConvert(Node n)
     case Kind::LAMBDA:
     case Kind::HO_APPLY:
     case Kind::FUNCTION_ARRAY_CONST:
-    case Kind::BITVECTOR_UBV_TO_INT:
-    case Kind::INT_TO_BITVECTOR_OP:
-    case Kind::INT_TO_BITVECTOR:
     /* from arith */
     case Kind::ADD:
     case Kind::MULT:
@@ -352,6 +370,33 @@ Node AletheNodeConverter::postConvert(Node n)
     case Kind::TO_INTEGER:
     case Kind::TO_REAL:
     case Kind::POW2:
+    /* from arrays */
+    case Kind::ARRAY_TYPE:
+    case Kind::SELECT:
+    case Kind::STORE:
+    case Kind::ARRAY_LAMBDA:
+    /* from quantifiers */
+    case Kind::EXISTS:
+    case Kind::BOUND_VAR_LIST:
+    case Kind::INST_PATTERN:
+    case Kind::INST_NO_PATTERN:
+    case Kind::INST_ATTRIBUTE:
+    case Kind::INST_POOL:
+    case Kind::INST_ADD_TO_POOL:
+    case Kind::SKOLEM_ADD_TO_POOL:
+    case Kind::INST_PATTERN_LIST:
+    {
+      return n;
+    }
+    // BV, datatypes, strings, and constant array kinds are no-op in
+    // conversion but are reported as unsupported when running in Alethe
+    // testing mode.
+    /* from arrays (constant arrays) */
+    case Kind::STORE_ALL:
+    /* from uf (BV-related) */
+    case Kind::BITVECTOR_UBV_TO_INT:
+    case Kind::INT_TO_BITVECTOR_OP:
+    case Kind::INT_TO_BITVECTOR:
     /* from BV */
     case Kind::BITVECTOR_TYPE:
     case Kind::CONST_BITVECTOR:
@@ -403,12 +448,6 @@ Node AletheNodeConverter::postConvert(Node n)
     case Kind::BITVECTOR_SIGN_EXTEND:
     case Kind::BITVECTOR_ZERO_EXTEND_OP:
     case Kind::BITVECTOR_ZERO_EXTEND:
-    /* from arrays */
-    case Kind::ARRAY_TYPE:
-    case Kind::SELECT:
-    case Kind::STORE:
-    case Kind::STORE_ALL:
-    case Kind::ARRAY_LAMBDA:
     /* from datatypes */
     case Kind::CONSTRUCTOR_TYPE:
     case Kind::SELECTOR_TYPE:
@@ -468,17 +507,11 @@ Node AletheNodeConverter::postConvert(Node n)
     case Kind::REGEXP_LOOP_OP:
     case Kind::REGEXP_LOOP:
     case Kind::REGEXP_RV:
-    /* from quantifiers */
-    case Kind::EXISTS:
-    case Kind::BOUND_VAR_LIST:
-    case Kind::INST_PATTERN:
-    case Kind::INST_NO_PATTERN:
-    case Kind::INST_ATTRIBUTE:
-    case Kind::INST_POOL:
-    case Kind::INST_ADD_TO_POOL:
-    case Kind::SKOLEM_ADD_TO_POOL:
-    case Kind::INST_PATTERN_LIST:
     {
+      if (d_isTesting)
+      {
+        return recordUnsupportedKind(k);
+      }
       return n;
     }
     case Kind::BOUND_VARIABLE:
@@ -503,13 +536,22 @@ Node AletheNodeConverter::postConvert(Node n)
           case Kind::SORT_TYPE:
           case Kind::INSTANTIATED_SORT_TYPE:
           case Kind::FUNCTION_TYPE:
-          case Kind::BITVECTOR_TYPE:
           case Kind::ARRAY_TYPE:
+          {
+            continue;
+          }
+          // BV and datatypes type kinds are unsupported under testing mode.
+          case Kind::BITVECTOR_TYPE:
           case Kind::CONSTRUCTOR_TYPE:
           case Kind::SELECTOR_TYPE:
           case Kind::TESTER_TYPE:
           case Kind::ASCRIPTION_TYPE:
           {
+            if (d_isTesting)
+            {
+              unsupported = ttn;
+              break;
+            }
             continue;
           }
           default:
@@ -523,17 +565,27 @@ Node AletheNodeConverter::postConvert(Node n)
                 case TypeConstant::BOOLEAN_TYPE:
                 case TypeConstant::REAL_TYPE:
                 case TypeConstant::INTEGER_TYPE:
+                {
+                  continue;
+                }
+                // String and regexp types are unsupported under testing mode.
                 case TypeConstant::STRING_TYPE:
                 case TypeConstant::REGEXP_TYPE:
                 {
-                  continue;
+                  if (!d_isTesting)
+                  {
+                    continue;
+                  }
+                  break;  // fallthrough to the error handling below
                 }
                 default:  // fallthrough to the error handling below
                   break;
               }
             }
-            // Only regular datatypes (parametric or not) are supported
-            else if (ttn.isDatatype() && !ttn.getDType().isCodatatype()
+            // Only regular datatypes (parametric or not) are supported, and
+            // only outside testing mode.
+            else if (!d_isTesting && ttn.isDatatype()
+                     && !ttn.getDType().isCodatatype()
                      && (tnk == Kind::DATATYPE_TYPE
                          || tnk == Kind::PARAMETRIC_DATATYPE))
             {
@@ -571,11 +623,7 @@ Node AletheNodeConverter::postConvert(Node n)
     }
     default:
     {
-      Trace("alethe-conv") << "AletheNodeConverter: ...unsupported kind\n";
-      std::stringstream ss;
-      ss << "\"Proof unsupported by Alethe: contains operator " << k << "\"";
-      d_error = ss.str();
-      return Node::null();
+      return recordUnsupportedKind(k);
     }
   }
   return n;

--- a/src/proof/alethe/alethe_node_converter.h
+++ b/src/proof/alethe/alethe_node_converter.h
@@ -34,9 +34,15 @@ class AletheNodeConverter : public BaseEoNodeConverter
    * @param nm The node manager
    * @param defineSkolems Whether Skolem definitions will be saved to be printed
    * separately.
+   * @param isTesting Whether the converter is running in Alethe testing mode
+   * (excludes BV, datatypes, and strings kinds/types).
    */
-  AletheNodeConverter(NodeManager* nm, bool defineSkolems = false)
-      : BaseEoNodeConverter(nm), d_defineSkolems(defineSkolems)
+  AletheNodeConverter(NodeManager* nm,
+                      bool defineSkolems = false,
+                      bool isTesting = false)
+      : BaseEoNodeConverter(nm),
+        d_defineSkolems(defineSkolems),
+        d_isTesting(isTesting)
   {
   }
   ~AletheNodeConverter() {}
@@ -89,6 +95,13 @@ class AletheNodeConverter : public BaseEoNodeConverter
   std::string d_error;
   /** Whether Skolem definitions will be saved to be printed separately. */
   bool d_defineSkolems;
+  /** Whether the converter is running in Alethe testing mode. When true, BV,
+   * datatypes, and strings kinds/types are reported as unsupported. */
+  bool d_isTesting;
+
+  /** Set d_error to indicate that kind k is unsupported and return a null
+   * node. */
+  Node recordUnsupportedKind(Kind k);
 
   /**
    * As above but uses the s-expression type.

--- a/src/proof/alethe/alethe_post_processor.cpp
+++ b/src/proof/alethe/alethe_post_processor.cpp
@@ -1061,14 +1061,14 @@ bool AletheProofPostprocessCallback::update(Node res,
     }
     case ProofRule::TRUST_THEORY_REWRITE:
     {
-      return addAletheStep(options().proof.proofAletheTesting
-                               ? AletheRule::UNDEFINED
-                               : AletheRule::HOLE,
-                           res,
-                           nm->mkNode(Kind::SEXPR, d_cl, res),
-                           children,
-                           {nm->mkRawSymbol("\"untranslated rewrite\"", nm->sExprType())},
-                           *cdp);
+      return addAletheStep(
+          options().proof.proofAletheTesting ? AletheRule::UNDEFINED
+                                             : AletheRule::HOLE,
+          res,
+          nm->mkNode(Kind::SEXPR, d_cl, res),
+          children,
+          {nm->mkRawSymbol("\"untranslated rewrite\"", nm->sExprType())},
+          *cdp);
     }
     // ======== Resolution and N-ary Resolution
     // Because the RESOLUTION rule is merely a special case of CHAIN_RESOLUTION,

--- a/src/proof/alethe/alethe_post_processor.cpp
+++ b/src/proof/alethe/alethe_post_processor.cpp
@@ -1013,8 +1013,6 @@ bool AletheProofPostprocessCallback::update(Node res,
                            {},
                            *cdp);
     }
-    // If the trusted rule is a theory lemma from arithmetic, we try to phrase
-    // it with "lia_generic".
     case ProofRule::TRUST:
     {
       // check for case where the trust step is introducing an equality between
@@ -1034,36 +1032,6 @@ bool AletheProofPostprocessCallback::update(Node res,
       }
       TrustId tid;
       bool hasTrustId = getTrustId(args[0], tid);
-      if (hasTrustId && tid == TrustId::THEORY_LEMMA)
-      {
-        // if we are in the arithmetic case, we rather add a LIA_GENERIC step
-        if (res.getKind() == Kind::NOT && res[0].getKind() == Kind::AND)
-        {
-          Trace("alethe-proof") << "... test each arg if ineq\n";
-          bool allIneqs = true;
-          for (const Node& arg : res[0])
-          {
-            Node toTest = arg.getKind() == Kind::NOT ? arg[0] : arg;
-            Kind k = toTest.getKind();
-            if (k != Kind::LT && k != Kind::LEQ && k != Kind::GT
-                && k != Kind::GEQ && k != Kind::EQUAL)
-            {
-              Trace("alethe-proof") << "... arg " << arg << " not ineq\n";
-              allIneqs = false;
-              break;
-            }
-          }
-          if (allIneqs)
-          {
-            return addAletheStep(AletheRule::LIA_GENERIC,
-                                 res,
-                                 nm->mkNode(Kind::SEXPR, d_cl, res),
-                                 children,
-                                 {},
-                                 *cdp);
-          }
-        }
-      }
       std::stringstream ss;
       if (hasTrustId)
       {
@@ -1082,11 +1050,24 @@ bool AletheProofPostprocessCallback::update(Node res,
       std::vector<Node> newArgs{
           NodeManager::mkRawSymbol(ss.str(), nm->sExprType())};
       newArgs.insert(newArgs.end(), args.begin() + 1, args.end());
-      return addAletheStep(AletheRule::HOLE,
+      return addAletheStep(options().proof.proofAletheTesting
+                               ? AletheRule::UNDEFINED
+                               : AletheRule::HOLE,
                            res,
                            nm->mkNode(Kind::SEXPR, d_cl, res),
                            children,
                            newArgs,
+                           *cdp);
+    }
+    case ProofRule::TRUST_THEORY_REWRITE:
+    {
+      return addAletheStep(options().proof.proofAletheTesting
+                               ? AletheRule::UNDEFINED
+                               : AletheRule::HOLE,
+                           res,
+                           nm->mkNode(Kind::SEXPR, d_cl, res),
+                           children,
+                           {nm->mkRawSymbol("\"untranslated rewrite\"", nm->sExprType())},
                            *cdp);
     }
     // ======== Resolution and N-ary Resolution
@@ -2871,6 +2852,41 @@ bool AletheProofPostprocessCallback::update(Node res,
         }
       }
       return success;
+    }
+    // incremental linearization rules for multiplication
+    case ProofRule::ARITH_MULT_SIGN:
+    {
+      return addAletheStep(AletheRule::LA_MULT_SIGN,
+                           res,
+                           nm->mkNode(Kind::SEXPR, d_cl, res),
+                           {},
+                           {},
+                           *cdp);
+    }
+    case ProofRule::ARITH_MULT_ABS_COMPARISON:
+    {
+      return addAletheStep(AletheRule::LA_MULT_ABS_COMPARISON,
+                           res,
+                           nm->mkNode(Kind::SEXPR, d_cl, res),
+                           {},
+                           {},
+                           *cdp);
+    }
+    case ProofRule::ARITH_MULT_TANGENT:
+    {
+      // upper
+      Node ruleStr = nm->mkRawSymbol(args.back().getConst<bool>()
+                                         ? "\"mult-tangent-upper\""
+                                         : "\"mult-tangent-lower\"",
+                                     nm->sExprType());
+      std::vector<Node> ruleArgs{ruleStr};
+      ruleArgs.insert(ruleArgs.end(), args.begin(), args.end() - 1);
+      return addAletheStep(AletheRule::RARE_REWRITE,
+                           res,
+                           nm->mkNode(Kind::SEXPR, d_cl, res),
+                           {},
+                           ruleArgs,
+                           *cdp);
     }
     // arrays_idx
     case ProofRule::ARRAYS_READ_OVER_WRITE_1:

--- a/src/proof/alethe/alethe_proof_rule.cpp
+++ b/src/proof/alethe/alethe_proof_rule.cpp
@@ -61,6 +61,8 @@ const char* aletheRuleToString(AletheRule id)
     case AletheRule::LA_GENERIC: return "la_generic";
     case AletheRule::LA_MULT_POS: return "la_mult_pos";
     case AletheRule::LA_MULT_NEG: return "la_mult_neg";
+    case AletheRule::LA_MULT_SIGN: return "la_mult_sign";
+    case AletheRule::LA_MULT_ABS_COMPARISON: return "la_mult_abs_comparison";
     case AletheRule::LIA_GENERIC: return "lia_generic";
     case AletheRule::LA_DISEQUALITY: return "la_disequality";
     case AletheRule::LA_TOTALITY: return "la_totality";

--- a/src/proof/alethe/alethe_proof_rule.h
+++ b/src/proof/alethe/alethe_proof_rule.h
@@ -191,6 +191,25 @@ enum class AletheRule : uint32_t
   LA_MULT_POS,
   // Tautology for multiplying both sides of inequality by negative factor
   LA_MULT_NEG,
+  // ======== la_mult_sign
+  // > i. (f1 ^ ... ^ fn) -> m <> 0
+  //
+  // in which each fi are variables compared to zero (less, greater or not
+  // equal), m is a monomial from these variables and <> is the comparison (less
+  // or greater) that results from the signs of the variables.
+  LA_MULT_SIGN,
+  // ======== la_mult_abs_comparison
+  // > i1. F1
+  // ...
+  // > in. Fn
+  // ----------
+  // > j. F
+  //
+ // where F is of the form |t1 * tn| <> |s1 <> sn|. If <> is an equality, than
+ // each Fi is |ti| = |si|. Otherwise <> is > then each ti is different from
+ // zero, and each Fi is either an equality or > between the absolute values of
+ // ti, si.
+  LA_MULT_ABS_COMPARISON,
   // Tautology of linear integer arithmetic
   // > i. (cl F1 ... Fn)
   LIA_GENERIC,

--- a/src/proof/alethe/alethe_proof_rule.h
+++ b/src/proof/alethe/alethe_proof_rule.h
@@ -205,10 +205,10 @@ enum class AletheRule : uint32_t
   // ----------
   // > j. F
   //
- // where F is of the form |t1 * tn| <> |s1 <> sn|. If <> is an equality, than
- // each Fi is |ti| = |si|. Otherwise <> is > then each ti is different from
- // zero, and each Fi is either an equality or > between the absolute values of
- // ti, si.
+  // where F is of the form |t1 * tn| <> |s1 <> sn|. If <> is an equality, than
+  // each Fi is |ti| = |si|. Otherwise <> is > then each ti is different from
+  // zero, and each Fi is either an equality or > between the absolute values of
+  // ti, si.
   LA_MULT_ABS_COMPARISON,
   // Tautology of linear integer arithmetic
   // > i. (cl F1 ... Fn)

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -341,7 +341,8 @@ void PfManager::printProof(std::ostream& out,
     options::ProofCheckMode oldMode = options().proof.proofCheck;
     d_pnm->getChecker()->setProofCheckMode(options::ProofCheckMode::NONE);
     proof::AletheNodeConverter anc(nodeManager(),
-                                   options().proof.proofAletheDefineSkolems);
+                                   options().proof.proofAletheDefineSkolems,
+                                   options().proof.proofAletheTesting);
     proof::AletheProofPostprocess vpfpp(d_env, anc);
     if (vpfpp.process(fp))
     {

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -4498,6 +4498,7 @@ macro(cvc5_add_regression_test level file)
     --lfsc-binary ${PROJECT_SOURCE_DIR}/deps/bin/lfscc
     --lfsc-sig-dir ${PROJECT_SOURCE_DIR}/proofs/lfsc/signatures
     --carcara-binary ${PROJECT_SOURCE_DIR}/deps/bin/carcara
+    --carcara-rare ${PROJECT_SOURCE_DIR}/deps/carcara/rewrites.eo
     --ethos-binary ${PROJECT_SOURCE_DIR}/deps/bin/ethos
     --cpc-sig-dir ${PROJECT_SOURCE_DIR}/proofs/eo
     ${wrapper}

--- a/test/regress/cli/run_regression.py
+++ b/test/regress/cli/run_regression.py
@@ -277,7 +277,9 @@ class AletheTester(Tester):
         with tempfile.NamedTemporaryFile(suffix=".smt2.proof") as tmpf:
             cvc5_args = benchmark_info.command_line_args + [
                 "--dump-proofs",
-                "--proof-format=alethe"
+                "--proof-format=alethe",
+                "--proof-granularity=dsl-rewrite",
+                "--proof-alethe-testing"
             ]
             # remove duplicates
             cvc5_args = list(dict.fromkeys(cvc5_args))
@@ -306,7 +308,12 @@ class AletheTester(Tester):
             carcara_args = [
                 "--allow-int-real-subtyping",
                 "--expand-let-bindings",
-                "--ignore-unknown-rules"
+                "--allowed-rules",
+                "undefined",
+                "la_mult_sign",
+                "la_mult_abs_comparison",
+                "--rare-file",
+                benchmark_info.carcara_rare,
             ]
             output, error, exit_status = run_process(
                 [benchmark_info.carcara_binary] + ["check"] +
@@ -317,7 +324,7 @@ class AletheTester(Tester):
             output, error = output.decode(), error.decode()
             exit_code = self.check_exit_status(EXIT_OK, exit_status, output,
                                                error, cvc5_args)
-            if "valid" not in output and "holey" not in output:
+            if "valid" not in output:
                 print_error("Invalid proof")
                 print()
                 print_outputs(output, error)
@@ -551,6 +558,7 @@ BenchmarkInfo = collections.namedtuple(
         "lfsc_binary",
         "lfsc_sigs",
         "carcara_binary",
+        "carcara_rare",
         "ethos_binary",
         "benchmark_dir",
         "benchmark_basename",
@@ -764,6 +772,7 @@ def run_regression(
     lfsc_binary,
     lfsc_sigs,
     carcara_binary,
+    carcara_rare,
     ethos_binary,
     benchmark_path,
     timeout,
@@ -906,6 +915,7 @@ def run_regression(
             lfsc_binary=lfsc_binary,
             lfsc_sigs=lfsc_sigs,
             carcara_binary=carcara_binary,
+            carcara_rare=carcara_rare,
             ethos_binary=ethos_binary,
             benchmark_dir=benchmark_dir,
             benchmark_basename=benchmark_basename,
@@ -949,7 +959,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="Runs benchmark and checks for correct exit status and output."
     )
-    
+
     g_testers_keys = list(g_testers.keys())
     tester_choices = ["all"] + g_testers_keys
     parser.add_argument("--use-skip-return-code", action="store_true")
@@ -959,6 +969,7 @@ def main():
     parser.add_argument("--lfsc-binary", default="")
     parser.add_argument("--lfsc-sig-dir", default="")
     parser.add_argument("--carcara-binary", default="")
+    parser.add_argument("--carcara-rare", default="")
     parser.add_argument("--ethos-binary", default="")
     parser.add_argument("--cpc-sig-dir", default="")
     parser.add_argument("wrapper", nargs="*")
@@ -975,6 +986,7 @@ def main():
     cvc5_binary = os.path.abspath(g_args.cvc5_binary)
     lfsc_binary = os.path.abspath(g_args.lfsc_binary)
     carcara_binary = os.path.abspath(g_args.carcara_binary)
+    carcara_rare = os.path.abspath(g_args.carcara_rare)
     ethos_binary = os.path.abspath(g_args.ethos_binary)
 
     wrapper = g_args.wrapper
@@ -1011,6 +1023,7 @@ def main():
         lfsc_binary,
         lfsc_sigs,
         carcara_binary,
+        carcara_rare,
         ethos_binary,
         g_args.benchmark,
         timeout,


### PR DESCRIPTION
This commit changes the Alethe tester to only accept proofs that Carcara considers `valid`, rather than also accept proofs whose result is `holey`. And CI now tests Alethe proofs with DSL granularity.

There are a couple caveats:
- an option, `--proof-alethe-testing`, is introduced to guard the proof production so that proofs involving BV, strings, constant arrays, and datatypes are considered unspported for the purpose of CI. These are experimental in Alethe/Carcara and will move away from that option in time.
- proof holes coming from CPC, i.e, not introduced by the Alethe translation, are shown as `undefined` rather than `hole`, and Carcara, since given the option `--allowed-rules undefined`, will not consider the proof holey for the purposes of CI.
- the checking of some of the non-linear arithmetic rules has not been implemented in Carcara yet so they are also allowed without making the proof holey.

The Carcara version is bumped. And the regression script is updated to take a path for the Rare file that Carcara is using to check proofs.

This commit includes the changes from #12638.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>