### PR TITLE
Assert non-null Constraint pointer

### DIFF
--- a/src/theory/arith/linear/theory_arith_private.cpp
+++ b/src/theory/arith/linear/theory_arith_private.cpp
@@ -2731,7 +2731,7 @@ std::vector<ConstraintCPVec> TheoryArithPrivate::replayLogRec(
             ++d_statistics.d_cutsProven;
 
             const ConstraintCPVec& exp = ci->getExplanation();
-            Assert (con != NullConstraint);
+            Assert(con != NullConstraint);
             // success
             if (con->isTrue())
             {

--- a/src/theory/arith/linear/theory_arith_private.cpp
+++ b/src/theory/arith/linear/theory_arith_private.cpp
@@ -2731,6 +2731,7 @@ std::vector<ConstraintCPVec> TheoryArithPrivate::replayLogRec(
             ++d_statistics.d_cutsProven;
 
             const ConstraintCPVec& exp = ci->getExplanation();
+            Assert (con != NullConstraint);
             // success
             if (con->isTrue())
             {


### PR DESCRIPTION
Recent versions of clang-tidy (e.g. 20.1.8) warn about a potential null object pointer dereference:
```
[...]/src/theory/arith/linear/theory_arith_private.cpp:2735:17: warning: Called C++ object pointer is null [clang-analyzer-core.CallAndMessage]
2735 | if (con->isTrue())
     |     ^~~
```
This PR adds an assert enforcing the implicit assumption that the `Constraint` pointer is non-null.