### PR TITLE
Remove unnecessary check in dual_simplex

### DIFF
--- a/src/theory/arith/linear/dual_simplex.cpp
+++ b/src/theory/arith/linear/dual_simplex.cpp
@@ -90,19 +90,17 @@ Result::Status DualSimplexDecisionProcedure::dualFindModel(bool exactResult)
   exactResult |= d_varOrderPivotLimit < 0;
 
   uint32_t checkPeriod = options().arith.arithSimplexCheckPeriod;
-  if (result == Result::UNKNOWN)
+
+  uint32_t numDifferencePivots = options().arith.arithHeuristicPivots < 0
+                                      ? d_numVariables + 1
+                                      : options().arith.arithHeuristicPivots;
+  // The signed to unsigned conversion is safe.
+  if (numDifferencePivots > 0)
   {
-    uint32_t numDifferencePivots = options().arith.arithHeuristicPivots < 0
-                                       ? d_numVariables + 1
-                                       : options().arith.arithHeuristicPivots;
-    // The signed to unsigned conversion is safe.
-    if (numDifferencePivots > 0)
+    d_errorSet.setSelectionRule(d_heuristicRule);
+    if (searchForFeasibleSolution(numDifferencePivots))
     {
-      d_errorSet.setSelectionRule(d_heuristicRule);
-      if (searchForFeasibleSolution(numDifferencePivots))
-      {
-        result = Result::UNSAT;
-      }
+      result = Result::UNSAT;
     }
   }
   Assert(!d_errorSet.moreSignals());

--- a/src/theory/arith/linear/dual_simplex.cpp
+++ b/src/theory/arith/linear/dual_simplex.cpp
@@ -92,8 +92,8 @@ Result::Status DualSimplexDecisionProcedure::dualFindModel(bool exactResult)
   uint32_t checkPeriod = options().arith.arithSimplexCheckPeriod;
 
   uint32_t numDifferencePivots = options().arith.arithHeuristicPivots < 0
-                                      ? d_numVariables + 1
-                                      : options().arith.arithHeuristicPivots;
+                                     ? d_numVariables + 1
+                                     : options().arith.arithHeuristicPivots;
   // The signed to unsigned conversion is safe.
   if (numDifferencePivots > 0)
   {


### PR DESCRIPTION
This addresses the following [comment](https://github.com/cvc5/cvc5/pull/12448#issuecomment-3935948289):
> As a sidenote, this check
> 
> https://github.com/cvc5/cvc5/blob/7af3f3305c5c8854e3daa6d97175fd76ff75fb34/src/theory/arith/linear/dual_simplex.cpp#L91
> 
> seems completely pointless, since the guard value is initialized just a couple of lines above and it's not changed. The compiler will probably optimize it away anyway, but could it be removed to reduce the clutter?

