### PR TITLE
Modernize deprecated headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@
 #   clang-analyzer-*
 # Additional checks:
 Checks: >
+  modernize-deprecated-headers,
   modernize-use-nullptr
 HeaderFilterRegex: '.*'
 # Use .clang-format for formatting changes

--- a/src/main/driver_unified.cpp
+++ b/src/main/driver_unified.cpp
@@ -12,9 +12,9 @@
 
 #include <cvc5/cvc5.h>
 #include <cvc5/cvc5_parser.h>
-#include <stdio.h>
 #include <unistd.h>
 
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>

--- a/src/main/portfolio_driver.cpp
+++ b/src/main/portfolio_driver.cpp
@@ -11,9 +11,10 @@
 #include "main/portfolio_driver.h"
 
 #if HAVE_SYS_WAIT_H
-#include <signal.h>
 #include <sys/wait.h>
 #include <unistd.h>
+
+#include <csignal>
 #endif
 
 #include <cvc5/cvc5.h>

--- a/src/main/signal_handlers.cpp
+++ b/src/main/signal_handlers.cpp
@@ -14,18 +14,18 @@
  * a list of async-signal-safe POSIX.1 functions.
  */
 
-#include <string.h>
-
 #include <cerrno>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <exception>
 
 #ifndef __WIN32__
 
-#include <signal.h>
 #include <sys/resource.h>
 #include <unistd.h>
+
+#include <csignal>
 
 #endif /* __WIN32__ */
 

--- a/src/main/time_limit.cpp
+++ b/src/main/time_limit.cpp
@@ -41,8 +41,9 @@
 #include "base/cvc5config.h"
 
 #if HAVE_SETITIMER
-#include <signal.h>
 #include <sys/time.h>
+
+#include <csignal>
 #else
 #include <atomic>
 #include <chrono>

--- a/src/options/managed_streams.cpp
+++ b/src/options/managed_streams.cpp
@@ -15,9 +15,8 @@
 
 #include "options/managed_streams.h"
 
-#include <string.h>
-
 #include <cerrno>
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <sstream>

--- a/src/parser/smt2/smt2_term_parser.cpp
+++ b/src/parser/smt2/smt2_term_parser.cpp
@@ -12,7 +12,7 @@
 
 #include "parser/smt2/smt2_term_parser.h"
 
-#include <string.h>
+#include <cstring>
 
 #include "base/check.h"
 #include "base/output.h"

--- a/src/prop/minisat/core/Solver.cc
+++ b/src/prop/minisat/core/Solver.cc
@@ -20,7 +20,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 
 #include "prop/minisat/core/Solver.h"
 
-#include <math.h>
+#include <cmath>
 
 #include <iostream>
 #include <unordered_set>

--- a/src/theory/arith/linear/approx_simplex.cpp
+++ b/src/theory/arith/linear/approx_simplex.cpp
@@ -14,8 +14,6 @@
  */
 #include "theory/arith/linear/approx_simplex.h"
 
-#include <math.h>
-
 #include <cfloat>
 #include <cmath>
 #include <unordered_set>

--- a/src/theory/arith/linear/cut_log.cpp
+++ b/src/theory/arith/linear/cut_log.cpp
@@ -11,9 +11,7 @@
 
 #include "theory/arith/linear/cut_log.h"
 
-#include <limits.h>
-#include <math.h>
-
+#include <climits>
 #include <cmath>
 #include <iomanip>
 #include <map>

--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -12,7 +12,7 @@
 
 #include "theory/evaluator.h"
 
-#include <math.h>
+#include <cmath>
 
 #include "theory/builtin/theory_builtin_rewriter.h"
 #include "theory/bv/theory_bv_utils.h"

--- a/src/theory/partition_generator.cpp
+++ b/src/theory/partition_generator.cpp
@@ -12,9 +12,8 @@
 
 #include "theory/partition_generator.h"
 
-#include <math.h>
-
 #include <algorithm>
+#include <cmath>
 #include <random>
 
 #include "expr/node_algorithm.h"

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -12,7 +12,7 @@
 
 #include "theory/quantifiers/sygus/sygus_unif_io.h"
 
-#include <math.h>
+#include <cmath>
 
 #include "options/quantifiers_options.h"
 #include "theory/datatypes/sygus_datatype_utils.h"

--- a/src/theory/quantifiers/sygus/sygus_unif_rl.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_rl.cpp
@@ -12,7 +12,7 @@
 
 #include "theory/quantifiers/sygus/sygus_unif_rl.h"
 
-#include <math.h>
+#include <cmath>
 
 #include "expr/skolem_manager.h"
 #include "options/base_options.h"

--- a/src/util/floatingpoint.cpp
+++ b/src/util/floatingpoint.cpp
@@ -15,7 +15,7 @@
 
 #include "util/floatingpoint.h"
 
-#include <math.h>
+#include <cmath>
 
 #include "base/check.h"
 #include "util/floatingpoint_literal.h"

--- a/src/util/safe_print.cpp
+++ b/src/util/safe_print.cpp
@@ -18,10 +18,10 @@
 
 #include "safe_print.h"
 
-#include <time.h>
 #include <unistd.h>
 
 #include <cstdlib>
+#include <ctime>
 
 /* Size of buffers used */
 #define BUFFER_SIZE 20


### PR DESCRIPTION
This fixes all warnings reported by the clang-tidy `modernize-deprecated-headers` check. Some C standard library headers are deprecated in C++ and should not be used in C++ codebases.