### PR TITLE
Add Term::isConst across C/C++/Python/Java APIs

### DIFF
--- a/include/cvc5/c/cvc5.h
+++ b/include/cvc5/c/cvc5.h
@@ -1449,6 +1449,13 @@ CVC5_EXPORT bool cvc5_term_is_real_value(Cvc5Term term);
 CVC5_EXPORT const char* cvc5_term_get_real_value(Cvc5Term term);
 
 /**
+ * Determine if a given term is a constant.
+ * @param term The term.
+ * @return True if the term is a constant.
+ */
+CVC5_EXPORT bool cvc5_term_is_const(Cvc5Term term);
+
+/**
  * Determine if a given term is a constant array.
  * @param term The term.
  * @return True if the term is a constant array.

--- a/include/cvc5/cvc5.h
+++ b/include/cvc5/cvc5.h
@@ -1653,6 +1653,12 @@ class CVC5_EXPORT Term
   std::string getRealValue() const;
 
   /**
+   * Determine if this term is a constant.
+   * @return True if the term is a constant.
+   */
+  bool isConst() const;
+
+  /**
    * Determine if this term is a constant array.
    * @return True if the term is a constant array.
    */

--- a/src/api/c/cvc5.cpp
+++ b/src/api/c/cvc5.cpp
@@ -2135,6 +2135,16 @@ const char* cvc5_term_get_real_value(Cvc5Term term)
   return res.c_str();
 }
 
+bool cvc5_term_is_const(Cvc5Term term)
+{
+  bool res = false;
+  CVC5_CAPI_TRY_CATCH_BEGIN;
+  CVC5_CAPI_CHECK_TERM(term);
+  res = term->d_term.isConst();
+  CVC5_CAPI_TRY_CATCH_END;
+  return res;
+}
+
 bool cvc5_term_is_const_array(Cvc5Term term)
 {
   bool res = false;

--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -3244,6 +3244,16 @@ std::string Term::getRealValue() const
   CVC5_API_TRY_CATCH_END;
 }
 
+bool Term::isConst() const
+{
+  CVC5_API_TRY_CATCH_BEGIN;
+  CVC5_API_CHECK_NOT_NULL;
+  //////// all checks before this line
+  return d_node->isConst();
+  ////////
+  CVC5_API_TRY_CATCH_END;
+}
+
 bool Term::isConstArray() const
 {
   CVC5_API_TRY_CATCH_BEGIN;

--- a/src/api/java/io/github/cvc5/Term.java
+++ b/src/api/java/io/github/cvc5/Term.java
@@ -447,6 +447,18 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   private native boolean isRealValue(long pointer);
 
   /**
+   * Determine if the term is a constant.
+   *
+   * @return True if the term is a constant.
+   */
+  public boolean isConst()
+  {
+    return isConst(pointer);
+  }
+
+  private native boolean isConst(long pointer);
+
+  /**
    * Asserts isRealValue().
    * @return The representation of a rational value as a pair of its numerator.
    *         and denominator.

--- a/src/api/java/jni/term.cpp
+++ b/src/api/java/jni/term.cpp
@@ -307,6 +307,21 @@ JNIEXPORT jboolean JNICALL Java_io_github_cvc5_Term_isNull(JNIEnv* env,
 
 /*
  * Class:     io_github_cvc5_Term
+ * Method:    isConst
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL Java_io_github_cvc5_Term_isConst(JNIEnv* env,
+                                                            jobject,
+                                                            jlong pointer)
+{
+  CVC5_JAVA_API_TRY_CATCH_BEGIN;
+  Term* current = reinterpret_cast<Term*>(pointer);
+  return static_cast<jboolean>(current->isConst());
+  CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, static_cast<jboolean>(false));
+}
+
+/*
+ * Class:     io_github_cvc5_Term
  * Method:    isConstArray
  * Signature: (J)Z
  */

--- a/src/api/python/cvc5.pxd
+++ b/src/api/python/cvc5.pxd
@@ -663,6 +663,7 @@ cdef extern from "<cvc5/cvc5.h>" namespace "cvc5":
         SkolemId getSkolemId() except +
         vector[Term] getSkolemIndices() except +
 
+        bint isConst() except +
         bint isConstArray() except +
         bint isBooleanValue() except +
         bint getBooleanValue() except +

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -5678,6 +5678,12 @@ cdef class Term:
         """
         return _term(self.tm, self.cterm.iteTerm(then_t.cterm, else_t.cterm))
 
+    def isConst(self):
+        """
+            :return: True iff this term is a constant.
+        """
+        return self.cterm.isConst()
+
     def isConstArray(self):
         """
             :return: True iff this term is a constant array.

--- a/test/unit/api/c/capi_term_black.cpp
+++ b/test/unit/api/c/capi_term_black.cpp
@@ -673,6 +673,19 @@ TEST_F(TestCApiBlackTerm, get_const_array_base)
   ASSERT_DEATH(cvc5_term_get_const_array_base(one), "invalid argument");
 }
 
+TEST_F(TestCApiBlackTerm, is_const)
+{
+  Cvc5Term one = cvc5_mk_integer_int64(d_tm, 1);
+  Cvc5Term x = cvc5_mk_var(d_tm, d_int, "x");
+  Cvc5Sort arr_sort = cvc5_mk_array_sort(d_tm, d_int, d_int);
+  Cvc5Term const_arr = cvc5_mk_const_array(d_tm, arr_sort, one);
+
+  ASSERT_DEATH(cvc5_term_is_const(nullptr), "invalid term");
+  ASSERT_TRUE(cvc5_term_is_const(one));
+  ASSERT_TRUE(cvc5_term_is_const(const_arr));
+  ASSERT_FALSE(cvc5_term_is_const(x));
+}
+
 TEST_F(TestCApiBlackTerm, get_boolean_value)
 {
   Cvc5Term b1 = cvc5_mk_true(d_tm);

--- a/test/unit/api/cpp/api_term_black.cpp
+++ b/test/unit/api/cpp/api_term_black.cpp
@@ -875,6 +875,19 @@ TEST_F(TestApiBlackTerm, getConstArrayBase)
   ASSERT_THROW(one.getConstArrayBase(), CVC5ApiException);
 }
 
+TEST_F(TestApiBlackTerm, isConst)
+{
+  Sort intsort = d_tm.getIntegerSort();
+  Sort arrsort = d_tm.mkArraySort(intsort, intsort);
+  Term one = d_tm.mkInteger(1);
+  Term constarr = d_tm.mkConstArray(arrsort, one);
+  Term x = d_tm.mkConst(intsort, "x");
+
+  ASSERT_TRUE(one.isConst());
+  ASSERT_TRUE(constarr.isConst());
+  ASSERT_FALSE(x.isConst());
+}
+
 TEST_F(TestApiBlackTerm, getBoolean)
 {
   Term b1 = d_tm.mkBoolean(true);

--- a/test/unit/api/java/TermTest.java
+++ b/test/unit/api/java/TermTest.java
@@ -844,6 +844,20 @@ class TermTest
   }
 
   @Test
+  void isConst()
+  {
+    Sort intsort = d_tm.getIntegerSort();
+    Sort arrsort = d_tm.mkArraySort(intsort, intsort);
+    Term one = d_tm.mkInteger(1);
+    Term constarr = d_tm.mkConstArray(arrsort, one);
+    Term x = d_tm.mkConst(intsort, "x");
+
+    assertTrue(one.isConst());
+    assertTrue(constarr.isConst());
+    assertFalse(x.isConst());
+  }
+
+  @Test
   void getBoolean()
   {
     Term b1 = d_tm.mkBoolean(true);

--- a/test/unit/api/python/test_term.py
+++ b/test/unit/api/python/test_term.py
@@ -898,6 +898,18 @@ def test_get_const_array_base(tm):
         a.getConstArrayBase()
 
 
+    def test_is_const(tm):
+        intsort = tm.getIntegerSort()
+        arrsort = tm.mkArraySort(intsort, intsort)
+        one = tm.mkInteger(1)
+        constarr = tm.mkConstArray(arrsort, one)
+        x = tm.mkConst(intsort, "x")
+
+        assert one.isConst()
+        assert constarr.isConst()
+        assert not x.isConst()
+
+
 def test_get_uninterpreted_sort_value(tm, solver):
     solver.setOption("produce-models", "true")
     uSort = tm.mkUninterpretedSort("u")


### PR DESCRIPTION
Expose term constness checks consistently across bindings by adding:
- C++ API: Term::isConst()
- C API: cvc5_term_is_const()
- Python API: Term.isConst()
- Java API: Term.isConst() + JNI bridge

Also add black-box/unit coverage for each API:
- C: capi_term_black
- C++: api_term_black
- Python: test_term
- Java: TermTest

Resolves #12675

Co-Authored-By: ChatGPT 5.3 noreply@openai.com