### PR TITLE
Add SyGuS 2.1 weights to the core C++ API.

### DIFF
--- a/docs/api/cpp/classes/weight.rst
+++ b/docs/api/cpp/classes/weight.rst
@@ -1,0 +1,18 @@
+Weight
+======
+
+This class encapsulates a SyGuS grammar weight attribute. It is created via
+:cpp:func:`cvc5::Solver::declareWeight()` and can be used to assign weights to
+the rules of a :doc:`grammar`, according to the definition of weights in the
+SyGuS IF 2.1 standard.
+
+----
+
+- class :cpp:class:`cvc5::Weight`
+
+----
+
+.. doxygenclass:: cvc5::Weight
+    :project: cvc5
+    :members:
+    :undoc-members:

--- a/docs/api/cpp/cpp.rst
+++ b/docs/api/cpp/cpp.rst
@@ -42,6 +42,7 @@ entry point to cvc5.
     classes/synthresult
     classes/term
     classes/termmanager
+    classes/weight
     enums/unknownexplanation
 
 
@@ -79,6 +80,8 @@ Class hierarchy
   * class :doc:`classes/term`
 
     * class :cpp:class:`const_iterator <cvc5::Term::const_iterator>`
+
+  * class :doc:`classes/weight`
 
   * enum class :doc:`enums/kind`
   * enum class :doc:`enums/sortkind`

--- a/docs/examples/examples.rst
+++ b/docs/examples/examples.rst
@@ -28,6 +28,7 @@ input mechanisms.
     combination
     sygus-fun
     sygus-inv
+    sygus-weight
     parser
     parser_sym_manager
     uf

--- a/docs/examples/sygus-weight.rst
+++ b/docs/examples/sygus-weight.rst
@@ -1,0 +1,15 @@
+SyGuS: Weights
+===================
+
+
+.. api-examples::
+    <examples>/api/cpp/sygus-weight.cpp
+    :skip: c, java, py-pythonicapi, py-regular, smt2
+
+The utility method used for printing the synthesis solutions in the example
+above is defined separately in the ``utils`` module:
+
+.. api-examples::
+    <examples>/api/cpp/utils.h
+    <examples>/api/cpp/utils.cpp
+    :skip: c, java, py-pythonicapi, py-regular, smt2

--- a/examples/api/cpp/CMakeLists.txt
+++ b/examples/api/cpp/CMakeLists.txt
@@ -46,6 +46,7 @@ endif()
 set(SYGUS_EXAMPLES_API_CPP
   sygus-fun
   sygus-inv
+  sygus-weight
 )
 
 foreach(example ${SYGUS_EXAMPLES_API_CPP})

--- a/examples/api/cpp/sygus-weight.cpp
+++ b/examples/api/cpp/sygus-weight.cpp
@@ -1,0 +1,96 @@
+/******************************************************************************
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2026 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * A demonstration of the SyGuS weight API.
+ *
+ * Find a synthesis of 3*x using only `+` (weight 1) or `*` (weight 31),
+ * constrained to have a total `w` weight of 2. The expected solution is
+ * `(+ x (+ x x))`.
+ */
+
+#include <cvc5/cvc5.h>
+
+#include <iostream>
+
+#include "utils.h"
+
+using namespace cvc5;
+
+int main()
+{
+  TermManager tm;
+  Solver slv(tm);
+
+  // required options
+  slv.setOption("sygus", "true");
+  slv.setOption("incremental", "false");
+
+  // set the logic
+  slv.setLogic("NIA");
+
+  Sort integer = tm.getIntegerSort();
+
+  // declare input variables for the functions-to-synthesize
+  Term x = tm.mkVar(integer, "x");
+
+  // declare the grammar non-terminals
+  Term start = tm.mkVar(integer, "Start");
+
+  // define the rules
+  Term zero = tm.mkInteger(0);
+  Term one = tm.mkInteger(1);
+  Term two = tm.mkInteger(2);
+  Term three = tm.mkInteger(3);
+  Term thirtyOne = tm.mkInteger(31);
+
+  Term add = tm.mkTerm(Kind::ADD, {start, start});
+  Term mult = tm.mkTerm(Kind::MULT, {start, start});
+
+  // declare a weight attribute with a default of 0
+  Weight w = slv.declareWeight("w");
+
+  // create the grammar object
+  Grammar g = slv.mkGrammar({x}, {start});
+
+  // bind each non-terminal to its rules
+  g.addRules(start, {zero, one, three, x});
+  g.addRule(start, add, {{w, one}});
+  g.addRule(start, mult, {{w, thirtyOne}});
+
+  // declare the function-to-synthesize
+  Term f = slv.synthFun("f", {x}, integer, g);
+
+  // declare universal variables
+  Term varX = slv.declareSygusVar("x", integer);
+
+  Term fX = tm.mkTerm(Kind::APPLY_UF, {f, varX});
+  Term threeX = tm.mkTerm(Kind::MULT, {three, varX});
+
+  // add the semantic constraint: (= (f x) (* 3 x))
+  slv.addSygusConstraint(tm.mkTerm(Kind::EQUAL, {fX, threeX}));
+
+  // declare a weight symbol: (_ w f)
+  Term wF = slv.mkWeightSymbol(w, f);
+
+  // add the weight constraint: (= (_ w f) 2)
+  slv.addSygusConstraint(tm.mkTerm(Kind::EQUAL, {wF, two}));
+
+  // print solutions if available
+  if (slv.checkSynth().hasSolution())
+  {
+    // Output should be equivalent to:
+    // (
+    //   (define-fun f ((x Int)) Int (+ x (+ x x)))
+    // )
+    std::vector<Term> terms = {f};
+    utils::printSynthSolutions(terms, slv.getSynthSolutions(terms));
+  }
+
+  return 0;
+}

--- a/include/cvc5/cvc5.h
+++ b/include/cvc5/cvc5.h
@@ -72,6 +72,7 @@ class Statistics;
 struct APIStatistics;
 class Term;
 class PluginInternal;
+class Weight;
 
 /* -------------------------------------------------------------------------- */
 /* Exception                                                                  */
@@ -1194,6 +1195,7 @@ class CVC5_EXPORT Term
   friend class Grammar;
   friend class PluginInternal;
   friend class SynthResult;
+  friend class Weight;
   friend struct std::hash<Term>;
 
  public:
@@ -3079,6 +3081,103 @@ struct CVC5_EXPORT hash<cvc5::Datatype>
 namespace cvc5 {
 
 /* -------------------------------------------------------------------------- */
+/* Weight                                                                     */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A weight attribute for Sygus grammars. A weight attribute is declared via
+ * ``Solver::declareWeight()`` and can then be used to assign weights to
+ * grammar rules, according to the definition of weights in the SyGuS IF 2.1
+ * standard.
+ */
+class CVC5_EXPORT Weight
+{
+  friend class Grammar;
+  friend class Solver;
+  friend struct std::hash<Weight>;
+
+ public:
+  /**
+   * Get the name of this weight attribute.
+   *
+   * @return The name of this weight attribute.
+   */
+  std::string getName() const;
+
+  /**
+   * Get the default value of this weight attribute.
+   *
+   * @return The default value of this weight attribute.
+   */
+  cvc5::Term getDefaultValue() const;
+
+  /**
+   * Equality operator.
+   *
+   * @note Both weights must belong to the same term manager.
+   *
+   * @param w The weight to compare to for equality.
+   * @return True if both weights are equal.
+   */
+  bool operator==(const Weight& w) const;
+
+  /**
+   * Disequality operator.
+   * @param w The weight to compare to for disequality.
+   * @return True if both weights are not equal.
+   */
+  bool operator!=(const Weight& w) const;
+
+  /**
+   * Less-than operator.
+   * @param w The weight to compare to.
+   * @return True if this weight compares less than @p w.
+   */
+  bool operator<(const Weight& w) const;
+
+  /** Nullary constructor. Needed for the Cython API. */
+  Weight();
+
+ private:
+  /**
+   * Constructor.
+   * @param tm The term manager associated with this weight.
+   * @param name The name of this weight attribute.
+   * @param defaultValue The default integer value for the weight attribute.
+   */
+  Weight(TermManager* tm, const std::string& name, const Term& defaultValue);
+
+  /** Helper to convert a public weight map to an internal node map. */
+  static std::map<internal::Node, internal::Node> weightMapToNodeMap(
+      const std::map<Weight, Term>& weights);
+
+  /** The associated term manager. */
+  TermManager* d_tm;
+  /** Internal node representing the weight. */
+  std::shared_ptr<internal::Node> d_node;
+};
+
+}  // namespace cvc5
+
+namespace std {
+
+/**
+ * Hash function for Weights.
+ */
+template <>
+struct CVC5_EXPORT hash<cvc5::Weight>
+{
+  size_t operator()(const cvc5::Weight& w) const;
+};
+
+}  // namespace std
+
+namespace cvc5 {
+
+/** A mapping from weight attributes to values. */
+using WeightMap = std::map<Weight, Term>;
+
+/* -------------------------------------------------------------------------- */
 /* Grammar                                                                    */
 /* -------------------------------------------------------------------------- */
 
@@ -3128,28 +3227,36 @@ class CVC5_EXPORT Grammar
    * Add `rule` to the set of rules corresponding to `ntSymbol`.
    * @param ntSymbol The non-terminal to which the rule is added.
    * @param rule The rule to add.
+   * @param weights The weights of this rule.
    */
-  void addRule(const Term& ntSymbol, const Term& rule);
+  void addRule(const Term& ntSymbol,
+               const Term& rule,
+               const WeightMap& weights = {});
 
   /**
    * Add `rules` to the set of rules corresponding to `ntSymbol`.
    * @param ntSymbol The non-terminal to which the rules are added.
    * @param rules The rules to add.
+   * @param weights The weights of each rule in `rules`.
    */
-  void addRules(const Term& ntSymbol, const std::vector<Term>& rules);
+  void addRules(const Term& ntSymbol,
+                const std::vector<Term>& rules,
+                const std::vector<WeightMap>& weights = {});
 
   /**
    * Allow `ntSymbol` to be an arbitrary constant.
    * @param ntSymbol The non-terminal allowed to be any constant.
+   * @param weights The weights of this constant.
    */
-  void addAnyConstant(const Term& ntSymbol);
+  void addAnyConstant(const Term& ntSymbol, const WeightMap& weights = {});
 
   /**
    * Allow `ntSymbol` to be any input variable to corresponding
    * synth-fun/synth-inv with the same sort as `ntSymbol`.
    * @param ntSymbol The non-terminal allowed to be any input variable.
+   * @param weights The weights of the input variables.
    */
-  void addAnyVariable(const Term& ntSymbol);
+  void addAnyVariable(const Term& ntSymbol, const WeightMap& weights = {});
 
   /**
    * @return A string representation of this grammar.
@@ -3771,6 +3878,7 @@ class CVC5_EXPORT TermManager
   friend class Grammar;
   friend class Plugin;
   friend class Solver;
+  friend class Weight;
 
  public:
   /** Constructor. */
@@ -6750,6 +6858,57 @@ class CVC5_EXPORT Solver
    * @return The universal variable.
    */
   Term declareSygusVar(const std::string& symbol, const Sort& sort) const;
+
+  /**
+   * Declare a new weight attribute \p symbol for Sygus grammars.
+   *
+   * SyGuS v2:
+   *
+   * \verbatim embed:rst:leading-asterisk
+   * .. code:: smtlib
+   *
+   *     (declare-weight <symbol>)
+   * \endverbatim
+   *
+   * @param symbol The name of the weight attribute.
+   * @return The weight attribute.
+   */
+  Weight declareWeight(const std::string& symbol) const;
+
+  /**
+   * Declare a new weight attribute \p symbol for Sygus grammars.
+   *
+   * SyGuS v2:
+   *
+   * \verbatim embed:rst:leading-asterisk
+   * .. code:: smtlib
+   *
+   *     (declare-weight <symbol> :default <defaultValue>)
+   * \endverbatim
+   *
+   * @param symbol The name of the weight attribute.
+   * @param defaultValue The default integer value for the weight attribute.
+   * @return The weight attribute.
+   */
+  Weight declareWeight(const std::string& symbol,
+                       const Term& defaultValue) const;
+
+  /**
+   * Create a weight symbol for \p term with weight attribute \p weight.
+   *
+   * SyGuS v2:
+   *
+   * \verbatim embed:rst:leading-asterisk
+   * .. code:: smtlib
+   *
+   *     (_ <weight> <term>)
+   * \endverbatim
+   *
+   * @param weight The weight attribute for the weight symbol.
+   * @param term The term with which to create the weight symbol.
+   * @return The weight symbol.
+   */
+  Term mkWeightSymbol(const Weight& weight, const Term& term) const;
 
   /**
    * Create a Sygus grammar. The first non-terminal is treated as the starting

--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -54,6 +54,7 @@
 #include "expr/skolem_manager.h"
 #include "expr/sygus_grammar.h"
 #include "expr/type_node.h"
+#include "expr/weight_symbol.h"
 #include "options/base_options.h"
 #include "options/expr_options.h"
 #include "options/main_options.h"
@@ -69,6 +70,7 @@
 #include "smt/solver_engine.h"
 #include "theory/arith/nl/poly_conversion.h"
 #include "theory/datatypes/project_op.h"
+#include "theory/datatypes/sygus_datatype_utils.h"
 #include "theory/logic_info.h"
 #include "theory/theory_model.h"
 #include "util/bitvector.h"
@@ -4734,6 +4736,58 @@ std::ostream& operator<<(std::ostream& out, const Datatype& dtype)
 }
 
 /* -------------------------------------------------------------------------- */
+/* Weight                                                                     */
+/* -------------------------------------------------------------------------- */
+
+Weight::Weight(TermManager* tm,
+               const std::string& name,
+               const Term& defaultValue)
+    : d_tm(tm),
+      d_node(std::make_shared<internal::Node>(
+          tm->d_nm->getSkolemManager()->mkDummySkolem(
+              name,
+              tm->d_nm->integerType(),
+              internal::SkolemFlags::SKOLEM_EXACT_NAME)))
+{
+  tm->d_nm->setAttribute(
+      *d_node, internal::theory::SygusWeightAttribute(), *defaultValue.d_node);
+}
+
+std::string Weight::getName() const { return d_node->getName(); }
+
+Term Weight::getDefaultValue() const
+{
+  internal::Node defaultValue = d_tm->d_nm->getAttribute(
+      *d_node, internal::theory::SygusWeightAttribute());
+  return Term(d_tm, defaultValue);
+}
+
+bool Weight::operator==(const Weight& w) const
+{
+  return d_tm == w.d_tm && *d_node == *w.d_node;
+}
+
+bool Weight::operator!=(const Weight& w) const { return !(*this == w); }
+
+bool Weight::operator<(const Weight& w) const
+{
+  return d_node && w.d_node && *d_node < *w.d_node;
+}
+
+Weight::Weight() : d_tm(nullptr), d_node() {}
+
+std::map<internal::Node, internal::Node> Weight::weightMapToNodeMap(
+    const WeightMap& weights)
+{
+  std::map<internal::Node, internal::Node> nodeWeights;
+  for (const std::pair<const Weight, Term>& pair : weights)
+  {
+    nodeWeights.emplace(*pair.first.d_node, *pair.second.d_node);
+  }
+  return nodeWeights;
+}
+
+/* -------------------------------------------------------------------------- */
 /* Grammar                                                                    */
 /* -------------------------------------------------------------------------- */
 
@@ -4758,7 +4812,9 @@ bool contains(const std::vector<internal::Node>& ns, const internal::Node& n)
   return std::find(ns.cbegin(), ns.cend(), n) != ns.cend();
 }
 
-void Grammar::addRule(const Term& ntSymbol, const Term& rule)
+void Grammar::addRule(const Term& ntSymbol,
+                      const Term& rule,
+                      const WeightMap& weights)
 {
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK(!d_grammar->isResolved())
@@ -4774,12 +4830,15 @@ void Grammar::addRule(const Term& ntSymbol, const Term& rule)
       ntSymbol.d_node->getType().isInstanceOf(rule.d_node->getType()))
       << "expected ntSymbol and rule to have the same sort";
   //////// all checks before this line
-  d_grammar->addRule(*ntSymbol.d_node, *rule.d_node);
+  d_grammar->addRule(
+      *ntSymbol.d_node, *rule.d_node, Weight::weightMapToNodeMap(weights));
   ////////
   CVC5_API_TRY_CATCH_END;
 }
 
-void Grammar::addRules(const Term& ntSymbol, const std::vector<Term>& rules)
+void Grammar::addRules(const Term& ntSymbol,
+                       const std::vector<Term>& rules,
+                       const std::vector<WeightMap>& weights)
 {
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK(!d_grammar->isResolved())
@@ -4792,12 +4851,18 @@ void Grammar::addRules(const Term& ntSymbol, const std::vector<Term>& rules)
       << "ntSymbol to be one of the non-terminal symbols given in the "
          "predeclaration";
   //////// all checks before this line
-  d_grammar->addRules(*ntSymbol.d_node, Term::termVectorToNodes(rules));
+  std::vector<std::map<internal::Node, internal::Node>> nodeWeights;
+  for (const WeightMap& weight : weights)
+  {
+    nodeWeights.push_back(Weight::weightMapToNodeMap(weight));
+  }
+  d_grammar->addRules(
+      *ntSymbol.d_node, Term::termVectorToNodes(rules), nodeWeights);
   ////////
   CVC5_API_TRY_CATCH_END;
 }
 
-void Grammar::addAnyConstant(const Term& ntSymbol)
+void Grammar::addAnyConstant(const Term& ntSymbol, const WeightMap& weights)
 {
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK(!d_grammar->isResolved())
@@ -4809,12 +4874,14 @@ void Grammar::addAnyConstant(const Term& ntSymbol)
       << "ntSymbol to be one of the non-terminal symbols given in the "
          "predeclaration";
   //////// all checks before this line
-  d_grammar->addAnyConstant(*ntSymbol.d_node, ntSymbol.d_node->getType());
+  d_grammar->addAnyConstant(*ntSymbol.d_node,
+                            ntSymbol.d_node->getType(),
+                            Weight::weightMapToNodeMap(weights));
   ////////
   CVC5_API_TRY_CATCH_END;
 }
 
-void Grammar::addAnyVariable(const Term& ntSymbol)
+void Grammar::addAnyVariable(const Term& ntSymbol, const WeightMap& weights)
 {
   CVC5_API_TRY_CATCH_BEGIN;
   CVC5_API_CHECK(!d_grammar->isResolved())
@@ -4826,7 +4893,8 @@ void Grammar::addAnyVariable(const Term& ntSymbol)
       << "ntSymbol to be one of the non-terminal symbols given in the "
          "predeclaration";
   //////// all checks before this line
-  d_grammar->addAnyVariable(*ntSymbol.d_node);
+  d_grammar->addAnyVariable(*ntSymbol.d_node,
+                            Weight::weightMapToNodeMap(weights));
   ////////
   CVC5_API_TRY_CATCH_END;
 }
@@ -8673,6 +8741,53 @@ Term Solver::declareSygusVar(const std::string& symbol, const Sort& sort) const
   CVC5_API_TRY_CATCH_END;
 }
 
+Weight Solver::declareWeight(const std::string& symbol) const
+{
+  CVC5_API_TRY_CATCH_BEGIN;
+  CVC5_API_CHECK(d_slv->getOptions().quantifiers.sygus)
+      << "cannot call declareWeight unless sygus is enabled (use --"
+      << internal::options::quantifiers::longName::sygus << ")";
+  //////// all checks before this line
+  Term zero(&d_tm, d_tm.d_nm->mkConstInt(0));
+  return Weight(&d_tm, symbol, zero);
+  ////////
+  CVC5_API_TRY_CATCH_END;
+}
+
+Weight Solver::declareWeight(const std::string& symbol,
+                             const Term& defaultValue) const
+{
+  CVC5_API_TRY_CATCH_BEGIN;
+  CVC5_API_SOLVER_CHECK_TERM_WITH_SORT(defaultValue, getIntegerSort());
+  CVC5_API_CHECK(defaultValue.isIntegerValue())
+      << "expected default weight to be an integer value";
+  CVC5_API_CHECK(d_slv->getOptions().quantifiers.sygus)
+      << "cannot call declareWeight unless sygus is enabled (use --"
+      << internal::options::quantifiers::longName::sygus << ")";
+  //////// all checks before this line
+  return Weight(&d_tm, symbol, defaultValue);
+  ////////
+  CVC5_API_TRY_CATCH_END;
+}
+
+Term Solver::mkWeightSymbol(const Weight& weight, const Term& term) const
+{
+  CVC5_API_TRY_CATCH_BEGIN;
+  CVC5_API_CHECK(&d_tm == weight.d_tm)
+      << "given weight is not associated with the term manager of this solver";
+  CVC5_API_SOLVER_CHECK_TERM(term);
+  CVC5_API_CHECK(d_slv->getOptions().quantifiers.sygus)
+      << "cannot call mkWeightSymbol unless sygus is enabled (use --"
+      << internal::options::quantifiers::longName::sygus << ")";
+  //////// all checks before this line
+  return Term(&d_tm,
+              d_tm.d_nm->mkNode(internal::Kind::WEIGHT_SYMBOL,
+                                d_tm.d_nm->mkConst(internal::WeightSymbol(
+                                    *weight.d_node, *term.d_node))));
+  ////////
+  CVC5_API_TRY_CATCH_END;
+}
+
 Grammar Solver::mkGrammar(const std::vector<Term>& boundVars,
                           const std::vector<Term>& ntSymbols) const
 {
@@ -9114,6 +9229,11 @@ size_t hash<cvc5::Grammar>::operator()(const cvc5::Grammar& grammar) const
     return 0;
   }
   return std::hash<cvc5::internal::SygusGrammar>{}(*grammar.d_grammar);
+}
+
+size_t hash<cvc5::Weight>::operator()(const cvc5::Weight& w) const
+{
+  return std::hash<cvc5::internal::Node>()(*w.d_node);
 }
 
 }  // namespace std

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -1044,7 +1044,7 @@ cdef class Grammar:
         """
         self.cgrammar.addAnyVariable(ntSymbol.cterm)
 
-    def addRules(self, Term ntSymbol not None, rules):
+    def addRules(self, Term ntSymbol not None, list rules):
         """
             Add ``ntSymbol`` to the set of rules corresponding to ``ntSymbol``.
 
@@ -3379,7 +3379,7 @@ cdef class Solver:
         r.cr = self.csolver.checkSat()
         return r
 
-    def mkGrammar(self, boundVars, ntSymbols):
+    def mkGrammar(self, list boundVars, list ntSymbols):
         """
             Create a SyGuS grammar. The first non-terminal is treated as the
             starting non-terminal, so the order of non-terminals matters.
@@ -3485,7 +3485,7 @@ cdef class Solver:
         self.csolver.addSygusInvConstraint(
                 inv_f.cterm, pre_f.cterm, trans_f.cterm, post_f.cterm)
 
-    def synthFun(self, str symbol, bound_vars, Sort sort not None, Grammar grammar=None):
+    def synthFun(self, str symbol, list bound_vars, Sort sort not None, Grammar grammar=None):
         """
             Synthesize n-ary function following specified syntactic constraints.
 

--- a/src/expr/CMakeLists.txt
+++ b/src/expr/CMakeLists.txt
@@ -124,6 +124,8 @@ libcvc5_add_sources(
   non_closed_node_converter.h
   normalize_sort_converter.cpp
   normalize_sort_converter.h
+  weight_symbol.cpp
+  weight_symbol.h
 )
 
 libcvc5_add_sources(GENERATED

--- a/src/expr/dtype.cpp
+++ b/src/expr/dtype.cpp
@@ -281,7 +281,8 @@ void DType::addConstructor(std::shared_ptr<DTypeConstructor> c)
 void DType::addSygusConstructor(Node op,
                                 const std::string& cname,
                                 const std::vector<TypeNode>& cargs,
-                                int weight)
+                                int weight,
+                                const std::map<Node, Node>& weights)
 {
   // avoid name clashes
   std::stringstream ss;
@@ -289,7 +290,7 @@ void DType::addSygusConstructor(Node op,
   std::string name = ss.str();
   unsigned cweight = weight >= 0 ? weight : (cargs.empty() ? 0 : 1);
   std::shared_ptr<DTypeConstructor> c =
-      std::make_shared<DTypeConstructor>(name, cweight);
+      std::make_shared<DTypeConstructor>(name, cweight, weights);
   c->setSygus(op);
   for (size_t j = 0, nargs = cargs.size(); j < nargs; j++)
   {

--- a/src/expr/dtype.h
+++ b/src/expr/dtype.h
@@ -168,7 +168,7 @@ class DType
    * sygus constructor, and following a naming convention that avoids
    * constructors with the same name.
    *
-   * @param op : the builtin operator, constant, or variable that this
+   * @param op the builtin operator, constant, or variable that this
    * constructor encodes
    * @param cname the name of the constructor (for printing only)
    * @param cargs the arguments of the constructor.
@@ -184,7 +184,8 @@ class DType
   void addSygusConstructor(Node op,
                            const std::string& cname,
                            const std::vector<TypeNode>& cargs,
-                           int weight = -1);
+                           int weight = -1,
+                           const std::map<Node, Node>& weights = {});
 
   /** set sygus
    *

--- a/src/expr/dtype_cons.cpp
+++ b/src/expr/dtype_cons.cpp
@@ -30,7 +30,8 @@ struct SygusAnyConstAttributeId
 typedef expr::Attribute<SygusAnyConstAttributeId, bool> SygusAnyConstAttribute;
 
 DTypeConstructor::DTypeConstructor(std::string name,
-                                   unsigned weight)
+                                   unsigned weight,
+                                   const std::map<Node, Node>& weights)
     :  // We don't want to introduce a new data member, because eventually
        // we're going to be a constant stuffed inside a node.  So we stow
        // the tester name away inside the constructor name until
@@ -38,7 +39,8 @@ DTypeConstructor::DTypeConstructor(std::string name,
       d_name(name),
       d_tester(),
       d_args(),
-      d_weight(weight)
+      d_weight(weight),
+      d_weights(weights)
 {
   Assert(name != "");
 }
@@ -146,6 +148,12 @@ unsigned DTypeConstructor::getWeight() const
 {
   Assert(isResolved());
   return d_weight;
+}
+
+const std::map<Node, Node>& DTypeConstructor::getWeights() const
+{
+  Assert(isResolved());
+  return d_weights;
 }
 
 size_t DTypeConstructor::getNumArgs() const { return d_args.size(); }

--- a/src/expr/dtype_cons.h
+++ b/src/expr/dtype_cons.h
@@ -47,7 +47,9 @@ class DTypeConstructor
    * for SyGuS. For example, if A, B, C have weights 0, 1, and 3 respectively,
    * then C( B( A() ), B( A() ) ) has size 5.
    */
-  DTypeConstructor(std::string name, unsigned weight = 1);
+  DTypeConstructor(std::string name,
+                   unsigned weight = 1,
+                   const std::map<Node, Node>& weights = {});
 
   ~DTypeConstructor() {}
   /**
@@ -126,6 +128,12 @@ class DTypeConstructor
    * size of datatype terms that involve this constructor.
    */
   unsigned getWeight() const;
+  /** get weights
+   *
+   * Get the weights of this constructor. This value is used when computing the
+   * size of datatype terms that involve this constructor.
+   */
+  const std::map<Node, Node>& getWeights() const;
   //-------------------------------------- end sygus
 
   /**
@@ -325,6 +333,8 @@ class DTypeConstructor
   Node d_sygusOp;
   /** weight */
   unsigned d_weight;
+  /** weight attributes of this constructor */
+  std::map<Node, Node> d_weights;
   /** shared selectors for each type
    *
    * This stores the shared (constructor-agnotic)

--- a/src/expr/sygus_datatype.cpp
+++ b/src/expr/sygus_datatype.cpp
@@ -27,13 +27,15 @@ std::string SygusDatatype::getName() const { return d_dt.getName(); }
 void SygusDatatype::addConstructor(Node op,
                                    const std::string& name,
                                    const std::vector<TypeNode>& argTypes,
-                                   int weight)
+                                   int weight,
+                                   const std::map<Node, Node>& weights)
 {
   d_cons.push_back(SygusDatatypeConstructor());
   d_cons.back().d_op = op;
   d_cons.back().d_name = name;
   d_cons.back().d_argTypes = argTypes;
   d_cons.back().d_weight = weight;
+  d_cons.back().d_weights = weights;
 }
 
 void SygusDatatype::addAnyConstantConstructor(TypeNode tn)
@@ -49,12 +51,14 @@ void SygusDatatype::addAnyConstantConstructor(TypeNode tn)
   builtinArg.push_back(tn);
   addConstructor(av, cname, builtinArg, 0);
 }
+
 void SygusDatatype::addConstructor(NodeManager* nm,
                                    Kind k,
                                    const std::vector<TypeNode>& argTypes,
-                                   int weight)
+                                   int weight,
+                                   const std::map<Node, Node>& weights)
 {
-  addConstructor(nm->operatorOf(k), kindToString(k), argTypes, weight);
+  addConstructor(nm->operatorOf(k), kindToString(k), argTypes, weight, weights);
 }
 
 size_t SygusDatatype::getNumConstructors() const { return d_cons.size(); }
@@ -83,7 +87,8 @@ void SygusDatatype::initializeDatatype(TypeNode sygusType,
     d_dt.addSygusConstructor(d_cons[i].d_op,
                              d_cons[i].d_name,
                              d_cons[i].d_argTypes,
-                             d_cons[i].d_weight);
+                             d_cons[i].d_weight,
+                             d_cons[i].d_weights);
   }
   Trace("sygus-type-cons") << "...built datatype " << d_dt << " ";
 }

--- a/src/expr/sygus_datatype.h
+++ b/src/expr/sygus_datatype.h
@@ -39,6 +39,8 @@ class SygusDatatypeConstructor
   std::vector<TypeNode> d_argTypes;
   /** Weight of the constructor. */
   int d_weight;
+  /** Weights of the constructor. */
+  std::map<Node, Node> d_weights;
 };
 
 /**
@@ -79,7 +81,8 @@ class SygusDatatype
   void addConstructor(Node op,
                       const std::string& name,
                       const std::vector<TypeNode>& argTypes,
-                      int weight = -1);
+                      int weight = -1,
+                      const std::map<Node, Node>& weights = {});
   /**
    * Add constructor that encodes an application of builtin kind k. Like above,
    * the arguments argTypes should correspond to sygus datatypes that encode
@@ -88,7 +91,8 @@ class SygusDatatype
   void addConstructor(NodeManager* nm,
                       Kind k,
                       const std::vector<TypeNode>& argTypes,
-                      int weight = -1);
+                      int weight = -1,
+                      const std::map<Node, Node>& weights = {});
   /**
    * This adds a constructor that corresponds to the any constant constructor
    * for the given (builtin) type tn.

--- a/src/expr/sygus_grammar.cpp
+++ b/src/expr/sygus_grammar.cpp
@@ -30,7 +30,7 @@ SygusGrammar::SygusGrammar(const std::vector<Node>& sygusVars,
 {
   for (const Node& ntSym : ntSyms)
   {
-    d_rules.emplace(ntSym, std::vector<Node>{});
+    d_rules.emplace(ntSym, std::vector<std::pair<Node, NodeMap>>{});
   }
 }
 
@@ -53,7 +53,7 @@ SygusGrammar::SygusGrammar(const std::vector<Node>& sygusVars,
     Node v = NodeManager::mkBoundVar(ss.str(), dt.getSygusType());
     ntsyms[tn] = v;
     d_ntSyms.push_back(v);
-    d_rules.emplace(v, std::vector<Node>{});
+    d_rules.emplace(v, std::vector<std::pair<Node, NodeMap>>{});
     // process the subfield types
     std::unordered_set<TypeNode> tns = dt.getSubfieldTypes();
     for (const TypeNode& tnsc : tns)
@@ -92,42 +92,60 @@ SygusGrammar::SygusGrammar(const std::vector<Node>& sygusVars,
         args.push_back(itn->second);
       }
       Node rule = theory::datatypes::utils::mkSygusTerm(op, args, true);
-      addRule(nts, rule);
+      addRule(nts, rule, cons.getWeights());
     }
   }
 }
 
-void SygusGrammar::addRule(const Node& ntSym, const Node& rule)
+void SygusGrammar::addRule(const Node& ntSym,
+                           const Node& rule,
+                           const NodeMap& weights)
 {
   Assert(d_rules.find(ntSym) != d_rules.cend());
   Assert(rule.getType().isInstanceOf(ntSym.getType()));
   // avoid duplication
-  std::vector<Node>& rs = d_rules[ntSym];
-  if (std::find(rs.begin(), rs.end(), rule) == rs.end())
+  std::vector<std::pair<Node, NodeMap>>& rs = d_rules[ntSym];
+  auto it = std::find_if(
+      rs.begin(), rs.end(), [&](const std::pair<Node, NodeMap>& p) {
+        return p.first == rule && p.second == weights;
+      });
+  if (it == rs.end())
   {
-    rs.push_back(rule);
+    rs.push_back({rule, weights});
   }
 }
 
-void SygusGrammar::addRules(const Node& ntSym, const std::vector<Node>& rules)
+void SygusGrammar::addRules(const Node& ntSym,
+                            const std::vector<Node>& rules,
+                            const std::vector<NodeMap>& weights)
 {
-  for (const Node& rule : rules)
+  Assert(weights.empty() || weights.size() == rules.size());
+  for (size_t i = 0, n = rules.size(); i < n; ++i)
   {
-    addRule(ntSym, rule);
+    if (weights.empty())
+    {
+      addRule(ntSym, rules[i]);
+    }
+    else
+    {
+      addRule(ntSym, rules[i], weights[i]);
+    }
   }
 }
 
-void SygusGrammar::addAnyConstant(const Node& ntSym, const TypeNode& tn)
+void SygusGrammar::addAnyConstant(const Node& ntSym,
+                                  const TypeNode& tn,
+                                  const NodeMap& weights)
 {
   Assert(d_rules.find(ntSym) != d_rules.cend());
   Assert(tn.isInstanceOf(ntSym.getType()));
   SkolemManager* sm = tn.getNodeManager()->getSkolemManager();
   Node anyConst =
       sm->mkInternalSkolemFunction(InternalSkolemId::SYGUS_ANY_CONSTANT, tn);
-  addRule(ntSym, anyConst);
+  addRule(ntSym, anyConst, weights);
 }
 
-void SygusGrammar::addAnyVariable(const Node& ntSym)
+void SygusGrammar::addAnyVariable(const Node& ntSym, const NodeMap& weights)
 {
   Assert(d_rules.find(ntSym) != d_rules.cend());
   // each variable of appropriate type becomes a rule.
@@ -135,18 +153,22 @@ void SygusGrammar::addAnyVariable(const Node& ntSym)
   {
     if (v.getType().isInstanceOf(ntSym.getType()))
     {
-      addRule(ntSym, v);
+      addRule(ntSym, v, weights);
     }
   }
 }
 
 void SygusGrammar::removeRule(const Node& ntSym, const Node& rule)
 {
-  std::unordered_map<Node, std::vector<Node>>::iterator itr =
-      d_rules.find(ntSym);
+  std::unordered_map<Node, std::vector<std::pair<Node, NodeMap>>>::iterator
+      itr = d_rules.find(ntSym);
   Assert(itr != d_rules.end());
-  std::vector<Node>::iterator it =
-      std::find(itr->second.begin(), itr->second.end(), rule);
+  std::vector<std::pair<Node, NodeMap>>::const_iterator it =
+      std::find_if(itr->second.cbegin(),
+                   itr->second.cend(),
+                   [&rule](const std::pair<Node, NodeMap>& pair) {
+                     return pair.first == rule;
+                   });
   Assert(it != itr->second.end());
   itr->second.erase(it);
 }
@@ -228,7 +250,8 @@ bool isId(const Node& n)
 void addSygusConstructor(DType& dt,
                          const Node& rule,
                          const std::vector<Node>& nts,
-                         const std::unordered_map<Node, TypeNode>& ntsToUnres)
+                         const std::unordered_map<Node, TypeNode>& ntsToUnres,
+                         const NodeMap& weights)
 {
   NodeManager* nm = rule.getNodeManager();
   std::stringstream ss;
@@ -260,7 +283,7 @@ void addSygusConstructor(DType& dt,
       op = nm->mkNode(Kind::LAMBDA, lbvl, op);
     }
     // assign identity rules a weight of 0.
-    dt.addSygusConstructor(op, ss.str(), cargs, isId(op) ? 0 : -1);
+    dt.addSygusConstructor(op, ss.str(), cargs, isId(op) ? 0 : -1, weights);
   }
 }
 
@@ -315,16 +338,15 @@ TypeNode SygusGrammar::resolve(bool allowAny)
     {
       // make the datatype, which encodes terms generated by this non-terminal
       DType dt(ntSym.getName());
-
-      for (const Node& rule : d_rules[ntSym])
+      for (const std::pair<Node, NodeMap>& rule : d_rules[ntSym])
       {
-        if (rule.getKind() == Kind::SKOLEM
-            && rule.getInternalSkolemId()
+        if (rule.first.getKind() == Kind::SKOLEM
+            && rule.first.getInternalSkolemId()
                    == InternalSkolemId::SYGUS_ANY_CONSTANT)
         {
           allowConsts.insert(ntSym);
         }
-        addSygusConstructor(dt, rule, d_ntSyms, ntsToUnres);
+        addSygusConstructor(dt, rule.first, d_ntSyms, ntsToUnres, rule.second);
       }
       bool allowConst = allowConsts.find(ntSym) != allowConsts.end();
       dt.setSygus(ntSym.getType(), bvl, allowConst || allowAny, allowAny);
@@ -350,12 +372,18 @@ const std::vector<Node>& SygusGrammar::getSygusVars() const
 
 const std::vector<Node>& SygusGrammar::getNtSyms() const { return d_ntSyms; }
 
-const std::vector<Node>& SygusGrammar::getRulesFor(const Node& ntSym) const
+std::vector<Node> SygusGrammar::getRulesFor(const Node& ntSym) const
 {
-  std::unordered_map<Node, std::vector<Node>>::const_iterator itr =
-      d_rules.find(ntSym);
+  std::unordered_map<Node,
+                     std::vector<std::pair<Node, NodeMap>>>::const_iterator
+      itr = d_rules.find(ntSym);
   Assert(itr != d_rules.end());
-  return itr->second;
+  std::vector<Node> rules;
+  for (const std::pair<Node, NodeMap>& rule : itr->second)
+  {
+    rules.push_back(rule.first);
+  }
+  return rules;
 }
 
 std::string SygusGrammar::toString() const
@@ -389,7 +417,14 @@ size_t hash<cvc5::internal::SygusGrammar>::operator()(
     for (const auto& n : r.second)
     {
       rhash = cvc5::internal::fnv1a::fnv1a_64(
-          rhash, std::hash<cvc5::internal::Node>{}(n));
+          rhash, std::hash<cvc5::internal::Node>{}(n.first));
+      for (const auto& w : n.second)
+      {
+        rhash = cvc5::internal::fnv1a::fnv1a_64(
+            rhash, std::hash<cvc5::internal::Node>{}(w.first));
+        rhash = cvc5::internal::fnv1a::fnv1a_64(
+            rhash, std::hash<cvc5::internal::Node>{}(w.second));
+      }
     }
     rhash = cvc5::internal::fnv1a::fnv1a_64(
         rhash, std::hash<cvc5::internal::Node>{}(r.first));

--- a/src/expr/sygus_grammar.h
+++ b/src/expr/sygus_grammar.h
@@ -14,11 +14,14 @@
 #ifndef CVC5__EXPR__SYGUS_GRAMMAR_H
 #define CVC5__EXPR__SYGUS_GRAMMAR_H
 
+#include <map>
 #include <vector>
 
 #include "expr/node.h"
 
 namespace cvc5::internal {
+
+using NodeMap = std::map<Node, Node>;
 
 /**
  * A Sygus Grammar. This class can be used to define a context-free grammar
@@ -46,29 +49,39 @@ class SygusGrammar
    * Add \p rule to the set of rules corresponding to \p ntSym.
    * @param ntSym The non-terminal to which the rule is added.
    * @param rule The rule to add.
+   * @param weights The weights of this rule.
    */
-  void addRule(const Node& ntSym, const Node& rule);
+  void addRule(const Node& ntSym,
+               const Node& rule,
+               const NodeMap& weights = {});
 
   /**
    * Add \p rules to the set of rules corresponding to \p ntSym.
    * @param ntSym The non-terminal to which the rules are added.
    * @param rules The rules to add.
+   * @param weights The weights of each rule in `rules`.
    */
-  void addRules(const Node& ntSym, const std::vector<Node>& rules);
+  void addRules(const Node& ntSym,
+                const std::vector<Node>& rules,
+                const std::vector<NodeMap>& weights = {});
 
   /**
    * Allow \p ntSym to be an arbitrary constant of type \p tn.
    * @param ntSym The non-terminal allowed to be any constant.
    * @param tn The type of allowed constants.
+   * @param weights The weights of any constant.
    */
-  void addAnyConstant(const Node& ntSym, const TypeNode& tn);
+  void addAnyConstant(const Node& ntSym,
+                      const TypeNode& tn,
+                      const NodeMap& weights = {});
 
   /**
    * Allow \p ntSym to be any input variable to corresponding
    * synth-fun/synth-inv with the same type as \p ntSym.
    * @param ntSym The non-terminal allowed to be any input variable.
+   * @param weights The weights of any variable.
    */
-  void addAnyVariable(const Node& ntSym);
+  void addAnyVariable(const Node& ntSym, const NodeMap& weights = {});
 
   /**
    * Remove \p rule from the set of rules corresponding to \p ntSym.
@@ -101,7 +114,7 @@ class SygusGrammar
   /**
    * @return The rules for non-terminal ntSym
    */
-  const std::vector<Node>& getRulesFor(const Node& ntSym) const;
+  std::vector<Node> getRulesFor(const Node& ntSym) const;
 
   /**
    * @return A string representation of this grammar.
@@ -126,12 +139,12 @@ class SygusGrammar
   bool hasRules() const;
 
  private:
-  /** Input variables to the corresponding function/invariant to synthesize.*/
+  /** Input variables to the corresponding function/invariant to synthesize. */
   std::vector<Node> d_sygusVars;
   /** The non-terminal symbols of this grammar. */
   std::vector<Node> d_ntSyms;
-  /** Mapping from non-terminal symbols to their production rules. */
-  std::unordered_map<Node, std::vector<Node>> d_rules;
+  /** Map from non-terminal symbols to their production rules and weights. */
+  std::unordered_map<Node, std::vector<std::pair<Node, NodeMap>>> d_rules;
   /** The datatype type constructed by this grammar. */
   TypeNode d_datatype;
 };

--- a/src/expr/weight_symbol.cpp
+++ b/src/expr/weight_symbol.cpp
@@ -1,0 +1,41 @@
+/******************************************************************************
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2026 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The weight symbol operator implementation
+ */
+
+#include "expr/weight_symbol.h"
+
+namespace cvc5::internal {
+
+WeightSymbol::WeightSymbol(const Node& weight, const Node& uf)
+    : d_weight(weight), d_uf(uf)
+{
+}
+
+const Node& WeightSymbol::getWeight() const { return d_weight; }
+
+const Node& WeightSymbol::getUF() const { return d_uf; }
+
+bool WeightSymbol::operator==(const WeightSymbol& ws) const
+{
+  return d_weight == ws.d_weight && d_uf == ws.d_uf;
+}
+
+std::ostream& operator<<(std::ostream& out, const WeightSymbol& ws)
+{
+  return out << ws.getWeight() << '(' << ws.getUF() << ')';
+}
+
+size_t WeightSymbolHashFunction::operator()(const WeightSymbol& ws) const
+{
+  return std::hash<Node>()(ws.getWeight()) * std::hash<Node>()(ws.getUF());
+}
+
+}  // namespace cvc5::internal

--- a/src/expr/weight_symbol.h
+++ b/src/expr/weight_symbol.h
@@ -1,0 +1,60 @@
+/******************************************************************************
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2026 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The weight symbol operator interface
+ */
+
+#include "cvc5_public.h"
+
+#ifndef CVC5__EXPR__WEIGHT_SYMBOL_H
+#define CVC5__EXPR__WEIGHT_SYMBOL_H
+
+#include "node.h"
+
+namespace cvc5::internal {
+
+/**
+ * The payload of the WEIGHT_SYMBOL_OP operator. It pairs a SyGuS weight
+ * attribute with the function-to-synthesize whose accumulated term weight is
+ * being constrained, as introduced by `(_ <weight> <function>)` in the SyGuS
+ * IF 2.1 standard.
+ */
+class WeightSymbol
+{
+ public:
+  /**
+   * Construct a weight symbol.
+   * @param weight The weight attribute (an integer variable carrying a
+   * SygusWeightAttribute).
+   * @param uf The function-to-synthesize whose term weight is constrained.
+   */
+  WeightSymbol(const Node& weight, const Node& uf);
+  /** Get the weight attribute. */
+  const Node& getWeight() const;
+  /** Get the function-to-synthesize. */
+  const Node& getUF() const;
+  bool operator==(const WeightSymbol& ws) const;
+
+ private:
+  /** The weight attribute. */
+  Node d_weight;
+  /** The function-to-synthesize whose term weight is constrained. */
+  Node d_uf;
+};
+
+std::ostream& operator<<(std::ostream& out, const WeightSymbol& ws);
+
+struct WeightSymbolHashFunction
+{
+  size_t operator()(const WeightSymbol& ws) const;
+};
+
+}  // namespace cvc5::internal
+
+#endif

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -31,6 +31,7 @@
 #include "expr/node_visitor.h"
 #include "expr/sequence.h"
 #include "expr/skolem_manager.h"
+#include "expr/weight_symbol.h"
 #include "options/io_utils.h"
 #include "options/language.h"
 #include "printer/let_binding.h"
@@ -519,6 +520,10 @@ bool Smt2Printer::toStreamBase(std::ostream& out,
       case Kind::REGEXP_LOOP_OP:
         out << "(_ re.loop " << n.getConst<RegExpLoop>().d_loopMinOcc << " "
             << n.getConst<RegExpLoop>().d_loopMaxOcc << ")";
+        break;
+      case Kind::WEIGHT_SYMBOL_OP:
+        out << "(_ " << n.getConst<WeightSymbol>().getWeight() << ' '
+            << n.getConst<WeightSymbol>().getUF() << ')';
         break;
       case Kind::TUPLE_PROJECT_OP:
       case Kind::TABLE_PROJECT_OP:
@@ -2292,8 +2297,21 @@ std::string Smt2Printer::sygusGrammarString(const TypeNode& t)
           }
           Node consToPrint = nm->mkNode(Kind::APPLY_CONSTRUCTOR, cchildren);
           // now, print it using the conversion to builtin with external
+          const std::map<Node, Node>& ws = cons.getWeights();
+          if (!ws.empty())
+          {
+            types_list << "(! ";
+          }
           types_list << theory::datatypes::utils::sygusToBuiltin(consToPrint,
                                                                  true);
+          if (!ws.empty())
+          {
+            for (const std::pair<const Node, Node>& w : ws)
+            {
+              types_list << " :" << w.first.getName() << ' ' << w.second;
+            }
+            types_list << ')';
+          }
         }
       }
       types_list << "))";

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -316,6 +316,35 @@ RewriteResponse DatatypesRewriter::postRewrite(TNode in)
       return RewriteResponse(REWRITE_AGAIN_FULL, res);
     }
   }
+  else if (kind == Kind::DT_SYGUS_WEIGHT)
+  {
+    if (in[1].getKind() == Kind::APPLY_CONSTRUCTOR)
+    {
+      std::vector<Node> children;
+      for (unsigned i = 0, size = in[1].getNumChildren(); i < size; i++)
+      {
+        if (in[1][i].getType().isDatatype())
+        {
+          children.push_back(
+              nm->mkNode(Kind::DT_SYGUS_WEIGHT, in[0], in[1][i]));
+        }
+      }
+      TNode constructor = in[1].getOperator();
+      size_t constructorIndex = utils::indexOf(constructor);
+      const DType& dt = utils::datatypeOf(constructor);
+      const DTypeConstructor& c = dt[constructorIndex];
+      const Node& weight = c.getWeights().find(in[0]) == c.getWeights().cend()
+                               ? in[0].getAttribute(SygusWeightAttribute())
+                               : c.getWeights().at(in[0]);
+      children.push_back(weight);
+      Node res =
+          children.size() == 1 ? children[0] : nm->mkNode(Kind::ADD, children);
+      Trace("datatypes-rewrite")
+          << "DatatypesRewriter::postRewrite: rewrite weight " << in << " to "
+          << res << std::endl;
+      return RewriteResponse(REWRITE_AGAIN_FULL, res);
+    }
+  }
   else if (kind == Kind::DT_HEIGHT_BOUND)
   {
     if (in[0].getKind() == Kind::APPLY_CONSTRUCTOR)

--- a/src/theory/datatypes/kinds.toml
+++ b/src/theory/datatypes/kinds.toml
@@ -191,6 +191,31 @@ children = "1:"
 comment  = "datatypes sygus evaluation function"
 typerule = "::cvc5::internal::theory::datatypes::DtSygusEvalTypeRule"
 
+[[kinds]]
+type     = "operator"
+name     = "DT_SYGUS_WEIGHT"
+children = 2
+comment  = "datatypes sygus weight"
+typerule = "::cvc5::internal::theory::datatypes::DtSygusWeightTypeRule"
+
+[[kinds]]
+type      = "constant"
+name      = "WEIGHT_SYMBOL_OP"
+class_key = "class"
+cpp_type  = "WeightSymbol"
+hasher    = "::cvc5::internal::WeightSymbolHashFunction"
+header    = "expr/weight_symbol.h"
+comment   = "the weight symbol operator; payload is an instance of the cvc5::internal::WeightSymbol class"
+typerule  = "::cvc5::internal::theory::datatypes::WeightSymbolOpTypeRule"
+
+[[kinds]]
+type     = "parameterized"
+K1       = "WEIGHT_SYMBOL"
+K2       = "WEIGHT_SYMBOL_OP"
+children = 0
+comment  = "a symbol denoting the weight of a function to synthesize"
+typerule = "::cvc5::internal::theory::datatypes::WeightSymbolTypeRule"
+
 # Kinds for match terms. For example, the match term
 #   (match l (((cons h t) h) (nil 0))) 
 # is represented by the AST

--- a/src/theory/datatypes/sygus_datatype_utils.h
+++ b/src/theory/datatypes/sygus_datatype_utils.h
@@ -67,6 +67,15 @@ struct SygusVarFreeAttributeId
 {
 };
 typedef expr::Attribute<SygusVarFreeAttributeId, Node> SygusVarFreeAttribute;
+
+/** Sygus Weight
+ *
+ * This attribute is used to mark the weight of Sygus grammar rules.
+ */
+struct SygusWeightAttributeId
+{
+};
+typedef expr::Attribute<SygusWeightAttributeId, Node> SygusWeightAttribute;
 // ----------------------- end sygus datatype attributes
 
 namespace datatypes {

--- a/src/theory/datatypes/theory_datatypes_type_rules.cpp
+++ b/src/theory/datatypes/theory_datatypes_type_rules.cpp
@@ -19,7 +19,9 @@
 #include "expr/dtype.h"
 #include "expr/dtype_cons.h"
 #include "expr/type_matcher.h"
+#include "expr/weight_symbol.h"
 #include "theory/datatypes/project_op.h"
+#include "theory/datatypes/sygus_datatype_utils.h"
 #include "theory/datatypes/theory_datatypes_utils.h"
 #include "theory/datatypes/tuple_utils.h"
 #include "util/rational.h"
@@ -513,6 +515,78 @@ TypeNode DtSygusEvalTypeRule::computeType(CVC5_UNUSED NodeManager* nodeManager,
     }
   }
   return dt.getSygusType();
+}
+
+TypeNode DtSygusWeightTypeRule::preComputeType(NodeManager* nm,
+                                               CVC5_UNUSED TNode n)
+{
+  return nm->integerType();
+}
+TypeNode DtSygusWeightTypeRule::computeType(NodeManager* nodeManager,
+                                            TNode n,
+                                            bool check,
+                                            CVC5_UNUSED std::ostream* errOut)
+{
+  if (check)
+  {
+    if (!n[0].getType(check).isInteger()
+        || !n[0].hasAttribute(SygusWeightAttribute()))
+    {
+      throw TypeCheckingExceptionPrivate(
+          n,
+          "datatype sygus weight must be an integer variable with a sygus "
+          "weight attribute");
+    }
+    TypeNode t = n[1].getType(check);
+    if (!t.isDatatype() || !t.getDType().isSygus())
+    {
+      throw TypeCheckingExceptionPrivate(
+          n, "datatype sygus weight takes a sygus datatype");
+    }
+  }
+  return nodeManager->integerType();
+}
+
+TypeNode WeightSymbolOpTypeRule::preComputeType(NodeManager* nm,
+                                                CVC5_UNUSED TNode n)
+{
+  return nm->builtinOperatorType();
+}
+TypeNode WeightSymbolOpTypeRule::computeType(NodeManager* nodeManager,
+                                             TNode n,
+                                             bool check,
+                                             CVC5_UNUSED std::ostream* errOut)
+{
+  if (check)
+  {
+    const WeightSymbol& ws = n.getConst<WeightSymbol>();
+    const Node& wn = ws.getWeight();
+    if (!wn.isVar() || !wn.getType(check).isInteger()
+        || !wn.hasAttribute(SygusWeightAttribute()))
+    {
+      throw TypeCheckingExceptionPrivate(
+          n, "weight must be an integer variable with a weight attribute");
+    }
+    if (!ws.getUF().isVar())
+    {
+      throw TypeCheckingExceptionPrivate(
+          n, "weight symbol takes a variable denoting function to synthesize");
+    }
+  }
+  return nodeManager->builtinOperatorType();
+}
+
+TypeNode WeightSymbolTypeRule::preComputeType(NodeManager* nm,
+                                              CVC5_UNUSED TNode n)
+{
+  return nm->integerType();
+}
+TypeNode WeightSymbolTypeRule::computeType(NodeManager* nodeManager,
+                                           CVC5_UNUSED TNode n,
+                                           CVC5_UNUSED bool check,
+                                           CVC5_UNUSED std::ostream* errOut)
+{
+  return nodeManager->integerType();
 }
 
 TypeNode MatchTypeRule::preComputeType(CVC5_UNUSED NodeManager* nm,

--- a/src/theory/datatypes/theory_datatypes_type_rules.h
+++ b/src/theory/datatypes/theory_datatypes_type_rules.h
@@ -149,6 +149,48 @@ class DtSygusEvalTypeRule
 };
 
 /**
+ * The type rule for sygus weight functions. DT_SYGUS_WEIGHT expects a weight
+ * and a datatype and returns the integer type.
+ */
+class DtSygusWeightTypeRule
+{
+ public:
+  static TypeNode preComputeType(NodeManager* nm, TNode n);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
+};
+
+/**
+ * The type rule for sygus weight symbol operator, which is indexed by a weight
+ * and a function to synthesize. Ensures that weight is a variable with weight
+ * attribute and returns the builtin type.
+ */
+class WeightSymbolOpTypeRule
+{
+ public:
+  static TypeNode preComputeType(NodeManager* nm, TNode n);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
+};
+
+/**
+ * A weight symbol specified by its operator, returns the integer type.
+ */
+class WeightSymbolTypeRule
+{
+ public:
+  static TypeNode preComputeType(NodeManager* nm, TNode n);
+  static TypeNode computeType(NodeManager* nodeManager,
+                              TNode n,
+                              bool check,
+                              std::ostream* errOut);
+};
+
+/**
  * The type rule for match. Recall that a match term:
  *   (match l (((cons h t) h) (nil 0)))
  * is represented by the AST

--- a/src/theory/quantifiers/sygus/embedding_converter.cpp
+++ b/src/theory/quantifiers/sygus/embedding_converter.cpp
@@ -12,6 +12,7 @@
 
 #include "theory/quantifiers/sygus/embedding_converter.h"
 
+#include "expr/weight_symbol.h"
 #include "options/base_options.h"
 #include "options/quantifiers_options.h"
 #include "printer/smt2/smt2_printer.h"
@@ -391,6 +392,13 @@ Node EmbeddingConverter::convertToEmbedding(Node n)
           ret = nm->mkNode(
               Kind::LAMBDA, lvl, nm->mkNode(Kind::DT_SYGUS_EVAL, eargs));
         }
+      }
+      else if (ret_k == Kind::WEIGHT_SYMBOL)
+      {
+        const WeightSymbol& ws = cur.getOperator().getConst<WeightSymbol>();
+        ret = nm->mkNode(Kind::DT_SYGUS_WEIGHT,
+                         ws.getWeight(),
+                         d_synth_fun_vars[ws.getUF()]);
       }
       else if (childChanged)
       {

--- a/src/theory/quantifiers/sygus/sygus_enumerator_callback.cpp
+++ b/src/theory/quantifiers/sygus/sygus_enumerator_callback.cpp
@@ -12,6 +12,7 @@
 
 #include "theory/quantifiers/sygus/sygus_enumerator_callback.h"
 
+#include "expr/dtype_cons.h"
 #include "theory/datatypes/sygus_datatype_utils.h"
 #include "theory/quantifiers/sygus/example_eval_cache.h"
 #include "theory/quantifiers/sygus/sygus_enumerator.h"
@@ -62,12 +63,62 @@ bool SygusEnumeratorCallback::addTerm(const Node& n,
   return true;
 }
 
-Node SygusEnumeratorCallback::getCacheValue(CVC5_UNUSED const Node& n,
-                                            const Node& bn)
+Node SygusEnumeratorCallback::getCacheValue(const Node& n, const Node& bn)
 {
-  // By default, we cache based on the rewritten form.
-  // Further criteria for uniqueness (e.g. weights) may go here.
-  return d_tds == nullptr ? extendedRewrite(bn) : d_tds->rewriteNode(bn);
+  // By default, we cache based on the rewritten form. Additional uniqueness
+  // criteria (e.g. SyGuS 2.1 weights) are folded in below.
+  Node rewritten =
+      d_tds == nullptr ? extendedRewrite(bn) : d_tds->rewriteNode(bn);
+  // Fast path: grammars without weight annotations keep the legacy cache key.
+  const std::vector<Node>& weights = getWeightVars(n.getType());
+  if (weights.empty())
+  {
+    return rewritten;
+  }
+  NodeManager* nm = n.getNodeManager();
+  std::vector<Node> cvals;
+  cvals.reserve(weights.size() + 1);
+  cvals.push_back(rewritten);
+  for (const Node& weight : weights)
+  {
+    Node wn = nm->mkNode(Kind::DT_SYGUS_WEIGHT, weight, n);
+    cvals.push_back(d_tds == nullptr ? extendedRewrite(wn)
+                                     : d_tds->rewriteNode(wn));
+  }
+  return nm->mkNode(Kind::SEXPR, cvals);
+}
+
+const std::vector<Node>& SygusEnumeratorCallback::getWeightVars(
+    const TypeNode& tn)
+{
+  std::unordered_map<TypeNode, std::vector<Node>>::iterator it =
+      d_weightVars.find(tn);
+  if (it != d_weightVars.end())
+  {
+    return it->second;
+  }
+  std::vector<Node>& weights = d_weightVars[tn];
+  if (!tn.isDatatype())
+  {
+    return weights;
+  }
+  const DType& dt = tn.getDType();
+  if (!dt.isSygus())
+  {
+    return weights;
+  }
+  std::unordered_set<Node> seen;
+  for (const std::shared_ptr<DTypeConstructor>& cons : dt.getConstructors())
+  {
+    for (const std::pair<const Node, Node>& pair : cons->getWeights())
+    {
+      if (seen.insert(pair.first).second)
+      {
+        weights.push_back(pair.first);
+      }
+    }
+  }
+  return weights;
 }
 
 bool SygusEnumeratorCallback::addTermInternal(const Node& n,

--- a/src/theory/quantifiers/sygus/sygus_enumerator_callback.h
+++ b/src/theory/quantifiers/sygus/sygus_enumerator_callback.h
@@ -15,10 +15,12 @@
 #ifndef CVC5__THEORY__QUANTIFIERS__SYGUS__SYGUS_ENUMERATOR_CALLBACK_H
 #define CVC5__THEORY__QUANTIFIERS__SYGUS__SYGUS_ENUMERATOR_CALLBACK_H
 
+#include <unordered_map>
 #include <unordered_set>
 
 #include "expr/node.h"
 #include "expr/sygus_term_enumerator.h"
+#include "expr/type_node.h"
 #include "smt/env_obj.h"
 #include "theory/quantifiers/extended_rewrite.h"
 
@@ -68,6 +70,13 @@ class SygusEnumeratorCallback : public SygusTermEnumeratorCallback,
    * @return true if the term should be considered in the enumeration.
    */
   bool addTermInternal(const Node& n, const Node& bn, const Node& cval);
+  /**
+   * Return the distinct weight attributes referenced by any constructor of
+   * the sygus datatype @p tn, computing and caching the result on first
+   * access. Returns an empty vector for non-sygus types and for grammars
+   * with no weight annotations.
+   */
+  const std::vector<Node>& getWeightVars(const TypeNode& tn);
   /** Term database sygus */
   TermDbSygus* d_tds;
   /** pointer to the statistics */
@@ -77,6 +86,8 @@ class SygusEnumeratorCallback : public SygusTermEnumeratorCallback,
    * breaking).
    */
   ExampleEvalCache* d_eec;
+  /** Per-type cache of distinct weight attributes. */
+  std::unordered_map<TypeNode, std::vector<Node>> d_weightVars;
 };
 
 }  // namespace quantifiers

--- a/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
@@ -102,7 +102,8 @@ void SygusGrammarNorm::TypeObject::addConsInfo(SygusGrammarNorm* sygus_norm,
     consTypes.push_back(atype);
   }
 
-  d_sdt.addConstructor(sygus_op, cons.getName(), consTypes, cons.getWeight());
+  d_sdt.addConstructor(
+      sygus_op, cons.getName(), consTypes, cons.getWeight(), cons.getWeights());
 }
 
 void SygusGrammarNorm::TypeObject::initializeDatatype(

--- a/test/unit/api/cpp/CMakeLists.txt
+++ b/test/unit/api/cpp/CMakeLists.txt
@@ -31,6 +31,7 @@ cvc5_add_unit_test_black(api_term_black api/cpp)
 cvc5_add_unit_test_white(api_term_white api/cpp)
 cvc5_add_unit_test_black(api_term_manager_black api/cpp)
 cvc5_add_unit_test_black(api_types_black api/cpp)
+cvc5_add_unit_test_black(api_weight_black api/cpp)
 
 # do not issue deprecation warnings when using deprecated functions
 set_source_files_properties(input_parser_black.cpp

--- a/test/unit/api/cpp/api_weight_black.cpp
+++ b/test/unit/api/cpp/api_weight_black.cpp
@@ -1,0 +1,271 @@
+/******************************************************************************
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2026 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Black box testing of the SyGuS weight C++ API.
+ */
+
+#include "test_api.h"
+
+namespace cvc5::internal {
+
+namespace test {
+
+class TestApiBlackWeight : public TestApi
+{
+ protected:
+  void SetUp() override
+  {
+    TestApi::SetUp();
+    d_solver->setOption("sygus", "true");
+    d_solver->setLogic("NIA");
+  }
+};
+
+TEST_F(TestApiBlackWeight, declareWeight)
+{
+  Weight w = d_solver->declareWeight("w");
+  ASSERT_EQ(w.getName(), "w");
+  // declared without :default, so the default value is 0.
+  ASSERT_TRUE(w.getDefaultValue() == d_tm.mkInteger(0));
+}
+
+TEST_F(TestApiBlackWeight, declareWeightRequiresSygus)
+{
+  // Without the sygus option, declareWeight must fail.
+  Solver s(d_tm);
+  ASSERT_THROW(s.declareWeight("w"), CVC5ApiException);
+}
+
+TEST_F(TestApiBlackWeight, declareWeightWithDefault)
+{
+  Term five = d_tm.mkInteger(5);
+  Weight w = d_solver->declareWeight("w", five);
+  ASSERT_EQ(w.getName(), "w");
+  ASSERT_TRUE(w.getDefaultValue() == five);
+
+  Term nullTerm;
+  // The default must be a non-null integer constant.
+  ASSERT_THROW(d_solver->declareWeight("bad", nullTerm), CVC5ApiException);
+  ASSERT_THROW(d_solver->declareWeight("bad", d_tm.mkBoolean(true)),
+               CVC5ApiException);
+  ASSERT_THROW(d_solver->declareWeight("bad", d_tm.mkReal(1, 2)),
+               CVC5ApiException);
+  // An integer term that is not a value is rejected.
+  ASSERT_THROW(d_solver->declareWeight("bad", d_tm.mkVar(d_int)),
+               CVC5ApiException);
+
+  // Still requires sygus.
+  Solver s(d_tm);
+  ASSERT_THROW(s.declareWeight("w", five), CVC5ApiException);
+}
+
+TEST_F(TestApiBlackWeight, getDefaultValue)
+{
+  Term five = d_tm.mkInteger(5);
+  Weight wDefault = d_solver->declareWeight("a", five);
+  ASSERT_TRUE(wDefault.getDefaultValue() == five);
+  // Weights declared without :default get 0.
+  Weight wZero = d_solver->declareWeight("b");
+  ASSERT_TRUE(wZero.getDefaultValue() == d_tm.mkInteger(0));
+}
+
+TEST_F(TestApiBlackWeight, equalHashOrder)
+{
+  Weight w1 = d_solver->declareWeight("a");
+  Weight w2 = d_solver->declareWeight("b");
+
+  ASSERT_TRUE(w1 == w1);
+  ASSERT_FALSE(w1 == w2);
+  ASSERT_TRUE(w1 != w2);
+  ASSERT_FALSE(w1 != w1);
+
+  // operator< is a strict order: irreflexive and asymmetric.
+  ASSERT_FALSE(w1 < w1);
+  ASSERT_NE(w1 < w2, w2 < w1);
+
+  // Equal weights have equal hashes.
+  ASSERT_EQ(std::hash<Weight>{}(w1), std::hash<Weight>{}(w1));
+
+  // Weights from different term managers are not equal.
+  TermManager tm2;
+  Solver s2(tm2);
+  s2.setOption("sygus", "true");
+  Weight w3 = s2.declareWeight("a");
+  ASSERT_FALSE(w1 == w3);
+  ASSERT_TRUE(w1 != w3);
+
+  // Weights are usable as keys of a WeightMap.
+  WeightMap m;
+  m[w1] = d_tm.mkInteger(1);
+  m[w2] = d_tm.mkInteger(2);
+  m[w1] = d_tm.mkInteger(3);
+  ASSERT_EQ(m.size(), 2);
+  ASSERT_TRUE(m[w1] == d_tm.mkInteger(3));
+}
+
+TEST_F(TestApiBlackWeight, mkWeightSymbol)
+{
+  Term x = d_tm.mkVar(d_int, "x");
+  Term start = d_tm.mkVar(d_int, "Start");
+  Weight w = d_solver->declareWeight("w");
+
+  Grammar g = d_solver->mkGrammar({x}, {start});
+  g.addRule(start, x);
+  Term f = d_solver->synthFun("f", {x}, d_int, g);
+
+  Term ws = d_solver->mkWeightSymbol(w, f);
+  // The weight symbol has integer sort.
+  ASSERT_EQ(ws.getSort(), d_int);
+
+  Term nullTerm;
+  ASSERT_THROW(d_solver->mkWeightSymbol(w, nullTerm), CVC5ApiException);
+
+  // The weight must belong to this solver's term manager.
+  TermManager tm2;
+  Solver s2(tm2);
+  s2.setOption("sygus", "true");
+  Weight w2 = s2.declareWeight("w");
+  ASSERT_THROW(d_solver->mkWeightSymbol(w2, f), CVC5ApiException);
+
+  // mkWeightSymbol requires sygus mode.
+  Solver s3(d_tm);
+  ASSERT_THROW(s3.mkWeightSymbol(w, f), CVC5ApiException);
+}
+
+TEST_F(TestApiBlackWeight, addRuleWithWeights)
+{
+  Term nullTerm;
+  Term x = d_tm.mkVar(d_int, "x");
+  Term start = d_tm.mkVar(d_int, "Start");
+  Term nts = d_tm.mkVar(d_int, "nts");
+  Weight w = d_solver->declareWeight("w");
+  WeightMap weights{{w, d_tm.mkInteger(1)}};
+
+  Grammar g = d_solver->mkGrammar({x}, {start});
+  Term add = d_tm.mkTerm(Kind::ADD, {start, start});
+
+  ASSERT_NO_THROW(g.addRule(start, add, weights));
+  // An empty weight map keeps the legacy behavior.
+  ASSERT_NO_THROW(g.addRule(start, x, {}));
+
+  ASSERT_THROW(g.addRule(nullTerm, x, weights), CVC5ApiException);
+  ASSERT_THROW(g.addRule(start, nullTerm, weights), CVC5ApiException);
+  ASSERT_THROW(g.addRule(nts, x, weights), CVC5ApiException);
+  // Rule must have a matching sort.
+  ASSERT_THROW(g.addRule(start, d_tm.mkBoolean(true), weights),
+               CVC5ApiException);
+
+  // After the grammar is bound to a synth-fun, adding is rejected.
+  d_solver->synthFun("f", {x}, d_int, g);
+  ASSERT_THROW(g.addRule(start, x, weights), CVC5ApiException);
+}
+
+TEST_F(TestApiBlackWeight, addRulesWithWeights)
+{
+  Term nullTerm;
+  Term x = d_tm.mkVar(d_int, "x");
+  Term start = d_tm.mkVar(d_int, "Start");
+  Term nts = d_tm.mkVar(d_int, "nts");
+  Weight w = d_solver->declareWeight("w");
+
+  Grammar g = d_solver->mkGrammar({x}, {start});
+  std::vector<Term> rules = {d_tm.mkInteger(0), d_tm.mkInteger(1), x};
+  std::vector<WeightMap> weights = {
+      {}, {{w, d_tm.mkInteger(1)}}, {{w, d_tm.mkInteger(2)}}};
+
+  ASSERT_NO_THROW(g.addRules(start, rules, weights));
+  // An empty weights vector keeps the legacy behavior.
+  ASSERT_NO_THROW(g.addRules(start, {d_tm.mkInteger(3)}));
+
+  ASSERT_THROW(g.addRules(nullTerm, rules, weights), CVC5ApiException);
+  ASSERT_THROW(g.addRules(start, {nullTerm}, {{}}), CVC5ApiException);
+  ASSERT_THROW(g.addRules(nts, rules, weights), CVC5ApiException);
+  ASSERT_THROW(g.addRules(start, {d_tm.mkBoolean(true)}, {{}}),
+               CVC5ApiException);
+
+  d_solver->synthFun("f", {x}, d_int, g);
+  ASSERT_THROW(g.addRules(start, rules, weights), CVC5ApiException);
+}
+
+TEST_F(TestApiBlackWeight, addAnyConstantWithWeights)
+{
+  Term nullTerm;
+  Term start = d_tm.mkVar(d_int, "Start");
+  Term nts = d_tm.mkVar(d_int, "nts");
+  Weight w = d_solver->declareWeight("w");
+  WeightMap weights{{w, d_tm.mkInteger(3)}};
+
+  Grammar g = d_solver->mkGrammar({}, {start});
+
+  ASSERT_NO_THROW(g.addAnyConstant(start, weights));
+  ASSERT_NO_THROW(g.addAnyConstant(start, {}));
+
+  ASSERT_THROW(g.addAnyConstant(nullTerm, weights), CVC5ApiException);
+  ASSERT_THROW(g.addAnyConstant(nts, weights), CVC5ApiException);
+
+  d_solver->synthFun("f", {}, d_int, g);
+  ASSERT_THROW(g.addAnyConstant(start, weights), CVC5ApiException);
+}
+
+TEST_F(TestApiBlackWeight, addAnyVariableWithWeights)
+{
+  Term nullTerm;
+  Term x = d_tm.mkVar(d_int, "x");
+  Term start = d_tm.mkVar(d_int, "Start");
+  Term nts = d_tm.mkVar(d_int, "nts");
+  Weight w = d_solver->declareWeight("w");
+  WeightMap weights{{w, d_tm.mkInteger(7)}};
+
+  Grammar g = d_solver->mkGrammar({x}, {start});
+
+  ASSERT_NO_THROW(g.addAnyVariable(start, weights));
+  ASSERT_NO_THROW(g.addAnyVariable(start, {}));
+
+  ASSERT_THROW(g.addAnyVariable(nullTerm, weights), CVC5ApiException);
+  ASSERT_THROW(g.addAnyVariable(nts, weights), CVC5ApiException);
+
+  d_solver->synthFun("f", {x}, d_int, g);
+  ASSERT_THROW(g.addAnyVariable(start, weights), CVC5ApiException);
+}
+
+TEST_F(TestApiBlackWeight, synthesizeWithWeightConstraint)
+{
+  d_solver->setOption("incremental", "false");
+
+  Term x = d_tm.mkVar(d_int, "x");
+  Term start = d_tm.mkVar(d_int, "Start");
+  Term add = d_tm.mkTerm(Kind::ADD, {start, start});
+  Term mult = d_tm.mkTerm(Kind::MULT, {start, start});
+
+  Weight w = d_solver->declareWeight("w");
+  Grammar g = d_solver->mkGrammar({x}, {start});
+  // Constants and the input variable have the default weight 0.
+  g.addRules(start, {d_tm.mkInteger(0), d_tm.mkInteger(1), x});
+  // `+` costs 1, `*` costs 31.
+  g.addRule(start, add, {{w, d_tm.mkInteger(1)}});
+  g.addRule(start, mult, {{w, d_tm.mkInteger(31)}});
+
+  Term f = d_solver->synthFun("f", {x}, d_int, g);
+  Term varX = d_solver->declareSygusVar("x", d_int);
+  Term fX = d_tm.mkTerm(Kind::APPLY_UF, {f, varX});
+
+  // (= (f x) (* 3 x))
+  d_solver->addSygusConstraint(d_tm.mkTerm(
+      Kind::EQUAL, {fX, d_tm.mkTerm(Kind::MULT, {d_tm.mkInteger(3), varX})}));
+  // (= (_ w f) 2): a solution must use exactly two `+` applications.
+  Term wF = d_solver->mkWeightSymbol(w, f);
+  d_solver->addSygusConstraint(
+      d_tm.mkTerm(Kind::EQUAL, {wF, d_tm.mkInteger(2)}));
+
+  ASSERT_TRUE(d_solver->checkSynth().hasSolution());
+  ASSERT_NO_THROW(d_solver->getSynthSolution(f));
+}
+
+}  // namespace test
+}  // namespace cvc5::internal

--- a/test/unit/api/java/GrammarTest.java
+++ b/test/unit/api/java/GrammarTest.java
@@ -182,7 +182,13 @@ class GrammarTest
     {
       g1 = d_solver.mkGrammar(new Term[] {x}, new Term[] {start1});
       g2 = d_solver.mkGrammar(new Term[] {x}, new Term[] {start2});
-      assertNotEquals(g1.hashCode(), g2.hashCode());
+      // g1 and g2 differ only by the identity of their (identically named and
+      // sorted) non-terminal, so they are not equal. The assertion below is
+      // commented out: Java's hashCode() is the C++ 64-bit hash truncated to
+      // 32 bits, and whether these two distinct grammars collide in 32 bits
+      // depends on the (nondeterministic) node ids of start1/start2 -- with
+      // some ids the truncated hashes collide.
+      // assertNotEquals(g1.hashCode(), g2.hashCode());
       assertTrue(g1.equals(g1));
       assertFalse(g1.equals(g2));
     }

--- a/test/unit/api/python/test_grammar.py
+++ b/test/unit/api/python/test_grammar.py
@@ -63,7 +63,7 @@ def test_add_rule(tm, solver):
         g.addRule(start, tm.mkInteger(0))
 
     # expecting no errors
-    solver.synthFun("f", {}, boolean, g)
+    solver.synthFun("f", [], boolean, g)
 
     # expecting an error
     with pytest.raises(RuntimeError):
@@ -80,7 +80,7 @@ def test_add_rules(tm, solver):
 
     g = solver.mkGrammar([], [start])
 
-    g.addRules(start, {tm.mkBoolean(False)})
+    g.addRules(start, [tm.mkBoolean(False)])
 
     #Expecting errors
     with pytest.raises(RuntimeError):
@@ -89,11 +89,11 @@ def test_add_rules(tm, solver):
         g.addRules(start, [tm.mkInteger(0)])
 
     #Expecting no errors
-    solver.synthFun("f", {}, boolean, g)
+    solver.synthFun("f", [], boolean, g)
 
     #Expecting an error
     with pytest.raises(RuntimeError):
-        g.addRules(start, tm.mkBoolean(False))
+        g.addRules(start, [tm.mkBoolean(False)])
 
 
 def test_add_any_constant(tm, solver):
@@ -103,7 +103,7 @@ def test_add_any_constant(tm, solver):
     start = tm.mkVar(boolean)
     nts = tm.mkVar(boolean)
 
-    g = solver.mkGrammar({}, {start})
+    g = solver.mkGrammar([], [start])
 
     g.addAnyConstant(start)
     g.addAnyConstant(start)
@@ -111,7 +111,7 @@ def test_add_any_constant(tm, solver):
     with pytest.raises(RuntimeError):
         g.addAnyConstant(nts)
 
-    solver.synthFun("f", {}, boolean, g)
+    solver.synthFun("f", [], boolean, g)
 
     with pytest.raises(RuntimeError):
         g.addAnyConstant(start)
@@ -125,8 +125,8 @@ def test_add_any_variable(tm, solver):
     start = tm.mkVar(boolean)
     nts = tm.mkVar(boolean)
 
-    g1 = solver.mkGrammar({x}, {start})
-    g2 = solver.mkGrammar({}, {start})
+    g1 = solver.mkGrammar([x], [start])
+    g2 = solver.mkGrammar([], [start])
 
     g1.addAnyVariable(start)
     g1.addAnyVariable(start)
@@ -135,63 +135,63 @@ def test_add_any_variable(tm, solver):
     with pytest.raises(RuntimeError):
         g1.addAnyVariable(nts)
 
-    solver.synthFun("f", {}, boolean, g1)
+    solver.synthFun("f", [], boolean, g1)
 
     with pytest.raises(RuntimeError):
         g1.addAnyVariable(start)
 
-def tesT_hash(tm, solver):
+def test_hash(tm, solver):
     solver.setOption("sygus", "true")
     bool_sort = tm.getBooleanSort()
     x = tm.mkVar(bool_sort, "x")
     start1 = tm.mkVar(bool_sort, "start")
     start2 = tm.mkVar(bool_sort, "start")
 
-    g1 = solver.mkGrammar({}, {start1})
-    g2 = solver.mkGrammar({}, {start1})
+    g1 = solver.mkGrammar([], [start1])
+    g2 = solver.mkGrammar([], [start1])
     assert hash(g1) == hash(g1)
     assert hash(g1) == hash(g2)
     assert g1 == g1
     assert g1 != g2
 
-    g1 = solver.mkGrammar({}, {start1})
-    g2 = solver.mkGrammar({x}, {start1})
+    g1 = solver.mkGrammar([], [start1])
+    g2 = solver.mkGrammar([x], [start1])
     assert hash(g1) != hash(g2)
     assert g1 == g1
     assert g1 != g2
 
-    g1 = solver.mkGrammar({x}, {start1})
-    g2 = solver.mkGrammar({x}, {start2})
-    assert hash(g1) == hash(g2)
+    g1 = solver.mkGrammar([x], [start1])
+    g2 = solver.mkGrammar([x], [start2])
+    assert hash(g1) != hash(g2)
     assert g1 == g1
     assert g1 != g2
 
-    g1 = solver.mkGrammar({x}, {start1})
-    g2 = solver.mkGrammar({x}, {start1})
+    g1 = solver.mkGrammar([x], [start1])
+    g2 = solver.mkGrammar([x], [start1])
     g2.addAnyVariable(start1)
     assert hash(g1) != hash(g2)
     assert g1 == g1
     assert g1 != g2
 
-    g1 = solver.mkGrammar({x}, {start1})
-    g2 = solver.mkGrammar({x}, {start1})
-    g1.addRules(start1, tm.mkFalse())
-    g2.addRules(start1, tm.mkFalse())
+    g1 = solver.mkGrammar([x], [start1])
+    g2 = solver.mkGrammar([x], [start1])
+    g1.addRules(start1, [tm.mkFalse()])
+    g2.addRules(start1, [tm.mkFalse()])
     assert hash(g1) == hash(g2)
     assert g1 == g1
     assert g1 != g2
 
-    g1 = solver.mkGrammar({x}, {start1})
-    g2 = solver.mkGrammar({x}, {start1})
-    g2.addRules(start1, tm.mkFalse())
+    g1 = solver.mkGrammar([x], [start1])
+    g2 = solver.mkGrammar([x], [start1])
+    g2.addRules(start1, [tm.mkFalse()])
     assert hash(g1) != hash(g2)
     assert g1 == g1
     assert g1 != g2
 
-    g1 = solver.mkGrammar({x}, {start1})
-    g2 = solver.mkGrammar({x}, {start1})
-    g1.addRules(start1, tm.mkTrue())
-    g2.addRules(start1, tm.mkFalse())
+    g1 = solver.mkGrammar([x], [start1])
+    g2 = solver.mkGrammar([x], [start1])
+    g1.addRules(start1, [tm.mkTrue()])
+    g2.addRules(start1, [tm.mkFalse()])
     assert hash(g1) != hash(g2)
     assert g1 == g1
     assert g1 != g2

--- a/test/unit/api/python/test_solver.py
+++ b/test/unit/api/python/test_solver.py
@@ -2075,10 +2075,10 @@ def test_synth_fun(tm, solver):
     start1 = tm.mkVar(boolean)
     start2 = tm.mkVar(integer)
 
-    g1 = solver.mkGrammar(x, [start1])
+    g1 = solver.mkGrammar([x], [start1])
     g1.addRule(start1, tm.mkBoolean(False))
 
-    g2 = solver.mkGrammar(x, [start2])
+    g2 = solver.mkGrammar([x], [start2])
     g2.addRule(start2, tm.mkInteger(0))
 
     solver.synthFun("", [], boolean)

--- a/test/unit/api/python/test_synth_result.py
+++ b/test/unit/api/python/test_synth_result.py
@@ -35,7 +35,7 @@ def test_is_null(solver):
 
 def test_equal(tm, solver):
     solver.setOption("sygus", "true")
-    solver.synthFun("f", {}, tm.getBooleanSort())
+    solver.synthFun("f", [], tm.getBooleanSort())
     tfalse = tm.mkFalse()
     ttrue = tm.mkTrue()
     solver.addSygusConstraint(ttrue)


### PR DESCRIPTION
First of a PR series splitting the SyGuS 2.1 weights work (#12619). This adds weighted-grammar support, as defined in the SyGuS IF 2.1 standard, to the core C++ API. Later PRs add SMT-LIB parser/printer support with regression tests, then the C, Java, and Python bindings. The NEWS.md entry for the feature is deferred to the final PR of the series.

### What's new

- New public `cvc5::Weight` class representing a weight attribute, plus a `WeightMap` (`std::map<Weight, Term>`) alias.
- `Solver::declareWeight(symbol[, defaultValue])` and `Solver::mkWeightSymbol(weight, term)` for the `(_ <weight> <function>)` weight symbol.
- Optional `weights` arguments on `Grammar::addRule`, `addRules`, `addAnyConstant`, and `addAnyVariable` (default empty — fully backward compatible).

### Internals

- `WeightSymbol` payload class and new kinds `DT_SYGUS_WEIGHT`, `WEIGHT_SYMBOL_OP`, `WEIGHT_SYMBOL` with their type rules.
- Per-constructor weight maps threaded through `DType`/`DTypeConstructor`, `SygusDatatype`, and `SygusGrammar`.
- `DT_SYGUS_WEIGHT` rewrite summing constructor weights (with attribute default fallback), SMT2 printing of `(! ... :w <v>)` annotations, embedding conversion, and weight-aware uniqueness in the SyGuS enumerator cache key.

### Python binding hardening

- `Grammar.addRules`, `Solver.mkGrammar`, and `Solver.synthFun` now declare their collection parameters as `list`. Previously these were untyped: passing a bare `Term` (or a set) to `addRules` was silently iterated over the term's *children* — a no-op for childless terms — instead of raising. They now raise `TypeError`, matching the C++/Java contract.

### Tests & example

- `examples/api/cpp/sygus-weight.cpp`: synthesize `3*x` from `+` (weight 1) and `*` (weight 31) with the total `w` weight constrained to 2.
- `test/unit/api/cpp/api_weight_black.cpp`: comprehensive black-box tests for every API guard plus an end-to-end synthesis check.
- Test fixes surfaced by this change:
  - `test_grammar.py`: the hash test was dead code (misnamed `tesT_hash`, never collected). Enabling it exposed two
    pre-existing bugs — a wrong `hash(g1) == hash(g2)` expectation for two grammars differing only by an alpha-equivalent non-terminal (the 64-bit hash differs, like the C++ test asserts), and several `addRules(nt, term)` calls passing a bare term instead of a list (now a hard error per the binding change). Both fixed.
  - `test_solver.py`, `test_synth_result.py`: updated `mkGrammar`/`synthFun` calls to pass lists.
  - `test/unit/api/java/GrammarTest.java`: the analogous `equalHash` assertion is commented out with an explanation — Java truncates the 64-bit hash to 32 bits, where these two grammars collide for some nondeterministic node ids, so asserting hash (in)equality of two unequal grammars is not valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>