### PR TITLE
py_plugin: Include Python.h first to avoid redefinition warnings

### DIFF
--- a/src/api/python/py_plugin.h
+++ b/src/api/python/py_plugin.h
@@ -13,6 +13,9 @@
 #ifndef CVC5__PY_PLUGIN_H
 #define CVC5__PY_PLUGIN_H
 
+// Python.h must come first to avoid libc macro redefinition warnings
+#include <Python.h>
+
 #include <cvc5/cvc5.h>
 
 // Created by Cython when providing 'public api' keywords

--- a/src/api/python/py_plugin.h
+++ b/src/api/python/py_plugin.h
@@ -15,7 +15,6 @@
 
 // Python.h must come first to avoid libc macro redefinition warnings
 #include <Python.h>
-
 #include <cvc5/cvc5.h>
 
 // Created by Cython when providing 'public api' keywords


### PR DESCRIPTION
When using recent versions of glibc, compiling `py_plugin` triggered the following warning:
```
In file included from /home/daniel/.pyenv/versions/3.14.3/include/python3.14/Python.h:14,
from cvc5_python_base_api.h:8,
from py_plugin.h:19,
from py_plugin.cpp:12:
/home/daniel/.pyenv/versions/3.14.3/include/python3.14/pyconfig.h:2007:9: warning: ‘_POSIX_C_SOURCE’ redefined
2007 | #define _POSIX_C_SOURCE 200809L
| ^~~~~~~~~~~~~~~
In file included from /usr/include/x86_64-linux-gnu/c++/15/bits/os_defines.h:39,
from /usr/include/x86_64-linux-gnu/c++/15/bits/c++config.h:727,
from /usr/include/c++/15/cstdint:40,
from /home/daniel/Projects/cvc5/python-header-warning/include/cvc5/cvc5_kind.h:24,
from /home/daniel/Projects/cvc5/python-header-warning/include/cvc5/cvc5.h:18,
from py_plugin.h:16:
/usr/include/features.h:319:10: note: this is the location of the previous definition
319 | # define _POSIX_C_SOURCE 202405L
| ^~~~~~~~~~~~~~~
/home/daniel/.pyenv/versions/3.14.3/include/python3.14/pyconfig.h:2043:9: warning: ‘_XOPEN_SOURCE’ redefined
2043 | #define _XOPEN_SOURCE 700
| ^~~~~~~~~~~~~
```
Python’s [documentation](https://docs.python.org/3/c-api/intro.html?utm_source=chatgpt.com#include-files) recommends including `#include <Python.h>` before any system headers, because it may define or modify feature-test macros such as `_POSIX_C_SOURCE` and `_XOPEN_SOURCE`.