### PR TITLE
Symfpu 1.2.0 update

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -65,7 +65,7 @@ this library does not affect the license terms of the cvc5 code.
 
 The implementation of the floating point solver in cvc5 depends on symfpu
 (https://github.com/martin-cs/symfpu) written by Martin Brain.
-See https://raw.githubusercontent.com/martin-cs/symfpu/CVC4/LICENSE for
+See https://raw.githubusercontent.com/martin-cs/symfpu/main/LICENSE for
 copyright and licensing information.
 
 When building with GCC, cvc5 links against the libgcc and libstdc++ libraries,

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -180,7 +180,7 @@ versions; more recent versions should be compatible.
   + module `pyparsing <https://pypi.org/project/pyparsing/>`_
 - `GMP v6.3 (GNU Multi-Precision arithmetic library) <https://gmplib.org>`_
 - `CaDiCaL >= 2.1.0 (SAT solver) <https://github.com/arminbiere/cadical>`_
-- `SymFPU <https://github.com/martin-cs/symfpu/tree/CVC4>`_
+- `SymFPU <https://github.com/martin-cs/symfpu/tree/main>`_
 
 If ``--auto-download`` is given, the Python modules will be installed automatically in
 a virtual environment if they are missing. To install the modules globally and skip
@@ -205,7 +205,7 @@ automatically when ``--auto-download`` is given.
 SymFPU (Support for the Theory of Floating Point Numbers)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-`SymFPU <https://github.com/martin-cs/symfpu/tree/CVC4>`_ is an implementation
+`SymFPU <https://github.com/martin-cs/symfpu/tree/main>`_ is an implementation
 of SMT-LIB/IEEE-754 floating-point operations in terms of bit-vector operations.
 It is required for supporting the theory of floating-point numbers and can be
 downloaded and built automatically.

--- a/cmake/FindSymFPU.cmake
+++ b/cmake/FindSymFPU.cmake
@@ -29,13 +29,13 @@ if(NOT SymFPU_FOUND_SYSTEM)
   include(ExternalProject)
   include(deps-helper)
 
-  set(SymFPU_COMMIT "227a7246b8ce513b393cc2645d6d65d3490ea1de")
-  set(SymFPU_CHECKSUM "ff22e37dbc133120ada5760878974811737bec65b12a8883f92b1ed9e3f96e99")
+  set(SymFPU_COMMIT "40bdec00e99f8ea1b96c3dac0a05eed11c541639")
+  set(SymFPU_CHECKSUM "ba17877fbf0c851e113fddaab225152f1c0b2044429396b56b2f113832e36ce5")
 
   ExternalProject_Add(
     SymFPU-EP
     ${COMMON_EP_CONFIG}
-    URL https://github.com/cvc5/symfpu/archive/${SymFPU_COMMIT}.tar.gz
+    URL https://github.com/martin-cs/symfpu/archive/${SymFPU_COMMIT}.tar.gz
     URL_HASH SHA256=${SymFPU_CHECKSUM}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/src/base/configuration.cpp
+++ b/src/base/configuration.cpp
@@ -110,7 +110,7 @@ std::string Configuration::copyright()
   }
 
   ss << "  SymFPU - The Symbolic Floating Point Unit\n"
-     << "  See https://github.com/martin-cs/symfpu/tree/CVC4 for copyright "
+     << "  See https://github.com/martin-cs/symfpu/tree/main for copyright "
      << "information.\n\n";
 
   if (isBuiltWithGmp() || isBuiltWithPoly())

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -959,10 +959,12 @@ set(regress_0_tests
   regress0/fp/issue6164.smt2
   regress0/fp/issue7002.smt2
   regress0/fp/issue7569.smt2
+  regress0/fp/issue7858-1.smt2
   regress0/fp/issue9078-1.smt2
   regress0/fp/issue9078-2.smt2
   regress0/fp/issue9078-3.smt2
   regress0/fp/issue9505.smt2
+  regress0/fp/issue9697.smt2
   regress0/fp/issue9854.smt2
   regress0/fp/issue9858.smt2
   regress0/fp/issue9864.smt2

--- a/test/regress/cli/regress0/fp/issue7585-1.smt2
+++ b/test/regress/cli/regress0/fp/issue7585-1.smt2
@@ -1,0 +1,13 @@
+;; An issue with the rounder in SymFPU not handling some exotic formats
+;; Fixed in SymFPU 1.2.0
+
+(set-info :smt-lib-version 2.6)
+(set-logic ALL)
+(set-info :source |https://github.com/cvc5/cvc5/issues/7585|)
+(set-option :produce-models true)
+(set-option :check-models true)
+(set-info :status sat)
+
+(declare-fun v () Float64)
+(assert (= ((_ to_fp 9 53) RNE v) (fp (_ bv0 1) (_ bv0 9) (_ bv0 52))))
+(check-sat)

--- a/test/regress/cli/regress0/fp/issue7858-1.smt2
+++ b/test/regress/cli/regress0/fp/issue7858-1.smt2
@@ -1,6 +1,6 @@
 ;; An issue with the rounder in SymFPU not handling some exotic formats
 ;; Fixed in SymFPU 1.2.0
-
+; COMMAND-LINE: --fp-exp
 (set-info :smt-lib-version 2.6)
 (set-logic QF_FP)
 (set-info :source |https://github.com/cvc5/cvc5/issues/7858|)

--- a/test/regress/cli/regress0/fp/issue7858-1.smt2
+++ b/test/regress/cli/regress0/fp/issue7858-1.smt2
@@ -2,8 +2,8 @@
 ;; Fixed in SymFPU 1.2.0
 
 (set-info :smt-lib-version 2.6)
-(set-logic ALL)
-(set-info :source |https://github.com/cvc5/cvc5/issues/7585|)
+(set-logic QF_FP)
+(set-info :source |https://github.com/cvc5/cvc5/issues/7858|)
 (set-option :produce-models true)
 (set-option :check-models true)
 (set-info :status sat)

--- a/test/regress/cli/regress0/fp/issue9697.smt2
+++ b/test/regress/cli/regress0/fp/issue9697.smt2
@@ -1,0 +1,14 @@
+;; Originally a seg fault cause by a zero width vector, fixed by SymFPU 1.2.0
+
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BVFP)
+(set-info :source |https://github.com/cvc5/cvc5/issues/9697|)
+(set-option :produce-models true)
+(set-option :check-models true)
+(set-info :status sat)
+
+(declare-const c5 (_ BitVec 1))
+(declare-const c35 (_ FloatingPoint 8 24))
+(declare-const c72 RoundingMode)
+(assert (not (= c5 ((_ fp.to_sbv 1) c72 c35))))
+(check-sat)


### PR DESCRIPTION
This updates cvc5 to use SymFPU 1.2.0 in the fp (floating-point) solver.

I am in the process of working out which bugs this has fixed and if there are others that need work.  I will push new commits as and when I find issues that are fixed by this branch.

Fixes #12662.
Fixes #9697.