### PR TITLE
Fix comparisons to zero in Eunoia+Cpc arith mult sign, abs comparison

### DIFF
--- a/proofs/eo/cpc/rules/Arith.eo
+++ b/proofs/eo/cpc/rules/Arith.eo
@@ -325,13 +325,13 @@
   :signature (Bool Bool T) Bool
   (
   (($mk_arith_mult_sign_sgn sgn (and (not (= t z)) F) (* t t m))  ; ensures non-empty
-      (eo::requires (eo::to_z z) 0
+      (eo::requires ($sgn z) 0
         ($mk_arith_mult_sign_sgn sgn F ($strip_even_exponent t m))))
   (($mk_arith_mult_sign_sgn sgn (and (> t z) F) (* t m))
-      (eo::requires (eo::to_z z) 0
+      (eo::requires ($sgn z) 0
         ($mk_arith_mult_sign_sgn sgn F ($strip_even_exponent t m))))
   (($mk_arith_mult_sign_sgn sgn (and (< t z) F) (* t m))
-      (eo::requires (eo::to_z z) 0
+      (eo::requires ($sgn z) 0
         ($mk_arith_mult_sign_sgn (eo::not sgn) F ($strip_even_exponent t m))))
   ; base case
   (($mk_arith_mult_sign_sgn sgn true one)   (eo::requires (eo::to_q one) 1/1 sgn))
@@ -375,7 +375,7 @@
         (r (eo::list_concat * a (* t)) (eo::list_concat * b (* u)))))
     (($mk_arith_mult_abs_comparison_rec (and (and (= (abs t) (abs u))
                                                   (not (= t z))) B) (> a b))
-      (eo::requires (eo::to_z z) 0
+      (eo::requires ($sgn z) 0
         ($mk_arith_mult_abs_comparison_rec B
           (> (eo::list_concat * a (* t)) (eo::list_concat * b (* u))))))
     (($mk_arith_mult_abs_comparison_rec true (r a b))  (r (abs a) (abs b)))

--- a/proofs/eo/cpc/rules/Arith.eo
+++ b/proofs/eo/cpc/rules/Arith.eo
@@ -325,13 +325,13 @@
   :signature (Bool Bool T) Bool
   (
   (($mk_arith_mult_sign_sgn sgn (and (not (= t z)) F) (* t t m))  ; ensures non-empty
-      (eo::requires ($sgn z) 0
+      (eo::requires (eo::to_q z) 0/1
         ($mk_arith_mult_sign_sgn sgn F ($strip_even_exponent t m))))
   (($mk_arith_mult_sign_sgn sgn (and (> t z) F) (* t m))
-      (eo::requires ($sgn z) 0
+      (eo::requires (eo::to_q z) 0/1
         ($mk_arith_mult_sign_sgn sgn F ($strip_even_exponent t m))))
   (($mk_arith_mult_sign_sgn sgn (and (< t z) F) (* t m))
-      (eo::requires ($sgn z) 0
+      (eo::requires (eo::to_q z) 0/1
         ($mk_arith_mult_sign_sgn (eo::not sgn) F ($strip_even_exponent t m))))
   ; base case
   (($mk_arith_mult_sign_sgn sgn true one)   (eo::requires (eo::to_q one) 1/1 sgn))
@@ -375,7 +375,7 @@
         (r (eo::list_concat * a (* t)) (eo::list_concat * b (* u)))))
     (($mk_arith_mult_abs_comparison_rec (and (and (= (abs t) (abs u))
                                                   (not (= t z))) B) (> a b))
-      (eo::requires ($sgn z) 0
+      (eo::requires (eo::to_q z) 0/1
         ($mk_arith_mult_abs_comparison_rec B
           (> (eo::list_concat * a (* t)) (eo::list_concat * b (* u))))))
     (($mk_arith_mult_abs_comparison_rec true (r a b))  (r (abs a) (abs b)))

--- a/proofs/eo/cpc/rules/Arith.eo
+++ b/proofs/eo/cpc/rules/Arith.eo
@@ -335,8 +335,21 @@
         ($mk_arith_mult_sign_sgn (eo::not sgn) F ($strip_even_exponent t m))))
   ; base case
   (($mk_arith_mult_sign_sgn sgn true one)   (eo::requires (eo::to_q one) 1/1 sgn))
-  ; handles the singleton antecedant case
-  (($mk_arith_mult_sign_sgn sgn l m)      ($mk_arith_mult_sign_sgn sgn (and l) m))
+  )
+)
+
+; program: $to_cube
+; args:
+; - F Bool: The formula to convert to a cube.
+; return: >
+;   The result of converting F to a cube. In particular, if F is not
+;   an and-list, we return (and F), otherwise F is unchanged.
+(program $to_cube ((F1 Bool) (F2 Bool :list))
+  :signature (Bool) Bool
+  (
+  (($to_cube (and F1 F2)) (and F1 F2))
+  (($to_cube true)        true)
+  (($to_cube F1)          (and F1))
   )
 )
 
@@ -351,7 +364,7 @@
 (declare-rule arith_mult_sign ((T Type) (F Bool) (m T))
   :args (F m)
   :conclusion (=> F
-                (eo::define ((r (eo::ite ($mk_arith_mult_sign_sgn true F m) > <)))
+                (eo::define ((r (eo::ite ($mk_arith_mult_sign_sgn true ($to_cube F) m) > <)))
                   (r m ($arith_mk_zero (eo::typeof m)))))
 )
 


### PR DESCRIPTION
Was intended to check Int/Real comparison to zero. However, we were casting to Int instead of Real, allowing unsound coefficients due to rounding.

Also updates the mult sign rule to use simple recursion.

Found by logos verification.