### PR TITLE
Fix Cpc+Eunoia definition of ARITH_MULT_POS

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -2140,7 +2140,7 @@ enum ENUM(ProofRule)
    *
    *   \inferrule{- \mid m, l \diamond r}{(m > 0 \land l \diamond r) \rightarrow m \cdot l \diamond m \cdot r}
    *
-   * where :math:`\diamond \in \{=, \neq, <, \leq, >, \geq\}`.
+   * where :math:`\diamond \in \{=, <, \leq, >, \geq\}`.
    * \endverbatim
    */
   EVALUE(ARITH_MULT_POS),
@@ -2152,9 +2152,9 @@ enum ENUM(ProofRule)
    *
    *   \inferrule{- \mid m, l \diamond r}{(m < 0 \land l \diamond r) \rightarrow m \cdot l \diamond_{inv} m \cdot r}
    *
-   * where :math:`\diamond \in \{=, \neq, <, \leq, >, \geq\}` and
+   * where :math:`\diamond \in \{=, <, \leq, >, \geq\}` and
    * :math:`\diamond_{inv}` is the inverted relation symbol. The inverse of
-   * :math:`\neq` is itself.
+   * :math:`=` is itself.
    * \endverbatim
    */
   EVALUE(ARITH_MULT_NEG),

--- a/proofs/eo/cpc/rules/Arith.eo
+++ b/proofs/eo/cpc/rules/Arith.eo
@@ -83,7 +83,11 @@
 (program $mk_arith_mult_pos ((T Type) (r (-> T T Bool)) (a T) (b T) (m T))
   :signature (T Bool) Bool
   (
-    (($mk_arith_mult_pos m (r a b)) (r (* m a) (* m b)))
+  (($mk_arith_mult_pos m (= a b))   (= (* m a) (* m b)))
+  (($mk_arith_mult_pos m (< a b))   (< (* m a) (* m b)))
+  (($mk_arith_mult_pos m (<= a b))  (<= (* m a) (* m b)))
+  (($mk_arith_mult_pos m (>= a b))  (>= (* m a) (* m b)))
+  (($mk_arith_mult_pos m (> a b))   (> (* m a) (* m b)))
   )
 )
 
@@ -132,7 +136,7 @@
 (program $mk_arith_mult_neg ((T Type) (r (-> T T Bool)) (a T) (b T) (m T))
   :signature (T Bool) Bool
   (
-    (($mk_arith_mult_neg m (r a b)) ($arith_rel_inv r (* m a) (* m b)))
+  (($mk_arith_mult_neg m (r a b)) ($arith_rel_inv r (* m a) (* m b)))
   )
 )
 

--- a/src/theory/arith/proof_checker.cpp
+++ b/src/theory/arith/proof_checker.cpp
@@ -85,8 +85,8 @@ Node ArithProofRuleChecker::checkInternal(ProofRule id,
       Assert(args.size() == 2);
       Node mult = args[0];
       Kind rel = args[1].getKind();
-      Assert(rel == Kind::EQUAL || rel == Kind::LT
-             || rel == Kind::LEQ || rel == Kind::GT || rel == Kind::GEQ);
+      Assert(rel == Kind::EQUAL || rel == Kind::LT || rel == Kind::LEQ
+             || rel == Kind::GT || rel == Kind::GEQ);
       Node lhs = args[1][0];
       Node rhs = args[1][1];
       Node zero = nm->mkConstRealOrInt(mult.getType(), Rational(0));
@@ -103,8 +103,8 @@ Node ArithProofRuleChecker::checkInternal(ProofRule id,
       Assert(args.size() == 2);
       Node mult = args[0];
       Kind rel = args[1].getKind();
-      Assert(rel == Kind::EQUAL || rel == Kind::LT
-             || rel == Kind::LEQ || rel == Kind::GT || rel == Kind::GEQ);
+      Assert(rel == Kind::EQUAL || rel == Kind::LT || rel == Kind::LEQ
+             || rel == Kind::GT || rel == Kind::GEQ);
       Kind rel_inv = reverseRelationKind(rel);
       Node lhs = args[1][0];
       Node rhs = args[1][1];

--- a/src/theory/arith/proof_checker.cpp
+++ b/src/theory/arith/proof_checker.cpp
@@ -85,7 +85,7 @@ Node ArithProofRuleChecker::checkInternal(ProofRule id,
       Assert(args.size() == 2);
       Node mult = args[0];
       Kind rel = args[1].getKind();
-      Assert(rel == Kind::EQUAL || rel == Kind::DISTINCT || rel == Kind::LT
+      Assert(rel == Kind::EQUAL || rel == Kind::LT
              || rel == Kind::LEQ || rel == Kind::GT || rel == Kind::GEQ);
       Node lhs = args[1][0];
       Node rhs = args[1][1];
@@ -103,9 +103,9 @@ Node ArithProofRuleChecker::checkInternal(ProofRule id,
       Assert(args.size() == 2);
       Node mult = args[0];
       Kind rel = args[1].getKind();
-      Assert(rel == Kind::EQUAL || rel == Kind::DISTINCT || rel == Kind::LT
+      Assert(rel == Kind::EQUAL || rel == Kind::LT
              || rel == Kind::LEQ || rel == Kind::GT || rel == Kind::GEQ);
-      Kind rel_inv = (rel == Kind::DISTINCT ? rel : reverseRelationKind(rel));
+      Kind rel_inv = reverseRelationKind(rel);
       Node lhs = args[1][0];
       Node rhs = args[1][1];
       Node zero = nm->mkConstRealOrInt(mult.getType(), Rational(0));


### PR DESCRIPTION
We should only allow the expected relation types in this rule.

Found by logos verification.

Also removes distinct as a case from ARITH_MULT_POS/ARITH_MULT_NEG.