### PR TITLE
SyGuS AnyConst hashing fix

### DIFF
--- a/src/theory/quantifiers/sygus/sygus_pbe.cpp
+++ b/src/theory/quantifiers/sygus/sygus_pbe.cpp
@@ -54,6 +54,19 @@ bool SygusPbe::initialize(CVC5_UNUSED Node conj,
     return false;
   }
 
+  // PBE does not repair symbolic any-constant constructors in candidate
+  // solutions. Let CEGIS handle these grammars so SygusRepairConst can repair
+  // the concrete values for any-constant holes.
+  for (const Node& c : candidates)
+  {
+    TypeNode tn = c.getType();
+    d_tds->registerSygusType(tn);
+    if (d_tds->getTypeInfo(tn).hasSubtermSymbolicCons())
+    {
+      return false;
+    }
+  }
+
   // check if all candidates are valid examples
   ExampleInfer* ei = d_parent->getExampleInfer();
   d_is_pbe = true;

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -331,18 +331,25 @@ Node SygusRepairConst::getSkeleton(Node n,
     {
       if (isRepairable(cur))
       {
-        // replace the argument of the any-constant constructor with a skolem
+        // If the root node is repairable, there is no parent child loop to
+        // replace it. Create a fresh purify variable here.
         Node sk_var = d_tds->getFreeVarInc(cur[0].getType(), free_var_count);
         sk_var = skm->mkPurifySkolem(sk_var);
         sk_vars.push_back(sk_var);
         visited[cur] = nm->mkNode(cur.getKind(), cur.getOperator(), sk_var);
         continue;
       }
+      // Repairable non-root nodes are handled in the parent child loop below
+      // so each occurrence gets its own fresh purify variable, even when the
+      // any-constant constructor applications are structurally equal.
       visited[cur] = Node::null();
       visit.push_back(cur);
       for (const Node& cn : cur)
       {
-        visit.push_back(cn);
+        if (!isRepairable(cn))
+        {
+          visit.push_back(cn);
+        }
       }
     }
     else if (it->second.isNull())
@@ -356,10 +363,21 @@ Node SygusRepairConst::getSkeleton(Node n,
       }
       for (const Node& cn : cur)
       {
-        it = visited.find(cn);
-        Assert(it != visited.end());
-        Assert(!it->second.isNull());
-        Node child = it->second;
+        Node child;
+        if (isRepairable(cn))
+        {
+          Node sk_var = d_tds->getFreeVarInc(cn[0].getType(), free_var_count);
+          sk_var = skm->mkPurifySkolem(sk_var);
+          sk_vars.push_back(sk_var);
+          child = nm->mkNode(cn.getKind(), cn.getOperator(), sk_var);
+        }
+        else
+        {
+          it = visited.find(cn);
+          Assert(it != visited.end());
+          Assert(!it->second.isNull());
+          child = it->second;
+        }
         childChanged = childChanged || cn != child;
         children.push_back(child);
       }


### PR DESCRIPTION
This fix targets 2 issues:
https://github.com/cvc5/cvc5/issues/12559
https://github.com/cvc5/cvc5/issues/12560

The fix includes:
Fix SyGuS any-constant repair for repeated holes
Disable the PBE module for grammars that contain symbolic any-constant
constructors. PBE does not repair these symbolic constants in candidate
solutions, so such conjectures should be handled by CEGIS where
SygusRepairConst can assign concrete values to the holes.

Also fix SygusRepairConst::getSkeleton to create a fresh repair variable for
each occurrence of an any-constant constructor, rather than reusing one value
for structurally equal/hash-consed nodes. This avoids incorrectly merging
distinct Constant holes in the repair query. Preserve the root-repairable case
by creating a repair variable when the whole candidate value is itself an
any-constant constructor.

This fixes SyGuS benchmarks with Int, BV, FP, and hierarchical any-constant
uses, including cases where multiple Constant grammar terms must be repaired
independently.