### PR TITLE
[TPTP models 1/3] Add LANG_SMTLIB_V2_6_TPTP output language and tptp-models options

### DIFF
--- a/src/options/language.cpp
+++ b/src/options/language.cpp
@@ -22,6 +22,7 @@ std::ostream& operator<<(std::ostream& out, Language lang)
   {
     case Language::LANG_AUTO: out << "LANG_AUTO"; break;
     case Language::LANG_SMTLIB_V2_6: out << "LANG_SMTLIB_V2_6"; break;
+    case Language::LANG_SMTLIB_V2_6_TPTP: out << "LANG_SMTLIB_V2_6_TPTP"; break;
     case Language::LANG_SYGUS_V2: out << "LANG_SYGUS_V2"; break;
     default: out << "undefined_language";
   }
@@ -37,6 +38,11 @@ Language toLanguage(const std::string& language)
       || language == "LANG_SMTLIB_V2_6" || language == "LANG_SMTLIB_V2")
   {
     return Language::LANG_SMTLIB_V2_6;
+  }
+  else if (language == "smt2-tptp" || language == "smtlib2.6-tptp"
+           || language == "tptp-smt2" || language == "LANG_SMTLIB_V2_6_TPTP")
+  {
+    return Language::LANG_SMTLIB_V2_6_TPTP;
   }
   else if (language == "sygus" || language == "LANG_SYGUS"
            || language == "sygus2" || language == "LANG_SYGUS_V2")

--- a/src/options/language.cpp
+++ b/src/options/language.cpp
@@ -39,8 +39,7 @@ Language toLanguage(const std::string& language)
   {
     return Language::LANG_SMTLIB_V2_6;
   }
-  else if (language == "smt2-tptp" || language == "smtlib2.6-tptp"
-           || language == "tptp-smt2" || language == "LANG_SMTLIB_V2_6_TPTP")
+  else if (language == "smt2-tptp")
   {
     return Language::LANG_SMTLIB_V2_6_TPTP;
   }

--- a/src/options/language.h
+++ b/src/options/language.h
@@ -31,6 +31,8 @@ enum class Language
 
   /** The SMTLIB v2.6 language, with support for the strings standard */
   LANG_SMTLIB_V2_6 = 0,
+  /** A custom SMTLIB v2.6-derived output format for TPTP output */
+  LANG_SMTLIB_V2_6_TPTP,
   /** The SyGuS language version 2.0 */
   LANG_SYGUS_V2,
 
@@ -48,7 +50,8 @@ namespace language {
 /** Is the language a variant of the smtlib version 2 language? */
 inline bool isLangSmt2(Language lang)
 {
-  return lang == Language::LANG_SMTLIB_V2_6;
+  return lang == Language::LANG_SMTLIB_V2_6
+         || lang == Language::LANG_SMTLIB_V2_6_TPTP;
 }
 
 /** Is the language a variant of the SyGuS input language? */

--- a/src/options/main_options.toml
+++ b/src/options/main_options.toml
@@ -130,6 +130,22 @@ name   = "Driver"
   help       = "output proofs after every UNSAT/VALID response"
 
 [[option]]
+  name       = "tptpModels"
+  category   = "regular"
+  long       = "tptp-models"
+  type       = "bool"
+  default    = "false"
+  help       = "print finite models in TPTP format"
+
+[[option]]
+  name       = "tptpModelVerification"
+  category   = "regular"
+  long       = "tptp-model-verification"
+  type       = "bool"
+  default    = "false"
+  help       = "when printing TPTP models for verification, preserve the input TPTP dialect when it is provided explicitly"
+
+[[option]]
   name       = "dumpInstantiations"
   category   = "regular"
   long       = "dump-instantiations"

--- a/src/options/main_options.toml
+++ b/src/options/main_options.toml
@@ -131,7 +131,7 @@ name   = "Driver"
 
 [[option]]
   name       = "tptpModels"
-  category   = "regular"
+  category   = "expert"
   long       = "tptp-models"
   type       = "bool"
   default    = "false"

--- a/src/options/main_options.toml
+++ b/src/options/main_options.toml
@@ -139,7 +139,7 @@ name   = "Driver"
 
 [[option]]
   name       = "tptpModelVerification"
-  category   = "regular"
+  category   = "expert"
   long       = "tptp-model-verification"
   type       = "bool"
   default    = "false"

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -127,6 +127,7 @@ Languages currently supported as arguments to the --output-lang option:
   auto                           match output language to input language
   smt | smtlib | smt2 |
   smt2.6 | smtlib2.6             SMT-LIB format 2.6 with support for the strings standard
+  smt2-tptp | smtlib2.6-tptp     custom SMT-LIB v2.6-derived output format for tptpmodels
   ast                            internal format (simple syntax trees)
 )FOOBAR" << std::endl;
     throw OptionException("help is not a valid language");
@@ -148,9 +149,9 @@ Languages currently supported as arguments to the --output-lang option:
 void OptionsHandler::setInputLanguage(const std::string& flag,
                                       const Language lang) const
 {
-  if (lang == Language::LANG_AST)
+  if (lang == Language::LANG_AST || lang == Language::LANG_SMTLIB_V2_6_TPTP)
   {
-    throw OptionException("Language LANG_AST is not allowed for " + flag);
+    throw OptionException("This language is not allowed for " + flag);
   }
   if (!d_options->printer.outputLanguageWasSetByUser)
   {

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -127,7 +127,7 @@ Languages currently supported as arguments to the --output-lang option:
   auto                           match output language to input language
   smt | smtlib | smt2 |
   smt2.6 | smtlib2.6             SMT-LIB format 2.6 with support for the strings standard
-  smt2-tptp | smtlib2.6-tptp     custom SMT-LIB v2.6-derived output format for tptpmodels
+  smt2-tptp                      custom SMT-LIB v2.6-derived output format for tptpmodels
   ast                            internal format (simple syntax trees)
 )FOOBAR" << std::endl;
     throw OptionException("help is not a valid language");


### PR DESCRIPTION
This is the first of three PRs adding support for printing finite models in TPTP format (see #12518 for the full context).

This PR adds the foundational infrastructure:

A new LANG_SMTLIB_V2_6_TPTP variant to the Language enum, with isLangSmt2() and toLanguage() updated accordingly
Two new CLI options: --tptp-models (print finite models in TPTP format) and --tptp-model-verification (preserve the input TPTP dialect in the output)
LANG_SMTLIB_V2_6_TPTP is rejected as an input language
No functional behaviour is introduced here — this just lays the groundwork for the printer in PR 2/3.