### PR TITLE
Fix soundness bug: disable sort inference when --finite-model-find is active

### DIFF
--- a/src/preprocessing/passes/sort_infer.cpp
+++ b/src/preprocessing/passes/sort_infer.cpp
@@ -12,6 +12,7 @@
 
 #include "preprocessing/passes/sort_infer.h"
 
+#include "options/quantifiers_options.h"
 #include "options/smt_options.h"
 #include "options/uf_options.h"
 #include "preprocessing/assertion_pipeline.h"
@@ -37,7 +38,11 @@ PreprocessingPassResult SortInferencePass::applyInternal(
   theory::SortInference* si =
       d_preprocContext->getTheoryEngine()->getSortInference();
 
-  if (options().smt.sortInference)
+  // Sort inference is unsound with finite model finding: FMF only bounds
+  // non-monotonic subsorts, leaving monotonic subsorts unbounded. This breaks
+  // the cardinality constraints imposed by the injections between subsorts,
+  // allowing FMF to find spurious models.
+  if (options().smt.sortInference && !options().quantifiers.finiteModelFind)
   {
     si->initialize(assertionsToPreprocess->ref());
     std::map<Node, Node> model_replace_f;

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2872,6 +2872,7 @@ set(regress_1_tests
   regress1/fmf/sc-crash-052316.smt2
   regress1/fmf/sort-inf-int-real.smt2
   regress1/fmf/sort-inf-int.smt2
+  regress1/fmf/sort-infer-fmf-pigeon.smt2
   regress1/fmf/with-ind-104-core.smt2
   regress1/gensys_brn001.smt2
   regress1/get-learned-literals.smt2

--- a/test/regress/cli/regress1/fmf/sort-infer-fmf-pigeon.smt2
+++ b/test/regress/cli/regress1/fmf/sort-infer-fmf-pigeon.smt2
@@ -1,0 +1,22 @@
+; Sort inference + FMF soundness regression test.
+; Sort inference splits U into subsorts and marks some monotonic. FMF only bounds
+; non-monotonic subsorts, leaving monotonic subsorts unbounded. This breaks the
+; cardinality constraints imposed by the injections sort inference adds between
+; subsorts, allowing FMF to find spurious models on UNSAT problems.
+; The fix: sort inference is disabled when --finite-model-find is active.
+; COMMAND-LINE: --finite-model-find --sort-inference
+; EXPECT: unsat
+(set-logic UF)
+(set-info :status unsat)
+(declare-sort U 0)
+; Bound U to 2 elements
+(declare-const e1 U)
+(declare-const e2 U)
+(assert (not (= e1 e2)))
+(assert (forall ((x U)) (or (= x e1) (= x e2))))
+; Pigeonhole: injective f: U -> U with constant c not in range of f
+(declare-fun f (U) U)
+(declare-const c U)
+(assert (forall ((X U)) (not (= (f X) c))))
+(assert (forall ((X U) (Y U)) (=> (= (f X) (f Y)) (= X Y))))
+(check-sat)


### PR DESCRIPTION
## Summary

- `--sort-inference` splits an uninterpreted sort `U` into subsorts based on symbol interactions and adds injection axioms between them to preserve equisatisfiability.
- `--finite-model-find` (FMF) only bounds **non-monotonic** subsorts to finite cardinalities; **monotonic** subsorts remain unconstrained.
- Together, the combination is unsound: FMF can assign arbitrarily large cardinalities to monotonic subsorts, violating the injection-enforced cardinality constraints that sort inference relies on. This allows FMF to return `sat` on UNSAT problems (e.g., the `GRA121+1` TPTP benchmark based on Ramsey theory `R(3,4)=9`).

## Fix

In `SortInferencePass::applyInternal` ([sort_infer.cpp](src/preprocessing/passes/sort_infer.cpp)), skip sort inference when `--finite-model-find` is active:

```cpp
if (options().smt.sortInference && !options().quantifiers.finiteModelFind)
