### PR TITLE
Archive SMT-COMP 2025 run scripts

### DIFF
--- a/contrib/competitions/smt-comp/run-script-smtcomp2025
+++ b/contrib/competitions/smt-comp/run-script-smtcomp2025
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+cvc5=$(dirname "$(readlink -f "$0")")/cvc5
+bench="$1"
+
+# Output other than "sat"/"unsat" is either written to stderr or to "err.log"
+# in the directory specified by $2 if it has been set (e.g. when running on
+# StarExec).
+out_file=/dev/stderr
+
+if [ -n "$STAREXEC_WALLCLOCK_LIMIT" ]; then
+  # If we are running on StarExec, don't print to `/dev/stderr/` even when $2
+  # is not provided.
+  out_file="/dev/null"
+fi
+
+if [ -n "$2" ]; then
+  out_file="$2/err.log"
+fi
+
+result="$({ $cvc5 -L smt2.6 --no-incremental --no-type-checking --no-interactive --fp-exp --use-portfolio $bench; } 2>&1)"
+case "$result" in
+  sat|unsat) echo "$result"; exit 0;;
+  *)         echo "$result" &> "$out_file";;
+esac
+

--- a/contrib/competitions/smt-comp/run-script-smtcomp2025-incremental
+++ b/contrib/competitions/smt-comp/run-script-smtcomp2025-incremental
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cvc5=$(dirname "$(readlink -f "$0")")/cvc5
+
+# we run in this way for line-buffered input, otherwise memory's a
+# concern (plus it mimics what we'll end up getting from an
+# application-track trace runner?)
+$cvc5 --incremental --use-portfolio -L smt2.6 --print-success --no-type-checking --no-interactive --fp-exp <&0-

--- a/contrib/competitions/smt-comp/run-script-smtcomp2025-model-validation
+++ b/contrib/competitions/smt-comp/run-script-smtcomp2025-model-validation
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+cvc5=$(dirname "$(readlink -f "$0")")/cvc5
+bench="$1"
+
+# Output other than "sat"/"unsat" is either written to stderr or to "err.log"
+# in the directory specified by $2 if it has been set (e.g. when running on
+# StarExec).
+out_file=/dev/stderr
+
+if [ -n "$STAREXEC_WALLCLOCK_LIMIT" ]; then
+  # If we are running on StarExec, don't print to `/dev/stderr/` even when $2
+  # is not provided.
+  out_file="/dev/null"
+fi
+
+if [ -n "$2" ]; then
+  out_file="$2/err.log"
+fi
+
+$cvc5 -L smt2.6 --no-incremental --no-type-checking --no-interactive --fp-exp --use-portfolio $bench
+

--- a/contrib/competitions/smt-comp/run-script-smtcomp2025-unsat-cores
+++ b/contrib/competitions/smt-comp/run-script-smtcomp2025-unsat-cores
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+cvc5=$(dirname "$(readlink -f "$0")")/cvc5
+bench="$1"
+
+# Output other than "sat"/"unsat" is either written to stderr or to "err.log"
+# in the directory specified by $2 if it has been set (e.g. when running on
+# StarExec).
+out_file=/dev/stderr
+
+if [ -n "$STAREXEC_WALLCLOCK_LIMIT" ]; then
+  # If we are running on StarExec, don't print to `/dev/stderr/` even when $2
+  # is not provided.
+  out_file="/dev/null"
+fi
+
+if [ -n "$2" ]; then
+  out_file="$2/err.log"
+fi
+
+$cvc5 -L smt2.6 --no-incremental --no-type-checking --no-interactive --fp-exp --use-portfolio $bench
+


### PR DESCRIPTION
This commit copies the `run-script-smtcomp-current*` scripts to `run-script-smtcomp2025*` to archive them.