### PR TITLE
Fix monotonic sorts policy in sort inference

### DIFF
--- a/proofs/eo/cpc/expert/CpcExpert.eo
+++ b/proofs/eo/cpc/expert/CpcExpert.eo
@@ -33,6 +33,8 @@
 
 ; Used in the --ho-elim preprocessing pass
 (declare-const @ho-elim-sort (-> Type Type))
+; Used in the --sort-inference preprocessing pass
+(declare-const @sort-infer-subsort (-> Int Type))
 (declare-parameterized-const @fmf-fun-sort ((T Type :implicit)) (-> T Type))
 
 ; Datatypes shared selector

--- a/src/expr/node_manager_attributes.h
+++ b/src/expr/node_manager_attributes.h
@@ -28,9 +28,6 @@ struct VarNameTag
 struct SortArityTag
 {
 };
-struct RawSymbolTypeTag
-{
-};
 struct TypeTag
 {
 };
@@ -56,7 +53,6 @@ struct OracleIndexTag
 
 typedef Attribute<attr::VarNameTag, std::string> VarNameAttr;
 typedef Attribute<attr::SortArityTag, uint64_t> SortArityAttr;
-typedef Attribute<attr::RawSymbolTypeTag, std::string> RawSymbolTypeAttr;
 typedef expr::Attribute<expr::attr::TypeTag, TypeNode> TypeAttr;
 typedef expr::Attribute<expr::attr::TypeCheckedTag, bool> TypeCheckedAttr;
 

--- a/src/expr/node_manager_attributes.h
+++ b/src/expr/node_manager_attributes.h
@@ -28,6 +28,9 @@ struct VarNameTag
 struct SortArityTag
 {
 };
+struct RawSymbolTypeTag
+{
+};
 struct TypeTag
 {
 };
@@ -53,6 +56,7 @@ struct OracleIndexTag
 
 typedef Attribute<attr::VarNameTag, std::string> VarNameAttr;
 typedef Attribute<attr::SortArityTag, uint64_t> SortArityAttr;
+typedef Attribute<attr::RawSymbolTypeTag, std::string> RawSymbolTypeAttr;
 typedef expr::Attribute<expr::attr::TypeTag, TypeNode> TypeAttr;
 typedef expr::Attribute<expr::attr::TypeCheckedTag, bool> TypeCheckedAttr;
 

--- a/src/expr/node_manager_template.cpp
+++ b/src/expr/node_manager_template.cpp
@@ -251,6 +251,7 @@ NodeManager::~NodeManager()
   d_dtypes.clear();
   d_oracles.clear();
   d_nfreshSorts.clear();
+  d_rawSymbolTypes.clear();
   d_nfreshVars.clear();
 
   Assert(!d_attrManager->inGarbageCollection());
@@ -1017,6 +1018,20 @@ TypeNode NodeManager::mkSort()
 TypeNode NodeManager::mkSort(const std::string& name, bool fresh)
 {
   return mkSortConstructor(name, 0, fresh);
+}
+
+TypeNode NodeManager::mkRawSymbolType(const std::string& symbol)
+{
+  std::map<std::string, TypeNode>::iterator it = d_rawSymbolTypes.find(symbol);
+  if (it != d_rawSymbolTypes.end())
+  {
+    return it->second;
+  }
+  NodeBuilder nb(this, Kind::SORT_TYPE);
+  TypeNode type = nb.constructTypeNode();
+  setAttribute(type, expr::RawSymbolTypeAttr(), symbol);
+  d_rawSymbolTypes[symbol] = type;
+  return type;
 }
 
 TypeNode NodeManager::mkSort(TypeNode constructor,

--- a/src/expr/node_manager_template.cpp
+++ b/src/expr/node_manager_template.cpp
@@ -251,7 +251,6 @@ NodeManager::~NodeManager()
   d_dtypes.clear();
   d_oracles.clear();
   d_nfreshSorts.clear();
-  d_rawSymbolTypes.clear();
   d_nfreshVars.clear();
 
   Assert(!d_attrManager->inGarbageCollection());
@@ -1022,15 +1021,9 @@ TypeNode NodeManager::mkSort(const std::string& name, bool fresh)
 
 TypeNode NodeManager::mkRawSymbolType(const std::string& symbol)
 {
-  std::map<std::string, TypeNode>::iterator it = d_rawSymbolTypes.find(symbol);
-  if (it != d_rawSymbolTypes.end())
-  {
-    return it->second;
-  }
-  NodeBuilder nb(this, Kind::SORT_TYPE);
+  NodeBuilder nb(this, Kind::RAW_SYMBOL_TYPE);
   TypeNode type = nb.constructTypeNode();
-  setAttribute(type, expr::RawSymbolTypeAttr(), symbol);
-  d_rawSymbolTypes[symbol] = type;
+  setAttribute(type, expr::VarNameAttr(), symbol);
   return type;
 }
 

--- a/src/expr/node_manager_template.h
+++ b/src/expr/node_manager_template.h
@@ -1094,9 +1094,6 @@ class NodeManager
   /** A mapping for sorts allocated by mkSortConstructor where fresh is false */
   std::map<std::pair<std::string, size_t>, TypeNode> d_nfreshSorts;
 
-  /** A mapping for raw symbol types */
-  std::map<std::string, TypeNode> d_rawSymbolTypes;
-
   /** A mapping for variables constructed when fresh is false */
   std::map<std::pair<std::string, TypeNode>, Node> d_nfreshVars;
 

--- a/src/expr/node_manager_template.h
+++ b/src/expr/node_manager_template.h
@@ -768,6 +768,9 @@ class NodeManager
   /** Make a new sort with the given name of arity 0. */
   TypeNode mkSort(const std::string& name, bool fresh = true);
 
+  /** Make a type that prints as the given raw symbol. */
+  TypeNode mkRawSymbolType(const std::string& symbol);
+
   /** Make a new sort by parameterizing the given sort constructor. */
   TypeNode mkSort(TypeNode constructor, const std::vector<TypeNode>& children);
 
@@ -1090,6 +1093,9 @@ class NodeManager
 
   /** A mapping for sorts allocated by mkSortConstructor where fresh is false */
   std::map<std::pair<std::string, size_t>, TypeNode> d_nfreshSorts;
+
+  /** A mapping for raw symbol types */
+  std::map<std::string, TypeNode> d_rawSymbolTypes;
 
   /** A mapping for variables constructed when fresh is false */
   std::map<std::pair<std::string, TypeNode>, Node> d_nfreshVars;

--- a/src/expr/type_node.cpp
+++ b/src/expr/type_node.cpp
@@ -636,14 +636,13 @@ bool TypeNode::isUninterpretedSortConstructor() const
 
 bool TypeNode::isRawSymbolType() const
 {
-  return getKind() == Kind::SORT_TYPE && !hasAttribute(expr::SortArityAttr())
-         && hasAttribute(expr::RawSymbolTypeAttr());
+  return getKind() == Kind::RAW_SYMBOL_TYPE;
 }
 
 std::string TypeNode::getRawSymbol() const
 {
   Assert(isRawSymbolType());
-  return getAttribute(expr::RawSymbolTypeAttr());
+  return getName();
 }
 
 bool TypeNode::isFloatingPoint() const

--- a/src/expr/type_node.cpp
+++ b/src/expr/type_node.cpp
@@ -634,6 +634,18 @@ bool TypeNode::isUninterpretedSortConstructor() const
   return getKind() == Kind::SORT_TYPE && hasAttribute(expr::SortArityAttr());
 }
 
+bool TypeNode::isRawSymbolType() const
+{
+  return getKind() == Kind::SORT_TYPE && !hasAttribute(expr::SortArityAttr())
+         && hasAttribute(expr::RawSymbolTypeAttr());
+}
+
+std::string TypeNode::getRawSymbol() const
+{
+  Assert(isRawSymbolType());
+  return getAttribute(expr::RawSymbolTypeAttr());
+}
+
 bool TypeNode::isFloatingPoint() const
 {
   return getKind() == Kind::FLOATINGPOINT_TYPE;

--- a/src/expr/type_node.h
+++ b/src/expr/type_node.h
@@ -734,6 +734,12 @@ class CVC5_EXPORT TypeNode
   /** Is this a sort constructor kind? */
   bool isUninterpretedSortConstructor() const;
 
+  /** Is this an atomic type that prints as a raw symbol? */
+  bool isRawSymbolType() const;
+
+  /** Get the symbol printed by this raw symbol type. */
+  std::string getRawSymbol() const;
+
   /** Get sort constructor arity. */
   uint64_t getUninterpretedSortConstructorArity() const;
 

--- a/src/options/uf_options.toml
+++ b/src/options/uf_options.toml
@@ -45,14 +45,6 @@ name   = "Uninterpreted Functions Theory"
   help       = "use fair strategy for finite model finding multiple sorts"
 
 [[option]]
-  name       = "ufssFairnessMonotone"
-  category   = "expert"
-  long       = "uf-ss-fair-monotone"
-  type       = "bool"
-  default    = "false"
-  help       = "group monotone sorts when enforcing fairness for finite model finding"
-
-[[option]]
   name       = "ufHoExt"
   category   = "expert"
   long       = "uf-ho-ext"

--- a/src/preprocessing/passes/sort_infer.cpp
+++ b/src/preprocessing/passes/sort_infer.cpp
@@ -13,7 +13,6 @@
 #include "preprocessing/passes/sort_infer.h"
 
 #include "options/smt_options.h"
-#include "options/uf_options.h"
 #include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "theory/rewriter.h"
@@ -71,13 +70,6 @@ PreprocessingPassResult SortInferencePass::applyInternal(
     // could indicate correspondence between the functions
     // for (f1, f2) in model_replace_f, f1's model should be based on f2.
     // See cvc4-wishues/issues/75.
-
-    // only need to compute monotonicity on the resulting formula if we are
-    // using this option
-    if (options().uf.ufssFairnessMonotone)
-    {
-      si->computeMonotonicity(assertionsToPreprocess->ref());
-    }
   }
   return PreprocessingPassResult::NO_CONFLICT;
 }

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -28,6 +28,7 @@
 #include "expr/emptybag.h"
 #include "expr/emptyset.h"
 #include "expr/function_array_const.h"
+#include "expr/node_manager_attributes.h"
 #include "expr/node_visitor.h"
 #include "expr/sequence.h"
 #include "expr/skolem_manager.h"
@@ -631,8 +632,12 @@ bool Smt2Printer::toStreamBase(std::ostream& out,
     }
     if (!printed)
     {
+      if (k == Kind::SORT_TYPE && n.hasAttribute(expr::RawSymbolTypeAttr()))
+      {
+        out << n.getAttribute(expr::RawSymbolTypeAttr());
+      }
       // variable
-      if (n.hasName())
+      else if (n.hasName())
       {
         std::string s = n.getName();
         if (k == Kind::RAW_SYMBOL)

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -28,7 +28,6 @@
 #include "expr/emptybag.h"
 #include "expr/emptyset.h"
 #include "expr/function_array_const.h"
-#include "expr/node_manager_attributes.h"
 #include "expr/node_visitor.h"
 #include "expr/sequence.h"
 #include "expr/skolem_manager.h"
@@ -632,15 +631,11 @@ bool Smt2Printer::toStreamBase(std::ostream& out,
     }
     if (!printed)
     {
-      if (k == Kind::SORT_TYPE && n.hasAttribute(expr::RawSymbolTypeAttr()))
-      {
-        out << n.getAttribute(expr::RawSymbolTypeAttr());
-      }
       // variable
-      else if (n.hasName())
+      if (n.hasName())
       {
         std::string s = n.getName();
-        if (k == Kind::RAW_SYMBOL)
+        if (k == Kind::RAW_SYMBOL || k == Kind::RAW_SYMBOL_TYPE)
         {
           // raw symbols are never quoted
           out << s;

--- a/src/smt/print_benchmark.cpp
+++ b/src/smt/print_benchmark.cpp
@@ -72,6 +72,12 @@ void PrintBenchmark::printDeclarationsFrom(std::ostream& outDecl,
     std::vector<TypeNode> datatypeBlock;
     for (const TypeNode& ctn : connectedTypes)
     {
+      if (ctn.isRawSymbolType())
+      {
+        // Raw symbol types are used as atoms in larger type expressions.
+        // They are not declared as ordinary sort symbols.
+        continue;
+      }
       if ((ctn.isUninterpretedSort() && ctn.getNumChildren() == 0)
           || ctn.isUninterpretedSortConstructor())
       {

--- a/src/smt/process_assertions.cpp
+++ b/src/smt/process_assertions.cpp
@@ -23,7 +23,6 @@
 #include "options/sep_options.h"
 #include "options/smt_options.h"
 #include "options/strings_options.h"
-#include "options/uf_options.h"
 #include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "preprocessing/preprocessing_pass_registry.h"
@@ -261,7 +260,7 @@ bool ProcessAssertions::apply(AssertionPipeline& ap)
     // were already solved for in incremental mode
     applyPass("apply-substs", ap);
   }
-  if (options().smt.sortInference || options().uf.ufssFairnessMonotone)
+  if (options().smt.sortInference)
   {
     applyPass("sort-inference", ap);
   }

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -1275,7 +1275,6 @@ bool SetDefaults::incompatibleWithIncremental(const LogicInfo& logic,
 
   // disable modes not supported by incremental
   SET_AND_NOTIFY(smt, sortInference, false, "incremental solving");
-  SET_AND_NOTIFY(uf, ufssFairnessMonotone, false, "incremental solving");
   SET_AND_NOTIFY(quantifiers, globalNegate, false, "incremental solving");
   SET_AND_NOTIFY(quantifiers, cegqiNestedQE, false, "incremental solving");
   SET_AND_NOTIFY(arith, arithMLTrick, false, "incremental solving");

--- a/src/theory/builtin/kinds.toml
+++ b/src/theory/builtin/kinds.toml
@@ -417,6 +417,11 @@ name    = "RAW_SYMBOL"
 comment = "a variable that is not quoted in the smt2 printer (internal only)"
 
 [[kinds]]
+type    = "variable"
+name    = "RAW_SYMBOL_TYPE"
+comment = "a type that is not quoted in the smt2 printer (internal only)"
+
+[[kinds]]
 type      = "constant"
 name      = "ABSTRACT_TYPE"
 class_key = "class"

--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -192,27 +192,19 @@ void SortInference::initialize(const std::vector<Node>& assertions)
     Trace("sort-inference") << std::endl;
   }
 
-  // Determine monotonicity of the original sorts. This is used below to
-  // conservatively classify all inferred subsorts of a non-monotonic sort.
+  Trace("sort-inference-proc")
+      << "Calculating monotonicty for original sorts..." << std::endl;
   std::map<Node, std::map<int, bool> > visitedmt;
   for (const Node& a : assertions)
   {
+    Trace("sort-inference-debug")
+        << "Process type monotonicity for " << a << std::endl;
     std::map<Node, Node> var_bound;
     processMonotonic(a, true, true, var_bound, visitedmt, true);
   }
-
-  // determine monotonicity of sorts
-  Trace("sort-inference-proc")
-      << "Calculating monotonicty for subsorts..." << std::endl;
-  std::map<Node, std::map<int, bool> > visitedm;
-  for (const Node& a : assertions)
-  {
-    Trace("sort-inference-debug")
-        << "Process monotonicity for " << a << std::endl;
-    std::map<Node, Node> var_bound;
-    processMonotonic(a, true, true, var_bound, visitedm);
-  }
   Trace("sort-inference-proc") << "...done" << std::endl;
+
+  // Classify inferred subsorts based on monotonicity of their original sorts.
   for (const std::pair<const TypeNode, std::vector<int> >& tss :
        d_type_sub_sorts)
   {

--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -339,22 +339,6 @@ void SortInference::getNewAssertions(std::vector<Node>& new_asserts)
   Trace("sort-inference-debug") << "Finished sort inference" << std::endl;
 }
 
-void SortInference::computeMonotonicity(const std::vector<Node>& assertions)
-{
-  d_non_monotonic_sorts_orig.clear();
-  std::map<Node, std::map<int, bool> > visitedmt;
-  Trace("sort-inference-proc")
-      << "Calculating monotonicty for types..." << std::endl;
-  for (const Node& a : assertions)
-  {
-    Trace("sort-inference-debug")
-        << "Process type monotonicity for " << a << std::endl;
-    std::map<Node, Node> var_bound;
-    processMonotonic(a, true, true, var_bound, visitedmt, true);
-  }
-  Trace("sort-inference-proc") << "...done" << std::endl;
-}
-
 void SortInference::setEqual(int t1, int t2)
 {
   if (t1 != t2)

--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -1071,13 +1071,6 @@ bool SortInference::isWellSorted(Node n)
   }
 }
 
-bool SortInference::isMonotonic(TypeNode tn) const
-{
-  Assert(tn.isUninterpretedSort());
-  return d_non_monotonic_sorts_orig.find(tn)
-         == d_non_monotonic_sorts_orig.end();
-}
-
 bool SortInference::isHandledApplyUf(Kind k) const
 {
   return k == Kind::APPLY_UF && !logicInfo().isHigherOrder();

--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -37,6 +37,12 @@ using namespace std;
 namespace cvc5::internal {
 namespace theory {
 
+SortInference::SortInference(Env& env) : EnvObj(env), d_sortCount(1)
+{
+  d_sortInferSubsortSc =
+      nodeManager()->mkSortConstructor("@sort-infer-subsort", 1);
+}
+
 void SortInference::UnionFind::print(CVC5_UNUSED const char* c)
 {
   for (std::map<int, int>::iterator it = d_eqc.begin(); it != d_eqc.end(); ++it)
@@ -705,8 +711,9 @@ TypeNode SortInference::getOrCreateTypeForId(int t, TypeNode pref)
     {
       // must create new type
       std::stringstream ss;
-      ss << "it_" << t << "_" << pref;
-      retType = nodeManager()->mkSort(ss.str());
+      ss << rt;
+      TypeNode indexType = nodeManager()->mkRawSymbolType(ss.str());
+      retType = nodeManager()->mkSort(d_sortInferSubsortSc, {indexType});
     }
     Trace("sort-inference")
         << "-> Make type " << retType << " to correspond to ";

--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -145,6 +145,7 @@ void SortInference::reset()
 void SortInference::initialize(const std::vector<Node>& assertions)
 {
   Trace("sort-inference-proc") << "Calculating sort inference..." << std::endl;
+  d_non_monotonic_sorts_orig.clear();
   // process all assertions
   std::map<Node, int> visited;
   NodeManager* nm = nodeManager();
@@ -191,6 +192,15 @@ void SortInference::initialize(const std::vector<Node>& assertions)
     Trace("sort-inference") << std::endl;
   }
 
+  // Determine monotonicity of the original sorts. This is used below to
+  // conservatively classify all inferred subsorts of a non-monotonic sort.
+  std::map<Node, std::map<int, bool> > visitedmt;
+  for (const Node& a : assertions)
+  {
+    std::map<Node, Node> var_bound;
+    processMonotonic(a, true, true, var_bound, visitedmt, true);
+  }
+
   // determine monotonicity of sorts
   Trace("sort-inference-proc")
       << "Calculating monotonicty for subsorts..." << std::endl;
@@ -203,6 +213,19 @@ void SortInference::initialize(const std::vector<Node>& assertions)
     processMonotonic(a, true, true, var_bound, visitedm);
   }
   Trace("sort-inference-proc") << "...done" << std::endl;
+  for (const std::pair<const TypeNode, std::vector<int> >& tss :
+       d_type_sub_sorts)
+  {
+    if (d_non_monotonic_sorts_orig.find(tss.first)
+        == d_non_monotonic_sorts_orig.end())
+    {
+      continue;
+    }
+    for (int ss : tss.second)
+    {
+      d_non_monotonic_sorts[ss] = true;
+    }
+  }
 
   Trace("sort-inference") << "We have " << d_sub_sorts.size()
                           << " sub-sorts : " << std::endl;
@@ -320,6 +343,7 @@ void SortInference::getNewAssertions(std::vector<Node>& new_asserts)
 
 void SortInference::computeMonotonicity(const std::vector<Node>& assertions)
 {
+  d_non_monotonic_sorts_orig.clear();
   std::map<Node, std::map<int, bool> > visitedmt;
   Trace("sort-inference-proc")
       << "Calculating monotonicty for types..." << std::endl;

--- a/src/theory/sort_inference.h
+++ b/src/theory/sort_inference.h
@@ -77,6 +77,8 @@ class SortInference : protected EnvObj
  private:
   /** the id count for all subsorts we have allocated */
   int d_sortCount;
+  /** The sort constructor for fresh subsorts introduced by sort inference. */
+  TypeNode d_sortInferSubsortSc;
   UnionFind d_type_union_find;
   std::map<int, TypeNode> d_type_types;
   std::map<TypeNode, int> d_id_for_types;
@@ -125,7 +127,7 @@ class SortInference : protected EnvObj
   void reset();
 
  public:
-  SortInference(Env& env) : EnvObj(env), d_sortCount(1) {}
+  SortInference(Env& env);
   ~SortInference() {}
 
   /** initialize

--- a/src/theory/sort_inference.h
+++ b/src/theory/sort_inference.h
@@ -157,8 +157,6 @@ class SortInference : protected EnvObj
    * equisatisfiable.
    */
   void getNewAssertions(std::vector<Node>& new_asserts);
-  /** return true if tn was inferred to be monotonic */
-  bool isMonotonic(TypeNode tn) const;
   // get sort id for term n
   int getSortId(Node n);
   // get sort id for variable of quantified formula f

--- a/src/theory/sort_inference.h
+++ b/src/theory/sort_inference.h
@@ -157,13 +157,6 @@ class SortInference : protected EnvObj
    * equisatisfiable.
    */
   void getNewAssertions(std::vector<Node>& new_asserts);
-  /** compute monotonicity
-   *
-   * This computes whether sorts are monotonic (see e.g. Claessen 2011). If
-   * this function is called, then calls to isMonotonic() can subsequently be
-   * used to query whether sorts are monotonic.
-   */
-  void computeMonotonicity(const std::vector<Node>& assertions);
   /** return true if tn was inferred to be monotonic */
   bool isMonotonic(TypeNode tn) const;
   // get sort id for term n

--- a/src/theory/uf/cardinality_extension.cpp
+++ b/src/theory/uf/cardinality_extension.cpp
@@ -1906,7 +1906,6 @@ void CardinalityExtension::checkCombinedCardinality()
         << "Check combined cardinality, get maximum negative cardinalities..."
         << std::endl;
     uint32_t totalCombinedCard = 0;
-    uint32_t maxMonoSlave = 0;
     TypeNode maxSlaveType;
     for (std::map<TypeNode, SortModel*>::iterator it = d_rep_model.begin();
          it != d_rep_model.end();

--- a/src/theory/uf/cardinality_extension.cpp
+++ b/src/theory/uf/cardinality_extension.cpp
@@ -1560,62 +1560,6 @@ void CardinalityExtension::assertNode(Node n, bool isDecision)
       uint32_t nCard = cc.getUpperBound().getUnsignedInt();
       Trace("uf-ss-debug") << "...check cardinality constraint : " << tn
                            << std::endl;
-      if (options().uf.ufssFairnessMonotone)
-      {
-        SortInference* si = d_state.getSortInference();
-        Trace("uf-ss-com-card-debug") << "...set master/slave" << std::endl;
-        if (tn != d_tn_mono_master)
-        {
-          std::map<TypeNode, bool>::iterator it = d_tn_mono_slave.find(tn);
-          if (it == d_tn_mono_slave.end())
-          {
-            bool isMonotonic;
-            if (si != nullptr)
-            {
-              isMonotonic = si->isMonotonic(tn);
-            }
-            else
-            {
-              // if ground, everything is monotonic
-              isMonotonic = true;
-            }
-            if (isMonotonic)
-            {
-              if (d_tn_mono_master.isNull())
-              {
-                Trace("uf-ss-com-card-debug")
-                    << "uf-ss-fair-monotone: Set master : " << tn << std::endl;
-                d_tn_mono_master = tn;
-              }
-              else
-              {
-                Trace("uf-ss-com-card-debug")
-                    << "uf-ss-fair-monotone: Set slave : " << tn << std::endl;
-                d_tn_mono_slave[tn] = true;
-              }
-            }
-            else
-            {
-              Trace("uf-ss-com-card-debug")
-                  << "uf-ss-fair-monotone: Set non-monotonic : " << tn
-                  << std::endl;
-              d_tn_mono_slave[tn] = false;
-            }
-          }
-        }
-        // set the minimum positive cardinality for master if necessary
-        if (polarity && tn == d_tn_mono_master)
-        {
-          Trace("uf-ss-com-card-debug")
-              << "...set min positive cardinality" << std::endl;
-          if (!d_min_pos_tn_master_card_set.get()
-              || nCard < d_min_pos_tn_master_card.get())
-          {
-            d_min_pos_tn_master_card_set.set(true);
-            d_min_pos_tn_master_card.set(nCard);
-          }
-        }
-      }
       Trace("uf-ss-com-card-debug") << "...assert cardinality" << std::endl;
       d_rep_model[tn]->assertCardinality(nCard, polarity);
       // check if combined cardinality is violated
@@ -1969,55 +1913,11 @@ void CardinalityExtension::checkCombinedCardinality()
          ++it)
     {
       uint32_t max_neg = it->second->getMaximumNegativeCardinality();
-      if (!options().uf.ufssFairnessMonotone)
-      {
-        totalCombinedCard += max_neg;
-      }
-      else
-      {
-        std::map<TypeNode, bool>::iterator its =
-            d_tn_mono_slave.find(it->first);
-        if (its == d_tn_mono_slave.end() || !its->second)
-        {
-          totalCombinedCard += max_neg;
-        }
-        else
-        {
-          if (max_neg > maxMonoSlave)
-          {
-            maxMonoSlave = max_neg;
-            maxSlaveType = it->first;
-          }
-        }
-      }
+      totalCombinedCard += max_neg;
     }
     Trace("uf-ss-com-card-debug")
         << "Check combined cardinality, total combined card : "
         << totalCombinedCard << std::endl;
-    if (options().uf.ufssFairnessMonotone)
-    {
-      Trace("uf-ss-com-card-debug")
-          << "Max slave monotonic negated cardinality : " << maxMonoSlave
-          << std::endl;
-      if (!d_min_pos_tn_master_card_set.get()
-          && maxMonoSlave > d_min_pos_tn_master_card.get())
-      {
-        uint32_t mc = d_min_pos_tn_master_card.get();
-        std::vector<Node> conf;
-        conf.push_back(
-            d_rep_model[d_tn_mono_master]->getCardinalityLiteral(mc));
-        conf.push_back(d_rep_model[maxSlaveType]
-                           ->getCardinalityLiteral(maxMonoSlave)
-                           .negate());
-        Node cf = nodeManager()->mkNode(Kind::AND, conf);
-        Trace("uf-ss-lemma") << "*** Combined monotone cardinality conflict"
-                             << " : " << cf << std::endl;
-        Trace("uf-ss-com-card") << "*** Combined monotone cardinality conflict"
-                                << " : " << cf << std::endl;
-        d_im.conflict(cf, InferenceId::UF_CARD_MONOTONE_COMBINED);
-        return;
-      }
-    }
     uint32_t cc = d_min_pos_com_card.get();
     if (d_min_pos_com_card_set.get() && totalCombinedCard > cc)
     {
@@ -2030,28 +1930,15 @@ void CardinalityExtension::checkCombinedCardinality()
            it != d_rep_model.end();
            ++it)
       {
-        bool doAdd = true;
-        if (options().uf.ufssFairnessMonotone)
+        uint32_t c = it->second->getMaximumNegativeCardinality();
+        if (c > 0)
         {
-          std::map<TypeNode, bool>::iterator its =
-              d_tn_mono_slave.find(it->first);
-          if (its != d_tn_mono_slave.end() && its->second)
-          {
-            doAdd = false;
-          }
+          conf.push_back(it->second->getCardinalityLiteral(c).negate());
+          totalAdded += c;
         }
-        if (doAdd)
+        if (totalAdded > cc)
         {
-          uint32_t c = it->second->getMaximumNegativeCardinality();
-          if (c > 0)
-          {
-            conf.push_back(it->second->getCardinalityLiteral(c).negate());
-            totalAdded += c;
-          }
-          if (totalAdded > cc)
-          {
-            break;
-          }
+          break;
         }
       }
       Node cf = nodeManager()->mkNode(Kind::AND, conf);

--- a/src/theory/uf/cardinality_extension.h
+++ b/src/theory/uf/cardinality_extension.h
@@ -460,9 +460,6 @@ class CardinalityExtension : protected EnvObj
 
   /** cardinality literals for which we have added */
   NodeBoolMap d_card_assertions_eqv_lemma;
-  /** the master monotone type (if ufssFairnessMonotone enabled) */
-  TypeNode d_tn_mono_master;
-  std::map<TypeNode, bool> d_tn_mono_slave;
   /** The minimum positive asserted master cardinality */
   context::CDO<uint32_t> d_min_pos_tn_master_card;
   /** Whether the field above has been set */

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -936,6 +936,8 @@ set(regress_0_tests
   regress0/fmf/quant_real_univ.cvc.smt2
   regress0/fmf/sat-logic.smt2
   regress0/fmf/sc_bad_model_1221.smt2
+  regress0/fmf/sort-infer-nonmonotonic-orig.smt2‎
+  regress0/fmf/sort-infer-original-injection.smt2
   regress0/fmf/sort-infer-typed-082718.smt2
   regress0/fmf/syn002-si-real-int.smt2
   regress0/fmf/tail_rec.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -937,7 +937,7 @@ set(regress_0_tests
   regress0/fmf/quant_real_univ.cvc.smt2
   regress0/fmf/sat-logic.smt2
   regress0/fmf/sc_bad_model_1221.smt2
-  regress0/fmf/sort-infer-nonmonotonic-orig.smt2‎
+  regress0/fmf/sort-infer-nonmonotonic-orig.smt2
   regress0/fmf/sort-infer-original-injection.smt2
   regress0/fmf/sort-infer-typed-082718.smt2
   regress0/fmf/syn002-si-real-int.smt2

--- a/test/regress/cli/regress0/fmf/sort-infer-nonmonotonic-orig.smt2
+++ b/test/regress/cli/regress0/fmf/sort-infer-nonmonotonic-orig.smt2
@@ -1,0 +1,17 @@
+; COMMAND-LINE: --finite-model-find --sort-inference
+; EXPECT: unsat
+(set-logic UFC)
+(declare-sort U 0)
+(declare-fun r (U) Bool)
+(declare-fun f (U) U)
+(declare-const a U)
+(declare-const b U)
+(declare-const c U)
+(assert (_ fmf.card U 2))
+(assert (not (= a b)))
+(assert (r a))
+(assert (r b))
+(assert (forall ((X U) (Y U)) (or (= X Y) (r X))))
+(assert (forall ((X U)) (not (= (f X) c))))
+(assert (forall ((X U) (Y U)) (=> (= (f X) (f Y)) (= X Y))))
+(check-sat)

--- a/test/regress/cli/regress0/fmf/sort-infer-original-injection.smt2
+++ b/test/regress/cli/regress0/fmf/sort-infer-original-injection.smt2
@@ -1,0 +1,11 @@
+; COMMAND-LINE: --finite-model-find --sort-inference
+; EXPECT: unsat
+(set-logic UFC)
+(declare-sort U 0)
+(declare-const a U)
+(declare-const b U)
+(declare-const q Bool)
+(assert (= (ite q a b) a))
+(assert (not (_ fmf.card U 1)))
+(assert (forall ((x U) (y U)) (= x y)))
+(check-sat)

--- a/test/regress/cli/regress1/fmf/jasmin-cdt-crash.smt2
+++ b/test/regress/cli/regress1/fmf/jasmin-cdt-crash.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --finite-model-find --e-matching --uf-ss-fair-monotone
+; COMMAND-LINE: --finite-model-find --e-matching
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)

--- a/test/regress/cli/regress1/fmf/loopy_coda.smt2
+++ b/test/regress/cli/regress1/fmf/loopy_coda.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --finite-model-find --e-matching --uf-ss-fair-monotone
+; COMMAND-LINE: --finite-model-find --e-matching
 ; EXPECT: sat
 (set-logic ALL)
 (set-info :status sat)


### PR DESCRIPTION
The old code was computing monotonicity on inferred subsorts, which is not correct. This PR changes sort inference to infer monotonicity on original sorts and carries this property to all inferred subsorts of that sort.

This correct potential model unsoundness when using `--finite-model-find --sort-inference`, a regression is added.

Also updates the names of sorts introduced by sort inference to a standard convention so they can be used in proofs, introducing a raw symbol type (similar to raw symbol terms).

Also removes ufssFairnessMonotone option, which is expert and likely had bugs caused by the above issue.

Co-Authored-By: ChatGPT 5.5 <noreply@openai.com>