### PR TITLE
Minor improvement to proof reconstruction for BV variable elimination

### DIFF
--- a/src/theory/quantifiers/quantifiers_rewriter.cpp
+++ b/src/theory/quantifiers/quantifiers_rewriter.cpp
@@ -1264,18 +1264,14 @@ Node QuantifiersRewriter::getVarElimEqBv(Node lit,
 
   // if the option varEntEqElimQuant is disabled, we must preserve equivalence
   // when solving the variable, meaning that BITVECTOR_CONCAT cannot be
-  // on the path to the variable.
+  // on the path to the variable. We also only support proofs for such cases,
+  // so we disallow this case as well during reconstruction.
   std::unordered_set<Kind> disallowedKinds;
-  if (!d_opts.quantifiers.varEntEqElimQuant)
+  if (!d_opts.quantifiers.varEntEqElimQuant || cdp != nullptr)
   {
     // concatenation does not perserve equivalence i.e.
     // (concat x y) = z is not equivalent to x = ((_ extract n m) z)
     disallowedKinds.insert(Kind::BITVECTOR_CONCAT);
-  }
-  else if (cdp != nullptr)
-  {
-    // does not support proofs
-    return Node::null();
   }
 
   // compute a subset active_args of the bound variables args that occur in lit

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1694,6 +1694,7 @@ set(regress_0_tests
   regress0/quantifiers/dd_check_eq_bvnot_32bit.smt2
   regress0/quantifiers/dd_check_ic_sext_4_4.smt2
   regress0/quantifiers/dd.example10714-core-no-miniscope-user.smt2
+  regress0/quantifiers/dd.sparknacl-stream-bv-var-elim.smt2
   regress0/quantifiers/dd_german169_semi_eval.smt2
   regress0/quantifiers/dd_kmdf_osrubvfx2.smt2
   regress0/quantifiers/dd_nra_key_subtype_ineq.smt2

--- a/test/regress/cli/regress0/quantifiers/dd.sparknacl-stream-bv-var-elim.smt2
+++ b/test/regress/cli/regress0/quantifiers/dd.sparknacl-stream-bv-var-elim.smt2
@@ -1,0 +1,8 @@
+; EXPECT: unsat
+(set-logic ALL)
+(declare-sort b 0)
+(declare-fun t (b) (_ BitVec 1))
+(declare-sort a 0)
+(declare-datatypes ((u 0)) (((z))))
+(assert (exists ((z a)) (and (exists ((e a)) (and (exists ((o Int)) (or (forall ((o Int)) (or (forall ((o Int)) (or (forall ((o Int)) (or (forall ((o Int)) (or (forall ((o Int)) (or (forall ((o Int)) (or (forall ((b Int)) (or (forall ((o Int)) (or (forall ((o Int)) (or (forall ((e u)) (or (forall ((o Int)) (or (forall ((o Int)) (or (forall ((o Int)) (or (forall ((o Int)) (or (forall ((o Int)) (or (forall ((c a)) (or (forall ((s Bool)) (or (forall ((o Int)) (or (forall ((e a)) (or (forall ((z a)) (or (forall ((u a)) (or (forall ((z a)) (or (forall ((s Bool)) (or (forall ((o Int)) (or (forall ((o Int)) (or (forall ((z a)) (or (forall ((x a)) (or (forall ((i Int)) (or (forall ((o Int)) (or (forall ((o Int)) (or (forall ((o Bool)) (or (forall ((o Int)) (or (forall ((o Int)) (or (forall ((o Int)) (or (forall ((o Int)) (or (forall ((o Int)) (or (forall ((o Int)) (or (forall ((i Int)) (or (forall ((o Int)) (or (forall ((o Int)) (or (forall ((o (_ BitVec 1))) (or (forall ((o (_ BitVec 1))) (or (forall ((o3 b)) (distinct (t o3) (bvxor o (_ bv1 1)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+(check-sat)


### PR DESCRIPTION
This makes it so that proof reconstruction for BV variable elimination succeeds in cases where varEntEqElimQuant is enabled but the specific proof can nevertheless be successfully reconstructed. This makes it so that proofs are more complete in non-safe-mode builds.