### PR TITLE
Don't override dio solver option if set by user

### DIFF
--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -847,7 +847,7 @@ void SetDefaults::setDefaultsPost(const LogicInfo& logic, Options& opts) const
   // DIO solver typically makes things worse for quantifier-free logics with
   // non-linear arithmetic.
   if (!logic.isQuantified() && logic.isTheoryEnabled(THEORY_ARITH)
-      && !logic.isLinear())
+      && !logic.isLinear() && !opts.arith.arithDioSolverWasSetByUser)
   {
     SET_AND_NOTIFY(
         arith, arithDioSolver, false, "quantifier-free non-linear logic");


### PR DESCRIPTION
We should allow this option if set by the user, see https://github.com/cvc5/cvc5/discussions/12722.