### PR TITLE
Capture C API errors instead of aborting the process

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 This file contains a summary of important user-visible changes.
 
+cvc5 1.3.5 prerelease
+=====================
+
+## Changes
+
+- The C API no longer terminates the process when an error occurs. Instead of
+  printing to stderr and calling `exit()`, C API functions now record the error
+  in thread-local state and return a default value (e.g., `NULL`, `false`, or
+  `0`). Callers can query the error via the new functions `cvc5_has_error()` and
+  `cvc5_get_error_message()`, and clear it via `cvc5_reset_error()`. The error
+  state is reset at the start of the next C API call that can raise an error.
+
 cvc5 1.3.4
 ==========
 

--- a/docs/api/c/c.rst
+++ b/docs/api/c/c.rst
@@ -67,6 +67,7 @@ The C API offers **two modes** of memory management:
   .. toctree::
 
    quickstart
+   error_handling
    types/cvc5
    types/cvc5command
    types/cvc5datatype

--- a/docs/api/c/error_handling.rst
+++ b/docs/api/c/error_handling.rst
@@ -9,9 +9,11 @@ error in **thread-local** state and return a default value (e.g., ``NULL``,
 
 After invoking a C API function, the caller can check whether it succeeded via
 :cpp:func:`cvc5_has_error()` and retrieve the associated message via
-:cpp:func:`cvc5_get_error_message()`. The error state is reset at the beginning
-of each C API call, so it always reflects the outcome of the most recent call.
-For example:
+:cpp:func:`cvc5_get_error_message()`. The error state is reset at the start of
+the next C API call that can raise an error, so it reflects the outcome of the
+most recent such call. The query functions :cpp:func:`cvc5_has_error()` and
+:cpp:func:`cvc5_get_error_message()` never modify the error state themselves; it
+can also be cleared explicitly via :cpp:func:`cvc5_reset_error()`. For example:
 
 .. code:: c
 

--- a/docs/api/c/error_handling.rst
+++ b/docs/api/c/error_handling.rst
@@ -1,0 +1,37 @@
+Error handling
+==============
+
+Unlike the C++ API, which reports errors by throwing exceptions, the C API
+cannot propagate exceptions across the language boundary. Instead of
+terminating the process when an error occurs, cvc5 C API functions record the
+error in **thread-local** state and return a default value (e.g., ``NULL``,
+``false``, or ``0``).
+
+After invoking a C API function, the caller can check whether it succeeded via
+:cpp:func:`cvc5_has_error()` and retrieve the associated message via
+:cpp:func:`cvc5_get_error_message()`. The error state is reset at the beginning
+of each C API call, so it always reflects the outcome of the most recent call.
+For example:
+
+.. code:: c
+
+   Cvc5TermManager* tm = cvc5_term_manager_new();
+   Cvc5* cvc5 = cvc5_new(tm);
+   // Trigger an error by passing an invalid (NULL) argument.
+   cvc5_assert_formula(cvc5, NULL);
+   if (cvc5_has_error())
+   {
+     fprintf(stderr, "cvc5 error: %s\n", cvc5_get_error_message());
+   }
+   cvc5_delete(cvc5);
+   cvc5_term_manager_delete(tm);
+
+.. container:: hide-toctree
+
+  .. toctree::
+
+----
+
+.. doxygengroup:: c_error_handling
+    :project: cvc5_c
+    :content-only:

--- a/include/cvc5/c/cvc5.h
+++ b/include/cvc5/c/cvc5.h
@@ -153,6 +153,59 @@ typedef struct cvc5_stat_t* Cvc5Stat;
 typedef struct cvc5_stats_t* Cvc5Statistics;
 
 /* -------------------------------------------------------------------------- */
+/* Error handling                                                             */
+/* -------------------------------------------------------------------------- */
+
+/** \addtogroup c_error_handling
+ *  @{
+ */
+
+/**
+ * Determine if an error occurred during the most recent cvc5 C API call on the
+ * current thread.
+ *
+ * Rather than terminating the process, cvc5 C API functions record errors in
+ * thread-local state and return a default value (e.g., `NULL`, `false`, or `0`)
+ * on failure. After invoking a C API function, the caller can use this function
+ * to check whether the call succeeded, and `cvc5_get_error_message()` to
+ * retrieve the associated error message.
+ *
+ * The error state is reset at the beginning of each (non-query) C API call,
+ * thus it always reflects the outcome of the most recent such call. It can also
+ * be reset manually via `cvc5_reset_error()`.
+ *
+ * @note This function does not itself modify the error state.
+ *
+ * @return True if the most recent C API call on this thread resulted in an
+ *         error.
+ */
+CVC5_EXPORT bool cvc5_has_error(void);
+
+/**
+ * Retrieve the error message associated with the most recent error on the
+ * current thread.
+ *
+ * @note This function does not itself modify the error state. The returned
+ *       pointer is owned by cvc5 and is only valid until the next C API call on
+ *       this thread.
+ *
+ * @return The message of the most recent error, or the empty string if no
+ *         error has occurred (i.e., if `cvc5_has_error()` returns false).
+ */
+CVC5_EXPORT const char* cvc5_get_error_message(void);
+
+/**
+ * Reset the thread-local error state.
+ *
+ * After calling this function, `cvc5_has_error()` returns false and
+ * `cvc5_get_error_message()` returns the empty string, until the next error
+ * occurs.
+ */
+CVC5_EXPORT void cvc5_reset_error(void);
+
+/** @} */
+
+/* -------------------------------------------------------------------------- */
 /* Cvc5Result                                                                 */
 /* -------------------------------------------------------------------------- */
 

--- a/src/api/c/cvc5.cpp
+++ b/src/api/c/cvc5.cpp
@@ -30,7 +30,10 @@ extern "C" {
 
 bool cvc5_has_error() { return cvc5::cvc5_capi_has_error(); }
 
-const char* cvc5_get_error_message() { return cvc5::cvc5_capi_get_error_message(); }
+const char* cvc5_get_error_message()
+{
+  return cvc5::cvc5_capi_get_error_message();
+}
 
 void cvc5_reset_error() { cvc5::cvc5_capi_reset_error(); }
 

--- a/src/api/c/cvc5.cpp
+++ b/src/api/c/cvc5.cpp
@@ -25,6 +25,16 @@ extern "C" {
 #include "api/c/cvc5_checks.h"
 
 /* -------------------------------------------------------------------------- */
+/* Error handling                                                             */
+/* -------------------------------------------------------------------------- */
+
+bool cvc5_has_error() { return cvc5::cvc5_capi_has_error(); }
+
+const char* cvc5_get_error_message() { return cvc5::cvc5_capi_get_error_message(); }
+
+void cvc5_reset_error() { cvc5::cvc5_capi_reset_error(); }
+
+/* -------------------------------------------------------------------------- */
 /* Cvc5Kind                                                                   */
 /* -------------------------------------------------------------------------- */
 
@@ -736,7 +746,9 @@ const Cvc5Sort* cvc5_sort_get_instantiated_parameters(Cvc5Sort sort,
   }
   *size = res.size();
   CVC5_CAPI_TRY_CATCH_END;
-  return *size > 0 ? res.data() : nullptr;
+  // On error, `size` may be invalid (e.g. NULL) and `res` may hold stale data,
+  // so we must not dereference `size` here; gate on the error state instead.
+  return cvc5::cvc5_capi_has_error() || res.empty() ? nullptr : res.data();
 }
 
 Cvc5Sort cvc5_sort_substitute(Cvc5Sort sort, Cvc5Sort s, Cvc5Sort replacement)
@@ -826,7 +838,9 @@ const Cvc5Sort* cvc5_sort_dt_constructor_get_domain(Cvc5Sort sort, size_t* size)
   }
   *size = res.size();
   CVC5_CAPI_TRY_CATCH_END;
-  return *size > 0 ? res.data() : nullptr;
+  // On error, `size` may be invalid (e.g. NULL) and `res` may hold stale data,
+  // so we must not dereference `size` here; gate on the error state instead.
+  return cvc5::cvc5_capi_has_error() || res.empty() ? nullptr : res.data();
 }
 
 Cvc5Sort cvc5_sort_dt_constructor_get_codomain(Cvc5Sort sort)
@@ -911,7 +925,9 @@ const Cvc5Sort* cvc5_sort_fun_get_domain(Cvc5Sort sort, size_t* size)
   }
   *size = res.size();
   CVC5_CAPI_TRY_CATCH_END;
-  return *size > 0 ? res.data() : nullptr;
+  // On error, `size` may be invalid (e.g. NULL) and `res` may hold stale data,
+  // so we must not dereference `size` here; gate on the error state instead.
+  return cvc5::cvc5_capi_has_error() || res.empty() ? nullptr : res.data();
 }
 
 Cvc5Sort cvc5_sort_fun_get_codomain(Cvc5Sort sort)
@@ -1091,7 +1107,9 @@ const Cvc5Sort* cvc5_sort_tuple_get_element_sorts(Cvc5Sort sort, size_t* size)
   }
   *size = res.size();
   CVC5_CAPI_TRY_CATCH_END;
-  return *size > 0 ? res.data() : nullptr;
+  // On error, `size` may be invalid (e.g. NULL) and `res` may hold stale data,
+  // so we must not dereference `size` here; gate on the error state instead.
+  return cvc5::cvc5_capi_has_error() || res.empty() ? nullptr : res.data();
 }
 
 Cvc5Sort cvc5_sort_nullable_get_element_sort(Cvc5Sort sort)
@@ -1638,7 +1656,9 @@ const Cvc5Sort* cvc5_dt_get_parameters(Cvc5Datatype dt, size_t* size)
   }
   *size = res.size();
   CVC5_CAPI_TRY_CATCH_END;
-  return *size > 0 ? res.data() : nullptr;
+  // On error, `size` may be invalid (e.g. NULL) and `res` may hold stale data,
+  // so we must not dereference `size` here; gate on the error state instead.
+  return cvc5::cvc5_capi_has_error() || res.empty() ? nullptr : res.data();
 }
 
 bool cvc5_dt_is_parametric(Cvc5Datatype dt)
@@ -5273,11 +5293,13 @@ const char* cvc5_get_model(Cvc5* cvc5,
   std::vector<cvc5::Sort> csorts;
   for (size_t i = 0; i < nsorts; ++i)
   {
+    CVC5_CAPI_CHECK_SORT_AT_IDX(sorts, i);
     csorts.push_back(sorts[i]->d_sort);
   }
   std::vector<cvc5::Term> cconsts;
   for (size_t i = 0; i < nconsts; ++i)
   {
+    CVC5_CAPI_CHECK_TERM_AT_IDX(consts, i);
     cconsts.push_back(consts[i]->d_term);
   }
   str = cvc5->d_solver.getModel(csorts, cconsts);
@@ -5704,7 +5726,9 @@ const Cvc5Term* cvc5_get_sygus_constraints(Cvc5* cvc5, size_t* size)
   }
   *size = res.size();
   CVC5_CAPI_TRY_CATCH_END;
-  return *size > 0 ? res.data() : nullptr;
+  // On error, `size` may be invalid (e.g. NULL) and `res` may hold stale data,
+  // so we must not dereference `size` here; gate on the error state instead.
+  return cvc5::cvc5_capi_has_error() || res.empty() ? nullptr : res.data();
 }
 
 void cvc5_add_sygus_assume(Cvc5* cvc5, Cvc5Term term)
@@ -5730,7 +5754,9 @@ const Cvc5Term* cvc5_get_sygus_assumptions(Cvc5* cvc5, size_t* size)
   }
   *size = res.size();
   CVC5_CAPI_TRY_CATCH_END;
-  return *size > 0 ? res.data() : nullptr;
+  // On error, `size` may be invalid (e.g. NULL) and `res` may hold stale data,
+  // so we must not dereference `size` here; gate on the error state instead.
+  return cvc5::cvc5_capi_has_error() || res.empty() ? nullptr : res.data();
 }
 
 void cvc5_add_sygus_inv_constraint(

--- a/src/api/c/cvc5_c_structs.cpp
+++ b/src/api/c/cvc5_c_structs.cpp
@@ -15,6 +15,37 @@
 #include "api/c/cvc5_checks.h"
 
 /* -------------------------------------------------------------------------- */
+/* Thread-local error state                                                   */
+/* -------------------------------------------------------------------------- */
+
+namespace cvc5 {
+
+namespace {
+/** Whether an error occurred during the most recent guarded C API call. */
+thread_local bool s_error_flag = false;
+/** The message associated with the most recent error (if any). */
+thread_local std::string s_error_msg;
+}  // namespace
+
+void cvc5_capi_set_error(const std::string& msg)
+{
+  s_error_flag = true;
+  s_error_msg = msg;
+}
+
+void cvc5_capi_reset_error()
+{
+  s_error_flag = false;
+  s_error_msg.clear();
+}
+
+bool cvc5_capi_has_error() { return s_error_flag; }
+
+const char* cvc5_capi_get_error_message() { return s_error_msg.c_str(); }
+
+}  // namespace cvc5
+
+/* -------------------------------------------------------------------------- */
 /* Cvc5TermManager struct                                                     */
 /* -------------------------------------------------------------------------- */
 

--- a/src/api/c/cvc5_checks.h
+++ b/src/api/c/cvc5_checks.h
@@ -82,9 +82,13 @@ CVC5_EXPORT const char* cvc5_capi_get_error_message();
  * through and returns its default-initialized return value; the caller is
  * expected to check `cvc5_has_error()`.
  *
- * @note The trailing `catch (...)` ensures that even foreign exception types
- *       that do not derive from `std::exception` cannot escape the `extern "C"`
- *       boundary (which would call `std::terminate`).
+ * @note The trailing `catch (...)` ensures that no exception can escape the
+ *       `extern "C"` boundary, which would call `std::terminate`. This is not
+ *       merely theoretical: cvc5 links third-party libraries whose exception
+ *       types do not derive from `std::exception` (e.g. CoCoALib's
+ *       `CoCoA::ErrorInfo`, used by the finite-field theory). Should such an
+ *       exception ever reach the C API uncaught (e.g. via a missed catch on
+ *       some C++ code path), the catch-all records it instead of aborting.
  */
 #define CVC5_CAPI_TRY_CATCH_END                                            \
   }                                                                        \

--- a/src/api/c/cvc5_checks.h
+++ b/src/api/c/cvc5_checks.h
@@ -30,39 +30,68 @@ namespace cvc5 {
 
 /* -------------------------------------------------------------------------- */
 
-class Cvc5CApiAbortStream
-{
- public:
-  Cvc5CApiAbortStream(const std::string& msg_prefix)
-  {
-    stream() << msg_prefix << " ";
-  }
-  ~Cvc5CApiAbortStream()
-  {
-    std::cerr << d_stream.str() << std::endl;
-    exit(EXIT_FAILURE);
-  }
-  std::ostream& stream() { return d_stream; }
+/**
+ * Record an error that occurred during a cvc5 C API call.
+ *
+ * This sets the thread-local error flag and stores `msg` as the associated
+ * error message. It is invoked by #CVC5_CAPI_TRY_CATCH_END whenever a C API
+ * function catches an exception, instead of terminating the process. The
+ * recorded state can be queried via `cvc5_has_error()` and
+ * `cvc5_get_error_message()`.
+ *
+ * @param msg The error message to store.
+ *
+ * @note Exported for linkage of the parser library, which uses the
+ *       #CVC5_CAPI_TRY_CATCH_END macro.
+ */
+CVC5_EXPORT void cvc5_capi_set_error(const std::string& msg);
+/**
+ * Clear the thread-local error state.
+ *
+ * This is invoked by #CVC5_CAPI_TRY_CATCH_BEGIN on entry of each guarded C API
+ * function so that the error state always reflects the most recent call. It is
+ * also exposed to users via `cvc5_reset_error()`.
+ */
+CVC5_EXPORT void cvc5_capi_reset_error();
+/**
+ * @return True if an error occurred during the most recent guarded C API call
+ *         on the current thread.
+ */
+CVC5_EXPORT bool cvc5_capi_has_error();
+/**
+ * @return The message associated with the most recent error on the current
+ *         thread, or the empty string if no error occurred. The returned
+ *         pointer is valid until the next guarded C API call on this thread.
+ */
+CVC5_EXPORT const char* cvc5_capi_get_error_message();
 
- private:
-  void flush()
-  {
-    stream() << std::endl;
-    stream().flush();
-  }
-  std::stringstream d_stream;
-};
-
-#define CVC5_CAPI_ABORT           \
-  cvc5::internal::OstreamVoider() \
-      & cvc5::Cvc5CApiAbortStream("cvc5: error:").stream()
-
+/**
+ * Reset the thread-local error state on entry of a guarded C API function.
+ *
+ * @note We do not start the `try` block here so that the reset is performed
+ *       unconditionally, even for functions that perform work before their
+ *       #CVC5_CAPI_TRY_CATCH_BEGIN.
+ */
 #define CVC5_CAPI_TRY_CATCH_BEGIN \
+  cvc5::cvc5_capi_reset_error();  \
   try                             \
   {
-#define CVC5_CAPI_TRY_CATCH_END \
-  }                             \
-  catch (cvc5::CVC5ApiException & e) { CVC5_CAPI_ABORT << e.getMessage(); }
+/**
+ * Capture any exception thrown by a guarded C API function as a thread-local
+ * error instead of terminating the process. On error, the function falls
+ * through and returns its default-initialized return value; the caller is
+ * expected to check `cvc5_has_error()`.
+ */
+#define CVC5_CAPI_TRY_CATCH_END                          \
+  }                                                      \
+  catch (const cvc5::CVC5ApiException& e)                \
+  {                                                      \
+    cvc5::cvc5_capi_set_error(e.getMessage());           \
+  }                                                      \
+  catch (const std::exception& e)                        \
+  {                                                      \
+    cvc5::cvc5_capi_set_error(e.what());                 \
+  }
 
 #endif
 

--- a/src/api/c/cvc5_checks.h
+++ b/src/api/c/cvc5_checks.h
@@ -86,20 +86,14 @@ CVC5_EXPORT const char* cvc5_capi_get_error_message();
  *       that do not derive from `std::exception` cannot escape the `extern "C"`
  *       boundary (which would call `std::terminate`).
  */
-#define CVC5_CAPI_TRY_CATCH_END                          \
-  }                                                      \
-  catch (const cvc5::CVC5ApiException& e)                \
-  {                                                      \
-    cvc5::cvc5_capi_set_error(e.getMessage());           \
-  }                                                      \
-  catch (const std::exception& e)                        \
-  {                                                      \
-    cvc5::cvc5_capi_set_error(e.what());                 \
-  }                                                      \
-  catch (...)                                            \
-  {                                                      \
-    cvc5::cvc5_capi_set_error("unknown C++ exception");  \
-  }
+#define CVC5_CAPI_TRY_CATCH_END                                            \
+  }                                                                        \
+  catch (const cvc5::CVC5ApiException& e)                                  \
+  {                                                                        \
+    cvc5::cvc5_capi_set_error(e.getMessage());                             \
+  }                                                                        \
+  catch (const std::exception& e) { cvc5::cvc5_capi_set_error(e.what()); } \
+  catch (...) { cvc5::cvc5_capi_set_error("unknown C++ exception"); }
 
 #endif
 

--- a/src/api/c/cvc5_checks.h
+++ b/src/api/c/cvc5_checks.h
@@ -81,6 +81,10 @@ CVC5_EXPORT const char* cvc5_capi_get_error_message();
  * error instead of terminating the process. On error, the function falls
  * through and returns its default-initialized return value; the caller is
  * expected to check `cvc5_has_error()`.
+ *
+ * @note The trailing `catch (...)` ensures that even foreign exception types
+ *       that do not derive from `std::exception` cannot escape the `extern "C"`
+ *       boundary (which would call `std::terminate`).
  */
 #define CVC5_CAPI_TRY_CATCH_END                          \
   }                                                      \
@@ -91,6 +95,10 @@ CVC5_EXPORT const char* cvc5_capi_get_error_message();
   catch (const std::exception& e)                        \
   {                                                      \
     cvc5::cvc5_capi_set_error(e.what());                 \
+  }                                                      \
+  catch (...)                                            \
+  {                                                      \
+    cvc5::cvc5_capi_set_error("unknown C++ exception");  \
   }
 
 #endif

--- a/src/api/c/cvc5_parser.cpp
+++ b/src/api/c/cvc5_parser.cpp
@@ -182,7 +182,9 @@ const Cvc5Sort* cvc5_sm_get_declared_sorts(Cvc5SymbolManager* sm, size_t* size)
   }
   *size = res.size();
   CVC5_CAPI_TRY_CATCH_END;
-  return *size > 0 ? res.data() : nullptr;
+  // On error, `size` may be invalid (e.g. NULL) and `res` may hold stale data,
+  // so we must not dereference `size` here; gate on the error state instead.
+  return cvc5::cvc5_capi_has_error() || res.empty() ? nullptr : res.data();
 }
 
 const Cvc5Term* cvc5_sm_get_declared_terms(Cvc5SymbolManager* sm, size_t* size)
@@ -200,7 +202,9 @@ const Cvc5Term* cvc5_sm_get_declared_terms(Cvc5SymbolManager* sm, size_t* size)
   }
   *size = res.size();
   CVC5_CAPI_TRY_CATCH_END;
-  return *size > 0 ? res.data() : nullptr;
+  // On error, `size` may be invalid (e.g. NULL) and `res` may hold stale data,
+  // so we must not dereference `size` here; gate on the error state instead.
+  return cvc5::cvc5_capi_has_error() || res.empty() ? nullptr : res.data();
 }
 
 void cvc5_sm_get_named_terms(Cvc5SymbolManager* sm,

--- a/test/unit/api/c/CMakeLists.txt
+++ b/test/unit/api/c/CMakeLists.txt
@@ -13,6 +13,7 @@
 # Generate and add unit test.
 cvc5_add_unit_test_black(capi_command_black api/c)
 cvc5_add_unit_test_black(capi_datatype_black api/c)
+cvc5_add_unit_test_black(capi_error_handling_black api/c)
 cvc5_add_unit_test_black(capi_grammar_black api/c)
 cvc5_add_unit_test_black(capi_input_parser_black api/c)
 cvc5_add_unit_test_black(capi_kind_black api/c)

--- a/test/unit/api/c/capi_command_black.cpp
+++ b/test/unit/api/c/capi_command_black.cpp
@@ -17,6 +17,7 @@ extern "C" {
 #include <sstream>
 
 #include "gtest/gtest.h"
+#include "test_capi.h"
 
 namespace cvc5::internal::test {
 
@@ -74,9 +75,9 @@ TEST_F(TestCApiBlackCommand, invoke)
       "(error \"cannot get model unless model generation is enabled (try "
       "--produce-models)\")\n",
       std::string(out));
-  ASSERT_DEATH(cvc5_cmd_invoke(nullptr, d_solver, d_sm), "invalid command");
-  ASSERT_DEATH(cvc5_cmd_invoke(cmd, nullptr, d_sm), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_cmd_invoke(cmd, d_solver, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_cmd_invoke(nullptr, d_solver, d_sm), "invalid command");
+  ASSERT_CVC5_ERROR(cvc5_cmd_invoke(cmd, nullptr, d_sm), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_cmd_invoke(cmd, d_solver, nullptr),
                "unexpected NULL argument");
   // logic already set
   parse_command(
@@ -90,7 +91,7 @@ TEST_F(TestCApiBlackCommand, to_string)
   ASSERT_NE(cmd, nullptr);
   // note normalizes wrt whitespace
   ASSERT_EQ(cvc5_cmd_to_string(cmd), std::string("(set-logic QF_LIA)"));
-  ASSERT_DEATH(cvc5_cmd_to_string(nullptr), "invalid command");
+  ASSERT_CVC5_ERROR(cvc5_cmd_to_string(nullptr), "invalid command");
 }
 
 TEST_F(TestCApiBlackCommand, get_name)
@@ -99,6 +100,6 @@ TEST_F(TestCApiBlackCommand, get_name)
   parse_command("(get-model)", &cmd);
   ASSERT_NE(cmd, nullptr);
   ASSERT_EQ(cvc5_cmd_get_name(cmd), std::string("get-model"));
-  ASSERT_DEATH(cvc5_cmd_get_name(nullptr), "invalid command");
+  ASSERT_CVC5_ERROR(cvc5_cmd_get_name(nullptr), "invalid command");
 }
 }  // namespace cvc5::internal::test

--- a/test/unit/api/c/capi_command_black.cpp
+++ b/test/unit/api/c/capi_command_black.cpp
@@ -75,10 +75,12 @@ TEST_F(TestCApiBlackCommand, invoke)
       "(error \"cannot get model unless model generation is enabled (try "
       "--produce-models)\")\n",
       std::string(out));
-  ASSERT_CVC5_ERROR(cvc5_cmd_invoke(nullptr, d_solver, d_sm), "invalid command");
-  ASSERT_CVC5_ERROR(cvc5_cmd_invoke(cmd, nullptr, d_sm), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_cmd_invoke(nullptr, d_solver, d_sm),
+                    "invalid command");
+  ASSERT_CVC5_ERROR(cvc5_cmd_invoke(cmd, nullptr, d_sm),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_cmd_invoke(cmd, d_solver, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   // logic already set
   parse_command(
       "(set-logic QF_LRA)", &cmd, true, "Only one set-logic is allowed");

--- a/test/unit/api/c/capi_datatype_black.cpp
+++ b/test/unit/api/c/capi_datatype_black.cpp
@@ -82,7 +82,8 @@ TEST_F(TestCApiBlackDatatype, mk_dt_sort)
   cvc5_dt_decl_add_constructor(decl, nil);
 
   ASSERT_CVC5_ERROR(cvc5_mk_dt_sort(nullptr, decl), "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_mk_dt_sort(d_tm, nullptr), "invalid datatype declaration");
+  ASSERT_CVC5_ERROR(cvc5_mk_dt_sort(d_tm, nullptr),
+                    "invalid datatype declaration");
   Cvc5Sort list_sort = cvc5_mk_dt_sort(d_tm, decl);
   Cvc5Datatype dt = cvc5_sort_get_datatype(list_sort);
   Cvc5DatatypeConstructor cons_cons = cvc5_dt_get_constructor(dt, 0);
@@ -147,7 +148,7 @@ TEST_F(TestCApiBlackDatatype, equal_hash)
   ASSERT_FALSE(cvc5_dt_is_equal(dt1, dt2));
 
   ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_hash(nullptr),
-               "invalid datatype constructor declaration");
+                    "invalid datatype constructor declaration");
   ASSERT_CVC5_ERROR(cvc5_dt_decl_hash(nullptr), "invalid datatype declaration");
   ASSERT_CVC5_ERROR(cvc5_dt_cons_hash(nullptr), "invalid datatype constructor");
   ASSERT_CVC5_ERROR(cvc5_dt_sel_hash(nullptr), "invalid datatype selector");
@@ -224,23 +225,24 @@ TEST_F(TestCApiBlackDatatype, mk_datatype_sorts)
       cvc5_dt_sel_get_codomain_sort(dt_tree_node_left), dtsorts[0]));
 
   ASSERT_CVC5_ERROR(cvc5_mk_dt_sorts(nullptr, dtdecls.size(), dtdecls.data()),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_dt_sorts(d_tm, dtdecls.size(), nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 
   // fails due to empty datatype
   std::vector<Cvc5DatatypeDecl> dtdecls_bad{
       cvc5_mk_dt_decl(d_tm, "emptyD", false)};
-  ASSERT_CVC5_ERROR(cvc5_mk_dt_sorts(d_tm, dtdecls_bad.size(), dtdecls_bad.data()),
-               "invalid datatype declaration");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_dt_sorts(d_tm, dtdecls_bad.size(), dtdecls_bad.data()),
+      "invalid datatype declaration");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_decl_copy_release)
 {
   ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_copy(nullptr),
-               "invalid datatype constructor declaration");
+                    "invalid datatype constructor declaration");
   ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_release(nullptr),
-               "invalid datatype constructor declaration");
+                    "invalid datatype constructor declaration");
   Cvc5DatatypeConstructorDecl decl = cvc5_mk_dt_cons_decl(d_tm, "cons");
   Cvc5DatatypeConstructorDecl decl_copy = cvc5_dt_cons_decl_copy(decl);
   ASSERT_EQ(cvc5_dt_cons_decl_hash(decl), cvc5_dt_cons_decl_hash(decl_copy));
@@ -255,37 +257,40 @@ TEST_F(TestCApiBlackDatatype, dt_cons_decl_add_selector)
 {
   Cvc5DatatypeConstructorDecl cons = cvc5_mk_dt_cons_decl(d_tm, "cons");
   ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_add_selector(nullptr, "foo", d_int),
-               "invalid datatype constructor declaration");
+                    "invalid datatype constructor declaration");
   ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_add_selector(cons, nullptr, d_int),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_add_selector(cons, "foo", nullptr),
-               "invalid sort");
+                    "invalid sort");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_decl_add_selector_self)
 {
   Cvc5DatatypeConstructorDecl cons = cvc5_mk_dt_cons_decl(d_tm, "cons");
   ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_add_selector_self(nullptr, "foo"),
-               "invalid datatype constructor declaration");
+                    "invalid datatype constructor declaration");
   ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_add_selector_self(cons, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_decl_add_selector_unresolved)
 {
   Cvc5DatatypeConstructorDecl cons = cvc5_mk_dt_cons_decl(d_tm, "cons");
-  ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_add_selector_unresolved(nullptr, "foo", "bar"),
-               "invalid datatype constructor declaration");
-  ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_add_selector_unresolved(cons, nullptr, "bar"),
-               "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_add_selector_unresolved(cons, "foo", nullptr),
-               "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_dt_cons_decl_add_selector_unresolved(nullptr, "foo", "bar"),
+      "invalid datatype constructor declaration");
+  ASSERT_CVC5_ERROR(
+      cvc5_dt_cons_decl_add_selector_unresolved(cons, nullptr, "bar"),
+      "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_dt_cons_decl_add_selector_unresolved(cons, "foo", nullptr),
+      "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_decl_to_string)
 {
   ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_to_string(nullptr),
-               "invalid datatype constructor declaration");
+                    "invalid datatype constructor declaration");
   Cvc5DatatypeConstructorDecl cons = cvc5_mk_dt_cons_decl(d_tm, "cons");
   (void)cvc5_dt_cons_decl_to_string(cons);
 }
@@ -293,13 +298,14 @@ TEST_F(TestCApiBlackDatatype, dt_cons_decl_to_string)
 TEST_F(TestCApiBlackDatatype, dt_cons_decl_hash)
 {
   ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_hash(nullptr),
-               "invalid datatype constructor declaration");
+                    "invalid datatype constructor declaration");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_decl_copy_release)
 {
   ASSERT_CVC5_ERROR(cvc5_dt_decl_copy(nullptr), "invalid datatype declaration");
-  ASSERT_CVC5_ERROR(cvc5_dt_decl_release(nullptr), "invalid datatype declaration");
+  ASSERT_CVC5_ERROR(cvc5_dt_decl_release(nullptr),
+                    "invalid datatype declaration");
   Cvc5DatatypeDecl decl = cvc5_mk_dt_decl(d_tm, "tree", false);
   Cvc5DatatypeDecl decl_copy = cvc5_dt_decl_copy(decl);
   ASSERT_EQ(cvc5_dt_decl_hash(decl), cvc5_dt_decl_hash(decl_copy));
@@ -315,15 +321,15 @@ TEST_F(TestCApiBlackDatatype, dt_decl_add_constructor)
   Cvc5DatatypeDecl decl = cvc5_mk_dt_decl(d_tm, "tree", false);
   Cvc5DatatypeConstructorDecl node = cvc5_mk_dt_cons_decl(d_tm, "node");
   ASSERT_CVC5_ERROR(cvc5_dt_decl_add_constructor(nullptr, node),
-               "invalid datatype declaration");
+                    "invalid datatype declaration");
   ASSERT_CVC5_ERROR(cvc5_dt_decl_add_constructor(decl, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_decl_get_num_constructors)
 {
   ASSERT_CVC5_ERROR(cvc5_dt_decl_get_num_constructors(nullptr),
-               "invalid datatype declaration");
+                    "invalid datatype declaration");
   Cvc5DatatypeDecl decl = create_datatype_decl();
   ASSERT_EQ(cvc5_dt_decl_get_num_constructors(decl), 2);
 }
@@ -331,7 +337,7 @@ TEST_F(TestCApiBlackDatatype, dt_decl_get_num_constructors)
 TEST_F(TestCApiBlackDatatype, dt_decl_is_parametric)
 {
   ASSERT_CVC5_ERROR(cvc5_dt_decl_is_parametric(nullptr),
-               "invalid datatype declaration");
+                    "invalid datatype declaration");
   Cvc5DatatypeDecl decl = create_datatype_decl();
   ASSERT_FALSE(cvc5_dt_decl_is_parametric(decl));
 }
@@ -339,21 +345,23 @@ TEST_F(TestCApiBlackDatatype, dt_decl_is_parametric)
 TEST_F(TestCApiBlackDatatype, dt_decl_is_resolved)
 {
   ASSERT_CVC5_ERROR(cvc5_dt_decl_is_resolved(nullptr),
-               "invalid datatype declaration");
+                    "invalid datatype declaration");
   Cvc5DatatypeDecl decl = create_datatype_decl();
   ASSERT_FALSE(cvc5_dt_decl_is_resolved(decl));
 }
 
 TEST_F(TestCApiBlackDatatype, dt_decl_get_name)
 {
-  ASSERT_CVC5_ERROR(cvc5_dt_decl_get_name(nullptr), "invalid datatype declaration");
+  ASSERT_CVC5_ERROR(cvc5_dt_decl_get_name(nullptr),
+                    "invalid datatype declaration");
   Cvc5DatatypeDecl decl = create_datatype_decl();
   ASSERT_EQ(cvc5_dt_decl_get_name(decl), std::string("list"));
 }
 
 TEST_F(TestCApiBlackDatatype, dt_decl_to_string)
 {
-  ASSERT_CVC5_ERROR(cvc5_dt_decl_to_string(nullptr), "invalid datatype declaration");
+  ASSERT_CVC5_ERROR(cvc5_dt_decl_to_string(nullptr),
+                    "invalid datatype declaration");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_decl_hash)
@@ -389,18 +397,19 @@ TEST_F(TestCApiBlackDatatype, dt_sel_get_term)
 TEST_F(TestCApiBlackDatatype, dt_sel_get_updater_term)
 {
   ASSERT_CVC5_ERROR(cvc5_dt_sel_get_updater_term(nullptr),
-               "invalid datatype selector");
+                    "invalid datatype selector");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_sel_get_codomain_sort)
 {
   ASSERT_CVC5_ERROR(cvc5_dt_sel_get_codomain_sort(nullptr),
-               "invalid datatype selector");
+                    "invalid datatype selector");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_sel_to_string)
 {
-  ASSERT_CVC5_ERROR(cvc5_dt_sel_to_string(nullptr), "invalid datatype selector");
+  ASSERT_CVC5_ERROR(cvc5_dt_sel_to_string(nullptr),
+                    "invalid datatype selector");
   Cvc5Datatype dt = create_datatype();
   Cvc5DatatypeSelector head =
       cvc5_dt_cons_get_selector_by_name(cvc5_dt_get_constructor(dt, 0), "head");
@@ -415,7 +424,8 @@ TEST_F(TestCApiBlackDatatype, dt_sel_hash)
 TEST_F(TestCApiBlackDatatype, dt_cons_copy_release)
 {
   ASSERT_CVC5_ERROR(cvc5_dt_cons_copy(nullptr), "invalid datatype constructor");
-  ASSERT_CVC5_ERROR(cvc5_dt_cons_release(nullptr), "invalid datatype constructor");
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_release(nullptr),
+                    "invalid datatype constructor");
   Cvc5Datatype dt = create_datatype();
   Cvc5DatatypeConstructor cons = cvc5_dt_get_constructor(dt, 0);
   Cvc5DatatypeConstructor cons_copy = cvc5_dt_cons_copy(cons);
@@ -429,12 +439,14 @@ TEST_F(TestCApiBlackDatatype, dt_cons_copy_release)
 
 TEST_F(TestCApiBlackDatatype, dt_cons_get_name)
 {
-  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_name(nullptr), "invalid datatype constructor");
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_name(nullptr),
+                    "invalid datatype constructor");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_get_term)
 {
-  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_term(nullptr), "invalid datatype constructor");
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_term(nullptr),
+                    "invalid datatype constructor");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_get_instantiated_term)
@@ -442,27 +454,27 @@ TEST_F(TestCApiBlackDatatype, dt_cons_get_instantiated_term)
   Cvc5Datatype dt = create_datatype();
   Cvc5DatatypeConstructor cons = cvc5_dt_get_constructor(dt, 0);
   ASSERT_CVC5_ERROR(cvc5_dt_cons_get_instantiated_term(nullptr, d_int),
-               "invalid datatype constructor");
+                    "invalid datatype constructor");
   ASSERT_CVC5_ERROR(cvc5_dt_cons_get_instantiated_term(cons, nullptr),
-               "invalid sort");
+                    "invalid sort");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_get_tester_term)
 {
   ASSERT_CVC5_ERROR(cvc5_dt_cons_get_tester_term(nullptr),
-               "invalid datatype constructor");
+                    "invalid datatype constructor");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_get_num_selectors)
 {
   ASSERT_CVC5_ERROR(cvc5_dt_cons_get_num_selectors(nullptr),
-               "invalid datatype constructor");
+                    "invalid datatype constructor");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_get_selector)
 {
   ASSERT_CVC5_ERROR(cvc5_dt_cons_get_selector(nullptr, 0),
-               "invalid datatype constructor");
+                    "invalid datatype constructor");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_get_selector_by_name)
@@ -470,9 +482,9 @@ TEST_F(TestCApiBlackDatatype, dt_cons_get_selector_by_name)
   Cvc5Datatype dt = create_datatype();
   Cvc5DatatypeConstructor cons = cvc5_dt_get_constructor(dt, 0);
   ASSERT_CVC5_ERROR(cvc5_dt_cons_get_selector_by_name(nullptr, "cons"),
-               "invalid datatype constructor");
+                    "invalid datatype constructor");
   ASSERT_CVC5_ERROR(cvc5_dt_cons_get_selector_by_name(cons, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_copy_release)
@@ -491,7 +503,8 @@ TEST_F(TestCApiBlackDatatype, dt_copy_release)
 
 TEST_F(TestCApiBlackDatatype, dt_cons_to_string)
 {
-  ASSERT_CVC5_ERROR(cvc5_dt_cons_to_string(nullptr), "invalid datatype constructor");
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_to_string(nullptr),
+                    "invalid datatype constructor");
   Cvc5Datatype dt = create_datatype();
   Cvc5DatatypeConstructor cons = cvc5_dt_get_constructor(dt, 0);
   ASSERT_EQ(cvc5_dt_cons_to_string(cons),
@@ -512,16 +525,17 @@ TEST_F(TestCApiBlackDatatype, dt_get_constructor_by_name)
 {
   Cvc5Datatype dt = create_datatype();
   ASSERT_CVC5_ERROR(cvc5_dt_get_constructor_by_name(nullptr, "cons"),
-               "invalid datatype");
+                    "invalid datatype");
   ASSERT_CVC5_ERROR(cvc5_dt_get_constructor_by_name(dt, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_get_selector)
 {
   Cvc5Datatype dt = create_datatype();
   ASSERT_CVC5_ERROR(cvc5_dt_get_selector(nullptr, "cons"), "invalid datatype");
-  ASSERT_CVC5_ERROR(cvc5_dt_get_selector(dt, nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_dt_get_selector(dt, nullptr),
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_get_name)
@@ -539,7 +553,8 @@ TEST_F(TestCApiBlackDatatype, dt_get_parameters)
   size_t size;
   Cvc5Datatype dt = create_datatype();
   ASSERT_CVC5_ERROR(cvc5_dt_get_parameters(nullptr, &size), "invalid datatype");
-  ASSERT_CVC5_ERROR(cvc5_dt_get_parameters(dt, nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_dt_get_parameters(dt, nullptr),
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_is_parametric)
@@ -638,7 +653,7 @@ TEST_F(TestCApiBlackDatatype, datatype_structs)
   cvc5_dt_cons_decl_add_selector_self(cons, "tail");
 
   ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_add_selector(cons, "head", nullptr),
-               "invalid sort");
+                    "invalid sort");
   ;
 
   cvc5_dt_decl_add_constructor(decl, cons);
@@ -726,12 +741,12 @@ TEST_F(TestCApiBlackDatatype, datatype_names)
   Cvc5Datatype dt = cvc5_sort_get_datatype(dt_sort);
   size_t size;
   ASSERT_CVC5_ERROR(cvc5_dt_get_parameters(dt, &size),
-               "expected parametric datatype");
+                    "expected parametric datatype");
   ASSERT_EQ(cvc5_dt_get_name(dt), std::string("list"));
   (void)cvc5_dt_get_constructor_by_name(dt, "nil");
   (void)cvc5_dt_get_constructor_by_name(dt, "cons");
   ASSERT_CVC5_ERROR(cvc5_dt_get_constructor_by_name(dt, "head"),
-               "no constructor head");
+                    "no constructor head");
   ASSERT_CVC5_ERROR(cvc5_dt_get_constructor_by_name(dt, ""), "no constructor");
 
   Cvc5DatatypeConstructor dt_cons = cvc5_dt_get_constructor(dt, 0);
@@ -739,7 +754,7 @@ TEST_F(TestCApiBlackDatatype, datatype_names)
   (void)cvc5_dt_cons_get_selector_by_name(dt_cons, "head");
   (void)cvc5_dt_cons_get_selector_by_name(dt_cons, "tail");
   ASSERT_CVC5_ERROR(cvc5_dt_cons_get_selector_by_name(dt_cons, "cons"),
-               "no selector");
+                    "no selector");
 
   // get selector
   Cvc5DatatypeSelector dt_sel_tail = cvc5_dt_cons_get_selector(dt_cons, 1);
@@ -751,9 +766,11 @@ TEST_F(TestCApiBlackDatatype, datatype_names)
   (void)cvc5_dt_get_selector(dt, "head");
   ASSERT_CVC5_ERROR(cvc5_dt_get_selector(dt, "cons"), "no selector");
 
-  ASSERT_CVC5_ERROR(cvc5_dt_decl_get_name(nullptr), "invalid datatype declaration");
+  ASSERT_CVC5_ERROR(cvc5_dt_decl_get_name(nullptr),
+                    "invalid datatype declaration");
   ASSERT_CVC5_ERROR(cvc5_dt_get_name(nullptr), "invalid datatype");
-  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_name(nullptr), "invalid datatype constructor");
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_name(nullptr),
+                    "invalid datatype constructor");
   ASSERT_CVC5_ERROR(cvc5_dt_sel_get_name(nullptr), "invalid datatype selector");
 }
 
@@ -830,7 +847,7 @@ TEST_F(TestCApiBlackDatatype, is_finite)
 
   Cvc5Sort pdt_sort = cvc5_mk_dt_sort(d_tm, pdecl);
   ASSERT_CVC5_ERROR(cvc5_dt_is_finite(cvc5_sort_get_datatype(pdt_sort)),
-               "expected non-parametric datatype");
+                    "expected non-parametric datatype");
 }
 
 TEST_F(TestCApiBlackDatatype, datatype_simply_rec)
@@ -1045,6 +1062,6 @@ TEST_F(TestCApiBlackDatatype, datatype_specialized_cons)
   ASSERT_TRUE(cvc5_term_is_disequal(cons_term, cvc5_dt_cons_get_term(nilc)));
   // error to get the specialized constructor term for Int
   ASSERT_CVC5_ERROR(cvc5_dt_cons_get_instantiated_term(nilc, d_int),
-               "cannot get specialized constructor");
+                    "cannot get specialized constructor");
 }
 }  // namespace cvc5::internal::test

--- a/test/unit/api/c/capi_datatype_black.cpp
+++ b/test/unit/api/c/capi_datatype_black.cpp
@@ -16,6 +16,7 @@ extern "C" {
 
 #include "base/output.h"
 #include "gtest/gtest.h"
+#include "test_capi.h"
 
 namespace cvc5::internal::test {
 
@@ -80,13 +81,13 @@ TEST_F(TestCApiBlackDatatype, mk_dt_sort)
   Cvc5DatatypeConstructorDecl nil = cvc5_mk_dt_cons_decl(d_tm, "nil");
   cvc5_dt_decl_add_constructor(decl, nil);
 
-  ASSERT_DEATH(cvc5_mk_dt_sort(nullptr, decl), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_dt_sort(d_tm, nullptr), "invalid datatype declaration");
+  ASSERT_CVC5_ERROR(cvc5_mk_dt_sort(nullptr, decl), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_dt_sort(d_tm, nullptr), "invalid datatype declaration");
   Cvc5Sort list_sort = cvc5_mk_dt_sort(d_tm, decl);
   Cvc5Datatype dt = cvc5_sort_get_datatype(list_sort);
   Cvc5DatatypeConstructor cons_cons = cvc5_dt_get_constructor(dt, 0);
   Cvc5DatatypeConstructor cons_nil = cvc5_dt_get_constructor(dt, 1);
-  ASSERT_DEATH(cvc5_dt_get_constructor(dt, 2), "index out of bounds");
+  ASSERT_CVC5_ERROR(cvc5_dt_get_constructor(dt, 2), "index out of bounds");
   (void)cvc5_dt_cons_get_term(cons_cons);
   (void)cvc5_dt_cons_get_term(cons_nil);
 }
@@ -145,12 +146,12 @@ TEST_F(TestCApiBlackDatatype, equal_hash)
   ASSERT_TRUE(cvc5_dt_is_equal(dt1, dt1));
   ASSERT_FALSE(cvc5_dt_is_equal(dt1, dt2));
 
-  ASSERT_DEATH(cvc5_dt_cons_decl_hash(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_hash(nullptr),
                "invalid datatype constructor declaration");
-  ASSERT_DEATH(cvc5_dt_decl_hash(nullptr), "invalid datatype declaration");
-  ASSERT_DEATH(cvc5_dt_cons_hash(nullptr), "invalid datatype constructor");
-  ASSERT_DEATH(cvc5_dt_sel_hash(nullptr), "invalid datatype selector");
-  ASSERT_DEATH(cvc5_dt_hash(nullptr), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_decl_hash(nullptr), "invalid datatype declaration");
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_hash(nullptr), "invalid datatype constructor");
+  ASSERT_CVC5_ERROR(cvc5_dt_sel_hash(nullptr), "invalid datatype selector");
+  ASSERT_CVC5_ERROR(cvc5_dt_hash(nullptr), "invalid datatype");
 
   ASSERT_EQ(cvc5_dt_decl_hash(decl1), cvc5_dt_decl_hash(decl1));
   ASSERT_EQ(cvc5_dt_decl_hash(decl1), cvc5_dt_decl_hash(decl2));
@@ -222,23 +223,23 @@ TEST_F(TestCApiBlackDatatype, mk_datatype_sorts)
   ASSERT_TRUE(cvc5_sort_is_equal(
       cvc5_dt_sel_get_codomain_sort(dt_tree_node_left), dtsorts[0]));
 
-  ASSERT_DEATH(cvc5_mk_dt_sorts(nullptr, dtdecls.size(), dtdecls.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_dt_sorts(nullptr, dtdecls.size(), dtdecls.data()),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_dt_sorts(d_tm, dtdecls.size(), nullptr),
+  ASSERT_CVC5_ERROR(cvc5_mk_dt_sorts(d_tm, dtdecls.size(), nullptr),
                "unexpected NULL argument");
 
   // fails due to empty datatype
   std::vector<Cvc5DatatypeDecl> dtdecls_bad{
       cvc5_mk_dt_decl(d_tm, "emptyD", false)};
-  ASSERT_DEATH(cvc5_mk_dt_sorts(d_tm, dtdecls_bad.size(), dtdecls_bad.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_dt_sorts(d_tm, dtdecls_bad.size(), dtdecls_bad.data()),
                "invalid datatype declaration");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_decl_copy_release)
 {
-  ASSERT_DEATH(cvc5_dt_cons_decl_copy(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_copy(nullptr),
                "invalid datatype constructor declaration");
-  ASSERT_DEATH(cvc5_dt_cons_decl_release(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_release(nullptr),
                "invalid datatype constructor declaration");
   Cvc5DatatypeConstructorDecl decl = cvc5_mk_dt_cons_decl(d_tm, "cons");
   Cvc5DatatypeConstructorDecl decl_copy = cvc5_dt_cons_decl_copy(decl);
@@ -253,37 +254,37 @@ TEST_F(TestCApiBlackDatatype, dt_cons_decl_copy_release)
 TEST_F(TestCApiBlackDatatype, dt_cons_decl_add_selector)
 {
   Cvc5DatatypeConstructorDecl cons = cvc5_mk_dt_cons_decl(d_tm, "cons");
-  ASSERT_DEATH(cvc5_dt_cons_decl_add_selector(nullptr, "foo", d_int),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_add_selector(nullptr, "foo", d_int),
                "invalid datatype constructor declaration");
-  ASSERT_DEATH(cvc5_dt_cons_decl_add_selector(cons, nullptr, d_int),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_add_selector(cons, nullptr, d_int),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_dt_cons_decl_add_selector(cons, "foo", nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_add_selector(cons, "foo", nullptr),
                "invalid sort");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_decl_add_selector_self)
 {
   Cvc5DatatypeConstructorDecl cons = cvc5_mk_dt_cons_decl(d_tm, "cons");
-  ASSERT_DEATH(cvc5_dt_cons_decl_add_selector_self(nullptr, "foo"),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_add_selector_self(nullptr, "foo"),
                "invalid datatype constructor declaration");
-  ASSERT_DEATH(cvc5_dt_cons_decl_add_selector_self(cons, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_add_selector_self(cons, nullptr),
                "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_decl_add_selector_unresolved)
 {
   Cvc5DatatypeConstructorDecl cons = cvc5_mk_dt_cons_decl(d_tm, "cons");
-  ASSERT_DEATH(cvc5_dt_cons_decl_add_selector_unresolved(nullptr, "foo", "bar"),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_add_selector_unresolved(nullptr, "foo", "bar"),
                "invalid datatype constructor declaration");
-  ASSERT_DEATH(cvc5_dt_cons_decl_add_selector_unresolved(cons, nullptr, "bar"),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_add_selector_unresolved(cons, nullptr, "bar"),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_dt_cons_decl_add_selector_unresolved(cons, "foo", nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_add_selector_unresolved(cons, "foo", nullptr),
                "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_decl_to_string)
 {
-  ASSERT_DEATH(cvc5_dt_cons_decl_to_string(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_to_string(nullptr),
                "invalid datatype constructor declaration");
   Cvc5DatatypeConstructorDecl cons = cvc5_mk_dt_cons_decl(d_tm, "cons");
   (void)cvc5_dt_cons_decl_to_string(cons);
@@ -291,14 +292,14 @@ TEST_F(TestCApiBlackDatatype, dt_cons_decl_to_string)
 
 TEST_F(TestCApiBlackDatatype, dt_cons_decl_hash)
 {
-  ASSERT_DEATH(cvc5_dt_cons_decl_hash(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_hash(nullptr),
                "invalid datatype constructor declaration");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_decl_copy_release)
 {
-  ASSERT_DEATH(cvc5_dt_decl_copy(nullptr), "invalid datatype declaration");
-  ASSERT_DEATH(cvc5_dt_decl_release(nullptr), "invalid datatype declaration");
+  ASSERT_CVC5_ERROR(cvc5_dt_decl_copy(nullptr), "invalid datatype declaration");
+  ASSERT_CVC5_ERROR(cvc5_dt_decl_release(nullptr), "invalid datatype declaration");
   Cvc5DatatypeDecl decl = cvc5_mk_dt_decl(d_tm, "tree", false);
   Cvc5DatatypeDecl decl_copy = cvc5_dt_decl_copy(decl);
   ASSERT_EQ(cvc5_dt_decl_hash(decl), cvc5_dt_decl_hash(decl_copy));
@@ -313,15 +314,15 @@ TEST_F(TestCApiBlackDatatype, dt_decl_add_constructor)
 {
   Cvc5DatatypeDecl decl = cvc5_mk_dt_decl(d_tm, "tree", false);
   Cvc5DatatypeConstructorDecl node = cvc5_mk_dt_cons_decl(d_tm, "node");
-  ASSERT_DEATH(cvc5_dt_decl_add_constructor(nullptr, node),
+  ASSERT_CVC5_ERROR(cvc5_dt_decl_add_constructor(nullptr, node),
                "invalid datatype declaration");
-  ASSERT_DEATH(cvc5_dt_decl_add_constructor(decl, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_decl_add_constructor(decl, nullptr),
                "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_decl_get_num_constructors)
 {
-  ASSERT_DEATH(cvc5_dt_decl_get_num_constructors(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_decl_get_num_constructors(nullptr),
                "invalid datatype declaration");
   Cvc5DatatypeDecl decl = create_datatype_decl();
   ASSERT_EQ(cvc5_dt_decl_get_num_constructors(decl), 2);
@@ -329,7 +330,7 @@ TEST_F(TestCApiBlackDatatype, dt_decl_get_num_constructors)
 
 TEST_F(TestCApiBlackDatatype, dt_decl_is_parametric)
 {
-  ASSERT_DEATH(cvc5_dt_decl_is_parametric(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_decl_is_parametric(nullptr),
                "invalid datatype declaration");
   Cvc5DatatypeDecl decl = create_datatype_decl();
   ASSERT_FALSE(cvc5_dt_decl_is_parametric(decl));
@@ -337,7 +338,7 @@ TEST_F(TestCApiBlackDatatype, dt_decl_is_parametric)
 
 TEST_F(TestCApiBlackDatatype, dt_decl_is_resolved)
 {
-  ASSERT_DEATH(cvc5_dt_decl_is_resolved(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_decl_is_resolved(nullptr),
                "invalid datatype declaration");
   Cvc5DatatypeDecl decl = create_datatype_decl();
   ASSERT_FALSE(cvc5_dt_decl_is_resolved(decl));
@@ -345,25 +346,25 @@ TEST_F(TestCApiBlackDatatype, dt_decl_is_resolved)
 
 TEST_F(TestCApiBlackDatatype, dt_decl_get_name)
 {
-  ASSERT_DEATH(cvc5_dt_decl_get_name(nullptr), "invalid datatype declaration");
+  ASSERT_CVC5_ERROR(cvc5_dt_decl_get_name(nullptr), "invalid datatype declaration");
   Cvc5DatatypeDecl decl = create_datatype_decl();
   ASSERT_EQ(cvc5_dt_decl_get_name(decl), std::string("list"));
 }
 
 TEST_F(TestCApiBlackDatatype, dt_decl_to_string)
 {
-  ASSERT_DEATH(cvc5_dt_decl_to_string(nullptr), "invalid datatype declaration");
+  ASSERT_CVC5_ERROR(cvc5_dt_decl_to_string(nullptr), "invalid datatype declaration");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_decl_hash)
 {
-  ASSERT_DEATH(cvc5_dt_decl_hash(nullptr), "invalid datatype declaration");
+  ASSERT_CVC5_ERROR(cvc5_dt_decl_hash(nullptr), "invalid datatype declaration");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_sel_copy_release)
 {
-  ASSERT_DEATH(cvc5_dt_sel_copy(nullptr), "invalid datatype selector");
-  ASSERT_DEATH(cvc5_dt_sel_release(nullptr), "invalid datatype selector");
+  ASSERT_CVC5_ERROR(cvc5_dt_sel_copy(nullptr), "invalid datatype selector");
+  ASSERT_CVC5_ERROR(cvc5_dt_sel_release(nullptr), "invalid datatype selector");
   Cvc5Datatype dt = create_datatype();
   Cvc5DatatypeSelector sel = cvc5_dt_get_selector(dt, "head");
   Cvc5DatatypeSelector sel_copy = cvc5_dt_sel_copy(sel);
@@ -377,29 +378,29 @@ TEST_F(TestCApiBlackDatatype, dt_sel_copy_release)
 
 TEST_F(TestCApiBlackDatatype, dt_sel_get_name)
 {
-  ASSERT_DEATH(cvc5_dt_sel_get_name(nullptr), "invalid datatype selector");
+  ASSERT_CVC5_ERROR(cvc5_dt_sel_get_name(nullptr), "invalid datatype selector");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_sel_get_term)
 {
-  ASSERT_DEATH(cvc5_dt_sel_get_term(nullptr), "invalid datatype selector");
+  ASSERT_CVC5_ERROR(cvc5_dt_sel_get_term(nullptr), "invalid datatype selector");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_sel_get_updater_term)
 {
-  ASSERT_DEATH(cvc5_dt_sel_get_updater_term(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_sel_get_updater_term(nullptr),
                "invalid datatype selector");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_sel_get_codomain_sort)
 {
-  ASSERT_DEATH(cvc5_dt_sel_get_codomain_sort(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_sel_get_codomain_sort(nullptr),
                "invalid datatype selector");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_sel_to_string)
 {
-  ASSERT_DEATH(cvc5_dt_sel_to_string(nullptr), "invalid datatype selector");
+  ASSERT_CVC5_ERROR(cvc5_dt_sel_to_string(nullptr), "invalid datatype selector");
   Cvc5Datatype dt = create_datatype();
   Cvc5DatatypeSelector head =
       cvc5_dt_cons_get_selector_by_name(cvc5_dt_get_constructor(dt, 0), "head");
@@ -408,13 +409,13 @@ TEST_F(TestCApiBlackDatatype, dt_sel_to_string)
 
 TEST_F(TestCApiBlackDatatype, dt_sel_hash)
 {
-  ASSERT_DEATH(cvc5_dt_sel_hash(nullptr), "invalid datatype selector");
+  ASSERT_CVC5_ERROR(cvc5_dt_sel_hash(nullptr), "invalid datatype selector");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_copy_release)
 {
-  ASSERT_DEATH(cvc5_dt_cons_copy(nullptr), "invalid datatype constructor");
-  ASSERT_DEATH(cvc5_dt_cons_release(nullptr), "invalid datatype constructor");
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_copy(nullptr), "invalid datatype constructor");
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_release(nullptr), "invalid datatype constructor");
   Cvc5Datatype dt = create_datatype();
   Cvc5DatatypeConstructor cons = cvc5_dt_get_constructor(dt, 0);
   Cvc5DatatypeConstructor cons_copy = cvc5_dt_cons_copy(cons);
@@ -428,39 +429,39 @@ TEST_F(TestCApiBlackDatatype, dt_cons_copy_release)
 
 TEST_F(TestCApiBlackDatatype, dt_cons_get_name)
 {
-  ASSERT_DEATH(cvc5_dt_cons_get_name(nullptr), "invalid datatype constructor");
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_name(nullptr), "invalid datatype constructor");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_get_term)
 {
-  ASSERT_DEATH(cvc5_dt_cons_get_term(nullptr), "invalid datatype constructor");
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_term(nullptr), "invalid datatype constructor");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_get_instantiated_term)
 {
   Cvc5Datatype dt = create_datatype();
   Cvc5DatatypeConstructor cons = cvc5_dt_get_constructor(dt, 0);
-  ASSERT_DEATH(cvc5_dt_cons_get_instantiated_term(nullptr, d_int),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_instantiated_term(nullptr, d_int),
                "invalid datatype constructor");
-  ASSERT_DEATH(cvc5_dt_cons_get_instantiated_term(cons, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_instantiated_term(cons, nullptr),
                "invalid sort");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_get_tester_term)
 {
-  ASSERT_DEATH(cvc5_dt_cons_get_tester_term(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_tester_term(nullptr),
                "invalid datatype constructor");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_get_num_selectors)
 {
-  ASSERT_DEATH(cvc5_dt_cons_get_num_selectors(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_num_selectors(nullptr),
                "invalid datatype constructor");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_cons_get_selector)
 {
-  ASSERT_DEATH(cvc5_dt_cons_get_selector(nullptr, 0),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_selector(nullptr, 0),
                "invalid datatype constructor");
 }
 
@@ -468,16 +469,16 @@ TEST_F(TestCApiBlackDatatype, dt_cons_get_selector_by_name)
 {
   Cvc5Datatype dt = create_datatype();
   Cvc5DatatypeConstructor cons = cvc5_dt_get_constructor(dt, 0);
-  ASSERT_DEATH(cvc5_dt_cons_get_selector_by_name(nullptr, "cons"),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_selector_by_name(nullptr, "cons"),
                "invalid datatype constructor");
-  ASSERT_DEATH(cvc5_dt_cons_get_selector_by_name(cons, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_selector_by_name(cons, nullptr),
                "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_copy_release)
 {
-  ASSERT_DEATH(cvc5_dt_copy(nullptr), "invalid datatype");
-  ASSERT_DEATH(cvc5_dt_release(nullptr), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_copy(nullptr), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_release(nullptr), "invalid datatype");
   Cvc5Datatype dt = create_datatype();
   Cvc5Datatype dt_copy = cvc5_dt_copy(dt);
   ASSERT_EQ(cvc5_dt_hash(dt), cvc5_dt_hash(dt_copy));
@@ -490,7 +491,7 @@ TEST_F(TestCApiBlackDatatype, dt_copy_release)
 
 TEST_F(TestCApiBlackDatatype, dt_cons_to_string)
 {
-  ASSERT_DEATH(cvc5_dt_cons_to_string(nullptr), "invalid datatype constructor");
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_to_string(nullptr), "invalid datatype constructor");
   Cvc5Datatype dt = create_datatype();
   Cvc5DatatypeConstructor cons = cvc5_dt_get_constructor(dt, 0);
   ASSERT_EQ(cvc5_dt_cons_to_string(cons),
@@ -499,86 +500,86 @@ TEST_F(TestCApiBlackDatatype, dt_cons_to_string)
 
 TEST_F(TestCApiBlackDatatype, dt_cons_hash)
 {
-  ASSERT_DEATH(cvc5_dt_cons_hash(nullptr), "invalid datatype constructor");
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_hash(nullptr), "invalid datatype constructor");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_get_constructor)
 {
-  ASSERT_DEATH(cvc5_dt_get_constructor(nullptr, 0), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_get_constructor(nullptr, 0), "invalid datatype");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_get_constructor_by_name)
 {
   Cvc5Datatype dt = create_datatype();
-  ASSERT_DEATH(cvc5_dt_get_constructor_by_name(nullptr, "cons"),
+  ASSERT_CVC5_ERROR(cvc5_dt_get_constructor_by_name(nullptr, "cons"),
                "invalid datatype");
-  ASSERT_DEATH(cvc5_dt_get_constructor_by_name(dt, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_get_constructor_by_name(dt, nullptr),
                "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_get_selector)
 {
   Cvc5Datatype dt = create_datatype();
-  ASSERT_DEATH(cvc5_dt_get_selector(nullptr, "cons"), "invalid datatype");
-  ASSERT_DEATH(cvc5_dt_get_selector(dt, nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_dt_get_selector(nullptr, "cons"), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_get_selector(dt, nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_get_name)
 {
-  ASSERT_DEATH(cvc5_dt_get_name(nullptr), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_get_name(nullptr), "invalid datatype");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_get_num_constructors)
 {
-  ASSERT_DEATH(cvc5_dt_get_num_constructors(nullptr), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_get_num_constructors(nullptr), "invalid datatype");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_get_parameters)
 {
   size_t size;
   Cvc5Datatype dt = create_datatype();
-  ASSERT_DEATH(cvc5_dt_get_parameters(nullptr, &size), "invalid datatype");
-  ASSERT_DEATH(cvc5_dt_get_parameters(dt, nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_dt_get_parameters(nullptr, &size), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_get_parameters(dt, nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_is_parametric)
 {
-  ASSERT_DEATH(cvc5_dt_is_parametric(nullptr), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_is_parametric(nullptr), "invalid datatype");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_is_codatatype)
 {
-  ASSERT_DEATH(cvc5_dt_is_codatatype(nullptr), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_is_codatatype(nullptr), "invalid datatype");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_is_tuple)
 {
-  ASSERT_DEATH(cvc5_dt_is_tuple(nullptr), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_is_tuple(nullptr), "invalid datatype");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_is_record)
 {
-  ASSERT_DEATH(cvc5_dt_is_record(nullptr), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_is_record(nullptr), "invalid datatype");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_is_finite)
 {
-  ASSERT_DEATH(cvc5_dt_is_finite(nullptr), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_is_finite(nullptr), "invalid datatype");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_is_well_founded)
 {
-  ASSERT_DEATH(cvc5_dt_is_well_founded(nullptr), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_is_well_founded(nullptr), "invalid datatype");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_to_string)
 {
-  ASSERT_DEATH(cvc5_dt_to_string(nullptr), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_to_string(nullptr), "invalid datatype");
 }
 
 TEST_F(TestCApiBlackDatatype, dt_hash)
 {
-  ASSERT_DEATH(cvc5_dt_hash(nullptr), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_hash(nullptr), "invalid datatype");
 }
 
 TEST_F(TestCApiBlackDatatype, mk_dt_sorts_sel_unres)
@@ -636,7 +637,7 @@ TEST_F(TestCApiBlackDatatype, datatype_structs)
   cvc5_dt_cons_decl_add_selector(cons, "head", d_int);
   cvc5_dt_cons_decl_add_selector_self(cons, "tail");
 
-  ASSERT_DEATH(cvc5_dt_cons_decl_add_selector(cons, "head", nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_decl_add_selector(cons, "head", nullptr),
                "invalid sort");
   ;
 
@@ -724,20 +725,20 @@ TEST_F(TestCApiBlackDatatype, datatype_names)
   Cvc5Sort dt_sort = cvc5_mk_dt_sort(d_tm, list);
   Cvc5Datatype dt = cvc5_sort_get_datatype(dt_sort);
   size_t size;
-  ASSERT_DEATH(cvc5_dt_get_parameters(dt, &size),
+  ASSERT_CVC5_ERROR(cvc5_dt_get_parameters(dt, &size),
                "expected parametric datatype");
   ASSERT_EQ(cvc5_dt_get_name(dt), std::string("list"));
   (void)cvc5_dt_get_constructor_by_name(dt, "nil");
   (void)cvc5_dt_get_constructor_by_name(dt, "cons");
-  ASSERT_DEATH(cvc5_dt_get_constructor_by_name(dt, "head"),
+  ASSERT_CVC5_ERROR(cvc5_dt_get_constructor_by_name(dt, "head"),
                "no constructor head");
-  ASSERT_DEATH(cvc5_dt_get_constructor_by_name(dt, ""), "no constructor");
+  ASSERT_CVC5_ERROR(cvc5_dt_get_constructor_by_name(dt, ""), "no constructor");
 
   Cvc5DatatypeConstructor dt_cons = cvc5_dt_get_constructor(dt, 0);
   ASSERT_EQ(cvc5_dt_cons_get_name(dt_cons), std::string("cons"));
   (void)cvc5_dt_cons_get_selector_by_name(dt_cons, "head");
   (void)cvc5_dt_cons_get_selector_by_name(dt_cons, "tail");
-  ASSERT_DEATH(cvc5_dt_cons_get_selector_by_name(dt_cons, "cons"),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_selector_by_name(dt_cons, "cons"),
                "no selector");
 
   // get selector
@@ -748,12 +749,12 @@ TEST_F(TestCApiBlackDatatype, datatype_names)
 
   // get selector from datatype
   (void)cvc5_dt_get_selector(dt, "head");
-  ASSERT_DEATH(cvc5_dt_get_selector(dt, "cons"), "no selector");
+  ASSERT_CVC5_ERROR(cvc5_dt_get_selector(dt, "cons"), "no selector");
 
-  ASSERT_DEATH(cvc5_dt_decl_get_name(nullptr), "invalid datatype declaration");
-  ASSERT_DEATH(cvc5_dt_get_name(nullptr), "invalid datatype");
-  ASSERT_DEATH(cvc5_dt_cons_get_name(nullptr), "invalid datatype constructor");
-  ASSERT_DEATH(cvc5_dt_sel_get_name(nullptr), "invalid datatype selector");
+  ASSERT_CVC5_ERROR(cvc5_dt_decl_get_name(nullptr), "invalid datatype declaration");
+  ASSERT_CVC5_ERROR(cvc5_dt_get_name(nullptr), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_name(nullptr), "invalid datatype constructor");
+  ASSERT_CVC5_ERROR(cvc5_dt_sel_get_name(nullptr), "invalid datatype selector");
 }
 
 TEST_F(TestCApiBlackDatatype, parametric_datatype)
@@ -793,14 +794,14 @@ TEST_F(TestCApiBlackDatatype, parametric_datatype)
   ASSERT_FALSE(cvc5_sort_is_equal(pair_int_int, pair_real_int));
   ASSERT_FALSE(cvc5_sort_is_equal(pair_int_real, pair_real_int));
 
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_dt_decl_with_params(nullptr, "pair", v.size(), v.data(), false),
       "unexpected NULL argument");
   v = {};
   (void)cvc5_mk_dt_decl_with_params(d_tm, "some", v.size(), v.data(), false);
   (void)cvc5_mk_dt_decl_with_params(d_tm, "some", v.size(), nullptr, false);
   v = {nullptr};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_dt_decl_with_params(d_tm, "pair", v.size(), v.data(), false),
       "invalid sort at index 0");
 }
@@ -825,10 +826,10 @@ TEST_F(TestCApiBlackDatatype, is_finite)
   cvc5_dt_cons_decl_add_selector(pcons, "sel", p);
   cvc5_dt_decl_add_constructor(pdecl, pcons);
 
-  ASSERT_DEATH(cvc5_dt_is_finite(nullptr), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_is_finite(nullptr), "invalid datatype");
 
   Cvc5Sort pdt_sort = cvc5_mk_dt_sort(d_tm, pdecl);
-  ASSERT_DEATH(cvc5_dt_is_finite(cvc5_sort_get_datatype(pdt_sort)),
+  ASSERT_CVC5_ERROR(cvc5_dt_is_finite(cvc5_sort_get_datatype(pdt_sort)),
                "expected non-parametric datatype");
 }
 
@@ -1043,7 +1044,7 @@ TEST_F(TestCApiBlackDatatype, datatype_specialized_cons)
   // get the specialized constructor term for list[Int]
   ASSERT_TRUE(cvc5_term_is_disequal(cons_term, cvc5_dt_cons_get_term(nilc)));
   // error to get the specialized constructor term for Int
-  ASSERT_DEATH(cvc5_dt_cons_get_instantiated_term(nilc, d_int),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_instantiated_term(nilc, d_int),
                "cannot get specialized constructor");
 }
 }  // namespace cvc5::internal::test

--- a/test/unit/api/c/capi_error_handling_black.cpp
+++ b/test/unit/api/c/capi_error_handling_black.cpp
@@ -1,0 +1,112 @@
+/******************************************************************************
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2026 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Black box testing of the error handling of the cvc5 C API.
+ */
+
+extern "C" {
+#include <cvc5/c/cvc5.h>
+}
+
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "test_capi.h"
+
+namespace cvc5::internal::test {
+
+class TestCApiBlackErrorHandling : public ::testing::Test
+{
+ protected:
+  void SetUp() override
+  {
+    d_tm = cvc5_term_manager_new();
+    d_solver = cvc5_new(d_tm);
+  }
+  void TearDown() override
+  {
+    cvc5_delete(d_solver);
+    cvc5_term_manager_delete(d_tm);
+  }
+  Cvc5TermManager* d_tm;
+  Cvc5* d_solver;
+};
+
+TEST_F(TestCApiBlackErrorHandling, no_error_initially)
+{
+  cvc5_reset_error();
+  ASSERT_FALSE(cvc5_has_error());
+  ASSERT_STREQ(cvc5_get_error_message(), "");
+}
+
+TEST_F(TestCApiBlackErrorHandling, error_is_captured_not_fatal)
+{
+  // An invalid call records an error instead of terminating the process.
+  Cvc5Sort sort = cvc5_sort_array_get_index_sort(nullptr);
+  ASSERT_EQ(sort, nullptr);
+  ASSERT_TRUE(cvc5_has_error());
+  ASSERT_NE(std::string(cvc5_get_error_message()).find("invalid sort"),
+            std::string::npos);
+}
+
+TEST_F(TestCApiBlackErrorHandling, error_state_resets_on_next_call)
+{
+  // Trigger an error.
+  (void)cvc5_sort_array_get_index_sort(nullptr);
+  ASSERT_TRUE(cvc5_has_error());
+  // A subsequent successful call clears the error state.
+  Cvc5Sort b = cvc5_get_boolean_sort(d_tm);
+  ASSERT_NE(b, nullptr);
+  ASSERT_FALSE(cvc5_has_error());
+  ASSERT_STREQ(cvc5_get_error_message(), "");
+}
+
+TEST_F(TestCApiBlackErrorHandling, reset_error)
+{
+  (void)cvc5_sort_array_get_index_sort(nullptr);
+  ASSERT_TRUE(cvc5_has_error());
+  cvc5_reset_error();
+  ASSERT_FALSE(cvc5_has_error());
+  ASSERT_STREQ(cvc5_get_error_message(), "");
+}
+
+TEST_F(TestCApiBlackErrorHandling, query_does_not_clear_error)
+{
+  (void)cvc5_sort_array_get_index_sort(nullptr);
+  // Querying the error state must not reset it.
+  ASSERT_TRUE(cvc5_has_error());
+  ASSERT_TRUE(cvc5_has_error());
+  std::string msg = cvc5_get_error_message();
+  ASSERT_FALSE(msg.empty());
+  ASSERT_EQ(msg, std::string(cvc5_get_error_message()));
+}
+
+TEST_F(TestCApiBlackErrorHandling, recover_and_continue)
+{
+  // Errors do not corrupt the solver: usage continues normally afterwards.
+  (void)cvc5_sort_array_get_index_sort(nullptr);
+  ASSERT_TRUE(cvc5_has_error());
+
+  Cvc5Sort int_sort = cvc5_get_integer_sort(d_tm);
+  Cvc5Term x = cvc5_mk_const(d_tm, int_sort, "x");
+  std::vector<Cvc5Term> args = {x, x};
+  cvc5_assert_formula(
+      d_solver, cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, args.size(), args.data()));
+  Cvc5Result res = cvc5_check_sat(d_solver);
+  ASSERT_FALSE(cvc5_has_error());
+  ASSERT_TRUE(cvc5_result_is_sat(res));
+}
+
+TEST_F(TestCApiBlackErrorHandling, error_macro)
+{
+  ASSERT_CVC5_ERROR(cvc5_sort_array_get_index_sort(nullptr), "invalid sort");
+}
+
+}  // namespace cvc5::internal::test

--- a/test/unit/api/c/capi_error_handling_black.cpp
+++ b/test/unit/api/c/capi_error_handling_black.cpp
@@ -104,6 +104,43 @@ TEST_F(TestCApiBlackErrorHandling, recover_and_continue)
   ASSERT_TRUE(cvc5_result_is_sat(res));
 }
 
+TEST_F(TestCApiBlackErrorHandling, error_message_reflects_most_recent)
+{
+  // The first error sets the message.
+  (void)cvc5_sort_array_get_index_sort(nullptr);
+  ASSERT_TRUE(cvc5_has_error());
+  std::string first = cvc5_get_error_message();
+  ASSERT_NE(first.find("invalid sort"), std::string::npos);
+
+  // A second failing call overwrites it: the message reflects the most recent
+  // error, not the first one.
+  (void)cvc5_term_get_kind(nullptr);
+  ASSERT_TRUE(cvc5_has_error());
+  std::string second = cvc5_get_error_message();
+  ASSERT_NE(second.find("invalid term"), std::string::npos);
+  ASSERT_NE(first, second);
+}
+
+TEST_F(TestCApiBlackErrorHandling, captures_non_recoverable_error)
+{
+  // Errors are not limited to argument validation: a genuine error raised from
+  // deep in the solver (here, an ill-typed term) is captured the same way,
+  // without aborting the process.
+  Cvc5Sort int_sort = cvc5_get_integer_sort(d_tm);
+  Cvc5Term i = cvc5_mk_const(d_tm, int_sort, "i");
+  Cvc5Term t = cvc5_mk_true(d_tm);
+  std::vector<Cvc5Term> args = {i, t};
+  // Equating an Integer and a Boolean is ill-typed.
+  (void)cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, args.size(), args.data());
+  ASSERT_TRUE(cvc5_has_error());
+  ASSERT_STRNE(cvc5_get_error_message(), "");
+
+  // The term manager remains usable after such an error.
+  Cvc5Term ok = cvc5_mk_term(d_tm, CVC5_KIND_NOT, 1, &t);
+  ASSERT_FALSE(cvc5_has_error());
+  ASSERT_NE(ok, nullptr);
+}
+
 TEST_F(TestCApiBlackErrorHandling, error_macro)
 {
   ASSERT_CVC5_ERROR(cvc5_sort_array_get_index_sort(nullptr), "invalid sort");

--- a/test/unit/api/c/capi_grammar_black.cpp
+++ b/test/unit/api/c/capi_grammar_black.cpp
@@ -16,6 +16,7 @@ extern "C" {
 
 #include "base/output.h"
 #include "gtest/gtest.h"
+#include "test_capi.h"
 
 namespace cvc5::internal::test {
 
@@ -57,7 +58,7 @@ TEST_F(TestCApiBlackGrammar, to_string)
       d_solver, bvars.size(), bvars.data(), symbols.size(), symbols.data());
   ASSERT_EQ(cvc5_grammar_to_string(g), std::string(""));
   cvc5_grammar_add_rule(g, start, cvc5_mk_false(d_tm));
-  ASSERT_DEATH(cvc5_grammar_to_string(nullptr), "invalid grammar");
+  ASSERT_CVC5_ERROR(cvc5_grammar_to_string(nullptr), "invalid grammar");
   ASSERT_NE(cvc5_grammar_to_string(g), std::string(""));
 }
 
@@ -74,19 +75,19 @@ TEST_F(TestCApiBlackGrammar, add_rule)
 
   cvc5_grammar_add_rule(g, start, cvc5_mk_false(d_tm));
 
-  ASSERT_DEATH(cvc5_grammar_add_rule(nullptr, start, cvc5_mk_false(d_tm)),
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_rule(nullptr, start, cvc5_mk_false(d_tm)),
                "invalid grammar");
-  ASSERT_DEATH(cvc5_grammar_add_rule(g, nullptr, cvc5_mk_false(d_tm)),
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_rule(g, nullptr, cvc5_mk_false(d_tm)),
                "invalid term");
-  ASSERT_DEATH(cvc5_grammar_add_rule(g, start, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_rule(g, start, nullptr), "invalid term");
 
-  ASSERT_DEATH(cvc5_grammar_add_rule(g, nts, cvc5_mk_false(d_tm)),
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_rule(g, nts, cvc5_mk_false(d_tm)),
                "invalid argument");
-  ASSERT_DEATH(cvc5_grammar_add_rule(g, start, cvc5_mk_integer_int64(d_tm, 0)),
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_rule(g, start, cvc5_mk_integer_int64(d_tm, 0)),
                "same sort");
 
   (void)cvc5_synth_fun_with_grammar(d_solver, "f", 0, nullptr, d_bool, g);
-  ASSERT_DEATH(cvc5_grammar_add_rule(g, start, cvc5_mk_false(d_tm)),
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_rule(g, start, cvc5_mk_false(d_tm)),
                "cannot be modified");
 }
 
@@ -104,30 +105,30 @@ TEST_F(TestCApiBlackGrammar, add_rules)
   std::vector<Cvc5Term> rules = {cvc5_mk_false(d_tm)};
   cvc5_grammar_add_rules(g, start, rules.size(), rules.data());
 
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_grammar_add_rules(nullptr, start, rules.size(), rules.data()),
       "invalid grammar");
-  ASSERT_DEATH(cvc5_grammar_add_rules(g, nullptr, rules.size(), rules.data()),
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_rules(g, nullptr, rules.size(), rules.data()),
                "invalid term");
-  ASSERT_DEATH(cvc5_grammar_add_rules(g, start, 0, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_rules(g, start, 0, nullptr),
                "unexpected NULL argument");
 
-  ASSERT_DEATH(cvc5_grammar_add_rules(g, nts, rules.size(), rules.data()),
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_rules(g, nts, rules.size(), rules.data()),
                "invalid argument");
   rules.push_back(nullptr);
-  ASSERT_DEATH(cvc5_grammar_add_rules(g, start, rules.size(), rules.data()),
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_rules(g, start, rules.size(), rules.data()),
                "invalid term at index 1");
   rules = {cvc5_mk_false(d_tm)};
-  ASSERT_DEATH(cvc5_grammar_add_rules(g, nts, rules.size(), rules.data()),
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_rules(g, nts, rules.size(), rules.data()),
                "invalid argument");
   rules = {cvc5_mk_integer_int64(d_tm, 0)};
-  ASSERT_DEATH(cvc5_grammar_add_rules(g, start, rules.size(), rules.data()),
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_rules(g, start, rules.size(), rules.data()),
                "Expected term with sort Bool");
 
   (void)cvc5_synth_fun_with_grammar(d_solver, "f", 0, nullptr, d_bool, g);
 
   rules = {cvc5_mk_false(d_tm)};
-  ASSERT_DEATH(cvc5_grammar_add_rules(g, start, rules.size(), rules.data()),
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_rules(g, start, rules.size(), rules.data()),
                "cannot be modified");
 }
 
@@ -146,15 +147,15 @@ TEST_F(TestCApiBlackGrammar, add_any_constant)
   cvc5_grammar_add_any_constant(g, start);
   cvc5_grammar_add_any_constant(g, start);
 
-  ASSERT_DEATH(cvc5_grammar_add_any_constant(nullptr, start),
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_any_constant(nullptr, start),
                "invalid grammar");
-  ASSERT_DEATH(cvc5_grammar_add_any_constant(g, nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_grammar_add_any_constant(g, nts),
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_any_constant(g, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_any_constant(g, nts),
                "expected ntSymbol to be one of the non-terminal symbols");
 
   (void)cvc5_synth_fun_with_grammar(d_solver, "f", 0, nullptr, d_bool, g);
 
-  ASSERT_DEATH(cvc5_grammar_add_any_constant(g, start), "cannot be modified");
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_any_constant(g, start), "cannot be modified");
 }
 
 TEST_F(TestCApiBlackGrammar, add_any_variable)
@@ -176,15 +177,15 @@ TEST_F(TestCApiBlackGrammar, add_any_variable)
   cvc5_grammar_add_any_variable(g1, start);
   cvc5_grammar_add_any_variable(g2, start);
 
-  ASSERT_DEATH(cvc5_grammar_add_any_variable(nullptr, start),
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_any_variable(nullptr, start),
                "invalid grammar");
-  ASSERT_DEATH(cvc5_grammar_add_any_variable(g1, nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_grammar_add_any_variable(g1, nts),
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_any_variable(g1, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_any_variable(g1, nts),
                "expected ntSymbol to be one of the non-terminal symbols");
 
   (void)cvc5_synth_fun_with_grammar(d_solver, "f", 0, nullptr, d_bool, g1);
 
-  ASSERT_DEATH(cvc5_grammar_add_any_variable(g1, start), "cannot be modified");
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_any_variable(g1, start), "cannot be modified");
 }
 
 TEST_F(TestCApiBlackGrammar, equal_hash)
@@ -300,13 +301,13 @@ TEST_F(TestCApiBlackGrammar, equal_hash)
     ASSERT_FALSE(cvc5_grammar_is_equal(g1, g2));
     ASSERT_TRUE(cvc5_grammar_is_disequal(g1, g2));
   }
-  ASSERT_DEATH(cvc5_grammar_hash(nullptr), "invalid grammar");
+  ASSERT_CVC5_ERROR(cvc5_grammar_hash(nullptr), "invalid grammar");
 }
 
 TEST_F(TestCApiBlackGrammar, copy_release)
 {
-  ASSERT_DEATH(cvc5_grammar_copy(nullptr), "invalid grammar");
-  ASSERT_DEATH(cvc5_grammar_release(nullptr), "invalid grammar");
+  ASSERT_CVC5_ERROR(cvc5_grammar_copy(nullptr), "invalid grammar");
+  ASSERT_CVC5_ERROR(cvc5_grammar_release(nullptr), "invalid grammar");
   cvc5_set_option(d_solver, "sygus", "true");
   Cvc5Term start = cvc5_mk_var(d_tm, d_bool, "start");
   Cvc5Term x = cvc5_mk_var(d_tm, d_bool, "x");

--- a/test/unit/api/c/capi_grammar_black.cpp
+++ b/test/unit/api/c/capi_grammar_black.cpp
@@ -76,19 +76,20 @@ TEST_F(TestCApiBlackGrammar, add_rule)
   cvc5_grammar_add_rule(g, start, cvc5_mk_false(d_tm));
 
   ASSERT_CVC5_ERROR(cvc5_grammar_add_rule(nullptr, start, cvc5_mk_false(d_tm)),
-               "invalid grammar");
+                    "invalid grammar");
   ASSERT_CVC5_ERROR(cvc5_grammar_add_rule(g, nullptr, cvc5_mk_false(d_tm)),
-               "invalid term");
+                    "invalid term");
   ASSERT_CVC5_ERROR(cvc5_grammar_add_rule(g, start, nullptr), "invalid term");
 
   ASSERT_CVC5_ERROR(cvc5_grammar_add_rule(g, nts, cvc5_mk_false(d_tm)),
-               "invalid argument");
-  ASSERT_CVC5_ERROR(cvc5_grammar_add_rule(g, start, cvc5_mk_integer_int64(d_tm, 0)),
-               "same sort");
+                    "invalid argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_grammar_add_rule(g, start, cvc5_mk_integer_int64(d_tm, 0)),
+      "same sort");
 
   (void)cvc5_synth_fun_with_grammar(d_solver, "f", 0, nullptr, d_bool, g);
   ASSERT_CVC5_ERROR(cvc5_grammar_add_rule(g, start, cvc5_mk_false(d_tm)),
-               "cannot be modified");
+                    "cannot be modified");
 }
 
 TEST_F(TestCApiBlackGrammar, add_rules)
@@ -108,28 +109,32 @@ TEST_F(TestCApiBlackGrammar, add_rules)
   ASSERT_CVC5_ERROR(
       cvc5_grammar_add_rules(nullptr, start, rules.size(), rules.data()),
       "invalid grammar");
-  ASSERT_CVC5_ERROR(cvc5_grammar_add_rules(g, nullptr, rules.size(), rules.data()),
-               "invalid term");
+  ASSERT_CVC5_ERROR(
+      cvc5_grammar_add_rules(g, nullptr, rules.size(), rules.data()),
+      "invalid term");
   ASSERT_CVC5_ERROR(cvc5_grammar_add_rules(g, start, 0, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 
   ASSERT_CVC5_ERROR(cvc5_grammar_add_rules(g, nts, rules.size(), rules.data()),
-               "invalid argument");
+                    "invalid argument");
   rules.push_back(nullptr);
-  ASSERT_CVC5_ERROR(cvc5_grammar_add_rules(g, start, rules.size(), rules.data()),
-               "invalid term at index 1");
+  ASSERT_CVC5_ERROR(
+      cvc5_grammar_add_rules(g, start, rules.size(), rules.data()),
+      "invalid term at index 1");
   rules = {cvc5_mk_false(d_tm)};
   ASSERT_CVC5_ERROR(cvc5_grammar_add_rules(g, nts, rules.size(), rules.data()),
-               "invalid argument");
+                    "invalid argument");
   rules = {cvc5_mk_integer_int64(d_tm, 0)};
-  ASSERT_CVC5_ERROR(cvc5_grammar_add_rules(g, start, rules.size(), rules.data()),
-               "Expected term with sort Bool");
+  ASSERT_CVC5_ERROR(
+      cvc5_grammar_add_rules(g, start, rules.size(), rules.data()),
+      "Expected term with sort Bool");
 
   (void)cvc5_synth_fun_with_grammar(d_solver, "f", 0, nullptr, d_bool, g);
 
   rules = {cvc5_mk_false(d_tm)};
-  ASSERT_CVC5_ERROR(cvc5_grammar_add_rules(g, start, rules.size(), rules.data()),
-               "cannot be modified");
+  ASSERT_CVC5_ERROR(
+      cvc5_grammar_add_rules(g, start, rules.size(), rules.data()),
+      "cannot be modified");
 }
 
 TEST_F(TestCApiBlackGrammar, add_any_constant)
@@ -148,14 +153,15 @@ TEST_F(TestCApiBlackGrammar, add_any_constant)
   cvc5_grammar_add_any_constant(g, start);
 
   ASSERT_CVC5_ERROR(cvc5_grammar_add_any_constant(nullptr, start),
-               "invalid grammar");
+                    "invalid grammar");
   ASSERT_CVC5_ERROR(cvc5_grammar_add_any_constant(g, nullptr), "invalid term");
   ASSERT_CVC5_ERROR(cvc5_grammar_add_any_constant(g, nts),
-               "expected ntSymbol to be one of the non-terminal symbols");
+                    "expected ntSymbol to be one of the non-terminal symbols");
 
   (void)cvc5_synth_fun_with_grammar(d_solver, "f", 0, nullptr, d_bool, g);
 
-  ASSERT_CVC5_ERROR(cvc5_grammar_add_any_constant(g, start), "cannot be modified");
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_any_constant(g, start),
+                    "cannot be modified");
 }
 
 TEST_F(TestCApiBlackGrammar, add_any_variable)
@@ -178,14 +184,15 @@ TEST_F(TestCApiBlackGrammar, add_any_variable)
   cvc5_grammar_add_any_variable(g2, start);
 
   ASSERT_CVC5_ERROR(cvc5_grammar_add_any_variable(nullptr, start),
-               "invalid grammar");
+                    "invalid grammar");
   ASSERT_CVC5_ERROR(cvc5_grammar_add_any_variable(g1, nullptr), "invalid term");
   ASSERT_CVC5_ERROR(cvc5_grammar_add_any_variable(g1, nts),
-               "expected ntSymbol to be one of the non-terminal symbols");
+                    "expected ntSymbol to be one of the non-terminal symbols");
 
   (void)cvc5_synth_fun_with_grammar(d_solver, "f", 0, nullptr, d_bool, g1);
 
-  ASSERT_CVC5_ERROR(cvc5_grammar_add_any_variable(g1, start), "cannot be modified");
+  ASSERT_CVC5_ERROR(cvc5_grammar_add_any_variable(g1, start),
+                    "cannot be modified");
 }
 
 TEST_F(TestCApiBlackGrammar, equal_hash)

--- a/test/unit/api/c/capi_input_parser_black.cpp
+++ b/test/unit/api/c/capi_input_parser_black.cpp
@@ -74,15 +74,15 @@ TEST_F(TestCApiBlackInputParser, set_file_input)
   cvc5_parser_set_file_input(
       parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "parse.smt2");
   ASSERT_CVC5_ERROR(cvc5_parser_set_file_input(
-                   nullptr, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "parse.smt2"),
-               "unexpected NULL argument");
+                        nullptr, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "parse.smt2"),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_parser_set_file_input(
-                   parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, nullptr),
-               "unexpected NULL argument");
+                        parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, nullptr),
+                    "unexpected NULL argument");
   std::remove(filename);
   ASSERT_CVC5_ERROR(cvc5_parser_set_file_input(
-                   parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "parse.smt2"),
-               "Couldn't open file");
+                        parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "parse.smt2"),
+                    "Couldn't open file");
   cvc5_parser_delete(parser);
 }
 
@@ -93,17 +93,19 @@ TEST_F(TestCApiBlackInputParser, set_and_append_inc_str_input)
       parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "parser_black");
   ASSERT_FALSE(cvc5_parser_done(parser));
 
+  ASSERT_CVC5_ERROR(
+      cvc5_parser_set_inc_str_input(
+          nullptr, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "parser_black"),
+      "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_parser_set_inc_str_input(
-                   nullptr, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "parser_black"),
-               "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_parser_set_inc_str_input(
-                   parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, nullptr),
-               "unexpected NULL argument");
+                        parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, nullptr),
+                    "unexpected NULL argument");
 
-  ASSERT_CVC5_ERROR(cvc5_parser_append_inc_str_input(nullptr, "(set-logic ALL)"),
-               "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_parser_append_inc_str_input(nullptr, "(set-logic ALL)"),
+      "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_parser_append_inc_str_input(parser, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 
   cvc5_parser_append_inc_str_input(parser, "(set-logic ALL)");
   cvc5_parser_append_inc_str_input(parser, "(declare-fun a () Bool)");
@@ -161,7 +163,7 @@ TEST_F(TestCApiBlackInputParser, append_inc_str_no_set)
 {
   Cvc5InputParser* parser = cvc5_parser_new(d_solver, nullptr);
   ASSERT_CVC5_ERROR(cvc5_parser_append_inc_str_input(parser, "(set-logic ALL)"),
-               "parser not initialized");
+                    "parser not initialized");
   cvc5_parser_delete(parser);
 }
 
@@ -170,10 +172,10 @@ TEST_F(TestCApiBlackInputParser, set_str_input)
   Cvc5InputParser* parser = cvc5_parser_new(d_solver, nullptr);
 
   ASSERT_CVC5_ERROR(cvc5_parser_set_str_input(nullptr,
-                                         CVC5_INPUT_LANGUAGE_SMT_LIB_2_6,
-                                         "(set-logic ALL)",
-                                         "parser_black"),
-               "unexpected NULL argument");
+                                              CVC5_INPUT_LANGUAGE_SMT_LIB_2_6,
+                                              "(set-logic ALL)",
+                                              "parser_black"),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(
       cvc5_parser_set_str_input(
           parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, nullptr, "parser_black"),
@@ -203,15 +205,16 @@ TEST_F(TestCApiBlackInputParser, next_command)
 {
   const char* error_msg;
   Cvc5InputParser* parser = cvc5_parser_new(d_solver, nullptr);
-  ASSERT_CVC5_ERROR(cvc5_parser_next_command(parser, &error_msg), "not initialized");
+  ASSERT_CVC5_ERROR(cvc5_parser_next_command(parser, &error_msg),
+                    "not initialized");
   cvc5_parser_set_str_input(
       parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "", "parser_black");
   Cvc5Command cmd = cvc5_parser_next_command(parser, &error_msg);
   ASSERT_EQ(cmd, nullptr);
   ASSERT_CVC5_ERROR(cvc5_parser_next_command(nullptr, &error_msg),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_parser_next_command(parser, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   cvc5_parser_delete(parser);
 }
 
@@ -233,16 +236,17 @@ TEST_F(TestCApiBlackInputParser, next_term)
 {
   const char* error_msg;
   Cvc5InputParser* parser = cvc5_parser_new(d_solver, nullptr);
-  ASSERT_CVC5_ERROR(cvc5_parser_next_term(parser, &error_msg), "not initialized");
+  ASSERT_CVC5_ERROR(cvc5_parser_next_term(parser, &error_msg),
+                    "not initialized");
   cvc5_parser_set_str_input(
       parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "", "parser_black");
   Cvc5Term term = cvc5_parser_next_term(parser, &error_msg);
   ASSERT_EQ(term, nullptr);
   ASSERT_EQ(error_msg, nullptr);
   ASSERT_CVC5_ERROR(cvc5_parser_next_term(nullptr, &error_msg),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_parser_next_term(parser, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   cvc5_parser_delete(parser);
 }
 
@@ -316,9 +320,10 @@ TEST_F(TestCApiBlackInputParser, multiple_parsers)
   Cvc5* solver4 = cvc5_new(d_tm);
   cvc5_set_logic(solver4, "QF_LRA");
   Cvc5InputParser* parser5 = cvc5_parser_new(solver4, d_sm);
-  ASSERT_CVC5_ERROR(cvc5_parser_set_inc_str_input(
-                   parser5, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "parser_black"),
-               "Logic mismatch");
+  ASSERT_CVC5_ERROR(
+      cvc5_parser_set_inc_str_input(
+          parser5, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "parser_black"),
+      "Logic mismatch");
   cvc5_parser_delete(parser5);
   cvc5_parser_delete(parser4);
   cvc5_parser_delete(parser3);

--- a/test/unit/api/c/capi_input_parser_black.cpp
+++ b/test/unit/api/c/capi_input_parser_black.cpp
@@ -18,6 +18,7 @@ extern "C" {
 #include <sstream>
 
 #include "gtest/gtest.h"
+#include "test_capi.h"
 
 namespace cvc5::internal::test {
 
@@ -61,7 +62,7 @@ TEST_F(TestCApiBlackInputParser, get_solver)
 
 TEST_F(TestCApiBlackInputParser, set_file_input)
 {
-  ASSERT_DEATH(cvc5_parser_new(nullptr, d_sm), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_parser_new(nullptr, d_sm), "unexpected NULL argument");
 
   const char* filename = "parse.smt2";
   std::ofstream smt2(filename);
@@ -72,14 +73,14 @@ TEST_F(TestCApiBlackInputParser, set_file_input)
   Cvc5InputParser* parser = cvc5_parser_new(d_solver, nullptr);
   cvc5_parser_set_file_input(
       parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "parse.smt2");
-  ASSERT_DEATH(cvc5_parser_set_file_input(
+  ASSERT_CVC5_ERROR(cvc5_parser_set_file_input(
                    nullptr, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "parse.smt2"),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_parser_set_file_input(
+  ASSERT_CVC5_ERROR(cvc5_parser_set_file_input(
                    parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, nullptr),
                "unexpected NULL argument");
   std::remove(filename);
-  ASSERT_DEATH(cvc5_parser_set_file_input(
+  ASSERT_CVC5_ERROR(cvc5_parser_set_file_input(
                    parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "parse.smt2"),
                "Couldn't open file");
   cvc5_parser_delete(parser);
@@ -92,16 +93,16 @@ TEST_F(TestCApiBlackInputParser, set_and_append_inc_str_input)
       parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "parser_black");
   ASSERT_FALSE(cvc5_parser_done(parser));
 
-  ASSERT_DEATH(cvc5_parser_set_inc_str_input(
+  ASSERT_CVC5_ERROR(cvc5_parser_set_inc_str_input(
                    nullptr, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "parser_black"),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_parser_set_inc_str_input(
+  ASSERT_CVC5_ERROR(cvc5_parser_set_inc_str_input(
                    parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, nullptr),
                "unexpected NULL argument");
 
-  ASSERT_DEATH(cvc5_parser_append_inc_str_input(nullptr, "(set-logic ALL)"),
+  ASSERT_CVC5_ERROR(cvc5_parser_append_inc_str_input(nullptr, "(set-logic ALL)"),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_parser_append_inc_str_input(parser, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_parser_append_inc_str_input(parser, nullptr),
                "unexpected NULL argument");
 
   cvc5_parser_append_inc_str_input(parser, "(set-logic ALL)");
@@ -159,7 +160,7 @@ TEST_F(TestCApiBlackInputParser, set_and_append_inc_str_input_interleave)
 TEST_F(TestCApiBlackInputParser, append_inc_str_no_set)
 {
   Cvc5InputParser* parser = cvc5_parser_new(d_solver, nullptr);
-  ASSERT_DEATH(cvc5_parser_append_inc_str_input(parser, "(set-logic ALL)"),
+  ASSERT_CVC5_ERROR(cvc5_parser_append_inc_str_input(parser, "(set-logic ALL)"),
                "parser not initialized");
   cvc5_parser_delete(parser);
 }
@@ -168,16 +169,16 @@ TEST_F(TestCApiBlackInputParser, set_str_input)
 {
   Cvc5InputParser* parser = cvc5_parser_new(d_solver, nullptr);
 
-  ASSERT_DEATH(cvc5_parser_set_str_input(nullptr,
+  ASSERT_CVC5_ERROR(cvc5_parser_set_str_input(nullptr,
                                          CVC5_INPUT_LANGUAGE_SMT_LIB_2_6,
                                          "(set-logic ALL)",
                                          "parser_black"),
                "unexpected NULL argument");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_parser_set_str_input(
           parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, nullptr, "parser_black"),
       "unexpected NULL argument");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_parser_set_str_input(
           parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "(set-logic ALL)", nullptr),
       "unexpected NULL argument");
@@ -202,14 +203,14 @@ TEST_F(TestCApiBlackInputParser, next_command)
 {
   const char* error_msg;
   Cvc5InputParser* parser = cvc5_parser_new(d_solver, nullptr);
-  ASSERT_DEATH(cvc5_parser_next_command(parser, &error_msg), "not initialized");
+  ASSERT_CVC5_ERROR(cvc5_parser_next_command(parser, &error_msg), "not initialized");
   cvc5_parser_set_str_input(
       parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "", "parser_black");
   Cvc5Command cmd = cvc5_parser_next_command(parser, &error_msg);
   ASSERT_EQ(cmd, nullptr);
-  ASSERT_DEATH(cvc5_parser_next_command(nullptr, &error_msg),
+  ASSERT_CVC5_ERROR(cvc5_parser_next_command(nullptr, &error_msg),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_parser_next_command(parser, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_parser_next_command(parser, nullptr),
                "unexpected NULL argument");
   cvc5_parser_delete(parser);
 }
@@ -232,15 +233,15 @@ TEST_F(TestCApiBlackInputParser, next_term)
 {
   const char* error_msg;
   Cvc5InputParser* parser = cvc5_parser_new(d_solver, nullptr);
-  ASSERT_DEATH(cvc5_parser_next_term(parser, &error_msg), "not initialized");
+  ASSERT_CVC5_ERROR(cvc5_parser_next_term(parser, &error_msg), "not initialized");
   cvc5_parser_set_str_input(
       parser, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "", "parser_black");
   Cvc5Term term = cvc5_parser_next_term(parser, &error_msg);
   ASSERT_EQ(term, nullptr);
   ASSERT_EQ(error_msg, nullptr);
-  ASSERT_DEATH(cvc5_parser_next_term(nullptr, &error_msg),
+  ASSERT_CVC5_ERROR(cvc5_parser_next_term(nullptr, &error_msg),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_parser_next_term(parser, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_parser_next_term(parser, nullptr),
                "unexpected NULL argument");
   cvc5_parser_delete(parser);
 }
@@ -287,7 +288,7 @@ TEST_F(TestCApiBlackInputParser, multiple_parsers)
   ASSERT_EQ(cvc5_sm_is_logic_set(d_sm), true);
   ASSERT_EQ(cvc5_sm_get_logic(d_sm), std::string("QF_LIA"));
   // cannot set logic on solver now
-  ASSERT_DEATH(cvc5_set_logic(d_solver, "QF_LRA"), "logic is already set");
+  ASSERT_CVC5_ERROR(cvc5_set_logic(d_solver, "QF_LRA"), "logic is already set");
   // possible to construct another parser with the same solver and symbol
   // manager
   Cvc5InputParser* parser2 = cvc5_parser_new(d_solver, d_sm);
@@ -315,7 +316,7 @@ TEST_F(TestCApiBlackInputParser, multiple_parsers)
   Cvc5* solver4 = cvc5_new(d_tm);
   cvc5_set_logic(solver4, "QF_LRA");
   Cvc5InputParser* parser5 = cvc5_parser_new(solver4, d_sm);
-  ASSERT_DEATH(cvc5_parser_set_inc_str_input(
+  ASSERT_CVC5_ERROR(cvc5_parser_set_inc_str_input(
                    parser5, CVC5_INPUT_LANGUAGE_SMT_LIB_2_6, "parser_black"),
                "Logic mismatch");
   cvc5_parser_delete(parser5);

--- a/test/unit/api/c/capi_kind_black.cpp
+++ b/test/unit/api/c/capi_kind_black.cpp
@@ -24,7 +24,7 @@ class TestCApiKind : public ::testing::Test
 TEST_F(TestCApiKind, kind_to_string)
 {
   ASSERT_CVC5_ERROR(cvc5_kind_to_string(static_cast<Cvc5Kind>(-5)),
-               "invalid term kind");
+                    "invalid term kind");
 
   for (int32_t k = static_cast<int32_t>(CVC5_KIND_INTERNAL_KIND);
        k < static_cast<int32_t>(CVC5_KIND_LAST_KIND);

--- a/test/unit/api/c/capi_kind_black.cpp
+++ b/test/unit/api/c/capi_kind_black.cpp
@@ -13,6 +13,7 @@
 #include <cvc5/c/cvc5.h>
 
 #include "gtest/gtest.h"
+#include "test_capi.h"
 
 namespace cvc5::internal::test {
 
@@ -22,7 +23,7 @@ class TestCApiKind : public ::testing::Test
 
 TEST_F(TestCApiKind, kind_to_string)
 {
-  ASSERT_DEATH(cvc5_kind_to_string(static_cast<Cvc5Kind>(-5)),
+  ASSERT_CVC5_ERROR(cvc5_kind_to_string(static_cast<Cvc5Kind>(-5)),
                "invalid term kind");
 
   for (int32_t k = static_cast<int32_t>(CVC5_KIND_INTERNAL_KIND);

--- a/test/unit/api/c/capi_op_black.cpp
+++ b/test/unit/api/c/capi_op_black.cpp
@@ -16,6 +16,7 @@ extern "C" {
 
 #include "base/output.h"
 #include "gtest/gtest.h"
+#include "test_capi.h"
 
 namespace cvc5::internal::test {
 
@@ -55,7 +56,7 @@ TEST_F(TestCApiBlackOp, equal)
 
 TEST_F(TestCApiBlackOp, hash)
 {
-  ASSERT_DEATH(cvc5_op_hash(nullptr), "invalid operator");
+  ASSERT_CVC5_ERROR(cvc5_op_hash(nullptr), "invalid operator");
   std::vector<uint32_t> idxs = {4, 0};
   Cvc5Op op1 =
       cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_EXTRACT, idxs.size(), idxs.data());
@@ -68,8 +69,8 @@ TEST_F(TestCApiBlackOp, hash)
 
 TEST_F(TestCApiBlackOp, copy_release)
 {
-  ASSERT_DEATH(cvc5_op_copy(nullptr), "invalid op");
-  ASSERT_DEATH(cvc5_op_release(nullptr), "invalid op");
+  ASSERT_CVC5_ERROR(cvc5_op_copy(nullptr), "invalid op");
+  ASSERT_CVC5_ERROR(cvc5_op_release(nullptr), "invalid op");
   std::vector<uint32_t> idxs = {4, 0};
   Cvc5Op op =
       cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_EXTRACT, idxs.size(), idxs.data());
@@ -86,7 +87,7 @@ TEST_F(TestCApiBlackOp, copy_release)
 
 TEST_F(TestCApiBlackOp, get_kind)
 {
-  ASSERT_DEATH(cvc5_op_get_kind(nullptr), "invalid operator");
+  ASSERT_CVC5_ERROR(cvc5_op_get_kind(nullptr), "invalid operator");
   std::vector<uint32_t> idxs = {4, 0};
   ASSERT_EQ(cvc5_op_get_kind(cvc5_mk_op(
                 d_tm, CVC5_KIND_BITVECTOR_EXTRACT, idxs.size(), idxs.data())),
@@ -96,23 +97,23 @@ TEST_F(TestCApiBlackOp, get_kind)
 TEST_F(TestCApiBlackOp, mk_op)
 {
   std::vector<uint32_t> idxs = {4, 0};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_op(
           nullptr, CVC5_KIND_BITVECTOR_EXTRACT, idxs.size(), idxs.data()),
       "unexpected NULL argument");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_EXTRACT, idxs.size(), nullptr),
       "unexpected NULL argument");
   (void)cvc5_mk_op(d_tm, CVC5_KIND_ADD, 0, nullptr);
   idxs.push_back(2);
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_EXTRACT, idxs.size(), idxs.data()),
       "invalid number of indices");
 }
 
 TEST_F(TestCApiBlackOp, get_num_indices)
 {
-  ASSERT_DEATH(cvc5_op_get_num_indices(nullptr), "invalid operator");
+  ASSERT_CVC5_ERROR(cvc5_op_get_num_indices(nullptr), "invalid operator");
 
   // Operators with 0 indices
   Cvc5Op add = cvc5_mk_op(d_tm, CVC5_KIND_ADD, 0, nullptr);
@@ -213,8 +214,8 @@ TEST_F(TestCApiBlackOp, subscript_operator)
 {
   // Operators with 0 indices
   Cvc5Op add = cvc5_mk_op(d_tm, CVC5_KIND_ADD, 0, nullptr);
-  ASSERT_DEATH(cvc5_op_get_index(nullptr, 0), "invalid operator");
-  ASSERT_DEATH(cvc5_op_get_index(add, 0), "Op is not indexed");
+  ASSERT_CVC5_ERROR(cvc5_op_get_index(nullptr, 0), "invalid operator");
+  ASSERT_CVC5_ERROR(cvc5_op_get_index(add, 0), "Op is not indexed");
 
   // Operators with 1 index
   std::vector<uint32_t> idxs = {4};

--- a/test/unit/api/c/capi_parametric_datatype_black.cpp
+++ b/test/unit/api/c/capi_parametric_datatype_black.cpp
@@ -40,11 +40,11 @@ TEST_F(TestCApiBlackParametricDatatype, mk_dt_decl_with_params)
   Cvc5Sort p = cvc5_mk_param_sort(d_tm, "_x4");
   std::vector<Cvc5Sort> params = {p};
   ASSERT_CVC5_ERROR(cvc5_mk_dt_decl_with_params(
-                   nullptr, "_x0", params.size(), params.data(), false),
-               "unexpected NULL argument");
+                        nullptr, "_x0", params.size(), params.data(), false),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_dt_decl_with_params(
-                   d_tm, nullptr, params.size(), params.data(), false),
-               "unexpected NULL argument");
+                        d_tm, nullptr, params.size(), params.data(), false),
+                    "unexpected NULL argument");
   (void)cvc5_mk_dt_decl_with_params(d_tm, "_x0", 0, nullptr, false);
 }
 
@@ -60,7 +60,7 @@ TEST_F(TestCApiBlackParametricDatatype, proj_issue387)
   (void)cvc5_mk_dt_cons_decl(d_tm, "_x18");
   params = {p1, p2};
   ASSERT_CVC5_ERROR(cvc5_sort_instantiate(u2, params.size(), params.data()),
-               "arity mismatch");
+                    "arity mismatch");
 }
 
 }  // namespace cvc5::internal::test

--- a/test/unit/api/c/capi_parametric_datatype_black.cpp
+++ b/test/unit/api/c/capi_parametric_datatype_black.cpp
@@ -16,6 +16,7 @@ extern "C" {
 
 #include "base/output.h"
 #include "gtest/gtest.h"
+#include "test_capi.h"
 
 namespace cvc5::internal::test {
 
@@ -38,10 +39,10 @@ TEST_F(TestCApiBlackParametricDatatype, mk_dt_decl_with_params)
 {
   Cvc5Sort p = cvc5_mk_param_sort(d_tm, "_x4");
   std::vector<Cvc5Sort> params = {p};
-  ASSERT_DEATH(cvc5_mk_dt_decl_with_params(
+  ASSERT_CVC5_ERROR(cvc5_mk_dt_decl_with_params(
                    nullptr, "_x0", params.size(), params.data(), false),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_dt_decl_with_params(
+  ASSERT_CVC5_ERROR(cvc5_mk_dt_decl_with_params(
                    d_tm, nullptr, params.size(), params.data(), false),
                "unexpected NULL argument");
   (void)cvc5_mk_dt_decl_with_params(d_tm, "_x0", 0, nullptr, false);
@@ -58,7 +59,7 @@ TEST_F(TestCApiBlackParametricDatatype, proj_issue387)
       d_tm, "_x0", params.size(), params.data(), false);
   (void)cvc5_mk_dt_cons_decl(d_tm, "_x18");
   params = {p1, p2};
-  ASSERT_DEATH(cvc5_sort_instantiate(u2, params.size(), params.data()),
+  ASSERT_CVC5_ERROR(cvc5_sort_instantiate(u2, params.size(), params.data()),
                "arity mismatch");
 }
 

--- a/test/unit/api/c/capi_proof_black.cpp
+++ b/test/unit/api/c/capi_proof_black.cpp
@@ -137,7 +137,8 @@ TEST_F(TestCApiBlackProof, get_rewrite_rule)
   ASSERT_CVC5_ERROR(cvc5_proof_get_rewrite_rule(nullptr), "invalid proof");
 
   Cvc5Proof proof = create_rewrite_proof();
-  ASSERT_CVC5_ERROR(cvc5_proof_get_rewrite_rule(proof), "to return `DSL_REWRITE`");
+  ASSERT_CVC5_ERROR(cvc5_proof_get_rewrite_rule(proof),
+                    "to return `DSL_REWRITE`");
   Cvc5ProofRule rule;
   std::vector<Cvc5Proof> stack = {proof};
   do
@@ -170,7 +171,7 @@ TEST_F(TestCApiBlackProof, get_children)
   ASSERT_TRUE(size > 0);
   ASSERT_CVC5_ERROR(cvc5_proof_get_children(nullptr, &size), "invalid proof");
   ASSERT_CVC5_ERROR(cvc5_proof_get_children(proof, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackProof, get_arguments)
@@ -180,7 +181,7 @@ TEST_F(TestCApiBlackProof, get_arguments)
   (void)cvc5_proof_get_arguments(proof, &size);
   ASSERT_CVC5_ERROR(cvc5_proof_get_arguments(nullptr, &size), "invalid proof");
   ASSERT_CVC5_ERROR(cvc5_proof_get_arguments(proof, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackProof, is_equal_disequal_hash)

--- a/test/unit/api/c/capi_proof_black.cpp
+++ b/test/unit/api/c/capi_proof_black.cpp
@@ -17,6 +17,7 @@ extern "C" {
 #include "base/check.h"
 #include "base/output.h"
 #include "gtest/gtest.h"
+#include "test_capi.h"
 
 namespace cvc5::internal::test {
 
@@ -126,17 +127,17 @@ class TestCApiBlackProof : public ::testing::Test
 
 TEST_F(TestCApiBlackProof, get_rule)
 {
-  ASSERT_DEATH(cvc5_proof_get_rule(nullptr), "invalid proof");
+  ASSERT_CVC5_ERROR(cvc5_proof_get_rule(nullptr), "invalid proof");
   Cvc5Proof proof = create_proof();
   ASSERT_EQ(cvc5_proof_get_rule(proof), CVC5_PROOF_RULE_SCOPE);
 }
 
 TEST_F(TestCApiBlackProof, get_rewrite_rule)
 {
-  ASSERT_DEATH(cvc5_proof_get_rewrite_rule(nullptr), "invalid proof");
+  ASSERT_CVC5_ERROR(cvc5_proof_get_rewrite_rule(nullptr), "invalid proof");
 
   Cvc5Proof proof = create_rewrite_proof();
-  ASSERT_DEATH(cvc5_proof_get_rewrite_rule(proof), "to return `DSL_REWRITE`");
+  ASSERT_CVC5_ERROR(cvc5_proof_get_rewrite_rule(proof), "to return `DSL_REWRITE`");
   Cvc5ProofRule rule;
   std::vector<Cvc5Proof> stack = {proof};
   do
@@ -156,7 +157,7 @@ TEST_F(TestCApiBlackProof, get_rewrite_rule)
 
 TEST_F(TestCApiBlackProof, get_result)
 {
-  ASSERT_DEATH(cvc5_proof_get_result(nullptr), "invalid proof");
+  ASSERT_CVC5_ERROR(cvc5_proof_get_result(nullptr), "invalid proof");
   Cvc5Proof proof = create_proof();
   (void)cvc5_proof_get_result(proof);
 }
@@ -167,8 +168,8 @@ TEST_F(TestCApiBlackProof, get_children)
   size_t size;
   (void)cvc5_proof_get_children(proof, &size);
   ASSERT_TRUE(size > 0);
-  ASSERT_DEATH(cvc5_proof_get_children(nullptr, &size), "invalid proof");
-  ASSERT_DEATH(cvc5_proof_get_children(proof, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_proof_get_children(nullptr, &size), "invalid proof");
+  ASSERT_CVC5_ERROR(cvc5_proof_get_children(proof, nullptr),
                "unexpected NULL argument");
 }
 
@@ -177,8 +178,8 @@ TEST_F(TestCApiBlackProof, get_arguments)
   Cvc5Proof proof = create_proof();
   size_t size;
   (void)cvc5_proof_get_arguments(proof, &size);
-  ASSERT_DEATH(cvc5_proof_get_arguments(nullptr, &size), "invalid proof");
-  ASSERT_DEATH(cvc5_proof_get_arguments(proof, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_proof_get_arguments(nullptr, &size), "invalid proof");
+  ASSERT_CVC5_ERROR(cvc5_proof_get_arguments(proof, nullptr),
                "unexpected NULL argument");
 }
 
@@ -201,13 +202,13 @@ TEST_F(TestCApiBlackProof, is_equal_disequal_hash)
 
   ASSERT_EQ(cvc5_proof_hash(x), cvc5_proof_hash(x));
   ASSERT_NE(cvc5_proof_hash(x), cvc5_proof_hash(y));
-  ASSERT_DEATH(cvc5_proof_hash(nullptr), "invalid proof");
+  ASSERT_CVC5_ERROR(cvc5_proof_hash(nullptr), "invalid proof");
 }
 
 TEST_F(TestCApiBlackProof, copy_release)
 {
-  ASSERT_DEATH(cvc5_proof_copy(nullptr), "invalid proof");
-  ASSERT_DEATH(cvc5_proof_release(nullptr), "invalid proof");
+  ASSERT_CVC5_ERROR(cvc5_proof_copy(nullptr), "invalid proof");
+  ASSERT_CVC5_ERROR(cvc5_proof_release(nullptr), "invalid proof");
   Cvc5Proof proof = create_proof();
   ASSERT_EQ(cvc5_proof_get_rule(proof), CVC5_PROOF_RULE_SCOPE);
   Cvc5Proof proof2 = cvc5_proof_copy(proof);

--- a/test/unit/api/c/capi_result_black.cpp
+++ b/test/unit/api/c/capi_result_black.cpp
@@ -17,6 +17,7 @@ extern "C" {
 #include "base/check.h"
 #include "base/output.h"
 #include "gtest/gtest.h"
+#include "test_capi.h"
 
 namespace cvc5::internal::test {
 
@@ -45,7 +46,7 @@ class TestCApiBlackResult : public ::testing::Test
 
 TEST_F(TestCApiBlackResult, is_null)
 {
-  ASSERT_DEATH(cvc5_result_is_null(nullptr), "invalid result");
+  ASSERT_CVC5_ERROR(cvc5_result_is_null(nullptr), "invalid result");
   Cvc5Term x = cvc5_mk_const(d_tm, d_uninterpreted, "x");
   std::vector<Cvc5Term> args = {x, x};
   cvc5_assert_formula(
@@ -78,7 +79,7 @@ TEST_F(TestCApiBlackResult, is_equal_disequal)
 
 TEST_F(TestCApiBlackResult, is_sat)
 {
-  ASSERT_DEATH(cvc5_result_is_sat(nullptr), "invalid result");
+  ASSERT_CVC5_ERROR(cvc5_result_is_sat(nullptr), "invalid result");
 
   Cvc5Term x = cvc5_mk_const(d_tm, d_uninterpreted, "x");
   std::vector<Cvc5Term> args = {x, x};
@@ -92,7 +93,7 @@ TEST_F(TestCApiBlackResult, is_sat)
 
 TEST_F(TestCApiBlackResult, is_unsat)
 {
-  ASSERT_DEATH(cvc5_result_is_unsat(nullptr), "invalid result");
+  ASSERT_CVC5_ERROR(cvc5_result_is_unsat(nullptr), "invalid result");
 
   Cvc5Term x = cvc5_mk_const(d_tm, d_uninterpreted, "x");
   std::vector<Cvc5Term> args = {x, x};
@@ -107,7 +108,7 @@ TEST_F(TestCApiBlackResult, is_unsat)
 
 TEST_F(TestCApiBlackResult, is_unknown)
 {
-  ASSERT_DEATH(cvc5_result_is_unknown(nullptr), "invalid result");
+  ASSERT_CVC5_ERROR(cvc5_result_is_unknown(nullptr), "invalid result");
 
   cvc5_set_logic(d_solver, "QF_NIA");
   cvc5_set_option(d_solver, "incremental", "false");
@@ -142,13 +143,13 @@ TEST_F(TestCApiBlackResult, hash)
   Cvc5Result res2 = cvc5_check_sat(d_solver);
   ASSERT_EQ(cvc5_result_hash(res1), cvc5_result_hash(res1));
   ASSERT_NE(cvc5_result_hash(res1), cvc5_result_hash(res2));
-  ASSERT_DEATH(cvc5_result_hash(nullptr), "invalid result");
+  ASSERT_CVC5_ERROR(cvc5_result_hash(nullptr), "invalid result");
 }
 
 TEST_F(TestCApiBlackResult, copy_release)
 {
-  ASSERT_DEATH(cvc5_result_copy(nullptr), "invalid result");
-  ASSERT_DEATH(cvc5_result_release(nullptr), "invalid result");
+  ASSERT_CVC5_ERROR(cvc5_result_copy(nullptr), "invalid result");
+  ASSERT_CVC5_ERROR(cvc5_result_release(nullptr), "invalid result");
   Cvc5Term x = cvc5_mk_const(d_tm, d_uninterpreted, "x");
   std::vector<Cvc5Term> args = {x, x};
   cvc5_assert_formula(

--- a/test/unit/api/c/capi_solver_black.cpp
+++ b/test/unit/api/c/capi_solver_black.cpp
@@ -98,7 +98,7 @@ TEST_F(TestCApiBlackSolver, pow2_large1)
   Cvc5Term t258 = cvc5_mk_term(d_tm, CVC5_KIND_GEQ, args.size(), args.data());
   cvc5_assert_formula(d_solver, t258);
   ASSERT_CVC5_ERROR(cvc5_simplify(d_solver, t82, true),
-               "can only be a positive integral constant below");
+                    "can only be a positive integral constant below");
 }
 
 TEST_F(TestCApiBlackSolver, pow2_large2)
@@ -158,7 +158,8 @@ TEST_F(TestCApiBlackSolver, simplify)
   Cvc5Term x = cvc5_mk_const(d_tm, bv_sort, "x");
   (void)cvc5_simplify(d_solver, x, false);
 
-  ASSERT_CVC5_ERROR(cvc5_simplify(nullptr, x, false), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_simplify(nullptr, x, false),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_simplify(d_solver, nullptr, false), "invalid term");
 
   Cvc5Term a = cvc5_mk_const(d_tm, bv_sort, "a");
@@ -246,8 +247,9 @@ TEST_F(TestCApiBlackSolver, simplify)
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
-  ASSERT_CVC5_ERROR(cvc5_simplify(slv, x, false),
-               "term is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_simplify(slv, x, false),
+      "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
 }
@@ -269,15 +271,16 @@ TEST_F(TestCApiBlackSolver, simplify_apply_subs)
 TEST_F(TestCApiBlackSolver, assert_formula)
 {
   ASSERT_CVC5_ERROR(cvc5_assert_formula(nullptr, cvc5_mk_true(d_tm)),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_assert_formula(d_solver, nullptr), "invalid term");
 
   cvc5_assert_formula(d_solver, cvc5_mk_true(d_tm));
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
-  ASSERT_CVC5_ERROR(cvc5_assert_formula(slv, cvc5_mk_true(d_tm)),
-               "term is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_assert_formula(slv, cvc5_mk_true(d_tm)),
+      "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
 }
@@ -302,7 +305,7 @@ TEST_F(TestCApiBlackSolver, check_sat_assuming)
       cvc5_check_sat_assuming(nullptr, assumptions.size(), assumptions.data()),
       "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_check_sat_assuming(d_solver, 0, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 
   cvc5_set_option(d_solver, "incremental", "false");
   cvc5_check_sat_assuming(d_solver, assumptions.size(), assumptions.data());
@@ -422,30 +425,33 @@ TEST_F(TestCApiBlackSolver, declare_datatype)
   nil = cvc5_mk_dt_cons_decl(d_tm, "nil");
   ctors = {cons, nil};
   ASSERT_CVC5_ERROR(cvc5_declare_dt(nullptr, "c", ctors.size(), ctors.data()),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ctors = {nullptr};
   ASSERT_CVC5_ERROR(cvc5_declare_dt(d_solver, "c", ctors.size(), ctors.data()),
-               "invalid datatype constructor declaration at index 0");
+                    "invalid datatype constructor declaration at index 0");
 
   // must have at least one constructor
   ctors = {};
-  ASSERT_CVC5_ERROR(cvc5_declare_dt(d_solver, "c", ctors.size(), ctors.data()),
-               "expected a datatype declaration with at least one constructor");
+  ASSERT_CVC5_ERROR(
+      cvc5_declare_dt(d_solver, "c", ctors.size(), ctors.data()),
+      "expected a datatype declaration with at least one constructor");
   // constructors may not be reused
   Cvc5DatatypeConstructorDecl ctor1 = cvc5_mk_dt_cons_decl(d_tm, "_x21");
   Cvc5DatatypeConstructorDecl ctor2 = cvc5_mk_dt_cons_decl(d_tm, "_x31");
   ctors = {ctor1, ctor2};
   (void)cvc5_declare_dt(d_solver, "_x17", ctors.size(), ctors.data());
-  ASSERT_CVC5_ERROR(cvc5_declare_dt(d_solver, "_x86", ctors.size(), ctors.data()),
-               "cannot use a constructor for multiple datatypes");
+  ASSERT_CVC5_ERROR(
+      cvc5_declare_dt(d_solver, "_x86", ctors.size(), ctors.data()),
+      "cannot use a constructor for multiple datatypes");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
   nil = cvc5_mk_dt_cons_decl(d_tm, "nil");
   ctors = {nil};
-  ASSERT_CVC5_ERROR(cvc5_declare_dt(slv, "a", ctors.size(), ctors.data()),
-               "expected a datatype constructor declaration associated with "
-               "the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_declare_dt(slv, "a", ctors.size(), ctors.data()),
+      "expected a datatype constructor declaration associated with "
+      "the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
 }
@@ -461,9 +467,9 @@ TEST_F(TestCApiBlackSolver, dt_get_arity)
 TEST_F(TestCApiBlackSolver, declare_fun)
 {
   ASSERT_CVC5_ERROR(cvc5_declare_fun(nullptr, "b", 0, nullptr, d_bool, true),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_declare_fun(d_solver, "b", 0, nullptr, nullptr, true),
-               "invalid sort");
+                    "invalid sort");
 
   Cvc5Sort bv_sort = cvc5_mk_bv_sort(d_tm, 32);
   std::vector<Cvc5Sort> domain = {d_uninterpreted};
@@ -473,8 +479,9 @@ TEST_F(TestCApiBlackSolver, declare_fun)
   domain = {bv_sort, d_int};
   (void)cvc5_declare_fun(
       d_solver, "f3", domain.size(), domain.data(), bv_sort, true);
-  ASSERT_CVC5_ERROR(cvc5_declare_fun(d_solver, "f3", 0, nullptr, fun_sort, true),
-               "invalid argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_declare_fun(d_solver, "f3", 0, nullptr, fun_sort, true),
+      "invalid argument");
   // functions as arguments is allowed
   domain = {bv_sort, fun_sort};
   (void)cvc5_declare_fun(
@@ -487,8 +494,9 @@ TEST_F(TestCApiBlackSolver, declare_fun)
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
-  ASSERT_CVC5_ERROR(cvc5_declare_fun(slv, "f1", 0, nullptr, bv_sort, true),
-               "sort is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_declare_fun(slv, "f1", 0, nullptr, bv_sort, true),
+      "sort is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
 }
@@ -509,8 +517,9 @@ TEST_F(TestCApiBlackSolver, declare_fun_fresh)
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
-  ASSERT_CVC5_ERROR(cvc5_declare_fun(slv, "b", 0, nullptr, d_int, false),
-               "sort is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_declare_fun(slv, "b", 0, nullptr, d_int, false),
+      "sort is not associated with the term manager of this solver");
   ;
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
@@ -519,9 +528,9 @@ TEST_F(TestCApiBlackSolver, declare_fun_fresh)
 TEST_F(TestCApiBlackSolver, declare_sort)
 {
   ASSERT_CVC5_ERROR(cvc5_declare_sort(nullptr, "s", 0, true),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_declare_sort(d_solver, nullptr, 0, true),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   (void)cvc5_declare_sort(d_solver, "s", 0, true);
   (void)cvc5_declare_sort(d_solver, "s", 2, true);
   (void)cvc5_declare_sort(d_solver, "", 2, true);
@@ -530,9 +539,9 @@ TEST_F(TestCApiBlackSolver, declare_sort)
 TEST_F(TestCApiBlackSolver, declare_sort_fresh)
 {
   ASSERT_CVC5_ERROR(cvc5_declare_sort(nullptr, "b", 0, true),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_declare_sort(d_solver, nullptr, 0, true),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 
   Cvc5Sort s1 = cvc5_declare_sort(d_solver, "b", 0, true);
   Cvc5Sort s2 = cvc5_declare_sort(d_solver, "b", 0, false);
@@ -561,10 +570,12 @@ TEST_F(TestCApiBlackSolver, define_fun)
   Cvc5Term v1 = cvc5_mk_const(d_tm, bv_sort, "v1");
   Cvc5Term v2 = cvc5_mk_const(d_tm, fun_sort, "v2");
 
-  ASSERT_CVC5_ERROR(cvc5_define_fun(nullptr, "f", 0, nullptr, bv_sort, v1, false),
-               "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_define_fun(d_solver, "f", 0, nullptr, nullptr, v1, false),
-               "invalid sort");
+  ASSERT_CVC5_ERROR(
+      cvc5_define_fun(nullptr, "f", 0, nullptr, bv_sort, v1, false),
+      "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_define_fun(d_solver, "f", 0, nullptr, nullptr, v1, false),
+      "invalid sort");
   ASSERT_CVC5_ERROR(
       cvc5_define_fun(d_solver, "f", 0, nullptr, bv_sort, nullptr, false),
       "invalid term");
@@ -574,13 +585,15 @@ TEST_F(TestCApiBlackSolver, define_fun)
   (void)cvc5_define_fun(
       d_solver, "f", vars.size(), vars.data(), bv_sort, v1, false);
   vars = {v1, b2};
-  ASSERT_CVC5_ERROR(cvc5_define_fun(
-                   d_solver, "f", vars.size(), vars.data(), bv_sort, v1, false),
-               "invalid bound variable");
+  ASSERT_CVC5_ERROR(
+      cvc5_define_fun(
+          d_solver, "f", vars.size(), vars.data(), bv_sort, v1, false),
+      "invalid bound variable");
   vars = {b1};
-  ASSERT_CVC5_ERROR(cvc5_define_fun(
-                   d_solver, "f", vars.size(), vars.data(), bv_sort, v2, false),
-               "invalid sort of function body");
+  ASSERT_CVC5_ERROR(
+      cvc5_define_fun(
+          d_solver, "f", vars.size(), vars.data(), bv_sort, v2, false),
+      "invalid sort of function body");
   ASSERT_CVC5_ERROR(
       cvc5_define_fun(
           d_solver, "f", vars.size(), vars.data(), fun_sort, v2, false),
@@ -705,13 +718,15 @@ TEST_F(TestCApiBlackSolver, define_fun_rec)
       "invalid term");
 
   vars = {b1};
-  ASSERT_CVC5_ERROR(cvc5_define_fun_rec(
-                   d_solver, "f", vars.size(), vars.data(), bv_sort, v3, false),
-               "invalid sort");
+  ASSERT_CVC5_ERROR(
+      cvc5_define_fun_rec(
+          d_solver, "f", vars.size(), vars.data(), bv_sort, v3, false),
+      "invalid sort");
   vars = {b1, v2};
-  ASSERT_CVC5_ERROR(cvc5_define_fun_rec(
-                   d_solver, "f", vars.size(), vars.data(), bv_sort, v1, false),
-               "invalid bound variable");
+  ASSERT_CVC5_ERROR(
+      cvc5_define_fun_rec(
+          d_solver, "f", vars.size(), vars.data(), bv_sort, v1, false),
+      "invalid bound variable");
   vars = {b1};
   ASSERT_CVC5_ERROR(
       cvc5_define_fun_rec(
@@ -730,21 +745,21 @@ TEST_F(TestCApiBlackSolver, define_fun_rec)
 
   vars = {b1};
   ASSERT_CVC5_ERROR(cvc5_define_fun_rec_from_const(
-                   d_solver, f1, vars.size(), vars.data(), v1, false),
-               "invalid size of argument 'bound_vars'");
+                        d_solver, f1, vars.size(), vars.data(), v1, false),
+                    "invalid size of argument 'bound_vars'");
   ASSERT_CVC5_ERROR(cvc5_define_fun_rec_from_const(
-                   d_solver, f2, vars.size(), vars.data(), v2, false),
-               "invalid sort");
+                        d_solver, f2, vars.size(), vars.data(), v2, false),
+                    "invalid sort");
   ASSERT_CVC5_ERROR(cvc5_define_fun_rec_from_const(
-                   d_solver, f3, vars.size(), vars.data(), v1, false),
-               "invalid argument");
+                        d_solver, f3, vars.size(), vars.data(), v1, false),
+                    "invalid argument");
   vars = {b1, b11};
   ASSERT_CVC5_ERROR(cvc5_define_fun_rec_from_const(
-                   d_solver, f1, vars.size(), vars.data(), v2, false),
-               "invalid sort");
+                        d_solver, f1, vars.size(), vars.data(), v2, false),
+                    "invalid sort");
   ASSERT_CVC5_ERROR(cvc5_define_fun_rec_from_const(
-                   d_solver, f1, vars.size(), vars.data(), v3, false),
-               "invalid sort");
+                        d_solver, f1, vars.size(), vars.data(), v3, false),
+                    "invalid sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
@@ -757,12 +772,14 @@ TEST_F(TestCApiBlackSolver, define_fun_rec)
       cvc5_define_fun_rec(
           d_solver, "f", vars.size(), vars.data(), bv_sort2, v12, false),
       "term is not associated with the term manager of this solver");
-  ASSERT_CVC5_ERROR(cvc5_define_fun_rec(
-                   slv, "f", vars.size(), vars.data(), bv_sort, v12, false),
-               "sort is not associated with the term manager of this solver");
-  ASSERT_CVC5_ERROR(cvc5_define_fun_rec(
-                   slv, "f", vars.size(), vars.data(), bv_sort2, v1, false),
-               "term is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_define_fun_rec(
+          slv, "f", vars.size(), vars.data(), bv_sort, v12, false),
+      "sort is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_define_fun_rec(
+          slv, "f", vars.size(), vars.data(), bv_sort2, v1, false),
+      "term is not associated with the term manager of this solver");
   vars = {b12, b22};
   (void)cvc5_define_fun_rec(
       slv, "f", vars.size(), vars.data(), bv_sort2, v12, false);
@@ -791,13 +808,14 @@ TEST_F(TestCApiBlackSolver, define_fun_rec_wrong_logic)
   Cvc5Term v = cvc5_mk_var(d_tm, bv_sort, "v");
   Cvc5Term f = cvc5_mk_var(d_tm, fun_sort, "f");
   std::vector<Cvc5Term> vars = {};
-  ASSERT_CVC5_ERROR(cvc5_define_fun_rec(
-                   d_solver, "f", vars.size(), vars.data(), bv_sort, v, false),
-               "require a logic with quantifiers");
+  ASSERT_CVC5_ERROR(
+      cvc5_define_fun_rec(
+          d_solver, "f", vars.size(), vars.data(), bv_sort, v, false),
+      "require a logic with quantifiers");
   vars = {b, b};
   ASSERT_CVC5_ERROR(cvc5_define_fun_rec_from_const(
-                   d_solver, f, vars.size(), vars.data(), v, false),
-               "require a logic with quantifiers");
+                        d_solver, f, vars.size(), vars.data(), v, false),
+                    "require a logic with quantifiers");
 }
 
 TEST_F(TestCApiBlackSolver, define_fun_rec_global)
@@ -909,58 +927,58 @@ TEST_F(TestCApiBlackSolver, define_funs_rec)
   vars1 = {v1, b11};
   vars = {vars1.data(), vars2.data()};
   ASSERT_CVC5_ERROR(cvc5_define_funs_rec(d_solver,
-                                    funs.size(),
-                                    funs.data(),
-                                    nvars.data(),
-                                    vars.data(),
-                                    terms.data(),
-                                    false),
-               "invalid bound variable");
+                                         funs.size(),
+                                         funs.data(),
+                                         nvars.data(),
+                                         vars.data(),
+                                         terms.data(),
+                                         false),
+                    "invalid bound variable");
   funs = {f1, f3};
   vars1 = {b1, b11};
   vars = {vars1.data(), vars2.data()};
   ASSERT_CVC5_ERROR(cvc5_define_funs_rec(d_solver,
-                                    funs.size(),
-                                    funs.data(),
-                                    nvars.data(),
-                                    vars.data(),
-                                    terms.data(),
-                                    false),
-               "invalid argument");
+                                         funs.size(),
+                                         funs.data(),
+                                         nvars.data(),
+                                         vars.data(),
+                                         terms.data(),
+                                         false),
+                    "invalid argument");
   funs = {f1, f2};
   vars1 = {b1};
   vars = {vars1.data(), vars2.data()};
   nvars = {1, 1};
   ASSERT_CVC5_ERROR(cvc5_define_funs_rec(d_solver,
-                                    funs.size(),
-                                    funs.data(),
-                                    nvars.data(),
-                                    vars.data(),
-                                    terms.data(),
-                                    false),
-               "invalid size of argument");
+                                         funs.size(),
+                                         funs.data(),
+                                         nvars.data(),
+                                         vars.data(),
+                                         terms.data(),
+                                         false),
+                    "invalid size of argument");
   vars1 = {b1, b2};
   vars = {vars1.data(), vars2.data()};
   nvars = {2, 1};
   ASSERT_CVC5_ERROR(cvc5_define_funs_rec(d_solver,
-                                    funs.size(),
-                                    funs.data(),
-                                    nvars.data(),
-                                    vars.data(),
-                                    terms.data(),
-                                    false),
-               "invalid sort");
+                                         funs.size(),
+                                         funs.data(),
+                                         nvars.data(),
+                                         vars.data(),
+                                         terms.data(),
+                                         false),
+                    "invalid sort");
   vars1 = {b1, b11};
   vars = {vars1.data(), vars2.data()};
   terms = {v1, v4};
   ASSERT_CVC5_ERROR(cvc5_define_funs_rec(d_solver,
-                                    funs.size(),
-                                    funs.data(),
-                                    nvars.data(),
-                                    vars.data(),
-                                    terms.data(),
-                                    false),
-               "invalid sort");
+                                         funs.size(),
+                                         funs.data(),
+                                         nvars.data(),
+                                         vars.data(),
+                                         terms.data(),
+                                         false),
+                    "invalid sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
@@ -1079,13 +1097,13 @@ TEST_F(TestCApiBlackSolver, define_funs_rec_wrong_logic)
   std::vector<Cvc5Term> terms = {v1, v2};
 
   ASSERT_CVC5_ERROR(cvc5_define_funs_rec(d_solver,
-                                    funs.size(),
-                                    funs.data(),
-                                    nvars.data(),
-                                    vars.data(),
-                                    terms.data(),
-                                    false),
-               "require a logic with quantifiers");
+                                         funs.size(),
+                                         funs.data(),
+                                         nvars.data(),
+                                         vars.data(),
+                                         terms.data(),
+                                         false),
+                    "require a logic with quantifiers");
 }
 
 TEST_F(TestCApiBlackSolver, define_funs_rec_global)
@@ -1140,9 +1158,10 @@ TEST_F(TestCApiBlackSolver, get_assertions)
   ASSERT_EQ(size, 2);
   ASSERT_TRUE(cvc5_term_is_equal(a, res[0]));
   ASSERT_TRUE(cvc5_term_is_equal(b, res[1]));
-  ASSERT_CVC5_ERROR(cvc5_get_assertions(nullptr, &size), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_assertions(nullptr, &size),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_assertions(d_solver, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, get_info)
@@ -1150,7 +1169,8 @@ TEST_F(TestCApiBlackSolver, get_info)
   ASSERT_EQ(cvc5_get_info(d_solver, "name"), std::string("\"cvc5\""));
   ASSERT_CVC5_ERROR(cvc5_get_info(d_solver, "asdf"), "unrecognized flag");
   ASSERT_CVC5_ERROR(cvc5_get_info(nullptr, "name"), "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_get_info(d_solver, nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_info(d_solver, nullptr),
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, get_option)
@@ -1158,8 +1178,9 @@ TEST_F(TestCApiBlackSolver, get_option)
   ASSERT_EQ(cvc5_get_option(d_solver, "incremental"), std::string("true"));
   ASSERT_CVC5_ERROR(cvc5_get_option(d_solver, "asdf"), "Unrecognized option");
   ASSERT_CVC5_ERROR(cvc5_get_option(nullptr, "incremental"),
-               "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_get_option(d_solver, nullptr), "unexpected NULL argument");
+                    "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_option(d_solver, nullptr),
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, get_option_names)
@@ -1183,22 +1204,22 @@ TEST_F(TestCApiBlackSolver, get_option_names)
   ASSERT_TRUE(found_verbose);
   ASSERT_FALSE(found_foobar);
   ASSERT_CVC5_ERROR(cvc5_get_option_names(nullptr, &size),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_option_names(d_solver, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, get_option_info)
 {
   Cvc5OptionInfo info;
   ASSERT_CVC5_ERROR(cvc5_get_option_info(nullptr, "verbose", &info),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_option_info(d_solver, nullptr, &info),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_option_info(d_solver, "verbose", nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_option_info(d_solver, "asdf-invalid", &info),
-               "Unrecognized option");
+                    "Unrecognized option");
 
   cvc5_set_option(d_solver, "verbosity", "2");
 
@@ -1309,11 +1330,11 @@ TEST_F(TestCApiBlackSolver, get_unsat_assumptions1)
   cvc5_check_sat_assuming(d_solver, assumptions.size(), assumptions.data());
   size_t size;
   ASSERT_CVC5_ERROR(cvc5_get_unsat_assumptions(nullptr, &size),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_unsat_assumptions(d_solver, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_unsat_assumptions(d_solver, &size),
-               "cannot get unsat assumptions");
+                    "cannot get unsat assumptions");
 }
 
 TEST_F(TestCApiBlackSolver, get_unsat_assumptions2)
@@ -1324,7 +1345,7 @@ TEST_F(TestCApiBlackSolver, get_unsat_assumptions2)
   cvc5_check_sat_assuming(d_solver, assumptions.size(), assumptions.data());
   size_t size;
   ASSERT_CVC5_ERROR(cvc5_get_unsat_assumptions(d_solver, &size),
-               "cannot get unsat assumptions");
+                    "cannot get unsat assumptions");
 }
 
 TEST_F(TestCApiBlackSolver, get_unsat_assumptions3)
@@ -1340,7 +1361,7 @@ TEST_F(TestCApiBlackSolver, get_unsat_assumptions3)
   assumptions = {cvc5_mk_true(d_tm)};
   cvc5_check_sat_assuming(d_solver, assumptions.size(), assumptions.data());
   ASSERT_CVC5_ERROR(cvc5_get_unsat_assumptions(d_solver, &size),
-               "cannot get unsat assumptions");
+                    "cannot get unsat assumptions");
 }
 
 TEST_F(TestCApiBlackSolver, get_unsat_core0)
@@ -1349,9 +1370,10 @@ TEST_F(TestCApiBlackSolver, get_unsat_core0)
   cvc5_assert_formula(d_solver, cvc5_mk_false(d_tm));
   cvc5_check_sat(d_solver);
   size_t size;
-  ASSERT_CVC5_ERROR(cvc5_get_unsat_core(nullptr, &size), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_unsat_core(nullptr, &size),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_unsat_core(d_solver, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, get_unsat_core1)
@@ -1360,7 +1382,8 @@ TEST_F(TestCApiBlackSolver, get_unsat_core1)
   cvc5_assert_formula(d_solver, cvc5_mk_false(d_tm));
   cvc5_check_sat(d_solver);
   size_t size;
-  ASSERT_CVC5_ERROR(cvc5_get_unsat_core(d_solver, &size), "cannot get unsat core");
+  ASSERT_CVC5_ERROR(cvc5_get_unsat_core(d_solver, &size),
+                    "cannot get unsat core");
 }
 
 TEST_F(TestCApiBlackSolver, get_unsat_core2)
@@ -1370,7 +1393,8 @@ TEST_F(TestCApiBlackSolver, get_unsat_core2)
   cvc5_assert_formula(d_solver, cvc5_mk_false(d_tm));
   cvc5_check_sat(d_solver);
   size_t size;
-  ASSERT_CVC5_ERROR(cvc5_get_unsat_core(d_solver, &size), "cannot get unsat core");
+  ASSERT_CVC5_ERROR(cvc5_get_unsat_core(d_solver, &size),
+                    "cannot get unsat core");
 }
 
 TEST_F(TestCApiBlackSolver, get_unsat_core_and_proof)
@@ -1447,16 +1471,16 @@ TEST_F(TestCApiBlackSolver, get_unsat_core_lemmas1)
   size_t size;
   // cannot ask before a check sat
   ASSERT_CVC5_ERROR(cvc5_get_unsat_core_lemmas(d_solver, &size),
-               "cannot get unsat core");
+                    "cannot get unsat core");
 
   cvc5_assert_formula(d_solver, cvc5_mk_false(d_tm));
   ASSERT_TRUE(cvc5_result_is_unsat(cvc5_check_sat(d_solver)));
   (void)cvc5_get_unsat_core_lemmas(d_solver, &size);
 
   ASSERT_CVC5_ERROR(cvc5_get_unsat_core_lemmas(nullptr, &size),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_unsat_core_lemmas(d_solver, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, get_unsat_core_lemmas2)
@@ -1518,16 +1542,16 @@ TEST_F(TestCApiBlackSolver, get_difficulty)
   size_t size;
   Cvc5Term *inputs, *values;
   ASSERT_CVC5_ERROR(cvc5_get_difficulty(nullptr, &size, &inputs, &values),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_difficulty(d_solver, nullptr, &inputs, &values),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_difficulty(d_solver, &size, nullptr, &values),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_difficulty(d_solver, &size, &inputs, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   // cannot ask before a check sat
   ASSERT_CVC5_ERROR(cvc5_get_difficulty(d_solver, &size, &inputs, &values),
-               "cannot get difficulty");
+                    "cannot get difficulty");
   cvc5_check_sat(d_solver);
   cvc5_get_difficulty(d_solver, &size, &inputs, &values);
 }
@@ -1539,7 +1563,7 @@ TEST_F(TestCApiBlackSolver, get_difficulty2)
   Cvc5Term *inputs, *values;
   // option is not set
   ASSERT_CVC5_ERROR(cvc5_get_difficulty(d_solver, &size, &inputs, &values),
-               "Cannot get difficulty");
+                    "Cannot get difficulty");
 }
 
 TEST_F(TestCApiBlackSolver, get_difficulty3)
@@ -1590,11 +1614,11 @@ TEST_F(TestCApiBlackSolver, get_timeout_core)
   ASSERT_TRUE(cvc5_term_is_equal(core[0], hard));
 
   ASSERT_CVC5_ERROR(cvc5_get_timeout_core(nullptr, &result, &size),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_timeout_core(d_solver, nullptr, &size),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_timeout_core(d_solver, &result, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, get_timeout_core_unsat)
@@ -1692,9 +1716,10 @@ TEST_F(TestCApiBlackSolver, get_proof_and_proof_to_string)
 
   size_t size;
   ASSERT_CVC5_ERROR(cvc5_get_proof(nullptr, CVC5_PROOF_COMPONENT_FULL, &size),
-               "unexpected NULL");
-  ASSERT_CVC5_ERROR(cvc5_get_proof(d_solver, CVC5_PROOF_COMPONENT_FULL, nullptr),
-               "unexpected NULL");
+                    "unexpected NULL");
+  ASSERT_CVC5_ERROR(
+      cvc5_get_proof(d_solver, CVC5_PROOF_COMPONENT_FULL, nullptr),
+      "unexpected NULL");
 
   const Cvc5Proof* proofs =
       cvc5_get_proof(d_solver, CVC5_PROOF_COMPONENT_FULL, &size);
@@ -1875,11 +1900,12 @@ TEST_F(TestCApiBlackSolver, get_value3)
   ASSERT_TRUE(cvc5_term_is_equal(a[0], b[0]));
   ASSERT_TRUE(cvc5_term_is_equal(a[1], b[1]));
   ASSERT_CVC5_ERROR(cvc5_get_values(nullptr, terms.size(), terms.data(), &size),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_values(d_solver, terms.size(), nullptr, &size),
-               "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_get_values(d_solver, terms.size(), terms.data(), nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_get_values(d_solver, terms.size(), terms.data(), nullptr),
+      "unexpected NULL argument");
 
   Cvc5* slv = cvc5_new(d_tm);
   ASSERT_CVC5_ERROR(cvc5_get_value(slv, x), "cannot get value");
@@ -1900,8 +1926,9 @@ TEST_F(TestCApiBlackSolver, get_value3)
   slv = cvc5_new(tm);
   cvc5_set_option(slv, "produce-models", "true");
   cvc5_check_sat(slv);
-  ASSERT_CVC5_ERROR(cvc5_get_value(slv, x),
-               "term is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_get_value(slv, x),
+      "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
 }
@@ -1919,22 +1946,24 @@ TEST_F(TestCApiBlackSolver, get_modelDomain_elements)
   size_t size;
   (void)cvc5_get_model_domain_elements(d_solver, d_uninterpreted, &size);
   ASSERT_TRUE(size >= 3);
-  ASSERT_CVC5_ERROR(cvc5_get_model_domain_elements(nullptr, d_uninterpreted, &size),
-               "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_get_model_domain_elements(nullptr, d_uninterpreted, &size),
+      "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_model_domain_elements(d_solver, nullptr, &size),
-               "invalid sort");
+                    "invalid sort");
   ASSERT_CVC5_ERROR(
       cvc5_get_model_domain_elements(d_solver, d_uninterpreted, nullptr),
       "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_model_domain_elements(d_solver, d_int, &size),
-               "expected an uninterpreted sort");
+                    "expected an uninterpreted sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
   cvc5_set_option(slv, "produce-models", "true");
   cvc5_check_sat(slv);
-  ASSERT_CVC5_ERROR(cvc5_get_model_domain_elements(slv, d_uninterpreted, &size),
-               "sort is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_get_model_domain_elements(slv, d_uninterpreted, &size),
+      "sort is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
 }
@@ -1977,17 +2006,18 @@ TEST_F(TestCApiBlackSolver, is_model_core_symbol)
   ASSERT_FALSE(cvc5_is_model_core_symbol(d_solver, z));
 
   ASSERT_CVC5_ERROR(cvc5_is_model_core_symbol(nullptr, x),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_FALSE(cvc5_is_model_core_symbol(d_solver, nullptr));
   ASSERT_CVC5_ERROR(cvc5_is_model_core_symbol(d_solver, zero),
-               "expected a free constant");
+                    "expected a free constant");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
   cvc5_set_option(slv, "produce-models", "true");
   cvc5_check_sat(slv);
-  ASSERT_CVC5_ERROR(cvc5_is_model_core_symbol(slv, x),
-               "term is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_is_model_core_symbol(slv, x),
+      "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
 }
@@ -2012,12 +2042,14 @@ TEST_F(TestCApiBlackSolver, get_model)
       cvc5_get_model(
           nullptr, sorts.size(), sorts.data(), terms.size(), terms.data()),
       "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_get_model(
-                   d_solver, sorts.size(), nullptr, terms.size(), terms.data()),
-               "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_get_model(
-                   d_solver, sorts.size(), sorts.data(), terms.size(), nullptr),
-               "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_get_model(
+          d_solver, sorts.size(), nullptr, terms.size(), terms.data()),
+      "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_get_model(
+          d_solver, sorts.size(), sorts.data(), terms.size(), nullptr),
+      "unexpected NULL argument");
   terms.push_back(nullptr);
   ASSERT_CVC5_ERROR(
       cvc5_get_model(
@@ -2066,18 +2098,20 @@ TEST_F(TestCApiBlackSolver, get_quantifier_elimination)
       cvc5_mk_term(d_tm, CVC5_KIND_FORALL, args.size(), args.data());
 
   ASSERT_CVC5_ERROR(cvc5_get_quantifier_elimination(nullptr, forall),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_quantifier_elimination(d_solver, nullptr),
-               "invalid term");
-  ASSERT_CVC5_ERROR(cvc5_get_quantifier_elimination(d_solver, cvc5_mk_false(d_tm)),
-               "Expecting a quantified formula");
+                    "invalid term");
+  ASSERT_CVC5_ERROR(
+      cvc5_get_quantifier_elimination(d_solver, cvc5_mk_false(d_tm)),
+      "Expecting a quantified formula");
   (void)cvc5_get_quantifier_elimination(d_solver, forall);
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
   cvc5_check_sat(slv);
-  ASSERT_CVC5_ERROR(cvc5_get_quantifier_elimination(slv, forall),
-               "term is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_get_quantifier_elimination(slv, forall),
+      "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
 }
@@ -2095,9 +2129,9 @@ TEST_F(TestCApiBlackSolver, get_quantifier_elimination_disjunct)
       cvc5_mk_term(d_tm, CVC5_KIND_FORALL, args.size(), args.data());
 
   ASSERT_CVC5_ERROR(cvc5_get_quantifier_elimination_disjunct(nullptr, forall),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_quantifier_elimination_disjunct(d_solver, nullptr),
-               "invalid term");
+                    "invalid term");
   ASSERT_CVC5_ERROR(
       cvc5_get_quantifier_elimination_disjunct(d_solver, cvc5_mk_false(d_tm)),
       "Expecting a quantified formula");
@@ -2106,8 +2140,9 @@ TEST_F(TestCApiBlackSolver, get_quantifier_elimination_disjunct)
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
   cvc5_check_sat(slv);
-  ASSERT_CVC5_ERROR(cvc5_get_quantifier_elimination(slv, forall),
-               "term is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_get_quantifier_elimination(slv, forall),
+      "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
 }
@@ -2119,25 +2154,27 @@ TEST_F(TestCApiBlackSolver, declare_sep_heap)
   cvc5_declare_sep_heap(d_solver, d_int, d_int);
   // cannot declare separation logic heap more than once
   ASSERT_CVC5_ERROR(cvc5_declare_sep_heap(d_solver, d_int, d_int),
-               "cannot declare heap types");
+                    "cannot declare heap types");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   // no logic set yet
   Cvc5* slv = cvc5_new(tm);
   ASSERT_CVC5_ERROR(cvc5_declare_sep_heap(d_solver, d_int, d_int),
-               "cannot declare heap types");
+                    "cannot declare heap types");
   cvc5_delete(slv);
 
   slv = cvc5_new(tm);
   cvc5_set_logic(slv, "ALL");
-  ASSERT_CVC5_ERROR(cvc5_declare_sep_heap(slv, cvc5_get_integer_sort(tm), d_int),
-               "sort is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_declare_sep_heap(slv, cvc5_get_integer_sort(tm), d_int),
+      "sort is not associated with the term manager of this solver");
   cvc5_delete(slv);
 
   slv = cvc5_new(tm);
   cvc5_set_logic(slv, "ALL");
-  ASSERT_CVC5_ERROR(cvc5_declare_sep_heap(slv, d_int, cvc5_get_integer_sort(tm)),
-               "sort is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_declare_sep_heap(slv, d_int, cvc5_get_integer_sort(tm)),
+      "sort is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
 }
@@ -2150,7 +2187,7 @@ TEST_F(TestCApiBlackSolver, get_value_sep_heap1)
   Cvc5Term t = cvc5_mk_true(d_tm);
   cvc5_assert_formula(d_solver, t);
   ASSERT_CVC5_ERROR(cvc5_get_value_sep_heap(d_solver),
-               "cannot obtain separation logic expressions");
+                    "cannot obtain separation logic expressions");
 }
 
 TEST_F(TestCApiBlackSolver, get_value_sep_heap2)
@@ -2160,7 +2197,7 @@ TEST_F(TestCApiBlackSolver, get_value_sep_heap2)
   cvc5_set_option(d_solver, "produce-models", "false");
   check_simple_separation_constraints();
   ASSERT_CVC5_ERROR(cvc5_get_value_sep_heap(d_solver),
-               "cannot get separation heap term");
+                    "cannot get separation heap term");
 }
 
 TEST_F(TestCApiBlackSolver, get_value_sep_heap3)
@@ -2182,7 +2219,8 @@ TEST_F(TestCApiBlackSolver, get_value_sep_heap4)
   Cvc5Term t = cvc5_mk_true(d_tm);
   cvc5_assert_formula(d_solver, t);
   cvc5_check_sat(d_solver);
-  ASSERT_CVC5_ERROR(cvc5_get_value_sep_heap(d_solver), "Failed to obtain heap/nil");
+  ASSERT_CVC5_ERROR(cvc5_get_value_sep_heap(d_solver),
+                    "Failed to obtain heap/nil");
 }
 
 TEST_F(TestCApiBlackSolver, get_value_sep_heap5)
@@ -2202,7 +2240,7 @@ TEST_F(TestCApiBlackSolver, get_value_sep_nil1)
   Cvc5Term t = cvc5_mk_true(d_tm);
   cvc5_assert_formula(d_solver, t);
   ASSERT_CVC5_ERROR(cvc5_get_value_sep_nil(d_solver),
-               "cannot obtain separation logic expressions");
+                    "cannot obtain separation logic expressions");
 }
 
 TEST_F(TestCApiBlackSolver, get_value_sep_nil2)
@@ -2211,7 +2249,8 @@ TEST_F(TestCApiBlackSolver, get_value_sep_nil2)
   cvc5_set_option(d_solver, "incremental", "false");
   cvc5_set_option(d_solver, "produce-models", "false");
   check_simple_separation_constraints();
-  ASSERT_CVC5_ERROR(cvc5_get_value_sep_nil(d_solver), "cannot get separation nil");
+  ASSERT_CVC5_ERROR(cvc5_get_value_sep_nil(d_solver),
+                    "cannot get separation nil");
 }
 
 TEST_F(TestCApiBlackSolver, get_value_sep_nil3)
@@ -2234,7 +2273,7 @@ TEST_F(TestCApiBlackSolver, get_value_sep_nil4)
   cvc5_assert_formula(d_solver, t);
   cvc5_check_sat(d_solver);
   ASSERT_CVC5_ERROR(cvc5_get_value_sep_nil(d_solver),
-               "Failed to obtain heap/nil expressions");
+                    "Failed to obtain heap/nil expressions");
 }
 
 TEST_F(TestCApiBlackSolver, get_value_sep_nil5)
@@ -2251,9 +2290,9 @@ TEST_F(TestCApiBlackSolver, push1)
   cvc5_set_option(d_solver, "incremental", "true");
   cvc5_push(d_solver, 1);
   ASSERT_CVC5_ERROR(cvc5_set_option(d_solver, "incremental", "false"),
-               "is already fully initialized");
+                    "is already fully initialized");
   ASSERT_CVC5_ERROR(cvc5_set_option(d_solver, "incremental", "true"),
-               "is already fully initialized");
+                    "is already fully initialized");
 }
 
 TEST_F(TestCApiBlackSolver, push2)
@@ -2297,18 +2336,18 @@ TEST_F(TestCApiBlackSolver, pop4)
 TEST_F(TestCApiBlackSolver, set_info)
 {
   ASSERT_CVC5_ERROR(cvc5_set_info(d_solver, "cvc5-lagic", "QF_BV"),
-               "unrecognized keyword");
+                    "unrecognized keyword");
   ASSERT_CVC5_ERROR(cvc5_set_info(d_solver, "cvc2-logic", "QF_BV"),
-               "unrecognized keyword");
+                    "unrecognized keyword");
   ASSERT_CVC5_ERROR(cvc5_set_info(d_solver, "cvc5-logic", "asdf"),
-               "unrecognized keyword");
+                    "unrecognized keyword");
 
   ASSERT_CVC5_ERROR(cvc5_set_info(nullptr, "source", "asdf"),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_set_info(d_solver, nullptr, "asdf"),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_set_info(d_solver, "source", nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 
   cvc5_set_info(d_solver, "source", "asdf");
   cvc5_set_info(d_solver, "category", "asdf");
@@ -2323,24 +2362,28 @@ TEST_F(TestCApiBlackSolver, set_info)
   cvc5_set_info(d_solver, "smt-lib-version", "2.5");
   cvc5_set_info(d_solver, "smt-lib-version", "2.6");
   ASSERT_CVC5_ERROR(cvc5_set_info(d_solver, "smt-lib-version", ".0"),
-               "invalid argument");
+                    "invalid argument");
 
   cvc5_set_info(d_solver, "status", "sat");
   cvc5_set_info(d_solver, "status", "unsat");
   cvc5_set_info(d_solver, "status", "unknown");
-  ASSERT_CVC5_ERROR(cvc5_set_info(d_solver, "status", "asdf"), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_set_info(d_solver, "status", "asdf"),
+                    "invalid argument");
 }
 
 TEST_F(TestCApiBlackSolver, set_logic)
 {
-  ASSERT_CVC5_ERROR(cvc5_set_logic(nullptr, "AUFLIRA"), "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_set_logic(d_solver, nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_set_logic(nullptr, "AUFLIRA"),
+                    "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_set_logic(d_solver, nullptr),
+                    "unexpected NULL argument");
 
   cvc5_set_logic(d_solver, "AUFLIRA");
 
   ASSERT_CVC5_ERROR(cvc5_set_logic(d_solver, "AF_BV"), "logic is already set");
   cvc5_assert_formula(d_solver, cvc5_mk_true(d_tm));
-  ASSERT_CVC5_ERROR(cvc5_set_logic(d_solver, "AUFLIRA"), "logic is already set");
+  ASSERT_CVC5_ERROR(cvc5_set_logic(d_solver, "AUFLIRA"),
+                    "logic is already set");
 }
 
 TEST_F(TestCApiBlackSolver, is_logic_set)
@@ -2363,20 +2406,20 @@ TEST_F(TestCApiBlackSolver, set_option)
 {
   cvc5_set_option(d_solver, "bv-sat-solver", "cadical");
   ASSERT_CVC5_ERROR(cvc5_set_option(d_solver, "bv-sat-solver", "1"),
-               "unknown option");
+                    "unknown option");
   cvc5_assert_formula(d_solver, cvc5_mk_true(d_tm));
   ASSERT_CVC5_ERROR(cvc5_set_option(d_solver, "bv-sat-solver", "cadical"),
-               "fully initialized");
+                    "fully initialized");
 }
 
 TEST_F(TestCApiBlackSolver, reset_assertions)
 {
   ASSERT_CVC5_ERROR(cvc5_set_option(nullptr, "incremental", "true"),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_set_option(d_solver, nullptr, "true"),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_set_option(d_solver, "incremental", nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 
   cvc5_set_option(d_solver, "incremental", "true");
 
@@ -2411,10 +2454,11 @@ TEST_F(TestCApiBlackSolver, declare_sygus_var)
   (void)cvc5_declare_sygus_var(d_solver, "b", d_bool);
 
   ASSERT_CVC5_ERROR(cvc5_declare_sygus_var(nullptr, "", d_bool),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_declare_sygus_var(d_solver, nullptr, d_bool),
-               "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_declare_sygus_var(d_solver, "", nullptr), "invalid sort");
+                    "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_declare_sygus_var(d_solver, "", nullptr),
+                    "invalid sort");
 
   Cvc5* slv = cvc5_new(d_tm);
   ASSERT_CVC5_ERROR(cvc5_declare_sygus_var(slv, "", d_bool), "cannot call");
@@ -2423,8 +2467,9 @@ TEST_F(TestCApiBlackSolver, declare_sygus_var)
   Cvc5TermManager* tm = cvc5_term_manager_new();
   slv = cvc5_new(tm);
   cvc5_set_option(slv, "sygus", "true");
-  ASSERT_CVC5_ERROR(cvc5_declare_sygus_var(slv, "", d_bool),
-               "sort is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_declare_sygus_var(slv, "", d_bool),
+      "sort is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
 }
@@ -2510,8 +2555,8 @@ TEST_F(TestCApiBlackSolver, synth_fun)
   (void)cvc5_synth_fun(d_solver, "", 0, nullptr, d_bool);
   (void)cvc5_synth_fun(d_solver, "f1", bvars.size(), bvars.data(), d_bool);
   ASSERT_CVC5_ERROR(cvc5_synth_fun_with_grammar(
-                   d_solver, "f2", bvars.size(), bvars.data(), d_bool, g1),
-               "invalid grammar");
+                        d_solver, "f2", bvars.size(), bvars.data(), d_bool, g1),
+                    "invalid grammar");
 
   cvc5_grammar_add_rule(g1, start1, cvc5_mk_false(d_tm));
 
@@ -2523,18 +2568,20 @@ TEST_F(TestCApiBlackSolver, synth_fun)
   cvc5_synth_fun_with_grammar(
       d_solver, "f2", bvars.size(), bvars.data(), d_bool, g1);
   ASSERT_CVC5_ERROR(cvc5_synth_fun_with_grammar(
-                   nullptr, "f2", bvars.size(), bvars.data(), d_bool, g1),
-               "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_synth_fun_with_grammar(
-                   d_solver, "f2", bvars.size(), bvars.data(), nullptr, g1),
-               "invalid sort");
-  ASSERT_CVC5_ERROR(cvc5_synth_fun_with_grammar(
-                   d_solver, "f2", bvars.size(), bvars.data(), d_bool, nullptr),
-               "invalid grammar");
+                        nullptr, "f2", bvars.size(), bvars.data(), d_bool, g1),
+                    "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_synth_fun_with_grammar(
+          d_solver, "f2", bvars.size(), bvars.data(), nullptr, g1),
+      "invalid sort");
+  ASSERT_CVC5_ERROR(
+      cvc5_synth_fun_with_grammar(
+          d_solver, "f2", bvars.size(), bvars.data(), d_bool, nullptr),
+      "invalid grammar");
 
   ASSERT_CVC5_ERROR(cvc5_synth_fun_with_grammar(
-                   d_solver, "f6", bvars.size(), bvars.data(), d_bool, g2),
-               "invalid Start symbol");
+                        d_solver, "f6", bvars.size(), bvars.data(), d_bool, g2),
+                    "invalid Start symbol");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
@@ -2559,8 +2606,9 @@ TEST_F(TestCApiBlackSolver, declare_pool)
   // pool should have the same sort
   ASSERT_TRUE(cvc5_sort_is_equal(cvc5_term_get_sort(p), set_sort));
 
-  ASSERT_CVC5_ERROR(cvc5_declare_pool(nullptr, "p", d_int, args.size(), args.data()),
-               "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_declare_pool(nullptr, "p", d_int, args.size(), args.data()),
+      "unexpected NULL argument");
   ASSERT_CVC5_ERROR(
       cvc5_declare_pool(d_solver, nullptr, d_int, args.size(), args.data()),
       "unexpected NULL argument");
@@ -2591,8 +2639,9 @@ TEST_F(TestCApiBlackSolver, declare_pool)
   Cvc5Term x2 = cvc5_mk_const(tm, cvc5_get_integer_sort(tm), "x");
   Cvc5Term y2 = cvc5_mk_const(tm, cvc5_get_integer_sort(tm), "y");
   std::vector<Cvc5Term> args2 = {zero2, x2, y2};
-  ASSERT_CVC5_ERROR(cvc5_declare_pool(slv, "p", d_int, args2.size(), args2.data()),
-               "sort is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_declare_pool(slv, "p", d_int, args2.size(), args2.data()),
+      "sort is not associated with the term manager of this solver");
   ASSERT_CVC5_ERROR(
       cvc5_declare_pool(
           slv, "p", cvc5_get_integer_sort(tm), args.size(), args.data()),
@@ -2661,24 +2710,24 @@ TEST_F(TestCApiBlackSolver, declare_oracle_fun_unsat)
             return cvc5_mk_integer_int64(ctm, 0);
           }),
       "expected a sort associated with the term manager of this solver");
-  ASSERT_CVC5_ERROR(cvc5_declare_oracle_fun(
-                   slv,
-                   "f",
-                   sorts2.size(),
-                   sorts2.data(),
-                   d_int,
-                   tm,
-                   [](size_t, const Cvc5Term* input, void* state) {
-                     Cvc5TermManager* ctm =
-                         static_cast<Cvc5TermManager*>(state);
-                     if (cvc5_term_is_uint32_value(input[0]))
-                     {
-                       return cvc5_mk_integer_int64(
-                           ctm, cvc5_term_get_uint32_value(input[0]) + 1);
-                     }
-                     return cvc5_mk_integer_int64(ctm, 0);
-                   }),
-               "sort is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_declare_oracle_fun(
+          slv,
+          "f",
+          sorts2.size(),
+          sorts2.data(),
+          d_int,
+          tm,
+          [](size_t, const Cvc5Term* input, void* state) {
+            Cvc5TermManager* ctm = static_cast<Cvc5TermManager*>(state);
+            if (cvc5_term_is_uint32_value(input[0]))
+            {
+              return cvc5_mk_integer_int64(
+                  ctm, cvc5_term_get_uint32_value(input[0]) + 1);
+            }
+            return cvc5_mk_integer_int64(ctm, 0);
+          }),
+      "sort is not associated with the term manager of this solver");
   // this cannot be caught during declaration, is caught during check-sat
   Cvc5Term f2 = cvc5_declare_oracle_fun(
       slv,
@@ -2704,9 +2753,10 @@ TEST_F(TestCApiBlackSolver, declare_oracle_fun_unsat)
   cvc5_assert_formula(
       slv, cvc5_mk_term(tm, CVC5_KIND_EQUAL, args2.size(), args2.data()));
   // (f 3) = 5
-  ASSERT_CVC5_ERROR(cvc5_check_sat(slv),
-               "Evaluated an oracle call that is not associated with the term "
-               "manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_check_sat(slv),
+      "Evaluated an oracle call that is not associated with the term "
+      "manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
 }
@@ -2790,33 +2840,33 @@ TEST_F(TestCApiBlackSolver, declare_oracle_fun_error1)
   cvc5_set_option(d_solver, "oracles", "true");
   std::vector<Cvc5Sort> sorts = {d_int, d_int};
   ASSERT_CVC5_ERROR(cvc5_declare_oracle_fun(
-                   nullptr,
-                   "eq",
-                   sorts.size(),
-                   sorts.data(),
-                   d_bool,
-                   d_tm,
-                   [](size_t size, const Cvc5Term* input, void* state) {
-                     Assert(size == 2);
-                     return cvc5_mk_boolean(
-                         static_cast<Cvc5TermManager*>(state),
-                         cvc5_term_is_equal(input[0], input[1]));
-                   }),
-               "unexpected NULL argument");
+                        nullptr,
+                        "eq",
+                        sorts.size(),
+                        sorts.data(),
+                        d_bool,
+                        d_tm,
+                        [](size_t size, const Cvc5Term* input, void* state) {
+                          Assert(size == 2);
+                          return cvc5_mk_boolean(
+                              static_cast<Cvc5TermManager*>(state),
+                              cvc5_term_is_equal(input[0], input[1]));
+                        }),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_declare_oracle_fun(
-                   d_solver,
-                   nullptr,
-                   sorts.size(),
-                   sorts.data(),
-                   d_bool,
-                   d_tm,
-                   [](size_t size, const Cvc5Term* input, void* state) {
-                     Assert(size == 2);
-                     return cvc5_mk_boolean(
-                         static_cast<Cvc5TermManager*>(state),
-                         cvc5_term_is_equal(input[0], input[1]));
-                   }),
-               "unexpected NULL argument");
+                        d_solver,
+                        nullptr,
+                        sorts.size(),
+                        sorts.data(),
+                        d_bool,
+                        d_tm,
+                        [](size_t size, const Cvc5Term* input, void* state) {
+                          Assert(size == 2);
+                          return cvc5_mk_boolean(
+                              static_cast<Cvc5TermManager*>(state),
+                              cvc5_term_is_equal(input[0], input[1]));
+                        }),
+                    "unexpected NULL argument");
   // Declaring an oracle function with no argument sorts triggers an internal
   // (debug-only) cvc5 assertion that aborts the process via FatalStream; this
   // is not a recoverable C API error, so it remains a death test.
@@ -2835,19 +2885,19 @@ TEST_F(TestCApiBlackSolver, declare_oracle_fun_error1)
                    }),
                "");
   ASSERT_CVC5_ERROR(cvc5_declare_oracle_fun(
-                   d_solver,
-                   "eq",
-                   sorts.size(),
-                   sorts.data(),
-                   nullptr,
-                   d_tm,
-                   [](size_t size, const Cvc5Term* input, void* state) {
-                     Assert(size == 2);
-                     return cvc5_mk_boolean(
-                         static_cast<Cvc5TermManager*>(state),
-                         cvc5_term_is_equal(input[0], input[1]));
-                   }),
-               "invalid sort");
+                        d_solver,
+                        "eq",
+                        sorts.size(),
+                        sorts.data(),
+                        nullptr,
+                        d_tm,
+                        [](size_t size, const Cvc5Term* input, void* state) {
+                          Assert(size == 2);
+                          return cvc5_mk_boolean(
+                              static_cast<Cvc5TermManager*>(state),
+                              cvc5_term_is_equal(input[0], input[1]));
+                        }),
+                    "invalid sort");
   // this won't die when declaring the function, only when the actual oracle
   // fun is called
   (void)cvc5_declare_oracle_fun(
@@ -2923,7 +2973,8 @@ TEST_F(TestCApiBlackSolver, get_interpolant)
   // We expect the resulting output to be a boolean formula
   ASSERT_TRUE(cvc5_sort_is_boolean(cvc5_term_get_sort(output)));
 
-  ASSERT_CVC5_ERROR(cvc5_get_interpolant(nullptr, conj), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_interpolant(nullptr, conj),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_interpolant(d_solver, nullptr), "invalid term");
 
   // try with a grammar, a simple grammar admitting true
@@ -2937,7 +2988,7 @@ TEST_F(TestCApiBlackSolver, get_interpolant)
   Cvc5Term conj2 =
       cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, args.size(), args.data());
   ASSERT_CVC5_ERROR(cvc5_get_interpolant_with_grammar(d_solver, conj2, g),
-               "invalid grammar, must have at least one rule");
+                    "invalid grammar, must have at least one rule");
   cvc5_grammar_add_rule(g, start, ttrue);
 
   // Call the interpolation api, while the resulting interpolant is the output
@@ -2946,11 +2997,11 @@ TEST_F(TestCApiBlackSolver, get_interpolant)
   ASSERT_TRUE(cvc5_term_is_equal(output2, ttrue));
 
   ASSERT_CVC5_ERROR(cvc5_get_interpolant_with_grammar(nullptr, conj2, g),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_interpolant_with_grammar(d_solver, nullptr, g),
-               "invalid term");
+                    "invalid term");
   ASSERT_CVC5_ERROR(cvc5_get_interpolant_with_grammar(d_solver, conj2, nullptr),
-               "invalid grammar");
+                    "invalid grammar");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
@@ -2965,10 +3016,12 @@ TEST_F(TestCApiBlackSolver, get_interpolant)
   Cvc5Term cconj2 =
       cvc5_mk_term(tm, CVC5_KIND_EQUAL, aargs.size(), aargs.data());
   (void)cvc5_get_interpolant_with_grammar(slv, cconj2, gg);
-  ASSERT_CVC5_ERROR(cvc5_get_interpolant(slv, conj2),
-               "term is not associated with the term manager of this solver");
-  ASSERT_CVC5_ERROR(cvc5_get_interpolant_with_grammar(slv, conj2, gg),
-               "term is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_get_interpolant(slv, conj2),
+      "term is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_get_interpolant_with_grammar(slv, conj2, gg),
+      "term is not associated with the term manager of this solver");
   ASSERT_CVC5_ERROR(
       cvc5_get_interpolant_with_grammar(slv, cconj2, g),
       "grammar is not associated with the term manager of this solver");
@@ -3009,10 +3062,12 @@ TEST_F(TestCApiBlackSolver, get_interpolant_next)
   Cvc5Term output = cvc5_get_interpolant(d_solver, conj);
   Cvc5Term output2 = cvc5_get_interpolant_next(d_solver);
 
-  ASSERT_CVC5_ERROR(cvc5_get_interpolant(nullptr, conj), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_interpolant(nullptr, conj),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_interpolant(d_solver, nullptr), "invalid term");
 
-  ASSERT_CVC5_ERROR(cvc5_get_interpolant_next(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_interpolant_next(nullptr),
+                    "unexpected NULL argument");
 
   // We expect the next output to be distinct
   ASSERT_TRUE(cvc5_term_is_disequal(output, output2));
@@ -3052,7 +3107,7 @@ TEST_F(TestCApiBlackSolver, get_abduct)
   args = {x, zero};
   Cvc5Term conj2 = cvc5_mk_term(d_tm, CVC5_KIND_GT, args.size(), args.data());
   ASSERT_CVC5_ERROR(cvc5_get_abduct_with_grammar(d_solver, conj2, g),
-               "invalid grammar, must have at least one rule");
+                    "invalid grammar, must have at least one rule");
   cvc5_grammar_add_rule(g, start, ttrue);
 
   // Call the abduction api, while the resulting abduct is the output
@@ -3061,11 +3116,11 @@ TEST_F(TestCApiBlackSolver, get_abduct)
   ASSERT_TRUE(cvc5_term_is_equal(output2, ttrue));
 
   ASSERT_CVC5_ERROR(cvc5_get_abduct_with_grammar(nullptr, conj2, g),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_abduct_with_grammar(d_solver, nullptr, g),
-               "invalid term");
+                    "invalid term");
   ASSERT_CVC5_ERROR(cvc5_get_abduct_with_grammar(d_solver, conj2, nullptr),
-               "invalid grammar");
+                    "invalid grammar");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
@@ -3088,10 +3143,12 @@ TEST_F(TestCApiBlackSolver, get_abduct)
   Cvc5Term cconj2 =
       cvc5_mk_term(tm, CVC5_KIND_EQUAL, aargs.size(), aargs.data());
   (void)cvc5_get_abduct_with_grammar(slv, cconj2, gg);
-  ASSERT_CVC5_ERROR(cvc5_get_abduct(slv, conj2),
-               "term is not associated with the term manager of this solver");
-  ASSERT_CVC5_ERROR(cvc5_get_abduct_with_grammar(slv, conj2, gg),
-               "term is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_get_abduct(slv, conj2),
+      "term is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_get_abduct_with_grammar(slv, conj2, gg),
+      "term is not associated with the term manager of this solver");
   ASSERT_CVC5_ERROR(
       cvc5_get_abduct_with_grammar(slv, cconj2, g),
       "grammar is not associated with the term manager of this solver");
@@ -3115,7 +3172,8 @@ TEST_F(TestCApiBlackSolver, get_abduct2)
   args = {y, zero};
   Cvc5Term conj = cvc5_mk_term(d_tm, CVC5_KIND_GT, args.size(), args.data());
   // Fails due to option not set
-  ASSERT_CVC5_ERROR(cvc5_get_abduct(d_solver, conj), "unless abducts are enabled");
+  ASSERT_CVC5_ERROR(cvc5_get_abduct(d_solver, conj),
+                    "unless abducts are enabled");
 }
 
 TEST_F(TestCApiBlackSolver, get_abduct_next)
@@ -3156,7 +3214,7 @@ TEST_F(TestCApiBlackSolver, block_model1)
       d_solver, cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, args.size(), args.data()));
   cvc5_check_sat(d_solver);
   ASSERT_CVC5_ERROR(cvc5_block_model(d_solver, CVC5_BLOCK_MODELS_MODE_LITERALS),
-               "cannot get value");
+                    "cannot get value");
 }
 
 TEST_F(TestCApiBlackSolver, block_model2)
@@ -3167,7 +3225,7 @@ TEST_F(TestCApiBlackSolver, block_model2)
   cvc5_assert_formula(
       d_solver, cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, args.size(), args.data()));
   ASSERT_CVC5_ERROR(cvc5_block_model(d_solver, CVC5_BLOCK_MODELS_MODE_LITERALS),
-               "after SAT or UNKNOWN");
+                    "after SAT or UNKNOWN");
 }
 
 TEST_F(TestCApiBlackSolver, block_model3)
@@ -3180,7 +3238,7 @@ TEST_F(TestCApiBlackSolver, block_model3)
   cvc5_check_sat(d_solver);
   cvc5_block_model(d_solver, CVC5_BLOCK_MODELS_MODE_LITERALS);
   ASSERT_CVC5_ERROR(cvc5_block_model(nullptr, CVC5_BLOCK_MODELS_MODE_LITERALS),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, block_model_values1)
@@ -3195,12 +3253,12 @@ TEST_F(TestCApiBlackSolver, block_model_values1)
   cvc5_block_model_values(d_solver, args.size(), args.data());
 
   ASSERT_CVC5_ERROR(cvc5_block_model_values(nullptr, args.size(), args.data()),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_block_model_values(d_solver, 0, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   args = {nullptr};
   ASSERT_CVC5_ERROR(cvc5_block_model_values(d_solver, args.size(), args.data()),
-               "invalid term at index 0");
+                    "invalid term at index 0");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
@@ -3235,7 +3293,7 @@ TEST_F(TestCApiBlackSolver, block_model_values3)
   cvc5_check_sat(d_solver);
   args = {x};
   ASSERT_CVC5_ERROR(cvc5_block_model_values(d_solver, args.size(), args.data()),
-               "cannot get value");
+                    "cannot get value");
 }
 
 TEST_F(TestCApiBlackSolver, block_model_values4)
@@ -3247,7 +3305,7 @@ TEST_F(TestCApiBlackSolver, block_model_values4)
       d_solver, cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, args.size(), args.data()));
   args = {x};
   ASSERT_CVC5_ERROR(cvc5_block_model_values(d_solver, args.size(), args.data()),
-               "SAT or UNKNOWN response");
+                    "SAT or UNKNOWN response");
 }
 
 TEST_F(TestCApiBlackSolver, block_model_values5)
@@ -3283,10 +3341,11 @@ TEST_F(TestCApiBlackSolver, get_instantiations)
   Cvc5Term app2 = cvc5_mk_term(d_tm, CVC5_KIND_NOT, args.size(), args.data());
   cvc5_assert_formula(d_solver, app2);
   ASSERT_CVC5_ERROR(cvc5_get_instantiations(d_solver),
-               "after a UNSAT, SAT or UNKNOWN response");
+                    "after a UNSAT, SAT or UNKNOWN response");
   cvc5_check_sat(d_solver);
   cvc5_get_instantiations(d_solver);
-  ASSERT_CVC5_ERROR(cvc5_get_instantiations(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_instantiations(nullptr),
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, add_sygus_constraint)
@@ -3296,14 +3355,16 @@ TEST_F(TestCApiBlackSolver, add_sygus_constraint)
 
   cvc5_add_sygus_constraint(d_solver, tbool);
   ASSERT_CVC5_ERROR(cvc5_add_sygus_constraint(nullptr, tbool),
-               "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_add_sygus_constraint(d_solver, nullptr), "invalid term");
+                    "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_constraint(d_solver, nullptr),
+                    "invalid term");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
   cvc5_set_option(slv, "sygus", "true");
-  ASSERT_CVC5_ERROR(cvc5_add_sygus_constraint(slv, tbool),
-               "term is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_add_sygus_constraint(slv, tbool),
+      "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
 }
@@ -3320,9 +3381,9 @@ TEST_F(TestCApiBlackSolver, get_sygus_constraints)
   ASSERT_TRUE(cvc5_term_is_equal(ttrue, constraints[0]));
   ASSERT_TRUE(cvc5_term_is_equal(tfalse, constraints[1]));
   ASSERT_CVC5_ERROR(cvc5_get_sygus_constraints(nullptr, &size),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_sygus_constraints(d_solver, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, add_sygus_assume)
@@ -3333,15 +3394,16 @@ TEST_F(TestCApiBlackSolver, add_sygus_assume)
 
   cvc5_add_sygus_assume(d_solver, tbool);
   ASSERT_CVC5_ERROR(cvc5_add_sygus_assume(nullptr, tbool),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_add_sygus_assume(d_solver, nullptr), "invalid term");
   ASSERT_CVC5_ERROR(cvc5_add_sygus_assume(d_solver, tint), "invalid argument");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
   cvc5_set_option(slv, "sygus", "true");
-  ASSERT_CVC5_ERROR(cvc5_add_sygus_assume(slv, tbool),
-               "term is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_add_sygus_assume(slv, tbool),
+      "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
 }
@@ -3360,9 +3422,9 @@ TEST_F(TestCApiBlackSolver, get_sygus_assumptions)
   ASSERT_TRUE(cvc5_term_is_equal(ttrue, assumptions[0]));
   ASSERT_TRUE(cvc5_term_is_equal(tfalse, assumptions[1]));
   ASSERT_CVC5_ERROR(cvc5_get_sygus_assumptions(nullptr, &size),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_sygus_assumptions(d_solver, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, add_sygus_inv_constraint)
@@ -3396,38 +3458,49 @@ TEST_F(TestCApiBlackSolver, add_sygus_inv_constraint)
 
   cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans, post);
 
-  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(nullptr, inv, pre, trans, post),
-               "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_add_sygus_inv_constraint(nullptr, inv, pre, trans, post),
+      "unexpected NULL argument");
   ASSERT_CVC5_ERROR(
       cvc5_add_sygus_inv_constraint(d_solver, nullptr, pre, trans, post),
       "invalid term");
   ASSERT_CVC5_ERROR(
       cvc5_add_sygus_inv_constraint(d_solver, inv, nullptr, trans, post),
       "invalid term");
-  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, nullptr, post),
-               "invalid term");
+  ASSERT_CVC5_ERROR(
+      cvc5_add_sygus_inv_constraint(d_solver, inv, pre, nullptr, post),
+      "invalid term");
   ASSERT_CVC5_ERROR(
       cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans, nullptr),
       "invalid term");
 
-  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, tint, pre, trans, post),
-               "invalid argument");
-  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, inv1, pre, trans, post),
-               "invalid argument");
-  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, inv, trans, trans, post),
-               "have the same sort");
-  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, tint, post),
-               "expected the sort of trans");
-  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, pre, post),
-               "expected the sort of trans");
-  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans1, post),
-               "expected the sort of trans");
-  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans2, post),
-               "expected the sort of trans");
-  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans3, post),
-               "expected the sort of trans");
-  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans, trans),
-               "expected inv and post to have the same sort");
+  ASSERT_CVC5_ERROR(
+      cvc5_add_sygus_inv_constraint(d_solver, tint, pre, trans, post),
+      "invalid argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_add_sygus_inv_constraint(d_solver, inv1, pre, trans, post),
+      "invalid argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_add_sygus_inv_constraint(d_solver, inv, trans, trans, post),
+      "have the same sort");
+  ASSERT_CVC5_ERROR(
+      cvc5_add_sygus_inv_constraint(d_solver, inv, pre, tint, post),
+      "expected the sort of trans");
+  ASSERT_CVC5_ERROR(
+      cvc5_add_sygus_inv_constraint(d_solver, inv, pre, pre, post),
+      "expected the sort of trans");
+  ASSERT_CVC5_ERROR(
+      cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans1, post),
+      "expected the sort of trans");
+  ASSERT_CVC5_ERROR(
+      cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans2, post),
+      "expected the sort of trans");
+  ASSERT_CVC5_ERROR(
+      cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans3, post),
+      "expected the sort of trans");
+  ASSERT_CVC5_ERROR(
+      cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans, trans),
+      "expected inv and post to have the same sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
@@ -3446,14 +3519,18 @@ TEST_F(TestCApiBlackSolver, add_sygus_inv_constraint)
   Cvc5Term post22 = cvc5_declare_fun(
       slv, "post", domain2.size(), domain2.data(), bool_sort, true);
   cvc5_add_sygus_inv_constraint(slv, inv22, pre22, trans22, post22);
-  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(slv, inv, pre22, trans22, post22),
-               "term is not associated with the term manager of this solver");
-  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(slv, inv22, pre, trans22, post22),
-               "term is not associated with the term manager of this solver");
-  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(slv, inv22, pre22, trans, post22),
-               "term is not associated with the term manager of this solver");
-  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(slv, inv22, pre22, trans22, post),
-               "term is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_add_sygus_inv_constraint(slv, inv, pre22, trans22, post22),
+      "term is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_add_sygus_inv_constraint(slv, inv22, pre, trans22, post22),
+      "term is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_add_sygus_inv_constraint(slv, inv22, pre22, trans, post22),
+      "term is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_add_sygus_inv_constraint(slv, inv22, pre22, trans22, post),
+      "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
 }
@@ -3462,7 +3539,7 @@ TEST_F(TestCApiBlackSolver, check_synth)
 {
   // requires option to be set
   ASSERT_CVC5_ERROR(cvc5_check_synth(d_solver),
-               "cannot check for a synthesis solution");
+                    "cannot check for a synthesis solution");
   cvc5_set_option(d_solver, "sygus", "true");
   cvc5_check_synth(d_solver);
   ASSERT_CVC5_ERROR(cvc5_check_synth(nullptr), "unexpected NULL argument");
@@ -3484,15 +3561,17 @@ TEST_F(TestCApiBlackSolver, get_synth_solution)
   cvc5_get_synth_solution(d_solver, f);
   cvc5_get_synth_solution(d_solver, f);
 
-  ASSERT_CVC5_ERROR(cvc5_get_synth_solution(nullptr, f), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_synth_solution(nullptr, f),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_synth_solution(d_solver, nullptr), "invalid term");
   ASSERT_CVC5_ERROR(cvc5_get_synth_solution(d_solver, x),
-               "synthesis solution not found for given term");
+                    "synthesis solution not found for given term");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
-  ASSERT_CVC5_ERROR(cvc5_get_synth_solution(slv, f),
-               "term is not associated with the term manager of this solver");
+  ASSERT_CVC5_ERROR(
+      cvc5_get_synth_solution(slv, f),
+      "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
 }
@@ -3506,8 +3585,9 @@ TEST_F(TestCApiBlackSolver, get_synth_solutions)
   Cvc5Term f = cvc5_synth_fun(d_solver, "f", 0, nullptr, d_bool);
 
   std::vector<Cvc5Term> args{f};
-  ASSERT_CVC5_ERROR(cvc5_get_synth_solutions(d_solver, args.size(), args.data()),
-               "not in a state");
+  ASSERT_CVC5_ERROR(
+      cvc5_get_synth_solutions(d_solver, args.size(), args.data()),
+      "not in a state");
 
   cvc5_check_synth(d_solver);
 
@@ -3516,15 +3596,17 @@ TEST_F(TestCApiBlackSolver, get_synth_solutions)
   cvc5_get_synth_solutions(d_solver, args.size(), args.data());
 
   ASSERT_CVC5_ERROR(cvc5_get_synth_solutions(d_solver, 0, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_synth_solutions(nullptr, args.size(), args.data()),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   args = {nullptr};
-  ASSERT_CVC5_ERROR(cvc5_get_synth_solutions(d_solver, args.size(), args.data()),
-               "invalid term at index 0");
+  ASSERT_CVC5_ERROR(
+      cvc5_get_synth_solutions(d_solver, args.size(), args.data()),
+      "invalid term at index 0");
   args = {x};
-  ASSERT_CVC5_ERROR(cvc5_get_synth_solutions(d_solver, args.size(), args.data()),
-               "synthesis solution not found for term at index 0");
+  ASSERT_CVC5_ERROR(
+      cvc5_get_synth_solutions(d_solver, args.size(), args.data()),
+      "synthesis solution not found for term at index 0");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
@@ -3562,7 +3644,7 @@ TEST_F(TestCApiBlackSolver, check_synth_next2)
   (void)cvc5_synth_fun(d_solver, "f", 0, nullptr, d_bool);
   cvc5_check_synth(d_solver);
   ASSERT_CVC5_ERROR(cvc5_check_synth_next(d_solver),
-               "cannot check for a next synthesis solution");
+                    "cannot check for a next synthesis solution");
 }
 
 TEST_F(TestCApiBlackSolver, check_synth_next3)
@@ -3570,7 +3652,8 @@ TEST_F(TestCApiBlackSolver, check_synth_next3)
   cvc5_set_option(d_solver, "sygus", "true");
   cvc5_set_option(d_solver, "incremental", "true");
   (void)cvc5_synth_fun(d_solver, "f", 0, nullptr, d_bool);
-  ASSERT_CVC5_ERROR(cvc5_check_synth_next(d_solver), "unless immediately preceded");
+  ASSERT_CVC5_ERROR(cvc5_check_synth_next(d_solver),
+                    "unless immediately preceded");
 }
 
 TEST_F(TestCApiBlackSolver, find_synth)
@@ -3596,19 +3679,20 @@ TEST_F(TestCApiBlackSolver, find_synth)
   ASSERT_TRUE(t && cvc5_sort_is_boolean(cvc5_term_get_sort(t)));
 
   ASSERT_CVC5_ERROR(cvc5_find_synth(nullptr, CVC5_FIND_SYNTH_TARGET_ENUM),
-               "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_find_synth(d_solver, static_cast<Cvc5FindSynthTarget>(125)),
-               "invalid find synthesis target");
+                    "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_find_synth(d_solver, static_cast<Cvc5FindSynthTarget>(125)),
+      "invalid find synthesis target");
 
   ASSERT_CVC5_ERROR(
       cvc5_find_synth_with_grammar(nullptr, CVC5_FIND_SYNTH_TARGET_ENUM, g),
       "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_find_synth_with_grammar(
-                   d_solver, static_cast<Cvc5FindSynthTarget>(125), g),
-               "invalid find synthesis target");
+                        d_solver, static_cast<Cvc5FindSynthTarget>(125), g),
+                    "invalid find synthesis target");
   ASSERT_CVC5_ERROR(cvc5_find_synth_with_grammar(
-                   d_solver, CVC5_FIND_SYNTH_TARGET_ENUM, nullptr),
-               "invalid grammar");
+                        d_solver, CVC5_FIND_SYNTH_TARGET_ENUM, nullptr),
+                    "invalid grammar");
 }
 
 TEST_F(TestCApiBlackSolver, find_synth2)
@@ -4002,25 +4086,26 @@ TEST_F(TestCApiBlackSolver, basic_finite_field_base)
 
 TEST_F(TestCApiBlackSolver, output1)
 {
-  ASSERT_CVC5_ERROR(cvc5_is_output_on(nullptr, "inst"), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_is_output_on(nullptr, "inst"),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_is_output_on(d_solver, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_is_output_on(d_solver, "foo-invalid"),
-               "invalid output tag");
+                    "invalid output tag");
 
   ASSERT_CVC5_ERROR(cvc5_get_output(nullptr, "inst", "<stdout>"),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_output(d_solver, nullptr, "<stdout>"),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_output(d_solver, "inst", nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_get_output(d_solver, "foo-invalid", "<stdout>"),
-               "invalid output tag");
+                    "invalid output tag");
 
   ASSERT_CVC5_ERROR(cvc5_close_output(nullptr, "<stdout>"),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_close_output(d_solver, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   // should not fail
   cvc5_close_output(d_solver, "<stdout>");
 }

--- a/test/unit/api/c/capi_solver_black.cpp
+++ b/test/unit/api/c/capi_solver_black.cpp
@@ -22,6 +22,7 @@ extern "C" {
 #include "base/check.h"
 #include "base/output.h"
 #include "gtest/gtest.h"
+#include "test_capi.h"
 
 namespace cvc5::internal::test {
 
@@ -96,7 +97,7 @@ TEST_F(TestCApiBlackSolver, pow2_large1)
   args = {t74, t180};
   Cvc5Term t258 = cvc5_mk_term(d_tm, CVC5_KIND_GEQ, args.size(), args.data());
   cvc5_assert_formula(d_solver, t258);
-  ASSERT_DEATH(cvc5_simplify(d_solver, t82, true),
+  ASSERT_CVC5_ERROR(cvc5_simplify(d_solver, t82, true),
                "can only be a positive integral constant below");
 }
 
@@ -113,7 +114,7 @@ TEST_F(TestCApiBlackSolver, pow2_large2)
   Cvc5Term t4 =
       cvc5_mk_term(d_tm, CVC5_KIND_DISTINCT, args.size(), args.data());
   std::vector<Cvc5Term> assumptions = {t4};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_check_sat_assuming(d_solver, assumptions.size(), assumptions.data()),
       "can only be a positive integral constant below");
 }
@@ -157,8 +158,8 @@ TEST_F(TestCApiBlackSolver, simplify)
   Cvc5Term x = cvc5_mk_const(d_tm, bv_sort, "x");
   (void)cvc5_simplify(d_solver, x, false);
 
-  ASSERT_DEATH(cvc5_simplify(nullptr, x, false), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_simplify(d_solver, nullptr, false), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_simplify(nullptr, x, false), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_simplify(d_solver, nullptr, false), "invalid term");
 
   Cvc5Term a = cvc5_mk_const(d_tm, bv_sort, "a");
   (void)cvc5_simplify(d_solver, a, false);
@@ -245,7 +246,7 @@ TEST_F(TestCApiBlackSolver, simplify)
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
-  ASSERT_DEATH(cvc5_simplify(slv, x, false),
+  ASSERT_CVC5_ERROR(cvc5_simplify(slv, x, false),
                "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
@@ -267,15 +268,15 @@ TEST_F(TestCApiBlackSolver, simplify_apply_subs)
 
 TEST_F(TestCApiBlackSolver, assert_formula)
 {
-  ASSERT_DEATH(cvc5_assert_formula(nullptr, cvc5_mk_true(d_tm)),
+  ASSERT_CVC5_ERROR(cvc5_assert_formula(nullptr, cvc5_mk_true(d_tm)),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_assert_formula(d_solver, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_assert_formula(d_solver, nullptr), "invalid term");
 
   cvc5_assert_formula(d_solver, cvc5_mk_true(d_tm));
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
-  ASSERT_DEATH(cvc5_assert_formula(slv, cvc5_mk_true(d_tm)),
+  ASSERT_CVC5_ERROR(cvc5_assert_formula(slv, cvc5_mk_true(d_tm)),
                "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
@@ -283,35 +284,35 @@ TEST_F(TestCApiBlackSolver, assert_formula)
 
 TEST_F(TestCApiBlackSolver, check_sat)
 {
-  ASSERT_DEATH(cvc5_check_sat(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_check_sat(nullptr), "unexpected NULL argument");
 
   cvc5_set_option(d_solver, "incremental", "false");
   cvc5_check_sat(d_solver);
-  ASSERT_DEATH(cvc5_check_sat(d_solver), "cannot make multiple queries");
+  ASSERT_CVC5_ERROR(cvc5_check_sat(d_solver), "cannot make multiple queries");
 }
 
 TEST_F(TestCApiBlackSolver, check_sat_assuming)
 {
   std::vector<Cvc5Term> assumptions = {nullptr};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_check_sat_assuming(d_solver, assumptions.size(), assumptions.data()),
       "invalid term at index 0");
   assumptions = {cvc5_mk_true(d_tm)};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_check_sat_assuming(nullptr, assumptions.size(), assumptions.data()),
       "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_check_sat_assuming(d_solver, 0, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_check_sat_assuming(d_solver, 0, nullptr),
                "unexpected NULL argument");
 
   cvc5_set_option(d_solver, "incremental", "false");
   cvc5_check_sat_assuming(d_solver, assumptions.size(), assumptions.data());
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_check_sat_assuming(d_solver, assumptions.size(), assumptions.data()),
       "cannot make multiple queries");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_check_sat_assuming(slv, assumptions.size(), assumptions.data()),
       "expected a term associated with the term manager of this solver");
   ;
@@ -420,29 +421,29 @@ TEST_F(TestCApiBlackSolver, declare_datatype)
   cons = cvc5_mk_dt_cons_decl(d_tm, "cons");
   nil = cvc5_mk_dt_cons_decl(d_tm, "nil");
   ctors = {cons, nil};
-  ASSERT_DEATH(cvc5_declare_dt(nullptr, "c", ctors.size(), ctors.data()),
+  ASSERT_CVC5_ERROR(cvc5_declare_dt(nullptr, "c", ctors.size(), ctors.data()),
                "unexpected NULL argument");
   ctors = {nullptr};
-  ASSERT_DEATH(cvc5_declare_dt(d_solver, "c", ctors.size(), ctors.data()),
+  ASSERT_CVC5_ERROR(cvc5_declare_dt(d_solver, "c", ctors.size(), ctors.data()),
                "invalid datatype constructor declaration at index 0");
 
   // must have at least one constructor
   ctors = {};
-  ASSERT_DEATH(cvc5_declare_dt(d_solver, "c", ctors.size(), ctors.data()),
+  ASSERT_CVC5_ERROR(cvc5_declare_dt(d_solver, "c", ctors.size(), ctors.data()),
                "expected a datatype declaration with at least one constructor");
   // constructors may not be reused
   Cvc5DatatypeConstructorDecl ctor1 = cvc5_mk_dt_cons_decl(d_tm, "_x21");
   Cvc5DatatypeConstructorDecl ctor2 = cvc5_mk_dt_cons_decl(d_tm, "_x31");
   ctors = {ctor1, ctor2};
   (void)cvc5_declare_dt(d_solver, "_x17", ctors.size(), ctors.data());
-  ASSERT_DEATH(cvc5_declare_dt(d_solver, "_x86", ctors.size(), ctors.data()),
+  ASSERT_CVC5_ERROR(cvc5_declare_dt(d_solver, "_x86", ctors.size(), ctors.data()),
                "cannot use a constructor for multiple datatypes");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
   nil = cvc5_mk_dt_cons_decl(d_tm, "nil");
   ctors = {nil};
-  ASSERT_DEATH(cvc5_declare_dt(slv, "a", ctors.size(), ctors.data()),
+  ASSERT_CVC5_ERROR(cvc5_declare_dt(slv, "a", ctors.size(), ctors.data()),
                "expected a datatype constructor declaration associated with "
                "the term manager of this solver");
   cvc5_delete(slv);
@@ -459,9 +460,9 @@ TEST_F(TestCApiBlackSolver, dt_get_arity)
 
 TEST_F(TestCApiBlackSolver, declare_fun)
 {
-  ASSERT_DEATH(cvc5_declare_fun(nullptr, "b", 0, nullptr, d_bool, true),
+  ASSERT_CVC5_ERROR(cvc5_declare_fun(nullptr, "b", 0, nullptr, d_bool, true),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_declare_fun(d_solver, "b", 0, nullptr, nullptr, true),
+  ASSERT_CVC5_ERROR(cvc5_declare_fun(d_solver, "b", 0, nullptr, nullptr, true),
                "invalid sort");
 
   Cvc5Sort bv_sort = cvc5_mk_bv_sort(d_tm, 32);
@@ -472,21 +473,21 @@ TEST_F(TestCApiBlackSolver, declare_fun)
   domain = {bv_sort, d_int};
   (void)cvc5_declare_fun(
       d_solver, "f3", domain.size(), domain.data(), bv_sort, true);
-  ASSERT_DEATH(cvc5_declare_fun(d_solver, "f3", 0, nullptr, fun_sort, true),
+  ASSERT_CVC5_ERROR(cvc5_declare_fun(d_solver, "f3", 0, nullptr, fun_sort, true),
                "invalid argument");
   // functions as arguments is allowed
   domain = {bv_sort, fun_sort};
   (void)cvc5_declare_fun(
       d_solver, "f4", domain.size(), domain.data(), bv_sort, true);
   domain = {bv_sort, bv_sort};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_declare_fun(
           d_solver, "f5", domain.size(), domain.data(), fun_sort, true),
       "invalid argument");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
-  ASSERT_DEATH(cvc5_declare_fun(slv, "f1", 0, nullptr, bv_sort, true),
+  ASSERT_CVC5_ERROR(cvc5_declare_fun(slv, "f1", 0, nullptr, bv_sort, true),
                "sort is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
@@ -508,7 +509,7 @@ TEST_F(TestCApiBlackSolver, declare_fun_fresh)
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
-  ASSERT_DEATH(cvc5_declare_fun(slv, "b", 0, nullptr, d_int, false),
+  ASSERT_CVC5_ERROR(cvc5_declare_fun(slv, "b", 0, nullptr, d_int, false),
                "sort is not associated with the term manager of this solver");
   ;
   cvc5_delete(slv);
@@ -517,9 +518,9 @@ TEST_F(TestCApiBlackSolver, declare_fun_fresh)
 
 TEST_F(TestCApiBlackSolver, declare_sort)
 {
-  ASSERT_DEATH(cvc5_declare_sort(nullptr, "s", 0, true),
+  ASSERT_CVC5_ERROR(cvc5_declare_sort(nullptr, "s", 0, true),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_declare_sort(d_solver, nullptr, 0, true),
+  ASSERT_CVC5_ERROR(cvc5_declare_sort(d_solver, nullptr, 0, true),
                "unexpected NULL argument");
   (void)cvc5_declare_sort(d_solver, "s", 0, true);
   (void)cvc5_declare_sort(d_solver, "s", 2, true);
@@ -528,9 +529,9 @@ TEST_F(TestCApiBlackSolver, declare_sort)
 
 TEST_F(TestCApiBlackSolver, declare_sort_fresh)
 {
-  ASSERT_DEATH(cvc5_declare_sort(nullptr, "b", 0, true),
+  ASSERT_CVC5_ERROR(cvc5_declare_sort(nullptr, "b", 0, true),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_declare_sort(d_solver, nullptr, 0, true),
+  ASSERT_CVC5_ERROR(cvc5_declare_sort(d_solver, nullptr, 0, true),
                "unexpected NULL argument");
 
   Cvc5Sort s1 = cvc5_declare_sort(d_solver, "b", 0, true);
@@ -560,11 +561,11 @@ TEST_F(TestCApiBlackSolver, define_fun)
   Cvc5Term v1 = cvc5_mk_const(d_tm, bv_sort, "v1");
   Cvc5Term v2 = cvc5_mk_const(d_tm, fun_sort, "v2");
 
-  ASSERT_DEATH(cvc5_define_fun(nullptr, "f", 0, nullptr, bv_sort, v1, false),
+  ASSERT_CVC5_ERROR(cvc5_define_fun(nullptr, "f", 0, nullptr, bv_sort, v1, false),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_define_fun(d_solver, "f", 0, nullptr, nullptr, v1, false),
+  ASSERT_CVC5_ERROR(cvc5_define_fun(d_solver, "f", 0, nullptr, nullptr, v1, false),
                "invalid sort");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun(d_solver, "f", 0, nullptr, bv_sort, nullptr, false),
       "invalid term");
 
@@ -573,14 +574,14 @@ TEST_F(TestCApiBlackSolver, define_fun)
   (void)cvc5_define_fun(
       d_solver, "f", vars.size(), vars.data(), bv_sort, v1, false);
   vars = {v1, b2};
-  ASSERT_DEATH(cvc5_define_fun(
+  ASSERT_CVC5_ERROR(cvc5_define_fun(
                    d_solver, "f", vars.size(), vars.data(), bv_sort, v1, false),
                "invalid bound variable");
   vars = {b1};
-  ASSERT_DEATH(cvc5_define_fun(
+  ASSERT_CVC5_ERROR(cvc5_define_fun(
                    d_solver, "f", vars.size(), vars.data(), bv_sort, v2, false),
                "invalid sort of function body");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun(
           d_solver, "f", vars.size(), vars.data(), fun_sort, v2, false),
       "invalid argument");
@@ -596,25 +597,25 @@ TEST_F(TestCApiBlackSolver, define_fun)
   Cvc5Term b12 = cvc5_mk_var(tm, bv_sort2, "b1");
   Cvc5Term b22 = cvc5_mk_var(tm, cvc5_get_integer_sort(tm), "b2");
   vars = {};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun(slv, "f", vars.size(), vars.data(), bv_sort, v12, false),
       "sort is not associated with the term manager of this solver");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun(slv, "f", vars.size(), vars.data(), bv_sort2, v1, false),
       "term is not associated with the term manager of this solver");
   vars = {b1, b22};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun(slv, "f", vars.size(), vars.data(), bv_sort2, v12, false),
       "expected a term associated with the term manager of this solver");
   vars = {b12, b2};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun(slv, "f", vars.size(), vars.data(), bv_sort2, v12, false),
       "expected a term associated with the term manager of this solver");
   vars = {b12, b22};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun(slv, "f", vars.size(), vars.data(), bv_sort, v12, false),
       "sort is not associated with the term manager of this solver");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun(slv, "f", vars.size(), vars.data(), bv_sort2, v1, false),
       "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
@@ -690,58 +691,58 @@ TEST_F(TestCApiBlackSolver, define_fun_rec)
   (void)cvc5_define_fun_rec(
       d_solver, "f", vars.size(), vars.data(), bv_sort, v1, false);
 
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun_rec(nullptr, "f", 0, nullptr, bv_sort, v1, false),
       "unexpected NULL argument");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun_rec(d_solver, nullptr, 0, nullptr, bv_sort, v1, false),
       "unexpected NULL argument");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun_rec(d_solver, "f", 0, nullptr, nullptr, v1, false),
       "invalid sort");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun_rec(d_solver, "f", 0, nullptr, bv_sort, nullptr, false),
       "invalid term");
 
   vars = {b1};
-  ASSERT_DEATH(cvc5_define_fun_rec(
+  ASSERT_CVC5_ERROR(cvc5_define_fun_rec(
                    d_solver, "f", vars.size(), vars.data(), bv_sort, v3, false),
                "invalid sort");
   vars = {b1, v2};
-  ASSERT_DEATH(cvc5_define_fun_rec(
+  ASSERT_CVC5_ERROR(cvc5_define_fun_rec(
                    d_solver, "f", vars.size(), vars.data(), bv_sort, v1, false),
                "invalid bound variable");
   vars = {b1};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun_rec(
           d_solver, "f", vars.size(), vars.data(), fun_sort2, v3, false),
       "invalid argument");
 
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun_rec_from_const(nullptr, f1, 0, nullptr, v1, false),
       "unexpected NULL argument");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun_rec_from_const(d_solver, nullptr, 0, nullptr, v1, false),
       "invalid term");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun_rec_from_const(d_solver, f1, 0, nullptr, nullptr, false),
       "invalid term");
 
   vars = {b1};
-  ASSERT_DEATH(cvc5_define_fun_rec_from_const(
+  ASSERT_CVC5_ERROR(cvc5_define_fun_rec_from_const(
                    d_solver, f1, vars.size(), vars.data(), v1, false),
                "invalid size of argument 'bound_vars'");
-  ASSERT_DEATH(cvc5_define_fun_rec_from_const(
+  ASSERT_CVC5_ERROR(cvc5_define_fun_rec_from_const(
                    d_solver, f2, vars.size(), vars.data(), v2, false),
                "invalid sort");
-  ASSERT_DEATH(cvc5_define_fun_rec_from_const(
+  ASSERT_CVC5_ERROR(cvc5_define_fun_rec_from_const(
                    d_solver, f3, vars.size(), vars.data(), v1, false),
                "invalid argument");
   vars = {b1, b11};
-  ASSERT_DEATH(cvc5_define_fun_rec_from_const(
+  ASSERT_CVC5_ERROR(cvc5_define_fun_rec_from_const(
                    d_solver, f1, vars.size(), vars.data(), v2, false),
                "invalid sort");
-  ASSERT_DEATH(cvc5_define_fun_rec_from_const(
+  ASSERT_CVC5_ERROR(cvc5_define_fun_rec_from_const(
                    d_solver, f1, vars.size(), vars.data(), v3, false),
                "invalid sort");
 
@@ -752,26 +753,26 @@ TEST_F(TestCApiBlackSolver, define_fun_rec)
   Cvc5Term b22 = cvc5_mk_var(tm, cvc5_get_integer_sort(tm), "b2");
   Cvc5Term v12 = cvc5_mk_const(tm, bv_sort2, "v1");
   vars = {};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun_rec(
           d_solver, "f", vars.size(), vars.data(), bv_sort2, v12, false),
       "term is not associated with the term manager of this solver");
-  ASSERT_DEATH(cvc5_define_fun_rec(
+  ASSERT_CVC5_ERROR(cvc5_define_fun_rec(
                    slv, "f", vars.size(), vars.data(), bv_sort, v12, false),
                "sort is not associated with the term manager of this solver");
-  ASSERT_DEATH(cvc5_define_fun_rec(
+  ASSERT_CVC5_ERROR(cvc5_define_fun_rec(
                    slv, "f", vars.size(), vars.data(), bv_sort2, v1, false),
                "term is not associated with the term manager of this solver");
   vars = {b12, b22};
   (void)cvc5_define_fun_rec(
       slv, "f", vars.size(), vars.data(), bv_sort2, v12, false);
   vars = {b1, b22};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun_rec(
           slv, "f", vars.size(), vars.data(), bv_sort2, v12, false),
       "expected a term associated with the term manager of this solver");
   vars = {b12, b2};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun_rec(
           slv, "f", vars.size(), vars.data(), bv_sort2, v12, false),
       "expected a term associated with the term manager of this solver");
@@ -790,11 +791,11 @@ TEST_F(TestCApiBlackSolver, define_fun_rec_wrong_logic)
   Cvc5Term v = cvc5_mk_var(d_tm, bv_sort, "v");
   Cvc5Term f = cvc5_mk_var(d_tm, fun_sort, "f");
   std::vector<Cvc5Term> vars = {};
-  ASSERT_DEATH(cvc5_define_fun_rec(
+  ASSERT_CVC5_ERROR(cvc5_define_fun_rec(
                    d_solver, "f", vars.size(), vars.data(), bv_sort, v, false),
                "require a logic with quantifiers");
   vars = {b, b};
-  ASSERT_DEATH(cvc5_define_fun_rec_from_const(
+  ASSERT_CVC5_ERROR(cvc5_define_fun_rec_from_const(
                    d_solver, f, vars.size(), vars.data(), v, false),
                "require a logic with quantifiers");
 }
@@ -840,7 +841,7 @@ TEST_F(TestCApiBlackSolver, define_fun_rec_global)
   Cvc5Term bb = cvc5_mk_var(tm, cvc5_get_boolean_sort(tm), "b");
   domain = {d_bool};
   vars = {bb};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun_rec_from_const(
           slv,
           cvc5_mk_const(
@@ -854,7 +855,7 @@ TEST_F(TestCApiBlackSolver, define_fun_rec_global)
       "term is not associated with the term manager of this solver");
   vars = {b};
   domain = {cvc5_get_boolean_sort(tm)};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_fun_rec_from_const(
           slv,
           cvc5_mk_const(
@@ -907,7 +908,7 @@ TEST_F(TestCApiBlackSolver, define_funs_rec)
                        false);
   vars1 = {v1, b11};
   vars = {vars1.data(), vars2.data()};
-  ASSERT_DEATH(cvc5_define_funs_rec(d_solver,
+  ASSERT_CVC5_ERROR(cvc5_define_funs_rec(d_solver,
                                     funs.size(),
                                     funs.data(),
                                     nvars.data(),
@@ -918,7 +919,7 @@ TEST_F(TestCApiBlackSolver, define_funs_rec)
   funs = {f1, f3};
   vars1 = {b1, b11};
   vars = {vars1.data(), vars2.data()};
-  ASSERT_DEATH(cvc5_define_funs_rec(d_solver,
+  ASSERT_CVC5_ERROR(cvc5_define_funs_rec(d_solver,
                                     funs.size(),
                                     funs.data(),
                                     nvars.data(),
@@ -930,7 +931,7 @@ TEST_F(TestCApiBlackSolver, define_funs_rec)
   vars1 = {b1};
   vars = {vars1.data(), vars2.data()};
   nvars = {1, 1};
-  ASSERT_DEATH(cvc5_define_funs_rec(d_solver,
+  ASSERT_CVC5_ERROR(cvc5_define_funs_rec(d_solver,
                                     funs.size(),
                                     funs.data(),
                                     nvars.data(),
@@ -941,7 +942,7 @@ TEST_F(TestCApiBlackSolver, define_funs_rec)
   vars1 = {b1, b2};
   vars = {vars1.data(), vars2.data()};
   nvars = {2, 1};
-  ASSERT_DEATH(cvc5_define_funs_rec(d_solver,
+  ASSERT_CVC5_ERROR(cvc5_define_funs_rec(d_solver,
                                     funs.size(),
                                     funs.data(),
                                     nvars.data(),
@@ -952,7 +953,7 @@ TEST_F(TestCApiBlackSolver, define_funs_rec)
   vars1 = {b1, b11};
   vars = {vars1.data(), vars2.data()};
   terms = {v1, v4};
-  ASSERT_DEATH(cvc5_define_funs_rec(d_solver,
+  ASSERT_CVC5_ERROR(cvc5_define_funs_rec(d_solver,
                                     funs.size(),
                                     funs.data(),
                                     nvars.data(),
@@ -995,7 +996,7 @@ TEST_F(TestCApiBlackSolver, define_funs_rec)
                        terms.data(),
                        false);
   funs = {f1, f22};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_funs_rec(slv,
                            funs.size(),
                            funs.data(),
@@ -1007,7 +1008,7 @@ TEST_F(TestCApiBlackSolver, define_funs_rec)
   funs = {f12, f22};
   vars1 = {b1, b112};
   vars = {vars1.data(), vars2.data()};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_funs_rec(slv,
                            funs.size(),
                            funs.data(),
@@ -1018,7 +1019,7 @@ TEST_F(TestCApiBlackSolver, define_funs_rec)
       "expected a term associated with the term manager of this solver");
   vars1 = {b12, b11};
   vars = {vars1.data(), vars2.data()};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_funs_rec(slv,
                            funs.size(),
                            funs.data(),
@@ -1030,7 +1031,7 @@ TEST_F(TestCApiBlackSolver, define_funs_rec)
   vars2 = {b42};
   vars = {vars1.data(), vars2.data()};
   terms = {v1, v22};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_funs_rec(slv,
                            funs.size(),
                            funs.data(),
@@ -1040,7 +1041,7 @@ TEST_F(TestCApiBlackSolver, define_funs_rec)
                            false),
       "expected a term associated with the term manager of this solver");
   terms = {v12, v2};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_define_funs_rec(slv,
                            funs.size(),
                            funs.data(),
@@ -1077,7 +1078,7 @@ TEST_F(TestCApiBlackSolver, define_funs_rec_wrong_logic)
   std::vector<const Cvc5Term*> vars = {vars1.data(), vars2.data()};
   std::vector<Cvc5Term> terms = {v1, v2};
 
-  ASSERT_DEATH(cvc5_define_funs_rec(d_solver,
+  ASSERT_CVC5_ERROR(cvc5_define_funs_rec(d_solver,
                                     funs.size(),
                                     funs.data(),
                                     nvars.data(),
@@ -1139,26 +1140,26 @@ TEST_F(TestCApiBlackSolver, get_assertions)
   ASSERT_EQ(size, 2);
   ASSERT_TRUE(cvc5_term_is_equal(a, res[0]));
   ASSERT_TRUE(cvc5_term_is_equal(b, res[1]));
-  ASSERT_DEATH(cvc5_get_assertions(nullptr, &size), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_assertions(d_solver, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_get_assertions(nullptr, &size), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_assertions(d_solver, nullptr),
                "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, get_info)
 {
   ASSERT_EQ(cvc5_get_info(d_solver, "name"), std::string("\"cvc5\""));
-  ASSERT_DEATH(cvc5_get_info(d_solver, "asdf"), "unrecognized flag");
-  ASSERT_DEATH(cvc5_get_info(nullptr, "name"), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_info(d_solver, nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_info(d_solver, "asdf"), "unrecognized flag");
+  ASSERT_CVC5_ERROR(cvc5_get_info(nullptr, "name"), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_info(d_solver, nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, get_option)
 {
   ASSERT_EQ(cvc5_get_option(d_solver, "incremental"), std::string("true"));
-  ASSERT_DEATH(cvc5_get_option(d_solver, "asdf"), "Unrecognized option");
-  ASSERT_DEATH(cvc5_get_option(nullptr, "incremental"),
+  ASSERT_CVC5_ERROR(cvc5_get_option(d_solver, "asdf"), "Unrecognized option");
+  ASSERT_CVC5_ERROR(cvc5_get_option(nullptr, "incremental"),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_option(d_solver, nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_option(d_solver, nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, get_option_names)
@@ -1181,22 +1182,22 @@ TEST_F(TestCApiBlackSolver, get_option_names)
   }
   ASSERT_TRUE(found_verbose);
   ASSERT_FALSE(found_foobar);
-  ASSERT_DEATH(cvc5_get_option_names(nullptr, &size),
+  ASSERT_CVC5_ERROR(cvc5_get_option_names(nullptr, &size),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_option_names(d_solver, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_get_option_names(d_solver, nullptr),
                "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, get_option_info)
 {
   Cvc5OptionInfo info;
-  ASSERT_DEATH(cvc5_get_option_info(nullptr, "verbose", &info),
+  ASSERT_CVC5_ERROR(cvc5_get_option_info(nullptr, "verbose", &info),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_option_info(d_solver, nullptr, &info),
+  ASSERT_CVC5_ERROR(cvc5_get_option_info(d_solver, nullptr, &info),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_option_info(d_solver, "verbose", nullptr),
+  ASSERT_CVC5_ERROR(cvc5_get_option_info(d_solver, "verbose", nullptr),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_option_info(d_solver, "asdf-invalid", &info),
+  ASSERT_CVC5_ERROR(cvc5_get_option_info(d_solver, "asdf-invalid", &info),
                "Unrecognized option");
 
   cvc5_set_option(d_solver, "verbosity", "2");
@@ -1307,11 +1308,11 @@ TEST_F(TestCApiBlackSolver, get_unsat_assumptions1)
   std::vector<Cvc5Term> assumptions = {cvc5_mk_false(d_tm)};
   cvc5_check_sat_assuming(d_solver, assumptions.size(), assumptions.data());
   size_t size;
-  ASSERT_DEATH(cvc5_get_unsat_assumptions(nullptr, &size),
+  ASSERT_CVC5_ERROR(cvc5_get_unsat_assumptions(nullptr, &size),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_unsat_assumptions(d_solver, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_get_unsat_assumptions(d_solver, nullptr),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_unsat_assumptions(d_solver, &size),
+  ASSERT_CVC5_ERROR(cvc5_get_unsat_assumptions(d_solver, &size),
                "cannot get unsat assumptions");
 }
 
@@ -1322,7 +1323,7 @@ TEST_F(TestCApiBlackSolver, get_unsat_assumptions2)
   std::vector<Cvc5Term> assumptions = {cvc5_mk_false(d_tm)};
   cvc5_check_sat_assuming(d_solver, assumptions.size(), assumptions.data());
   size_t size;
-  ASSERT_DEATH(cvc5_get_unsat_assumptions(d_solver, &size),
+  ASSERT_CVC5_ERROR(cvc5_get_unsat_assumptions(d_solver, &size),
                "cannot get unsat assumptions");
 }
 
@@ -1338,7 +1339,7 @@ TEST_F(TestCApiBlackSolver, get_unsat_assumptions3)
   ASSERT_TRUE(cvc5_term_is_equal(res[0], cvc5_mk_false(d_tm)));
   assumptions = {cvc5_mk_true(d_tm)};
   cvc5_check_sat_assuming(d_solver, assumptions.size(), assumptions.data());
-  ASSERT_DEATH(cvc5_get_unsat_assumptions(d_solver, &size),
+  ASSERT_CVC5_ERROR(cvc5_get_unsat_assumptions(d_solver, &size),
                "cannot get unsat assumptions");
 }
 
@@ -1348,8 +1349,8 @@ TEST_F(TestCApiBlackSolver, get_unsat_core0)
   cvc5_assert_formula(d_solver, cvc5_mk_false(d_tm));
   cvc5_check_sat(d_solver);
   size_t size;
-  ASSERT_DEATH(cvc5_get_unsat_core(nullptr, &size), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_unsat_core(d_solver, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_get_unsat_core(nullptr, &size), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_unsat_core(d_solver, nullptr),
                "unexpected NULL argument");
 }
 
@@ -1359,7 +1360,7 @@ TEST_F(TestCApiBlackSolver, get_unsat_core1)
   cvc5_assert_formula(d_solver, cvc5_mk_false(d_tm));
   cvc5_check_sat(d_solver);
   size_t size;
-  ASSERT_DEATH(cvc5_get_unsat_core(d_solver, &size), "cannot get unsat core");
+  ASSERT_CVC5_ERROR(cvc5_get_unsat_core(d_solver, &size), "cannot get unsat core");
 }
 
 TEST_F(TestCApiBlackSolver, get_unsat_core2)
@@ -1369,7 +1370,7 @@ TEST_F(TestCApiBlackSolver, get_unsat_core2)
   cvc5_assert_formula(d_solver, cvc5_mk_false(d_tm));
   cvc5_check_sat(d_solver);
   size_t size;
-  ASSERT_DEATH(cvc5_get_unsat_core(d_solver, &size), "cannot get unsat core");
+  ASSERT_CVC5_ERROR(cvc5_get_unsat_core(d_solver, &size), "cannot get unsat core");
 }
 
 TEST_F(TestCApiBlackSolver, get_unsat_core_and_proof)
@@ -1445,16 +1446,16 @@ TEST_F(TestCApiBlackSolver, get_unsat_core_lemmas1)
 
   size_t size;
   // cannot ask before a check sat
-  ASSERT_DEATH(cvc5_get_unsat_core_lemmas(d_solver, &size),
+  ASSERT_CVC5_ERROR(cvc5_get_unsat_core_lemmas(d_solver, &size),
                "cannot get unsat core");
 
   cvc5_assert_formula(d_solver, cvc5_mk_false(d_tm));
   ASSERT_TRUE(cvc5_result_is_unsat(cvc5_check_sat(d_solver)));
   (void)cvc5_get_unsat_core_lemmas(d_solver, &size);
 
-  ASSERT_DEATH(cvc5_get_unsat_core_lemmas(nullptr, &size),
+  ASSERT_CVC5_ERROR(cvc5_get_unsat_core_lemmas(nullptr, &size),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_unsat_core_lemmas(d_solver, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_get_unsat_core_lemmas(d_solver, nullptr),
                "unexpected NULL argument");
 }
 
@@ -1516,16 +1517,16 @@ TEST_F(TestCApiBlackSolver, get_difficulty)
   cvc5_set_option(d_solver, "produce-difficulty", "true");
   size_t size;
   Cvc5Term *inputs, *values;
-  ASSERT_DEATH(cvc5_get_difficulty(nullptr, &size, &inputs, &values),
+  ASSERT_CVC5_ERROR(cvc5_get_difficulty(nullptr, &size, &inputs, &values),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_difficulty(d_solver, nullptr, &inputs, &values),
+  ASSERT_CVC5_ERROR(cvc5_get_difficulty(d_solver, nullptr, &inputs, &values),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_difficulty(d_solver, &size, nullptr, &values),
+  ASSERT_CVC5_ERROR(cvc5_get_difficulty(d_solver, &size, nullptr, &values),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_difficulty(d_solver, &size, &inputs, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_get_difficulty(d_solver, &size, &inputs, nullptr),
                "unexpected NULL argument");
   // cannot ask before a check sat
-  ASSERT_DEATH(cvc5_get_difficulty(d_solver, &size, &inputs, &values),
+  ASSERT_CVC5_ERROR(cvc5_get_difficulty(d_solver, &size, &inputs, &values),
                "cannot get difficulty");
   cvc5_check_sat(d_solver);
   cvc5_get_difficulty(d_solver, &size, &inputs, &values);
@@ -1537,7 +1538,7 @@ TEST_F(TestCApiBlackSolver, get_difficulty2)
   size_t size;
   Cvc5Term *inputs, *values;
   // option is not set
-  ASSERT_DEATH(cvc5_get_difficulty(d_solver, &size, &inputs, &values),
+  ASSERT_CVC5_ERROR(cvc5_get_difficulty(d_solver, &size, &inputs, &values),
                "Cannot get difficulty");
 }
 
@@ -1588,11 +1589,11 @@ TEST_F(TestCApiBlackSolver, get_timeout_core)
   ASSERT_EQ(size, 1);
   ASSERT_TRUE(cvc5_term_is_equal(core[0], hard));
 
-  ASSERT_DEATH(cvc5_get_timeout_core(nullptr, &result, &size),
+  ASSERT_CVC5_ERROR(cvc5_get_timeout_core(nullptr, &result, &size),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_timeout_core(d_solver, nullptr, &size),
+  ASSERT_CVC5_ERROR(cvc5_get_timeout_core(d_solver, nullptr, &size),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_timeout_core(d_solver, &result, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_get_timeout_core(d_solver, &result, nullptr),
                "unexpected NULL argument");
 }
 
@@ -1636,7 +1637,7 @@ TEST_F(TestCApiBlackSolver, get_timeout_core_assuming_empty)
   std::vector<Cvc5Term> assumptions = {};
   Cvc5Result result;
   size_t size;
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_get_timeout_core_assuming(
           d_solver, assumptions.size(), assumptions.data(), &result, &size),
       "unexpected NULL argument");
@@ -1690,9 +1691,9 @@ TEST_F(TestCApiBlackSolver, get_proof_and_proof_to_string)
   ASSERT_TRUE(cvc5_result_is_unsat(cvc5_check_sat(d_solver)));
 
   size_t size;
-  ASSERT_DEATH(cvc5_get_proof(nullptr, CVC5_PROOF_COMPONENT_FULL, &size),
+  ASSERT_CVC5_ERROR(cvc5_get_proof(nullptr, CVC5_PROOF_COMPONENT_FULL, &size),
                "unexpected NULL");
-  ASSERT_DEATH(cvc5_get_proof(d_solver, CVC5_PROOF_COMPONENT_FULL, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_get_proof(d_solver, CVC5_PROOF_COMPONENT_FULL, nullptr),
                "unexpected NULL");
 
   const Cvc5Proof* proofs =
@@ -1749,7 +1750,7 @@ TEST_F(TestCApiBlackSolver, get_learned_literals)
 
   size_t size;
   // cannot ask before a check sat
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_get_learned_literals(d_solver, CVC5_LEARNED_LIT_TYPE_INPUT, &size),
       "cannot get learned literals");
 
@@ -1758,10 +1759,10 @@ TEST_F(TestCApiBlackSolver, get_learned_literals)
   (void)cvc5_get_learned_literals(
       d_solver, CVC5_LEARNED_LIT_TYPE_PREPROCESS, &size);
 
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_get_learned_literals(nullptr, CVC5_LEARNED_LIT_TYPE_INPUT, &size),
       "unexpected NULL argument");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_get_learned_literals(d_solver, CVC5_LEARNED_LIT_TYPE_INPUT, nullptr),
       "unexpected NULL argument");
 }
@@ -1794,7 +1795,7 @@ TEST_F(TestCApiBlackSolver, get_value1)
   Cvc5Term t = cvc5_mk_true(d_tm);
   cvc5_assert_formula(d_solver, t);
   cvc5_check_sat(d_solver);
-  ASSERT_DEATH(cvc5_get_value(d_solver, t), "cannot get value");
+  ASSERT_CVC5_ERROR(cvc5_get_value(d_solver, t), "cannot get value");
 }
 
 TEST_F(TestCApiBlackSolver, get_value2)
@@ -1803,7 +1804,7 @@ TEST_F(TestCApiBlackSolver, get_value2)
   Cvc5Term t = cvc5_mk_false(d_tm);
   cvc5_assert_formula(d_solver, t);
   cvc5_check_sat(d_solver);
-  ASSERT_DEATH(cvc5_get_value(d_solver, t), "cannot get value");
+  ASSERT_CVC5_ERROR(cvc5_get_value(d_solver, t), "cannot get value");
 }
 
 TEST_F(TestCApiBlackSolver, get_value3)
@@ -1860,8 +1861,8 @@ TEST_F(TestCApiBlackSolver, get_value3)
   (void)cvc5_get_value(d_solver, sum);
   (void)cvc5_get_value(d_solver, p_f_y);
 
-  ASSERT_DEATH(cvc5_get_value(nullptr, x), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_value(d_solver, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_get_value(nullptr, x), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_value(d_solver, nullptr), "invalid term");
 
   std::vector<Cvc5Term> a = {cvc5_get_value(d_solver, x),
                              cvc5_get_value(d_solver, y),
@@ -1873,20 +1874,20 @@ TEST_F(TestCApiBlackSolver, get_value3)
   ASSERT_EQ(size, 3);
   ASSERT_TRUE(cvc5_term_is_equal(a[0], b[0]));
   ASSERT_TRUE(cvc5_term_is_equal(a[1], b[1]));
-  ASSERT_DEATH(cvc5_get_values(nullptr, terms.size(), terms.data(), &size),
+  ASSERT_CVC5_ERROR(cvc5_get_values(nullptr, terms.size(), terms.data(), &size),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_values(d_solver, terms.size(), nullptr, &size),
+  ASSERT_CVC5_ERROR(cvc5_get_values(d_solver, terms.size(), nullptr, &size),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_values(d_solver, terms.size(), terms.data(), nullptr),
+  ASSERT_CVC5_ERROR(cvc5_get_values(d_solver, terms.size(), terms.data(), nullptr),
                "unexpected NULL argument");
 
   Cvc5* slv = cvc5_new(d_tm);
-  ASSERT_DEATH(cvc5_get_value(slv, x), "cannot get value");
+  ASSERT_CVC5_ERROR(cvc5_get_value(slv, x), "cannot get value");
   cvc5_delete(slv);
 
   slv = cvc5_new(d_tm);
   cvc5_set_option(slv, "produce-models", "true");
-  ASSERT_DEATH(cvc5_get_value(slv, x), "cannot get value");
+  ASSERT_CVC5_ERROR(cvc5_get_value(slv, x), "cannot get value");
   cvc5_delete(slv);
 
   slv = cvc5_new(d_tm);
@@ -1899,7 +1900,7 @@ TEST_F(TestCApiBlackSolver, get_value3)
   slv = cvc5_new(tm);
   cvc5_set_option(slv, "produce-models", "true");
   cvc5_check_sat(slv);
-  ASSERT_DEATH(cvc5_get_value(slv, x),
+  ASSERT_CVC5_ERROR(cvc5_get_value(slv, x),
                "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
@@ -1918,21 +1919,21 @@ TEST_F(TestCApiBlackSolver, get_modelDomain_elements)
   size_t size;
   (void)cvc5_get_model_domain_elements(d_solver, d_uninterpreted, &size);
   ASSERT_TRUE(size >= 3);
-  ASSERT_DEATH(cvc5_get_model_domain_elements(nullptr, d_uninterpreted, &size),
+  ASSERT_CVC5_ERROR(cvc5_get_model_domain_elements(nullptr, d_uninterpreted, &size),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_model_domain_elements(d_solver, nullptr, &size),
+  ASSERT_CVC5_ERROR(cvc5_get_model_domain_elements(d_solver, nullptr, &size),
                "invalid sort");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_get_model_domain_elements(d_solver, d_uninterpreted, nullptr),
       "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_model_domain_elements(d_solver, d_int, &size),
+  ASSERT_CVC5_ERROR(cvc5_get_model_domain_elements(d_solver, d_int, &size),
                "expected an uninterpreted sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
   cvc5_set_option(slv, "produce-models", "true");
   cvc5_check_sat(slv);
-  ASSERT_DEATH(cvc5_get_model_domain_elements(slv, d_uninterpreted, &size),
+  ASSERT_CVC5_ERROR(cvc5_get_model_domain_elements(slv, d_uninterpreted, &size),
                "sort is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
@@ -1975,17 +1976,17 @@ TEST_F(TestCApiBlackSolver, is_model_core_symbol)
   ASSERT_TRUE(cvc5_is_model_core_symbol(d_solver, y));
   ASSERT_FALSE(cvc5_is_model_core_symbol(d_solver, z));
 
-  ASSERT_DEATH(cvc5_is_model_core_symbol(nullptr, x),
+  ASSERT_CVC5_ERROR(cvc5_is_model_core_symbol(nullptr, x),
                "unexpected NULL argument");
   ASSERT_FALSE(cvc5_is_model_core_symbol(d_solver, nullptr));
-  ASSERT_DEATH(cvc5_is_model_core_symbol(d_solver, zero),
+  ASSERT_CVC5_ERROR(cvc5_is_model_core_symbol(d_solver, zero),
                "expected a free constant");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
   cvc5_set_option(slv, "produce-models", "true");
   cvc5_check_sat(slv);
-  ASSERT_DEATH(cvc5_is_model_core_symbol(slv, x),
+  ASSERT_CVC5_ERROR(cvc5_is_model_core_symbol(slv, x),
                "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
@@ -2007,18 +2008,18 @@ TEST_F(TestCApiBlackSolver, get_model)
   (void)cvc5_get_model(
       d_solver, sorts.size(), sorts.data(), terms.size(), terms.data());
 
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_get_model(
           nullptr, sorts.size(), sorts.data(), terms.size(), terms.data()),
       "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_model(
+  ASSERT_CVC5_ERROR(cvc5_get_model(
                    d_solver, sorts.size(), nullptr, terms.size(), terms.data()),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_model(
+  ASSERT_CVC5_ERROR(cvc5_get_model(
                    d_solver, sorts.size(), sorts.data(), terms.size(), nullptr),
                "unexpected NULL argument");
   terms.push_back(nullptr);
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_get_model(
           d_solver, sorts.size(), sorts.data(), terms.size(), terms.data()),
       "");
@@ -2029,7 +2030,7 @@ TEST_F(TestCApiBlackSolver, get_model2)
   cvc5_set_option(d_solver, "produce-models", "true");
   std::vector<Cvc5Sort> sorts;
   std::vector<Cvc5Term> terms;
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_get_model(
           d_solver, sorts.size(), sorts.data(), terms.size(), terms.data()),
       "unexpected NULL argument");
@@ -2041,12 +2042,12 @@ TEST_F(TestCApiBlackSolver, get_model3)
   std::vector<Cvc5Sort> sorts;
   std::vector<Cvc5Term> terms;
   cvc5_check_sat(d_solver);
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_get_model(
           d_solver, sorts.size(), sorts.data(), terms.size(), terms.data()),
       "unexpected NULL argument");
   sorts.push_back(d_int);
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_get_model(
           d_solver, sorts.size(), sorts.data(), terms.size(), terms.data()),
       "unexpected NULL argument");
@@ -2064,18 +2065,18 @@ TEST_F(TestCApiBlackSolver, get_quantifier_elimination)
   Cvc5Term forall =
       cvc5_mk_term(d_tm, CVC5_KIND_FORALL, args.size(), args.data());
 
-  ASSERT_DEATH(cvc5_get_quantifier_elimination(nullptr, forall),
+  ASSERT_CVC5_ERROR(cvc5_get_quantifier_elimination(nullptr, forall),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_quantifier_elimination(d_solver, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_get_quantifier_elimination(d_solver, nullptr),
                "invalid term");
-  ASSERT_DEATH(cvc5_get_quantifier_elimination(d_solver, cvc5_mk_false(d_tm)),
+  ASSERT_CVC5_ERROR(cvc5_get_quantifier_elimination(d_solver, cvc5_mk_false(d_tm)),
                "Expecting a quantified formula");
   (void)cvc5_get_quantifier_elimination(d_solver, forall);
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
   cvc5_check_sat(slv);
-  ASSERT_DEATH(cvc5_get_quantifier_elimination(slv, forall),
+  ASSERT_CVC5_ERROR(cvc5_get_quantifier_elimination(slv, forall),
                "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
@@ -2093,11 +2094,11 @@ TEST_F(TestCApiBlackSolver, get_quantifier_elimination_disjunct)
   Cvc5Term forall =
       cvc5_mk_term(d_tm, CVC5_KIND_FORALL, args.size(), args.data());
 
-  ASSERT_DEATH(cvc5_get_quantifier_elimination_disjunct(nullptr, forall),
+  ASSERT_CVC5_ERROR(cvc5_get_quantifier_elimination_disjunct(nullptr, forall),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_quantifier_elimination_disjunct(d_solver, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_get_quantifier_elimination_disjunct(d_solver, nullptr),
                "invalid term");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_get_quantifier_elimination_disjunct(d_solver, cvc5_mk_false(d_tm)),
       "Expecting a quantified formula");
   (void)cvc5_get_quantifier_elimination_disjunct(d_solver, forall);
@@ -2105,7 +2106,7 @@ TEST_F(TestCApiBlackSolver, get_quantifier_elimination_disjunct)
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
   cvc5_check_sat(slv);
-  ASSERT_DEATH(cvc5_get_quantifier_elimination(slv, forall),
+  ASSERT_CVC5_ERROR(cvc5_get_quantifier_elimination(slv, forall),
                "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
@@ -2117,25 +2118,25 @@ TEST_F(TestCApiBlackSolver, declare_sep_heap)
   cvc5_set_option(d_solver, "incremental", "false");
   cvc5_declare_sep_heap(d_solver, d_int, d_int);
   // cannot declare separation logic heap more than once
-  ASSERT_DEATH(cvc5_declare_sep_heap(d_solver, d_int, d_int),
+  ASSERT_CVC5_ERROR(cvc5_declare_sep_heap(d_solver, d_int, d_int),
                "cannot declare heap types");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   // no logic set yet
   Cvc5* slv = cvc5_new(tm);
-  ASSERT_DEATH(cvc5_declare_sep_heap(d_solver, d_int, d_int),
+  ASSERT_CVC5_ERROR(cvc5_declare_sep_heap(d_solver, d_int, d_int),
                "cannot declare heap types");
   cvc5_delete(slv);
 
   slv = cvc5_new(tm);
   cvc5_set_logic(slv, "ALL");
-  ASSERT_DEATH(cvc5_declare_sep_heap(slv, cvc5_get_integer_sort(tm), d_int),
+  ASSERT_CVC5_ERROR(cvc5_declare_sep_heap(slv, cvc5_get_integer_sort(tm), d_int),
                "sort is not associated with the term manager of this solver");
   cvc5_delete(slv);
 
   slv = cvc5_new(tm);
   cvc5_set_logic(slv, "ALL");
-  ASSERT_DEATH(cvc5_declare_sep_heap(slv, d_int, cvc5_get_integer_sort(tm)),
+  ASSERT_CVC5_ERROR(cvc5_declare_sep_heap(slv, d_int, cvc5_get_integer_sort(tm)),
                "sort is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
@@ -2148,7 +2149,7 @@ TEST_F(TestCApiBlackSolver, get_value_sep_heap1)
   cvc5_set_option(d_solver, "produce-models", "true");
   Cvc5Term t = cvc5_mk_true(d_tm);
   cvc5_assert_formula(d_solver, t);
-  ASSERT_DEATH(cvc5_get_value_sep_heap(d_solver),
+  ASSERT_CVC5_ERROR(cvc5_get_value_sep_heap(d_solver),
                "cannot obtain separation logic expressions");
 }
 
@@ -2158,7 +2159,7 @@ TEST_F(TestCApiBlackSolver, get_value_sep_heap2)
   cvc5_set_option(d_solver, "incremental", "false");
   cvc5_set_option(d_solver, "produce-models", "false");
   check_simple_separation_constraints();
-  ASSERT_DEATH(cvc5_get_value_sep_heap(d_solver),
+  ASSERT_CVC5_ERROR(cvc5_get_value_sep_heap(d_solver),
                "cannot get separation heap term");
 }
 
@@ -2170,7 +2171,7 @@ TEST_F(TestCApiBlackSolver, get_value_sep_heap3)
   Cvc5Term t = cvc5_mk_false(d_tm);
   cvc5_assert_formula(d_solver, t);
   cvc5_check_sat(d_solver);
-  ASSERT_DEATH(cvc5_get_value_sep_heap(d_solver), "after SAT or UNKNOWN");
+  ASSERT_CVC5_ERROR(cvc5_get_value_sep_heap(d_solver), "after SAT or UNKNOWN");
 }
 
 TEST_F(TestCApiBlackSolver, get_value_sep_heap4)
@@ -2181,7 +2182,7 @@ TEST_F(TestCApiBlackSolver, get_value_sep_heap4)
   Cvc5Term t = cvc5_mk_true(d_tm);
   cvc5_assert_formula(d_solver, t);
   cvc5_check_sat(d_solver);
-  ASSERT_DEATH(cvc5_get_value_sep_heap(d_solver), "Failed to obtain heap/nil");
+  ASSERT_CVC5_ERROR(cvc5_get_value_sep_heap(d_solver), "Failed to obtain heap/nil");
 }
 
 TEST_F(TestCApiBlackSolver, get_value_sep_heap5)
@@ -2200,7 +2201,7 @@ TEST_F(TestCApiBlackSolver, get_value_sep_nil1)
   cvc5_set_option(d_solver, "produce-models", "true");
   Cvc5Term t = cvc5_mk_true(d_tm);
   cvc5_assert_formula(d_solver, t);
-  ASSERT_DEATH(cvc5_get_value_sep_nil(d_solver),
+  ASSERT_CVC5_ERROR(cvc5_get_value_sep_nil(d_solver),
                "cannot obtain separation logic expressions");
 }
 
@@ -2210,7 +2211,7 @@ TEST_F(TestCApiBlackSolver, get_value_sep_nil2)
   cvc5_set_option(d_solver, "incremental", "false");
   cvc5_set_option(d_solver, "produce-models", "false");
   check_simple_separation_constraints();
-  ASSERT_DEATH(cvc5_get_value_sep_nil(d_solver), "cannot get separation nil");
+  ASSERT_CVC5_ERROR(cvc5_get_value_sep_nil(d_solver), "cannot get separation nil");
 }
 
 TEST_F(TestCApiBlackSolver, get_value_sep_nil3)
@@ -2221,7 +2222,7 @@ TEST_F(TestCApiBlackSolver, get_value_sep_nil3)
   Cvc5Term t = cvc5_mk_false(d_tm);
   cvc5_assert_formula(d_solver, t);
   cvc5_check_sat(d_solver);
-  ASSERT_DEATH(cvc5_get_value_sep_nil(d_solver), "after SAT or UNKNOWN");
+  ASSERT_CVC5_ERROR(cvc5_get_value_sep_nil(d_solver), "after SAT or UNKNOWN");
 }
 
 TEST_F(TestCApiBlackSolver, get_value_sep_nil4)
@@ -2232,7 +2233,7 @@ TEST_F(TestCApiBlackSolver, get_value_sep_nil4)
   Cvc5Term t = cvc5_mk_true(d_tm);
   cvc5_assert_formula(d_solver, t);
   cvc5_check_sat(d_solver);
-  ASSERT_DEATH(cvc5_get_value_sep_nil(d_solver),
+  ASSERT_CVC5_ERROR(cvc5_get_value_sep_nil(d_solver),
                "Failed to obtain heap/nil expressions");
 }
 
@@ -2249,34 +2250,34 @@ TEST_F(TestCApiBlackSolver, push1)
 {
   cvc5_set_option(d_solver, "incremental", "true");
   cvc5_push(d_solver, 1);
-  ASSERT_DEATH(cvc5_set_option(d_solver, "incremental", "false"),
+  ASSERT_CVC5_ERROR(cvc5_set_option(d_solver, "incremental", "false"),
                "is already fully initialized");
-  ASSERT_DEATH(cvc5_set_option(d_solver, "incremental", "true"),
+  ASSERT_CVC5_ERROR(cvc5_set_option(d_solver, "incremental", "true"),
                "is already fully initialized");
 }
 
 TEST_F(TestCApiBlackSolver, push2)
 {
   cvc5_set_option(d_solver, "incremental", "false");
-  ASSERT_DEATH(cvc5_push(d_solver, 1), "cannot push");
+  ASSERT_CVC5_ERROR(cvc5_push(d_solver, 1), "cannot push");
 }
 
 TEST_F(TestCApiBlackSolver, push3)
 {
   cvc5_set_option(d_solver, "incremental", "false");
-  ASSERT_DEATH(cvc5_push(nullptr, 1), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_push(nullptr, 1), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, pop1)
 {
   cvc5_set_option(d_solver, "incremental", "false");
-  ASSERT_DEATH(cvc5_pop(d_solver, 1), "cannot pop");
+  ASSERT_CVC5_ERROR(cvc5_pop(d_solver, 1), "cannot pop");
 }
 
 TEST_F(TestCApiBlackSolver, pop2)
 {
   cvc5_set_option(d_solver, "incremental", "true");
-  ASSERT_DEATH(cvc5_pop(d_solver, 1), "cannot pop");
+  ASSERT_CVC5_ERROR(cvc5_pop(d_solver, 1), "cannot pop");
 }
 
 TEST_F(TestCApiBlackSolver, pop3)
@@ -2284,29 +2285,29 @@ TEST_F(TestCApiBlackSolver, pop3)
   cvc5_set_option(d_solver, "incremental", "true");
   cvc5_push(d_solver, 1);
   cvc5_pop(d_solver, 1);
-  ASSERT_DEATH(cvc5_pop(d_solver, 1), "cannot pop");
+  ASSERT_CVC5_ERROR(cvc5_pop(d_solver, 1), "cannot pop");
 }
 
 TEST_F(TestCApiBlackSolver, pop4)
 {
   cvc5_set_option(d_solver, "incremental", "false");
-  ASSERT_DEATH(cvc5_pop(nullptr, 1), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_pop(nullptr, 1), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, set_info)
 {
-  ASSERT_DEATH(cvc5_set_info(d_solver, "cvc5-lagic", "QF_BV"),
+  ASSERT_CVC5_ERROR(cvc5_set_info(d_solver, "cvc5-lagic", "QF_BV"),
                "unrecognized keyword");
-  ASSERT_DEATH(cvc5_set_info(d_solver, "cvc2-logic", "QF_BV"),
+  ASSERT_CVC5_ERROR(cvc5_set_info(d_solver, "cvc2-logic", "QF_BV"),
                "unrecognized keyword");
-  ASSERT_DEATH(cvc5_set_info(d_solver, "cvc5-logic", "asdf"),
+  ASSERT_CVC5_ERROR(cvc5_set_info(d_solver, "cvc5-logic", "asdf"),
                "unrecognized keyword");
 
-  ASSERT_DEATH(cvc5_set_info(nullptr, "source", "asdf"),
+  ASSERT_CVC5_ERROR(cvc5_set_info(nullptr, "source", "asdf"),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_set_info(d_solver, nullptr, "asdf"),
+  ASSERT_CVC5_ERROR(cvc5_set_info(d_solver, nullptr, "asdf"),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_set_info(d_solver, "source", nullptr),
+  ASSERT_CVC5_ERROR(cvc5_set_info(d_solver, "source", nullptr),
                "unexpected NULL argument");
 
   cvc5_set_info(d_solver, "source", "asdf");
@@ -2321,30 +2322,30 @@ TEST_F(TestCApiBlackSolver, set_info)
   cvc5_set_info(d_solver, "smt-lib-version", "2.0");
   cvc5_set_info(d_solver, "smt-lib-version", "2.5");
   cvc5_set_info(d_solver, "smt-lib-version", "2.6");
-  ASSERT_DEATH(cvc5_set_info(d_solver, "smt-lib-version", ".0"),
+  ASSERT_CVC5_ERROR(cvc5_set_info(d_solver, "smt-lib-version", ".0"),
                "invalid argument");
 
   cvc5_set_info(d_solver, "status", "sat");
   cvc5_set_info(d_solver, "status", "unsat");
   cvc5_set_info(d_solver, "status", "unknown");
-  ASSERT_DEATH(cvc5_set_info(d_solver, "status", "asdf"), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_set_info(d_solver, "status", "asdf"), "invalid argument");
 }
 
 TEST_F(TestCApiBlackSolver, set_logic)
 {
-  ASSERT_DEATH(cvc5_set_logic(nullptr, "AUFLIRA"), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_set_logic(d_solver, nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_set_logic(nullptr, "AUFLIRA"), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_set_logic(d_solver, nullptr), "unexpected NULL argument");
 
   cvc5_set_logic(d_solver, "AUFLIRA");
 
-  ASSERT_DEATH(cvc5_set_logic(d_solver, "AF_BV"), "logic is already set");
+  ASSERT_CVC5_ERROR(cvc5_set_logic(d_solver, "AF_BV"), "logic is already set");
   cvc5_assert_formula(d_solver, cvc5_mk_true(d_tm));
-  ASSERT_DEATH(cvc5_set_logic(d_solver, "AUFLIRA"), "logic is already set");
+  ASSERT_CVC5_ERROR(cvc5_set_logic(d_solver, "AUFLIRA"), "logic is already set");
 }
 
 TEST_F(TestCApiBlackSolver, is_logic_set)
 {
-  ASSERT_DEATH(cvc5_is_logic_set(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_is_logic_set(nullptr), "unexpected NULL argument");
   ASSERT_FALSE(cvc5_is_logic_set(d_solver));
   cvc5_set_logic(d_solver, "QF_BV");
   ASSERT_TRUE(cvc5_is_logic_set(d_solver));
@@ -2352,8 +2353,8 @@ TEST_F(TestCApiBlackSolver, is_logic_set)
 
 TEST_F(TestCApiBlackSolver, get_logic)
 {
-  ASSERT_DEATH(cvc5_get_logic(nullptr), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_logic(d_solver), "logic has not yet been set");
+  ASSERT_CVC5_ERROR(cvc5_get_logic(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_logic(d_solver), "logic has not yet been set");
   cvc5_set_logic(d_solver, "QF_BV");
   ASSERT_EQ(cvc5_get_logic(d_solver), std::string("QF_BV"));
 }
@@ -2361,20 +2362,20 @@ TEST_F(TestCApiBlackSolver, get_logic)
 TEST_F(TestCApiBlackSolver, set_option)
 {
   cvc5_set_option(d_solver, "bv-sat-solver", "cadical");
-  ASSERT_DEATH(cvc5_set_option(d_solver, "bv-sat-solver", "1"),
+  ASSERT_CVC5_ERROR(cvc5_set_option(d_solver, "bv-sat-solver", "1"),
                "unknown option");
   cvc5_assert_formula(d_solver, cvc5_mk_true(d_tm));
-  ASSERT_DEATH(cvc5_set_option(d_solver, "bv-sat-solver", "cadical"),
+  ASSERT_CVC5_ERROR(cvc5_set_option(d_solver, "bv-sat-solver", "cadical"),
                "fully initialized");
 }
 
 TEST_F(TestCApiBlackSolver, reset_assertions)
 {
-  ASSERT_DEATH(cvc5_set_option(nullptr, "incremental", "true"),
+  ASSERT_CVC5_ERROR(cvc5_set_option(nullptr, "incremental", "true"),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_set_option(d_solver, nullptr, "true"),
+  ASSERT_CVC5_ERROR(cvc5_set_option(d_solver, nullptr, "true"),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_set_option(d_solver, "incremental", nullptr),
+  ASSERT_CVC5_ERROR(cvc5_set_option(d_solver, "incremental", nullptr),
                "unexpected NULL argument");
 
   cvc5_set_option(d_solver, "incremental", "true");
@@ -2409,20 +2410,20 @@ TEST_F(TestCApiBlackSolver, declare_sygus_var)
   (void)cvc5_declare_sygus_var(d_solver, "", fun_sort);
   (void)cvc5_declare_sygus_var(d_solver, "b", d_bool);
 
-  ASSERT_DEATH(cvc5_declare_sygus_var(nullptr, "", d_bool),
+  ASSERT_CVC5_ERROR(cvc5_declare_sygus_var(nullptr, "", d_bool),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_declare_sygus_var(d_solver, nullptr, d_bool),
+  ASSERT_CVC5_ERROR(cvc5_declare_sygus_var(d_solver, nullptr, d_bool),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_declare_sygus_var(d_solver, "", nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_declare_sygus_var(d_solver, "", nullptr), "invalid sort");
 
   Cvc5* slv = cvc5_new(d_tm);
-  ASSERT_DEATH(cvc5_declare_sygus_var(slv, "", d_bool), "cannot call");
+  ASSERT_CVC5_ERROR(cvc5_declare_sygus_var(slv, "", d_bool), "cannot call");
   cvc5_delete(slv);
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   slv = cvc5_new(tm);
   cvc5_set_option(slv, "sygus", "true");
-  ASSERT_DEATH(cvc5_declare_sygus_var(slv, "", d_bool),
+  ASSERT_CVC5_ERROR(cvc5_declare_sygus_var(slv, "", d_bool),
                "sort is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
@@ -2442,35 +2443,35 @@ TEST_F(TestCApiBlackSolver, mk_grammar)
   (void)cvc5_mk_grammar(
       d_solver, bvars.size(), bvars.data(), symbols.size(), symbols.data());
 
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_grammar(
           nullptr, bvars.size(), bvars.data(), symbols.size(), symbols.data()),
       "unexpected NULL argument");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_grammar(
           d_solver, bvars.size(), bvars.data(), symbols.size(), nullptr),
       "unexpected NULL argument");
 
   symbols = {nullptr};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_grammar(
           d_solver, bvars.size(), bvars.data(), symbols.size(), nullptr),
       "unexpected NULL argument");
   bvars = {nullptr};
   symbols = {iv};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_grammar(
           d_solver, bvars.size(), bvars.data(), symbols.size(), nullptr),
       "unexpected NULL argument");
   bvars = {};
   symbols = {bt};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_grammar(
           d_solver, bvars.size(), bvars.data(), symbols.size(), nullptr),
       "unexpected NULL argument");
   bvars = {bt};
   symbols = {iv};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_grammar(
           d_solver, bvars.size(), bvars.data(), symbols.size(), nullptr),
       "unexpected NULL argument");
@@ -2479,13 +2480,13 @@ TEST_F(TestCApiBlackSolver, mk_grammar)
   Cvc5* slv = cvc5_new(tm);
   bvars = {};
   symbols = {iv};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_grammar(
           slv, bvars.size(), bvars.data(), symbols.size(), symbols.data()),
       "expected a term associated with the term manager of this solver");
   bvars = {bv};
   symbols = {cvc5_mk_var(tm, cvc5_get_integer_sort(tm), "")};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_grammar(
           d_solver, bvars.size(), bvars.data(), symbols.size(), symbols.data()),
       "expected a term associated with the term manager of this solver");
@@ -2508,7 +2509,7 @@ TEST_F(TestCApiBlackSolver, synth_fun)
 
   (void)cvc5_synth_fun(d_solver, "", 0, nullptr, d_bool);
   (void)cvc5_synth_fun(d_solver, "f1", bvars.size(), bvars.data(), d_bool);
-  ASSERT_DEATH(cvc5_synth_fun_with_grammar(
+  ASSERT_CVC5_ERROR(cvc5_synth_fun_with_grammar(
                    d_solver, "f2", bvars.size(), bvars.data(), d_bool, g1),
                "invalid grammar");
 
@@ -2521,23 +2522,23 @@ TEST_F(TestCApiBlackSolver, synth_fun)
 
   cvc5_synth_fun_with_grammar(
       d_solver, "f2", bvars.size(), bvars.data(), d_bool, g1);
-  ASSERT_DEATH(cvc5_synth_fun_with_grammar(
+  ASSERT_CVC5_ERROR(cvc5_synth_fun_with_grammar(
                    nullptr, "f2", bvars.size(), bvars.data(), d_bool, g1),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_synth_fun_with_grammar(
+  ASSERT_CVC5_ERROR(cvc5_synth_fun_with_grammar(
                    d_solver, "f2", bvars.size(), bvars.data(), nullptr, g1),
                "invalid sort");
-  ASSERT_DEATH(cvc5_synth_fun_with_grammar(
+  ASSERT_CVC5_ERROR(cvc5_synth_fun_with_grammar(
                    d_solver, "f2", bvars.size(), bvars.data(), d_bool, nullptr),
                "invalid grammar");
 
-  ASSERT_DEATH(cvc5_synth_fun_with_grammar(
+  ASSERT_CVC5_ERROR(cvc5_synth_fun_with_grammar(
                    d_solver, "f6", bvars.size(), bvars.data(), d_bool, g2),
                "invalid Start symbol");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_synth_fun_with_grammar(
           slv, "f8", bvars.size(), bvars.data(), d_bool, g1),
       "expected a term associated with the term manager of this solver");
@@ -2558,12 +2559,12 @@ TEST_F(TestCApiBlackSolver, declare_pool)
   // pool should have the same sort
   ASSERT_TRUE(cvc5_sort_is_equal(cvc5_term_get_sort(p), set_sort));
 
-  ASSERT_DEATH(cvc5_declare_pool(nullptr, "p", d_int, args.size(), args.data()),
+  ASSERT_CVC5_ERROR(cvc5_declare_pool(nullptr, "p", d_int, args.size(), args.data()),
                "unexpected NULL argument");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_declare_pool(d_solver, nullptr, d_int, args.size(), args.data()),
       "unexpected NULL argument");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_declare_pool(d_solver, "p", nullptr, args.size(), args.data()),
       "invalid sort");
 
@@ -2571,15 +2572,15 @@ TEST_F(TestCApiBlackSolver, declare_pool)
   (void)cvc5_declare_pool(d_solver, "p", d_int, 0, nullptr);
 
   args = {nullptr, x, y};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_declare_pool(d_solver, "p", d_int, args.size(), args.data()),
       "invalid term at index 0");
   args = {zero, nullptr, y};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_declare_pool(d_solver, "p", d_int, args.size(), args.data()),
       "invalid term at index 1");
   args = {zero, x, nullptr};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_declare_pool(d_solver, "p", d_int, args.size(), args.data()),
       "invalid term at index 2");
 
@@ -2590,14 +2591,14 @@ TEST_F(TestCApiBlackSolver, declare_pool)
   Cvc5Term x2 = cvc5_mk_const(tm, cvc5_get_integer_sort(tm), "x");
   Cvc5Term y2 = cvc5_mk_const(tm, cvc5_get_integer_sort(tm), "y");
   std::vector<Cvc5Term> args2 = {zero2, x2, y2};
-  ASSERT_DEATH(cvc5_declare_pool(slv, "p", d_int, args2.size(), args2.data()),
+  ASSERT_CVC5_ERROR(cvc5_declare_pool(slv, "p", d_int, args2.size(), args2.data()),
                "sort is not associated with the term manager of this solver");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_declare_pool(
           slv, "p", cvc5_get_integer_sort(tm), args.size(), args.data()),
       "expected a term associated with the term manager of this solver");
   args2 = {zero2, x, y2};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_declare_pool(
           slv, "p", cvc5_get_integer_sort(tm), args2.size(), args2.data()),
       "expected a term associated with the term manager of this solver");
@@ -2642,7 +2643,7 @@ TEST_F(TestCApiBlackSolver, declare_oracle_fun_unsat)
   cvc5_set_option(slv, "oracles", "true");
   Cvc5Sort int_sort = cvc5_get_integer_sort(tm);
   std::vector<Cvc5Sort> sorts2 = {int_sort};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_declare_oracle_fun(
           slv,
           "f",
@@ -2660,7 +2661,7 @@ TEST_F(TestCApiBlackSolver, declare_oracle_fun_unsat)
             return cvc5_mk_integer_int64(ctm, 0);
           }),
       "expected a sort associated with the term manager of this solver");
-  ASSERT_DEATH(cvc5_declare_oracle_fun(
+  ASSERT_CVC5_ERROR(cvc5_declare_oracle_fun(
                    slv,
                    "f",
                    sorts2.size(),
@@ -2703,7 +2704,7 @@ TEST_F(TestCApiBlackSolver, declare_oracle_fun_unsat)
   cvc5_assert_formula(
       slv, cvc5_mk_term(tm, CVC5_KIND_EQUAL, args2.size(), args2.data()));
   // (f 3) = 5
-  ASSERT_DEATH(cvc5_check_sat(slv),
+  ASSERT_CVC5_ERROR(cvc5_check_sat(slv),
                "Evaluated an oracle call that is not associated with the term "
                "manager of this solver");
   cvc5_delete(slv);
@@ -2788,7 +2789,7 @@ TEST_F(TestCApiBlackSolver, declare_oracle_fun_error1)
 {
   cvc5_set_option(d_solver, "oracles", "true");
   std::vector<Cvc5Sort> sorts = {d_int, d_int};
-  ASSERT_DEATH(cvc5_declare_oracle_fun(
+  ASSERT_CVC5_ERROR(cvc5_declare_oracle_fun(
                    nullptr,
                    "eq",
                    sorts.size(),
@@ -2802,7 +2803,7 @@ TEST_F(TestCApiBlackSolver, declare_oracle_fun_error1)
                          cvc5_term_is_equal(input[0], input[1]));
                    }),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_declare_oracle_fun(
+  ASSERT_CVC5_ERROR(cvc5_declare_oracle_fun(
                    d_solver,
                    nullptr,
                    sorts.size(),
@@ -2816,6 +2817,9 @@ TEST_F(TestCApiBlackSolver, declare_oracle_fun_error1)
                          cvc5_term_is_equal(input[0], input[1]));
                    }),
                "unexpected NULL argument");
+  // Declaring an oracle function with no argument sorts triggers an internal
+  // (debug-only) cvc5 assertion that aborts the process via FatalStream; this
+  // is not a recoverable C API error, so it remains a death test.
   ASSERT_DEATH(cvc5_declare_oracle_fun(
                    d_solver,
                    "eq",
@@ -2830,7 +2834,7 @@ TEST_F(TestCApiBlackSolver, declare_oracle_fun_error1)
                          cvc5_term_is_equal(input[0], input[1]));
                    }),
                "");
-  ASSERT_DEATH(cvc5_declare_oracle_fun(
+  ASSERT_CVC5_ERROR(cvc5_declare_oracle_fun(
                    d_solver,
                    "eq",
                    sorts.size(),
@@ -2858,7 +2862,7 @@ TEST_F(TestCApiBlackSolver, declare_oracle_fun_error1)
         return cvc5_mk_boolean(static_cast<Cvc5TermManager*>(state),
                                cvc5_term_is_equal(input[0], input[1]));
       });
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_declare_oracle_fun(
           d_solver, "eq", sorts.size(), sorts.data(), d_bool, d_tm, nullptr),
       "unexpected NULL argument");
@@ -2868,7 +2872,7 @@ TEST_F(TestCApiBlackSolver, declare_oracle_fun_error2)
 {
   std::vector<Cvc5Sort> sorts = {d_int};
   // cannot declare without option
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_declare_oracle_fun(d_solver,
                               "f",
                               sorts.size(),
@@ -2919,8 +2923,8 @@ TEST_F(TestCApiBlackSolver, get_interpolant)
   // We expect the resulting output to be a boolean formula
   ASSERT_TRUE(cvc5_sort_is_boolean(cvc5_term_get_sort(output)));
 
-  ASSERT_DEATH(cvc5_get_interpolant(nullptr, conj), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_interpolant(d_solver, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_get_interpolant(nullptr, conj), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_interpolant(d_solver, nullptr), "invalid term");
 
   // try with a grammar, a simple grammar admitting true
   Cvc5Term ttrue = cvc5_mk_true(d_tm);
@@ -2932,7 +2936,7 @@ TEST_F(TestCApiBlackSolver, get_interpolant)
   args = {zero, zero};
   Cvc5Term conj2 =
       cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, args.size(), args.data());
-  ASSERT_DEATH(cvc5_get_interpolant_with_grammar(d_solver, conj2, g),
+  ASSERT_CVC5_ERROR(cvc5_get_interpolant_with_grammar(d_solver, conj2, g),
                "invalid grammar, must have at least one rule");
   cvc5_grammar_add_rule(g, start, ttrue);
 
@@ -2941,11 +2945,11 @@ TEST_F(TestCApiBlackSolver, get_interpolant)
   // interpolant must be true
   ASSERT_TRUE(cvc5_term_is_equal(output2, ttrue));
 
-  ASSERT_DEATH(cvc5_get_interpolant_with_grammar(nullptr, conj2, g),
+  ASSERT_CVC5_ERROR(cvc5_get_interpolant_with_grammar(nullptr, conj2, g),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_interpolant_with_grammar(d_solver, nullptr, g),
+  ASSERT_CVC5_ERROR(cvc5_get_interpolant_with_grammar(d_solver, nullptr, g),
                "invalid term");
-  ASSERT_DEATH(cvc5_get_interpolant_with_grammar(d_solver, conj2, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_get_interpolant_with_grammar(d_solver, conj2, nullptr),
                "invalid grammar");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
@@ -2961,11 +2965,11 @@ TEST_F(TestCApiBlackSolver, get_interpolant)
   Cvc5Term cconj2 =
       cvc5_mk_term(tm, CVC5_KIND_EQUAL, aargs.size(), aargs.data());
   (void)cvc5_get_interpolant_with_grammar(slv, cconj2, gg);
-  ASSERT_DEATH(cvc5_get_interpolant(slv, conj2),
+  ASSERT_CVC5_ERROR(cvc5_get_interpolant(slv, conj2),
                "term is not associated with the term manager of this solver");
-  ASSERT_DEATH(cvc5_get_interpolant_with_grammar(slv, conj2, gg),
+  ASSERT_CVC5_ERROR(cvc5_get_interpolant_with_grammar(slv, conj2, gg),
                "term is not associated with the term manager of this solver");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_get_interpolant_with_grammar(slv, cconj2, g),
       "grammar is not associated with the term manager of this solver");
   cvc5_delete(slv);
@@ -3005,10 +3009,10 @@ TEST_F(TestCApiBlackSolver, get_interpolant_next)
   Cvc5Term output = cvc5_get_interpolant(d_solver, conj);
   Cvc5Term output2 = cvc5_get_interpolant_next(d_solver);
 
-  ASSERT_DEATH(cvc5_get_interpolant(nullptr, conj), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_interpolant(d_solver, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_get_interpolant(nullptr, conj), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_interpolant(d_solver, nullptr), "invalid term");
 
-  ASSERT_DEATH(cvc5_get_interpolant_next(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_interpolant_next(nullptr), "unexpected NULL argument");
 
   // We expect the next output to be distinct
   ASSERT_TRUE(cvc5_term_is_disequal(output, output2));
@@ -3036,8 +3040,8 @@ TEST_F(TestCApiBlackSolver, get_abduct)
   // We expect the resulting output to be a boolean formula
   ASSERT_TRUE(cvc5_sort_is_boolean(cvc5_term_get_sort(output)));
 
-  ASSERT_DEATH(cvc5_get_abduct(nullptr, conj), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_abduct(d_solver, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_get_abduct(nullptr, conj), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_abduct(d_solver, nullptr), "invalid term");
 
   // try with a grammar, a simple grammar admitting true
   Cvc5Term ttrue = cvc5_mk_true(d_tm);
@@ -3047,7 +3051,7 @@ TEST_F(TestCApiBlackSolver, get_abduct)
       cvc5_mk_grammar(d_solver, 0, nullptr, symbols.size(), symbols.data());
   args = {x, zero};
   Cvc5Term conj2 = cvc5_mk_term(d_tm, CVC5_KIND_GT, args.size(), args.data());
-  ASSERT_DEATH(cvc5_get_abduct_with_grammar(d_solver, conj2, g),
+  ASSERT_CVC5_ERROR(cvc5_get_abduct_with_grammar(d_solver, conj2, g),
                "invalid grammar, must have at least one rule");
   cvc5_grammar_add_rule(g, start, ttrue);
 
@@ -3056,11 +3060,11 @@ TEST_F(TestCApiBlackSolver, get_abduct)
   // abduct must be true
   ASSERT_TRUE(cvc5_term_is_equal(output2, ttrue));
 
-  ASSERT_DEATH(cvc5_get_abduct_with_grammar(nullptr, conj2, g),
+  ASSERT_CVC5_ERROR(cvc5_get_abduct_with_grammar(nullptr, conj2, g),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_abduct_with_grammar(d_solver, nullptr, g),
+  ASSERT_CVC5_ERROR(cvc5_get_abduct_with_grammar(d_solver, nullptr, g),
                "invalid term");
-  ASSERT_DEATH(cvc5_get_abduct_with_grammar(d_solver, conj2, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_get_abduct_with_grammar(d_solver, conj2, nullptr),
                "invalid grammar");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
@@ -3084,11 +3088,11 @@ TEST_F(TestCApiBlackSolver, get_abduct)
   Cvc5Term cconj2 =
       cvc5_mk_term(tm, CVC5_KIND_EQUAL, aargs.size(), aargs.data());
   (void)cvc5_get_abduct_with_grammar(slv, cconj2, gg);
-  ASSERT_DEATH(cvc5_get_abduct(slv, conj2),
+  ASSERT_CVC5_ERROR(cvc5_get_abduct(slv, conj2),
                "term is not associated with the term manager of this solver");
-  ASSERT_DEATH(cvc5_get_abduct_with_grammar(slv, conj2, gg),
+  ASSERT_CVC5_ERROR(cvc5_get_abduct_with_grammar(slv, conj2, gg),
                "term is not associated with the term manager of this solver");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_get_abduct_with_grammar(slv, cconj2, g),
       "grammar is not associated with the term manager of this solver");
   cvc5_delete(slv);
@@ -3111,7 +3115,7 @@ TEST_F(TestCApiBlackSolver, get_abduct2)
   args = {y, zero};
   Cvc5Term conj = cvc5_mk_term(d_tm, CVC5_KIND_GT, args.size(), args.data());
   // Fails due to option not set
-  ASSERT_DEATH(cvc5_get_abduct(d_solver, conj), "unless abducts are enabled");
+  ASSERT_CVC5_ERROR(cvc5_get_abduct(d_solver, conj), "unless abducts are enabled");
 }
 
 TEST_F(TestCApiBlackSolver, get_abduct_next)
@@ -3135,10 +3139,10 @@ TEST_F(TestCApiBlackSolver, get_abduct_next)
   Cvc5Term output = cvc5_get_abduct(d_solver, conj);
   Cvc5Term output2 = cvc5_get_abduct_next(d_solver);
 
-  ASSERT_DEATH(cvc5_get_abduct(nullptr, conj), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_abduct(d_solver, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_get_abduct(nullptr, conj), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_abduct(d_solver, nullptr), "invalid term");
 
-  ASSERT_DEATH(cvc5_get_abduct_next(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_abduct_next(nullptr), "unexpected NULL argument");
 
   // should produce a different output
   ASSERT_TRUE(cvc5_term_is_disequal(output, output2));
@@ -3151,7 +3155,7 @@ TEST_F(TestCApiBlackSolver, block_model1)
   cvc5_assert_formula(
       d_solver, cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, args.size(), args.data()));
   cvc5_check_sat(d_solver);
-  ASSERT_DEATH(cvc5_block_model(d_solver, CVC5_BLOCK_MODELS_MODE_LITERALS),
+  ASSERT_CVC5_ERROR(cvc5_block_model(d_solver, CVC5_BLOCK_MODELS_MODE_LITERALS),
                "cannot get value");
 }
 
@@ -3162,7 +3166,7 @@ TEST_F(TestCApiBlackSolver, block_model2)
   std::vector<Cvc5Term> args = {x, x};
   cvc5_assert_formula(
       d_solver, cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, args.size(), args.data()));
-  ASSERT_DEATH(cvc5_block_model(d_solver, CVC5_BLOCK_MODELS_MODE_LITERALS),
+  ASSERT_CVC5_ERROR(cvc5_block_model(d_solver, CVC5_BLOCK_MODELS_MODE_LITERALS),
                "after SAT or UNKNOWN");
 }
 
@@ -3175,7 +3179,7 @@ TEST_F(TestCApiBlackSolver, block_model3)
       d_solver, cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, args.size(), args.data()));
   cvc5_check_sat(d_solver);
   cvc5_block_model(d_solver, CVC5_BLOCK_MODELS_MODE_LITERALS);
-  ASSERT_DEATH(cvc5_block_model(nullptr, CVC5_BLOCK_MODELS_MODE_LITERALS),
+  ASSERT_CVC5_ERROR(cvc5_block_model(nullptr, CVC5_BLOCK_MODELS_MODE_LITERALS),
                "unexpected NULL argument");
 }
 
@@ -3190,12 +3194,12 @@ TEST_F(TestCApiBlackSolver, block_model_values1)
   args = {cvc5_mk_true(d_tm)};
   cvc5_block_model_values(d_solver, args.size(), args.data());
 
-  ASSERT_DEATH(cvc5_block_model_values(nullptr, args.size(), args.data()),
+  ASSERT_CVC5_ERROR(cvc5_block_model_values(nullptr, args.size(), args.data()),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_block_model_values(d_solver, 0, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_block_model_values(d_solver, 0, nullptr),
                "unexpected NULL argument");
   args = {nullptr};
-  ASSERT_DEATH(cvc5_block_model_values(d_solver, args.size(), args.data()),
+  ASSERT_CVC5_ERROR(cvc5_block_model_values(d_solver, args.size(), args.data()),
                "invalid term at index 0");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
@@ -3203,7 +3207,7 @@ TEST_F(TestCApiBlackSolver, block_model_values1)
   cvc5_set_option(slv, "produce-models", "true");
   cvc5_check_sat(slv);
   args = {cvc5_mk_true(d_tm)};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_block_model_values(slv, args.size(), args.data()),
       "expected a term associated with the term manager of this solver");
   cvc5_delete(slv);
@@ -3230,7 +3234,7 @@ TEST_F(TestCApiBlackSolver, block_model_values3)
       d_solver, cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, args.size(), args.data()));
   cvc5_check_sat(d_solver);
   args = {x};
-  ASSERT_DEATH(cvc5_block_model_values(d_solver, args.size(), args.data()),
+  ASSERT_CVC5_ERROR(cvc5_block_model_values(d_solver, args.size(), args.data()),
                "cannot get value");
 }
 
@@ -3242,7 +3246,7 @@ TEST_F(TestCApiBlackSolver, block_model_values4)
   cvc5_assert_formula(
       d_solver, cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, args.size(), args.data()));
   args = {x};
-  ASSERT_DEATH(cvc5_block_model_values(d_solver, args.size(), args.data()),
+  ASSERT_CVC5_ERROR(cvc5_block_model_values(d_solver, args.size(), args.data()),
                "SAT or UNKNOWN response");
 }
 
@@ -3278,11 +3282,11 @@ TEST_F(TestCApiBlackSolver, get_instantiations)
   args = {cvc5_mk_term(d_tm, CVC5_KIND_APPLY_UF, args.size(), args.data())};
   Cvc5Term app2 = cvc5_mk_term(d_tm, CVC5_KIND_NOT, args.size(), args.data());
   cvc5_assert_formula(d_solver, app2);
-  ASSERT_DEATH(cvc5_get_instantiations(d_solver),
+  ASSERT_CVC5_ERROR(cvc5_get_instantiations(d_solver),
                "after a UNSAT, SAT or UNKNOWN response");
   cvc5_check_sat(d_solver);
   cvc5_get_instantiations(d_solver);
-  ASSERT_DEATH(cvc5_get_instantiations(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_instantiations(nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, add_sygus_constraint)
@@ -3291,14 +3295,14 @@ TEST_F(TestCApiBlackSolver, add_sygus_constraint)
   Cvc5Term tbool = cvc5_mk_true(d_tm);
 
   cvc5_add_sygus_constraint(d_solver, tbool);
-  ASSERT_DEATH(cvc5_add_sygus_constraint(nullptr, tbool),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_constraint(nullptr, tbool),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_add_sygus_constraint(d_solver, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_constraint(d_solver, nullptr), "invalid term");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
   cvc5_set_option(slv, "sygus", "true");
-  ASSERT_DEATH(cvc5_add_sygus_constraint(slv, tbool),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_constraint(slv, tbool),
                "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
@@ -3315,9 +3319,9 @@ TEST_F(TestCApiBlackSolver, get_sygus_constraints)
   const Cvc5Term* constraints = cvc5_get_sygus_constraints(d_solver, &size);
   ASSERT_TRUE(cvc5_term_is_equal(ttrue, constraints[0]));
   ASSERT_TRUE(cvc5_term_is_equal(tfalse, constraints[1]));
-  ASSERT_DEATH(cvc5_get_sygus_constraints(nullptr, &size),
+  ASSERT_CVC5_ERROR(cvc5_get_sygus_constraints(nullptr, &size),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_sygus_constraints(d_solver, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_get_sygus_constraints(d_solver, nullptr),
                "unexpected NULL argument");
 }
 
@@ -3328,15 +3332,15 @@ TEST_F(TestCApiBlackSolver, add_sygus_assume)
   Cvc5Term tint = cvc5_mk_integer_int64(d_tm, 1);
 
   cvc5_add_sygus_assume(d_solver, tbool);
-  ASSERT_DEATH(cvc5_add_sygus_assume(nullptr, tbool),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_assume(nullptr, tbool),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_add_sygus_assume(d_solver, nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_add_sygus_assume(d_solver, tint), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_assume(d_solver, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_assume(d_solver, tint), "invalid argument");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
   cvc5_set_option(slv, "sygus", "true");
-  ASSERT_DEATH(cvc5_add_sygus_assume(slv, tbool),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_assume(slv, tbool),
                "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
@@ -3355,9 +3359,9 @@ TEST_F(TestCApiBlackSolver, get_sygus_assumptions)
   const Cvc5Term* assumptions = cvc5_get_sygus_assumptions(d_solver, &size);
   ASSERT_TRUE(cvc5_term_is_equal(ttrue, assumptions[0]));
   ASSERT_TRUE(cvc5_term_is_equal(tfalse, assumptions[1]));
-  ASSERT_DEATH(cvc5_get_sygus_assumptions(nullptr, &size),
+  ASSERT_CVC5_ERROR(cvc5_get_sygus_assumptions(nullptr, &size),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_sygus_assumptions(d_solver, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_get_sygus_assumptions(d_solver, nullptr),
                "unexpected NULL argument");
 }
 
@@ -3392,37 +3396,37 @@ TEST_F(TestCApiBlackSolver, add_sygus_inv_constraint)
 
   cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans, post);
 
-  ASSERT_DEATH(cvc5_add_sygus_inv_constraint(nullptr, inv, pre, trans, post),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(nullptr, inv, pre, trans, post),
                "unexpected NULL argument");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_add_sygus_inv_constraint(d_solver, nullptr, pre, trans, post),
       "invalid term");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_add_sygus_inv_constraint(d_solver, inv, nullptr, trans, post),
       "invalid term");
-  ASSERT_DEATH(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, nullptr, post),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, nullptr, post),
                "invalid term");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans, nullptr),
       "invalid term");
 
-  ASSERT_DEATH(cvc5_add_sygus_inv_constraint(d_solver, tint, pre, trans, post),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, tint, pre, trans, post),
                "invalid argument");
-  ASSERT_DEATH(cvc5_add_sygus_inv_constraint(d_solver, inv1, pre, trans, post),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, inv1, pre, trans, post),
                "invalid argument");
-  ASSERT_DEATH(cvc5_add_sygus_inv_constraint(d_solver, inv, trans, trans, post),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, inv, trans, trans, post),
                "have the same sort");
-  ASSERT_DEATH(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, tint, post),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, tint, post),
                "expected the sort of trans");
-  ASSERT_DEATH(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, pre, post),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, pre, post),
                "expected the sort of trans");
-  ASSERT_DEATH(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans1, post),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans1, post),
                "expected the sort of trans");
-  ASSERT_DEATH(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans2, post),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans2, post),
                "expected the sort of trans");
-  ASSERT_DEATH(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans3, post),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans3, post),
                "expected the sort of trans");
-  ASSERT_DEATH(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans, trans),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(d_solver, inv, pre, trans, trans),
                "expected inv and post to have the same sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
@@ -3442,13 +3446,13 @@ TEST_F(TestCApiBlackSolver, add_sygus_inv_constraint)
   Cvc5Term post22 = cvc5_declare_fun(
       slv, "post", domain2.size(), domain2.data(), bool_sort, true);
   cvc5_add_sygus_inv_constraint(slv, inv22, pre22, trans22, post22);
-  ASSERT_DEATH(cvc5_add_sygus_inv_constraint(slv, inv, pre22, trans22, post22),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(slv, inv, pre22, trans22, post22),
                "term is not associated with the term manager of this solver");
-  ASSERT_DEATH(cvc5_add_sygus_inv_constraint(slv, inv22, pre, trans22, post22),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(slv, inv22, pre, trans22, post22),
                "term is not associated with the term manager of this solver");
-  ASSERT_DEATH(cvc5_add_sygus_inv_constraint(slv, inv22, pre22, trans, post22),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(slv, inv22, pre22, trans, post22),
                "term is not associated with the term manager of this solver");
-  ASSERT_DEATH(cvc5_add_sygus_inv_constraint(slv, inv22, pre22, trans22, post),
+  ASSERT_CVC5_ERROR(cvc5_add_sygus_inv_constraint(slv, inv22, pre22, trans22, post),
                "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
@@ -3457,11 +3461,11 @@ TEST_F(TestCApiBlackSolver, add_sygus_inv_constraint)
 TEST_F(TestCApiBlackSolver, check_synth)
 {
   // requires option to be set
-  ASSERT_DEATH(cvc5_check_synth(d_solver),
+  ASSERT_CVC5_ERROR(cvc5_check_synth(d_solver),
                "cannot check for a synthesis solution");
   cvc5_set_option(d_solver, "sygus", "true");
   cvc5_check_synth(d_solver);
-  ASSERT_DEATH(cvc5_check_synth(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_check_synth(nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, get_synth_solution)
@@ -3472,7 +3476,7 @@ TEST_F(TestCApiBlackSolver, get_synth_solution)
   Cvc5Term x = cvc5_mk_false(d_tm);
   Cvc5Term f = cvc5_synth_fun(d_solver, "f", 0, nullptr, d_bool);
 
-  ASSERT_DEATH(cvc5_get_synth_solution(d_solver, f), "not in a state");
+  ASSERT_CVC5_ERROR(cvc5_get_synth_solution(d_solver, f), "not in a state");
 
   Cvc5SynthResult res = cvc5_check_synth(d_solver);
   ASSERT_TRUE(cvc5_synth_result_has_solution(res));
@@ -3480,14 +3484,14 @@ TEST_F(TestCApiBlackSolver, get_synth_solution)
   cvc5_get_synth_solution(d_solver, f);
   cvc5_get_synth_solution(d_solver, f);
 
-  ASSERT_DEATH(cvc5_get_synth_solution(nullptr, f), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_synth_solution(d_solver, nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_get_synth_solution(d_solver, x),
+  ASSERT_CVC5_ERROR(cvc5_get_synth_solution(nullptr, f), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_synth_solution(d_solver, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_get_synth_solution(d_solver, x),
                "synthesis solution not found for given term");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
-  ASSERT_DEATH(cvc5_get_synth_solution(slv, f),
+  ASSERT_CVC5_ERROR(cvc5_get_synth_solution(slv, f),
                "term is not associated with the term manager of this solver");
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
@@ -3502,7 +3506,7 @@ TEST_F(TestCApiBlackSolver, get_synth_solutions)
   Cvc5Term f = cvc5_synth_fun(d_solver, "f", 0, nullptr, d_bool);
 
   std::vector<Cvc5Term> args{f};
-  ASSERT_DEATH(cvc5_get_synth_solutions(d_solver, args.size(), args.data()),
+  ASSERT_CVC5_ERROR(cvc5_get_synth_solutions(d_solver, args.size(), args.data()),
                "not in a state");
 
   cvc5_check_synth(d_solver);
@@ -3511,20 +3515,20 @@ TEST_F(TestCApiBlackSolver, get_synth_solutions)
   args = {f, f};
   cvc5_get_synth_solutions(d_solver, args.size(), args.data());
 
-  ASSERT_DEATH(cvc5_get_synth_solutions(d_solver, 0, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_get_synth_solutions(d_solver, 0, nullptr),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_synth_solutions(nullptr, args.size(), args.data()),
+  ASSERT_CVC5_ERROR(cvc5_get_synth_solutions(nullptr, args.size(), args.data()),
                "unexpected NULL argument");
   args = {nullptr};
-  ASSERT_DEATH(cvc5_get_synth_solutions(d_solver, args.size(), args.data()),
+  ASSERT_CVC5_ERROR(cvc5_get_synth_solutions(d_solver, args.size(), args.data()),
                "invalid term at index 0");
   args = {x};
-  ASSERT_DEATH(cvc5_get_synth_solutions(d_solver, args.size(), args.data()),
+  ASSERT_CVC5_ERROR(cvc5_get_synth_solutions(d_solver, args.size(), args.data()),
                "synthesis solution not found for term at index 0");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   Cvc5* slv = cvc5_new(tm);
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_get_synth_solutions(slv, args.size(), args.data()),
       "expected a term associated with the term manager of this solver");
   cvc5_delete(slv);
@@ -3548,7 +3552,7 @@ TEST_F(TestCApiBlackSolver, check_synth_next)
   ASSERT_TRUE(cvc5_synth_result_has_solution(res));
   cvc5_get_synth_solutions(d_solver, args.size(), args.data());
 
-  ASSERT_DEATH(cvc5_check_synth_next(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_check_synth_next(nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, check_synth_next2)
@@ -3557,7 +3561,7 @@ TEST_F(TestCApiBlackSolver, check_synth_next2)
   cvc5_set_option(d_solver, "incremental", "false");
   (void)cvc5_synth_fun(d_solver, "f", 0, nullptr, d_bool);
   cvc5_check_synth(d_solver);
-  ASSERT_DEATH(cvc5_check_synth_next(d_solver),
+  ASSERT_CVC5_ERROR(cvc5_check_synth_next(d_solver),
                "cannot check for a next synthesis solution");
 }
 
@@ -3566,7 +3570,7 @@ TEST_F(TestCApiBlackSolver, check_synth_next3)
   cvc5_set_option(d_solver, "sygus", "true");
   cvc5_set_option(d_solver, "incremental", "true");
   (void)cvc5_synth_fun(d_solver, "f", 0, nullptr, d_bool);
-  ASSERT_DEATH(cvc5_check_synth_next(d_solver), "unless immediately preceded");
+  ASSERT_CVC5_ERROR(cvc5_check_synth_next(d_solver), "unless immediately preceded");
 }
 
 TEST_F(TestCApiBlackSolver, find_synth)
@@ -3577,7 +3581,7 @@ TEST_F(TestCApiBlackSolver, find_synth)
   Cvc5Grammar g =
       cvc5_mk_grammar(d_solver, 0, nullptr, symbols.size(), symbols.data());
 
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_synth_fun_with_grammar(d_solver, "f", 0, nullptr, d_bool, g),
       "invalid grammar");
 
@@ -3591,18 +3595,18 @@ TEST_F(TestCApiBlackSolver, find_synth)
   Cvc5Term t = cvc5_find_synth(d_solver, CVC5_FIND_SYNTH_TARGET_ENUM);
   ASSERT_TRUE(t && cvc5_sort_is_boolean(cvc5_term_get_sort(t)));
 
-  ASSERT_DEATH(cvc5_find_synth(nullptr, CVC5_FIND_SYNTH_TARGET_ENUM),
+  ASSERT_CVC5_ERROR(cvc5_find_synth(nullptr, CVC5_FIND_SYNTH_TARGET_ENUM),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_find_synth(d_solver, static_cast<Cvc5FindSynthTarget>(125)),
+  ASSERT_CVC5_ERROR(cvc5_find_synth(d_solver, static_cast<Cvc5FindSynthTarget>(125)),
                "invalid find synthesis target");
 
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_find_synth_with_grammar(nullptr, CVC5_FIND_SYNTH_TARGET_ENUM, g),
       "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_find_synth_with_grammar(
+  ASSERT_CVC5_ERROR(cvc5_find_synth_with_grammar(
                    d_solver, static_cast<Cvc5FindSynthTarget>(125), g),
                "invalid find synthesis target");
-  ASSERT_DEATH(cvc5_find_synth_with_grammar(
+  ASSERT_CVC5_ERROR(cvc5_find_synth_with_grammar(
                    d_solver, CVC5_FIND_SYNTH_TARGET_ENUM, nullptr),
                "invalid grammar");
 }
@@ -3628,12 +3632,12 @@ TEST_F(TestCApiBlackSolver, find_synth2)
   t = cvc5_find_synth_next(d_solver);
   ASSERT_TRUE(t && cvc5_sort_is_boolean(cvc5_term_get_sort(t)));
 
-  ASSERT_DEATH(cvc5_find_synth_next(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_find_synth_next(nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSolver, get_statistics)
 {
-  ASSERT_DEATH(cvc5_get_statistics(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_statistics(nullptr), "unexpected NULL argument");
 
   // do some reasoning to make sure we have statistics
   {
@@ -3818,7 +3822,7 @@ TEST_F(TestCApiBlackSolver, tuple_project)
       args.size(),
       args.data());
 
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_term_from_op(
           d_tm,
           cvc5_mk_op(
@@ -3826,7 +3830,7 @@ TEST_F(TestCApiBlackSolver, tuple_project)
           args.size(),
           args.data()),
       "Project index 4");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_term_from_op(
           d_tm,
           cvc5_mk_op(
@@ -3998,24 +4002,24 @@ TEST_F(TestCApiBlackSolver, basic_finite_field_base)
 
 TEST_F(TestCApiBlackSolver, output1)
 {
-  ASSERT_DEATH(cvc5_is_output_on(nullptr, "inst"), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_is_output_on(d_solver, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_is_output_on(nullptr, "inst"), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_is_output_on(d_solver, nullptr),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_is_output_on(d_solver, "foo-invalid"),
+  ASSERT_CVC5_ERROR(cvc5_is_output_on(d_solver, "foo-invalid"),
                "invalid output tag");
 
-  ASSERT_DEATH(cvc5_get_output(nullptr, "inst", "<stdout>"),
+  ASSERT_CVC5_ERROR(cvc5_get_output(nullptr, "inst", "<stdout>"),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_output(d_solver, nullptr, "<stdout>"),
+  ASSERT_CVC5_ERROR(cvc5_get_output(d_solver, nullptr, "<stdout>"),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_output(d_solver, "inst", nullptr),
+  ASSERT_CVC5_ERROR(cvc5_get_output(d_solver, "inst", nullptr),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_get_output(d_solver, "foo-invalid", "<stdout>"),
+  ASSERT_CVC5_ERROR(cvc5_get_output(d_solver, "foo-invalid", "<stdout>"),
                "invalid output tag");
 
-  ASSERT_DEATH(cvc5_close_output(nullptr, "<stdout>"),
+  ASSERT_CVC5_ERROR(cvc5_close_output(nullptr, "<stdout>"),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_close_output(d_solver, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_close_output(d_solver, nullptr),
                "unexpected NULL argument");
   // should not fail
   cvc5_close_output(d_solver, "<stdout>");

--- a/test/unit/api/c/capi_sort_black.cpp
+++ b/test/unit/api/c/capi_sort_black.cpp
@@ -374,11 +374,11 @@ TEST_F(TestCApiBlackSort, dt_domain_codomain_sorts)
   Cvc5Datatype dt = cvc5_sort_get_datatype(sort);
   ASSERT_FALSE(cvc5_sort_is_dt_constructor(sort));
   ASSERT_CVC5_ERROR(cvc5_sort_dt_constructor_get_codomain(sort),
-               "not a constructor sort");
+                    "not a constructor sort");
   ASSERT_CVC5_ERROR(cvc5_sort_dt_constructor_get_domain(sort, &size),
-               "not a constructor sort");
+                    "not a constructor sort");
   ASSERT_CVC5_ERROR(cvc5_sort_dt_constructor_get_arity(sort),
-               "not a constructor sort");
+                    "not a constructor sort");
 
   // get constructor
   ASSERT_CVC5_ERROR(cvc5_dt_get_constructor(nullptr, 0), "invalid datatype");
@@ -397,9 +397,11 @@ TEST_F(TestCApiBlackSort, dt_domain_codomain_sorts)
 
   // get tester
   ASSERT_CVC5_ERROR(cvc5_dt_cons_get_tester_term(nullptr),
-               "invalid datatype constructor");
-  ASSERT_CVC5_ERROR(cvc5_sort_dt_tester_get_domain(d_bool), "not a tester sort");
-  ASSERT_CVC5_ERROR(cvc5_sort_dt_tester_get_codomain(d_bool), "not a tester sort");
+                    "invalid datatype constructor");
+  ASSERT_CVC5_ERROR(cvc5_sort_dt_tester_get_domain(d_bool),
+                    "not a tester sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_dt_tester_get_codomain(d_bool),
+                    "not a tester sort");
   Cvc5Term tester = cvc5_dt_cons_get_tester_term(cons);
   Cvc5Sort tester_sort = cvc5_term_get_sort(tester);
   ASSERT_TRUE(cvc5_sort_is_dt_tester(tester_sort));
@@ -410,10 +412,11 @@ TEST_F(TestCApiBlackSort, dt_domain_codomain_sorts)
 
   // get selector
   ASSERT_CVC5_ERROR(cvc5_dt_cons_get_selector(nullptr, 1),
-               "invalid datatype constructor");
-  ASSERT_CVC5_ERROR(cvc5_sort_dt_selector_get_domain(d_bool), "not a selector sort");
+                    "invalid datatype constructor");
+  ASSERT_CVC5_ERROR(cvc5_sort_dt_selector_get_domain(d_bool),
+                    "not a selector sort");
   ASSERT_CVC5_ERROR(cvc5_sort_dt_selector_get_codomain(d_bool),
-               "not a selector sort");
+                    "not a selector sort");
   Cvc5DatatypeSelector sel = cvc5_dt_cons_get_selector(cons, 1);
   Cvc5Term tail = cvc5_dt_sel_get_term(sel);
   Cvc5Sort tail_sort = cvc5_term_get_sort(tail);
@@ -431,7 +434,7 @@ TEST_F(TestCApiBlackSort, instantiate)
   // instantiate non-parametric datatype sort, check should fail
   Cvc5Sort sort = create_datatype_sort();
   ASSERT_CVC5_ERROR(cvc5_sort_instantiate(sort, 1, args.data()),
-               "expected parametric datatype or sort constructor sort");
+                    "expected parametric datatype or sort constructor sort");
   // instantiate uninterpreted sort constructor
   Cvc5Sort sort_cons_sort =
       cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 1, "s");
@@ -477,15 +480,15 @@ TEST_F(TestCApiBlackSort, get_instantiated_parameters)
   Cvc5Sort sort = cvc5_mk_dt_sort(d_tm, decl);
 
   ASSERT_CVC5_ERROR(cvc5_sort_get_instantiated_parameters(nullptr, &size),
-               "invalid sort");
+                    "invalid sort");
   ASSERT_CVC5_ERROR(cvc5_sort_get_instantiated_parameters(sort, &size),
-               "expected instantiated parametric sort");
+                    "expected instantiated parametric sort");
 
   {
     std::vector<Cvc5Sort> args = {d_real, d_bool};
     Cvc5Sort inst_sort = cvc5_sort_instantiate(sort, 2, args.data());
     ASSERT_CVC5_ERROR(cvc5_sort_get_instantiated_parameters(inst_sort, nullptr),
-                 "unexpected NULL argument");
+                      "unexpected NULL argument");
 
     const Cvc5Sort* inst_sorts =
         cvc5_sort_get_instantiated_parameters(inst_sort, &size);
@@ -496,8 +499,9 @@ TEST_F(TestCApiBlackSort, get_instantiated_parameters)
   // uninterpreted sort constructor sort instantiation
   Cvc5Sort sort_cons_sort =
       cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 4, "a");
-  ASSERT_CVC5_ERROR(cvc5_sort_get_instantiated_parameters(sort_cons_sort, &size),
-               "expected instantiated parametric sort");
+  ASSERT_CVC5_ERROR(
+      cvc5_sort_get_instantiated_parameters(sort_cons_sort, &size),
+      "expected instantiated parametric sort");
 
   {
     std::vector<Cvc5Sort> args = {d_bool, d_int, bv_sort, d_real};
@@ -511,7 +515,7 @@ TEST_F(TestCApiBlackSort, get_instantiated_parameters)
   }
 
   ASSERT_CVC5_ERROR(cvc5_sort_get_instantiated_parameters(d_int, &size),
-               "expected instantiated parametric sort");
+                    "expected instantiated parametric sort");
 }
 
 TEST_F(TestCApiBlackSort, get_uninterpreted_sort_constructor)
@@ -520,9 +524,9 @@ TEST_F(TestCApiBlackSort, get_uninterpreted_sort_constructor)
   Cvc5Sort sort = cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 4, "s");
   std::vector<Cvc5Sort> args = {d_bool, d_int, bv_sort, d_real};
   ASSERT_CVC5_ERROR(cvc5_sort_get_uninterpreted_sort_constructor(nullptr),
-               "invalid sort");
+                    "invalid sort");
   ASSERT_CVC5_ERROR(cvc5_sort_get_uninterpreted_sort_constructor(sort),
-               "expected instantiated uninterpreted sort");
+                    "expected instantiated uninterpreted sort");
   Cvc5Sort inst_sort = cvc5_sort_instantiate(sort, 4, args.data());
   ASSERT_TRUE(cvc5_sort_is_equal(
       sort, cvc5_sort_get_uninterpreted_sort_constructor(inst_sort)));
@@ -549,8 +553,9 @@ TEST_F(TestCApiBlackSort, get_fun_domain_sorts)
   ASSERT_TRUE(cvc5_sort_is_equal(sorts[1], d_int));
   ASSERT_CVC5_ERROR(cvc5_sort_fun_get_domain(nullptr, &size), "invalid sort");
   ASSERT_CVC5_ERROR(cvc5_sort_fun_get_domain(sort, nullptr),
-               "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_sort_fun_get_domain(d_int, &size), "not a function sort");
+                    "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_sort_fun_get_domain(d_int, &size),
+                    "not a function sort");
 }
 
 TEST_F(TestCApiBlackSort, get_fun_codomain)
@@ -575,7 +580,8 @@ TEST_F(TestCApiBlackSort, get_array_index_element)
   ASSERT_CVC5_ERROR(cvc5_sort_array_get_index_sort(nullptr), "invalid sort");
   ASSERT_CVC5_ERROR(cvc5_sort_array_get_element_sort(nullptr), "invalid sort");
   ASSERT_CVC5_ERROR(cvc5_sort_array_get_index_sort(d_int), "not an array sort");
-  ASSERT_CVC5_ERROR(cvc5_sort_array_get_element_sort(d_int), "not an array sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_array_get_element_sort(d_int),
+                    "not an array sort");
 }
 
 TEST_F(TestCApiBlackSort, get_set_element)
@@ -599,9 +605,10 @@ TEST_F(TestCApiBlackSort, get_sequence_element)
   Cvc5Sort sort = cvc5_mk_sequence_sort(d_tm, d_int);
   ASSERT_TRUE(
       cvc5_sort_is_equal(cvc5_sort_sequence_get_element_sort(sort), d_int));
-  ASSERT_CVC5_ERROR(cvc5_sort_sequence_get_element_sort(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_sequence_get_element_sort(nullptr),
+                    "invalid sort");
   ASSERT_CVC5_ERROR(cvc5_sort_sequence_get_element_sort(d_int),
-               "not a sequence sort");
+                    "not a sequence sort");
 }
 
 TEST_F(TestCApiBlackSort, abstract_get_kind)
@@ -630,9 +637,9 @@ TEST_F(TestCApiBlackSort, uninterpreted_sort_constructor_get_arity)
   Cvc5Sort sort = cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 2, "s");
   ASSERT_EQ(cvc5_sort_uninterpreted_sort_constructor_get_arity(sort), 2);
   ASSERT_CVC5_ERROR(cvc5_sort_uninterpreted_sort_constructor_get_arity(nullptr),
-               "invalid sort");
+                    "invalid sort");
   ASSERT_CVC5_ERROR(cvc5_sort_uninterpreted_sort_constructor_get_arity(d_int),
-               "not a sort constructor sort");
+                    "not a sort constructor sort");
 }
 
 TEST_F(TestCApiBlackSort, bv_get_size)
@@ -657,9 +664,11 @@ TEST_F(TestCApiBlackSort, fp_get_exp_sig_size)
   ASSERT_EQ(cvc5_sort_fp_get_exp_size(sort), 8);
   ASSERT_EQ(cvc5_sort_fp_get_sig_size(sort), 24);
   ASSERT_CVC5_ERROR(cvc5_sort_fp_get_exp_size(nullptr), "invalid sort");
-  ASSERT_CVC5_ERROR(cvc5_sort_fp_get_exp_size(d_int), "not a floating-point sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_fp_get_exp_size(d_int),
+                    "not a floating-point sort");
   ASSERT_CVC5_ERROR(cvc5_sort_fp_get_sig_size(nullptr), "invalid sort");
-  ASSERT_CVC5_ERROR(cvc5_sort_fp_get_sig_size(d_int), "not a floating-point sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_fp_get_sig_size(d_int),
+                    "not a floating-point sort");
 }
 
 TEST_F(TestCApiBlackSort, dt_get_arity)
@@ -690,11 +699,11 @@ TEST_F(TestCApiBlackSort, tuple_get_element_sorts)
   ASSERT_TRUE(cvc5_sort_is_equal(sorts[0], d_int));
   ASSERT_TRUE(cvc5_sort_is_equal(sorts[1], d_int));
   ASSERT_CVC5_ERROR(cvc5_sort_tuple_get_element_sorts(nullptr, &size),
-               "invalid sort");
+                    "invalid sort");
   ASSERT_CVC5_ERROR(cvc5_sort_tuple_get_element_sorts(sort, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_sort_tuple_get_element_sorts(d_int, &size),
-               "not a tuple sort");
+                    "not a tuple sort");
 }
 
 TEST_F(TestCApiBlackSort, nullable_get_element_sort)
@@ -702,9 +711,10 @@ TEST_F(TestCApiBlackSort, nullable_get_element_sort)
   Cvc5Sort sort = cvc5_mk_nullable_sort(d_tm, d_real);
   ASSERT_TRUE(
       cvc5_sort_is_equal(cvc5_sort_nullable_get_element_sort(sort), d_real));
-  ASSERT_CVC5_ERROR(cvc5_sort_nullable_get_element_sort(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_nullable_get_element_sort(nullptr),
+                    "invalid sort");
   ASSERT_CVC5_ERROR(cvc5_sort_nullable_get_element_sort(d_int),
-               "not a nullable sort");
+                    "not a nullable sort");
 }
 
 TEST_F(TestCApiBlackSort, scoped_to_string)

--- a/test/unit/api/c/capi_sort_black.cpp
+++ b/test/unit/api/c/capi_sort_black.cpp
@@ -16,6 +16,7 @@ extern "C" {
 
 #include "base/output.h"
 #include "gtest/gtest.h"
+#include "test_capi.h"
 
 namespace cvc5::internal::test {
 
@@ -64,7 +65,7 @@ class TestCApiBlackSort : public ::testing::Test
 
 TEST_F(TestCApiBlackSort, hash)
 {
-  ASSERT_DEATH(cvc5_sort_hash(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_hash(nullptr), "invalid sort");
   (void)cvc5_sort_hash(d_int);
   ASSERT_EQ(cvc5_sort_hash(d_int), cvc5_sort_hash(d_int));
   ASSERT_NE(cvc5_sort_hash(d_int), cvc5_sort_hash(d_bool));
@@ -72,8 +73,8 @@ TEST_F(TestCApiBlackSort, hash)
 
 TEST_F(TestCApiBlackSort, copy_release)
 {
-  ASSERT_DEATH(cvc5_sort_copy(nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_release(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_copy(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_release(nullptr), "invalid sort");
   size_t hash1 = cvc5_sort_hash(d_int);
   Cvc5Sort int_copy = cvc5_sort_copy(d_int);
   size_t hash2 = cvc5_sort_hash(int_copy);
@@ -87,8 +88,8 @@ TEST_F(TestCApiBlackSort, copy_release)
 
 TEST_F(TestCApiBlackSort, compare)
 {
-  ASSERT_DEATH(cvc5_sort_compare(d_int, nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_compare(nullptr, d_int), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_compare(d_int, nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_compare(nullptr, d_int), "invalid sort");
   ASSERT_TRUE(cvc5_sort_is_equal(d_int, d_int));
   ASSERT_TRUE(cvc5_sort_is_disequal(d_int, d_bool));
   ASSERT_FALSE(cvc5_sort_is_equal(d_int, nullptr));
@@ -98,7 +99,7 @@ TEST_F(TestCApiBlackSort, compare)
 
 TEST_F(TestCApiBlackSort, get_kind)
 {
-  ASSERT_DEATH(cvc5_sort_get_kind(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_get_kind(nullptr), "invalid sort");
   ASSERT_EQ(cvc5_sort_get_kind(d_bool), CVC5_SORT_KIND_BOOLEAN_SORT);
   Cvc5Sort dt_sort = create_datatype_sort();
   ASSERT_EQ(cvc5_sort_get_kind(dt_sort), CVC5_SORT_KIND_DATATYPE_SORT);
@@ -123,8 +124,8 @@ TEST_F(TestCApiBlackSort, has_get_symbol)
   ASSERT_TRUE(cvc5_sort_has_symbol(s0));
   ASSERT_TRUE(cvc5_sort_has_symbol(s1));
 
-  ASSERT_DEATH(cvc5_sort_get_symbol(nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_get_symbol(d_bool), "has no symbol");
+  ASSERT_CVC5_ERROR(cvc5_sort_get_symbol(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_get_symbol(d_bool), "has no symbol");
   ASSERT_EQ(cvc5_sort_get_symbol(s0), std::string("s0"));
   ASSERT_EQ(cvc5_sort_get_symbol(s1), std::string("|s1\\|"));
 }
@@ -203,7 +204,7 @@ TEST_F(TestCApiBlackSort, is_dt_constructor)
 {
   Cvc5Sort dt_sort = create_datatype_sort();
   Cvc5Datatype dt = cvc5_sort_get_datatype(dt_sort);
-  ASSERT_DEATH(cvc5_dt_get_constructor(dt, 3), "index out of bounds");
+  ASSERT_CVC5_ERROR(cvc5_dt_get_constructor(dt, 3), "index out of bounds");
   Cvc5DatatypeConstructor cons = cvc5_dt_get_constructor(dt, 0);
   Cvc5Sort cons_sort = cvc5_term_get_sort(cvc5_dt_cons_get_term(cons));
   ASSERT_FALSE(cvc5_sort_is_dt(nullptr));
@@ -216,7 +217,7 @@ TEST_F(TestCApiBlackSort, is_dt_selector)
   Cvc5Sort dt_sort = create_datatype_sort();
   Cvc5Datatype dt = cvc5_sort_get_datatype(dt_sort);
   Cvc5DatatypeConstructor cons = cvc5_dt_get_constructor(dt, 0);
-  ASSERT_DEATH(cvc5_dt_cons_get_selector(cons, 2), "index out of bounds");
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_selector(cons, 2), "index out of bounds");
   Cvc5DatatypeSelector sel = cvc5_dt_cons_get_selector(cons, 1);
   Cvc5Sort sel_sort = cvc5_term_get_sort(cvc5_dt_sel_get_term(sel));
   ASSERT_FALSE(cvc5_sort_is_dt_selector(nullptr));
@@ -363,7 +364,7 @@ TEST_F(TestCApiBlackSort, get_datatype)
   Cvc5Sort dt_sort = create_datatype_sort();
   (void)cvc5_sort_get_datatype(dt_sort);
   // create bv sort, check should fail
-  ASSERT_DEATH(cvc5_sort_get_datatype(d_int), "expected datatype sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_get_datatype(d_int), "expected datatype sort");
 }
 
 TEST_F(TestCApiBlackSort, dt_domain_codomain_sorts)
@@ -372,15 +373,15 @@ TEST_F(TestCApiBlackSort, dt_domain_codomain_sorts)
   Cvc5Sort sort = create_datatype_sort();
   Cvc5Datatype dt = cvc5_sort_get_datatype(sort);
   ASSERT_FALSE(cvc5_sort_is_dt_constructor(sort));
-  ASSERT_DEATH(cvc5_sort_dt_constructor_get_codomain(sort),
+  ASSERT_CVC5_ERROR(cvc5_sort_dt_constructor_get_codomain(sort),
                "not a constructor sort");
-  ASSERT_DEATH(cvc5_sort_dt_constructor_get_domain(sort, &size),
+  ASSERT_CVC5_ERROR(cvc5_sort_dt_constructor_get_domain(sort, &size),
                "not a constructor sort");
-  ASSERT_DEATH(cvc5_sort_dt_constructor_get_arity(sort),
+  ASSERT_CVC5_ERROR(cvc5_sort_dt_constructor_get_arity(sort),
                "not a constructor sort");
 
   // get constructor
-  ASSERT_DEATH(cvc5_dt_get_constructor(nullptr, 0), "invalid datatype");
+  ASSERT_CVC5_ERROR(cvc5_dt_get_constructor(nullptr, 0), "invalid datatype");
   Cvc5DatatypeConstructor cons = cvc5_dt_get_constructor(dt, 0);
   Cvc5Sort cons_sort = cvc5_term_get_sort(cvc5_dt_cons_get_term(cons));
   ASSERT_TRUE(cvc5_sort_is_dt_constructor(cons_sort));
@@ -395,10 +396,10 @@ TEST_F(TestCApiBlackSort, dt_domain_codomain_sorts)
       cvc5_sort_dt_constructor_get_codomain(cons_sort), sort));
 
   // get tester
-  ASSERT_DEATH(cvc5_dt_cons_get_tester_term(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_tester_term(nullptr),
                "invalid datatype constructor");
-  ASSERT_DEATH(cvc5_sort_dt_tester_get_domain(d_bool), "not a tester sort");
-  ASSERT_DEATH(cvc5_sort_dt_tester_get_codomain(d_bool), "not a tester sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_dt_tester_get_domain(d_bool), "not a tester sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_dt_tester_get_codomain(d_bool), "not a tester sort");
   Cvc5Term tester = cvc5_dt_cons_get_tester_term(cons);
   Cvc5Sort tester_sort = cvc5_term_get_sort(tester);
   ASSERT_TRUE(cvc5_sort_is_dt_tester(tester_sort));
@@ -408,10 +409,10 @@ TEST_F(TestCApiBlackSort, dt_domain_codomain_sorts)
                                  d_bool));
 
   // get selector
-  ASSERT_DEATH(cvc5_dt_cons_get_selector(nullptr, 1),
+  ASSERT_CVC5_ERROR(cvc5_dt_cons_get_selector(nullptr, 1),
                "invalid datatype constructor");
-  ASSERT_DEATH(cvc5_sort_dt_selector_get_domain(d_bool), "not a selector sort");
-  ASSERT_DEATH(cvc5_sort_dt_selector_get_codomain(d_bool),
+  ASSERT_CVC5_ERROR(cvc5_sort_dt_selector_get_domain(d_bool), "not a selector sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_dt_selector_get_codomain(d_bool),
                "not a selector sort");
   Cvc5DatatypeSelector sel = cvc5_dt_cons_get_selector(cons, 1);
   Cvc5Term tail = cvc5_dt_sel_get_term(sel);
@@ -429,7 +430,7 @@ TEST_F(TestCApiBlackSort, instantiate)
   (void)cvc5_sort_instantiate(param_sort, 1, args.data());
   // instantiate non-parametric datatype sort, check should fail
   Cvc5Sort sort = create_datatype_sort();
-  ASSERT_DEATH(cvc5_sort_instantiate(sort, 1, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_sort_instantiate(sort, 1, args.data()),
                "expected parametric datatype or sort constructor sort");
   // instantiate uninterpreted sort constructor
   Cvc5Sort sort_cons_sort =
@@ -475,15 +476,15 @@ TEST_F(TestCApiBlackSort, get_instantiated_parameters)
   cvc5_dt_decl_add_constructor(decl, nil);
   Cvc5Sort sort = cvc5_mk_dt_sort(d_tm, decl);
 
-  ASSERT_DEATH(cvc5_sort_get_instantiated_parameters(nullptr, &size),
+  ASSERT_CVC5_ERROR(cvc5_sort_get_instantiated_parameters(nullptr, &size),
                "invalid sort");
-  ASSERT_DEATH(cvc5_sort_get_instantiated_parameters(sort, &size),
+  ASSERT_CVC5_ERROR(cvc5_sort_get_instantiated_parameters(sort, &size),
                "expected instantiated parametric sort");
 
   {
     std::vector<Cvc5Sort> args = {d_real, d_bool};
     Cvc5Sort inst_sort = cvc5_sort_instantiate(sort, 2, args.data());
-    ASSERT_DEATH(cvc5_sort_get_instantiated_parameters(inst_sort, nullptr),
+    ASSERT_CVC5_ERROR(cvc5_sort_get_instantiated_parameters(inst_sort, nullptr),
                  "unexpected NULL argument");
 
     const Cvc5Sort* inst_sorts =
@@ -495,7 +496,7 @@ TEST_F(TestCApiBlackSort, get_instantiated_parameters)
   // uninterpreted sort constructor sort instantiation
   Cvc5Sort sort_cons_sort =
       cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 4, "a");
-  ASSERT_DEATH(cvc5_sort_get_instantiated_parameters(sort_cons_sort, &size),
+  ASSERT_CVC5_ERROR(cvc5_sort_get_instantiated_parameters(sort_cons_sort, &size),
                "expected instantiated parametric sort");
 
   {
@@ -509,7 +510,7 @@ TEST_F(TestCApiBlackSort, get_instantiated_parameters)
     ASSERT_TRUE(cvc5_sort_is_equal(inst_sorts[3], d_real));
   }
 
-  ASSERT_DEATH(cvc5_sort_get_instantiated_parameters(d_int, &size),
+  ASSERT_CVC5_ERROR(cvc5_sort_get_instantiated_parameters(d_int, &size),
                "expected instantiated parametric sort");
 }
 
@@ -518,9 +519,9 @@ TEST_F(TestCApiBlackSort, get_uninterpreted_sort_constructor)
   Cvc5Sort bv_sort = cvc5_mk_bv_sort(d_tm, 8);
   Cvc5Sort sort = cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 4, "s");
   std::vector<Cvc5Sort> args = {d_bool, d_int, bv_sort, d_real};
-  ASSERT_DEATH(cvc5_sort_get_uninterpreted_sort_constructor(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_sort_get_uninterpreted_sort_constructor(nullptr),
                "invalid sort");
-  ASSERT_DEATH(cvc5_sort_get_uninterpreted_sort_constructor(sort),
+  ASSERT_CVC5_ERROR(cvc5_sort_get_uninterpreted_sort_constructor(sort),
                "expected instantiated uninterpreted sort");
   Cvc5Sort inst_sort = cvc5_sort_instantiate(sort, 4, args.data());
   ASSERT_TRUE(cvc5_sort_is_equal(
@@ -532,8 +533,8 @@ TEST_F(TestCApiBlackSort, get_fun_arity)
   std::vector<Cvc5Sort> domain = {cvc5_mk_uninterpreted_sort(d_tm, "u"), d_int};
   Cvc5Sort sort = cvc5_mk_fun_sort(d_tm, 2, domain.data(), d_int);
   ASSERT_EQ(cvc5_sort_fun_get_arity(sort), 2);
-  ASSERT_DEATH(cvc5_sort_fun_get_arity(nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_fun_get_arity(d_int), "not a function sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_fun_get_arity(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_fun_get_arity(d_int), "not a function sort");
 }
 
 TEST_F(TestCApiBlackSort, get_fun_domain_sorts)
@@ -546,10 +547,10 @@ TEST_F(TestCApiBlackSort, get_fun_domain_sorts)
   ASSERT_EQ(size, 2);
   ASSERT_TRUE(cvc5_sort_is_equal(sorts[0], usort));
   ASSERT_TRUE(cvc5_sort_is_equal(sorts[1], d_int));
-  ASSERT_DEATH(cvc5_sort_fun_get_domain(nullptr, &size), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_fun_get_domain(sort, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_sort_fun_get_domain(nullptr, &size), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_fun_get_domain(sort, nullptr),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_sort_fun_get_domain(d_int, &size), "not a function sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_fun_get_domain(d_int, &size), "not a function sort");
 }
 
 TEST_F(TestCApiBlackSort, get_fun_codomain)
@@ -558,8 +559,8 @@ TEST_F(TestCApiBlackSort, get_fun_codomain)
   std::vector<Cvc5Sort> domain = {usort, d_int};
   Cvc5Sort sort = cvc5_mk_fun_sort(d_tm, 2, domain.data(), d_int);
   ASSERT_TRUE(cvc5_sort_is_equal(cvc5_sort_fun_get_codomain(sort), d_int));
-  ASSERT_DEATH(cvc5_sort_fun_get_codomain(nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_fun_get_codomain(d_int), "not a function sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_fun_get_codomain(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_fun_get_codomain(d_int), "not a function sort");
 }
 
 TEST_F(TestCApiBlackSort, get_array_index_element)
@@ -571,26 +572,26 @@ TEST_F(TestCApiBlackSort, get_array_index_element)
       cvc5_sort_is_equal(cvc5_sort_array_get_index_sort(sort), index_sort));
   ASSERT_TRUE(
       cvc5_sort_is_equal(cvc5_sort_array_get_element_sort(sort), elem_sort));
-  ASSERT_DEATH(cvc5_sort_array_get_index_sort(nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_array_get_element_sort(nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_array_get_index_sort(d_int), "not an array sort");
-  ASSERT_DEATH(cvc5_sort_array_get_element_sort(d_int), "not an array sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_array_get_index_sort(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_array_get_element_sort(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_array_get_index_sort(d_int), "not an array sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_array_get_element_sort(d_int), "not an array sort");
 }
 
 TEST_F(TestCApiBlackSort, get_set_element)
 {
   Cvc5Sort sort = cvc5_mk_set_sort(d_tm, d_int);
   ASSERT_TRUE(cvc5_sort_is_equal(cvc5_sort_set_get_element_sort(sort), d_int));
-  ASSERT_DEATH(cvc5_sort_set_get_element_sort(nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_set_get_element_sort(d_int), "not a set sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_set_get_element_sort(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_set_get_element_sort(d_int), "not a set sort");
 }
 
 TEST_F(TestCApiBlackSort, get_bag_element)
 {
   Cvc5Sort sort = cvc5_mk_bag_sort(d_tm, d_int);
   ASSERT_TRUE(cvc5_sort_is_equal(cvc5_sort_bag_get_element_sort(sort), d_int));
-  ASSERT_DEATH(cvc5_sort_bag_get_element_sort(nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_bag_get_element_sort(d_int), "not a bag sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_bag_get_element_sort(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_bag_get_element_sort(d_int), "not a bag sort");
 }
 
 TEST_F(TestCApiBlackSort, get_sequence_element)
@@ -598,8 +599,8 @@ TEST_F(TestCApiBlackSort, get_sequence_element)
   Cvc5Sort sort = cvc5_mk_sequence_sort(d_tm, d_int);
   ASSERT_TRUE(
       cvc5_sort_is_equal(cvc5_sort_sequence_get_element_sort(sort), d_int));
-  ASSERT_DEATH(cvc5_sort_sequence_get_element_sort(nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_sequence_get_element_sort(d_int),
+  ASSERT_CVC5_ERROR(cvc5_sort_sequence_get_element_sort(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_sequence_get_element_sort(d_int),
                "not a sequence sort");
 }
 
@@ -611,7 +612,7 @@ TEST_F(TestCApiBlackSort, abstract_get_kind)
   // is an Array sort, not an abstract sort and its abstract kind cannot be
   // extracted.
   sort = cvc5_mk_abstract_sort(d_tm, CVC5_SORT_KIND_ARRAY_SORT);
-  ASSERT_DEATH(cvc5_sort_abstract_get_kind(sort), "not an abstract sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_abstract_get_kind(sort), "not an abstract sort");
   sort = cvc5_mk_abstract_sort(d_tm, CVC5_SORT_KIND_ABSTRACT_SORT);
   ASSERT_EQ(cvc5_sort_abstract_get_kind(sort), CVC5_SORT_KIND_ABSTRACT_SORT);
 }
@@ -620,17 +621,17 @@ TEST_F(TestCApiBlackSort, get_uninterpreted_sort_constructor_name)
 {
   Cvc5Sort sort = cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 2, "s");
   ASSERT_EQ(cvc5_sort_get_symbol(sort), std::string("s"));
-  ASSERT_DEATH(cvc5_sort_get_symbol(nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_get_symbol(d_int), "has no symbol");
+  ASSERT_CVC5_ERROR(cvc5_sort_get_symbol(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_get_symbol(d_int), "has no symbol");
 }
 
 TEST_F(TestCApiBlackSort, uninterpreted_sort_constructor_get_arity)
 {
   Cvc5Sort sort = cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 2, "s");
   ASSERT_EQ(cvc5_sort_uninterpreted_sort_constructor_get_arity(sort), 2);
-  ASSERT_DEATH(cvc5_sort_uninterpreted_sort_constructor_get_arity(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_sort_uninterpreted_sort_constructor_get_arity(nullptr),
                "invalid sort");
-  ASSERT_DEATH(cvc5_sort_uninterpreted_sort_constructor_get_arity(d_int),
+  ASSERT_CVC5_ERROR(cvc5_sort_uninterpreted_sort_constructor_get_arity(d_int),
                "not a sort constructor sort");
 }
 
@@ -638,16 +639,16 @@ TEST_F(TestCApiBlackSort, bv_get_size)
 {
   Cvc5Sort sort = cvc5_mk_bv_sort(d_tm, 32);
   ASSERT_EQ(cvc5_sort_bv_get_size(sort), 32);
-  ASSERT_DEATH(cvc5_sort_bv_get_size(nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_bv_get_size(d_int), "not a bit-vector sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_bv_get_size(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_bv_get_size(d_int), "not a bit-vector sort");
 }
 
 TEST_F(TestCApiBlackSort, ff_get_size)
 {
   Cvc5Sort sort = cvc5_mk_ff_sort(d_tm, "31", 10);
   ASSERT_EQ(cvc5_sort_ff_get_size(sort), std::string("31"));
-  ASSERT_DEATH(cvc5_sort_ff_get_size(nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_ff_get_size(d_int), "not a finite field sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_ff_get_size(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_ff_get_size(d_int), "not a finite field sort");
 }
 
 TEST_F(TestCApiBlackSort, fp_get_exp_sig_size)
@@ -655,10 +656,10 @@ TEST_F(TestCApiBlackSort, fp_get_exp_sig_size)
   Cvc5Sort sort = cvc5_mk_fp_sort(d_tm, 8, 24);
   ASSERT_EQ(cvc5_sort_fp_get_exp_size(sort), 8);
   ASSERT_EQ(cvc5_sort_fp_get_sig_size(sort), 24);
-  ASSERT_DEATH(cvc5_sort_fp_get_exp_size(nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_fp_get_exp_size(d_int), "not a floating-point sort");
-  ASSERT_DEATH(cvc5_sort_fp_get_sig_size(nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_fp_get_sig_size(d_int), "not a floating-point sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_fp_get_exp_size(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_fp_get_exp_size(d_int), "not a floating-point sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_fp_get_sig_size(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_fp_get_sig_size(d_int), "not a floating-point sort");
 }
 
 TEST_F(TestCApiBlackSort, dt_get_arity)
@@ -667,8 +668,8 @@ TEST_F(TestCApiBlackSort, dt_get_arity)
   Cvc5Sort sort = create_datatype_sort();
   ASSERT_EQ(cvc5_sort_dt_get_arity(sort), 0);
   // create bv sort, check should fail
-  ASSERT_DEATH(cvc5_sort_dt_get_arity(nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_dt_get_arity(d_int), "not a datatype sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_dt_get_arity(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_dt_get_arity(d_int), "not a datatype sort");
 }
 
 TEST_F(TestCApiBlackSort, tuple_get_length)
@@ -676,8 +677,8 @@ TEST_F(TestCApiBlackSort, tuple_get_length)
   std::vector<Cvc5Sort> args = {d_int, d_int};
   Cvc5Sort sort = cvc5_mk_tuple_sort(d_tm, 2, args.data());
   ASSERT_EQ(cvc5_sort_tuple_get_length(sort), 2);
-  ASSERT_DEATH(cvc5_sort_tuple_get_length(nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_tuple_get_length(d_int), "not a tuple sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_tuple_get_length(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_tuple_get_length(d_int), "not a tuple sort");
 }
 
 TEST_F(TestCApiBlackSort, tuple_get_element_sorts)
@@ -688,11 +689,11 @@ TEST_F(TestCApiBlackSort, tuple_get_element_sorts)
   const Cvc5Sort* sorts = cvc5_sort_tuple_get_element_sorts(sort, &size);
   ASSERT_TRUE(cvc5_sort_is_equal(sorts[0], d_int));
   ASSERT_TRUE(cvc5_sort_is_equal(sorts[1], d_int));
-  ASSERT_DEATH(cvc5_sort_tuple_get_element_sorts(nullptr, &size),
+  ASSERT_CVC5_ERROR(cvc5_sort_tuple_get_element_sorts(nullptr, &size),
                "invalid sort");
-  ASSERT_DEATH(cvc5_sort_tuple_get_element_sorts(sort, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_sort_tuple_get_element_sorts(sort, nullptr),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_sort_tuple_get_element_sorts(d_int, &size),
+  ASSERT_CVC5_ERROR(cvc5_sort_tuple_get_element_sorts(d_int, &size),
                "not a tuple sort");
 }
 
@@ -701,8 +702,8 @@ TEST_F(TestCApiBlackSort, nullable_get_element_sort)
   Cvc5Sort sort = cvc5_mk_nullable_sort(d_tm, d_real);
   ASSERT_TRUE(
       cvc5_sort_is_equal(cvc5_sort_nullable_get_element_sort(sort), d_real));
-  ASSERT_DEATH(cvc5_sort_nullable_get_element_sort(nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_sort_nullable_get_element_sort(d_int),
+  ASSERT_CVC5_ERROR(cvc5_sort_nullable_get_element_sort(nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_sort_nullable_get_element_sort(d_int),
                "not a nullable sort");
 }
 

--- a/test/unit/api/c/capi_sort_kind_black.cpp
+++ b/test/unit/api/c/capi_sort_kind_black.cpp
@@ -24,7 +24,7 @@ class TestCApiSortKind : public ::testing::Test
 TEST_F(TestCApiSortKind, sort_kind_to_string)
 {
   ASSERT_CVC5_ERROR(cvc5_sort_kind_to_string(static_cast<Cvc5SortKind>(-5)),
-               "invalid sort kind");
+                    "invalid sort kind");
 
   std::stringstream ss;
   for (int32_t k = static_cast<int32_t>(CVC5_SORT_KIND_INTERNAL_SORT_KIND);

--- a/test/unit/api/c/capi_sort_kind_black.cpp
+++ b/test/unit/api/c/capi_sort_kind_black.cpp
@@ -13,6 +13,7 @@
 #include <cvc5/c/cvc5.h>
 
 #include "gtest/gtest.h"
+#include "test_capi.h"
 
 namespace cvc5::internal::test {
 
@@ -22,7 +23,7 @@ class TestCApiSortKind : public ::testing::Test
 
 TEST_F(TestCApiSortKind, sort_kind_to_string)
 {
-  ASSERT_DEATH(cvc5_sort_kind_to_string(static_cast<Cvc5SortKind>(-5)),
+  ASSERT_CVC5_ERROR(cvc5_sort_kind_to_string(static_cast<Cvc5SortKind>(-5)),
                "invalid sort kind");
 
   std::stringstream ss;

--- a/test/unit/api/c/capi_statistics_black.cpp
+++ b/test/unit/api/c/capi_statistics_black.cpp
@@ -19,6 +19,7 @@ extern "C" {
 #include "base/check.h"
 #include "base/output.h"
 #include "gtest/gtest.h"
+#include "test_capi.h"
 
 namespace cvc5::internal::test {
 
@@ -42,7 +43,7 @@ class TestCApiBlackStatistics : public ::testing::Test
 
 TEST_F(TestCApiBlackStatistics, stat_is_internal)
 {
-  ASSERT_DEATH(cvc5_stat_is_internal(nullptr), "invalid statistic");
+  ASSERT_CVC5_ERROR(cvc5_stat_is_internal(nullptr), "invalid statistic");
   Cvc5Stat stat = cvc5_stats_get(cvc5_get_statistics(d_solver),
                                  "theory::strings::checkRuns");
   ASSERT_TRUE(cvc5_stat_is_int(stat));
@@ -51,7 +52,7 @@ TEST_F(TestCApiBlackStatistics, stat_is_internal)
 
 TEST_F(TestCApiBlackStatistics, stat_is_default)
 {
-  ASSERT_DEATH(cvc5_stat_is_default(nullptr), "invalid statistic");
+  ASSERT_CVC5_ERROR(cvc5_stat_is_default(nullptr), "invalid statistic");
   Cvc5Stat stat = cvc5_stats_get(cvc5_get_statistics(d_solver),
                                  "theory::strings::checkRuns");
   ASSERT_TRUE(cvc5_stat_is_int(stat));
@@ -60,7 +61,7 @@ TEST_F(TestCApiBlackStatistics, stat_is_default)
 
 TEST_F(TestCApiBlackStatistics, stat_is_int)
 {
-  ASSERT_DEATH(cvc5_stat_is_int(nullptr), "invalid statistic");
+  ASSERT_CVC5_ERROR(cvc5_stat_is_int(nullptr), "invalid statistic");
   Cvc5Stat stat = cvc5_stats_get(cvc5_get_statistics(d_solver),
                                  "theory::strings::checkRuns");
   ASSERT_TRUE(cvc5_stat_is_int(stat));
@@ -68,19 +69,19 @@ TEST_F(TestCApiBlackStatistics, stat_is_int)
 
 TEST_F(TestCApiBlackStatistics, stat_get_int)
 {
-  ASSERT_DEATH(cvc5_stat_get_int(nullptr), "invalid statistic");
+  ASSERT_CVC5_ERROR(cvc5_stat_get_int(nullptr), "invalid statistic");
   Cvc5Stat stat = cvc5_stats_get(cvc5_get_statistics(d_solver),
                                  "theory::strings::checkRuns");
   ASSERT_TRUE(cvc5_stat_is_int(stat));
   (void)cvc5_stat_get_int(stat);
   stat = cvc5_stats_get(cvc5_get_statistics(d_solver), "global::totalTime");
   ASSERT_TRUE(cvc5_stat_is_string(stat));
-  ASSERT_DEATH(cvc5_stat_get_int(stat), "expected Stat of type int64_t");
+  ASSERT_CVC5_ERROR(cvc5_stat_get_int(stat), "expected Stat of type int64_t");
 }
 
 TEST_F(TestCApiBlackStatistics, stat_is_double)
 {
-  ASSERT_DEATH(cvc5_stat_is_double(nullptr), "invalid statistic");
+  ASSERT_CVC5_ERROR(cvc5_stat_is_double(nullptr), "invalid statistic");
   Cvc5Stat stat =
       cvc5_stats_get(cvc5_get_statistics(d_solver), "global::totalTime");
   ASSERT_FALSE(cvc5_stat_is_double(stat));
@@ -88,16 +89,16 @@ TEST_F(TestCApiBlackStatistics, stat_is_double)
 
 TEST_F(TestCApiBlackStatistics, stat_get_double)
 {
-  ASSERT_DEATH(cvc5_stat_get_double(nullptr), "invalid statistic");
+  ASSERT_CVC5_ERROR(cvc5_stat_get_double(nullptr), "invalid statistic");
   Cvc5Stat stat =
       cvc5_stats_get(cvc5_get_statistics(d_solver), "global::totalTime");
   ASSERT_FALSE(cvc5_stat_is_double(stat));
-  ASSERT_DEATH(cvc5_stat_get_double(stat), "expected Stat of type double");
+  ASSERT_CVC5_ERROR(cvc5_stat_get_double(stat), "expected Stat of type double");
 }
 
 TEST_F(TestCApiBlackStatistics, stat_is_string)
 {
-  ASSERT_DEATH(cvc5_stat_is_string(nullptr), "invalid statistic");
+  ASSERT_CVC5_ERROR(cvc5_stat_is_string(nullptr), "invalid statistic");
   Cvc5Stat stat =
       cvc5_stats_get(cvc5_get_statistics(d_solver), "global::totalTime");
   ASSERT_TRUE(cvc5_stat_is_string(stat));
@@ -105,7 +106,7 @@ TEST_F(TestCApiBlackStatistics, stat_is_string)
 
 TEST_F(TestCApiBlackStatistics, stat_get_string)
 {
-  ASSERT_DEATH(cvc5_stat_get_string(nullptr), "invalid statistic");
+  ASSERT_CVC5_ERROR(cvc5_stat_get_string(nullptr), "invalid statistic");
   Cvc5Stat stat =
       cvc5_stats_get(cvc5_get_statistics(d_solver), "global::totalTime");
   ASSERT_TRUE(cvc5_stat_is_string(stat));
@@ -113,12 +114,12 @@ TEST_F(TestCApiBlackStatistics, stat_get_string)
   stat = cvc5_stats_get(cvc5_get_statistics(d_solver),
                         "theory::strings::checkRuns");
   ASSERT_FALSE(cvc5_stat_is_string(stat));
-  ASSERT_DEATH(cvc5_stat_get_string(stat), "expected Stat of type std::string");
+  ASSERT_CVC5_ERROR(cvc5_stat_get_string(stat), "expected Stat of type std::string");
 }
 
 TEST_F(TestCApiBlackStatistics, stat_is_histogram)
 {
-  ASSERT_DEATH(cvc5_stat_is_histogram(nullptr), "invalid statistic");
+  ASSERT_CVC5_ERROR(cvc5_stat_is_histogram(nullptr), "invalid statistic");
   Cvc5Stat stat = cvc5_stats_get(cvc5_get_statistics(d_solver),
                                  "theory::strings::reductions");
   ASSERT_TRUE(cvc5_stat_is_histogram(stat));
@@ -133,24 +134,24 @@ TEST_F(TestCApiBlackStatistics, stat_get_histogram)
                                  "theory::strings::reductions");
   ASSERT_TRUE(cvc5_stat_is_histogram(stat));
   cvc5_stat_get_histogram(stat, &keys, &values, &size);
-  ASSERT_DEATH(cvc5_stat_get_histogram(nullptr, &keys, &values, &size),
+  ASSERT_CVC5_ERROR(cvc5_stat_get_histogram(nullptr, &keys, &values, &size),
                "invalid statistic");
-  ASSERT_DEATH(cvc5_stat_get_histogram(stat, nullptr, &values, &size),
+  ASSERT_CVC5_ERROR(cvc5_stat_get_histogram(stat, nullptr, &values, &size),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_stat_get_histogram(stat, &keys, nullptr, &size),
+  ASSERT_CVC5_ERROR(cvc5_stat_get_histogram(stat, &keys, nullptr, &size),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_stat_get_histogram(stat, &keys, &values, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_stat_get_histogram(stat, &keys, &values, nullptr),
                "unexpected NULL argument");
   stat = cvc5_stats_get(cvc5_get_statistics(d_solver),
                         "theory::strings::checkRuns");
   ASSERT_FALSE(cvc5_stat_is_histogram(stat));
-  ASSERT_DEATH(cvc5_stat_get_histogram(stat, &keys, &values, &size),
+  ASSERT_CVC5_ERROR(cvc5_stat_get_histogram(stat, &keys, &values, &size),
                "expected Stat of typ");
 }
 
 TEST_F(TestCApiBlackStatistics, stat_to_string)
 {
-  ASSERT_DEATH(cvc5_stat_to_string(nullptr), "invalid statistic");
+  ASSERT_CVC5_ERROR(cvc5_stat_to_string(nullptr), "invalid statistic");
   Cvc5Stat stat = cvc5_stats_get(cvc5_get_statistics(d_solver),
                                  "theory::strings::reductions");
   (void)cvc5_stat_to_string(stat);
@@ -158,7 +159,7 @@ TEST_F(TestCApiBlackStatistics, stat_to_string)
 
 TEST_F(TestCApiBlackStatistics, stats_iter_init)
 {
-  ASSERT_DEATH(cvc5_stats_iter_init(nullptr, false, false),
+  ASSERT_CVC5_ERROR(cvc5_stats_iter_init(nullptr, false, false),
                "invalid statistics");
   Cvc5Statistics stats = cvc5_get_statistics(d_solver);
   cvc5_stats_iter_init(stats, true, true);
@@ -166,16 +167,16 @@ TEST_F(TestCApiBlackStatistics, stats_iter_init)
 
 TEST_F(TestCApiBlackStatistics, stats_iter_has_next)
 {
-  ASSERT_DEATH(cvc5_stats_iter_has_next(nullptr), "invalid statistics");
+  ASSERT_CVC5_ERROR(cvc5_stats_iter_has_next(nullptr), "invalid statistics");
   Cvc5Statistics stats = cvc5_get_statistics(d_solver);
-  ASSERT_DEATH(cvc5_stats_iter_has_next(stats), "iterator not initialized");
+  ASSERT_CVC5_ERROR(cvc5_stats_iter_has_next(stats), "iterator not initialized");
   cvc5_stats_iter_init(stats, true, true);
   ASSERT_TRUE(cvc5_stats_iter_has_next(stats));
 }
 
 TEST_F(TestCApiBlackStatistics, stats_iter_next)
 {
-  ASSERT_DEATH(cvc5_stats_iter_next(nullptr, nullptr), "invalid statistics");
+  ASSERT_CVC5_ERROR(cvc5_stats_iter_next(nullptr, nullptr), "invalid statistics");
   Cvc5Statistics stats = cvc5_get_statistics(d_solver);
   cvc5_stats_iter_init(stats, true, true);
   ASSERT_TRUE(cvc5_stats_iter_has_next(stats));
@@ -185,15 +186,15 @@ TEST_F(TestCApiBlackStatistics, stats_iter_next)
 TEST_F(TestCApiBlackStatistics, stats_get)
 {
   Cvc5Statistics stats = cvc5_get_statistics(d_solver);
-  ASSERT_DEATH(cvc5_stats_get(nullptr, "global::totalTime"),
+  ASSERT_CVC5_ERROR(cvc5_stats_get(nullptr, "global::totalTime"),
                "invalid statistics");
-  ASSERT_DEATH(cvc5_stats_get(stats, nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_stats_get(stats, nullptr), "unexpected NULL argument");
   (void)cvc5_stats_get(stats, "global::totalTime");
 }
 
 TEST_F(TestCApiBlackStatistics, stats_to_string)
 {
-  ASSERT_DEATH(cvc5_stats_to_string(nullptr), "invalid statistics");
+  ASSERT_CVC5_ERROR(cvc5_stats_to_string(nullptr), "invalid statistics");
   Cvc5Statistics stats = cvc5_get_statistics(d_solver);
   (void)cvc5_stats_to_string(stats);
 }

--- a/test/unit/api/c/capi_statistics_black.cpp
+++ b/test/unit/api/c/capi_statistics_black.cpp
@@ -114,7 +114,8 @@ TEST_F(TestCApiBlackStatistics, stat_get_string)
   stat = cvc5_stats_get(cvc5_get_statistics(d_solver),
                         "theory::strings::checkRuns");
   ASSERT_FALSE(cvc5_stat_is_string(stat));
-  ASSERT_CVC5_ERROR(cvc5_stat_get_string(stat), "expected Stat of type std::string");
+  ASSERT_CVC5_ERROR(cvc5_stat_get_string(stat),
+                    "expected Stat of type std::string");
 }
 
 TEST_F(TestCApiBlackStatistics, stat_is_histogram)
@@ -135,18 +136,18 @@ TEST_F(TestCApiBlackStatistics, stat_get_histogram)
   ASSERT_TRUE(cvc5_stat_is_histogram(stat));
   cvc5_stat_get_histogram(stat, &keys, &values, &size);
   ASSERT_CVC5_ERROR(cvc5_stat_get_histogram(nullptr, &keys, &values, &size),
-               "invalid statistic");
+                    "invalid statistic");
   ASSERT_CVC5_ERROR(cvc5_stat_get_histogram(stat, nullptr, &values, &size),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_stat_get_histogram(stat, &keys, nullptr, &size),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_stat_get_histogram(stat, &keys, &values, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   stat = cvc5_stats_get(cvc5_get_statistics(d_solver),
                         "theory::strings::checkRuns");
   ASSERT_FALSE(cvc5_stat_is_histogram(stat));
   ASSERT_CVC5_ERROR(cvc5_stat_get_histogram(stat, &keys, &values, &size),
-               "expected Stat of typ");
+                    "expected Stat of typ");
 }
 
 TEST_F(TestCApiBlackStatistics, stat_to_string)
@@ -160,7 +161,7 @@ TEST_F(TestCApiBlackStatistics, stat_to_string)
 TEST_F(TestCApiBlackStatistics, stats_iter_init)
 {
   ASSERT_CVC5_ERROR(cvc5_stats_iter_init(nullptr, false, false),
-               "invalid statistics");
+                    "invalid statistics");
   Cvc5Statistics stats = cvc5_get_statistics(d_solver);
   cvc5_stats_iter_init(stats, true, true);
 }
@@ -169,14 +170,16 @@ TEST_F(TestCApiBlackStatistics, stats_iter_has_next)
 {
   ASSERT_CVC5_ERROR(cvc5_stats_iter_has_next(nullptr), "invalid statistics");
   Cvc5Statistics stats = cvc5_get_statistics(d_solver);
-  ASSERT_CVC5_ERROR(cvc5_stats_iter_has_next(stats), "iterator not initialized");
+  ASSERT_CVC5_ERROR(cvc5_stats_iter_has_next(stats),
+                    "iterator not initialized");
   cvc5_stats_iter_init(stats, true, true);
   ASSERT_TRUE(cvc5_stats_iter_has_next(stats));
 }
 
 TEST_F(TestCApiBlackStatistics, stats_iter_next)
 {
-  ASSERT_CVC5_ERROR(cvc5_stats_iter_next(nullptr, nullptr), "invalid statistics");
+  ASSERT_CVC5_ERROR(cvc5_stats_iter_next(nullptr, nullptr),
+                    "invalid statistics");
   Cvc5Statistics stats = cvc5_get_statistics(d_solver);
   cvc5_stats_iter_init(stats, true, true);
   ASSERT_TRUE(cvc5_stats_iter_has_next(stats));
@@ -187,7 +190,7 @@ TEST_F(TestCApiBlackStatistics, stats_get)
 {
   Cvc5Statistics stats = cvc5_get_statistics(d_solver);
   ASSERT_CVC5_ERROR(cvc5_stats_get(nullptr, "global::totalTime"),
-               "invalid statistics");
+                    "invalid statistics");
   ASSERT_CVC5_ERROR(cvc5_stats_get(stats, nullptr), "unexpected NULL argument");
   (void)cvc5_stats_get(stats, "global::totalTime");
 }

--- a/test/unit/api/c/capi_symbol_manager_black.cpp
+++ b/test/unit/api/c/capi_symbol_manager_black.cpp
@@ -17,6 +17,7 @@ extern "C" {
 #include <sstream>
 
 #include "gtest/gtest.h"
+#include "test_capi.h"
 
 namespace cvc5::internal::test {
 
@@ -62,7 +63,7 @@ class TestCApiBlackSymbolManager : public ::testing::Test
 
 TEST_F(TestCApiBlackSymbolManager, is_logic_set)
 {
-  ASSERT_DEATH(cvc5_sm_is_logic_set(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_sm_is_logic_set(nullptr), "unexpected NULL argument");
   ASSERT_EQ(cvc5_sm_is_logic_set(d_sm), false);
   parse_and_set_logic("QF_LIA");
   ASSERT_EQ(cvc5_sm_is_logic_set(d_sm), true);
@@ -70,10 +71,10 @@ TEST_F(TestCApiBlackSymbolManager, is_logic_set)
 
 TEST_F(TestCApiBlackSymbolManager, get_logic)
 {
-  ASSERT_DEATH(cvc5_sm_get_logic(d_sm), "logic has not yet been set");
+  ASSERT_CVC5_ERROR(cvc5_sm_get_logic(d_sm), "logic has not yet been set");
   parse_and_set_logic("QF_LIA");
   ASSERT_EQ(cvc5_sm_get_logic(d_sm), std::string("QF_LIA"));
-  ASSERT_DEATH(cvc5_sm_get_logic(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_sm_get_logic(nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackSymbolManager, get_declared_sorts)
@@ -81,9 +82,9 @@ TEST_F(TestCApiBlackSymbolManager, get_declared_sorts)
   size_t size;
   (void)cvc5_sm_get_declared_sorts(d_sm, &size);
   ASSERT_EQ(size, 0);
-  ASSERT_DEATH(cvc5_sm_get_declared_sorts(nullptr, &size),
+  ASSERT_CVC5_ERROR(cvc5_sm_get_declared_sorts(nullptr, &size),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_sm_get_declared_sorts(d_sm, nullptr), "NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_sm_get_declared_sorts(d_sm, nullptr), "NULL argument");
 }
 
 TEST_F(TestCApiBlackSymbolManager, get_declared_terms)
@@ -91,9 +92,9 @@ TEST_F(TestCApiBlackSymbolManager, get_declared_terms)
   size_t size;
   (void)cvc5_sm_get_declared_terms(d_sm, &size);
   ASSERT_EQ(size, 0);
-  ASSERT_DEATH(cvc5_sm_get_declared_terms(nullptr, &size),
+  ASSERT_CVC5_ERROR(cvc5_sm_get_declared_terms(nullptr, &size),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_sm_get_declared_terms(d_sm, nullptr), "NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_sm_get_declared_terms(d_sm, nullptr), "NULL argument");
 }
 
 TEST_F(TestCApiBlackSymbolManager, getNamedTerms)

--- a/test/unit/api/c/capi_symbol_manager_black.cpp
+++ b/test/unit/api/c/capi_symbol_manager_black.cpp
@@ -83,7 +83,7 @@ TEST_F(TestCApiBlackSymbolManager, get_declared_sorts)
   (void)cvc5_sm_get_declared_sorts(d_sm, &size);
   ASSERT_EQ(size, 0);
   ASSERT_CVC5_ERROR(cvc5_sm_get_declared_sorts(nullptr, &size),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_sm_get_declared_sorts(d_sm, nullptr), "NULL argument");
 }
 
@@ -93,7 +93,7 @@ TEST_F(TestCApiBlackSymbolManager, get_declared_terms)
   (void)cvc5_sm_get_declared_terms(d_sm, &size);
   ASSERT_EQ(size, 0);
   ASSERT_CVC5_ERROR(cvc5_sm_get_declared_terms(nullptr, &size),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_sm_get_declared_terms(d_sm, nullptr), "NULL argument");
 }
 

--- a/test/unit/api/c/capi_synth_result_black.cpp
+++ b/test/unit/api/c/capi_synth_result_black.cpp
@@ -42,13 +42,14 @@ class TestCApiBlackSynthResult : public ::testing::Test
 
 TEST_F(TestCApiBlackSynthResult, is_null)
 {
-  ASSERT_CVC5_ERROR(cvc5_synth_result_is_null(nullptr), "invalid synthesis result");
+  ASSERT_CVC5_ERROR(cvc5_synth_result_is_null(nullptr),
+                    "invalid synthesis result");
 }
 
 TEST_F(TestCApiBlackSynthResult, has_solution)
 {
   ASSERT_CVC5_ERROR(cvc5_synth_result_has_solution(nullptr),
-               "invalid synthesis result");
+                    "invalid synthesis result");
 
   cvc5_set_option(d_solver, "sygus", "true");
   (void)cvc5_synth_fun(d_solver, "f", 0, nullptr, d_bool);
@@ -66,13 +67,13 @@ TEST_F(TestCApiBlackSynthResult, has_solution)
 TEST_F(TestCApiBlackSynthResult, has_no_solution)
 {
   ASSERT_CVC5_ERROR(cvc5_synth_result_has_no_solution(nullptr),
-               "invalid synthesis result");
+                    "invalid synthesis result");
 }
 
 TEST_F(TestCApiBlackSynthResult, is_unknown)
 {
   ASSERT_CVC5_ERROR(cvc5_synth_result_is_unknown(nullptr),
-               "invalid synthesis result");
+                    "invalid synthesis result");
 
   cvc5_set_option(d_solver, "sygus", "true");
   (void)cvc5_synth_fun(d_solver, "f", 0, nullptr, d_bool);
@@ -117,13 +118,16 @@ TEST_F(TestCApiBlackSynthResult, hash)
   Cvc5SynthResult res2 = cvc5_check_synth(d_solver);
   ASSERT_EQ(cvc5_synth_result_hash(res1), cvc5_synth_result_hash(res1));
   ASSERT_NE(cvc5_synth_result_hash(res1), cvc5_synth_result_hash(res2));
-  ASSERT_CVC5_ERROR(cvc5_synth_result_hash(nullptr), "invalid synthesis result");
+  ASSERT_CVC5_ERROR(cvc5_synth_result_hash(nullptr),
+                    "invalid synthesis result");
 }
 
 TEST_F(TestCApiBlackSynthResult, copy_release)
 {
-  ASSERT_CVC5_ERROR(cvc5_synth_result_copy(nullptr), "invalid synthesis result");
-  ASSERT_CVC5_ERROR(cvc5_synth_result_release(nullptr), "invalid synthesis result");
+  ASSERT_CVC5_ERROR(cvc5_synth_result_copy(nullptr),
+                    "invalid synthesis result");
+  ASSERT_CVC5_ERROR(cvc5_synth_result_release(nullptr),
+                    "invalid synthesis result");
   cvc5_set_option(d_solver, "sygus", "true");
   (void)cvc5_synth_fun(d_solver, "f", 0, nullptr, d_bool);
   Cvc5Term ttrue = cvc5_mk_true(d_tm);

--- a/test/unit/api/c/capi_synth_result_black.cpp
+++ b/test/unit/api/c/capi_synth_result_black.cpp
@@ -17,6 +17,7 @@ extern "C" {
 #include "base/check.h"
 #include "base/output.h"
 #include "gtest/gtest.h"
+#include "test_capi.h"
 
 namespace cvc5::internal::test {
 
@@ -41,12 +42,12 @@ class TestCApiBlackSynthResult : public ::testing::Test
 
 TEST_F(TestCApiBlackSynthResult, is_null)
 {
-  ASSERT_DEATH(cvc5_synth_result_is_null(nullptr), "invalid synthesis result");
+  ASSERT_CVC5_ERROR(cvc5_synth_result_is_null(nullptr), "invalid synthesis result");
 }
 
 TEST_F(TestCApiBlackSynthResult, has_solution)
 {
-  ASSERT_DEATH(cvc5_synth_result_has_solution(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_synth_result_has_solution(nullptr),
                "invalid synthesis result");
 
   cvc5_set_option(d_solver, "sygus", "true");
@@ -64,13 +65,13 @@ TEST_F(TestCApiBlackSynthResult, has_solution)
 
 TEST_F(TestCApiBlackSynthResult, has_no_solution)
 {
-  ASSERT_DEATH(cvc5_synth_result_has_no_solution(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_synth_result_has_no_solution(nullptr),
                "invalid synthesis result");
 }
 
 TEST_F(TestCApiBlackSynthResult, is_unknown)
 {
-  ASSERT_DEATH(cvc5_synth_result_is_unknown(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_synth_result_is_unknown(nullptr),
                "invalid synthesis result");
 
   cvc5_set_option(d_solver, "sygus", "true");
@@ -116,13 +117,13 @@ TEST_F(TestCApiBlackSynthResult, hash)
   Cvc5SynthResult res2 = cvc5_check_synth(d_solver);
   ASSERT_EQ(cvc5_synth_result_hash(res1), cvc5_synth_result_hash(res1));
   ASSERT_NE(cvc5_synth_result_hash(res1), cvc5_synth_result_hash(res2));
-  ASSERT_DEATH(cvc5_synth_result_hash(nullptr), "invalid synthesis result");
+  ASSERT_CVC5_ERROR(cvc5_synth_result_hash(nullptr), "invalid synthesis result");
 }
 
 TEST_F(TestCApiBlackSynthResult, copy_release)
 {
-  ASSERT_DEATH(cvc5_synth_result_copy(nullptr), "invalid synthesis result");
-  ASSERT_DEATH(cvc5_synth_result_release(nullptr), "invalid synthesis result");
+  ASSERT_CVC5_ERROR(cvc5_synth_result_copy(nullptr), "invalid synthesis result");
+  ASSERT_CVC5_ERROR(cvc5_synth_result_release(nullptr), "invalid synthesis result");
   cvc5_set_option(d_solver, "sygus", "true");
   (void)cvc5_synth_fun(d_solver, "f", 0, nullptr, d_bool);
   Cvc5Term ttrue = cvc5_mk_true(d_tm);

--- a/test/unit/api/c/capi_term_black.cpp
+++ b/test/unit/api/c/capi_term_black.cpp
@@ -413,7 +413,7 @@ TEST_F(TestCApiBlackTerm, get_integer)
   ASSERT_CVC5_ERROR(cvc5_term_get_uint32_value(nullptr), "invalid term");
   ASSERT_CVC5_ERROR(cvc5_term_get_uint64_value(nullptr), "invalid term");
   ASSERT_CVC5_ERROR(cvc5_term_get_real_or_integer_value_sign(nullptr),
-               "invalid term");
+                    "invalid term");
 
   ASSERT_TRUE(
       !cvc5_term_is_int32_value(int1) && !cvc5_term_is_uint32_value(int1)
@@ -529,11 +529,11 @@ TEST_F(TestCApiBlackTerm, get_integer)
 TEST_F(TestCApiBlackTerm, get_string)
 {
   ASSERT_CVC5_ERROR(cvc5_mk_string(nullptr, "abcde", false),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_term_is_string_value(nullptr), "invalid term");
   ASSERT_CVC5_ERROR(cvc5_term_get_u32string_value(nullptr), "invalid term");
   ASSERT_CVC5_ERROR(cvc5_mk_string(d_tm, nullptr, false),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   Cvc5Term s1 = cvc5_mk_string(d_tm, "abcde", false);
   ASSERT_TRUE(cvc5_term_is_string_value(s1));
   ASSERT_EQ(cvc5_term_get_u32string_value(s1), std::u32string(U"abcde"));
@@ -565,19 +565,19 @@ TEST_F(TestCApiBlackTerm, get_real)
   ASSERT_CVC5_ERROR(cvc5_term_is_real_value(nullptr), "invalid term");
   ASSERT_CVC5_ERROR(cvc5_term_get_real_value(nullptr), "invalid term");
   ASSERT_CVC5_ERROR(cvc5_term_get_real32_value(nullptr, &num32, &den32),
-               "invalid term");
+                    "invalid term");
   ASSERT_CVC5_ERROR(cvc5_term_get_real32_value(real1, nullptr, &den32),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_term_get_real32_value(real1, &num32, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_term_get_real64_value(real1, nullptr, &den64),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_term_get_real64_value(real1, &num64, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_term_get_real64_value(nullptr, &num64, &den64),
-               "invalid term");
+                    "invalid term");
   ASSERT_CVC5_ERROR(cvc5_term_get_real_or_integer_value_sign(nullptr),
-               "invalid term");
+                    "invalid term");
 
   ASSERT_TRUE(cvc5_term_is_real_value(real1) && cvc5_term_is_real64_value(real1)
               && cvc5_term_is_real32_value(real1));
@@ -689,7 +689,8 @@ TEST_F(TestCApiBlackTerm, get_boolean_value)
 
 TEST_F(TestCApiBlackTerm, get_bv_value)
 {
-  ASSERT_CVC5_ERROR(cvc5_mk_bv_uint64(nullptr, 8, 15), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_bv_uint64(nullptr, 8, 15),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_term_is_bv_value(nullptr), "invalid term");
 
   Cvc5Term b1 = cvc5_mk_bv_uint64(d_tm, 8, 15);
@@ -749,12 +750,13 @@ TEST_F(TestCApiBlackTerm, get_ff_value)
   ASSERT_EQ(std::string("1"), cvc5_term_get_ff_value(fv));
   Cvc5Term b1 = cvc5_mk_bv_uint64(d_tm, 8, 15);
   ASSERT_CVC5_ERROR(cvc5_term_get_ff_value(b1),
-               "expected Term to be a finite field value");
+                    "expected Term to be a finite field value");
 }
 
 TEST_F(TestCApiBlackTerm, get_uninterpreted_sort_value)
 {
-  ASSERT_CVC5_ERROR(cvc5_term_get_uninterpreted_sort_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_uninterpreted_sort_value(nullptr),
+                    "invalid term");
   cvc5_set_option(d_solver, "produce-models", "true");
   Cvc5Term x = cvc5_mk_const(d_tm, d_uninterpreted, "x");
   Cvc5Term y = cvc5_mk_const(d_tm, d_uninterpreted, "y");
@@ -785,7 +787,7 @@ TEST_F(TestCApiBlackTerm, get_rm_value)
 {
   ASSERT_CVC5_ERROR(cvc5_term_get_rm_value(nullptr), "invalid term");
   ASSERT_CVC5_ERROR(cvc5_term_get_rm_value(cvc5_mk_integer_int64(d_tm, 15)),
-               "invalid argument");
+                    "invalid argument");
 
   ASSERT_EQ(cvc5_term_get_rm_value(
                 cvc5_mk_rm(d_tm, CVC5_RM_ROUND_NEAREST_TIES_TO_EVEN)),
@@ -814,7 +816,7 @@ TEST_F(TestCApiBlackTerm, get_tuple)
   size_t size;
   ASSERT_CVC5_ERROR(cvc5_term_get_tuple_value(nullptr, &size), "invalid term");
   ASSERT_CVC5_ERROR(cvc5_term_get_tuple_value(tup, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_term_is_tuple_value(nullptr), "invalid term");
 
   ASSERT_TRUE(cvc5_term_is_tuple_value(tup));
@@ -838,13 +840,14 @@ TEST_F(TestCApiBlackTerm, get_fp_value)
   ASSERT_CVC5_ERROR(cvc5_term_is_fp_pos_inf(nullptr), "invalid term");
   ASSERT_CVC5_ERROR(cvc5_term_is_fp_neg_inf(nullptr), "invalid term");
   ASSERT_CVC5_ERROR(cvc5_term_is_fp_nan(nullptr), "invalid term");
-  ASSERT_CVC5_ERROR(cvc5_term_get_fp_value(nullptr, &ew, &sw, &res), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_fp_value(nullptr, &ew, &sw, &res),
+                    "invalid term");
   ASSERT_CVC5_ERROR(cvc5_term_get_fp_value(fp_val, nullptr, &sw, &res),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_term_get_fp_value(fp_val, &ew, nullptr, &res),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_term_get_fp_value(fp_val, &ew, &sw, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 
   ASSERT_TRUE(cvc5_term_is_fp_value(fp_val));
   ASSERT_FALSE(cvc5_term_is_fp_pos_zero(fp_val));
@@ -899,7 +902,7 @@ TEST_F(TestCApiBlackTerm, get_set_value)
   size_t size;
   ASSERT_CVC5_ERROR(cvc5_term_get_set_value(nullptr, &size), "invalid term");
   ASSERT_CVC5_ERROR(cvc5_term_get_set_value(s1, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   (void)cvc5_term_get_set_value(s1, &size);
   ASSERT_EQ(size, 0);
   const Cvc5Term* res2 = cvc5_term_get_set_value(s2, &size);
@@ -940,7 +943,7 @@ TEST_F(TestCApiBlackTerm, get_sequence_value)
       cvc5_mk_term(d_tm, CVC5_KIND_SEQ_CONCAT, args.size(), args.data());
 
   ASSERT_CVC5_ERROR(cvc5_mk_empty_sequence(nullptr, seq_sort),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_empty_sequence(d_tm, nullptr), "invalid sort");
   ASSERT_CVC5_ERROR(cvc5_term_is_sequence_value(nullptr), "invalid term");
 
@@ -959,9 +962,10 @@ TEST_F(TestCApiBlackTerm, get_sequence_value)
   ASSERT_TRUE(cvc5_term_is_sequence_value(s5));
 
   size_t size;
-  ASSERT_CVC5_ERROR(cvc5_term_get_sequence_value(nullptr, &size), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_sequence_value(nullptr, &size),
+                    "invalid term");
   ASSERT_CVC5_ERROR(cvc5_term_get_sequence_value(s1, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   (void)cvc5_term_get_sequence_value(s1, &size);
   ASSERT_EQ(size, 0);
   const Cvc5Term* res2 = cvc5_term_get_sequence_value(s2, &size);
@@ -991,7 +995,8 @@ TEST_F(TestCApiBlackTerm, get_sequence_value)
   args = {cvc5_mk_real_int64(d_tm, 1)};
   Cvc5Term su =
       cvc5_mk_term(d_tm, CVC5_KIND_SEQ_UNIT, args.size(), args.data());
-  ASSERT_CVC5_ERROR(cvc5_term_get_sequence_value(su, &size), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_term_get_sequence_value(su, &size),
+                    "invalid argument");
 }
 
 TEST_F(TestCApiBlackTerm, substitute)
@@ -1006,14 +1011,15 @@ TEST_F(TestCApiBlackTerm, substitute)
       cvc5_mk_term(d_tm, CVC5_KIND_ADD, args.size(), args.data());
 
   ASSERT_CVC5_ERROR(cvc5_term_substitute_term(nullptr, x, one), "invalid term");
-  ASSERT_CVC5_ERROR(cvc5_term_substitute_term(xpx, nullptr, one), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_substitute_term(xpx, nullptr, one),
+                    "invalid term");
   ASSERT_CVC5_ERROR(cvc5_term_substitute_term(xpx, x, nullptr), "invalid term");
 
   ASSERT_TRUE(
       cvc5_term_is_equal(cvc5_term_substitute_term(xpx, x, one), onepone));
   // incorrect due to type
   ASSERT_CVC5_ERROR(cvc5_term_substitute_term(xpx, one, ttrue),
-               "expected terms of the same sort");
+                    "expected terms of the same sort");
 
   // simultaneous substitution
   Cvc5Term y = cvc5_mk_const(d_tm, d_int, "y");
@@ -1028,24 +1034,29 @@ TEST_F(TestCApiBlackTerm, substitute)
 
   // incorrect substitution due to types
   rs[1] = ttrue;
-  ASSERT_CVC5_ERROR(cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
-               "expecting terms of the same sort at index 1");
+  ASSERT_CVC5_ERROR(
+      cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
+      "expecting terms of the same sort at index 1");
 
   // null cannot substitute
   es = {nullptr, y};
   rs = {y, one};
-  ASSERT_CVC5_ERROR(cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
-               "invalid term at index 0");
+  ASSERT_CVC5_ERROR(
+      cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
+      "invalid term at index 0");
   es = {x, nullptr};
-  ASSERT_CVC5_ERROR(cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
-               "invalid term at index 1");
+  ASSERT_CVC5_ERROR(
+      cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
+      "invalid term at index 1");
   es = {x, y};
   rs = {nullptr, one};
-  ASSERT_CVC5_ERROR(cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
-               "invalid term at index 0");
+  ASSERT_CVC5_ERROR(
+      cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
+      "invalid term at index 0");
   rs = {y, nullptr};
-  ASSERT_CVC5_ERROR(cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
-               "invalid term at index 1");
+  ASSERT_CVC5_ERROR(
+      cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
+      "invalid term at index 1");
 }
 
 TEST_F(TestCApiBlackTerm, const_array)
@@ -1058,11 +1069,12 @@ TEST_F(TestCApiBlackTerm, const_array)
   Cvc5Term const_arr = cvc5_mk_const_array(d_tm, arr_sort, one);
 
   ASSERT_CVC5_ERROR(cvc5_mk_const_array(nullptr, arr_sort, one),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_const_array(d_tm, nullptr, one), "invalid sort");
-  ASSERT_CVC5_ERROR(cvc5_mk_const_array(d_tm, arr_sort, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_mk_const_array(d_tm, arr_sort, nullptr),
+                    "invalid term");
   ASSERT_CVC5_ERROR(cvc5_mk_const_array(d_tm, arr_sort, two),
-               "value does not match element sort");
+                    "value does not match element sort");
   ASSERT_CVC5_ERROR(cvc5_mk_const_array(d_tm, arr_sort, i), "invalid argument");
 
   ASSERT_CVC5_ERROR(cvc5_term_get_const_array_base(nullptr), "invalid term");
@@ -1088,22 +1100,25 @@ TEST_F(TestCApiBlackTerm, const_array)
 TEST_F(TestCApiBlackTerm, get_cardinality_constraint)
 {
   ASSERT_CVC5_ERROR(cvc5_mk_cardinality_constraint(nullptr, d_uninterpreted, 3),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_cardinality_constraint(d_tm, nullptr, 3),
-               "invalid sort");
-  ASSERT_CVC5_ERROR(cvc5_term_is_cardinality_constraint(nullptr), "invalid term");
+                    "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_term_is_cardinality_constraint(nullptr),
+                    "invalid term");
 
   Cvc5Term t = cvc5_mk_cardinality_constraint(d_tm, d_uninterpreted, 3);
   ASSERT_TRUE(cvc5_term_is_cardinality_constraint(t));
 
   Cvc5Sort res;
   uint32_t res_upper;
-  ASSERT_CVC5_ERROR(cvc5_term_get_cardinality_constraint(nullptr, &res, &res_upper),
-               "invalid term");
-  ASSERT_CVC5_ERROR(cvc5_term_get_cardinality_constraint(t, nullptr, &res_upper),
-               "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_term_get_cardinality_constraint(nullptr, &res, &res_upper),
+      "invalid term");
+  ASSERT_CVC5_ERROR(
+      cvc5_term_get_cardinality_constraint(t, nullptr, &res_upper),
+      "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_term_get_cardinality_constraint(t, &res, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 
   cvc5_term_get_cardinality_constraint(t, &res, &res_upper);
   ASSERT_TRUE(cvc5_sort_is_equal(res, d_uninterpreted));
@@ -1112,7 +1127,7 @@ TEST_F(TestCApiBlackTerm, get_cardinality_constraint)
   Cvc5Term x = cvc5_mk_const(d_tm, d_int, "x");
   ASSERT_FALSE(cvc5_term_is_cardinality_constraint(x));
   ASSERT_CVC5_ERROR(cvc5_term_get_cardinality_constraint(x, &res, &res_upper),
-               "invalid argument");
+                    "invalid argument");
 }
 
 TEST_F(TestCApiBlackTerm, get_real_algebraic_number)
@@ -1128,7 +1143,8 @@ TEST_F(TestCApiBlackTerm, get_real_algebraic_number)
   Cvc5Term eq = cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, args.size(), args.data());
   cvc5_assert_formula(d_solver, eq);
 
-  ASSERT_CVC5_ERROR(cvc5_term_is_real_algebraic_number(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_real_algebraic_number(nullptr),
+                    "invalid term");
   ASSERT_CVC5_ERROR(
       cvc5_term_get_real_algebraic_number_defining_polynomial(nullptr, y),
       "invalid term");
@@ -1136,9 +1152,9 @@ TEST_F(TestCApiBlackTerm, get_real_algebraic_number)
       cvc5_term_get_real_algebraic_number_defining_polynomial(x, nullptr),
       "invalid term");
   ASSERT_CVC5_ERROR(cvc5_term_get_real_algebraic_number_lower_bound(nullptr),
-               "invalid term");
+                    "invalid term");
   ASSERT_CVC5_ERROR(cvc5_term_get_real_algebraic_number_upper_bound(nullptr),
-               "invalid term");
+                    "invalid term");
 
   // Note that check-sat should only return "sat" if libpoly is enabled.
   // Otherwise, we do not test the following functionality.
@@ -1175,9 +1191,10 @@ TEST_F(TestCApiBlackTerm, get_skolem)
   ASSERT_FALSE(cvc5_term_is_skolem(x));
   ASSERT_CVC5_ERROR(cvc5_term_get_skolem_id(x), "invalid argument");
   ASSERT_CVC5_ERROR(cvc5_term_get_skolem_indices(x, &size), "invalid argument");
-  ASSERT_CVC5_ERROR(cvc5_term_get_skolem_indices(nullptr, &size), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_skolem_indices(nullptr, &size),
+                    "invalid term");
   ASSERT_CVC5_ERROR(cvc5_term_get_skolem_indices(x, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTerm, term_scoped_to_string)

--- a/test/unit/api/c/capi_term_black.cpp
+++ b/test/unit/api/c/capi_term_black.cpp
@@ -16,6 +16,7 @@ extern "C" {
 
 #include "base/output.h"
 #include "gtest/gtest.h"
+#include "test_capi.h"
 
 namespace cvc5::internal::test {
 
@@ -47,7 +48,7 @@ class TestCApiBlackTerm : public ::testing::Test
 
 TEST_F(TestCApiBlackTerm, hash)
 {
-  ASSERT_DEATH(cvc5_term_hash(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_hash(nullptr), "invalid term");
   (void)cvc5_term_hash(cvc5_mk_integer_int64(d_tm, 2));
   Cvc5Term x = cvc5_mk_var(d_tm, d_int, "x");
   Cvc5Term y = cvc5_mk_var(d_tm, d_int, "y");
@@ -57,8 +58,8 @@ TEST_F(TestCApiBlackTerm, hash)
 
 TEST_F(TestCApiBlackTerm, copy_release)
 {
-  ASSERT_DEATH(cvc5_term_copy(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_release(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_copy(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_release(nullptr), "invalid term");
   Cvc5Term tint = cvc5_mk_integer_int64(d_tm, 2);
   size_t hash1 = cvc5_term_hash(tint);
   Cvc5Term tint_copy = cvc5_term_copy(tint);
@@ -75,8 +76,8 @@ TEST_F(TestCApiBlackTerm, compare)
 {
   Cvc5Term x = cvc5_mk_var(d_tm, d_uninterpreted, "x");
   Cvc5Term y = cvc5_mk_var(d_tm, d_uninterpreted, "y");
-  ASSERT_DEATH(cvc5_term_compare(x, nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_compare(nullptr, y), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_compare(x, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_compare(nullptr, y), "invalid term");
   ASSERT_FALSE(cvc5_term_is_equal(x, nullptr));
   ASSERT_TRUE(cvc5_term_is_disequal(x, nullptr));
   ASSERT_EQ(cvc5_term_compare(x, x), 0);
@@ -85,7 +86,7 @@ TEST_F(TestCApiBlackTerm, compare)
 
 TEST_F(TestCApiBlackTerm, get_id)
 {
-  ASSERT_DEATH(cvc5_term_get_id(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_id(nullptr), "invalid term");
   Cvc5Term x = cvc5_mk_var(d_tm, d_int, "x");
   Cvc5Term y = cvc5_term_copy(x);
   Cvc5Term z = cvc5_mk_var(d_tm, d_int, "z");
@@ -104,7 +105,7 @@ TEST_F(TestCApiBlackTerm, get_kind)
   Cvc5Sort fun_sort2 =
       cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), d_int);
 
-  ASSERT_DEATH(cvc5_term_get_kind(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_kind(nullptr), "invalid term");
 
   Cvc5Term x = cvc5_mk_var(d_tm, d_uninterpreted, "x");
   ASSERT_EQ(cvc5_term_get_kind(x), CVC5_KIND_VARIABLE);
@@ -159,7 +160,7 @@ TEST_F(TestCApiBlackTerm, get_sort)
   Cvc5Sort fun_sort2 =
       cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), d_bool);
 
-  ASSERT_DEATH(cvc5_term_get_sort(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_sort(nullptr), "invalid term");
 
   Cvc5Term x = cvc5_mk_var(d_tm, bv_sort, "x");
   ASSERT_TRUE(cvc5_sort_is_equal(cvc5_term_get_sort(x), bv_sort));
@@ -198,8 +199,8 @@ TEST_F(TestCApiBlackTerm, get_sort)
 
 TEST_F(TestCApiBlackTerm, get_op)
 {
-  ASSERT_DEATH(cvc5_term_has_op(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_op(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_has_op(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_op(nullptr), "invalid term");
 
   Cvc5Sort bv_sort = cvc5_mk_bv_sort(d_tm, 8);
   Cvc5Sort arr_sort = cvc5_mk_array_sort(d_tm, bv_sort, d_int);
@@ -212,7 +213,7 @@ TEST_F(TestCApiBlackTerm, get_op)
   Cvc5Term b = cvc5_mk_const(d_tm, bv_sort, "b");
 
   ASSERT_FALSE(cvc5_term_has_op(x));
-  ASSERT_DEATH(cvc5_term_get_op(x), "expected Term to have an Op");
+  ASSERT_CVC5_ERROR(cvc5_term_get_op(x), "expected Term to have an Op");
 
   std::vector<Cvc5Term> args = {a, b};
   Cvc5Term ab = cvc5_mk_term(d_tm, CVC5_KIND_SELECT, args.size(), args.data());
@@ -247,7 +248,7 @@ TEST_F(TestCApiBlackTerm, get_op)
   Cvc5Term fx =
       cvc5_mk_term(d_tm, CVC5_KIND_APPLY_UF, args.size(), args.data());
   ASSERT_FALSE(cvc5_term_has_op(f));
-  ASSERT_DEATH(cvc5_term_get_op(f), "expected Term to have an Op");
+  ASSERT_CVC5_ERROR(cvc5_term_get_op(f), "expected Term to have an Op");
   ASSERT_TRUE(cvc5_term_has_op(fx));
 
   // testing rebuild from op and children
@@ -316,8 +317,8 @@ TEST_F(TestCApiBlackTerm, get_op)
 
 TEST_F(TestCApiBlackTerm, has_get_symbol)
 {
-  ASSERT_DEATH(cvc5_term_has_symbol(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_symbol(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_has_symbol(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_symbol(nullptr), "invalid term");
 
   Cvc5Term t = cvc5_mk_true(d_tm);
   Cvc5Term c = cvc5_mk_const(d_tm, d_bool, "|\\|");
@@ -325,7 +326,7 @@ TEST_F(TestCApiBlackTerm, has_get_symbol)
   ASSERT_FALSE(cvc5_term_has_symbol(t));
   ASSERT_TRUE(cvc5_term_has_symbol(c));
 
-  ASSERT_DEATH(cvc5_term_get_symbol(t), "cannot get symbol");
+  ASSERT_CVC5_ERROR(cvc5_term_get_symbol(t), "cannot get symbol");
   ASSERT_EQ(cvc5_term_get_symbol(c), std::string("|\\|"));
 }
 
@@ -345,8 +346,8 @@ TEST_F(TestCApiBlackTerm, assignment)
 
 TEST_F(TestCApiBlackTerm, children)
 {
-  ASSERT_DEATH(cvc5_term_get_num_children(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_child(nullptr, 0), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_num_children(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_child(nullptr, 0), "invalid term");
   // simple term 2+3
   Cvc5Term two = cvc5_mk_integer_int64(d_tm, 2);
   std::vector<Cvc5Term> args = {two, cvc5_mk_integer_int64(d_tm, 3)};
@@ -375,8 +376,8 @@ TEST_F(TestCApiBlackTerm, children)
 
 TEST_F(TestCApiBlackTerm, get_integer)
 {
-  ASSERT_DEATH(cvc5_mk_integer(nullptr, "2"), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(nullptr, "2"), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, nullptr), "unexpected NULL argument");
 
   Cvc5Term int1 = cvc5_mk_integer(d_tm, "-18446744073709551616");
   Cvc5Term int2 = cvc5_mk_integer(d_tm, "-18446744073709551615");
@@ -391,27 +392,27 @@ TEST_F(TestCApiBlackTerm, get_integer)
   Cvc5Term int11 = cvc5_mk_integer(d_tm, "18446744073709551616");
   Cvc5Term int12 = cvc5_mk_integer(d_tm, "-0");
 
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, ""), "invalid argument");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, "-"), "invalid argument");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, "-1-"), "invalid argument");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, "0.0"), "invalid argument");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, "-0.1"), "invalid argument");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, "012"), "invalid argument");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, "0000"), "invalid argument");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, "-01"), "invalid argument");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, "-00"), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, ""), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "-"), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "-1-"), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "0.0"), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "-0.1"), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "012"), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "0000"), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "-01"), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "-00"), "invalid argument");
 
-  ASSERT_DEATH(cvc5_term_is_int32_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_is_uint32_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_is_int64_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_is_uint64_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_is_integer_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_integer_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_int32_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_int64_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_uint32_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_uint64_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_real_or_integer_value_sign(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_term_is_int32_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_uint32_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_int64_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_uint64_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_integer_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_integer_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_int32_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_int64_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_uint32_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_uint64_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_real_or_integer_value_sign(nullptr),
                "invalid term");
 
   ASSERT_TRUE(
@@ -527,11 +528,11 @@ TEST_F(TestCApiBlackTerm, get_integer)
 
 TEST_F(TestCApiBlackTerm, get_string)
 {
-  ASSERT_DEATH(cvc5_mk_string(nullptr, "abcde", false),
+  ASSERT_CVC5_ERROR(cvc5_mk_string(nullptr, "abcde", false),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_term_is_string_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_u32string_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_mk_string(d_tm, nullptr, false),
+  ASSERT_CVC5_ERROR(cvc5_term_is_string_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_u32string_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_mk_string(d_tm, nullptr, false),
                "unexpected NULL argument");
   Cvc5Term s1 = cvc5_mk_string(d_tm, "abcde", false);
   ASSERT_TRUE(cvc5_term_is_string_value(s1));
@@ -545,8 +546,8 @@ TEST_F(TestCApiBlackTerm, get_real)
   int64_t num64;
   uint64_t den64;
 
-  ASSERT_DEATH(cvc5_mk_real(nullptr, "2"), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_real(d_tm, nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_real(nullptr, "2"), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_real(d_tm, nullptr), "unexpected NULL argument");
 
   Cvc5Term real1 = cvc5_mk_real(d_tm, "0");
   Cvc5Term real2 = cvc5_mk_real(d_tm, ".0");
@@ -559,23 +560,23 @@ TEST_F(TestCApiBlackTerm, get_real)
   Cvc5Term real9 = cvc5_mk_real(d_tm, "18446744073709551617");
   Cvc5Term real10 = cvc5_mk_real(d_tm, "2343.2343");
 
-  ASSERT_DEATH(cvc5_term_is_real32_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_is_real64_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_is_real_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_real_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_real32_value(nullptr, &num32, &den32),
+  ASSERT_CVC5_ERROR(cvc5_term_is_real32_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_real64_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_real_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_real_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_real32_value(nullptr, &num32, &den32),
                "invalid term");
-  ASSERT_DEATH(cvc5_term_get_real32_value(real1, nullptr, &den32),
+  ASSERT_CVC5_ERROR(cvc5_term_get_real32_value(real1, nullptr, &den32),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_term_get_real32_value(real1, &num32, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_term_get_real32_value(real1, &num32, nullptr),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_term_get_real64_value(real1, nullptr, &den64),
+  ASSERT_CVC5_ERROR(cvc5_term_get_real64_value(real1, nullptr, &den64),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_term_get_real64_value(real1, &num64, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_term_get_real64_value(real1, &num64, nullptr),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_term_get_real64_value(nullptr, &num64, &den64),
+  ASSERT_CVC5_ERROR(cvc5_term_get_real64_value(nullptr, &num64, &den64),
                "invalid term");
-  ASSERT_DEATH(cvc5_term_get_real_or_integer_value_sign(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_term_get_real_or_integer_value_sign(nullptr),
                "invalid term");
 
   ASSERT_TRUE(cvc5_term_is_real_value(real1) && cvc5_term_is_real64_value(real1)
@@ -661,16 +662,16 @@ TEST_F(TestCApiBlackTerm, get_const_array_base)
   Cvc5Term one = cvc5_mk_integer_int64(d_tm, 1);
   Cvc5Term const_arr = cvc5_mk_const_array(d_tm, arr_sort, one);
 
-  ASSERT_DEATH(cvc5_term_is_const_array(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_const_array_base(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_const_array(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_const_array_base(nullptr), "invalid term");
 
   ASSERT_TRUE(cvc5_term_is_const_array(const_arr));
   ASSERT_TRUE(
       cvc5_term_is_equal(cvc5_term_get_const_array_base(const_arr), one));
 
   Cvc5Term a = cvc5_mk_const(d_tm, arr_sort, "a");
-  ASSERT_DEATH(cvc5_term_get_const_array_base(a), "invalid argument");
-  ASSERT_DEATH(cvc5_term_get_const_array_base(one), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_term_get_const_array_base(a), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_term_get_const_array_base(one), "invalid argument");
 }
 
 TEST_F(TestCApiBlackTerm, get_boolean_value)
@@ -678,8 +679,8 @@ TEST_F(TestCApiBlackTerm, get_boolean_value)
   Cvc5Term b1 = cvc5_mk_true(d_tm);
   Cvc5Term b2 = cvc5_mk_false(d_tm);
 
-  ASSERT_DEATH(cvc5_term_is_boolean_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_boolean_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_boolean_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_boolean_value(nullptr), "invalid term");
   ASSERT_TRUE(cvc5_term_is_boolean_value(b1));
   ASSERT_TRUE(cvc5_term_is_boolean_value(b2));
   ASSERT_TRUE(cvc5_term_get_boolean_value(b1));
@@ -688,8 +689,8 @@ TEST_F(TestCApiBlackTerm, get_boolean_value)
 
 TEST_F(TestCApiBlackTerm, get_bv_value)
 {
-  ASSERT_DEATH(cvc5_mk_bv_uint64(nullptr, 8, 15), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_term_is_bv_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_mk_bv_uint64(nullptr, 8, 15), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_term_is_bv_value(nullptr), "invalid term");
 
   Cvc5Term b1 = cvc5_mk_bv_uint64(d_tm, 8, 15);
   Cvc5Term b2 = cvc5_mk_bv(d_tm, 8, "00001111", 2);
@@ -732,7 +733,7 @@ TEST_F(TestCApiBlackTerm, get_bv_value)
 
 TEST_F(TestCApiBlackTerm, is_ff_value)
 {
-  ASSERT_DEATH(cvc5_term_is_ff_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_ff_value(nullptr), "invalid term");
   Cvc5Sort fs = cvc5_mk_ff_sort(d_tm, "7", 10);
   Cvc5Term fv = cvc5_mk_ff_elem(d_tm, "1", fs, 10);
   ASSERT_TRUE(cvc5_term_is_ff_value(fv));
@@ -742,18 +743,18 @@ TEST_F(TestCApiBlackTerm, is_ff_value)
 
 TEST_F(TestCApiBlackTerm, get_ff_value)
 {
-  ASSERT_DEATH(cvc5_term_get_ff_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_ff_value(nullptr), "invalid term");
   Cvc5Sort fs = cvc5_mk_ff_sort(d_tm, "7", 10);
   Cvc5Term fv = cvc5_mk_ff_elem(d_tm, "1", fs, 10);
   ASSERT_EQ(std::string("1"), cvc5_term_get_ff_value(fv));
   Cvc5Term b1 = cvc5_mk_bv_uint64(d_tm, 8, 15);
-  ASSERT_DEATH(cvc5_term_get_ff_value(b1),
+  ASSERT_CVC5_ERROR(cvc5_term_get_ff_value(b1),
                "expected Term to be a finite field value");
 }
 
 TEST_F(TestCApiBlackTerm, get_uninterpreted_sort_value)
 {
-  ASSERT_DEATH(cvc5_term_get_uninterpreted_sort_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_uninterpreted_sort_value(nullptr), "invalid term");
   cvc5_set_option(d_solver, "produce-models", "true");
   Cvc5Term x = cvc5_mk_const(d_tm, d_uninterpreted, "x");
   Cvc5Term y = cvc5_mk_const(d_tm, d_uninterpreted, "y");
@@ -772,7 +773,7 @@ TEST_F(TestCApiBlackTerm, get_uninterpreted_sort_value)
 
 TEST_F(TestCApiBlackTerm, is_rm_value)
 {
-  ASSERT_DEATH(cvc5_term_is_rm_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_rm_value(nullptr), "invalid term");
   ASSERT_FALSE(cvc5_term_is_rm_value(cvc5_mk_integer_int64(d_tm, 15)));
   ASSERT_TRUE(cvc5_term_is_rm_value(
       cvc5_mk_rm(d_tm, CVC5_RM_ROUND_NEAREST_TIES_TO_EVEN)));
@@ -782,8 +783,8 @@ TEST_F(TestCApiBlackTerm, is_rm_value)
 
 TEST_F(TestCApiBlackTerm, get_rm_value)
 {
-  ASSERT_DEATH(cvc5_term_get_rm_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_rm_value(cvc5_mk_integer_int64(d_tm, 15)),
+  ASSERT_CVC5_ERROR(cvc5_term_get_rm_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_rm_value(cvc5_mk_integer_int64(d_tm, 15)),
                "invalid argument");
 
   ASSERT_EQ(cvc5_term_get_rm_value(
@@ -811,10 +812,10 @@ TEST_F(TestCApiBlackTerm, get_tuple)
   Cvc5Term tup = cvc5_mk_tuple(d_tm, args.size(), args.data());
 
   size_t size;
-  ASSERT_DEATH(cvc5_term_get_tuple_value(nullptr, &size), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_tuple_value(tup, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_term_get_tuple_value(nullptr, &size), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_tuple_value(tup, nullptr),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_term_is_tuple_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_tuple_value(nullptr), "invalid term");
 
   ASSERT_TRUE(cvc5_term_is_tuple_value(tup));
   const Cvc5Term* val = cvc5_term_get_tuple_value(tup, &size);
@@ -831,18 +832,18 @@ TEST_F(TestCApiBlackTerm, get_fp_value)
   Cvc5Term bv_val = cvc5_mk_bv(d_tm, 16, "0000110000000011", 2);
   Cvc5Term fp_val = cvc5_mk_fp(d_tm, 5, 11, bv_val);
 
-  ASSERT_DEATH(cvc5_term_is_fp_value(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_is_fp_pos_zero(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_is_fp_neg_zero(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_is_fp_pos_inf(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_is_fp_neg_inf(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_is_fp_nan(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_fp_value(nullptr, &ew, &sw, &res), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_fp_value(fp_val, nullptr, &sw, &res),
+  ASSERT_CVC5_ERROR(cvc5_term_is_fp_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_fp_pos_zero(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_fp_neg_zero(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_fp_pos_inf(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_fp_neg_inf(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_fp_nan(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_fp_value(nullptr, &ew, &sw, &res), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_fp_value(fp_val, nullptr, &sw, &res),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_term_get_fp_value(fp_val, &ew, nullptr, &res),
+  ASSERT_CVC5_ERROR(cvc5_term_get_fp_value(fp_val, &ew, nullptr, &res),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_term_get_fp_value(fp_val, &ew, &sw, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_term_get_fp_value(fp_val, &ew, &sw, nullptr),
                "unexpected NULL argument");
 
   ASSERT_TRUE(cvc5_term_is_fp_value(fp_val));
@@ -886,7 +887,7 @@ TEST_F(TestCApiBlackTerm, get_set_value)
   Cvc5Term s5 =
       cvc5_mk_term(d_tm, CVC5_KIND_SET_UNION, args.size(), args.data());
 
-  ASSERT_DEATH(cvc5_term_is_set_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_set_value(nullptr), "invalid term");
   ASSERT_TRUE(cvc5_term_is_set_value(s1));
   ASSERT_TRUE(cvc5_term_is_set_value(s2));
   ASSERT_TRUE(cvc5_term_is_set_value(s3));
@@ -896,8 +897,8 @@ TEST_F(TestCApiBlackTerm, get_set_value)
   ASSERT_TRUE(cvc5_term_is_set_value(s5));
 
   size_t size;
-  ASSERT_DEATH(cvc5_term_get_set_value(nullptr, &size), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_set_value(s1, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_term_get_set_value(nullptr, &size), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_set_value(s1, nullptr),
                "unexpected NULL argument");
   (void)cvc5_term_get_set_value(s1, &size);
   ASSERT_EQ(size, 0);
@@ -938,10 +939,10 @@ TEST_F(TestCApiBlackTerm, get_sequence_value)
   Cvc5Term s5 =
       cvc5_mk_term(d_tm, CVC5_KIND_SEQ_CONCAT, args.size(), args.data());
 
-  ASSERT_DEATH(cvc5_mk_empty_sequence(nullptr, seq_sort),
+  ASSERT_CVC5_ERROR(cvc5_mk_empty_sequence(nullptr, seq_sort),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_empty_sequence(d_tm, nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_term_is_sequence_value(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_mk_empty_sequence(d_tm, nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_term_is_sequence_value(nullptr), "invalid term");
 
   ASSERT_TRUE(cvc5_term_is_sequence_value(s1));
   ASSERT_FALSE(cvc5_term_is_sequence_value(s2));
@@ -958,8 +959,8 @@ TEST_F(TestCApiBlackTerm, get_sequence_value)
   ASSERT_TRUE(cvc5_term_is_sequence_value(s5));
 
   size_t size;
-  ASSERT_DEATH(cvc5_term_get_sequence_value(nullptr, &size), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_sequence_value(s1, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_term_get_sequence_value(nullptr, &size), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_sequence_value(s1, nullptr),
                "unexpected NULL argument");
   (void)cvc5_term_get_sequence_value(s1, &size);
   ASSERT_EQ(size, 0);
@@ -990,7 +991,7 @@ TEST_F(TestCApiBlackTerm, get_sequence_value)
   args = {cvc5_mk_real_int64(d_tm, 1)};
   Cvc5Term su =
       cvc5_mk_term(d_tm, CVC5_KIND_SEQ_UNIT, args.size(), args.data());
-  ASSERT_DEATH(cvc5_term_get_sequence_value(su, &size), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_term_get_sequence_value(su, &size), "invalid argument");
 }
 
 TEST_F(TestCApiBlackTerm, substitute)
@@ -1004,14 +1005,14 @@ TEST_F(TestCApiBlackTerm, substitute)
   Cvc5Term onepone =
       cvc5_mk_term(d_tm, CVC5_KIND_ADD, args.size(), args.data());
 
-  ASSERT_DEATH(cvc5_term_substitute_term(nullptr, x, one), "invalid term");
-  ASSERT_DEATH(cvc5_term_substitute_term(xpx, nullptr, one), "invalid term");
-  ASSERT_DEATH(cvc5_term_substitute_term(xpx, x, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_substitute_term(nullptr, x, one), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_substitute_term(xpx, nullptr, one), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_substitute_term(xpx, x, nullptr), "invalid term");
 
   ASSERT_TRUE(
       cvc5_term_is_equal(cvc5_term_substitute_term(xpx, x, one), onepone));
   // incorrect due to type
-  ASSERT_DEATH(cvc5_term_substitute_term(xpx, one, ttrue),
+  ASSERT_CVC5_ERROR(cvc5_term_substitute_term(xpx, one, ttrue),
                "expected terms of the same sort");
 
   // simultaneous substitution
@@ -1027,23 +1028,23 @@ TEST_F(TestCApiBlackTerm, substitute)
 
   // incorrect substitution due to types
   rs[1] = ttrue;
-  ASSERT_DEATH(cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
+  ASSERT_CVC5_ERROR(cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
                "expecting terms of the same sort at index 1");
 
   // null cannot substitute
   es = {nullptr, y};
   rs = {y, one};
-  ASSERT_DEATH(cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
+  ASSERT_CVC5_ERROR(cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
                "invalid term at index 0");
   es = {x, nullptr};
-  ASSERT_DEATH(cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
+  ASSERT_CVC5_ERROR(cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
                "invalid term at index 1");
   es = {x, y};
   rs = {nullptr, one};
-  ASSERT_DEATH(cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
+  ASSERT_CVC5_ERROR(cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
                "invalid term at index 0");
   rs = {y, nullptr};
-  ASSERT_DEATH(cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
+  ASSERT_CVC5_ERROR(cvc5_term_substitute_terms(xpy, es.size(), es.data(), rs.data()),
                "invalid term at index 1");
 }
 
@@ -1056,20 +1057,20 @@ TEST_F(TestCApiBlackTerm, const_array)
   Cvc5Term i = cvc5_mk_const(d_tm, d_int, "i");
   Cvc5Term const_arr = cvc5_mk_const_array(d_tm, arr_sort, one);
 
-  ASSERT_DEATH(cvc5_mk_const_array(nullptr, arr_sort, one),
+  ASSERT_CVC5_ERROR(cvc5_mk_const_array(nullptr, arr_sort, one),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_const_array(d_tm, nullptr, one), "invalid sort");
-  ASSERT_DEATH(cvc5_mk_const_array(d_tm, arr_sort, nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_mk_const_array(d_tm, arr_sort, two),
+  ASSERT_CVC5_ERROR(cvc5_mk_const_array(d_tm, nullptr, one), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_mk_const_array(d_tm, arr_sort, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_mk_const_array(d_tm, arr_sort, two),
                "value does not match element sort");
-  ASSERT_DEATH(cvc5_mk_const_array(d_tm, arr_sort, i), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_const_array(d_tm, arr_sort, i), "invalid argument");
 
-  ASSERT_DEATH(cvc5_term_get_const_array_base(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_const_array_base(nullptr), "invalid term");
 
   ASSERT_EQ(cvc5_term_get_kind(const_arr), CVC5_KIND_CONST_ARRAY);
   ASSERT_TRUE(
       cvc5_term_is_equal(cvc5_term_get_const_array_base(const_arr), one));
-  ASSERT_DEATH(cvc5_term_get_const_array_base(a), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_term_get_const_array_base(a), "invalid argument");
 
   arr_sort = cvc5_mk_array_sort(d_tm, d_real, d_real);
   Cvc5Term zero_array =
@@ -1086,22 +1087,22 @@ TEST_F(TestCApiBlackTerm, const_array)
 
 TEST_F(TestCApiBlackTerm, get_cardinality_constraint)
 {
-  ASSERT_DEATH(cvc5_mk_cardinality_constraint(nullptr, d_uninterpreted, 3),
+  ASSERT_CVC5_ERROR(cvc5_mk_cardinality_constraint(nullptr, d_uninterpreted, 3),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_cardinality_constraint(d_tm, nullptr, 3),
+  ASSERT_CVC5_ERROR(cvc5_mk_cardinality_constraint(d_tm, nullptr, 3),
                "invalid sort");
-  ASSERT_DEATH(cvc5_term_is_cardinality_constraint(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_cardinality_constraint(nullptr), "invalid term");
 
   Cvc5Term t = cvc5_mk_cardinality_constraint(d_tm, d_uninterpreted, 3);
   ASSERT_TRUE(cvc5_term_is_cardinality_constraint(t));
 
   Cvc5Sort res;
   uint32_t res_upper;
-  ASSERT_DEATH(cvc5_term_get_cardinality_constraint(nullptr, &res, &res_upper),
+  ASSERT_CVC5_ERROR(cvc5_term_get_cardinality_constraint(nullptr, &res, &res_upper),
                "invalid term");
-  ASSERT_DEATH(cvc5_term_get_cardinality_constraint(t, nullptr, &res_upper),
+  ASSERT_CVC5_ERROR(cvc5_term_get_cardinality_constraint(t, nullptr, &res_upper),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_term_get_cardinality_constraint(t, &res, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_term_get_cardinality_constraint(t, &res, nullptr),
                "unexpected NULL argument");
 
   cvc5_term_get_cardinality_constraint(t, &res, &res_upper);
@@ -1110,7 +1111,7 @@ TEST_F(TestCApiBlackTerm, get_cardinality_constraint)
 
   Cvc5Term x = cvc5_mk_const(d_tm, d_int, "x");
   ASSERT_FALSE(cvc5_term_is_cardinality_constraint(x));
-  ASSERT_DEATH(cvc5_term_get_cardinality_constraint(x, &res, &res_upper),
+  ASSERT_CVC5_ERROR(cvc5_term_get_cardinality_constraint(x, &res, &res_upper),
                "invalid argument");
 }
 
@@ -1127,16 +1128,16 @@ TEST_F(TestCApiBlackTerm, get_real_algebraic_number)
   Cvc5Term eq = cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, args.size(), args.data());
   cvc5_assert_formula(d_solver, eq);
 
-  ASSERT_DEATH(cvc5_term_is_real_algebraic_number(nullptr), "invalid term");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(cvc5_term_is_real_algebraic_number(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(
       cvc5_term_get_real_algebraic_number_defining_polynomial(nullptr, y),
       "invalid term");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_term_get_real_algebraic_number_defining_polynomial(x, nullptr),
       "invalid term");
-  ASSERT_DEATH(cvc5_term_get_real_algebraic_number_lower_bound(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_term_get_real_algebraic_number_lower_bound(nullptr),
                "invalid term");
-  ASSERT_DEATH(cvc5_term_get_real_algebraic_number_upper_bound(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_term_get_real_algebraic_number_upper_bound(nullptr),
                "invalid term");
 
   // Note that check-sat should only return "sat" if libpoly is enabled.
@@ -1158,7 +1159,7 @@ TEST_F(TestCApiBlackTerm, get_real_algebraic_number)
     ASSERT_TRUE(cvc5_term_is_real_value(ub));
     // cannot call with non-variable
     Cvc5Term yc = cvc5_mk_const(d_tm, d_real, "y");
-    ASSERT_DEATH(
+    ASSERT_CVC5_ERROR(
         cvc5_term_get_real_algebraic_number_defining_polynomial(vx, yc),
         "invalid argument");
   }
@@ -1167,15 +1168,15 @@ TEST_F(TestCApiBlackTerm, get_real_algebraic_number)
 TEST_F(TestCApiBlackTerm, get_skolem)
 {
   size_t size;
-  ASSERT_DEATH(cvc5_term_is_skolem(nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_skolem_id(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_is_skolem(nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_skolem_id(nullptr), "invalid term");
   // ordinary variables are not skolems
   Cvc5Term x = cvc5_mk_const(d_tm, d_int, "x");
   ASSERT_FALSE(cvc5_term_is_skolem(x));
-  ASSERT_DEATH(cvc5_term_get_skolem_id(x), "invalid argument");
-  ASSERT_DEATH(cvc5_term_get_skolem_indices(x, &size), "invalid argument");
-  ASSERT_DEATH(cvc5_term_get_skolem_indices(nullptr, &size), "invalid term");
-  ASSERT_DEATH(cvc5_term_get_skolem_indices(x, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_term_get_skolem_id(x), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_term_get_skolem_indices(x, &size), "invalid argument");
+  ASSERT_CVC5_ERROR(cvc5_term_get_skolem_indices(nullptr, &size), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_term_get_skolem_indices(x, nullptr),
                "unexpected NULL argument");
 }
 

--- a/test/unit/api/c/capi_term_manager_black.cpp
+++ b/test/unit/api/c/capi_term_manager_black.cpp
@@ -18,6 +18,7 @@ extern "C" {
 
 #include "base/output.h"
 #include "gtest/gtest.h"
+#include "test_capi.h"
 
 namespace cvc5::internal::test {
 
@@ -43,49 +44,49 @@ TEST_F(TestCApiBlackTermManager, new) {}
 
 TEST_F(TestCApiBlackTermManager, delete)
 {
-  ASSERT_DEATH(cvc5_term_manager_delete(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_term_manager_delete(nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, release)
 {
-  ASSERT_DEATH(cvc5_term_manager_release(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_term_manager_release(nullptr), "unexpected NULL argument");
   cvc5_term_manager_release(d_tm);
 }
 
 TEST_F(TestCApiBlackTermManager, get_boolean_sort)
 {
   (void)cvc5_get_boolean_sort(d_tm);
-  ASSERT_DEATH(cvc5_get_boolean_sort(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_boolean_sort(nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, get_integer_sort)
 {
   (void)cvc5_get_integer_sort(d_tm);
-  ASSERT_DEATH(cvc5_get_integer_sort(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_integer_sort(nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, get_real_sort)
 {
   (void)cvc5_get_real_sort(d_tm);
-  ASSERT_DEATH(cvc5_get_real_sort(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_real_sort(nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, get_regexp_sort)
 {
   (void)cvc5_get_regexp_sort(d_tm);
-  ASSERT_DEATH(cvc5_get_regexp_sort(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_regexp_sort(nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, get_string_sort)
 {
   (void)cvc5_get_string_sort(d_tm);
-  ASSERT_DEATH(cvc5_get_string_sort(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_string_sort(nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, get_rm_sort)
 {
   (void)cvc5_get_rm_sort(d_tm);
-  ASSERT_DEATH(cvc5_get_rm_sort(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_get_rm_sort(nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_array_sort)
@@ -102,13 +103,13 @@ TEST_F(TestCApiBlackTermManager, mk_array_sort)
   (void)cvc5_mk_array_sort(d_tm, fpsort, fpsort);
   (void)cvc5_mk_array_sort(d_tm, bvsort, fpsort);
 
-  ASSERT_DEATH(cvc5_mk_array_sort(nullptr, bvsort, fpsort),
+  ASSERT_CVC5_ERROR(cvc5_mk_array_sort(nullptr, bvsort, fpsort),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_array_sort(d_tm, nullptr, fpsort), "invalid sort");
-  ASSERT_DEATH(cvc5_mk_array_sort(d_tm, bvsort, nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_mk_array_sort(d_tm, nullptr, fpsort), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_mk_array_sort(d_tm, bvsort, nullptr), "invalid sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_array_sort(
+  ASSERT_CVC5_ERROR(cvc5_mk_array_sort(
                    d_tm, cvc5_get_boolean_sort(tm), cvc5_get_integer_sort(tm)),
                "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
@@ -117,18 +118,18 @@ TEST_F(TestCApiBlackTermManager, mk_array_sort)
 TEST_F(TestCApiBlackTermManager, mk_bv_sort)
 {
   (void)cvc5_mk_bv_sort(d_tm, 32);
-  ASSERT_DEATH(cvc5_mk_bv_sort(nullptr, 4), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_bv_sort(d_tm, 0), "expected size > 0");
+  ASSERT_CVC5_ERROR(cvc5_mk_bv_sort(nullptr, 4), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_bv_sort(d_tm, 0), "expected size > 0");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_ff_sort)
 {
   (void)cvc5_mk_ff_sort(d_tm, "31", 10);
-  ASSERT_DEATH(cvc5_mk_ff_sort(nullptr, "31", 10), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_ff_sort(d_tm, nullptr, 10), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_ff_sort(d_tm, "6", 10), "expected modulus is prime");
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(nullptr, "31", 10), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, nullptr, 10), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "6", 10), "expected modulus is prime");
 
-  ASSERT_DEATH(cvc5_mk_ff_sort(d_tm, "b", 10), "");
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "b", 10), "");
 
   (void)cvc5_mk_ff_sort(d_tm, "1100101", 2);
   (void)cvc5_mk_ff_sort(d_tm, "10202", 3);
@@ -137,23 +138,23 @@ TEST_F(TestCApiBlackTermManager, mk_ff_sort)
   (void)cvc5_mk_ff_sort(d_tm, "970f", 16);
   (void)cvc5_mk_ff_sort(d_tm, "8CC5", 16);
 
-  ASSERT_DEATH(cvc5_mk_ff_sort(d_tm, "1100100", 2),
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "1100100", 2),
                "expected modulus is prime");
-  ASSERT_DEATH(cvc5_mk_ff_sort(d_tm, "10201", 3), "expected modulus is prime");
-  ASSERT_DEATH(cvc5_mk_ff_sort(d_tm, "400", 5), "expected modulus is prime");
-  ASSERT_DEATH(cvc5_mk_ff_sort(d_tm, "7919", 11), "expected modulus is prime");
-  ASSERT_DEATH(cvc5_mk_ff_sort(d_tm, "970e", 16), "expected modulus is prime");
-  ASSERT_DEATH(cvc5_mk_ff_sort(d_tm, "8CC4", 16), "expected modulus is prime");
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "10201", 3), "expected modulus is prime");
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "400", 5), "expected modulus is prime");
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "7919", 11), "expected modulus is prime");
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "970e", 16), "expected modulus is prime");
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "8CC4", 16), "expected modulus is prime");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_fp_sort)
 {
   (void)cvc5_mk_fp_sort(d_tm, 4, 8);
-  ASSERT_DEATH(cvc5_mk_fp_sort(nullptr, 4, 8), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_fp_sort(d_tm, 0, 8), "expected exponent size > 1");
-  ASSERT_DEATH(cvc5_mk_fp_sort(d_tm, 4, 0), "expected significand size > 1");
-  ASSERT_DEATH(cvc5_mk_fp_sort(d_tm, 1, 8), "expected exponent size > 1");
-  ASSERT_DEATH(cvc5_mk_fp_sort(d_tm, 4, 1), "expected significand size > 1");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_sort(nullptr, 4, 8), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_sort(d_tm, 0, 8), "expected exponent size > 1");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_sort(d_tm, 4, 0), "expected significand size > 1");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_sort(d_tm, 1, 8), "expected exponent size > 1");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_sort(d_tm, 4, 1), "expected significand size > 1");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_dt_sort)
@@ -166,13 +167,13 @@ TEST_F(TestCApiBlackTermManager, mk_dt_sort)
     Cvc5DatatypeConstructorDecl nil = cvc5_mk_dt_cons_decl(d_tm, "nil");
     cvc5_dt_decl_add_constructor(decl, nil);
     (void)cvc5_mk_dt_sort(d_tm, decl);
-    ASSERT_DEATH(cvc5_mk_dt_sort(nullptr, decl), "unexpected NULL argument");
-    ASSERT_DEATH(cvc5_mk_dt_sort(d_tm, decl), "is already resolved");
+    ASSERT_CVC5_ERROR(cvc5_mk_dt_sort(nullptr, decl), "unexpected NULL argument");
+    ASSERT_CVC5_ERROR(cvc5_mk_dt_sort(d_tm, decl), "is already resolved");
   }
 
   {
     Cvc5DatatypeDecl decl = cvc5_mk_dt_decl(d_tm, "list", false);
-    ASSERT_DEATH(cvc5_mk_dt_sort(d_tm, decl), "at least one constructor");
+    ASSERT_CVC5_ERROR(cvc5_mk_dt_sort(d_tm, decl), "at least one constructor");
   }
 
   {
@@ -184,7 +185,7 @@ TEST_F(TestCApiBlackTermManager, mk_dt_sort)
     cvc5_dt_decl_add_constructor(decl, cons);
     Cvc5DatatypeConstructorDecl nil = cvc5_mk_dt_cons_decl(tm, "nil");
     cvc5_dt_decl_add_constructor(decl, nil);
-    ASSERT_DEATH(
+    ASSERT_CVC5_ERROR(
         cvc5_mk_dt_sort(d_tm, decl),
         "datatype declaration is not associated with this term manager");
     cvc5_term_manager_delete(tm);
@@ -208,19 +209,19 @@ TEST_F(TestCApiBlackTermManager, mk_dt_sorts)
     cvc5_dt_decl_add_constructor(decl2, nil2);
     std::vector<Cvc5DatatypeDecl> decls = {decl1, decl2};
     (void)cvc5_mk_dt_sorts(d_tm, decls.size(), decls.data());
-    ASSERT_DEATH(cvc5_mk_dt_sorts(nullptr, decls.size(), decls.data()),
+    ASSERT_CVC5_ERROR(cvc5_mk_dt_sorts(nullptr, decls.size(), decls.data()),
                  "unexpected NULL argument");
-    ASSERT_DEATH(cvc5_mk_dt_sorts(d_tm, decls.size(), nullptr),
+    ASSERT_CVC5_ERROR(cvc5_mk_dt_sorts(d_tm, decls.size(), nullptr),
                  "unexpected NULL argument");
 
-    ASSERT_DEATH(cvc5_mk_dt_sorts(d_tm, decls.size(), decls.data()),
+    ASSERT_CVC5_ERROR(cvc5_mk_dt_sorts(d_tm, decls.size(), decls.data()),
                  "is already resolved");
   }
 
   {
     std::vector<Cvc5DatatypeDecl> decls = {
         cvc5_mk_dt_decl(d_tm, "list", "false")};
-    ASSERT_DEATH(cvc5_mk_dt_sorts(d_tm, decls.size(), decls.data()),
+    ASSERT_CVC5_ERROR(cvc5_mk_dt_sorts(d_tm, decls.size(), decls.data()),
                  "at least one constructor");
   }
 
@@ -237,7 +238,7 @@ TEST_F(TestCApiBlackTermManager, mk_dt_sorts)
     std::vector<Cvc5DatatypeDecl> udecls = {ulist};
     (void)cvc5_mk_dt_sorts(d_tm, udecls.size(), udecls.data());
 
-    ASSERT_DEATH(cvc5_mk_dt_sorts(d_tm, udecls.size(), udecls.data()),
+    ASSERT_CVC5_ERROR(cvc5_mk_dt_sorts(d_tm, udecls.size(), udecls.data()),
                  "has already been used");
   }
 
@@ -296,7 +297,7 @@ TEST_F(TestCApiBlackTermManager, mk_dt_sorts)
     Cvc5DatatypeConstructorDecl nil2 = cvc5_mk_dt_cons_decl(tm, "nil2");
     cvc5_dt_decl_add_constructor(decl2, nil2);
     std::vector<Cvc5DatatypeDecl> decls = {decl1, decl2};
-    ASSERT_DEATH(
+    ASSERT_CVC5_ERROR(
         cvc5_mk_dt_sorts(d_tm, decls.size(), decls.data()),
         "expected a datatype declaration associated with this term manager");
     cvc5_term_manager_delete(tm);
@@ -313,15 +314,15 @@ TEST_F(TestCApiBlackTermManager, mk_fun_sort)
   // function arguments are allowed
   domain = {funsort};
   (void)cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), d_int);
-  ASSERT_DEATH(cvc5_mk_fun_sort(nullptr, domain.size(), domain.data(), d_int),
+  ASSERT_CVC5_ERROR(cvc5_mk_fun_sort(nullptr, domain.size(), domain.data(), d_int),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_fun_sort(d_tm, domain.size(), nullptr, d_int),
+  ASSERT_CVC5_ERROR(cvc5_mk_fun_sort(d_tm, domain.size(), nullptr, d_int),
                "unexpected NULL argument");
   domain = {nullptr};
-  ASSERT_DEATH(cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), d_int),
+  ASSERT_CVC5_ERROR(cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), d_int),
                "invalid sort at index 0");
   domain = {d_int};
-  ASSERT_DEATH(cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), funsort),
+  ASSERT_CVC5_ERROR(cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), funsort),
                "expected non-function sort as codomain sort");
 
   domain = {unsort, d_int};
@@ -335,7 +336,7 @@ TEST_F(TestCApiBlackTermManager, mk_fun_sort)
   (void)cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), d_int);
 
   domain = {d_int, unsort};
-  ASSERT_DEATH(cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), funsort),
+  ASSERT_CVC5_ERROR(cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), funsort),
                "expected non-function sort as codomain sort");
 
   domain = {d_bool, d_int, d_int};
@@ -344,11 +345,11 @@ TEST_F(TestCApiBlackTermManager, mk_fun_sort)
   (void)cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), d_int);
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_fun_sort(
+  ASSERT_CVC5_ERROR(cvc5_mk_fun_sort(
                    tm, domain.size(), domain.data(), cvc5_get_integer_sort(tm)),
                "expected a sort associated with this term manager");
   domain = {cvc5_get_boolean_sort(tm), cvc5_get_integer_sort(tm)};
-  ASSERT_DEATH(cvc5_mk_fun_sort(tm, domain.size(), domain.data(), d_int),
+  ASSERT_CVC5_ERROR(cvc5_mk_fun_sort(tm, domain.size(), domain.data(), d_int),
                "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -357,28 +358,28 @@ TEST_F(TestCApiBlackTermManager, mk_param_sort)
 {
   (void)cvc5_mk_param_sort(d_tm, "T");
   (void)cvc5_mk_param_sort(d_tm, "");
-  ASSERT_DEATH(cvc5_mk_param_sort(nullptr, ""), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_param_sort(d_tm, nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_param_sort(nullptr, ""), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_param_sort(d_tm, nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_predicate_sort)
 {
   std::vector<Cvc5Sort> sorts = {d_int};
   (void)cvc5_mk_predicate_sort(d_tm, sorts.size(), sorts.data());
-  ASSERT_DEATH(cvc5_mk_predicate_sort(nullptr, sorts.size(), sorts.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_predicate_sort(nullptr, sorts.size(), sorts.data()),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_predicate_sort(d_tm, sorts.size(), nullptr),
+  ASSERT_CVC5_ERROR(cvc5_mk_predicate_sort(d_tm, sorts.size(), nullptr),
                "unexpected NULL argument");
   sorts = {nullptr};
-  ASSERT_DEATH(cvc5_mk_predicate_sort(d_tm, sorts.size(), sorts.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_predicate_sort(d_tm, sorts.size(), sorts.data()),
                "invalid sort at index 0");
 
   sorts = {};
-  ASSERT_DEATH(cvc5_mk_predicate_sort(d_tm, sorts.size(), sorts.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_predicate_sort(d_tm, sorts.size(), sorts.data()),
                "expected at least one parameter sort");
 
   sorts = {nullptr};
-  ASSERT_DEATH(cvc5_mk_predicate_sort(d_tm, sorts.size(), sorts.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_predicate_sort(d_tm, sorts.size(), sorts.data()),
                "invalid sort at index 0");
 
   sorts = {cvc5_mk_uninterpreted_sort(d_tm, "u"), d_int};
@@ -389,7 +390,7 @@ TEST_F(TestCApiBlackTermManager, mk_predicate_sort)
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   sorts = {d_int};
-  ASSERT_DEATH(cvc5_mk_predicate_sort(tm, sorts.size(), sorts.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_predicate_sort(tm, sorts.size(), sorts.data()),
                "expected a sort associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -399,19 +400,19 @@ TEST_F(TestCApiBlackTermManager, mk_record_sort)
   std::vector<const char*> names = {};
   std::vector<Cvc5Sort> sorts = {};
   (void)cvc5_mk_record_sort(d_tm, names.size(), names.data(), sorts.data());
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_record_sort(nullptr, names.size(), names.data(), sorts.data()),
       "unexpected NULL argument");
 
   names = {"b", nullptr, "i"};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_record_sort(d_tm, names.size(), names.data(), sorts.data()),
       "unexpected NULL argument");
 
   names = {"b", "bv", "i"};
 
   sorts = {nullptr, cvc5_mk_bv_sort(d_tm, 8), d_int};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_record_sort(d_tm, names.size(), names.data(), sorts.data()),
       "invalid sort at index 0");
 
@@ -425,7 +426,7 @@ TEST_F(TestCApiBlackTermManager, mk_record_sort)
   sorts = {cvc5_get_boolean_sort(tm),
            cvc5_mk_bv_sort(d_tm, 8),
            cvc5_get_integer_sort(tm)};
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_record_sort(d_tm, names.size(), names.data(), sorts.data()),
       "expected a sort associated with this term manager");
   cvc5_term_manager_delete(tm);
@@ -437,10 +438,10 @@ TEST_F(TestCApiBlackTermManager, mk_set_sort)
   (void)cvc5_mk_set_sort(d_tm, d_int);
   (void)cvc5_mk_set_sort(d_tm, cvc5_mk_bv_sort(d_tm, 4));
   (void)cvc5_mk_set_sort(d_tm, cvc5_mk_bv_sort(d_tm, 4));
-  ASSERT_DEATH(cvc5_mk_set_sort(nullptr, d_bool), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_set_sort(d_tm, nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_mk_set_sort(nullptr, d_bool), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_set_sort(d_tm, nullptr), "invalid sort");
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_set_sort(d_tm, cvc5_get_boolean_sort(tm)),
+  ASSERT_CVC5_ERROR(cvc5_mk_set_sort(d_tm, cvc5_get_boolean_sort(tm)),
                "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -451,10 +452,10 @@ TEST_F(TestCApiBlackTermManager, mk_bag_sort)
   (void)cvc5_mk_bag_sort(d_tm, d_int);
   (void)cvc5_mk_bag_sort(d_tm, cvc5_mk_bv_sort(d_tm, 4));
   (void)cvc5_mk_bag_sort(d_tm, cvc5_mk_bv_sort(d_tm, 4));
-  ASSERT_DEATH(cvc5_mk_bag_sort(nullptr, d_bool), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_bag_sort(d_tm, nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_mk_bag_sort(nullptr, d_bool), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_bag_sort(d_tm, nullptr), "invalid sort");
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_bag_sort(d_tm, cvc5_get_boolean_sort(tm)),
+  ASSERT_CVC5_ERROR(cvc5_mk_bag_sort(d_tm, cvc5_get_boolean_sort(tm)),
                "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -465,11 +466,11 @@ TEST_F(TestCApiBlackTermManager, mk_sequence_sort)
   (void)cvc5_mk_sequence_sort(d_tm, d_int);
   (void)cvc5_mk_sequence_sort(d_tm, cvc5_mk_bv_sort(d_tm, 4));
   (void)cvc5_mk_sequence_sort(d_tm, cvc5_mk_bv_sort(d_tm, 4));
-  ASSERT_DEATH(cvc5_mk_sequence_sort(nullptr, d_bool),
+  ASSERT_CVC5_ERROR(cvc5_mk_sequence_sort(nullptr, d_bool),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_sequence_sort(d_tm, nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_mk_sequence_sort(d_tm, nullptr), "invalid sort");
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_sequence_sort(d_tm, cvc5_get_boolean_sort(tm)),
+  ASSERT_CVC5_ERROR(cvc5_mk_sequence_sort(d_tm, cvc5_get_boolean_sort(tm)),
                "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -480,11 +481,11 @@ TEST_F(TestCApiBlackTermManager, mk_abstract_sort)
   (void)cvc5_mk_abstract_sort(d_tm, CVC5_SORT_KIND_BITVECTOR_SORT);
   (void)cvc5_mk_abstract_sort(d_tm, CVC5_SORT_KIND_TUPLE_SORT);
   (void)cvc5_mk_abstract_sort(d_tm, CVC5_SORT_KIND_SET_SORT);
-  ASSERT_DEATH(cvc5_mk_abstract_sort(nullptr, CVC5_SORT_KIND_SET_SORT),
+  ASSERT_CVC5_ERROR(cvc5_mk_abstract_sort(nullptr, CVC5_SORT_KIND_SET_SORT),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_abstract_sort(d_tm, CVC5_SORT_KIND_BOOLEAN_SORT),
+  ASSERT_CVC5_ERROR(cvc5_mk_abstract_sort(d_tm, CVC5_SORT_KIND_BOOLEAN_SORT),
                "cannot construct abstract type");
-  ASSERT_DEATH(cvc5_mk_abstract_sort(d_tm, static_cast<Cvc5SortKind>(-1)),
+  ASSERT_CVC5_ERROR(cvc5_mk_abstract_sort(d_tm, static_cast<Cvc5SortKind>(-1)),
                "cannot construct abstract type");
 }
 
@@ -492,7 +493,7 @@ TEST_F(TestCApiBlackTermManager, mk_uninterpreted_sort)
 {
   (void)cvc5_mk_uninterpreted_sort(d_tm, "u");
   (void)cvc5_mk_uninterpreted_sort(d_tm, "");
-  ASSERT_DEATH(cvc5_mk_uninterpreted_sort(nullptr, ""),
+  ASSERT_CVC5_ERROR(cvc5_mk_uninterpreted_sort(nullptr, ""),
                "unexpected NULL argument");
 }
 
@@ -502,9 +503,9 @@ TEST_F(TestCApiBlackTermManager, mk_unresolved_dt_sort)
   (void)cvc5_mk_unresolved_dt_sort(d_tm, "u", 1);
   (void)cvc5_mk_unresolved_dt_sort(d_tm, "", 0);
   (void)cvc5_mk_unresolved_dt_sort(d_tm, "", 1);
-  ASSERT_DEATH(cvc5_mk_unresolved_dt_sort(nullptr, "", 1),
+  ASSERT_CVC5_ERROR(cvc5_mk_unresolved_dt_sort(nullptr, "", 1),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_unresolved_dt_sort(d_tm, nullptr, 1),
+  ASSERT_CVC5_ERROR(cvc5_mk_unresolved_dt_sort(d_tm, nullptr, 1),
                "unexpected NULL argument");
 }
 
@@ -513,10 +514,10 @@ TEST_F(TestCApiBlackTermManager, mk_uninterpreted_sort_constructor_sort)
   (void)cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 2, "s");
   (void)cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 2, "");
   (void)cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 2, nullptr);
-  ASSERT_DEATH(cvc5_mk_uninterpreted_sort_constructor_sort(nullptr, 2, "s"),
+  ASSERT_CVC5_ERROR(cvc5_mk_uninterpreted_sort_constructor_sort(nullptr, 2, "s"),
                "unexpected NULL argument");
   (void)cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 2, nullptr);
-  ASSERT_DEATH(cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 0, ""),
+  ASSERT_CVC5_ERROR(cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 0, ""),
                "expected an arity > 0");
 }
 
@@ -524,12 +525,12 @@ TEST_F(TestCApiBlackTermManager, mk_tuple_sort)
 {
   std::vector<Cvc5Sort> sorts = {d_int};
   (void)cvc5_mk_tuple_sort(d_tm, sorts.size(), sorts.data());
-  ASSERT_DEATH(cvc5_mk_tuple_sort(nullptr, sorts.size(), sorts.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_tuple_sort(nullptr, sorts.size(), sorts.data()),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_tuple_sort(nullptr, sorts.size(), nullptr),
+  ASSERT_CVC5_ERROR(cvc5_mk_tuple_sort(nullptr, sorts.size(), nullptr),
                "unexpected NULL argument");
   sorts = {d_int, nullptr};
-  ASSERT_DEATH(cvc5_mk_tuple_sort(d_tm, sorts.size(), sorts.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_tuple_sort(d_tm, sorts.size(), sorts.data()),
                "invalid sort at index 1");
   sorts = {cvc5_mk_uninterpreted_sort(d_tm, "u"), d_int};
   Cvc5Sort funsort = cvc5_mk_tuple_sort(d_tm, sorts.size(), sorts.data());
@@ -540,7 +541,7 @@ TEST_F(TestCApiBlackTermManager, mk_tuple_sort)
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   sorts = {cvc5_get_boolean_sort(tm)};
-  ASSERT_DEATH(cvc5_mk_tuple_sort(d_tm, sorts.size(), sorts.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_tuple_sort(d_tm, sorts.size(), sorts.data()),
                "expected a sort associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -550,11 +551,11 @@ TEST_F(TestCApiBlackTermManager, mk_nullable_sort)
   (void)cvc5_mk_nullable_sort(d_tm, d_int);
   (void)cvc5_mk_nullable_sort(d_tm, d_int);
 
-  ASSERT_DEATH(cvc5_mk_nullable_sort(nullptr, d_int),
+  ASSERT_CVC5_ERROR(cvc5_mk_nullable_sort(nullptr, d_int),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_nullable_sort(d_tm, nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_mk_nullable_sort(d_tm, nullptr), "invalid sort");
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_nullable_sort(tm, d_int),
+  ASSERT_CVC5_ERROR(cvc5_mk_nullable_sort(tm, d_int),
                "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -569,37 +570,37 @@ TEST_F(TestCApiBlackTermManager, mk_bv)
   (void)cvc5_mk_bv(d_tm, 8, "-7f", 16);
   (void)cvc5_mk_bv(d_tm, 8, "a0", 16);
 
-  ASSERT_DEATH(cvc5_mk_bv(nullptr, 8, "-1111111", 2),
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(nullptr, 8, "-1111111", 2),
                "unexpected NULL argument");
 
-  ASSERT_DEATH(cvc5_mk_bv(d_tm, 0, "-127", 10),
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 0, "-127", 10),
                "invalid argument '0' for 'size'");
-  ASSERT_DEATH(cvc5_mk_bv(d_tm, 0, "a0", 16),
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 0, "a0", 16),
                "invalid argument '0' for 'size'");
 
-  ASSERT_DEATH(cvc5_mk_bv(d_tm, 8, "", 2), "expected a non-empty string");
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "", 2), "expected a non-empty string");
 
-  ASSERT_DEATH(cvc5_mk_bv(d_tm, 8, "101", 5), "expected base 2, 10, or 16");
-  ASSERT_DEATH(cvc5_mk_bv(d_tm, 8, "128", 11), "expected base 2, 10, or 16");
-  ASSERT_DEATH(cvc5_mk_bv(d_tm, 8, "a0", 21), "expected base 2, 10, or 16");
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "101", 5), "expected base 2, 10, or 16");
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "128", 11), "expected base 2, 10, or 16");
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "a0", 21), "expected base 2, 10, or 16");
 
-  ASSERT_DEATH(cvc5_mk_bv(d_tm, 8, "-11111111", 2),
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "-11111111", 2),
                "overflow in bit-vector construction");
-  ASSERT_DEATH(cvc5_mk_bv(d_tm, 8, "101010101", 2),
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "101010101", 2),
                "overflow in bit-vector construction");
-  ASSERT_DEATH(cvc5_mk_bv(d_tm, 8, "-256", 10),
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "-256", 10),
                "overflow in bit-vector construction");
-  ASSERT_DEATH(cvc5_mk_bv(d_tm, 8, "257", 10),
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "257", 10),
                "overflow in bit-vector construction");
-  ASSERT_DEATH(cvc5_mk_bv(d_tm, 8, "-a0", 16),
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "-a0", 16),
                "overflow in bit-vector construction");
-  ASSERT_DEATH(cvc5_mk_bv(d_tm, 8, "fffff", 16),
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "fffff", 16),
                "overflow in bit-vector construction");
 
-  ASSERT_DEATH(cvc5_mk_bv(d_tm, 8, "10201010", 2), "");
-  ASSERT_DEATH(cvc5_mk_bv(d_tm, 8, "-25x", 10), "");
-  ASSERT_DEATH(cvc5_mk_bv(d_tm, 8, "2x7", 10), "");
-  ASSERT_DEATH(cvc5_mk_bv(d_tm, 8, "fzff", 16), "");
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "10201010", 2), "");
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "-25x", 10), "");
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "2x7", 10), "");
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "fzff", 16), "");
 
   ASSERT_EQ(cvc5_mk_bv(d_tm, 8, "0101", 2), cvc5_mk_bv(d_tm, 8, "00000101", 2));
   ASSERT_EQ(cvc5_mk_bv(d_tm, 4, "-1", 2), cvc5_mk_bv(d_tm, 4, "1111", 2));
@@ -616,8 +617,8 @@ TEST_F(TestCApiBlackTermManager, mk_bv_uint64)
 {
   (void)cvc5_mk_bv_uint64(d_tm, 8, 2);
   (void)cvc5_mk_bv_uint64(d_tm, 32, 2);
-  ASSERT_DEATH(cvc5_mk_bv_uint64(nullptr, 0, 2), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_bv_uint64(d_tm, 0, 2),
+  ASSERT_CVC5_ERROR(cvc5_mk_bv_uint64(nullptr, 0, 2), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_bv_uint64(d_tm, 0, 2),
                "invalid argument '0' for 'size'");
 }
 
@@ -632,10 +633,10 @@ TEST_F(TestCApiBlackTermManager, mk_ff_elem)
   (void)cvc5_mk_ff_elem(d_tm, "8", ff_sort, 10);
   (void)cvc5_mk_ff_elem(d_tm, "-1", ff_sort, 10);
 
-  ASSERT_DEATH(cvc5_mk_ff_elem(nullptr, "-1", ff_sort, 10),
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_elem(nullptr, "-1", ff_sort, 10),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_ff_elem(d_tm, "a", ff_sort, 10), "");
-  ASSERT_DEATH(cvc5_mk_ff_elem(d_tm, "-1", bv_sort, 10),
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_elem(d_tm, "a", ff_sort, 10), "");
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_elem(d_tm, "-1", bv_sort, 10),
                "expected a finite field sort");
 
   ASSERT_EQ(cvc5_mk_ff_elem(d_tm, "-1", ff_sort, 10),
@@ -665,14 +666,14 @@ TEST_F(TestCApiBlackTermManager, mk_const_array)
   Cvc5Term zero = cvc5_mk_integer_int64(d_tm, 0);
   (void)cvc5_mk_const_array(d_tm, arr_sort, zero);
 
-  ASSERT_DEATH(cvc5_mk_const_array(nullptr, arr_sort, zero),
+  ASSERT_CVC5_ERROR(cvc5_mk_const_array(nullptr, arr_sort, zero),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_const_array(d_tm, nullptr, zero), "invalid sort");
-  ASSERT_DEATH(cvc5_mk_const_array(d_tm, arr_sort, nullptr), "invalid term");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(cvc5_mk_const_array(d_tm, nullptr, zero), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_mk_const_array(d_tm, arr_sort, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(
       cvc5_mk_const_array(d_tm, arr_sort, cvc5_mk_bv_uint64(d_tm, 1, 1)),
       "value does not match element sort");
-  ASSERT_DEATH(cvc5_mk_const_array(d_tm, d_int, zero),
+  ASSERT_CVC5_ERROR(cvc5_mk_const_array(d_tm, d_int, zero),
                "expected an array sort");
 
   Cvc5Sort arr_sort2 = cvc5_mk_array_sort(d_tm, d_int, d_int);
@@ -680,9 +681,9 @@ TEST_F(TestCApiBlackTermManager, mk_const_array)
   (void)cvc5_mk_const_array(d_tm, arr_sort2, zero);
   (void)cvc5_mk_const_array(d_tm, arr_sort, zero2);
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_const_array(tm, arr_sort, cvc5_mk_integer_int64(tm, 0)),
+  ASSERT_CVC5_ERROR(cvc5_mk_const_array(tm, arr_sort, cvc5_mk_integer_int64(tm, 0)),
                "sort is not associated with this term manager");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_const_array(
           tm,
           cvc5_mk_array_sort(
@@ -702,10 +703,10 @@ TEST_F(TestCApiBlackTermManager, mk_var)
   (void)cvc5_mk_var(d_tm, d_bool, "b");
   (void)cvc5_mk_var(d_tm, fun_sort, "");
 
-  ASSERT_DEATH(cvc5_mk_var(nullptr, d_bool, ""), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_var(d_tm, nullptr, ""), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_mk_var(nullptr, d_bool, ""), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_var(d_tm, nullptr, ""), "invalid sort");
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_var(tm, d_bool, "b"),
+  ASSERT_CVC5_ERROR(cvc5_mk_var(tm, d_bool, "b"),
                "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -714,7 +715,7 @@ TEST_F(TestCApiBlackTermManager, mk_boolean)
 {
   (void)cvc5_mk_boolean(d_tm, true);
   (void)cvc5_mk_boolean(d_tm, false);
-  ASSERT_DEATH(cvc5_mk_boolean(nullptr, true), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_boolean(nullptr, true), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_rm)
@@ -733,7 +734,7 @@ TEST_F(TestCApiBlackTermManager, mk_rm)
   ASSERT_EQ(
       cvc5_term_to_string(cvc5_mk_rm(d_tm, CVC5_RM_ROUND_NEAREST_TIES_TO_AWAY)),
       std::string("roundNearestTiesToAway"));
-  ASSERT_DEATH(cvc5_mk_rm(nullptr, CVC5_RM_ROUND_TOWARD_ZERO),
+  ASSERT_CVC5_ERROR(cvc5_mk_rm(nullptr, CVC5_RM_ROUND_TOWARD_ZERO),
                "unexpected NULL argument");
 }
 
@@ -743,13 +744,13 @@ TEST_F(TestCApiBlackTermManager, mk_fp)
   Cvc5Term t2 = cvc5_mk_bv_uint64(d_tm, 4, 0);
 
   (void)cvc5_mk_fp(d_tm, 3, 5, t1);
-  ASSERT_DEATH(cvc5_mk_fp(nullptr, 3, 5, t1), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_fp(d_tm, 3, 5, nullptr), "invalid term");
-  ASSERT_DEATH(cvc5_mk_fp(d_tm, 0, 5, t1), "expected exponent size > 1");
-  ASSERT_DEATH(cvc5_mk_fp(d_tm, 1, 5, t1), "expected exponent size > 1");
-  ASSERT_DEATH(cvc5_mk_fp(d_tm, 3, 0, t1), "expected significand size > 1");
-  ASSERT_DEATH(cvc5_mk_fp(d_tm, 3, 1, t1), "expected significand size > 1");
-  ASSERT_DEATH(cvc5_mk_fp(d_tm, 3, 5, t2),
+  ASSERT_CVC5_ERROR(cvc5_mk_fp(nullptr, 3, 5, t1), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp(d_tm, 3, 5, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp(d_tm, 0, 5, t1), "expected exponent size > 1");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp(d_tm, 1, 5, t1), "expected exponent size > 1");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp(d_tm, 3, 0, t1), "expected significand size > 1");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp(d_tm, 3, 1, t1), "expected significand size > 1");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp(d_tm, 3, 5, t2),
                "expected a bit-vector value with bit-width '8'");
 
   Cvc5Term sign = cvc5_mk_bv_uint64(d_tm, 1, 0);
@@ -758,39 +759,39 @@ TEST_F(TestCApiBlackTermManager, mk_fp)
   ASSERT_EQ(cvc5_mk_fp_from_ieee(d_tm, sign, exp, sig),
             cvc5_mk_fp(d_tm, 5, 11, cvc5_mk_bv_uint64(d_tm, 16, 0)));
 
-  ASSERT_DEATH(cvc5_mk_fp_from_ieee(nullptr, sign, exp, sig),
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_from_ieee(nullptr, sign, exp, sig),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_fp_from_ieee(d_tm, nullptr, exp, sig), "invalid term");
-  ASSERT_DEATH(cvc5_mk_fp_from_ieee(d_tm, sign, nullptr, sig), "invalid term");
-  ASSERT_DEATH(cvc5_mk_fp_from_ieee(d_tm, sign, exp, nullptr), "invalid term");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_from_ieee(d_tm, nullptr, exp, sig), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_from_ieee(d_tm, sign, nullptr, sig), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_from_ieee(d_tm, sign, exp, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(
       cvc5_mk_fp_from_ieee(
           d_tm, cvc5_mk_const(d_tm, cvc5_mk_bv_sort(d_tm, 1), ""), exp, sig),
       "expected bit-vector value");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_fp_from_ieee(
           d_tm, sign, cvc5_mk_const(d_tm, cvc5_mk_bv_sort(d_tm, 5), ""), sig),
       "expected bit-vector value");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_fp_from_ieee(
           d_tm, sign, exp, cvc5_mk_const(d_tm, cvc5_mk_bv_sort(d_tm, 10), "")),
       "expected bit-vector value");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_fp_from_ieee(d_tm, cvc5_mk_bv_uint64(d_tm, 2, 0), exp, sig),
       "expected a bit-vector value of size 1");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_fp(tm, 3, 5, t1),
+  ASSERT_CVC5_ERROR(cvc5_mk_fp(tm, 3, 5, t1),
                "term is not associated with this term manager");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_fp_from_ieee(
           tm, sign, cvc5_mk_bv_uint64(tm, 5, 0), cvc5_mk_bv_uint64(tm, 10, 0)),
       "term is not associated with this term manager");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_fp_from_ieee(
           tm, cvc5_mk_bv_uint64(tm, 1, 0), exp, cvc5_mk_bv_uint64(tm, 10, 0)),
       "term is not associated with this term manager");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_fp_from_ieee(
           tm, cvc5_mk_bv_uint64(tm, 1, 0), cvc5_mk_bv_uint64(tm, 5, 0), sig),
       "term is not associated with this term manager");
@@ -801,17 +802,17 @@ TEST_F(TestCApiBlackTermManager, mk_cardinality_constraint)
 {
   Cvc5Sort unsort = cvc5_mk_uninterpreted_sort(d_tm, "u");
   (void)cvc5_mk_cardinality_constraint(d_tm, unsort, 3);
-  ASSERT_DEATH(cvc5_mk_cardinality_constraint(nullptr, unsort, 3),
+  ASSERT_CVC5_ERROR(cvc5_mk_cardinality_constraint(nullptr, unsort, 3),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_cardinality_constraint(d_tm, nullptr, 3),
+  ASSERT_CVC5_ERROR(cvc5_mk_cardinality_constraint(d_tm, nullptr, 3),
                "invalid sort");
-  ASSERT_DEATH(cvc5_mk_cardinality_constraint(d_tm, d_int, 3),
+  ASSERT_CVC5_ERROR(cvc5_mk_cardinality_constraint(d_tm, d_int, 3),
                "expected an uninterpreted sort");
-  ASSERT_DEATH(cvc5_mk_cardinality_constraint(d_tm, unsort, 0),
+  ASSERT_CVC5_ERROR(cvc5_mk_cardinality_constraint(d_tm, unsort, 0),
                "expected a value > 0");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_cardinality_constraint(tm, unsort, 3),
+  ASSERT_CVC5_ERROR(cvc5_mk_cardinality_constraint(tm, unsort, 3),
                "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -820,13 +821,13 @@ TEST_F(TestCApiBlackTermManager, mk_empty_set)
 {
   Cvc5Sort sort = cvc5_mk_set_sort(d_tm, d_bool);
   (void)cvc5_mk_empty_set(d_tm, sort);
-  ASSERT_DEATH(cvc5_mk_empty_set(nullptr, sort), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_empty_set(d_tm, nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_mk_empty_set(d_tm, d_bool),
+  ASSERT_CVC5_ERROR(cvc5_mk_empty_set(nullptr, sort), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_empty_set(d_tm, nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_mk_empty_set(d_tm, d_bool),
                "expected null sort or set sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_empty_set(tm, sort),
+  ASSERT_CVC5_ERROR(cvc5_mk_empty_set(tm, sort),
                "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -835,13 +836,13 @@ TEST_F(TestCApiBlackTermManager, mk_empty_bag)
 {
   Cvc5Sort sort = cvc5_mk_bag_sort(d_tm, d_bool);
   (void)cvc5_mk_empty_bag(d_tm, sort);
-  ASSERT_DEATH(cvc5_mk_empty_bag(nullptr, sort), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_empty_bag(d_tm, nullptr), "invalid sort");
-  ASSERT_DEATH(cvc5_mk_empty_bag(d_tm, d_bool),
+  ASSERT_CVC5_ERROR(cvc5_mk_empty_bag(nullptr, sort), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_empty_bag(d_tm, nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_mk_empty_bag(d_tm, d_bool),
                "expected null sort or bag sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_empty_bag(tm, sort),
+  ASSERT_CVC5_ERROR(cvc5_mk_empty_bag(tm, sort),
                "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -851,12 +852,12 @@ TEST_F(TestCApiBlackTermManager, mk_empty_sequence)
   Cvc5Sort sort = cvc5_mk_sequence_sort(d_tm, d_bool);
   (void)cvc5_mk_empty_sequence(d_tm, sort);
   (void)cvc5_mk_empty_sequence(d_tm, d_bool);
-  ASSERT_DEATH(cvc5_mk_empty_sequence(nullptr, sort),
+  ASSERT_CVC5_ERROR(cvc5_mk_empty_sequence(nullptr, sort),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_empty_sequence(d_tm, nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_mk_empty_sequence(d_tm, nullptr), "invalid sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_empty_sequence(tm, sort),
+  ASSERT_CVC5_ERROR(cvc5_mk_empty_sequence(tm, sort),
                "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -866,58 +867,58 @@ TEST_F(TestCApiBlackTermManager, mk_false) { (void)cvc5_mk_false(d_tm); }
 TEST_F(TestCApiBlackTermManager, mk_fp_nan)
 {
   (void)cvc5_mk_fp_nan(d_tm, 3, 5);
-  ASSERT_DEATH(cvc5_mk_fp_nan(nullptr, 3, 5), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_nan(nullptr, 3, 5), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_fp_neg_zero)
 {
   (void)cvc5_mk_fp_neg_zero(d_tm, 3, 5);
-  ASSERT_DEATH(cvc5_mk_fp_neg_zero(nullptr, 3, 5), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_neg_zero(nullptr, 3, 5), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_fp_pos_zero)
 {
   (void)cvc5_mk_fp_pos_zero(d_tm, 3, 5);
-  ASSERT_DEATH(cvc5_mk_fp_pos_zero(nullptr, 3, 5), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_pos_zero(nullptr, 3, 5), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_fp_neg_inf)
 {
   (void)cvc5_mk_fp_neg_inf(d_tm, 3, 5);
-  ASSERT_DEATH(cvc5_mk_fp_neg_inf(nullptr, 3, 5), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_neg_inf(nullptr, 3, 5), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_fp_pos_inf)
 {
   (void)cvc5_mk_fp_pos_inf(d_tm, 3, 5);
-  ASSERT_DEATH(cvc5_mk_fp_pos_inf(nullptr, 3, 5), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_pos_inf(nullptr, 3, 5), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_op)
 {
   (void)cvc5_mk_op_from_str(d_tm, CVC5_KIND_DIVISIBLE, "2147483648");
-  ASSERT_DEATH(cvc5_mk_op_from_str(nullptr, CVC5_KIND_DIVISIBLE, "2147483648"),
+  ASSERT_CVC5_ERROR(cvc5_mk_op_from_str(nullptr, CVC5_KIND_DIVISIBLE, "2147483648"),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_op_from_str(d_tm, CVC5_KIND_DIVISIBLE, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_mk_op_from_str(d_tm, CVC5_KIND_DIVISIBLE, nullptr),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_op_from_str(d_tm, CVC5_KIND_BITVECTOR_EXTRACT, "1"),
+  ASSERT_CVC5_ERROR(cvc5_mk_op_from_str(d_tm, CVC5_KIND_BITVECTOR_EXTRACT, "1"),
                "expected DIVISIBLE");
 
   std::vector<uint32_t> idxs = {1};
   (void)cvc5_mk_op(d_tm, CVC5_KIND_DIVISIBLE, 1, idxs.data());
   (void)cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_ROTATE_LEFT, 1, idxs.data());
   (void)cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_ROTATE_RIGHT, 1, idxs.data());
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_op(nullptr, CVC5_KIND_BITVECTOR_ROTATE_RIGHT, 1, idxs.data()),
       "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_ROTATE_RIGHT, 1, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_ROTATE_RIGHT, 1, nullptr),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_EXTRACT, 1, idxs.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_EXTRACT, 1, idxs.data()),
                "expected 2 but got 1");
 
   idxs = {1, 1};
   (void)cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_EXTRACT, 2, idxs.data());
-  ASSERT_DEATH(cvc5_mk_op(d_tm, CVC5_KIND_DIVISIBLE, 2, idxs.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_op(d_tm, CVC5_KIND_DIVISIBLE, 2, idxs.data()),
                "expected 1 but got 2");
 
   idxs = {1, 2, 2};
@@ -927,26 +928,26 @@ TEST_F(TestCApiBlackTermManager, mk_op)
 TEST_F(TestCApiBlackTermManager, mk_pi)
 {
   (void)(cvc5_mk_pi(d_tm));
-  ASSERT_DEATH(cvc5_mk_pi(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_pi(nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_integer)
 {
   (void)cvc5_mk_integer(d_tm, "123");
-  ASSERT_DEATH(cvc5_mk_integer(nullptr, "123"), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, nullptr), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, "1.23"), "expected an integer");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, "1/23"), "expected an integer");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, "12/3"), "expected an integer");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, ".2"), "expected an integer");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, "2."), "expected an integer");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, ""), "expected an integer");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, "asdf"), "expected an integer");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, "1.2/3"), "expected an integer");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, "."), "expected an integer");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, "/"), "expected an integer");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, "2/"), "expected an integer");
-  ASSERT_DEATH(cvc5_mk_integer(d_tm, "/2"), "expected an integer");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(nullptr, "123"), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "1.23"), "expected an integer");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "1/23"), "expected an integer");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "12/3"), "expected an integer");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, ".2"), "expected an integer");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "2."), "expected an integer");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, ""), "expected an integer");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "asdf"), "expected an integer");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "1.2/3"), "expected an integer");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "."), "expected an integer");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "/"), "expected an integer");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "2/"), "expected an integer");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "/2"), "expected an integer");
 
   (void)cvc5_mk_integer_int64(d_tm, 1);
   (void)cvc5_mk_integer_int64(d_tm, -1);
@@ -964,29 +965,29 @@ TEST_F(TestCApiBlackTermManager, mkReal)
   (void)cvc5_mk_real(d_tm, "-1/-1");
   (void)cvc5_mk_real(d_tm, "1/-1");
   (void)cvc5_mk_real(d_tm, "-1/1");
-  ASSERT_DEATH(cvc5_mk_real(nullptr, "123"), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_real(d_tm, nullptr), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_real(d_tm, ""), "cannot construct Real");
-  ASSERT_DEATH(cvc5_mk_real(d_tm, "asdf"), "cannot construct Real");
-  ASSERT_DEATH(cvc5_mk_real(d_tm, "1.2/3"), "cannot construct Real");
-  ASSERT_DEATH(cvc5_mk_real(d_tm, "."), "invalid argument '.'");
-  ASSERT_DEATH(cvc5_mk_real(d_tm, "/"), "cannot construct Real");
-  ASSERT_DEATH(cvc5_mk_real(d_tm, "2/"), "cannot construct Real");
-  ASSERT_DEATH(cvc5_mk_real(d_tm, "/2"), "cannot construct Real");
-  ASSERT_DEATH(cvc5_mk_real(d_tm, "/-5"), "cannot construct Real");
+  ASSERT_CVC5_ERROR(cvc5_mk_real(nullptr, "123"), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_real(d_tm, nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_real(d_tm, ""), "cannot construct Real");
+  ASSERT_CVC5_ERROR(cvc5_mk_real(d_tm, "asdf"), "cannot construct Real");
+  ASSERT_CVC5_ERROR(cvc5_mk_real(d_tm, "1.2/3"), "cannot construct Real");
+  ASSERT_CVC5_ERROR(cvc5_mk_real(d_tm, "."), "invalid argument '.'");
+  ASSERT_CVC5_ERROR(cvc5_mk_real(d_tm, "/"), "cannot construct Real");
+  ASSERT_CVC5_ERROR(cvc5_mk_real(d_tm, "2/"), "cannot construct Real");
+  ASSERT_CVC5_ERROR(cvc5_mk_real(d_tm, "/2"), "cannot construct Real");
+  ASSERT_CVC5_ERROR(cvc5_mk_real(d_tm, "/-5"), "cannot construct Real");
 
   (void)cvc5_mk_real_int64(d_tm, 1);
   (void)cvc5_mk_real_int64(d_tm, -1);
   (void)cvc5_mk_real_int64(d_tm, 1);
-  ASSERT_DEATH(cvc5_mk_real_int64(nullptr, 1), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_real_int64(nullptr, 1), "unexpected NULL argument");
 
   (void)cvc5_mk_real_num_den(d_tm, 1, 1);
   (void)cvc5_mk_real_num_den(d_tm, -1, -1);
   (void)cvc5_mk_real_num_den(d_tm, 1, -1);
   (void)cvc5_mk_real_num_den(d_tm, -1, 1);
   (void)cvc5_mk_real_num_den(d_tm, 0, 1);
-  ASSERT_DEATH(cvc5_mk_real_num_den(nullptr, 1, 1), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_real_num_den(d_tm, 1, 0), "invalid denominator '0'");
+  ASSERT_CVC5_ERROR(cvc5_mk_real_num_den(nullptr, 1, 1), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_real_num_den(d_tm, 1, 0), "invalid denominator '0'");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_regexp_all)
@@ -995,7 +996,7 @@ TEST_F(TestCApiBlackTermManager, mk_regexp_all)
   Cvc5Term s = cvc5_mk_const(d_tm, sort, "s");
   std::vector<Cvc5Term> args = {s, cvc5_mk_regexp_all(d_tm)};
   (void)cvc5_mk_term(d_tm, CVC5_KIND_STRING_IN_REGEXP, 2, args.data());
-  ASSERT_DEATH(cvc5_mk_regexp_all(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_regexp_all(nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_regexp_allchar)
@@ -1004,7 +1005,7 @@ TEST_F(TestCApiBlackTermManager, mk_regexp_allchar)
   Cvc5Term s = cvc5_mk_const(d_tm, sort, "s");
   std::vector<Cvc5Term> args = {s, cvc5_mk_regexp_allchar(d_tm)};
   (void)cvc5_mk_term(d_tm, CVC5_KIND_STRING_IN_REGEXP, 2, args.data());
-  ASSERT_DEATH(cvc5_mk_regexp_allchar(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_regexp_allchar(nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_regexp_none)
@@ -1013,24 +1014,24 @@ TEST_F(TestCApiBlackTermManager, mk_regexp_none)
   Cvc5Term s = cvc5_mk_const(d_tm, sort, "s");
   std::vector<Cvc5Term> args = {s, cvc5_mk_regexp_none(d_tm)};
   (void)cvc5_mk_term(d_tm, CVC5_KIND_STRING_IN_REGEXP, 2, args.data());
-  ASSERT_DEATH(cvc5_mk_regexp_none(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_regexp_none(nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_sep_emp)
 {
   (void)cvc5_mk_sep_emp(d_tm);
-  ASSERT_DEATH(cvc5_mk_sep_emp(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_sep_emp(nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_sep_nil)
 {
   (void)cvc5_mk_sep_nil(d_tm, d_bool);
   (void)cvc5_mk_sep_nil(d_tm, d_int);
-  ASSERT_DEATH(cvc5_mk_sep_nil(nullptr, d_bool), "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_sep_nil(d_tm, nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_mk_sep_nil(nullptr, d_bool), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_sep_nil(d_tm, nullptr), "invalid sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_sep_nil(tm, d_bool),
+  ASSERT_CVC5_ERROR(cvc5_mk_sep_nil(tm, d_bool),
                "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -1087,15 +1088,15 @@ TEST_F(TestCApiBlackTermManager, mk_term)
       0,
       args.data());
 
-  ASSERT_DEATH(cvc5_mk_term(nullptr, CVC5_KIND_PI, 0, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(nullptr, CVC5_KIND_PI, 0, args.data()),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_PI, 1, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_PI, 1, nullptr),
                "unexpected NULL argument for 'children'");
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_PI, 1, {}),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_PI, 1, {}),
                "unexpected NULL argument for 'children'");
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_PI, 1, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_PI, 1, args.data()),
                "unexpected NULL argument for 'children'");
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_CONST_BITVECTOR, 0, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_CONST_BITVECTOR, 0, args.data()),
                "invalid kind");
 
   args = {cvc5_mk_true(d_tm)};
@@ -1110,10 +1111,10 @@ TEST_F(TestCApiBlackTermManager, mk_term)
       2,
       args.data());
   args = {nullptr};
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_NOT, 1, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_NOT, 1, args.data()),
                "invalid term at index 0");
   args = {a};
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_NOT, 1, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_NOT, 1, args.data()),
                "expecting a Boolean");
 
   args = {a, b};
@@ -1125,18 +1126,18 @@ TEST_F(TestCApiBlackTermManager, mk_term)
   (void)cvc5_mk_term_from_op(
       d_tm, cvc5_mk_op(d_tm, CVC5_KIND_EQUAL, 0, idxs.data()), 2, args.data());
 
-  ASSERT_DEATH(cvc5_mk_term(nullptr, CVC5_KIND_EQUAL, 2, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(nullptr, CVC5_KIND_EQUAL, 2, nullptr),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_term(nullptr, CVC5_KIND_EQUAL, 2, {}),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(nullptr, CVC5_KIND_EQUAL, 2, {}),
                "unexpected NULL argument");
   args = {nullptr, b};
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, 2, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, 2, args.data()),
                "invalid term at index 0");
   args = {a, nullptr};
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, 2, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, 2, args.data()),
                "invalid term at index 1");
   args = {a, cvc5_mk_true(d_tm)};
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, 2, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, 2, args.data()),
                "Subexpressions must have the same type");
 
   args = {cvc5_mk_true(d_tm), cvc5_mk_true(d_tm), cvc5_mk_true(d_tm)};
@@ -1144,19 +1145,19 @@ TEST_F(TestCApiBlackTermManager, mk_term)
   (void)cvc5_mk_term_from_op(
       d_tm, cvc5_mk_op(d_tm, CVC5_KIND_ITE, 0, idxs.data()), 3, args.data());
   args = {nullptr, cvc5_mk_true(d_tm), cvc5_mk_true(d_tm)};
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_ITE, 3, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_ITE, 3, args.data()),
                "invalid term at index 0");
   args = {cvc5_mk_true(d_tm), nullptr, cvc5_mk_true(d_tm)};
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_ITE, 3, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_ITE, 3, args.data()),
                "invalid term at index 1");
   args = {cvc5_mk_true(d_tm), cvc5_mk_true(d_tm), nullptr};
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_ITE, 3, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_ITE, 3, args.data()),
                "invalid term at index 2");
   args = {a, cvc5_mk_true(d_tm), cvc5_mk_true(d_tm)};
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_ITE, 3, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_ITE, 3, args.data()),
                "condition of ITE is not Boolean");
   args = {cvc5_mk_true(d_tm), cvc5_mk_true(d_tm), b};
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_ITE, 3, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_ITE, 3, args.data()),
                "Branches of the ITE must have comparable type");
 
   // Test cases that are nary via the API but have arity = 2 internally
@@ -1226,22 +1227,22 @@ TEST_F(TestCApiBlackTermManager, mk_term)
       args.data());
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_sep_nil(tm, d_bool),
+  ASSERT_CVC5_ERROR(cvc5_mk_sep_nil(tm, d_bool),
                "sort is not associated with this term manager");
   args = {t_bool,
           cvc5_mk_const(tm, cvc5_get_boolean_sort(tm), ""),
           cvc5_mk_const(tm, cvc5_get_boolean_sort(tm), "")};
-  ASSERT_DEATH(cvc5_mk_term(tm, CVC5_KIND_IMPLIES, 3, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(tm, CVC5_KIND_IMPLIES, 3, args.data()),
                "expected a term associated with this term manager");
   args = {cvc5_mk_const(tm, cvc5_get_boolean_sort(tm), ""),
           t_bool,
           cvc5_mk_const(tm, cvc5_get_boolean_sort(tm), "")};
-  ASSERT_DEATH(cvc5_mk_term(tm, CVC5_KIND_IMPLIES, 3, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(tm, CVC5_KIND_IMPLIES, 3, args.data()),
                "expected a term associated with this term manager");
   args = {cvc5_mk_const(tm, cvc5_get_boolean_sort(tm), ""),
           cvc5_mk_const(tm, cvc5_get_boolean_sort(tm), ""),
           t_bool};
-  ASSERT_DEATH(cvc5_mk_term(tm, CVC5_KIND_IMPLIES, 3, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(tm, CVC5_KIND_IMPLIES, 3, args.data()),
                "expected a term associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -1260,9 +1261,9 @@ TEST_F(TestCApiBlackTermManager, mk_term_from_op)
   idxs = {1};
   Cvc5Op op2 = cvc5_mk_op(d_tm, CVC5_KIND_DIVISIBLE, 1, idxs.data());
 
-  ASSERT_DEATH(cvc5_mk_op(nullptr, CVC5_KIND_BITVECTOR_EXTRACT, 2, idxs.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_op(nullptr, CVC5_KIND_BITVECTOR_EXTRACT, 2, idxs.data()),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_op(nullptr, CVC5_KIND_BITVECTOR_EXTRACT, 2, {}),
+  ASSERT_CVC5_ERROR(cvc5_mk_op(nullptr, CVC5_KIND_BITVECTOR_EXTRACT, 2, {}),
                "unexpected NULL argument");
 
   // list datatype
@@ -1295,16 +1296,16 @@ TEST_F(TestCApiBlackTermManager, mk_term_from_op)
   // mk_term(_from_op)
   std::vector<Cvc5Term> args = {nil_term};
   (void)cvc5_mk_term(d_tm, CVC5_KIND_APPLY_CONSTRUCTOR, 1, args.data());
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_APPLY_SELECTOR, 1, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_APPLY_SELECTOR, 1, args.data()),
                "");
   args = {cons_term};
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_APPLY_SELECTOR, 1, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_APPLY_SELECTOR, 1, args.data()),
                "");
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_APPLY_CONSTRUCTOR, 1, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_APPLY_CONSTRUCTOR, 1, args.data()),
                "");
 
   args = {head_term};
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_APPLY_SELECTOR, 1, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_APPLY_SELECTOR, 1, args.data()),
                "");
 
   args = {head_term, c};
@@ -1313,17 +1314,17 @@ TEST_F(TestCApiBlackTermManager, mk_term_from_op)
   args = {tail_term, c};
   (void)cvc5_mk_term(d_tm, CVC5_KIND_APPLY_SELECTOR, 2, args.data());
 
-  ASSERT_DEATH(cvc5_mk_term_from_op(d_tm, op1, 0, {}), "");
+  ASSERT_CVC5_ERROR(cvc5_mk_term_from_op(d_tm, op1, 0, {}), "");
   args = {a};
   (void)cvc5_mk_term_from_op(d_tm, op1, 1, args.data());
-  ASSERT_DEATH(cvc5_mk_term_from_op(d_tm, op2, 1, args.data()), "");
+  ASSERT_CVC5_ERROR(cvc5_mk_term_from_op(d_tm, op2, 1, args.data()), "");
   args = {cvc5_mk_integer_int64(d_tm, 1)};
   (void)cvc5_mk_term_from_op(d_tm, op2, 1, args.data());
   args = {nullptr};
-  ASSERT_DEATH(cvc5_mk_term_from_op(d_tm, op1, 1, args.data()), "");
+  ASSERT_CVC5_ERROR(cvc5_mk_term_from_op(d_tm, op1, 1, args.data()), "");
 
   args = {cons_term, cvc5_mk_integer_int64(d_tm, 0)};
-  ASSERT_DEATH(cvc5_mk_term(d_tm, CVC5_KIND_APPLY_CONSTRUCTOR, 2, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_APPLY_CONSTRUCTOR, 2, args.data()),
                "");
   args = {nil_term};
   args = {cons_term,
@@ -1332,26 +1333,26 @@ TEST_F(TestCApiBlackTermManager, mk_term_from_op)
   (void)cvc5_mk_term(d_tm, CVC5_KIND_APPLY_CONSTRUCTOR, 3, args.data());
 
   args = {cvc5_mk_integer_int64(d_tm, 1), cvc5_mk_integer_int64(d_tm, 2)};
-  ASSERT_DEATH(cvc5_mk_term_from_op(d_tm, op2, 2, args.data()), "");
+  ASSERT_CVC5_ERROR(cvc5_mk_term_from_op(d_tm, op2, 2, args.data()), "");
   args = {a, b};
-  ASSERT_DEATH(cvc5_mk_term_from_op(d_tm, op1, 2, args.data()), "");
+  ASSERT_CVC5_ERROR(cvc5_mk_term_from_op(d_tm, op1, 2, args.data()), "");
   args = {cvc5_mk_integer_int64(d_tm, 1), nullptr};
-  ASSERT_DEATH(cvc5_mk_term_from_op(d_tm, op2, 2, args.data()), "");
+  ASSERT_CVC5_ERROR(cvc5_mk_term_from_op(d_tm, op2, 2, args.data()), "");
   args = {nullptr, cvc5_mk_integer_int64(d_tm, 1)};
-  ASSERT_DEATH(cvc5_mk_term_from_op(d_tm, op2, 2, args.data()), "");
+  ASSERT_CVC5_ERROR(cvc5_mk_term_from_op(d_tm, op2, 2, args.data()), "");
 
   args = {a, b, a};
-  ASSERT_DEATH(cvc5_mk_term_from_op(d_tm, op1, 3, args.data()), "");
+  ASSERT_CVC5_ERROR(cvc5_mk_term_from_op(d_tm, op1, 3, args.data()), "");
   args = {
       cvc5_mk_integer_int64(d_tm, 1), cvc5_mk_integer_int64(d_tm, 1), nullptr};
-  ASSERT_DEATH(cvc5_mk_term_from_op(d_tm, op2, 3, args.data()), "");
+  ASSERT_CVC5_ERROR(cvc5_mk_term_from_op(d_tm, op2, 3, args.data()), "");
 
   args = {cvc5_mk_integer_int64(d_tm, 5)};
   (void)cvc5_mk_term_from_op(d_tm, op2, 1, args.data());
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   args = {cvc5_mk_integer_int64(tm, 1)};
-  ASSERT_DEATH(cvc5_mk_term_from_op(tm, op2, 1, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_term_from_op(tm, op2, 1, args.data()),
                "operator is not associated with this term manager");
   idxs = {1};
   (void)cvc5_mk_term_from_op(
@@ -1362,7 +1363,7 @@ TEST_F(TestCApiBlackTermManager, mk_term_from_op)
 TEST_F(TestCApiBlackTermManager, mk_true)
 {
   (void)cvc5_mk_true(d_tm);
-  ASSERT_DEATH(cvc5_mk_true(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_true(nullptr), "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_tuple)
@@ -1373,12 +1374,12 @@ TEST_F(TestCApiBlackTermManager, mk_tuple)
   (void)cvc5_mk_tuple(d_tm, 1, args.data());
   args = {cvc5_mk_real(d_tm, "5.3")};
   (void)cvc5_mk_tuple(d_tm, 1, args.data());
-  ASSERT_DEATH(cvc5_mk_tuple(nullptr, 1, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_tuple(nullptr, 1, args.data()),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_tuple(nullptr, 0, {}), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_tuple(nullptr, 0, {}), "unexpected NULL argument");
   Cvc5TermManager* tm = cvc5_term_manager_new();
   args = {cvc5_mk_bv(d_tm, 3, "101", 2)};
-  ASSERT_DEATH(cvc5_mk_tuple(tm, 1, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_tuple(tm, 1, args.data()),
                "expected a term associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -1388,12 +1389,12 @@ TEST_F(TestCApiBlackTermManager, mk_nullable_some)
   (void)cvc5_mk_nullable_some(d_tm, cvc5_mk_bv(d_tm, 3, "101", 2));
   (void)cvc5_mk_nullable_some(d_tm, cvc5_mk_integer(d_tm, "5"));
   (void)cvc5_mk_nullable_some(d_tm, cvc5_mk_real(d_tm, "5.3"));
-  ASSERT_DEATH(cvc5_mk_nullable_some(nullptr, cvc5_mk_real(d_tm, "5.3")),
+  ASSERT_CVC5_ERROR(cvc5_mk_nullable_some(nullptr, cvc5_mk_real(d_tm, "5.3")),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_nullable_some(d_tm, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_mk_nullable_some(d_tm, nullptr), "invalid term");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_nullable_some(tm, cvc5_mk_bv(d_tm, 3, "101", 2)),
+  ASSERT_CVC5_ERROR(cvc5_mk_nullable_some(tm, cvc5_mk_bv(d_tm, 3, "101", 2)),
                "term is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -1407,14 +1408,14 @@ TEST_F(TestCApiBlackTermManager, mk_nullable_val)
   cvc5_delete(solver);
 
   ASSERT_EQ(5, cvc5_term_get_int64_value(value));
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_nullable_val(
           nullptr, cvc5_mk_nullable_some(d_tm, cvc5_mk_integer_int64(d_tm, 5))),
       "unexpected NULL argument");
 
-  ASSERT_DEATH(cvc5_mk_nullable_val(d_tm, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_mk_nullable_val(d_tm, nullptr), "invalid term");
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_nullable_val(
           tm, cvc5_mk_nullable_some(d_tm, cvc5_mk_integer_int64(d_tm, 5))),
       "term is not associated with this term manager");
@@ -1430,14 +1431,14 @@ TEST_F(TestCApiBlackTermManager, mk_nullable_is_null)
   cvc5_delete(solver);
 
   ASSERT_EQ(false, cvc5_term_get_boolean_value(value));
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_nullable_is_null(
           nullptr, cvc5_mk_nullable_some(d_tm, cvc5_mk_integer_int64(d_tm, 5))),
       "unexpected NULL argument");
 
-  ASSERT_DEATH(cvc5_mk_nullable_is_null(d_tm, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_mk_nullable_is_null(d_tm, nullptr), "invalid term");
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_nullable_is_null(
           tm, cvc5_mk_nullable_some(d_tm, cvc5_mk_integer_int64(d_tm, 5))),
       "term is not associated with this term manager");
@@ -1453,14 +1454,14 @@ TEST_F(TestCApiBlackTermManager, mk_nullable_is_some)
   cvc5_delete(solver);
 
   ASSERT_EQ(true, cvc5_term_get_boolean_value(value));
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_nullable_is_some(
           nullptr, cvc5_mk_nullable_some(d_tm, cvc5_mk_integer_int64(d_tm, 5))),
       "unexpected NULL argument");
 
-  ASSERT_DEATH(cvc5_mk_nullable_is_some(d_tm, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_mk_nullable_is_some(d_tm, nullptr), "invalid term");
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_nullable_is_some(
           tm, cvc5_mk_nullable_some(d_tm, cvc5_mk_integer_int64(d_tm, 5))),
       "term is not associated with this term manager");
@@ -1477,12 +1478,12 @@ TEST_F(TestCApiBlackTermManager, mk_nullable_null)
   ASSERT_EQ(true, cvc5_term_get_boolean_value(value));
   cvc5_delete(solver);
 
-  ASSERT_DEATH(cvc5_mk_nullable_null(nullptr, sort),
+  ASSERT_CVC5_ERROR(cvc5_mk_nullable_null(nullptr, sort),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_nullable_null(d_tm, nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_mk_nullable_null(d_tm, nullptr), "invalid sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_nullable_null(tm, sort),
+  ASSERT_CVC5_ERROR(cvc5_mk_nullable_null(tm, sort),
                "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -1499,13 +1500,13 @@ TEST_F(TestCApiBlackTermManager, mk_nullable_lift)
   cvc5_delete(solver);
 
   ASSERT_EQ(3, cvc5_term_get_int64_value(three));
-  ASSERT_DEATH(cvc5_mk_nullable_lift(nullptr, CVC5_KIND_ADD, 2, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_nullable_lift(nullptr, CVC5_KIND_ADD, 2, args.data()),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_nullable_lift(d_tm, CVC5_KIND_ADD, 0, {}),
+  ASSERT_CVC5_ERROR(cvc5_mk_nullable_lift(d_tm, CVC5_KIND_ADD, 0, {}),
                "unexpected NULL argument");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_nullable_lift(tm, CVC5_KIND_ADD, 2, args.data()),
+  ASSERT_CVC5_ERROR(cvc5_mk_nullable_lift(tm, CVC5_KIND_ADD, 2, args.data()),
                "expected a term associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -1513,12 +1514,12 @@ TEST_F(TestCApiBlackTermManager, mk_nullable_lift)
 TEST_F(TestCApiBlackTermManager, mk_universe_set)
 {
   (void)cvc5_mk_universe_set(d_tm, d_bool);
-  ASSERT_DEATH(cvc5_mk_universe_set(nullptr, d_bool),
+  ASSERT_CVC5_ERROR(cvc5_mk_universe_set(nullptr, d_bool),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_universe_set(d_tm, nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_mk_universe_set(d_tm, nullptr), "invalid sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_universe_set(tm, d_bool),
+  ASSERT_CVC5_ERROR(cvc5_mk_universe_set(tm, d_bool),
                "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -1533,11 +1534,11 @@ TEST_F(TestCApiBlackTermManager, mk_const)
   (void)cvc5_mk_const(d_tm, d_int, "i");
   (void)cvc5_mk_const(d_tm, fun_sort, "f");
   (void)cvc5_mk_const(d_tm, fun_sort, "");
-  ASSERT_DEATH(cvc5_mk_const(nullptr, d_bool, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_mk_const(nullptr, d_bool, nullptr),
                "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_const(d_tm, nullptr, nullptr), "invalid sort");
+  ASSERT_CVC5_ERROR(cvc5_mk_const(d_tm, nullptr, nullptr), "invalid sort");
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_DEATH(cvc5_mk_const(tm, d_bool, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_mk_const(tm, d_bool, nullptr),
                "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
@@ -1569,11 +1570,11 @@ TEST_F(TestCApiBlackTermManager, mk_skolem)
   ASSERT_TRUE(cvc5_term_is_equal(ridxs[0], a));
   ASSERT_TRUE(cvc5_term_is_equal(ridxs[1], b));
 
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_mk_skolem(
           nullptr, CVC5_SKOLEM_ID_ARRAY_DEQ_DIFF, idxs.size(), idxs.data()),
       "unexpected NULL argument");
-  ASSERT_DEATH(cvc5_mk_skolem(d_tm, CVC5_SKOLEM_ID_ARRAY_DEQ_DIFF, 0, nullptr),
+  ASSERT_CVC5_ERROR(cvc5_mk_skolem(d_tm, CVC5_SKOLEM_ID_ARRAY_DEQ_DIFF, 0, nullptr),
                "invalid number of indices");
 }
 
@@ -1581,14 +1582,14 @@ TEST_F(TestCApiBlackTermManager, get_num_idxs_for_skolem_id)
 {
   ASSERT_EQ(
       cvc5_get_num_idxs_for_skolem_id(d_tm, CVC5_SKOLEM_ID_BAGS_MAP_INDEX), 5);
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_get_num_idxs_for_skolem_id(nullptr, CVC5_SKOLEM_ID_BAGS_MAP_INDEX),
       "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, get_statistics)
 {
-  ASSERT_DEATH(cvc5_term_manager_get_statistics(nullptr),
+  ASSERT_CVC5_ERROR(cvc5_term_manager_get_statistics(nullptr),
                "unexpected NULL argument");
 
   // do some array reasoning to make sure we have a double statistics

--- a/test/unit/api/c/capi_term_manager_black.cpp
+++ b/test/unit/api/c/capi_term_manager_black.cpp
@@ -44,12 +44,14 @@ TEST_F(TestCApiBlackTermManager, new) {}
 
 TEST_F(TestCApiBlackTermManager, delete)
 {
-  ASSERT_CVC5_ERROR(cvc5_term_manager_delete(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_term_manager_delete(nullptr),
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, release)
 {
-  ASSERT_CVC5_ERROR(cvc5_term_manager_release(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_term_manager_release(nullptr),
+                    "unexpected NULL argument");
   cvc5_term_manager_release(d_tm);
 }
 
@@ -104,14 +106,15 @@ TEST_F(TestCApiBlackTermManager, mk_array_sort)
   (void)cvc5_mk_array_sort(d_tm, bvsort, fpsort);
 
   ASSERT_CVC5_ERROR(cvc5_mk_array_sort(nullptr, bvsort, fpsort),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_array_sort(d_tm, nullptr, fpsort), "invalid sort");
   ASSERT_CVC5_ERROR(cvc5_mk_array_sort(d_tm, bvsort, nullptr), "invalid sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_CVC5_ERROR(cvc5_mk_array_sort(
-                   d_tm, cvc5_get_boolean_sort(tm), cvc5_get_integer_sort(tm)),
-               "sort is not associated with this term manager");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_array_sort(
+          d_tm, cvc5_get_boolean_sort(tm), cvc5_get_integer_sort(tm)),
+      "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -125,9 +128,12 @@ TEST_F(TestCApiBlackTermManager, mk_bv_sort)
 TEST_F(TestCApiBlackTermManager, mk_ff_sort)
 {
   (void)cvc5_mk_ff_sort(d_tm, "31", 10);
-  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(nullptr, "31", 10), "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, nullptr, 10), "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "6", 10), "expected modulus is prime");
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(nullptr, "31", 10),
+                    "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, nullptr, 10),
+                    "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "6", 10),
+                    "expected modulus is prime");
 
   ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "b", 10), "");
 
@@ -139,12 +145,17 @@ TEST_F(TestCApiBlackTermManager, mk_ff_sort)
   (void)cvc5_mk_ff_sort(d_tm, "8CC5", 16);
 
   ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "1100100", 2),
-               "expected modulus is prime");
-  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "10201", 3), "expected modulus is prime");
-  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "400", 5), "expected modulus is prime");
-  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "7919", 11), "expected modulus is prime");
-  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "970e", 16), "expected modulus is prime");
-  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "8CC4", 16), "expected modulus is prime");
+                    "expected modulus is prime");
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "10201", 3),
+                    "expected modulus is prime");
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "400", 5),
+                    "expected modulus is prime");
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "7919", 11),
+                    "expected modulus is prime");
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "970e", 16),
+                    "expected modulus is prime");
+  ASSERT_CVC5_ERROR(cvc5_mk_ff_sort(d_tm, "8CC4", 16),
+                    "expected modulus is prime");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_fp_sort)
@@ -152,9 +163,11 @@ TEST_F(TestCApiBlackTermManager, mk_fp_sort)
   (void)cvc5_mk_fp_sort(d_tm, 4, 8);
   ASSERT_CVC5_ERROR(cvc5_mk_fp_sort(nullptr, 4, 8), "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_fp_sort(d_tm, 0, 8), "expected exponent size > 1");
-  ASSERT_CVC5_ERROR(cvc5_mk_fp_sort(d_tm, 4, 0), "expected significand size > 1");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_sort(d_tm, 4, 0),
+                    "expected significand size > 1");
   ASSERT_CVC5_ERROR(cvc5_mk_fp_sort(d_tm, 1, 8), "expected exponent size > 1");
-  ASSERT_CVC5_ERROR(cvc5_mk_fp_sort(d_tm, 4, 1), "expected significand size > 1");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_sort(d_tm, 4, 1),
+                    "expected significand size > 1");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_dt_sort)
@@ -167,7 +180,8 @@ TEST_F(TestCApiBlackTermManager, mk_dt_sort)
     Cvc5DatatypeConstructorDecl nil = cvc5_mk_dt_cons_decl(d_tm, "nil");
     cvc5_dt_decl_add_constructor(decl, nil);
     (void)cvc5_mk_dt_sort(d_tm, decl);
-    ASSERT_CVC5_ERROR(cvc5_mk_dt_sort(nullptr, decl), "unexpected NULL argument");
+    ASSERT_CVC5_ERROR(cvc5_mk_dt_sort(nullptr, decl),
+                      "unexpected NULL argument");
     ASSERT_CVC5_ERROR(cvc5_mk_dt_sort(d_tm, decl), "is already resolved");
   }
 
@@ -210,19 +224,19 @@ TEST_F(TestCApiBlackTermManager, mk_dt_sorts)
     std::vector<Cvc5DatatypeDecl> decls = {decl1, decl2};
     (void)cvc5_mk_dt_sorts(d_tm, decls.size(), decls.data());
     ASSERT_CVC5_ERROR(cvc5_mk_dt_sorts(nullptr, decls.size(), decls.data()),
-                 "unexpected NULL argument");
+                      "unexpected NULL argument");
     ASSERT_CVC5_ERROR(cvc5_mk_dt_sorts(d_tm, decls.size(), nullptr),
-                 "unexpected NULL argument");
+                      "unexpected NULL argument");
 
     ASSERT_CVC5_ERROR(cvc5_mk_dt_sorts(d_tm, decls.size(), decls.data()),
-                 "is already resolved");
+                      "is already resolved");
   }
 
   {
     std::vector<Cvc5DatatypeDecl> decls = {
         cvc5_mk_dt_decl(d_tm, "list", "false")};
     ASSERT_CVC5_ERROR(cvc5_mk_dt_sorts(d_tm, decls.size(), decls.data()),
-                 "at least one constructor");
+                      "at least one constructor");
   }
 
   {
@@ -239,7 +253,7 @@ TEST_F(TestCApiBlackTermManager, mk_dt_sorts)
     (void)cvc5_mk_dt_sorts(d_tm, udecls.size(), udecls.data());
 
     ASSERT_CVC5_ERROR(cvc5_mk_dt_sorts(d_tm, udecls.size(), udecls.data()),
-                 "has already been used");
+                      "has already been used");
   }
 
   {
@@ -314,16 +328,18 @@ TEST_F(TestCApiBlackTermManager, mk_fun_sort)
   // function arguments are allowed
   domain = {funsort};
   (void)cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), d_int);
-  ASSERT_CVC5_ERROR(cvc5_mk_fun_sort(nullptr, domain.size(), domain.data(), d_int),
-               "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_fun_sort(nullptr, domain.size(), domain.data(), d_int),
+      "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_fun_sort(d_tm, domain.size(), nullptr, d_int),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   domain = {nullptr};
   ASSERT_CVC5_ERROR(cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), d_int),
-               "invalid sort at index 0");
+                    "invalid sort at index 0");
   domain = {d_int};
-  ASSERT_CVC5_ERROR(cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), funsort),
-               "expected non-function sort as codomain sort");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), funsort),
+      "expected non-function sort as codomain sort");
 
   domain = {unsort, d_int};
   (void)cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), d_int);
@@ -336,8 +352,9 @@ TEST_F(TestCApiBlackTermManager, mk_fun_sort)
   (void)cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), d_int);
 
   domain = {d_int, unsort};
-  ASSERT_CVC5_ERROR(cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), funsort),
-               "expected non-function sort as codomain sort");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), funsort),
+      "expected non-function sort as codomain sort");
 
   domain = {d_bool, d_int, d_int};
   (void)cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), d_int);
@@ -345,12 +362,13 @@ TEST_F(TestCApiBlackTermManager, mk_fun_sort)
   (void)cvc5_mk_fun_sort(d_tm, domain.size(), domain.data(), d_int);
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_CVC5_ERROR(cvc5_mk_fun_sort(
-                   tm, domain.size(), domain.data(), cvc5_get_integer_sort(tm)),
-               "expected a sort associated with this term manager");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_fun_sort(
+          tm, domain.size(), domain.data(), cvc5_get_integer_sort(tm)),
+      "expected a sort associated with this term manager");
   domain = {cvc5_get_boolean_sort(tm), cvc5_get_integer_sort(tm)};
   ASSERT_CVC5_ERROR(cvc5_mk_fun_sort(tm, domain.size(), domain.data(), d_int),
-               "sort is not associated with this term manager");
+                    "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -358,8 +376,10 @@ TEST_F(TestCApiBlackTermManager, mk_param_sort)
 {
   (void)cvc5_mk_param_sort(d_tm, "T");
   (void)cvc5_mk_param_sort(d_tm, "");
-  ASSERT_CVC5_ERROR(cvc5_mk_param_sort(nullptr, ""), "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_mk_param_sort(d_tm, nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_param_sort(nullptr, ""),
+                    "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_param_sort(d_tm, nullptr),
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_predicate_sort)
@@ -367,20 +387,20 @@ TEST_F(TestCApiBlackTermManager, mk_predicate_sort)
   std::vector<Cvc5Sort> sorts = {d_int};
   (void)cvc5_mk_predicate_sort(d_tm, sorts.size(), sorts.data());
   ASSERT_CVC5_ERROR(cvc5_mk_predicate_sort(nullptr, sorts.size(), sorts.data()),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_predicate_sort(d_tm, sorts.size(), nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   sorts = {nullptr};
   ASSERT_CVC5_ERROR(cvc5_mk_predicate_sort(d_tm, sorts.size(), sorts.data()),
-               "invalid sort at index 0");
+                    "invalid sort at index 0");
 
   sorts = {};
   ASSERT_CVC5_ERROR(cvc5_mk_predicate_sort(d_tm, sorts.size(), sorts.data()),
-               "expected at least one parameter sort");
+                    "expected at least one parameter sort");
 
   sorts = {nullptr};
   ASSERT_CVC5_ERROR(cvc5_mk_predicate_sort(d_tm, sorts.size(), sorts.data()),
-               "invalid sort at index 0");
+                    "invalid sort at index 0");
 
   sorts = {cvc5_mk_uninterpreted_sort(d_tm, "u"), d_int};
   Cvc5Sort funsort = cvc5_mk_fun_sort(d_tm, sorts.size(), sorts.data(), d_int);
@@ -391,7 +411,7 @@ TEST_F(TestCApiBlackTermManager, mk_predicate_sort)
   Cvc5TermManager* tm = cvc5_term_manager_new();
   sorts = {d_int};
   ASSERT_CVC5_ERROR(cvc5_mk_predicate_sort(tm, sorts.size(), sorts.data()),
-               "expected a sort associated with this term manager");
+                    "expected a sort associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -438,11 +458,12 @@ TEST_F(TestCApiBlackTermManager, mk_set_sort)
   (void)cvc5_mk_set_sort(d_tm, d_int);
   (void)cvc5_mk_set_sort(d_tm, cvc5_mk_bv_sort(d_tm, 4));
   (void)cvc5_mk_set_sort(d_tm, cvc5_mk_bv_sort(d_tm, 4));
-  ASSERT_CVC5_ERROR(cvc5_mk_set_sort(nullptr, d_bool), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_set_sort(nullptr, d_bool),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_set_sort(d_tm, nullptr), "invalid sort");
   Cvc5TermManager* tm = cvc5_term_manager_new();
   ASSERT_CVC5_ERROR(cvc5_mk_set_sort(d_tm, cvc5_get_boolean_sort(tm)),
-               "sort is not associated with this term manager");
+                    "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -452,11 +473,12 @@ TEST_F(TestCApiBlackTermManager, mk_bag_sort)
   (void)cvc5_mk_bag_sort(d_tm, d_int);
   (void)cvc5_mk_bag_sort(d_tm, cvc5_mk_bv_sort(d_tm, 4));
   (void)cvc5_mk_bag_sort(d_tm, cvc5_mk_bv_sort(d_tm, 4));
-  ASSERT_CVC5_ERROR(cvc5_mk_bag_sort(nullptr, d_bool), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_bag_sort(nullptr, d_bool),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_bag_sort(d_tm, nullptr), "invalid sort");
   Cvc5TermManager* tm = cvc5_term_manager_new();
   ASSERT_CVC5_ERROR(cvc5_mk_bag_sort(d_tm, cvc5_get_boolean_sort(tm)),
-               "sort is not associated with this term manager");
+                    "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -467,11 +489,11 @@ TEST_F(TestCApiBlackTermManager, mk_sequence_sort)
   (void)cvc5_mk_sequence_sort(d_tm, cvc5_mk_bv_sort(d_tm, 4));
   (void)cvc5_mk_sequence_sort(d_tm, cvc5_mk_bv_sort(d_tm, 4));
   ASSERT_CVC5_ERROR(cvc5_mk_sequence_sort(nullptr, d_bool),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_sequence_sort(d_tm, nullptr), "invalid sort");
   Cvc5TermManager* tm = cvc5_term_manager_new();
   ASSERT_CVC5_ERROR(cvc5_mk_sequence_sort(d_tm, cvc5_get_boolean_sort(tm)),
-               "sort is not associated with this term manager");
+                    "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -482,11 +504,11 @@ TEST_F(TestCApiBlackTermManager, mk_abstract_sort)
   (void)cvc5_mk_abstract_sort(d_tm, CVC5_SORT_KIND_TUPLE_SORT);
   (void)cvc5_mk_abstract_sort(d_tm, CVC5_SORT_KIND_SET_SORT);
   ASSERT_CVC5_ERROR(cvc5_mk_abstract_sort(nullptr, CVC5_SORT_KIND_SET_SORT),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_abstract_sort(d_tm, CVC5_SORT_KIND_BOOLEAN_SORT),
-               "cannot construct abstract type");
+                    "cannot construct abstract type");
   ASSERT_CVC5_ERROR(cvc5_mk_abstract_sort(d_tm, static_cast<Cvc5SortKind>(-1)),
-               "cannot construct abstract type");
+                    "cannot construct abstract type");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_uninterpreted_sort)
@@ -494,7 +516,7 @@ TEST_F(TestCApiBlackTermManager, mk_uninterpreted_sort)
   (void)cvc5_mk_uninterpreted_sort(d_tm, "u");
   (void)cvc5_mk_uninterpreted_sort(d_tm, "");
   ASSERT_CVC5_ERROR(cvc5_mk_uninterpreted_sort(nullptr, ""),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_unresolved_dt_sort)
@@ -504,9 +526,9 @@ TEST_F(TestCApiBlackTermManager, mk_unresolved_dt_sort)
   (void)cvc5_mk_unresolved_dt_sort(d_tm, "", 0);
   (void)cvc5_mk_unresolved_dt_sort(d_tm, "", 1);
   ASSERT_CVC5_ERROR(cvc5_mk_unresolved_dt_sort(nullptr, "", 1),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_unresolved_dt_sort(d_tm, nullptr, 1),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_uninterpreted_sort_constructor_sort)
@@ -514,11 +536,12 @@ TEST_F(TestCApiBlackTermManager, mk_uninterpreted_sort_constructor_sort)
   (void)cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 2, "s");
   (void)cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 2, "");
   (void)cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 2, nullptr);
-  ASSERT_CVC5_ERROR(cvc5_mk_uninterpreted_sort_constructor_sort(nullptr, 2, "s"),
-               "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_uninterpreted_sort_constructor_sort(nullptr, 2, "s"),
+      "unexpected NULL argument");
   (void)cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 2, nullptr);
   ASSERT_CVC5_ERROR(cvc5_mk_uninterpreted_sort_constructor_sort(d_tm, 0, ""),
-               "expected an arity > 0");
+                    "expected an arity > 0");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_tuple_sort)
@@ -526,12 +549,12 @@ TEST_F(TestCApiBlackTermManager, mk_tuple_sort)
   std::vector<Cvc5Sort> sorts = {d_int};
   (void)cvc5_mk_tuple_sort(d_tm, sorts.size(), sorts.data());
   ASSERT_CVC5_ERROR(cvc5_mk_tuple_sort(nullptr, sorts.size(), sorts.data()),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_tuple_sort(nullptr, sorts.size(), nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   sorts = {d_int, nullptr};
   ASSERT_CVC5_ERROR(cvc5_mk_tuple_sort(d_tm, sorts.size(), sorts.data()),
-               "invalid sort at index 1");
+                    "invalid sort at index 1");
   sorts = {cvc5_mk_uninterpreted_sort(d_tm, "u"), d_int};
   Cvc5Sort funsort = cvc5_mk_tuple_sort(d_tm, sorts.size(), sorts.data());
   sorts = {d_int, funsort};
@@ -542,7 +565,7 @@ TEST_F(TestCApiBlackTermManager, mk_tuple_sort)
   Cvc5TermManager* tm = cvc5_term_manager_new();
   sorts = {cvc5_get_boolean_sort(tm)};
   ASSERT_CVC5_ERROR(cvc5_mk_tuple_sort(d_tm, sorts.size(), sorts.data()),
-               "expected a sort associated with this term manager");
+                    "expected a sort associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -552,11 +575,11 @@ TEST_F(TestCApiBlackTermManager, mk_nullable_sort)
   (void)cvc5_mk_nullable_sort(d_tm, d_int);
 
   ASSERT_CVC5_ERROR(cvc5_mk_nullable_sort(nullptr, d_int),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_nullable_sort(d_tm, nullptr), "invalid sort");
   Cvc5TermManager* tm = cvc5_term_manager_new();
   ASSERT_CVC5_ERROR(cvc5_mk_nullable_sort(tm, d_int),
-               "sort is not associated with this term manager");
+                    "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -571,31 +594,34 @@ TEST_F(TestCApiBlackTermManager, mk_bv)
   (void)cvc5_mk_bv(d_tm, 8, "a0", 16);
 
   ASSERT_CVC5_ERROR(cvc5_mk_bv(nullptr, 8, "-1111111", 2),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 
   ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 0, "-127", 10),
-               "invalid argument '0' for 'size'");
+                    "invalid argument '0' for 'size'");
   ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 0, "a0", 16),
-               "invalid argument '0' for 'size'");
+                    "invalid argument '0' for 'size'");
 
   ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "", 2), "expected a non-empty string");
 
-  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "101", 5), "expected base 2, 10, or 16");
-  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "128", 11), "expected base 2, 10, or 16");
-  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "a0", 21), "expected base 2, 10, or 16");
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "101", 5),
+                    "expected base 2, 10, or 16");
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "128", 11),
+                    "expected base 2, 10, or 16");
+  ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "a0", 21),
+                    "expected base 2, 10, or 16");
 
   ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "-11111111", 2),
-               "overflow in bit-vector construction");
+                    "overflow in bit-vector construction");
   ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "101010101", 2),
-               "overflow in bit-vector construction");
+                    "overflow in bit-vector construction");
   ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "-256", 10),
-               "overflow in bit-vector construction");
+                    "overflow in bit-vector construction");
   ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "257", 10),
-               "overflow in bit-vector construction");
+                    "overflow in bit-vector construction");
   ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "-a0", 16),
-               "overflow in bit-vector construction");
+                    "overflow in bit-vector construction");
   ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "fffff", 16),
-               "overflow in bit-vector construction");
+                    "overflow in bit-vector construction");
 
   ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "10201010", 2), "");
   ASSERT_CVC5_ERROR(cvc5_mk_bv(d_tm, 8, "-25x", 10), "");
@@ -617,9 +643,10 @@ TEST_F(TestCApiBlackTermManager, mk_bv_uint64)
 {
   (void)cvc5_mk_bv_uint64(d_tm, 8, 2);
   (void)cvc5_mk_bv_uint64(d_tm, 32, 2);
-  ASSERT_CVC5_ERROR(cvc5_mk_bv_uint64(nullptr, 0, 2), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_bv_uint64(nullptr, 0, 2),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_bv_uint64(d_tm, 0, 2),
-               "invalid argument '0' for 'size'");
+                    "invalid argument '0' for 'size'");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_ff_elem)
@@ -634,10 +661,10 @@ TEST_F(TestCApiBlackTermManager, mk_ff_elem)
   (void)cvc5_mk_ff_elem(d_tm, "-1", ff_sort, 10);
 
   ASSERT_CVC5_ERROR(cvc5_mk_ff_elem(nullptr, "-1", ff_sort, 10),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_ff_elem(d_tm, "a", ff_sort, 10), "");
   ASSERT_CVC5_ERROR(cvc5_mk_ff_elem(d_tm, "-1", bv_sort, 10),
-               "expected a finite field sort");
+                    "expected a finite field sort");
 
   ASSERT_EQ(cvc5_mk_ff_elem(d_tm, "-1", ff_sort, 10),
             cvc5_mk_ff_elem(d_tm, "6", ff_sort, 10));
@@ -667,22 +694,24 @@ TEST_F(TestCApiBlackTermManager, mk_const_array)
   (void)cvc5_mk_const_array(d_tm, arr_sort, zero);
 
   ASSERT_CVC5_ERROR(cvc5_mk_const_array(nullptr, arr_sort, zero),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_const_array(d_tm, nullptr, zero), "invalid sort");
-  ASSERT_CVC5_ERROR(cvc5_mk_const_array(d_tm, arr_sort, nullptr), "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_mk_const_array(d_tm, arr_sort, nullptr),
+                    "invalid term");
   ASSERT_CVC5_ERROR(
       cvc5_mk_const_array(d_tm, arr_sort, cvc5_mk_bv_uint64(d_tm, 1, 1)),
       "value does not match element sort");
   ASSERT_CVC5_ERROR(cvc5_mk_const_array(d_tm, d_int, zero),
-               "expected an array sort");
+                    "expected an array sort");
 
   Cvc5Sort arr_sort2 = cvc5_mk_array_sort(d_tm, d_int, d_int);
   Cvc5Term zero2 = cvc5_mk_integer_int64(d_tm, 0);
   (void)cvc5_mk_const_array(d_tm, arr_sort2, zero);
   (void)cvc5_mk_const_array(d_tm, arr_sort, zero2);
   Cvc5TermManager* tm = cvc5_term_manager_new();
-  ASSERT_CVC5_ERROR(cvc5_mk_const_array(tm, arr_sort, cvc5_mk_integer_int64(tm, 0)),
-               "sort is not associated with this term manager");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_const_array(tm, arr_sort, cvc5_mk_integer_int64(tm, 0)),
+      "sort is not associated with this term manager");
   ASSERT_CVC5_ERROR(
       cvc5_mk_const_array(
           tm,
@@ -703,11 +732,12 @@ TEST_F(TestCApiBlackTermManager, mk_var)
   (void)cvc5_mk_var(d_tm, d_bool, "b");
   (void)cvc5_mk_var(d_tm, fun_sort, "");
 
-  ASSERT_CVC5_ERROR(cvc5_mk_var(nullptr, d_bool, ""), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_var(nullptr, d_bool, ""),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_var(d_tm, nullptr, ""), "invalid sort");
   Cvc5TermManager* tm = cvc5_term_manager_new();
   ASSERT_CVC5_ERROR(cvc5_mk_var(tm, d_bool, "b"),
-               "sort is not associated with this term manager");
+                    "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -735,7 +765,7 @@ TEST_F(TestCApiBlackTermManager, mk_rm)
       cvc5_term_to_string(cvc5_mk_rm(d_tm, CVC5_RM_ROUND_NEAREST_TIES_TO_AWAY)),
       std::string("roundNearestTiesToAway"));
   ASSERT_CVC5_ERROR(cvc5_mk_rm(nullptr, CVC5_RM_ROUND_TOWARD_ZERO),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_fp)
@@ -748,10 +778,12 @@ TEST_F(TestCApiBlackTermManager, mk_fp)
   ASSERT_CVC5_ERROR(cvc5_mk_fp(d_tm, 3, 5, nullptr), "invalid term");
   ASSERT_CVC5_ERROR(cvc5_mk_fp(d_tm, 0, 5, t1), "expected exponent size > 1");
   ASSERT_CVC5_ERROR(cvc5_mk_fp(d_tm, 1, 5, t1), "expected exponent size > 1");
-  ASSERT_CVC5_ERROR(cvc5_mk_fp(d_tm, 3, 0, t1), "expected significand size > 1");
-  ASSERT_CVC5_ERROR(cvc5_mk_fp(d_tm, 3, 1, t1), "expected significand size > 1");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp(d_tm, 3, 0, t1),
+                    "expected significand size > 1");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp(d_tm, 3, 1, t1),
+                    "expected significand size > 1");
   ASSERT_CVC5_ERROR(cvc5_mk_fp(d_tm, 3, 5, t2),
-               "expected a bit-vector value with bit-width '8'");
+                    "expected a bit-vector value with bit-width '8'");
 
   Cvc5Term sign = cvc5_mk_bv_uint64(d_tm, 1, 0);
   Cvc5Term exp = cvc5_mk_bv_uint64(d_tm, 5, 0);
@@ -760,10 +792,13 @@ TEST_F(TestCApiBlackTermManager, mk_fp)
             cvc5_mk_fp(d_tm, 5, 11, cvc5_mk_bv_uint64(d_tm, 16, 0)));
 
   ASSERT_CVC5_ERROR(cvc5_mk_fp_from_ieee(nullptr, sign, exp, sig),
-               "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_mk_fp_from_ieee(d_tm, nullptr, exp, sig), "invalid term");
-  ASSERT_CVC5_ERROR(cvc5_mk_fp_from_ieee(d_tm, sign, nullptr, sig), "invalid term");
-  ASSERT_CVC5_ERROR(cvc5_mk_fp_from_ieee(d_tm, sign, exp, nullptr), "invalid term");
+                    "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_from_ieee(d_tm, nullptr, exp, sig),
+                    "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_from_ieee(d_tm, sign, nullptr, sig),
+                    "invalid term");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_from_ieee(d_tm, sign, exp, nullptr),
+                    "invalid term");
   ASSERT_CVC5_ERROR(
       cvc5_mk_fp_from_ieee(
           d_tm, cvc5_mk_const(d_tm, cvc5_mk_bv_sort(d_tm, 1), ""), exp, sig),
@@ -782,7 +817,7 @@ TEST_F(TestCApiBlackTermManager, mk_fp)
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   ASSERT_CVC5_ERROR(cvc5_mk_fp(tm, 3, 5, t1),
-               "term is not associated with this term manager");
+                    "term is not associated with this term manager");
   ASSERT_CVC5_ERROR(
       cvc5_mk_fp_from_ieee(
           tm, sign, cvc5_mk_bv_uint64(tm, 5, 0), cvc5_mk_bv_uint64(tm, 10, 0)),
@@ -803,17 +838,17 @@ TEST_F(TestCApiBlackTermManager, mk_cardinality_constraint)
   Cvc5Sort unsort = cvc5_mk_uninterpreted_sort(d_tm, "u");
   (void)cvc5_mk_cardinality_constraint(d_tm, unsort, 3);
   ASSERT_CVC5_ERROR(cvc5_mk_cardinality_constraint(nullptr, unsort, 3),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_cardinality_constraint(d_tm, nullptr, 3),
-               "invalid sort");
+                    "invalid sort");
   ASSERT_CVC5_ERROR(cvc5_mk_cardinality_constraint(d_tm, d_int, 3),
-               "expected an uninterpreted sort");
+                    "expected an uninterpreted sort");
   ASSERT_CVC5_ERROR(cvc5_mk_cardinality_constraint(d_tm, unsort, 0),
-               "expected a value > 0");
+                    "expected a value > 0");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   ASSERT_CVC5_ERROR(cvc5_mk_cardinality_constraint(tm, unsort, 3),
-               "sort is not associated with this term manager");
+                    "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -821,14 +856,15 @@ TEST_F(TestCApiBlackTermManager, mk_empty_set)
 {
   Cvc5Sort sort = cvc5_mk_set_sort(d_tm, d_bool);
   (void)cvc5_mk_empty_set(d_tm, sort);
-  ASSERT_CVC5_ERROR(cvc5_mk_empty_set(nullptr, sort), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_empty_set(nullptr, sort),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_empty_set(d_tm, nullptr), "invalid sort");
   ASSERT_CVC5_ERROR(cvc5_mk_empty_set(d_tm, d_bool),
-               "expected null sort or set sort");
+                    "expected null sort or set sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   ASSERT_CVC5_ERROR(cvc5_mk_empty_set(tm, sort),
-               "sort is not associated with this term manager");
+                    "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -836,14 +872,15 @@ TEST_F(TestCApiBlackTermManager, mk_empty_bag)
 {
   Cvc5Sort sort = cvc5_mk_bag_sort(d_tm, d_bool);
   (void)cvc5_mk_empty_bag(d_tm, sort);
-  ASSERT_CVC5_ERROR(cvc5_mk_empty_bag(nullptr, sort), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_empty_bag(nullptr, sort),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_empty_bag(d_tm, nullptr), "invalid sort");
   ASSERT_CVC5_ERROR(cvc5_mk_empty_bag(d_tm, d_bool),
-               "expected null sort or bag sort");
+                    "expected null sort or bag sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   ASSERT_CVC5_ERROR(cvc5_mk_empty_bag(tm, sort),
-               "sort is not associated with this term manager");
+                    "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -853,12 +890,12 @@ TEST_F(TestCApiBlackTermManager, mk_empty_sequence)
   (void)cvc5_mk_empty_sequence(d_tm, sort);
   (void)cvc5_mk_empty_sequence(d_tm, d_bool);
   ASSERT_CVC5_ERROR(cvc5_mk_empty_sequence(nullptr, sort),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_empty_sequence(d_tm, nullptr), "invalid sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   ASSERT_CVC5_ERROR(cvc5_mk_empty_sequence(tm, sort),
-               "sort is not associated with this term manager");
+                    "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -873,36 +910,41 @@ TEST_F(TestCApiBlackTermManager, mk_fp_nan)
 TEST_F(TestCApiBlackTermManager, mk_fp_neg_zero)
 {
   (void)cvc5_mk_fp_neg_zero(d_tm, 3, 5);
-  ASSERT_CVC5_ERROR(cvc5_mk_fp_neg_zero(nullptr, 3, 5), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_neg_zero(nullptr, 3, 5),
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_fp_pos_zero)
 {
   (void)cvc5_mk_fp_pos_zero(d_tm, 3, 5);
-  ASSERT_CVC5_ERROR(cvc5_mk_fp_pos_zero(nullptr, 3, 5), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_pos_zero(nullptr, 3, 5),
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_fp_neg_inf)
 {
   (void)cvc5_mk_fp_neg_inf(d_tm, 3, 5);
-  ASSERT_CVC5_ERROR(cvc5_mk_fp_neg_inf(nullptr, 3, 5), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_neg_inf(nullptr, 3, 5),
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_fp_pos_inf)
 {
   (void)cvc5_mk_fp_pos_inf(d_tm, 3, 5);
-  ASSERT_CVC5_ERROR(cvc5_mk_fp_pos_inf(nullptr, 3, 5), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_fp_pos_inf(nullptr, 3, 5),
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_op)
 {
   (void)cvc5_mk_op_from_str(d_tm, CVC5_KIND_DIVISIBLE, "2147483648");
-  ASSERT_CVC5_ERROR(cvc5_mk_op_from_str(nullptr, CVC5_KIND_DIVISIBLE, "2147483648"),
-               "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_op_from_str(nullptr, CVC5_KIND_DIVISIBLE, "2147483648"),
+      "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_op_from_str(d_tm, CVC5_KIND_DIVISIBLE, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_op_from_str(d_tm, CVC5_KIND_BITVECTOR_EXTRACT, "1"),
-               "expected DIVISIBLE");
+                    "expected DIVISIBLE");
 
   std::vector<uint32_t> idxs = {1};
   (void)cvc5_mk_op(d_tm, CVC5_KIND_DIVISIBLE, 1, idxs.data());
@@ -911,15 +953,17 @@ TEST_F(TestCApiBlackTermManager, mk_op)
   ASSERT_CVC5_ERROR(
       cvc5_mk_op(nullptr, CVC5_KIND_BITVECTOR_ROTATE_RIGHT, 1, idxs.data()),
       "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_ROTATE_RIGHT, 1, nullptr),
-               "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_EXTRACT, 1, idxs.data()),
-               "expected 2 but got 1");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_ROTATE_RIGHT, 1, nullptr),
+      "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_EXTRACT, 1, idxs.data()),
+      "expected 2 but got 1");
 
   idxs = {1, 1};
   (void)cvc5_mk_op(d_tm, CVC5_KIND_BITVECTOR_EXTRACT, 2, idxs.data());
   ASSERT_CVC5_ERROR(cvc5_mk_op(d_tm, CVC5_KIND_DIVISIBLE, 2, idxs.data()),
-               "expected 1 but got 2");
+                    "expected 1 but got 2");
 
   idxs = {1, 2, 2};
   (void)cvc5_mk_op(d_tm, CVC5_KIND_TUPLE_PROJECT, 3, idxs.data());
@@ -934,7 +978,8 @@ TEST_F(TestCApiBlackTermManager, mk_pi)
 TEST_F(TestCApiBlackTermManager, mk_integer)
 {
   (void)cvc5_mk_integer(d_tm, "123");
-  ASSERT_CVC5_ERROR(cvc5_mk_integer(nullptr, "123"), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_integer(nullptr, "123"),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, nullptr), "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "1.23"), "expected an integer");
   ASSERT_CVC5_ERROR(cvc5_mk_integer(d_tm, "1/23"), "expected an integer");
@@ -986,8 +1031,10 @@ TEST_F(TestCApiBlackTermManager, mkReal)
   (void)cvc5_mk_real_num_den(d_tm, 1, -1);
   (void)cvc5_mk_real_num_den(d_tm, -1, 1);
   (void)cvc5_mk_real_num_den(d_tm, 0, 1);
-  ASSERT_CVC5_ERROR(cvc5_mk_real_num_den(nullptr, 1, 1), "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_mk_real_num_den(d_tm, 1, 0), "invalid denominator '0'");
+  ASSERT_CVC5_ERROR(cvc5_mk_real_num_den(nullptr, 1, 1),
+                    "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_real_num_den(d_tm, 1, 0),
+                    "invalid denominator '0'");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_regexp_all)
@@ -1005,7 +1052,8 @@ TEST_F(TestCApiBlackTermManager, mk_regexp_allchar)
   Cvc5Term s = cvc5_mk_const(d_tm, sort, "s");
   std::vector<Cvc5Term> args = {s, cvc5_mk_regexp_allchar(d_tm)};
   (void)cvc5_mk_term(d_tm, CVC5_KIND_STRING_IN_REGEXP, 2, args.data());
-  ASSERT_CVC5_ERROR(cvc5_mk_regexp_allchar(nullptr), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_regexp_allchar(nullptr),
+                    "unexpected NULL argument");
 }
 
 TEST_F(TestCApiBlackTermManager, mk_regexp_none)
@@ -1027,12 +1075,13 @@ TEST_F(TestCApiBlackTermManager, mk_sep_nil)
 {
   (void)cvc5_mk_sep_nil(d_tm, d_bool);
   (void)cvc5_mk_sep_nil(d_tm, d_int);
-  ASSERT_CVC5_ERROR(cvc5_mk_sep_nil(nullptr, d_bool), "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(cvc5_mk_sep_nil(nullptr, d_bool),
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_sep_nil(d_tm, nullptr), "invalid sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   ASSERT_CVC5_ERROR(cvc5_mk_sep_nil(tm, d_bool),
-               "sort is not associated with this term manager");
+                    "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -1089,15 +1138,16 @@ TEST_F(TestCApiBlackTermManager, mk_term)
       args.data());
 
   ASSERT_CVC5_ERROR(cvc5_mk_term(nullptr, CVC5_KIND_PI, 0, args.data()),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_PI, 1, nullptr),
-               "unexpected NULL argument for 'children'");
+                    "unexpected NULL argument for 'children'");
   ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_PI, 1, {}),
-               "unexpected NULL argument for 'children'");
+                    "unexpected NULL argument for 'children'");
   ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_PI, 1, args.data()),
-               "unexpected NULL argument for 'children'");
-  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_CONST_BITVECTOR, 0, args.data()),
-               "invalid kind");
+                    "unexpected NULL argument for 'children'");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_term(d_tm, CVC5_KIND_CONST_BITVECTOR, 0, args.data()),
+      "invalid kind");
 
   args = {cvc5_mk_true(d_tm)};
   (void)cvc5_mk_term(d_tm, CVC5_KIND_NOT, 1, args.data());
@@ -1112,10 +1162,10 @@ TEST_F(TestCApiBlackTermManager, mk_term)
       args.data());
   args = {nullptr};
   ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_NOT, 1, args.data()),
-               "invalid term at index 0");
+                    "invalid term at index 0");
   args = {a};
   ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_NOT, 1, args.data()),
-               "expecting a Boolean");
+                    "expecting a Boolean");
 
   args = {a, b};
   (void)cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, 2, args.data());
@@ -1127,18 +1177,18 @@ TEST_F(TestCApiBlackTermManager, mk_term)
       d_tm, cvc5_mk_op(d_tm, CVC5_KIND_EQUAL, 0, idxs.data()), 2, args.data());
 
   ASSERT_CVC5_ERROR(cvc5_mk_term(nullptr, CVC5_KIND_EQUAL, 2, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_term(nullptr, CVC5_KIND_EQUAL, 2, {}),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   args = {nullptr, b};
   ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, 2, args.data()),
-               "invalid term at index 0");
+                    "invalid term at index 0");
   args = {a, nullptr};
   ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, 2, args.data()),
-               "invalid term at index 1");
+                    "invalid term at index 1");
   args = {a, cvc5_mk_true(d_tm)};
   ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_EQUAL, 2, args.data()),
-               "Subexpressions must have the same type");
+                    "Subexpressions must have the same type");
 
   args = {cvc5_mk_true(d_tm), cvc5_mk_true(d_tm), cvc5_mk_true(d_tm)};
   (void)cvc5_mk_term(d_tm, CVC5_KIND_ITE, 3, args.data());
@@ -1146,19 +1196,19 @@ TEST_F(TestCApiBlackTermManager, mk_term)
       d_tm, cvc5_mk_op(d_tm, CVC5_KIND_ITE, 0, idxs.data()), 3, args.data());
   args = {nullptr, cvc5_mk_true(d_tm), cvc5_mk_true(d_tm)};
   ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_ITE, 3, args.data()),
-               "invalid term at index 0");
+                    "invalid term at index 0");
   args = {cvc5_mk_true(d_tm), nullptr, cvc5_mk_true(d_tm)};
   ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_ITE, 3, args.data()),
-               "invalid term at index 1");
+                    "invalid term at index 1");
   args = {cvc5_mk_true(d_tm), cvc5_mk_true(d_tm), nullptr};
   ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_ITE, 3, args.data()),
-               "invalid term at index 2");
+                    "invalid term at index 2");
   args = {a, cvc5_mk_true(d_tm), cvc5_mk_true(d_tm)};
   ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_ITE, 3, args.data()),
-               "condition of ITE is not Boolean");
+                    "condition of ITE is not Boolean");
   args = {cvc5_mk_true(d_tm), cvc5_mk_true(d_tm), b};
   ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_ITE, 3, args.data()),
-               "Branches of the ITE must have comparable type");
+                    "Branches of the ITE must have comparable type");
 
   // Test cases that are nary via the API but have arity = 2 internally
   Cvc5Term t_bool = cvc5_mk_const(d_tm, d_bool, "t_bool");
@@ -1228,22 +1278,22 @@ TEST_F(TestCApiBlackTermManager, mk_term)
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   ASSERT_CVC5_ERROR(cvc5_mk_sep_nil(tm, d_bool),
-               "sort is not associated with this term manager");
+                    "sort is not associated with this term manager");
   args = {t_bool,
           cvc5_mk_const(tm, cvc5_get_boolean_sort(tm), ""),
           cvc5_mk_const(tm, cvc5_get_boolean_sort(tm), "")};
   ASSERT_CVC5_ERROR(cvc5_mk_term(tm, CVC5_KIND_IMPLIES, 3, args.data()),
-               "expected a term associated with this term manager");
+                    "expected a term associated with this term manager");
   args = {cvc5_mk_const(tm, cvc5_get_boolean_sort(tm), ""),
           t_bool,
           cvc5_mk_const(tm, cvc5_get_boolean_sort(tm), "")};
   ASSERT_CVC5_ERROR(cvc5_mk_term(tm, CVC5_KIND_IMPLIES, 3, args.data()),
-               "expected a term associated with this term manager");
+                    "expected a term associated with this term manager");
   args = {cvc5_mk_const(tm, cvc5_get_boolean_sort(tm), ""),
           cvc5_mk_const(tm, cvc5_get_boolean_sort(tm), ""),
           t_bool};
   ASSERT_CVC5_ERROR(cvc5_mk_term(tm, CVC5_KIND_IMPLIES, 3, args.data()),
-               "expected a term associated with this term manager");
+                    "expected a term associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -1261,10 +1311,11 @@ TEST_F(TestCApiBlackTermManager, mk_term_from_op)
   idxs = {1};
   Cvc5Op op2 = cvc5_mk_op(d_tm, CVC5_KIND_DIVISIBLE, 1, idxs.data());
 
-  ASSERT_CVC5_ERROR(cvc5_mk_op(nullptr, CVC5_KIND_BITVECTOR_EXTRACT, 2, idxs.data()),
-               "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_op(nullptr, CVC5_KIND_BITVECTOR_EXTRACT, 2, idxs.data()),
+      "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_op(nullptr, CVC5_KIND_BITVECTOR_EXTRACT, 2, {}),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 
   // list datatype
   Cvc5Sort sort = cvc5_mk_param_sort(d_tm, "T");
@@ -1296,17 +1347,17 @@ TEST_F(TestCApiBlackTermManager, mk_term_from_op)
   // mk_term(_from_op)
   std::vector<Cvc5Term> args = {nil_term};
   (void)cvc5_mk_term(d_tm, CVC5_KIND_APPLY_CONSTRUCTOR, 1, args.data());
-  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_APPLY_SELECTOR, 1, args.data()),
-               "");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_term(d_tm, CVC5_KIND_APPLY_SELECTOR, 1, args.data()), "");
   args = {cons_term};
-  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_APPLY_SELECTOR, 1, args.data()),
-               "");
-  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_APPLY_CONSTRUCTOR, 1, args.data()),
-               "");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_term(d_tm, CVC5_KIND_APPLY_SELECTOR, 1, args.data()), "");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_term(d_tm, CVC5_KIND_APPLY_CONSTRUCTOR, 1, args.data()), "");
 
   args = {head_term};
-  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_APPLY_SELECTOR, 1, args.data()),
-               "");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_term(d_tm, CVC5_KIND_APPLY_SELECTOR, 1, args.data()), "");
 
   args = {head_term, c};
   (void)cvc5_mk_term(d_tm, CVC5_KIND_APPLY_SELECTOR, 2, args.data());
@@ -1324,8 +1375,8 @@ TEST_F(TestCApiBlackTermManager, mk_term_from_op)
   ASSERT_CVC5_ERROR(cvc5_mk_term_from_op(d_tm, op1, 1, args.data()), "");
 
   args = {cons_term, cvc5_mk_integer_int64(d_tm, 0)};
-  ASSERT_CVC5_ERROR(cvc5_mk_term(d_tm, CVC5_KIND_APPLY_CONSTRUCTOR, 2, args.data()),
-               "");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_term(d_tm, CVC5_KIND_APPLY_CONSTRUCTOR, 2, args.data()), "");
   args = {nil_term};
   args = {cons_term,
           cvc5_mk_integer_int64(d_tm, 0),
@@ -1353,7 +1404,7 @@ TEST_F(TestCApiBlackTermManager, mk_term_from_op)
   Cvc5TermManager* tm = cvc5_term_manager_new();
   args = {cvc5_mk_integer_int64(tm, 1)};
   ASSERT_CVC5_ERROR(cvc5_mk_term_from_op(tm, op2, 1, args.data()),
-               "operator is not associated with this term manager");
+                    "operator is not associated with this term manager");
   idxs = {1};
   (void)cvc5_mk_term_from_op(
       tm, cvc5_mk_op(tm, CVC5_KIND_DIVISIBLE, 1, idxs.data()), 1, args.data());
@@ -1375,12 +1426,12 @@ TEST_F(TestCApiBlackTermManager, mk_tuple)
   args = {cvc5_mk_real(d_tm, "5.3")};
   (void)cvc5_mk_tuple(d_tm, 1, args.data());
   ASSERT_CVC5_ERROR(cvc5_mk_tuple(nullptr, 1, args.data()),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_tuple(nullptr, 0, {}), "unexpected NULL argument");
   Cvc5TermManager* tm = cvc5_term_manager_new();
   args = {cvc5_mk_bv(d_tm, 3, "101", 2)};
   ASSERT_CVC5_ERROR(cvc5_mk_tuple(tm, 1, args.data()),
-               "expected a term associated with this term manager");
+                    "expected a term associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -1390,12 +1441,12 @@ TEST_F(TestCApiBlackTermManager, mk_nullable_some)
   (void)cvc5_mk_nullable_some(d_tm, cvc5_mk_integer(d_tm, "5"));
   (void)cvc5_mk_nullable_some(d_tm, cvc5_mk_real(d_tm, "5.3"));
   ASSERT_CVC5_ERROR(cvc5_mk_nullable_some(nullptr, cvc5_mk_real(d_tm, "5.3")),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_nullable_some(d_tm, nullptr), "invalid term");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   ASSERT_CVC5_ERROR(cvc5_mk_nullable_some(tm, cvc5_mk_bv(d_tm, 3, "101", 2)),
-               "term is not associated with this term manager");
+                    "term is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -1479,12 +1530,12 @@ TEST_F(TestCApiBlackTermManager, mk_nullable_null)
   cvc5_delete(solver);
 
   ASSERT_CVC5_ERROR(cvc5_mk_nullable_null(nullptr, sort),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_nullable_null(d_tm, nullptr), "invalid sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   ASSERT_CVC5_ERROR(cvc5_mk_nullable_null(tm, sort),
-               "sort is not associated with this term manager");
+                    "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -1500,14 +1551,15 @@ TEST_F(TestCApiBlackTermManager, mk_nullable_lift)
   cvc5_delete(solver);
 
   ASSERT_EQ(3, cvc5_term_get_int64_value(three));
-  ASSERT_CVC5_ERROR(cvc5_mk_nullable_lift(nullptr, CVC5_KIND_ADD, 2, args.data()),
-               "unexpected NULL argument");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_nullable_lift(nullptr, CVC5_KIND_ADD, 2, args.data()),
+      "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_nullable_lift(d_tm, CVC5_KIND_ADD, 0, {}),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   ASSERT_CVC5_ERROR(cvc5_mk_nullable_lift(tm, CVC5_KIND_ADD, 2, args.data()),
-               "expected a term associated with this term manager");
+                    "expected a term associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -1515,12 +1567,12 @@ TEST_F(TestCApiBlackTermManager, mk_universe_set)
 {
   (void)cvc5_mk_universe_set(d_tm, d_bool);
   ASSERT_CVC5_ERROR(cvc5_mk_universe_set(nullptr, d_bool),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_universe_set(d_tm, nullptr), "invalid sort");
 
   Cvc5TermManager* tm = cvc5_term_manager_new();
   ASSERT_CVC5_ERROR(cvc5_mk_universe_set(tm, d_bool),
-               "sort is not associated with this term manager");
+                    "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -1535,11 +1587,11 @@ TEST_F(TestCApiBlackTermManager, mk_const)
   (void)cvc5_mk_const(d_tm, fun_sort, "f");
   (void)cvc5_mk_const(d_tm, fun_sort, "");
   ASSERT_CVC5_ERROR(cvc5_mk_const(nullptr, d_bool, nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
   ASSERT_CVC5_ERROR(cvc5_mk_const(d_tm, nullptr, nullptr), "invalid sort");
   Cvc5TermManager* tm = cvc5_term_manager_new();
   ASSERT_CVC5_ERROR(cvc5_mk_const(tm, d_bool, nullptr),
-               "sort is not associated with this term manager");
+                    "sort is not associated with this term manager");
   cvc5_term_manager_delete(tm);
 }
 
@@ -1574,8 +1626,9 @@ TEST_F(TestCApiBlackTermManager, mk_skolem)
       cvc5_mk_skolem(
           nullptr, CVC5_SKOLEM_ID_ARRAY_DEQ_DIFF, idxs.size(), idxs.data()),
       "unexpected NULL argument");
-  ASSERT_CVC5_ERROR(cvc5_mk_skolem(d_tm, CVC5_SKOLEM_ID_ARRAY_DEQ_DIFF, 0, nullptr),
-               "invalid number of indices");
+  ASSERT_CVC5_ERROR(
+      cvc5_mk_skolem(d_tm, CVC5_SKOLEM_ID_ARRAY_DEQ_DIFF, 0, nullptr),
+      "invalid number of indices");
 }
 
 TEST_F(TestCApiBlackTermManager, get_num_idxs_for_skolem_id)
@@ -1590,7 +1643,7 @@ TEST_F(TestCApiBlackTermManager, get_num_idxs_for_skolem_id)
 TEST_F(TestCApiBlackTermManager, get_statistics)
 {
   ASSERT_CVC5_ERROR(cvc5_term_manager_get_statistics(nullptr),
-               "unexpected NULL argument");
+                    "unexpected NULL argument");
 
   // do some array reasoning to make sure we have a double statistics
   Cvc5* solver = cvc5_new(d_tm);

--- a/test/unit/api/c/capi_types_black.cpp
+++ b/test/unit/api/c/capi_types_black.cpp
@@ -16,6 +16,7 @@
 
 #include "base/output.h"
 #include "gtest/gtest.h"
+#include "test_capi.h"
 
 namespace cvc5::internal {
 
@@ -27,31 +28,31 @@ class TestCApiBlackTypes : public ::testing::Test
 
 TEST_F(TestCApiBlackTypes, printEnum)
 {
-  ASSERT_DEATH(cvc5_kind_to_string(static_cast<Cvc5Kind>(-5)),
+  ASSERT_CVC5_ERROR(cvc5_kind_to_string(static_cast<Cvc5Kind>(-5)),
                "invalid term kind");
-  ASSERT_DEATH(cvc5_sort_kind_to_string(static_cast<Cvc5SortKind>(-5)),
+  ASSERT_CVC5_ERROR(cvc5_sort_kind_to_string(static_cast<Cvc5SortKind>(-5)),
                "invalid sort kind");
-  ASSERT_DEATH(cvc5_rm_to_string(static_cast<Cvc5RoundingMode>(-5)),
+  ASSERT_CVC5_ERROR(cvc5_rm_to_string(static_cast<Cvc5RoundingMode>(-5)),
                "invalid rounding mode");
-  ASSERT_DEATH(cvc5_unknown_explanation_to_string(
+  ASSERT_CVC5_ERROR(cvc5_unknown_explanation_to_string(
                    static_cast<Cvc5UnknownExplanation>(-5)),
                "invalid unknown explanation kind");
-  ASSERT_DEATH(cvc5_modes_block_models_mode_to_string(
+  ASSERT_CVC5_ERROR(cvc5_modes_block_models_mode_to_string(
                    static_cast<Cvc5BlockModelsMode>(-5)),
                "invalid block models mode");
-  ASSERT_DEATH(cvc5_modes_find_synth_target_to_string(
+  ASSERT_CVC5_ERROR(cvc5_modes_find_synth_target_to_string(
                    static_cast<Cvc5FindSynthTarget>(-5)),
                "invalid find synthesis target");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_modes_input_language_to_string(static_cast<Cvc5InputLanguage>(-5)),
       "invalid input language");
-  ASSERT_DEATH(cvc5_modes_learned_lit_type_to_string(
+  ASSERT_CVC5_ERROR(cvc5_modes_learned_lit_type_to_string(
                    static_cast<Cvc5LearnedLitType>(-5)),
                "invalid learned literal type");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_modes_proof_component_to_string(static_cast<Cvc5ProofComponent>(-5)),
       "invalid proof component kind");
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_modes_proof_format_to_string(static_cast<Cvc5ProofFormat>(-5)),
       "invalid proof format");
   std::string expected =
@@ -79,7 +80,7 @@ TEST_F(TestCApiBlackTypes, printEnum)
 
 TEST_F(TestCApiBlackTypes, option_category_to_string)
 {
-  ASSERT_DEATH(
+  ASSERT_CVC5_ERROR(
       cvc5_modes_option_category_to_string(static_cast<Cvc5OptionCategory>(-5)),
       "invalid option category");
 

--- a/test/unit/api/c/capi_types_black.cpp
+++ b/test/unit/api/c/capi_types_black.cpp
@@ -29,26 +29,26 @@ class TestCApiBlackTypes : public ::testing::Test
 TEST_F(TestCApiBlackTypes, printEnum)
 {
   ASSERT_CVC5_ERROR(cvc5_kind_to_string(static_cast<Cvc5Kind>(-5)),
-               "invalid term kind");
+                    "invalid term kind");
   ASSERT_CVC5_ERROR(cvc5_sort_kind_to_string(static_cast<Cvc5SortKind>(-5)),
-               "invalid sort kind");
+                    "invalid sort kind");
   ASSERT_CVC5_ERROR(cvc5_rm_to_string(static_cast<Cvc5RoundingMode>(-5)),
-               "invalid rounding mode");
+                    "invalid rounding mode");
   ASSERT_CVC5_ERROR(cvc5_unknown_explanation_to_string(
-                   static_cast<Cvc5UnknownExplanation>(-5)),
-               "invalid unknown explanation kind");
+                        static_cast<Cvc5UnknownExplanation>(-5)),
+                    "invalid unknown explanation kind");
   ASSERT_CVC5_ERROR(cvc5_modes_block_models_mode_to_string(
-                   static_cast<Cvc5BlockModelsMode>(-5)),
-               "invalid block models mode");
+                        static_cast<Cvc5BlockModelsMode>(-5)),
+                    "invalid block models mode");
   ASSERT_CVC5_ERROR(cvc5_modes_find_synth_target_to_string(
-                   static_cast<Cvc5FindSynthTarget>(-5)),
-               "invalid find synthesis target");
+                        static_cast<Cvc5FindSynthTarget>(-5)),
+                    "invalid find synthesis target");
   ASSERT_CVC5_ERROR(
       cvc5_modes_input_language_to_string(static_cast<Cvc5InputLanguage>(-5)),
       "invalid input language");
   ASSERT_CVC5_ERROR(cvc5_modes_learned_lit_type_to_string(
-                   static_cast<Cvc5LearnedLitType>(-5)),
-               "invalid learned literal type");
+                        static_cast<Cvc5LearnedLitType>(-5)),
+                    "invalid learned literal type");
   ASSERT_CVC5_ERROR(
       cvc5_modes_proof_component_to_string(static_cast<Cvc5ProofComponent>(-5)),
       "invalid proof component kind");

--- a/test/unit/test_capi.h
+++ b/test/unit/test_capi.h
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2026 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Common header for cvc5 C API unit tests.
+ */
+
+#ifndef CVC5__TEST__UNIT__TEST_CAPI_H
+#define CVC5__TEST__UNIT__TEST_CAPI_H
+
+#include <cvc5/c/cvc5.h>
+
+#include <string>
+
+#include "gtest/gtest.h"
+
+/**
+ * Assert that statement `stmt` triggers a cvc5 C API error whose message
+ * contains the substring `msg`.
+ *
+ * The cvc5 C API does not terminate the process on error. Instead, it records
+ * the error in thread-local state, which can be queried via `cvc5_has_error()`
+ * and `cvc5_get_error_message()`. This macro is the C API counterpart of
+ * gtest's `ASSERT_DEATH`: it runs `stmt` and checks that it set the error
+ * state to a message containing `msg`.
+ */
+#define ASSERT_CVC5_ERROR(stmt, msg)                                        \
+  do                                                                        \
+  {                                                                         \
+    cvc5_reset_error();                                                     \
+    (void)(stmt);                                                           \
+    ASSERT_TRUE(cvc5_has_error())                                           \
+        << "expected an error containing '" << (msg)                        \
+        << "' but no error occurred";                                       \
+    ASSERT_NE(std::string(cvc5_get_error_message()).find(msg),             \
+              std::string::npos)                                            \
+        << "expected error message to contain '" << (msg) << "' but got '"  \
+        << cvc5_get_error_message() << "'";                                 \
+  } while (false)
+
+#endif

--- a/test/unit/test_capi.h
+++ b/test/unit/test_capi.h
@@ -20,26 +20,29 @@
 #include "gtest/gtest.h"
 
 /**
- * Assert that statement `stmt` triggers a cvc5 C API error whose message
+ * Assert that the expression `stmt` triggers a cvc5 C API error whose message
  * contains the substring `msg`.
  *
  * The cvc5 C API does not terminate the process on error. Instead, it records
  * the error in thread-local state, which can be queried via `cvc5_has_error()`
  * and `cvc5_get_error_message()`. This macro is the C API counterpart of
- * gtest's `ASSERT_DEATH`: it runs `stmt` and checks that it set the error
- * state to a message containing `msg`.
+ * gtest's `ASSERT_DEATH`: it evaluates `stmt` and checks that it set the error
+ * state to a message containing `msg`. Both `stmt` and `msg` are evaluated
+ * exactly once.
  */
-#define ASSERT_CVC5_ERROR(stmt, msg)                                           \
-  do                                                                           \
-  {                                                                            \
+#define ASSERT_CVC5_ERROR(stmt, msg)                                          \
+  do                                                                          \
+  {                                                                           \
+    const std::string cvc5_expected_msg{(msg)};                               \
     cvc5_reset_error();                                                        \
-    (void)(stmt);                                                              \
-    ASSERT_TRUE(cvc5_has_error()) << "expected an error containing '" << (msg) \
-                                  << "' but no error occurred";                \
-    ASSERT_NE(std::string(cvc5_get_error_message()).find(msg),                 \
-              std::string::npos)                                               \
-        << "expected error message to contain '" << (msg) << "' but got '"     \
-        << cvc5_get_error_message() << "'";                                    \
+    (void)(stmt);                                                             \
+    const std::string cvc5_actual_msg{cvc5_get_error_message()};              \
+    ASSERT_TRUE(cvc5_has_error())                                             \
+        << "expected an error containing '" << cvc5_expected_msg              \
+        << "' but no error occurred";                                         \
+    ASSERT_NE(cvc5_actual_msg.find(cvc5_expected_msg), std::string::npos)     \
+        << "expected error message to contain '" << cvc5_expected_msg         \
+        << "' but got '" << cvc5_actual_msg << "'";                           \
   } while (false)
 
 #endif

--- a/test/unit/test_capi.h
+++ b/test/unit/test_capi.h
@@ -30,19 +30,19 @@
  * state to a message containing `msg`. Both `stmt` and `msg` are evaluated
  * exactly once.
  */
-#define ASSERT_CVC5_ERROR(stmt, msg)                                          \
-  do                                                                          \
-  {                                                                           \
-    const std::string cvc5_expected_msg{(msg)};                               \
-    cvc5_reset_error();                                                        \
-    (void)(stmt);                                                             \
-    const std::string cvc5_actual_msg{cvc5_get_error_message()};              \
-    ASSERT_TRUE(cvc5_has_error())                                             \
-        << "expected an error containing '" << cvc5_expected_msg              \
-        << "' but no error occurred";                                         \
-    ASSERT_NE(cvc5_actual_msg.find(cvc5_expected_msg), std::string::npos)     \
-        << "expected error message to contain '" << cvc5_expected_msg         \
-        << "' but got '" << cvc5_actual_msg << "'";                           \
+#define ASSERT_CVC5_ERROR(stmt, msg)                                      \
+  do                                                                      \
+  {                                                                       \
+    const std::string cvc5_expected_msg{(msg)};                           \
+    cvc5_reset_error();                                                   \
+    (void)(stmt);                                                         \
+    const std::string cvc5_actual_msg{cvc5_get_error_message()};          \
+    ASSERT_TRUE(cvc5_has_error())                                         \
+        << "expected an error containing '" << cvc5_expected_msg          \
+        << "' but no error occurred";                                     \
+    ASSERT_NE(cvc5_actual_msg.find(cvc5_expected_msg), std::string::npos) \
+        << "expected error message to contain '" << cvc5_expected_msg     \
+        << "' but got '" << cvc5_actual_msg << "'";                       \
   } while (false)
 
 #endif

--- a/test/unit/test_capi.h
+++ b/test/unit/test_capi.h
@@ -29,18 +29,17 @@
  * gtest's `ASSERT_DEATH`: it runs `stmt` and checks that it set the error
  * state to a message containing `msg`.
  */
-#define ASSERT_CVC5_ERROR(stmt, msg)                                        \
-  do                                                                        \
-  {                                                                         \
-    cvc5_reset_error();                                                     \
-    (void)(stmt);                                                           \
-    ASSERT_TRUE(cvc5_has_error())                                           \
-        << "expected an error containing '" << (msg)                        \
-        << "' but no error occurred";                                       \
-    ASSERT_NE(std::string(cvc5_get_error_message()).find(msg),             \
-              std::string::npos)                                            \
-        << "expected error message to contain '" << (msg) << "' but got '"  \
-        << cvc5_get_error_message() << "'";                                 \
+#define ASSERT_CVC5_ERROR(stmt, msg)                                           \
+  do                                                                           \
+  {                                                                            \
+    cvc5_reset_error();                                                        \
+    (void)(stmt);                                                              \
+    ASSERT_TRUE(cvc5_has_error()) << "expected an error containing '" << (msg) \
+                                  << "' but no error occurred";                \
+    ASSERT_NE(std::string(cvc5_get_error_message()).find(msg),                 \
+              std::string::npos)                                               \
+        << "expected error message to contain '" << (msg) << "' but got '"     \
+        << cvc5_get_error_message() << "'";                                    \
   } while (false)
 
 #endif


### PR DESCRIPTION
Previously, the cvc5 C API printed to `stderr` and called `exit(EXIT_FAILURE)`
on any error via `Cvc5CApiAbortStream`, which is too abrupt for a library.

Instead of changing the signature of every C API function to return an error
value, this introduces thread-local state that records whether an error
occurred and the associated message. The `CVC5_CAPI_TRY_CATCH` macros now reset
this state on entry and capture any thrown exception on exit, letting the
function fall through and return its default-initialized value. Callers query
the state via the new `cvc5_has_error()`, `cvc5_get_error_message()`, and
`cvc5_reset_error()` functions.

Removing the process abort exposed latent bugs that were previously masked by
death tests:
- Nine functions ended with `return *size > 0 ? res.data() : nullptr;`, which
  dereferenced `size` after the catch. When the error itself was a NULL `size`,
  the old code exited before the return; these now gate on the error state.
- `cvc5_get_model` dereferenced array elements without a per-element NULL check;
  added `CVC5_CAPI_CHECK_{SORT,TERM}_AT_IDX`.

The `ASSERT_DEATH` unit tests for C API errors are converted to a new
`ASSERT_CVC5_ERROR` helper (`test/unit/test_capi.h`). The single exception is
`declare_oracle_fun_error1`, which hits an uncatchable debug-only internal
cvc5 assertion (`FatalStream`) and remains a death test.

Fixes https://github.com/cvc5/cvc5/issues/12522.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>