### PR TITLE
Fix CoCoALib build with non-GNU coreutils (e.g. Ubuntu 26.04)

### DIFF
--- a/cmake/deps-utils/CoCoALib-0.99800-trace.patch
+++ b/cmake/deps-utils/CoCoALib-0.99800-trace.patch
@@ -66,6 +66,32 @@ index 190dbb4..c8d281f 100755
      /bin/rm -rf "$TMP_DIR"  &&  /bin/mkdir -p "$TMP_DIR"
      if [ $? -ne 0 ]
      then
+@@ -25,22 +25,22 @@ echounderline()
+ echounderline()
+ {
+   echo "$*"
+-  echo "$*" | tr "\040-\377" "[-*]"
++  echo "$*" | tr "\040-\377" "-"
+ }
+
+ echobox()
+ {
+   mesg=">>>>  $*  <<<<"
+-  dashes=`echo "$mesg" | tr "\040-\377" "[-*]"`
++  dashes=`echo "$mesg" | tr "\040-\377" "-"`
+   echo "$dashes"
+   echo "$mesg"
+   echo "$dashes"
+ }
+
+ echoerror()
+ {
+   mesg=">>>>>  $*  <<<<<"
+-  equals=`echo "$mesg" | tr "\040-\377" "[=*]"`
++  equals=`echo "$mesg" | tr "\040-\377" "="`
+   echo "$equals"
+   echo "$mesg"
+   echo "$equals"
 diff --git a/include/CoCoA/TmpGPoly.H b/include/CoCoA/TmpGPoly.H
 index 4c4d51e..efe50f7 100644
 --- a/include/CoCoA/TmpGPoly.H
@@ -200,3 +226,29 @@ index 769750d..5ac5e90 100755
      fi
    fi
  fi
+diff --git a/include/CoCoA/MakeUnifiedHeader.sh b/include/CoCoA/MakeUnifiedHeader.sh
+index 1111111..2222222 100755
+--- a/include/CoCoA/MakeUnifiedHeader.sh
++++ b/include/CoCoA/MakeUnifiedHeader.sh
+@@ -33,7 +33,7 @@ echobox()
+ echobox()
+ {
+   mesg=">>>>  $*  <<<<"
+-  dashes=`echo "$mesg" | tr "\040-\377" "[-*]"`
++  dashes=`echo "$mesg" | tr "\040-\377" "-"`
+   echo "$dashes"
+   echo "$mesg"
+   echo "$dashes"
+diff --git a/src/AlgebraicCore/CheckSourceFiles.sh b/src/AlgebraicCore/CheckSourceFiles.sh
+index 3333333..4444444 100755
+--- a/src/AlgebraicCore/CheckSourceFiles.sh
++++ b/src/AlgebraicCore/CheckSourceFiles.sh
+@@ -24,7 +24,7 @@ done
+ done
+ sort "$TMPFILE2" > "$TMPFILE1"
+
+-/bin/ls -d ./*.C | cut -b 3- > "$TMPFILE2"
++/bin/ls -d ./*.C | cut -b 3- | sort > "$TMPFILE2"
+
+ cmp "$TMPFILE1" "$TMPFILE2" > /dev/null
+ if [ $? = 0 ]


### PR DESCRIPTION
Newer Ubuntu releases such as 26.04 ship the Rust-based uutils coreutils in place of GNU coreutils. Its tools differ from GNU in two ways that break the CoCoALib build:

1. `tr`: CoCoALib's shell helpers use GNU's `"[c*]"` repeat syntax, e.g. `tr "\040-\377" "[-*]"` to draw underline/box rules. uutils `tr` does not support this extension and errors out `("range-endpoints ... in reverse collating sequence order")`. Replace it with a single replacement character `(tr "\040-\377" "-" / "=")`, which both GNU and uutils expand by repeating the last character of SET2 -- producing identical output on either implementation. This extends `CoCoALib-0.99800-trace.patch` to cover `shell-fns.sh` and `MakeUnifiedHeader.sh`.

2. `sort`/`ls` collation: `CheckSourceFiles.sh` compared a `sort`ed source list against an `ls`-ordered listing. uutils `ls` does not honor LC_COLLATE (always codepoint order) while uutils `sort` does, so under UTF-8 the two orderings disagree and the comparison spuriously fails, aborting "make library". Pipe the `ls` listing through the same `sort` so both sides use one consistent ordering. This is locale-independent and needs no LC_ALL override.

The issue has been reported upstream [here](https://github.com/cocoa-official/CoCoALib/issues/136).