### PR TITLE
Check for resource out in prop engine layer

### DIFF
--- a/src/prop/prop_engine.cpp
+++ b/src/prop/prop_engine.cpp
@@ -494,11 +494,21 @@ Result PropEngine::checkSat()
     result = d_satSolver->solve(assumptions);
   }
 
+  ResourceManager* rm = resourceManager();
+  bool wasInterrupted = result == SAT_VALUE_UNKNOWN;
+  // If a resource limit expires during a full theory check, the SAT solver may
+  // still return SAT before observing its termination callback. In that case,
+  // the candidate model may not have been fully checked by the theories.
+  if (result == SAT_VALUE_TRUE && (d_interrupted || rm->out()))
+  {
+    wasInterrupted = true;
+    result = SAT_VALUE_UNKNOWN;
+  }
+
   d_theoryProxy->postsolve(result);
 
-  if (result == SAT_VALUE_UNKNOWN)
+  if (wasInterrupted)
   {
-    ResourceManager* rm = resourceManager();
     UnknownExplanation why = UnknownExplanation::INTERRUPTED;
     if (rm->outOfTime())
     {


### PR DESCRIPTION
Towards making cadical default.

Note that Minisat has special internal checks for whether a resource out occurs. This fixes an issue with cadical on regress1/sygus/sum-sq-unknown.sy, where we get `(error "Cannot get-value since model is not available. Perhaps the most recent call to check-sat was interrupted?")`. The root issue is that cadical doesn't implement the same checks, but its safer to do this check at the prop engine layer.

Co-Authored-By: ChatGPT 5.5 <noreply@openai.com>