### PR TITLE
Install downloaded GTest into CMAKE_INSTALL_LIBDIR

### DIFF
--- a/cmake/FindGTest.cmake
+++ b/cmake/FindGTest.cmake
@@ -67,13 +67,13 @@ if(NOT GTest_FOUND_SYSTEM)
         COMMAND ${CMAKE_COMMAND} --build .
             --config ${CMAKE_BUILD_TYPE} --target gtest_main
         BUILD_BYPRODUCTS
-            <INSTALL_DIR>/lib/libgtest.a
-            <INSTALL_DIR>/lib/libgtest_main.a
+            <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/libgtest.a
+            <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/libgtest_main.a
     )
 
     set(GTest_INCLUDE_DIR "${DEPS_BASE}/include/")
-    set(GTest_LIBRARIES "${DEPS_BASE}/lib/libgtest.a")
-    set(GTest_MAIN_LIBRARIES "${DEPS_BASE}/lib/libgtest_main.a")
+    set(GTest_LIBRARIES "${DEPS_BASE}/${CMAKE_INSTALL_LIBDIR}/libgtest.a")
+    set(GTest_MAIN_LIBRARIES "${DEPS_BASE}/${CMAKE_INSTALL_LIBDIR}/libgtest_main.a")
 endif()
 
 set(GTest_FOUND TRUE)


### PR DESCRIPTION
Newer GoogleTest releases use `GNUInstallDirs` and install libraries into `lib64` on multiarch systems such as Amazon Linux 2, instead of `lib`. Use `CMAKE_INSTALL_LIBDIR` for the `BUILD_BYPRODUCTS` and library paths so the built archives are found regardless of the target libdir.

It fixes nightlies.