### PR TITLE
cmake: Check -fno-operator-names for C++ only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,7 +267,7 @@ add_check_cxx_flag("-Wnon-virtual-dtor")
 add_check_c_cxx_flag("-Wimplicit-fallthrough")
 add_check_c_cxx_flag("-Wshadow")
 add_check_c_cxx_flag("-Wtype-limits")
-add_check_c_cxx_flag("-fno-operator-names")
+add_check_cxx_flag("-fno-operator-names")
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
    AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13


### PR DESCRIPTION
The `-fno-operator-names` option only applies to C++, as C does not treat operator names (like `and` or `or`) as built-in keywords. This prevents warnings in older GCC versions on Amazon Linux 2.