### PR TITLE
ci: Upgrade MSYS2 installation to use Clang 22

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -97,10 +97,10 @@ runs:
         echo "$(pwd)" >> $GITHUB_PATH
         echo "$(pwd)/upstream/emscripten" >> $GITHUB_PATH
 
-    # Pin MSYS2 installation to use Clang 19.1.4 (required by lean-cvc5)
+    # Pin MSYS2 installation to use Clang 22.1.7 (required by lean-cvc5)
     - name: Install Windows x86_64 software
       if: runner.os == 'Windows' && runner.arch == 'X64' && inputs.windows-build == 'true'
-      uses: msys2/setup-msys2@d44ca8e88d8b43d56cf5670f91747359d5537f97
+      uses: msys2/setup-msys2@v2.32.0
       with:
         update: false
         msystem: CLANG64
@@ -114,10 +114,10 @@ runs:
           mingw-w64-clang-x86_64-gmp
           zip
 
-    # Pin MSYS2 installation to use Clang 19.1.4 (required by lean-cvc5)
+    # Pin MSYS2 installation to use Clang 22.1.7 (required by lean-cvc5)
     - name: Install Windows arm64 software
       if: runner.os == 'Windows' && runner.arch == 'ARM64' && inputs.windows-build == 'true'
-      uses: msys2/setup-msys2@d44ca8e88d8b43d56cf5670f91747359d5537f97
+      uses: msys2/setup-msys2@v2.32.0
       with:
         update: false
         msystem: CLANGARM64


### PR DESCRIPTION
This follows the update of lean-cvc5 to use Lean toolchain v4.30.0, which uses LLVM 22.