### PR TITLE
Change positive RE unfolding for star

### DIFF
--- a/proofs/eo/cpc/rules/Strings.eo
+++ b/proofs/eo/cpc/rules/Strings.eo
@@ -307,10 +307,7 @@
       (or
         (= t "")
         (str.in_re t r)
-        (and
-            (and (= t (str.++ k1 k2 k3)) M)
-            (not (= k1 ""))
-            (not (= k3 "")))))
+        (and (= t (str.++ k1 k2 k3)) M)))
   )
 )
 
@@ -322,13 +319,14 @@
 (program $mk_re_unfold_pos ((t String) (r1 RegLan) (r2 RegLan :list))
   :signature (String RegLan) Bool
   (
-    (($mk_re_unfold_pos t (re.* r1))
-       ($mk_re_unfold_pos_star t r1 ($re_unfold_pos_concat t (re.++ r1 (re.* r1) r1))))
-    (($mk_re_unfold_pos t (re.++ r1 r2))
-        (eo::define ((res ($re_unfold_pos_concat t (re.++ r1 r2))))
-        (eo::define ((teq (= t ($pair_first res))))
-        (eo::define ((M ($pair_second res)))
-          (eo::ite (eo::eq M true) teq (_ and teq M))))))
+  (($mk_re_unfold_pos t (re.* r1))
+    (eo::define ((rd1 (re.diff r1 (str.to_re ""))))
+      ($mk_re_unfold_pos_star t r1 ($re_unfold_pos_concat t (re.++ rd1 (re.* r1) rd1)))))
+  (($mk_re_unfold_pos t (re.++ r1 r2))
+      (eo::define ((res ($re_unfold_pos_concat t (re.++ r1 r2))))
+      (eo::define ((teq (= t ($pair_first res))))
+      (eo::define ((M ($pair_second res)))
+        (eo::ite (eo::eq M true) teq (_ and teq M))))))
   )
 )
 

--- a/src/theory/strings/regexp_operation.cpp
+++ b/src/theory/strings/regexp_operation.cpp
@@ -1290,10 +1290,7 @@ Node RegExpOpr::reduceRegExpPos(NodeManager* nm,
     // This means that the overall conclusion is:
     //  (x = "") v (x in R) v (x = (str.++ k1 k2 k3) ^
     //                         k1 in (R \ "") ^ k2 in (re.* R) ^ k3 in (R \ ""))
-    conc = nm->mkNode(Kind::OR,
-                      se,
-                      sinr,
-                      sinRExp);
+    conc = nm->mkNode(Kind::OR, se, sinr, sinRExp);
   }
   else
   {

--- a/src/theory/strings/regexp_operation.cpp
+++ b/src/theory/strings/regexp_operation.cpp
@@ -1267,7 +1267,9 @@ Node RegExpOpr::reduceRegExpPos(NodeManager* nm,
     Node emp = Word::mkEmptyWord(s.getType());
     Node se = s.eqNode(emp);
     Node sinr = nm->mkNode(Kind::STRING_IN_REGEXP, s, r[0]);
-    Node reExpand = nm->mkNode(Kind::REGEXP_CONCAT, r[0], r, r[0]);
+    Node empr = nm->mkNode(Kind::STRING_TO_REGEXP, emp);
+    Node rd = nm->mkNode(Kind::REGEXP_DIFF, r[0], empr);
+    Node reExpand = nm->mkNode(Kind::REGEXP_CONCAT, rd, r, rd);
     Node sinRExp = nm->mkNode(Kind::STRING_IN_REGEXP, s, reExpand);
     // We unfold `x in R*` by considering three cases: `x` is empty, `x`
     // is matched by `R`, or `x` is matched by two or more `R`s. For the
@@ -1286,16 +1288,12 @@ Node RegExpOpr::reduceRegExpPos(NodeManager* nm,
     // make the return lemma
     // can also assume the component match the first and last R are non-empty.
     // This means that the overall conclusion is:
-    //   (x = "") v (x in R) v (x = (str.++ k1 k2 k3) ^
-    //                          k1 in R ^ k2 in (re.* R) ^ k3 in R ^
-    //                          k1 != ""  ^ k3 != "")
+    //  (x = "") v (x in R) v (x = (str.++ k1 k2 k3) ^
+    //                         k1 in (R \ "") ^ k2 in (re.* R) ^ k3 in (R \ ""))
     conc = nm->mkNode(Kind::OR,
                       se,
                       sinr,
-                      nm->mkNode(Kind::AND,
-                                 {sinRExp,
-                                  newSkolemsC[0].eqNode(emp).negate(),
-                                  newSkolemsC[2].eqNode(emp).negate()}));
+                      sinRExp);
   }
   else
   {


### PR DESCRIPTION
This PR updates the positive unfolding inference in cvc5, which changes:
- The inference `InferenceId::STRINGS_RE_UNFOLD_POS` used by the strings solver
- The CPC proof rule RE_UNFOLD_POS,
- Its Eunoia implementation.

The change fixes a subtle issue where `@re_unfold_pos_component` did not have a consistent semantics.

Conceptually, `(@re_unfold_pos_component s (r1 ++ ... ++ rn) 1)...(@re_unfold_pos_component s (r1 ++ ... ++ rn) n)` are arbitrary strings `k1 ... kn` that witness the existential:
`s in (r1 ++ ... ++ rn) => exists k1 ... kn. (s =  (k1 ++ ... ++ kn) ^ k1 in r1 ^ ... ^ kn in rn)`.

Unfolding RE star `r*` can be seen as a special case of concatenation where in the non-empty, non-singleton-case, we reduce `s in r*` to `s in r ++ r* ++ r` and insist that the first and last components are non-empty. 
We used skolems `(@re_unfold_pos_component s (r ++ r* ++ r) i) ` for `i=1,2,3` to witness this unfolding. However this is incorrect as the semantics for the skolem in the concatenation case does not insist on non-emptiness.

Instead, we change the rule to unfold to the membership to `s in (r \ "") ++ r* ++ (r \ "")` and drop the explicit assumptions that the components are non-empty. As a result, their non-emptiness is entailed naturally by the membership. This makes the underlying meaning of this skolem consistent in the concat/star cases.

This issue was discovered by Claude Fable 5 when trying to verify this rule in Lean/Logos.