### PR TITLE
Refactor CPC+Eunoia definition of distinct values

### DIFF
--- a/contrib/get-ethos-checker
+++ b/contrib/get-ethos-checker
@@ -27,7 +27,7 @@ EO_DIR="$BASE_DIR/ethos-checker"
 mkdir -p $EO_DIR
 
 # download and unpack ethos
-ETHOS_VERSION="b7c16c6861182cac53ebdb73e6bcf1aeb3d890d2"
+ETHOS_VERSION="1238fd167cc29377e554e28a7b776bb396eee8ee"
 download "https://github.com/cvc5/ethos/archive/$ETHOS_VERSION.tar.gz" $BASE_DIR/tmp/ethos.tgz
 tar --strip 1 -xzf $BASE_DIR/tmp/ethos.tgz -C $EO_DIR
 

--- a/proofs/eo/cpc/Cpc.eo
+++ b/proofs/eo/cpc/Cpc.eo
@@ -372,7 +372,7 @@
 ; conclusion: The term t is not equal to s.
 (declare-rule distinct_values ((U Type) (t U) (s U))
   :args (t s)
-  :requires ((($are_distinct_terms t s) true))
+  :requires ((($are_distinct_terms (eo::typeof t) t s) true))
   :conclusion (not (= t s))
 )
 

--- a/proofs/eo/cpc/programs/DistinctValues.eo
+++ b/proofs/eo/cpc/programs/DistinctValues.eo
@@ -10,7 +10,7 @@
 (include "Datatypes.eo")
 
 ; note: This is a forward declaration of $are_distinct_terms_list below.
-(program $are_distinct_terms_list () :signature (@List Type) Bool)
+(program $are_distinct_terms_type ((T Type)) :signature (T T Type) Bool)
 
 ; define: $are_distinct_terms
 ; args:
@@ -18,26 +18,8 @@
 ; - s T: The second term.
 ; return: >
 ;   True if we can shown that t and s are semantically distinct, e.g. (not (= t s)) holds.
-(define $are_distinct_terms ((T Type :implicit) (t T) (s T))
-  (eo::ite (eo::eq t s) false ($are_distinct_terms_list (@list t s) (eo::typeof t))))
-
-; program: $some_pairwise_distinct_term
-; args:
-; - ts T: The first list of terms.
-; - ss T: The second list of terms.
-; return: >
-;   True if there is some term in ts and ss at the same position which can be shown to be semantically distinct.
-;   This program expects ts and ss to be of the same length.
-(program $some_pairwise_distinct_term ((U Type) (t U) (s U) (ts @List :list) (ss @List :list))
-  :signature (@List @List) Bool
-  (
-  (($some_pairwise_distinct_term (@list t ts) (@list s ss))  (eo::ite ($are_distinct_terms t s)
-                                                                true
-                                                                ($some_pairwise_distinct_term ts ss)))
-  (($some_pairwise_distinct_term @list.nil @list.nil)        false)
-  ; unevaluated if different lengths
-  )
-)
+(define $are_distinct_terms ((T Type) (t T) (s T))
+  (eo::ite (eo::eq t s) false ($are_distinct_terms_type t s T)))
 
 ;;;;; Theory of sets
 
@@ -47,90 +29,103 @@
 ; - s (Set T): The second set terms.
 ; return: >
 ;   True if we can show that t is not a subset of s based on reasoning about values.
-(program $set_is_not_subset ((T Type) (ts (Set T) :list) (s (Set T)) (ss (Set T) :list) (e1 T) (e2 T))
-  :signature ((Set T) (Set T)) Bool
+(program $set_is_not_subset
+  ((T Type) (ts (Set T) :list) (s (Set T)) (ss (Set T) :list) (e1 T) (e2 T) (U Type))
+  :signature ((Set T) (Set T) Type) Bool
   (
-  (($set_is_not_subset (as set.empty (Set T)) s)                              false)
-  (($set_is_not_subset (set.singleton e1) (as set.empty (Set T)))             true)
-  (($set_is_not_subset (set.singleton e1) (set.singleton e2))                 ($are_distinct_terms e1 e2))
-  (($set_is_not_subset (set.singleton e1) (set.union (set.singleton e2) ss))  (eo::ite ($are_distinct_terms e1 e2)
-                                                                                ($set_is_not_subset (set.singleton e1) ss)
-                                                                                false))
-  (($set_is_not_subset (set.union (set.singleton e1) ts) s)                   (eo::ite ($set_is_not_subset (set.singleton e1) s)
-                                                                                true
-                                                                                ($set_is_not_subset ts s)))
-
+  (($set_is_not_subset (as set.empty (Set U)) s T)                  false)
+  (($set_is_not_subset (set.singleton e1) (as set.empty (Set U)) T) true)
+  (($set_is_not_subset (set.singleton e1) (set.singleton e2) T)
+    ($are_distinct_terms T e1 e2))
+  (($set_is_not_subset (set.singleton e1) (set.union (set.singleton e2) ss) T)  
+    (eo::ite ($are_distinct_terms T e1 e2)
+      ($set_is_not_subset (set.singleton e1) ss T)
+      false))
+  (($set_is_not_subset (set.union (set.singleton e1) ts) s T)
+    (eo::ite ($set_is_not_subset (set.singleton e1) s T)
+      true
+      ($set_is_not_subset ts s T)))
   )
 )
 
 ;;;;; Theory of sequences
 
+
+; program: $seq_is_non_empty
+; args:
+; - t (Seq T): The term, expected to be a constant-like sequence.
+; return: >
+;   True if we can derive that t is not the empty sequence.
+(program $seq_is_non_empty ((T Type) (t (Seq T)) (ts (Seq T) :list) (e1 T))
+  :signature ((Seq T)) Bool
+  (
+  (($seq_is_non_empty (seq.++ (seq.unit e1) ts)) true)
+  (($seq_is_non_empty (seq.unit e1)) true)
+  (($seq_is_non_empty t) false)
+  )
+)
+
 ; program: $seq_distinct_terms
 ; args:
-; - t (Seq T): The first term.
-; - s (Seq T): The second term.
+; - t (Seq T): The first term, expected to be a constant-like sequence.
+; - s (Seq T): The second term, expected to be a constant-like sequence.
 ; return: >
 ;   True if we can derive that t and s are distinct based on their length,
 ;   or by a character prefix that can be shown distinct.
-(program $seq_distinct_terms ((T Type) (t (Seq T)) (ts (Seq T) :list) (s (Seq T)) (ss (Seq T) :list) (e1 T) (e2 T))
-  :signature ((Seq T) (Seq T)) Bool
+(program $seq_distinct_terms
+  ((T Type) (t (Seq T)) (ts (Seq T) :list) (s (Seq T)) (ss (Seq T) :list)
+   (e1 T) (e2 T) (U Type))
+  :signature ((Seq T) (Seq T) Type) Bool
   (
-  ; handle singleton cases
-  (($seq_distinct_terms (seq.unit e1) s)                                     ($seq_distinct_terms (seq.++ (seq.unit e1)) s))
-  (($seq_distinct_terms t (seq.unit e2))                                     ($seq_distinct_terms t (seq.++ (seq.unit e2))))
-  (($seq_distinct_terms (seq.++ (seq.unit e1) ts) (seq.++ (seq.unit e2) ss)) (eo::ite ($are_distinct_terms e1 e2)
-                                                                               true
-                                                                               ($seq_distinct_terms ts ss)))
-  (($seq_distinct_terms t t)                                                 false)
-  (($seq_distinct_terms t s)                                                 true) ; otherwise different length
+  (($seq_distinct_terms (seq.++ (seq.unit e1) ts) (seq.++ (seq.unit e2) ss) T)
+    (eo::ite ($are_distinct_terms T e1 e2)
+      true
+      ($seq_distinct_terms ts ss T)))
+  (($seq_distinct_terms (seq.unit e1) (seq.unit e2) T)
+    ($are_distinct_terms T e1 e2))
+  (($seq_distinct_terms (seq.++ (seq.unit e1) ts) (seq.unit e2) T)
+    (eo::ite ($are_distinct_terms T e1 e2) true ($seq_is_non_empty ts)))
+  (($seq_distinct_terms (seq.unit e1) (seq.++ (seq.unit e2) ss) T)
+    (eo::ite ($are_distinct_terms T e1 e2) true ($seq_is_non_empty ss)))
+  (($seq_distinct_terms t (as seq.empty (Seq U)) T) ($seq_is_non_empty t))
+  (($seq_distinct_terms (as seq.empty (Seq U)) s T) ($seq_is_non_empty s))
+  (($seq_distinct_terms t s T) false)
   )
 )
 
 ;;;;; Theory of datatypes
 
-; program: $dt_distinct_terms_rec
+; program: $dt_distinct_terms_arg
 ; args:
 ; - t T: The first term, expected to be of datatype type.
 ; - s T: The second term, expected to be of datatype type.
-; - l1 @List: The accumulated list of arguments of t.
-; - l2 @List: The accumulated list of arguments of s.
 ; return: >
 ;   True if we can show that t and s denote distinct terms. This is true
 ;   if t and s are distinct constructor applications, or are applications
 ;   of the same constructor and one of their arguments can be shown distinct.
-(program $dt_distinct_terms_rec ((T Type) (U Type) (V Type) (W Type) (ct T) (cs V) (f (-> U W)) (a U) (l1 @List) (l2 @List))
-  :signature (T V @List @List) Bool
+(program $dt_distinct_terms
+  ((T Type) (U Type) (ct T) (cs T) (f (-> U T)) (a U) (g (-> U T)) (b U))
+  :signature (T T) Bool
   (
-    (($dt_distinct_terms_rec (f a) cs l1 l2) ($dt_distinct_terms_rec f cs (_ @list a l1) l2))
-    (($dt_distinct_terms_rec ct (f a) l1 l2) ($dt_distinct_terms_rec ct f l1 (_ @list a l2)))
-    (($dt_distinct_terms_rec ct cs l1 l2)
-      (eo::ite (eo::eq ($dt_is_cons ct) true)
-        (eo::ite (eo::eq ct cs)
-          ; recurse on each argument
-          ($some_pairwise_distinct_term l1 l2)  ; get the argument list of the datatypes
-          ; otherwise conflicting only if cs is also a constructor
-          (eo::eq ($dt_is_cons cs) true))
-        false))
+  (($dt_distinct_terms (f a) (g b))
+    ; Note that if the operators were shown to be distinct, then we return true.
+    ; If we returned false, then f and g are (partial) applications of the same
+    ; constructor, hence a and b have the same type and we recurse.
+    (eo::ite ($dt_distinct_terms f g) true ($are_distinct_terms (eo::typeof a) a b)))
+  (($dt_distinct_terms ct (g a))  ($dt_distinct_terms ct g))
+  (($dt_distinct_terms (f a) cs)  ($dt_distinct_terms f cs))
+  (($dt_distinct_terms ct cs)
+    (eo::requires (eo::and ($dt_is_cons ct) ($dt_is_cons cs)) true
+      (eo::not (eo::eq ct cs))))
   )
 )
-
-; define: $dt_distinct_terms
-; args:
-; - t T: The first term, expected to be of datatype type.
-; - s T: The second term, expected to be of datatype type.
-; return: >
-;   True if we can show that t and s denote distinct terms. This is true
-;   if t and s are distinct constructor applications, or are applications
-;   of the same constructor and one of their arguments can be shown distinct.
-(define $dt_distinct_terms ((T Type :implicit) (t T) (s T))
-  ($dt_distinct_terms_rec t s @list.nil @list.nil))
 
 ;;;;; Definitions
 
 ; program: $are_distinct_terms_type
 ; args:
 ; - t T: The first term.
-; - s T: The second term.
+; - s T: The second term, assumed to be syntactically different from the first.
 ; - T Type: The type of the arguments.
 ; return: >
 ;   True if we can shown that t and s are semantically distinct, e.g. (not (= t s)) holds.
@@ -138,14 +133,13 @@
   ((T Type) (t T) (s T) (U Type) (n Int) (st (Set U)) (ss (Set U)) (sst (Seq U)) (sss (Seq U)))
   :signature (T T Type) Bool
   (
-  (($are_distinct_terms_type t t T)           false)
   (($are_distinct_terms_type t s Int)         (eo::and (eo::is_z t) (eo::is_z s)))
   (($are_distinct_terms_type t s Real)        (eo::and (eo::is_q t) (eo::is_q s)))
   (($are_distinct_terms_type t s String)      (eo::and (eo::is_str t) (eo::is_str s)))
   (($are_distinct_terms_type t s (BitVec n))  (eo::and (eo::is_bin t) (eo::is_bin s)))
   (($are_distinct_terms_type t s Bool)        (eo::and (eo::is_bool t) (eo::is_bool s)))
-  (($are_distinct_terms_type st ss (Set U))   (eo::or ($set_is_not_subset st ss) ($set_is_not_subset ss st)))
-  (($are_distinct_terms_type sst sss (Seq U)) ($seq_distinct_terms sst sss))
+  (($are_distinct_terms_type st ss (Set U))   (eo::or ($set_is_not_subset st ss U) ($set_is_not_subset ss st U)))
+  (($are_distinct_terms_type sst sss (Seq U)) ($seq_distinct_terms sst sss U))
   (($are_distinct_terms_type t s T)           ($dt_distinct_terms t s)) ; otherwise assume we are a user datatype
   )
 )
@@ -157,13 +151,13 @@
 ; - T Type: The type of the arguments.
 ; return: >
 ;   True if t can be shown to be disequal from all terms in xs.
-(program $are_distinct_terms_list_rec ((T Type) (t T) (s T) (xs @List :list))
-  :signature (T @List Type) Bool
+(program $are_distinct_terms_list_rec ((T Type) (t T) (s T) (xs (@TList T) :list))
+  :signature (T (@TList T) Type) Bool
   (
-  (($are_distinct_terms_list_rec t (@list s xs) T)  (eo::ite ($are_distinct_terms_type t s T)
+  (($are_distinct_terms_list_rec t (@tlist s xs) T)  (eo::ite ($are_distinct_terms T t s)
                                                       ($are_distinct_terms_list_rec t xs T)
                                                       false))
-  (($are_distinct_terms_list_rec t @list.nil T)     true)
+  (($are_distinct_terms_list_rec t (@tlist.nil T) T)  true)
   )
 )
 
@@ -173,12 +167,13 @@
 ; - T Type: The type of the terms in the list.
 ; return: >
 ;   True if each pair of terms in xs can be shown to be pairwise disequal.
-(program $are_distinct_terms_list ((T Type) (t T) (xs @List :list))
-  :signature (@List Type) Bool
+(program $are_distinct_terms_list ((T Type) (t T) (xs (@TList T) :list))
+  :signature ((@TList T) Type) Bool
   (
-  (($are_distinct_terms_list @list.nil T)     true)
-  (($are_distinct_terms_list (@list t xs) T)  (eo::ite ($are_distinct_terms_list_rec t xs T)
-                                                ($are_distinct_terms_list xs T)
-                                                false))
+  (($are_distinct_terms_list (@tlist.nil T) T)     true)
+  (($are_distinct_terms_list (@tlist t xs) T)  
+    (eo::ite ($are_distinct_terms_list_rec t xs T)
+      ($are_distinct_terms_list xs T)
+      false))
   )
 )

--- a/proofs/eo/cpc/programs/DistinctValues.eo
+++ b/proofs/eo/cpc/programs/DistinctValues.eo
@@ -9,7 +9,7 @@
 (include "Utils.eo")
 (include "Datatypes.eo")
 
-; note: This is a forward declaration of $are_distinct_terms_list below.
+; note: This is a forward declaration of $are_distinct_terms_type below.
 (program $are_distinct_terms_type ((T Type)) :signature (T T Type) Bool)
 
 ; define: $are_distinct_terms
@@ -27,6 +27,7 @@
 ; args:
 ; - t (Set T): The first set terms.
 ; - s (Set T): The second set terms.
+; - T Type: The element type of t and s.
 ; return: >
 ;   True if we can show that t is not a subset of s based on reasoning about values.
 (program $set_is_not_subset
@@ -69,6 +70,7 @@
 ; args:
 ; - t (Seq T): The first term, expected to be a constant-like sequence.
 ; - s (Seq T): The second term, expected to be a constant-like sequence.
+; - T Type: The element type of t and s.
 ; return: >
 ;   True if we can derive that t and s are distinct based on their length,
 ;   or by a character prefix that can be shown distinct.

--- a/proofs/eo/cpc/programs/Strings.eo
+++ b/proofs/eo/cpc/programs/Strings.eo
@@ -1746,7 +1746,7 @@
     :signature ((Seq T) (Seq T)) Bool
     (
     (($str_is_compatible (str.++ c1 xs1) (str.++ c1 xs2)) ($str_is_compatible xs1 xs2))
-    (($str_is_compatible (str.++ c1 xs1) (str.++ c2 xs2)) (eo::requires ($are_distinct_terms c1 c2) true false))
+    (($str_is_compatible (str.++ c1 xs1) (str.++ c2 xs2)) (eo::requires ($are_distinct_terms (eo::typeof c1) c1 c2) true false))
     (($str_is_compatible c1 c2)                           (eo::or ($str_is_empty c1) ($str_is_empty c2)))
     )
 )

--- a/proofs/eo/cpc/programs/Utils.eo
+++ b/proofs/eo/cpc/programs/Utils.eo
@@ -63,19 +63,6 @@
   (($typed_list_element_type (@TList T)) T)
   )
 )
-
-; program: $typed_list_to_untyped
-; args:
-; - xs (@TList T): the typed list.
-; return: The result of converting xs to an untyped (heterogeneous) list.
-(program $typed_list_to_untyped ((T Type) (x T) (xs (@TList T) :list))
-  :signature ((@TList T)) @List
-  (
-  (($typed_list_to_untyped (@tlist x xs))   (_ @list x ($typed_list_to_untyped xs)))
-  (($typed_list_to_untyped (@tlist.nil T))  @list.nil)
-  )
-)
-
   
 ;; =============== evaluation utilities
 

--- a/proofs/eo/cpc/rules/Datatypes.eo
+++ b/proofs/eo/cpc/rules/Datatypes.eo
@@ -207,7 +207,7 @@
 ;   why the equality is conflicting.
 (declare-rule dt-cons-eq-clash ((D Type) (t D) (s D))
   :args ((= (= t s) false))
-  :requires ((($are_distinct_terms t s) true))
+  :requires ((($are_distinct_terms (eo::typeof t) t s) true))
   :conclusion (= (= t s) false)
 )
 
@@ -367,10 +367,12 @@
   ((D Type) (T Type) (U Type) (s (-> D T)) (t D) (a T) (c U) (n Int) (ss eo::List))
   :signature (D U eo::List) D
   (
-    (($mk_dt_updater_elim_rhs (update s t a) c ss)
-       ($dt_updater_elim_rhs (update s t a) ss ($dt_inst_cons_of (eo::typeof t) c))) ; ensure the constructor is annotated
-    (($mk_dt_updater_elim_rhs (tuple.update n t a) tuple ss)
-       ($tuple_updater_elim_rhs (tuple.update n t a) ss))
+  (($mk_dt_updater_elim_rhs (update s t a) c ss)
+    ; ensure the selector is in the list for this constructor
+    (eo::requires (eo::is_neg (eo::list_find @list ss s)) false
+      ($dt_updater_elim_rhs (update s t a) ss ($dt_inst_cons_of (eo::typeof t) c)))) ; ensure the constructor is annotated
+  (($mk_dt_updater_elim_rhs (tuple.update n t a) tuple ss)
+      ($tuple_updater_elim_rhs (tuple.update n t a) ss))
   )
 )
 

--- a/proofs/eo/cpc/rules/Datatypes.eo
+++ b/proofs/eo/cpc/rules/Datatypes.eo
@@ -367,12 +367,10 @@
   ((D Type) (T Type) (U Type) (s (-> D T)) (t D) (a T) (c U) (n Int) (ss eo::List))
   :signature (D U eo::List) D
   (
-  (($mk_dt_updater_elim_rhs (update s t a) c ss)
-    ; ensure the selector is in the list for this constructor
-    (eo::requires (eo::is_neg (eo::list_find @list ss s)) false
-      ($dt_updater_elim_rhs (update s t a) ss ($dt_inst_cons_of (eo::typeof t) c)))) ; ensure the constructor is annotated
-  (($mk_dt_updater_elim_rhs (tuple.update n t a) tuple ss)
-      ($tuple_updater_elim_rhs (tuple.update n t a) ss))
+    (($mk_dt_updater_elim_rhs (update s t a) c ss)
+       ($dt_updater_elim_rhs (update s t a) ss ($dt_inst_cons_of (eo::typeof t) c))) ; ensure the constructor is annotated
+    (($mk_dt_updater_elim_rhs (tuple.update n t a) tuple ss)
+       ($tuple_updater_elim_rhs (tuple.update n t a) ss))
   )
 )
 

--- a/proofs/eo/cpc/rules/Sets.eo
+++ b/proofs/eo/cpc/rules/Sets.eo
@@ -36,46 +36,46 @@
 ; return: >
 ;   A list of elements, whose union is equal to s.
 (program $set_union_to_list ((T Type) (t (Set T)) (e T))
-  :signature ((Set T)) @List
+  :signature ((Set T)) (@TList T)
   (
-    (($set_union_to_list (set.union (set.singleton e) t)) (_ @list e ($set_union_to_list t)))
-    (($set_union_to_list (as set.empty (Set T)))          @list.nil)
-    (($set_union_to_list (set.singleton e))               (@list e))
+  (($set_union_to_list (set.union (set.singleton e) t)) (_ @tlist e ($set_union_to_list t)))
+  (($set_union_to_list (as set.empty (Set T)))          (@tlist.nil T))
+  (($set_union_to_list (set.singleton e))               (@tlist e))
   )
 )
 
 ; program: $eval_sets_inter
 ; args:
-; - @List (Set T): The list of elements in the first set left to process.
-; - @List (Set T): The list of elements in the second set.
+; - s (@TList T): The list of elements in the first set left to process.
+; - t (@TList T): The list of elements in the second set.
 ; return: >
 ;   The elements in the set resulting in the set intersection of the arguments.
-(program $eval_sets_inter ((T Type) (a T) (as @List :list) (bs @List))
-  :signature (@List @List) @List
+(program $eval_sets_inter ((T Type) (a T) (as (@TList T) :list) (bs (@TList T)))
+  :signature ((@TList T) (@TList T)) (@TList T)
   (
-    (($eval_sets_inter (@list a as) bs)  (eo::define ((r ($eval_sets_inter as bs)))
-                                         (eo::ite (eo::is_neg (eo::list_find @list bs a))
+    (($eval_sets_inter (@tlist a as) bs)  (eo::define ((r ($eval_sets_inter as bs)))
+                                         (eo::ite (eo::is_neg (eo::list_find @tlist bs a))
                                            (eo::requires ($are_distinct_terms_list_rec a bs (eo::typeof a)) true r)
-                                           (_ @list a r))))
-    (($eval_sets_inter @list.nil bs)     @list.nil)
+                                           (_ @tlist a r))))
+    (($eval_sets_inter (@tlist.nil T) bs)   (@tlist.nil T))
   )
 )
 
 ; program: $eval_sets_minus
 ; args:
-; - @List (Set T): The list of elements in the first set left to process.
-; - @List (Set T): The list of elements in the second set.
+; - s (@TList T): The list of elements in the first set left to process.
+; - t (@TList T): The list of elements in the second set.
 ; return: >
 ;   The elements in the set resulting in the set difference of the arguments.
-(program $eval_sets_minus ((T Type) (a T) (as @List :list) (bs @List))
-  :signature (@List @List) @List
+(program $eval_sets_minus ((T Type) (a T) (as (@TList T) :list) (bs (@TList T)))
+  :signature ((@TList T) (@TList T)) (@TList T)
   (
-    (($eval_sets_minus (@list a as) bs)  (eo::define ((r ($eval_sets_minus as bs)))
-                                         (eo::ite (eo::is_neg (eo::list_find @list bs a))
-                                           (eo::requires ($are_distinct_terms_list_rec a bs (eo::typeof a)) true
-                                             (_ @list a r))
+    (($eval_sets_minus (@tlist a as) bs)  (eo::define ((r ($eval_sets_minus as bs)))
+                                          (eo::ite (eo::is_neg (eo::list_find @tlist bs a))
+                                            (eo::requires ($are_distinct_terms_list_rec a bs (eo::typeof a)) true
+                                              (_ @tlist a r))
                                             r)))
-    (($eval_sets_minus @list.nil bs)     @list.nil)
+    (($eval_sets_minus (@tlist.nil T) bs)  (@tlist.nil T))
   )
 )
 
@@ -85,9 +85,9 @@
 ; return: >
 ;   The result of evaluating the operator.
 (program $eval_sets_op ((T Type) (s (Set T)) (t (Set T)))
-  :signature ((Set T)) @List
+  :signature ((Set T)) (@TList T)
   (
-    (($eval_sets_op (set.union s t)) (eo::list_concat @list ($set_union_to_list s) ($set_union_to_list t)))
+    (($eval_sets_op (set.union s t)) (eo::list_concat @tlist ($set_union_to_list s) ($set_union_to_list t)))
     (($eval_sets_op (set.inter s t)) ($eval_sets_inter ($set_union_to_list s) ($set_union_to_list t)))
     (($eval_sets_op (set.minus s t)) ($eval_sets_minus ($set_union_to_list s) ($set_union_to_list t)))
   )
@@ -102,8 +102,8 @@
 ; conclusion: The given equality.
 (declare-rule sets-eval-op ((T Type) (a (Set T)) (b (Set T)))
   :args ((= a b))
-  :requires (((eo::list_meq @list
-              (eo::list_setof @list ($eval_sets_op a))
+  :requires (((eo::list_meq @tlist
+              (eo::list_setof @tlist ($eval_sets_op a))
               ($set_union_to_list b)) true))    ; b is already assumed to have no duplicates
   :conclusion (= a b)
 )
@@ -119,8 +119,8 @@
 (program $set_eval_insert ((T Type) (x T) (xs @List :list) (t (Set T)))
   :signature (@List (Set T)) (Set T)
   (
-    (($set_eval_insert (@list x xs) t) (set.union (set.singleton x) ($set_eval_insert xs t)))
-    (($set_eval_insert @list.nil t)    t)
+    (($set_eval_insert (@tlist x xs) t) (set.union (set.singleton x) ($set_eval_insert xs t)))
+    (($set_eval_insert (@tlist.nil T) t)    t)
   )
 )
 
@@ -130,7 +130,7 @@
 ; - eq Bool: The equality to prove with this rule.
 ; requires: the union of the elements in the first argument with the last argument equal the right hand side.
 ; conclusion: the equality between a and b.
-(declare-rule sets-insert-elim ((T Type) (s (Set T)) (es @List) (t (Set T)))
+(declare-rule sets-insert-elim ((T Type) (s (Set T)) (es (@TList T)) (t (Set T)))
   :args ((= (set.insert es s) t))
   :requires ((($set_eval_insert es s) t))
   :conclusion (= (set.insert es s) t)

--- a/proofs/eo/cpc/rules/Sets.eo
+++ b/proofs/eo/cpc/rules/Sets.eo
@@ -120,7 +120,7 @@
   :signature (@List (Set T)) (Set T)
   (
     (($set_eval_insert (@list x xs) t) (set.union (set.singleton x) ($set_eval_insert xs t)))
-    (($set_eval_insert list.nil t)    t)
+    (($set_eval_insert @list.nil t)    t)
   )
 )
 

--- a/proofs/eo/cpc/rules/Sets.eo
+++ b/proofs/eo/cpc/rules/Sets.eo
@@ -119,8 +119,8 @@
 (program $set_eval_insert ((T Type) (x T) (xs @List :list) (t (Set T)))
   :signature (@List (Set T)) (Set T)
   (
-    (($set_eval_insert (@tlist x xs) t) (set.union (set.singleton x) ($set_eval_insert xs t)))
-    (($set_eval_insert (@tlist.nil T) t)    t)
+    (($set_eval_insert (@list x xs) t) (set.union (set.singleton x) ($set_eval_insert xs t)))
+    (($set_eval_insert list.nil t)    t)
   )
 )
 
@@ -130,7 +130,7 @@
 ; - eq Bool: The equality to prove with this rule.
 ; requires: the union of the elements in the first argument with the last argument equal the right hand side.
 ; conclusion: the equality between a and b.
-(declare-rule sets-insert-elim ((T Type) (s (Set T)) (es (@TList T)) (t (Set T)))
+(declare-rule sets-insert-elim ((T Type) (s (Set T)) (es @List) (t (Set T)))
   :args ((= (set.insert es s) t))
   :requires ((($set_eval_insert es s) t))
   :conclusion (= (set.insert es s) t)

--- a/proofs/eo/cpc/rules/Strings.eo
+++ b/proofs/eo/cpc/rules/Strings.eo
@@ -219,7 +219,7 @@
 ; conclusion: The given witness skolem has length n.
 (declare-rule exists_string_length ((U Type) (n Int) (id Int))
   :args ((Seq U) n id)
-  :requires (((eo::gt n -1) true))
+  :requires (((eo::gt n -1) true) ((eo::gt id -1) true))
   :conclusion (= (str.len (@witness_string_length (Seq U) n id)) n)
 )
 
@@ -644,11 +644,13 @@
 ; return: >
 ;   The list of characters in s.
 (program $str_multiset_overapprox_word ((T Type) (s (Seq T)) (ss (Seq T) :list))
-    :signature ((Seq T)) @List
-    (
-      (($str_multiset_overapprox_word (str.++ s ss))  (_ @list s ($str_multiset_overapprox_word ss)))
-      (($str_multiset_overapprox_word s)              (eo::ite ($str_is_empty s) @list.nil (_ @list s @list.nil)))
-    )
+  :signature ((Seq T)) (@TList T)
+  (
+  (($str_multiset_overapprox_word (str.++ s ss))
+    (_ @tlist s ($str_multiset_overapprox_word ss)))
+  (($str_multiset_overapprox_word s)
+    (eo::ite ($str_is_empty s) (@tlist.nil (eo::typeof s)) (@tlist s)))
+  )
 )
 
 ; program: $str_multiset_overapprox
@@ -660,61 +662,67 @@
 ;   In particular, note that all string literals are broken up into string
 ;   literals of size one.
 (program $str_multiset_overapprox ((T Type) (s (Seq T)) (ss (Seq T) :list) (t (Seq T)) (r (Seq T)) (n Int) (m Int))
-    :signature ((Seq T)) @List
-    (
-      (($str_multiset_overapprox (str.++ s ss))        (eo::list_concat @list ($str_multiset_overapprox s) ($str_multiset_overapprox ss)))
-      (($str_multiset_overapprox (str.substr s n m))   ($str_multiset_overapprox s))
-      (($str_multiset_overapprox (str.replace s t r))  (eo::list_concat @list ($str_multiset_overapprox s) ($str_multiset_overapprox r)))
-      (($str_multiset_overapprox s)                    (eo::ite ($str_is_empty s)
-                                                          @list.nil
-                                                          (eo::ite (eo::is_str s)
-                                                            ($str_multiset_overapprox_word ($str_to_flat_form s false))
-                                                            (_ @list s @list.nil))))
-    )
+  :signature ((Seq T)) (@TList T)
+  (
+  (($str_multiset_overapprox (str.++ s ss))        (eo::list_concat @tlist ($str_multiset_overapprox s) ($str_multiset_overapprox ss)))
+  (($str_multiset_overapprox (str.substr s n m))   ($str_multiset_overapprox s))
+  (($str_multiset_overapprox (str.replace s t r))  (eo::list_concat @tlist ($str_multiset_overapprox s) ($str_multiset_overapprox r)))
+  (($str_multiset_overapprox s)                    (eo::ite ($str_is_empty s)
+                                                      (@tlist.nil (eo::typeof s))
+                                                      (eo::ite (eo::is_str s)
+                                                        ($str_multiset_overapprox_word ($str_to_flat_form s false))
+                                                        (@tlist s))))
+  )
 )
 
 ; program: $str_is_multiset_subset_strict_done
 ; args:
-; - xs @List: the remaining multiset (over)approximation of a string term.
-; - nr @List: the accumulated list of terms that were not removed from xs.
+; - xs (@TList T): the remaining multiset (over)approximation of a string term.
+; - nr (@TList T): the accumulated list of terms that were not removed from xs.
 ; return: >
-;   True if some accumulated term is provably distinct from every term in the
-;   remaining overapproximation xs.
-(program $str_is_multiset_subset_strict_done ((T Type) (s (Seq T)) (xs @List) (nr @List :list))
-    :signature (@List @List) Bool
-    (
-      (($str_is_multiset_subset_strict_done xs (@list s nr)) (eo::ite ($are_distinct_terms_list_rec s xs (eo::typeof s))
-                                                                 true
-                                                                 ($str_is_multiset_subset_strict_done xs nr)))
-      (($str_is_multiset_subset_strict_done xs nr)           false)
-    )
+;   True if some accumulated non-empty value component is provably distinct from
+;   every term in the remaining overapproximation xs.
+(program $str_is_multiset_subset_strict_done ((T Type) (s (Seq T)) (xs (@TList T)) (nr (@TList T) :list))
+  :signature ((@TList T) (@TList T)) Bool
+  (
+  (($str_is_multiset_subset_strict_done xs (@tlist s nr)) 
+    ; A missing symbolic term may be empty, so only definitely non-empty
+    ; components witness strictness.
+    (eo::define ((ls ($str_value_len s)))
+    (eo::define ((rec ($str_is_multiset_subset_strict_done xs nr)))
+      (eo::ite (eo::and (eo::is_eq ls 1) ($are_distinct_terms_list_rec s xs (eo::typeof s)))
+        true
+        rec))))
+  (($str_is_multiset_subset_strict_done xs nr)           false)
+  )
 )
 
 ; program: $str_is_multiset_subset_strict
 ; args:
 ; - s (Seq T): a string term, expected to be in flattened form.
-; - xs @List: the multiset (over)approximation of a string term.
-; - nr @List: the accumulated list of previously processed terms from s that were not removed from xs.
+; - xs (@TList T): the multiset (over)approximation of a string term.
+; - nr (@TList T): the accumulated list of previously processed terms from s that were not removed from xs.
 ; return: >
 ;   True if the string approximated by s is definitely not contained in the string
 ;   approximated by t. We compute this by iteratively removing the components of
 ;   s from t, and then checking if a term in nr is provably distinct from the final xs.
-(program $str_is_multiset_subset_strict ((T Type) (emp (Seq T)) (s (Seq T)) (ss (Seq T) :list) (xs @List) (nr @List :list))
-    :signature ((Seq T) @List @List) Bool
-    (
-      (($str_is_multiset_subset_strict (str.++ s ss) xs nr) (eo::define ((xsr (eo::list_erase @list xs s)))
+(program $str_is_multiset_subset_strict 
+  ((T Type) (emp (Seq T)) (s (Seq T)) (ss (Seq T) :list) (xs (@TList T)) (nr (@TList T) :list))
+  :signature ((Seq T) (@TList T) (@TList T)) Bool
+  (
+  (($str_is_multiset_subset_strict (str.++ s ss) xs nr) (eo::define ((xsr (eo::list_erase @tlist xs s)))
+                                                        (eo::define ((nrem (eo::eq xs xsr)))
+                                                          ($str_is_multiset_subset_strict ss xsr
+                                                            ; we add s to the accumulated list if it was not removed from xs
+                                                            (eo::ite nrem (_ @tlist s nr) nr)))))
+  (($str_is_multiset_subset_strict emp xs nr)           (eo::ite ($str_is_empty emp)
+                                                          ($str_is_multiset_subset_strict_done xs nr)
+                                                          (eo::define ((xsr (eo::list_erase @tlist xs emp)))
                                                             (eo::define ((nrem (eo::eq xs xsr)))
-                                                              ($str_is_multiset_subset_strict ss xsr
-                                                                ; we add s to the accumulated list if it was not removed from xs
-                                                                (eo::ite nrem (_ @list s nr) nr)))))
-      (($str_is_multiset_subset_strict emp xs nr)           (eo::ite ($str_is_empty emp)
-                                                              ($str_is_multiset_subset_strict_done xs nr)
-                                                              (eo::define ((xsr (eo::list_erase @list xs emp)))
-                                                                (eo::define ((nrem (eo::eq xs xsr)))
-                                                                  ($str_is_multiset_subset_strict_done xsr
-                                                                    ; we add emp to the accumulated list if it was not removed from xs
-                                                                    (eo::ite nrem (_ @list emp nr) nr))))))
-    )
+                                                              ($str_is_multiset_subset_strict_done xsr
+                                                                ; we add emp to the accumulated list if it was not removed from xs
+                                                                (eo::ite nrem (_ @tlist emp nr) nr))))))
+  )
 )
 
 ; rule: str-ctn-multiset-subset
@@ -728,7 +736,7 @@
   :args ((= (str.contains t s) false))
   :requires ((($str_is_multiset_subset_strict
                 ($str_to_flat_form s false)
-                ($str_multiset_overapprox t) @list.nil) true))
+                ($str_multiset_overapprox t) (@tlist.nil (eo::typeof t))) true))
   :conclusion (= (str.contains t s) false)
 )
 
@@ -947,7 +955,8 @@
   (($seq_is_prefix t t)                                               true)
   (($seq_is_prefix (seq.++ t ts) (seq.++ t ss))                       ($seq_is_prefix ts ss))
   (($seq_is_prefix (seq.++ (seq.unit et) ts) (seq.++ (seq.unit es) ss))
-    (eo::requires ($are_distinct_terms et es) true false))  ; we require showing the characters are truly disequal to return false
+    ; we require showing the characters are truly disequal to return false
+    (eo::requires ($are_distinct_terms (eo::typeof et) et es) true false))
   (($seq_is_prefix (as seq.empty (Seq T)) t)                          true)
   (($seq_is_prefix (seq.++ (seq.unit et) ts) (as seq.empty (Seq T)))  false)
   )

--- a/proofs/eo/cpc/rules/Strings.eo
+++ b/proofs/eo/cpc/rules/Strings.eo
@@ -686,10 +686,10 @@
   :signature ((@TList T) (@TList T)) Bool
   (
   (($str_is_multiset_subset_strict_done xs (@tlist s nr)) 
-    ; A missing symbolic term may be empty, so only definitely non-empty
-    ; components witness strictness.
     (eo::define ((ls ($str_value_len s)))
     (eo::define ((rec ($str_is_multiset_subset_strict_done xs nr)))
+      ; We must check that s has length exactly one, since we are trying to
+      ; show that it is distinct from xs which contains characters.
       (eo::ite (eo::and (eo::is_eq ls 1) ($are_distinct_terms_list_rec s xs (eo::typeof s)))
         true
         rec))))

--- a/proofs/eo/cpc/rules/Strings.eo
+++ b/proofs/eo/cpc/rules/Strings.eo
@@ -219,7 +219,7 @@
 ; conclusion: The given witness skolem has length n.
 (declare-rule exists_string_length ((U Type) (n Int) (id Int))
   :args ((Seq U) n id)
-  :requires (((eo::gt n -1) true) ((eo::gt id -1) true))
+  :requires (((eo::gt n -1) true))
   :conclusion (= (str.len (@witness_string_length (Seq U) n id)) n)
 )
 

--- a/proofs/eo/cpc/rules/Uf.eo
+++ b/proofs/eo/cpc/rules/Uf.eo
@@ -293,7 +293,7 @@
 ; conclusion: The given equality.
 (declare-rule distinct-true ((T Type) (xs (@TList T) :list))
   :args ((= (distinct xs) true))
-  :requires ((($are_distinct_terms_list ($typed_list_to_untyped xs) ($typed_list_element_type (eo::typeof xs))) true))
+  :requires ((($are_distinct_terms_list xs ($typed_list_element_type (eo::typeof xs))) true))
   :conclusion (= (distinct xs) true)
 )
 


### PR DESCRIPTION
This refactors the definition of the distinct values side condition in CPC to a version that is proven correct in Logos/Lean. 

Note this definition is much easier to prove terminating in Lean, it requires only a local size-based arguments. The changes include:
- Avoid n-ary introduction on intermediate terms,
- Pass element types to sequence/set helpers
- Use typed lists instead of untyped lists, and
- Don't accumulate intermediate lists for datatype subgoals.

This PR also corrects a bug in str-ctn-multiset-subset which did not properly check for non-flattened components in concatenation, which would lead us to spuriously check distinctness for string constants that did not have length one.

This updates multiple users of this side condition. All proof rules that rely on this side condition are now proven correct in Logos/Lean, pending further PRs to update CPC+Eunoia on cvc5 main, e.g.:
https://github.com/ajreynol/logos/pull/216
https://github.com/ajreynol/logos/pull/217
https://github.com/ajreynol/logos/pull/220
https://github.com/ajreynol/logos/pull/221
https://github.com/ajreynol/logos/pull/241
