### PR TITLE
Fix proof for bv inverter

### DIFF
--- a/src/rewriter/basic_rewrite_rcons.cpp
+++ b/src/rewriter/basic_rewrite_rcons.cpp
@@ -408,7 +408,11 @@ bool BasicRewriteRCons::ensureProofMacroBoolBvInvertSolve(CDProof* cdp,
   Assert(eq[0].getKind() == Kind::EQUAL);
   Assert(eq[0][0].getKind() == Kind::EQUAL
          && eq[0][1].getKind() == Kind::EQUAL);
+  // Use the same disallowed kinds as the rewrite (see rewriteViaRule for
+  // MACRO_BOOL_BV_INVERT_SOLVE), so that proof reconstruction matches the
+  // solving that was actually performed by the rewrite.
   std::unordered_set<Kind> disallowedKinds;
+  disallowedKinds.insert(Kind::BITVECTOR_CONCAT);
   theory::booleans::TheoryBoolRewriter::getBvInvertSolve(
       nodeManager(), eq[0][0], eq[0][1][0], disallowedKinds, cdp);
   // finish proof

--- a/src/theory/booleans/theory_bool_rewriter.cpp
+++ b/src/theory/booleans/theory_bool_rewriter.cpp
@@ -423,7 +423,7 @@ Node TheoryBoolRewriter::getBvInvertSolve(
       // constructed for the operator of t. For most operators (NOT, NEG,
       // ADD->SUB, XOR) the previously solved term is the first child of this
       // inversion term. For multiplication by an odd constant, however,
-      // solveBvLit builds (bvmul inv prevRhs), so the previously solved term
+      // solveBvLit builds (bvmul inv t), so the previously solved term
       // is the second child.
       size_t innerIndex = (t.getKind() == Kind::BITVECTOR_MULT) ? 1 : 0;
       Node next = t.eqNode(curr[1][innerIndex]);

--- a/src/theory/booleans/theory_bool_rewriter.cpp
+++ b/src/theory/booleans/theory_bool_rewriter.cpp
@@ -419,7 +419,14 @@ Node TheoryBoolRewriter::getBvInvertSolve(
     std::vector<Node> transEq;
     for (const Node& t : ts)
     {
-      Node next = t.eqNode(curr[1][0]);
+      // The right hand side of curr is the inversion term that solveBvLit
+      // constructed for the operator of t. For most operators (NOT, NEG,
+      // ADD->SUB, XOR) the previously solved term is the first child of this
+      // inversion term. For multiplication by an odd constant, however,
+      // solveBvLit builds (bvmul inv prevRhs), so the previously solved term
+      // is the second child.
+      size_t innerIndex = (t.getKind() == Kind::BITVECTOR_MULT) ? 1 : 0;
+      Node next = t.eqNode(curr[1][innerIndex]);
       Trace("quant-velim-bv") << "- " << next << " == " << curr << std::endl;
       Node eqc = next.eqNode(curr);
       if (t.getKind() == Kind::BITVECTOR_XOR && curr[0] != t[0])

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1547,6 +1547,7 @@ set(regress_0_tests
   regress0/proofs/issue12683-check-proofs-arith-mixed.smt2
   regress0/proofs/issue12696-check-proofs-subtype.smt2
   regress0/proofs/issue12697-check-proofs-arith.smt2
+  regress0/proofs/issue12746-bv-invert-solve-mult.smt2
   regress0/proofs/issue12708-check-proofs-arith-cm.smt2
   regress0/proofs/issue12709-open-sat-proof.smt2
   regress0/proofs/issue8983-trust-subs.smt2

--- a/test/regress/cli/regress0/proofs/issue12746-bv-invert-solve-mult.smt2
+++ b/test/regress/cli/regress0/proofs/issue12746-bv-invert-solve-mult.smt2
@@ -1,0 +1,9 @@
+; COMMAND-LINE: --check-proofs
+; DISABLE-TESTER: unsat-core
+; EXPECT: unsat
+(set-logic ALL)
+(declare-const a (_ BitVec 4))
+(declare-const t (_ BitVec 4))
+(assert (distinct true (exists ((x (_ BitVec 4)))
+        (= #b0001 (bvxor (bvadd x x x) a)))))
+(check-sat)

--- a/test/regress/cli/regress0/proofs/issue12746-bv-invert-solve-mult.smt2
+++ b/test/regress/cli/regress0/proofs/issue12746-bv-invert-solve-mult.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE: --check-proofs
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-const a (_ BitVec 4))

--- a/test/regress/cli/regress0/proofs/issue12746-bv-invert-solve-mult.smt2
+++ b/test/regress/cli/regress0/proofs/issue12746-bv-invert-solve-mult.smt2
@@ -1,5 +1,4 @@
 ; COMMAND-LINE: --check-proofs
-; DISABLE-TESTER: unsat-core
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-const a (_ BitVec 4))


### PR DESCRIPTION
Fixes #12746.

Also fixes an inconsistency with proof reconstruction related to solving for concat (which is not supported).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>