### PR TITLE
prop: cadical: Keep fixed assignments across backtrack.

### DIFF
--- a/src/prop/cadical/cdclt_propagator.cpp
+++ b/src/prop/cadical/cdclt_propagator.cpp
@@ -196,7 +196,7 @@ void CadicalPropagator::notify_backtrack(size_t level)
         << "re-enqueue (backtrack): " << lit << std::endl;
     d_proxy->enqueueTheoryLiteral(lit);
   }
-  // Clear the propgations since they are not valid anymore.
+  // Clear the propagations since they are not valid anymore.
   d_propagations.clear();
   ++d_stats.notifyBacktrack;
 
@@ -368,7 +368,7 @@ int CadicalPropagator::cb_propagate()
   {
     // Only propagate if all activation literals are processed. Activation
     // literals are always assumed first. If we don't do this, explanations
-    // for theory propgations may force activation literals to different
+    // for theory propagations may force activation literals to different
     // values before they can get decided on.
     if (d_decisions.size() < current_user_level())
     {

--- a/src/prop/cadical/cdclt_propagator.cpp
+++ b/src/prop/cadical/cdclt_propagator.cpp
@@ -149,23 +149,53 @@ void CadicalPropagator::notify_backtrack(size_t level)
     d_decisions.pop_back();
   }
 
-  // Backtrack assignments, resend fixed theory literals that got backtracked
+  // Backtrack assignments. Genuine decision-level assignments are undone,
+  // but fixed assignments are permanent (decision level 0): we keep them
+  // assigned and retain them in d_assignments so that the user_pop()
+  // renotification machinery still sees them (it relies on d_assignments
+  // holding exactly the fixed literals once we are back at decision level 0).
+  // The corresponding theory literals are re-enqueued below, after notifying
+  // the theory proxy about the backtrack.
   Assert(!d_assignment_control.empty());
   size_t pop_to = d_assignment_control[level];
   d_assignment_control.resize(level);
 
-  while (pop_to < d_assignments.size())
+  size_t keep = pop_to;
+  std::vector<SatLiteral> renotify;
+  for (size_t i = pop_to, n = d_assignments.size(); i < n; ++i)
   {
-    SatLiteral lit = d_assignments.back();
-    d_assignments.pop_back();
+    SatLiteral lit = d_assignments[i];
     SatVariable var = lit.getSatVariable();
     auto& info = d_var_info[var];
-    Trace("cadical::propagator") << "unassign: " << var << std::endl;
-    info.assignment = 0;
+    if (info.is_fixed)
+    {
+      // Permanent assignment: keep it and retain it in d_assignments.
+      Trace("cadical::propagator") << "keep fixed: " << var << std::endl;
+      d_assignments[keep++] = lit;
+      if (info.is_theory_atom)
+      {
+        renotify.push_back(lit);
+      }
+    }
+    else
+    {
+      Trace("cadical::propagator") << "unassign: " << var << std::endl;
+      info.assignment = 0;
+    }
   }
+  d_assignments.resize(keep);
 
   // Notify theory proxy about backtrack
   d_proxy->notifyBacktrack();
+  // Re-enqueue fixed theory literals that got backtracked at the theory level
+  // but remain assigned at the SAT level. This must happen after
+  // notifyBacktrack(), otherwise the theory backtrack would discard them.
+  for (const SatLiteral& lit : renotify)
+  {
+    Trace("cadical::propagator")
+        << "re-enqueue (backtrack): " << lit << std::endl;
+    d_proxy->enqueueTheoryLiteral(lit);
+  }
   // Clear the propgations since they are not valid anymore.
   d_propagations.clear();
   ++d_stats.notifyBacktrack;

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1638,6 +1638,7 @@ set(regress_0_tests
   regress0/prop/cadical_bug5.smt2
   regress0/prop/cadical_bug6.smt2
   regress0/prop/cadical_bug7.smt2
+  regress0/prop/cadical_bug8.smt2
   regress0/prop/issue11867.smt2
   regress0/prop/red-psyco-134.smt2
   regress0/push-pop/boolean/fuzz_12.smt2

--- a/test/regress/cli/regress0/prop/cadical_bug8.smt2
+++ b/test/regress/cli/regress0/prop/cadical_bug8.smt2
@@ -1,0 +1,12 @@
+; COMMAND-LINE: --sat-solver=cadical
+; EXPECT: sat
+(set-logic QF_AUFLIA)
+(set-info :status sat)
+(declare-fun a () (Array Int Int))
+(declare-fun e () Int)
+(declare-fun i () Int)
+(declare-fun i1 () Int)
+(declare-fun s ((Array Int Int) (Array Int Int)) Int)
+(assert (distinct 0 i1))
+(assert (distinct (select (store a 0 e) (s a (store (store (store (store a 0 0) i 0) 0 0) 1 0))) (select (store (store (store a 0 e) 1 0) i1 0) (s a (store (store (store (store a 0 0) i 0) 0 0) 1 0)))))
+(check-sat)


### PR DESCRIPTION
notify_backtrack() reset the assignment of every popped trail literal, including fixed ones. A literal fixed during search sits in a `decision-level > 0` segment of d_assignments, so a backtrack left it as
`is_fixed && assignment == 0`, tripping an assertion in add_clause(). It also dropped fixed literals from d_assignments, which user_pop() relies on to renotify them across user levels.

Retain fixed literals in d_assignments, keep them assigned, and re-enqueue the corresponding theory literals after notifying the theory proxy.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>