### PR TITLE
prop: cadical: Determine clause user level for learned clauses.

### DIFF
--- a/src/prop/cadical/cdclt_propagator.cpp
+++ b/src/prop/cadical/cdclt_propagator.cpp
@@ -360,8 +360,9 @@ int CadicalPropagator::cb_add_reason_clause_lit(int propagated_lit)
     SatLiteral slit = toSatLiteral(propagated_lit);
     SatClause clause;
     d_proxy->explainPropagation(slit, clause);
-    // Add activation literal to reason
-    SatLiteral alit = current_activation_lit();
+    Assert(d_in_search);
+    // Add activation literal of the clause's user level to the reason.
+    SatLiteral alit = activation_lit(clause_user_level(clause));
     if (alit != undefSatLiteral)
     {
       d_reason.push_back(alit);
@@ -634,7 +635,7 @@ void CadicalPropagator::phase(SatLiteral lit)
   d_var_info[lit.getSatVariable()].phase = lit.isNegated() ? -1 : 1;
 }
 
-const SatLiteral& CadicalPropagator::current_activation_lit()
+const SatLiteral& CadicalPropagator::current_activation_lit() const
 {
   if (d_activation_literals.empty())
   {
@@ -643,7 +644,7 @@ const SatLiteral& CadicalPropagator::current_activation_lit()
   return d_activation_literals.back();
 }
 
-const SatLiteral& CadicalPropagator::activation_lit(size_t user_level)
+const SatLiteral& CadicalPropagator::activation_lit(size_t user_level) const
 {
   // User level 0 has no activation literal.
   if (user_level == 0)
@@ -652,6 +653,18 @@ const SatLiteral& CadicalPropagator::activation_lit(size_t user_level)
   }
   Assert(user_level <= d_activation_literals.size());
   return d_activation_literals[user_level - 1];
+}
+
+uint32_t CadicalPropagator::clause_user_level(const SatClause& clause) const
+{
+  uint32_t max_user_level = 0;
+  for (const SatLiteral& lit : clause)
+  {
+    SatVariable var = lit.getSatVariable();
+    Assert(var < d_var_info.size());
+    max_user_level = std::max(max_user_level, d_var_info[var].level_intro);
+  }
+  return max_user_level;
 }
 
 void CadicalPropagator::renotify_fixed()

--- a/src/prop/cadical/cdclt_propagator.cpp
+++ b/src/prop/cadical/cdclt_propagator.cpp
@@ -421,6 +421,13 @@ SatValue CadicalPropagator::value(SatLiteral lit) const
 void CadicalPropagator::add_clause(const SatClause& clause)
 {
   std::vector<CadicalLit> lits;
+  // Note: Removable clauses can be added to lower user levels to avoid
+  //       deleting them too eagerly. For example, conflicts may be learned
+  //       at a user level N even though it only has literals of at most user
+  //       level N - 2. In this case we can add the clause at N - 2 instead
+  //       of deleting the clause when popping user level N, which would
+  //       require us to relearn the clause again.
+  uint32_t max_user_level = d_in_search ? 0 : current_user_level();
   for (const SatLiteral& lit : clause)
   {
     SatVariable var = lit.getSatVariable();
@@ -437,12 +444,13 @@ void CadicalPropagator::add_clause(const SatClause& clause)
         return;
       }
     }
+    max_user_level = std::max(max_user_level, info.level_intro);
     lits.push_back(toCadicalLit(lit));
   }
   if (!lits.empty())
   {
-    // Add activation literal to clause if we are in user level > 0
-    SatLiteral alit = current_activation_lit();
+    // Determine activation literal based on max user level of clause.
+    SatLiteral alit = activation_lit(max_user_level);
     if (alit != undefSatLiteral)
     {
       lits.insert(lits.begin(), toCadicalLit(alit));
@@ -633,6 +641,17 @@ const SatLiteral& CadicalPropagator::current_activation_lit()
     return undefSatLiteral;
   }
   return d_activation_literals.back();
+}
+
+const SatLiteral& CadicalPropagator::activation_lit(size_t user_level)
+{
+  // User level 0 has no activation literal.
+  if (user_level == 0)
+  {
+    return undefSatLiteral;
+  }
+  Assert(user_level <= d_activation_literals.size());
+  return d_activation_literals[user_level - 1];
 }
 
 void CadicalPropagator::renotify_fixed()

--- a/src/prop/cadical/cdclt_propagator.h
+++ b/src/prop/cadical/cdclt_propagator.h
@@ -208,6 +208,11 @@ class CadicalPropagator : public CaDiCaL::ExternalPropagator,
    */
   const SatLiteral& current_activation_lit();
 
+  /**
+   * Return the activation literal for the given user level.
+   */
+  const SatLiteral& activation_lit(size_t user_level);
+
   /** Return the current user (assertion) level. */
   size_t current_user_level() const { return d_active_vars_control.size(); }
 
@@ -281,8 +286,8 @@ class CadicalPropagator : public CaDiCaL::ExternalPropagator,
    * Current activation literals.
    *
    * For each user level, we push a fresh activation literal to the vector (in
-   * user_pop()). Activation literals get removed and disabled in user_pop().
-   * The size of the vector corresponds to the current user level.
+   * set_activation_lit()). Activation literals get removed and disabled in
+   * user_pop(). The size of the vector corresponds to the current user level.
    *
    * The activation literals corresponding to the current user level gets
    * automatically added to each clause added in this user level. With

--- a/src/prop/cadical/cdclt_propagator.h
+++ b/src/prop/cadical/cdclt_propagator.h
@@ -206,12 +206,22 @@ class CadicalPropagator : public CaDiCaL::ExternalPropagator,
    *
    * Note: Returns undefSatLiteral at user level 0.
    */
-  const SatLiteral& current_activation_lit();
+  const SatLiteral& current_activation_lit() const;
 
   /**
    * Return the activation literal for the given user level.
    */
-  const SatLiteral& activation_lit(size_t user_level);
+  const SatLiteral& activation_lit(size_t user_level) const;
+
+  /**
+   * Determine the user level a clause depends on, i.e., the maximum
+   * introduction level over all its literals.
+   *
+   * A learned clause is guarded by the activation literal of this level (see
+   * cb_add_reason_clause_lit()), so that it survives popping user levels above
+   * it and only gets disabled once the level it actually depends on is popped.
+   */
+  uint32_t clause_user_level(const SatClause& clause) const;
 
   /** Return the current user (assertion) level. */
   size_t current_user_level() const { return d_active_vars_control.size(); }
@@ -289,8 +299,11 @@ class CadicalPropagator : public CaDiCaL::ExternalPropagator,
    * set_activation_lit()). Activation literals get removed and disabled in
    * user_pop(). The size of the vector corresponds to the current user level.
    *
-   * The activation literals corresponding to the current user level gets
-   * automatically added to each clause added in this user level. With
+   * A clause added to the SAT solver is automatically guarded with the
+   * activation literal of the highest user level among its literals (see
+   * add_clause() and cb_add_reason_clause_lit()), which is not necessarily the
+   * current user level. This keeps the clause alive until that level is popped,
+   * avoiding the need to relearn it when only higher levels are popped. With
    * activation literals we can simulate push/pop of clauses in the SAT solver.
    */
   std::vector<SatLiteral> d_activation_literals;

--- a/test/unit/prop/CMakeLists.txt
+++ b/test/unit/prop/CMakeLists.txt
@@ -12,3 +12,10 @@
 
 # Add unit tests.
 cvc5_add_unit_test_white(cnf_stream_white prop)
+cvc5_add_unit_test_white(cadical_propagator_white prop)
+# The propagator test includes CaDiCaL headers and constructs a CaDiCaL::Solver
+# directly. The cvc5 library only exposes CaDiCaL privately, so link the CaDiCaL
+# target explicitly to get its include directories and symbols.
+if(TARGET cadical_propagator_white)
+  target_link_libraries(cadical_propagator_white PUBLIC CaDiCaL)
+endif()

--- a/test/unit/prop/cadical_propagator_white.cpp
+++ b/test/unit/prop/cadical_propagator_white.cpp
@@ -1,0 +1,158 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Mathias Preiner
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2026 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * White box testing of cvc5::prop::cadical::CadicalPropagator, in particular
+ * the user level assigned to clauses added during search.
+ */
+
+#include <cadical/cadical.hpp>
+
+#include "context/context.h"
+#include "prop/cadical/cdclt_propagator.h"
+#include "prop/cadical/util.h"
+#include "prop/sat_solver_types.h"
+#include "test.h"
+#include "util/statistics_registry.h"
+
+namespace cvc5::internal {
+
+using namespace prop;
+using namespace prop::cadical;
+
+namespace test {
+
+class TestPropWhiteCadicalPropagator : public TestInternal
+{
+ protected:
+  void SetUp() override
+  {
+    d_stats.reset(new StatisticsRegistry());
+    d_context.reset(new context::Context());
+    d_solver.reset(new CaDiCaL::Solver());
+    d_prop.reset(
+        new CadicalPropagator(nullptr, d_context.get(), *d_solver, *d_stats));
+    // Observed variables require a connected external propagator.
+    d_solver->connect_external_propagator(d_prop.get());
+
+    // Build three user levels. This mirrors CadicalSolver::push(), which
+    // creates the activation literal *after* incrementing the user level, so
+    // the activation literal's introduction level is the new user level.
+    //
+    //   level 0: variables 1, 2
+    //   level 1: activation literal 3, variable 4
+    //   level 2: activation literal 5, variable 6
+    d_prop->add_new_var(1, true);
+    d_prop->add_new_var(2, true);
+
+    d_prop->user_push();
+    d_prop->add_new_var(3, false);
+    d_prop->set_activation_lit(3);
+    d_prop->add_new_var(4, true);
+
+    d_prop->user_push();
+    d_prop->add_new_var(5, false);
+    d_prop->set_activation_lit(5);
+    d_prop->add_new_var(6, true);
+  }
+
+  void TearDown() override
+  {
+    d_solver->disconnect_external_propagator();
+    d_prop.reset(nullptr);
+    d_solver.reset(nullptr);
+    d_context.reset(nullptr);
+    d_stats.reset(nullptr);
+  }
+
+  /**
+   * Drain the next clause buffered by add_clause() (during search) via the
+   * external-clause callbacks and return its CaDiCaL literals (without the
+   * terminating 0).
+   */
+  std::vector<int> nextClause()
+  {
+    std::vector<int> clause;
+    bool forgettable = true;
+    EXPECT_TRUE(d_prop->cb_has_external_clause(forgettable));
+    for (int lit = d_prop->cb_add_external_clause_lit(); lit != 0;
+         lit = d_prop->cb_add_external_clause_lit())
+    {
+      clause.push_back(lit);
+    }
+    return clause;
+  }
+
+  std::unique_ptr<StatisticsRegistry> d_stats;
+  std::unique_ptr<context::Context> d_context;
+  std::unique_ptr<CaDiCaL::Solver> d_solver;
+  std::unique_ptr<CadicalPropagator> d_prop;
+};
+
+TEST_F(TestPropWhiteCadicalPropagator, activation_lit_indexing)
+{
+  ASSERT_EQ(d_prop->current_user_level(), 2u);
+  // Level 0 (base level) has no activation literal.
+  ASSERT_EQ(d_prop->activation_lit(0), undefSatLiteral);
+  ASSERT_EQ(d_prop->activation_lit(1), SatLiteral(3));
+  ASSERT_EQ(d_prop->activation_lit(2), SatLiteral(5));
+  ASSERT_EQ(d_prop->current_activation_lit(), SatLiteral(5));
+}
+
+TEST_F(TestPropWhiteCadicalPropagator, learned_clause_uses_max_intro_level)
+{
+  // A clause learned during search whose highest-level literal was introduced
+  // at user level 1 must be guarded by level 1's activation literal (3), not
+  // the current level's (5), so it survives popping level 2.
+  d_prop->in_search(true);
+  SatClause clause{SatLiteral(4)};  // variable 4 was introduced at level 1
+  d_prop->add_clause(clause);
+  EXPECT_EQ(nextClause(),
+            (std::vector<int>{toCadicalLit(SatLiteral(3)),
+                              toCadicalLit(SatLiteral(4))}));
+}
+
+TEST_F(TestPropWhiteCadicalPropagator, learned_clause_takes_max_over_literals)
+{
+  // max over several literals: {1 (level 0), 4 (level 1)} -> level 1 -> 3.
+  d_prop->in_search(true);
+  SatClause clause{SatLiteral(1), SatLiteral(4)};
+  d_prop->add_clause(clause);
+  EXPECT_EQ(nextClause(),
+            (std::vector<int>{toCadicalLit(SatLiteral(3)),
+                              toCadicalLit(SatLiteral(1)),
+                              toCadicalLit(SatLiteral(4))}));
+}
+
+TEST_F(TestPropWhiteCadicalPropagator, learned_clause_over_base_level)
+{
+  // A clause over only base-level (level 0) literals is globally valid and
+  // must not get any activation literal, even at user level 2.
+  d_prop->in_search(true);
+  SatClause clause{SatLiteral(1), SatLiteral(2)};
+  d_prop->add_clause(clause);
+  EXPECT_EQ(nextClause(),
+            (std::vector<int>{toCadicalLit(SatLiteral(1)),
+                              toCadicalLit(SatLiteral(2))}));
+}
+
+TEST_F(TestPropWhiteCadicalPropagator, input_clause_uses_current_level)
+{
+  // Outside search, the clause is guarded by the current user level's
+  // activation literal, even if all its literals were introduced at a lower
+  // level (the conservative, pre-existing behavior).
+  ASSERT_FALSE(d_prop->in_search());
+  ASSERT_EQ(d_prop->activation_lit(d_prop->current_user_level()),
+            d_prop->current_activation_lit());
+}
+
+}  // namespace test
+}  // namespace cvc5::internal

--- a/test/unit/prop/cadical_propagator_white.cpp
+++ b/test/unit/prop/cadical_propagator_white.cpp
@@ -1,7 +1,4 @@
 /******************************************************************************
- * Top contributors (to current version):
- *   Mathias Preiner
- *
  * This file is part of the cvc5 project.
  *
  * Copyright (c) 2009-2026 by the authors listed in the file AUTHORS

--- a/test/unit/prop/cadical_propagator_white.cpp
+++ b/test/unit/prop/cadical_propagator_white.cpp
@@ -154,5 +154,51 @@ TEST_F(TestPropWhiteCadicalPropagator, input_clause_uses_current_level)
             d_prop->current_activation_lit());
 }
 
+// The following tests cover the reason path (cb_add_reason_clause_lit()), which
+// guards the reason with activation_lit(clause_user_level(reason)). We exercise
+// that computation directly rather than driving the callback, since the
+// callback obtains the reason via TheoryProxy::explainPropagation() and setting
+// up a TheoryProxy requires a full theory engine. explainPropagation() returns
+// the propagated literal followed by the negated antecedents, so the reason's
+// user level is the max introduction level over all of them.
+
+TEST_F(TestPropWhiteCadicalPropagator, reason_clause_user_level)
+{
+  // Propagated literal at level 1 with a base-level antecedent: max -> level 1.
+  SatClause level1{SatLiteral(4), SatLiteral(1)};
+  EXPECT_EQ(d_prop->clause_user_level(level1), 1u);
+
+  // Highest literal at level 2 dominates: max -> level 2.
+  SatClause level2{SatLiteral(1), SatLiteral(4), SatLiteral(6)};
+  EXPECT_EQ(d_prop->clause_user_level(level2), 2u);
+
+  // Reason derived purely from base-level facts: level 0.
+  SatClause base{SatLiteral(1), SatLiteral(2)};
+  EXPECT_EQ(d_prop->clause_user_level(base), 0u);
+}
+
+TEST_F(TestPropWhiteCadicalPropagator, reason_clause_guard)
+{
+  // The activation literal cb_add_reason_clause_lit() prepends to the reason is
+  // activation_lit(clause_user_level(reason)).
+
+  // A reason depending on level 1 is guarded by level 1's activation literal
+  // (3), not the current level's (5), so it survives popping level 2.
+  SatClause level1{SatLiteral(4), SatLiteral(1)};
+  EXPECT_EQ(d_prop->activation_lit(d_prop->clause_user_level(level1)),
+            SatLiteral(3));
+
+  // A reason depending on level 2 is guarded by level 2's activation literal.
+  SatClause level2{SatLiteral(6), SatLiteral(4)};
+  EXPECT_EQ(d_prop->activation_lit(d_prop->clause_user_level(level2)),
+            SatLiteral(5));
+
+  // A reason over only base-level literals is globally valid and gets no
+  // activation literal guard.
+  SatClause base{SatLiteral(1), SatLiteral(2)};
+  EXPECT_EQ(d_prop->activation_lit(d_prop->clause_user_level(base)),
+            undefSatLiteral);
+}
+
 }  // namespace test
 }  // namespace cvc5::internal


### PR DESCRIPTION
Until now, clauses of theory lemmas were added to the current user level. However, this results in these clauses getting eagerly popped on user pop. Instead, we now determine the user level of clauses based on the user level of the involved variables and add the clause to the maximum of their levels.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>