### PR TITLE
cadical: Integrate support for marking clauses as forgettable.

### DIFF
--- a/src/prop/cadical/cadical.cpp
+++ b/src/prop/cadical/cadical.cpp
@@ -207,7 +207,7 @@ ClauseId CadicalSolver::addClause(const SatClause& clause, bool removable)
   }
   if (d_propagator)
   {
-    d_propagator->add_clause(clause);
+    d_propagator->add_clause(clause, removable);
   }
   else
   {

--- a/src/prop/cadical/cdclt_propagator.cpp
+++ b/src/prop/cadical/cdclt_propagator.cpp
@@ -393,6 +393,7 @@ int CadicalPropagator::cb_add_reason_clause_lit(int propagated_lit)
 bool CadicalPropagator::cb_has_external_clause(bool& forgettable)
 {
   ++d_stats.cbHasExternalClause;
+  forgettable = false;
   if (!d_new_clauses_forgettable.empty())
   {
     Assert(!d_new_clauses.empty());

--- a/src/prop/cadical/cdclt_propagator.cpp
+++ b/src/prop/cadical/cdclt_propagator.cpp
@@ -204,6 +204,7 @@ bool CadicalPropagator::cb_check_found_model(
     d_new_clauses.push_back(1);
     d_new_clauses.push_back(-1);
     d_new_clauses.push_back(0);
+    d_new_clauses_forgettable.push_back(true);
     return false;
   }
 
@@ -241,7 +242,8 @@ bool CadicalPropagator::cb_check_found_model(
           << "add propagation reason: " << p << std::endl;
       SatClause clause;
       d_proxy->explainPropagation(p, clause);
-      add_clause(clause);
+      // We explicitly mark propagation reason as not removable.
+      add_clause(clause, false);
     }
     d_propagations.clear();
 
@@ -267,6 +269,7 @@ bool CadicalPropagator::cb_check_found_model(
     d_new_clauses.push_back(1);
     d_new_clauses.push_back(-1);
     d_new_clauses.push_back(0);
+    d_new_clauses_forgettable.push_back(true);
     return false;
   }
   bool res = done();
@@ -387,10 +390,14 @@ int CadicalPropagator::cb_add_reason_clause_lit(int propagated_lit)
   return lit;
 }
 
-bool CadicalPropagator::cb_has_external_clause(bool& is_forgettable)
+bool CadicalPropagator::cb_has_external_clause(bool& forgettable)
 {
   ++d_stats.cbHasExternalClause;
-  is_forgettable = false;
+  if (!d_new_clauses_forgettable.empty())
+  {
+    Assert(!d_new_clauses.empty());
+    forgettable = d_new_clauses_forgettable.front();
+  }
   return !d_new_clauses.empty();
 }
 
@@ -399,6 +406,12 @@ int CadicalPropagator::cb_add_external_clause_lit()
   ++d_stats.cbAddExternalClauseLit;
   Assert(!d_new_clauses.empty());
   CadicalLit lit = d_new_clauses.front();
+  Assert(!d_new_clauses_forgettable.empty() || !d_in_search);
+  if (lit == 0)
+  {
+    Assert(!d_new_clauses_forgettable.empty());
+    d_new_clauses_forgettable.pop_front();
+  }
   d_new_clauses.pop_front();
   Trace("cadical::propagator")
       << "external_clause: " << toSatLiteral(lit) << std::endl;
@@ -418,7 +431,7 @@ SatValue CadicalPropagator::value(SatLiteral lit) const
   return val;
 }
 
-void CadicalPropagator::add_clause(const SatClause& clause)
+void CadicalPropagator::add_clause(const SatClause& clause, bool forgettable)
 {
   std::vector<CadicalLit> lits;
   for (const SatLiteral& lit : clause)
@@ -441,6 +454,16 @@ void CadicalPropagator::add_clause(const SatClause& clause)
   }
   if (!lits.empty())
   {
+    if (TraceIsOn("cadical::propagator"))
+    {
+      Trace("cadical::propagator") << "addClause (forgettable: " << forgettable
+                                   << ", in search: " << d_in_search << "):";
+      for (const SatLiteral& lit : clause)
+      {
+        Trace("cadical::propagator") << " " << lit;
+      }
+      Trace("cadical::propagator") << " 0" << std::endl;
+    }
     // Add activation literal to clause if we are in user level > 0
     SatLiteral alit = current_activation_lit();
     if (alit != undefSatLiteral)
@@ -453,6 +476,7 @@ void CadicalPropagator::add_clause(const SatClause& clause)
     {
       d_new_clauses.insert(d_new_clauses.end(), lits.begin(), lits.end());
       d_new_clauses.push_back(0);
+      d_new_clauses_forgettable.push_back(forgettable);
     }
     else
     {
@@ -461,6 +485,7 @@ void CadicalPropagator::add_clause(const SatClause& clause)
         d_solver.add(lit);
       }
       d_solver.add(0);
+      Assert(!forgettable);
     }
   }
   // // Add empty clause

--- a/src/prop/cadical/cdclt_propagator.cpp
+++ b/src/prop/cadical/cdclt_propagator.cpp
@@ -424,6 +424,7 @@ int CadicalPropagator::cb_add_reason_clause_lit(int propagated_lit)
 bool CadicalPropagator::cb_has_external_clause(bool& forgettable)
 {
   ++d_stats.cbHasExternalClause;
+  forgettable = false;
   if (!d_new_clauses_forgettable.empty())
   {
     Assert(!d_new_clauses.empty());

--- a/src/prop/cadical/cdclt_propagator.cpp
+++ b/src/prop/cadical/cdclt_propagator.cpp
@@ -234,6 +234,7 @@ bool CadicalPropagator::cb_check_found_model(
     d_new_clauses.push_back(1);
     d_new_clauses.push_back(-1);
     d_new_clauses.push_back(0);
+    d_new_clauses_forgettable.push_back(true);
     return false;
   }
 
@@ -271,7 +272,8 @@ bool CadicalPropagator::cb_check_found_model(
           << "add propagation reason: " << p << std::endl;
       SatClause clause;
       d_proxy->explainPropagation(p, clause);
-      add_clause(clause);
+      // We explicitly mark propagation reason as not removable.
+      add_clause(clause, false);
     }
     d_propagations.clear();
 
@@ -297,6 +299,7 @@ bool CadicalPropagator::cb_check_found_model(
     d_new_clauses.push_back(1);
     d_new_clauses.push_back(-1);
     d_new_clauses.push_back(0);
+    d_new_clauses_forgettable.push_back(true);
     return false;
   }
   bool res = done();
@@ -418,10 +421,14 @@ int CadicalPropagator::cb_add_reason_clause_lit(int propagated_lit)
   return lit;
 }
 
-bool CadicalPropagator::cb_has_external_clause(bool& is_forgettable)
+bool CadicalPropagator::cb_has_external_clause(bool& forgettable)
 {
   ++d_stats.cbHasExternalClause;
-  is_forgettable = false;
+  if (!d_new_clauses_forgettable.empty())
+  {
+    Assert(!d_new_clauses.empty());
+    forgettable = d_new_clauses_forgettable.front();
+  }
   return !d_new_clauses.empty();
 }
 
@@ -430,6 +437,12 @@ int CadicalPropagator::cb_add_external_clause_lit()
   ++d_stats.cbAddExternalClauseLit;
   Assert(!d_new_clauses.empty());
   CadicalLit lit = d_new_clauses.front();
+  Assert(!d_new_clauses_forgettable.empty() || !d_in_search);
+  if (lit == 0)
+  {
+    Assert(!d_new_clauses_forgettable.empty());
+    d_new_clauses_forgettable.pop_front();
+  }
   d_new_clauses.pop_front();
   Trace("cadical::propagator")
       << "external_clause: " << toSatLiteral(lit) << std::endl;
@@ -449,7 +462,7 @@ SatValue CadicalPropagator::value(SatLiteral lit) const
   return val;
 }
 
-void CadicalPropagator::add_clause(const SatClause& clause)
+void CadicalPropagator::add_clause(const SatClause& clause, bool forgettable)
 {
   std::vector<CadicalLit> lits;
   // Note: Removable clauses can be added to lower user levels to avoid
@@ -480,6 +493,16 @@ void CadicalPropagator::add_clause(const SatClause& clause)
   }
   if (!lits.empty())
   {
+    if (TraceIsOn("cadical::propagator"))
+    {
+      Trace("cadical::propagator") << "addClause (forgettable: " << forgettable
+                                   << ", in search: " << d_in_search << "):";
+      for (const SatLiteral& lit : clause)
+      {
+        Trace("cadical::propagator") << " " << lit;
+      }
+      Trace("cadical::propagator") << " 0" << std::endl;
+    }
     // Determine activation literal based on max user level of clause.
     SatLiteral alit = activation_lit(max_user_level);
     if (alit != undefSatLiteral)
@@ -492,6 +515,7 @@ void CadicalPropagator::add_clause(const SatClause& clause)
     {
       d_new_clauses.insert(d_new_clauses.end(), lits.begin(), lits.end());
       d_new_clauses.push_back(0);
+      d_new_clauses_forgettable.push_back(forgettable);
     }
     else
     {
@@ -500,6 +524,7 @@ void CadicalPropagator::add_clause(const SatClause& clause)
         d_solver.add(lit);
       }
       d_solver.add(0);
+      Assert(!forgettable);
     }
   }
   // // Add empty clause

--- a/src/prop/cadical/cdclt_propagator.h
+++ b/src/prop/cadical/cdclt_propagator.h
@@ -325,7 +325,7 @@ class CadicalPropagator : public CaDiCaL::ExternalPropagator,
    */
   std::deque<CadicalLit> d_new_clauses;
   /** Keep track of forgettable status of clauses buffered in d_new_clauses. */
-  std::deque<CadicalLit> d_new_clauses_forgettable;
+  std::deque<bool> d_new_clauses_forgettable;
 
   /**
    * Flag indicating whether cb_add_reason_clause_lit() is currently

--- a/src/prop/cadical/cdclt_propagator.h
+++ b/src/prop/cadical/cdclt_propagator.h
@@ -117,10 +117,10 @@ class CadicalPropagator : public CaDiCaL::ExternalPropagator,
 
   /**
    * Callback of the SAT solver to determine if we have a new clause to add.
-   * @param is_forgettable True if the clause is not irredundant.
+   * @param forgettable True if the clause is not irredundant.
    * @return True to indicate that we have clauses to add.
    */
-  bool cb_has_external_clause(bool& is_forgettable) override;
+  bool cb_has_external_clause(bool& forgettable) override;
 
   /**
    * Callback of the SAT solver to add a new clause.
@@ -155,9 +155,10 @@ class CadicalPropagator : public CaDiCaL::ExternalPropagator,
    *
    * Note: Filters out clauses satisfied by fixed literals.
    *
-   * @param clause The clause to add.
+   * @param clause      The clause to add.
+   * @param forgettable True if the clause is not irredundant.
    */
-  void add_clause(const SatClause& clause);
+  void add_clause(const SatClause& clause, bool forgettable);
 
   /**
    * Add new CaDiCaL variable.
@@ -323,6 +324,8 @@ class CadicalPropagator : public CaDiCaL::ExternalPropagator,
    * cb_add_reason_clause_lit().
    */
   std::deque<CadicalLit> d_new_clauses;
+  /** Keep track of forgettable status of clauses buffered in d_new_clauses. */
+  std::deque<CadicalLit> d_new_clauses_forgettable;
 
   /**
    * Flag indicating whether cb_add_reason_clause_lit() is currently

--- a/src/prop/cadical/cdclt_propagator.h
+++ b/src/prop/cadical/cdclt_propagator.h
@@ -117,10 +117,10 @@ class CadicalPropagator : public CaDiCaL::ExternalPropagator,
 
   /**
    * Callback of the SAT solver to determine if we have a new clause to add.
-   * @param is_forgettable True if the clause is not irredundant.
+   * @param forgettable True if the clause is not irredundant.
    * @return True to indicate that we have clauses to add.
    */
-  bool cb_has_external_clause(bool& is_forgettable) override;
+  bool cb_has_external_clause(bool& forgettable) override;
 
   /**
    * Callback of the SAT solver to add a new clause.
@@ -155,9 +155,10 @@ class CadicalPropagator : public CaDiCaL::ExternalPropagator,
    *
    * Note: Filters out clauses satisfied by fixed literals.
    *
-   * @param clause The clause to add.
+   * @param clause      The clause to add.
+   * @param forgettable True if the clause is not irredundant.
    */
-  void add_clause(const SatClause& clause);
+  void add_clause(const SatClause& clause, bool forgettable);
 
   /**
    * Add new CaDiCaL variable.
@@ -341,6 +342,8 @@ class CadicalPropagator : public CaDiCaL::ExternalPropagator,
    * cb_add_reason_clause_lit().
    */
   std::deque<CadicalLit> d_new_clauses;
+  /** Keep track of forgettable status of clauses buffered in d_new_clauses. */
+  std::deque<CadicalLit> d_new_clauses_forgettable;
 
   /**
    * Flag indicating whether cb_add_reason_clause_lit() is currently

--- a/src/prop/cadical/cdclt_propagator.h
+++ b/src/prop/cadical/cdclt_propagator.h
@@ -343,7 +343,7 @@ class CadicalPropagator : public CaDiCaL::ExternalPropagator,
    */
   std::deque<CadicalLit> d_new_clauses;
   /** Keep track of forgettable status of clauses buffered in d_new_clauses. */
-  std::deque<CadicalLit> d_new_clauses_forgettable;
+  std::deque<bool> d_new_clauses_forgettable;
 
   /**
    * Flag indicating whether cb_add_reason_clause_lit() is currently

--- a/test/unit/prop/cadical_propagator_white.cpp
+++ b/test/unit/prop/cadical_propagator_white.cpp
@@ -111,7 +111,7 @@ TEST_F(TestPropWhiteCadicalPropagator, learned_clause_uses_max_intro_level)
   // the current level's (5), so it survives popping level 2.
   d_prop->in_search(true);
   SatClause clause{SatLiteral(4)};  // variable 4 was introduced at level 1
-  d_prop->add_clause(clause);
+  d_prop->add_clause(clause, false);
   EXPECT_EQ(nextClause(),
             (std::vector<int>{toCadicalLit(SatLiteral(3)),
                               toCadicalLit(SatLiteral(4))}));
@@ -122,7 +122,7 @@ TEST_F(TestPropWhiteCadicalPropagator, learned_clause_takes_max_over_literals)
   // max over several literals: {1 (level 0), 4 (level 1)} -> level 1 -> 3.
   d_prop->in_search(true);
   SatClause clause{SatLiteral(1), SatLiteral(4)};
-  d_prop->add_clause(clause);
+  d_prop->add_clause(clause, false);
   EXPECT_EQ(nextClause(),
             (std::vector<int>{toCadicalLit(SatLiteral(3)),
                               toCadicalLit(SatLiteral(1)),
@@ -135,7 +135,7 @@ TEST_F(TestPropWhiteCadicalPropagator, learned_clause_over_base_level)
   // must not get any activation literal, even at user level 2.
   d_prop->in_search(true);
   SatClause clause{SatLiteral(1), SatLiteral(2)};
-  d_prop->add_clause(clause);
+  d_prop->add_clause(clause, false);
   EXPECT_EQ(nextClause(),
             (std::vector<int>{toCadicalLit(SatLiteral(1)),
                               toCadicalLit(SatLiteral(2))}));


### PR DESCRIPTION
This allows to now utilize CaDiCaL's feature to mark clauses as `forgettable`.
Forgettable clauses may be garbage collected by CaDiCaL (but are not
guaranteed to be). Note that this already plugs in parameter `removable`
of `CadicalSolver::addClause`.

Cluster runs to sanity check performance confirm that nothing changes.
