### PR TITLE
Update CoCoALib support to version 0.99850

### DIFF
--- a/cmake/FindCoCoA.cmake
+++ b/cmake/FindCoCoA.cmake
@@ -56,7 +56,7 @@ if(NOT CoCoA_FOUND_SYSTEM)
 
   include(ExternalProject)
 
-  set(CoCoA_VERSION "0.99800")
+  set(CoCoA_VERSION "0.99850")
 
   if("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles")
     # use $(MAKE) instead of "make" to allow for parallel builds
@@ -83,15 +83,17 @@ if(NOT CoCoA_FOUND_SYSTEM)
   ExternalProject_Add(
     CoCoA-EP
     ${COMMON_EP_CONFIG}
-    URL https://github.com/cvc5/cvc5-deps/blob/main/CoCoALib-${CoCoA_VERSION}.tgz?raw=true
-    URL_HASH SHA256=f8bb227e2e1729e171cf7ac2008af71df25914607712c35db7bcb5a044a928c6
+    URL https://cocoa.altervista.org/cocoalib/tgz/CoCoALib-${CoCoA_VERSION}.tgz
+    URL_HASH SHA256=d3e7af0153c6950f83f4e3556540f0177fedf5179f0f7667b7d6d670268fd445
     # CoCoA requires C++14, but the check does not work with compilers that
     # default to C++17 or newer. The patch fixes the check.
     PATCH_COMMAND patch -p1 -d <SOURCE_DIR>
         -i ${CMAKE_CURRENT_LIST_DIR}/deps-utils/CoCoALib-${CoCoA_VERSION}-trace.patch
     BUILD_IN_SOURCE YES
+    # We only need CoCoALib itself, not CoCoA-5; --only-cocoalib avoids the
+    # otherwise mandatory configure-time dependency on BOOST.
     CONFIGURE_COMMAND ${SHELL} ./configure --prefix=<INSTALL_DIR> --with-libgmp=${GMP_LIBRARY}
-        --with-cxx=${CMAKE_CXX_COMPILER} --with-cxxflags=${CoCoA_CXXFLAGS}
+        --with-cxx=${CMAKE_CXX_COMPILER} --with-cxxflags=${CoCoA_CXXFLAGS} --only-cocoalib
     BUILD_COMMAND ${make_cmd} library
     BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libcocoa.a
   )

--- a/cmake/deps-utils/CoCoALib-0.99850-trace.patch
+++ b/cmake/deps-utils/CoCoALib-0.99850-trace.patch
@@ -1,5 +1,5 @@
 diff --git a/configuration/cxx14.sh b/configuration/cxx14.sh
-index a5472cd..2a3e608 100755
+index e974ab6..65cd94e 100755
 --- a/configuration/cxx14.sh
 +++ b/configuration/cxx14.sh
 @@ -51,7 +51,7 @@ int main() {
@@ -11,7 +11,7 @@ index a5472cd..2a3e608 100755
  if [ $? -ne 0 ]
  then
      echo "ERROR: compilation unexpectedly failed; is $CXX a c++ compiler?   $SCRIPT_NAME" > /dev/stderr
-@@ -74,7 +74,7 @@ fi
+@@ -76,7 +76,7 @@ fi
  # Compilation without flag is not C++14 standard; try with -std=c++14
  
  CXX14="-std=c++14"
@@ -19,61 +19,32 @@ index a5472cd..2a3e608 100755
 +"$CXX" $CXXFLAGS  $CXX14  language-version.C  -o language-version  >> LogFile  2>& 1 
  if [ $? -ne 0 ]
  then
-     echo "ERROR: compilation with flag $CXX14 failed   $SCRIPT_NAME" > /dev/stderr
+     echo "ERROR: compilation with flag $CXX14 failed   $SCRIPT_NAME"                      > /dev/stderr
 diff --git a/configuration/gmp-version.sh b/configuration/gmp-version.sh
-index ebd85c7..5693280 100755
+index 4fe33b8..2a17749 100755
 --- a/configuration/gmp-version.sh
 +++ b/configuration/gmp-version.sh
-@@ -73,7 +73,7 @@ int main()
- EOF
+@@ -74,7 +74,7 @@ EOF
  
  # Use c++ compiler specified in CXX; no need to specify libgmp as all info is in header file!!
--$CXX -I"$COCOA_EXTLIB_DIR/include"  test-gmp-version.C  -o test-gmp-version  > LogFile 2>&1
-+$CXX $CXXFLAGS -I"$COCOA_EXTLIB_DIR/include"  test-gmp-version.C  -o test-gmp-version  > LogFile 2>&1
+ echo "$CXX -I"$EXTLIB_DIR_FULL/include"  test-gmp-version.C  -o test-gmp-version"  > LogFile
+-$CXX -I"$EXTLIB_DIR_FULL/include"  test-gmp-version.C  -o test-gmp-version  >> LogFile 2>&1
++$CXX $CXXFLAGS -I"$EXTLIB_DIR_FULL/include"  test-gmp-version.C  -o test-gmp-version  >> LogFile 2>&1
  
  # Check whether compilation failed; if so, complain.
  if [ $? -ne 0 ]
-diff --git a/configuration/verify-compiler.sh b/configuration/verify-compiler.sh
-index 7a70933..c752e34 100755
---- a/configuration/verify-compiler.sh
-+++ b/configuration/verify-compiler.sh
-@@ -55,15 +55,6 @@ int main()
- }
- EOF
- 
--# Try plain compiler (without CXXFLAGS):
--$CXX test-compiler-gnu.C -o test-compiler-gnu  > LogFile  2>&1
--if [ $? -ne 0 -o \! -f test-compiler-gnu -o \! -x test-compiler-gnu ]
--then
--  echo "ERROR: Are you sure \"$CXX\" is a C++ compiler?   $SCRIPT_NAME"  > /dev/stderr
--  exit 1
--fi
--/bin/rm test-compiler-gnu  # not necessary, just being tidy :-)
--
- # Try compiler with CXXFLAGS:
- $CXX $CXXFLAGS test-compiler-gnu.C -o test-compiler-gnu  > LogFile  2>&1
- if [ $? -ne 0 -o \! -f test-compiler-gnu -o \! -x test-compiler-gnu ]
 diff --git a/configuration/shell-fns.sh b/configuration/shell-fns.sh
-index 190dbb4..c8d281f 100755
+index 46d8155..3687819 100755
 --- a/configuration/shell-fns.sh
 +++ b/configuration/shell-fns.sh
-@@ -11,7 +11,7 @@ mktempdir()
- {
-     TODAY=`date "+%Y%m%d"`
-     TIME=`date "+%H%M%S"`
--    TMP_DIR="/tmp/CoCoALib-config/$USER-$TODAY/$1-$TIME-$$"
-+    TMP_DIR="/tmp/CoCoALib-config-$USER/$USER-$TODAY/$1-$TIME-$$"
-     /bin/rm -rf "$TMP_DIR"  &&  /bin/mkdir -p "$TMP_DIR"
-     if [ $? -ne 0 ]
-     then
-@@ -25,22 +25,22 @@ echounderline()
+@@ -27,13 +27,13 @@ mktempdir()
  echounderline()
  {
    echo "$*"
 -  echo "$*" | tr "\040-\377" "[-*]"
 +  echo "$*" | tr "\040-\377" "-"
  }
-
+ 
  echobox()
  {
    mesg=">>>>  $*  <<<<"
@@ -82,8 +53,7 @@ index 190dbb4..c8d281f 100755
    echo "$dashes"
    echo "$mesg"
    echo "$dashes"
- }
-
+@@ -42,7 +42,7 @@ echobox()
  echoerror()
  {
    mesg=">>>>>  $*  <<<<<"
@@ -92,8 +62,42 @@ index 190dbb4..c8d281f 100755
    echo "$equals"
    echo "$mesg"
    echo "$equals"
+diff --git a/configuration/verify-compiler.sh b/configuration/verify-compiler.sh
+index b5f5a95..8c28263 100755
+--- a/configuration/verify-compiler.sh
++++ b/configuration/verify-compiler.sh
+@@ -58,16 +58,6 @@ int main()
+ }
+ EOF
+ 
+-# Try plain compiler (without CXXFLAGS):
+-$CXX test-compiler-type.C -o test-compiler-type  > LogFile  2>&1
+-if [ $? -ne 0 -o \! -f test-compiler-type -o \! -x test-compiler-type ]
+-then
+-  echo "ERROR: Are you sure \"$CXX\" is a C++ compiler?   $SCRIPT_NAME"  > /dev/stderr
+-  echo "LOGFILE: $TMP_DIR/LogFile   $SCRIPT_NAME"                        > /dev/stderr
+-  exit 1
+-fi
+-/bin/rm test-compiler-type  # not necessary, just being tidy :-)
+-
+ # Try compiler with CXXFLAGS:
+ $CXX $CXXFLAGS test-compiler-type.C -o test-compiler-type  > LogFile  2>&1
+ if [ $? -ne 0 -o \! -f test-compiler-type -o \! -x test-compiler-type ]
+diff --git a/include/CoCoA/MakeUnifiedHeader.sh b/include/CoCoA/MakeUnifiedHeader.sh
+index e0e713b..156461b 100755
+--- a/include/CoCoA/MakeUnifiedHeader.sh
++++ b/include/CoCoA/MakeUnifiedHeader.sh
+@@ -33,7 +33,7 @@ fi
+ echobox()
+ {
+   mesg=">>>>  $*  <<<<"
+-  dashes=`echo "$mesg" | tr "\040-\377" "[-*]"`
++  dashes=`echo "$mesg" | tr "\040-\377" "-"`
+   echo "$dashes"
+   echo "$mesg"
+   echo "$dashes"
 diff --git a/include/CoCoA/TmpGPoly.H b/include/CoCoA/TmpGPoly.H
-index 4c4d51e..efe50f7 100644
+index 4c4d51e..b57fc17 100644
 --- a/include/CoCoA/TmpGPoly.H
 +++ b/include/CoCoA/TmpGPoly.H
 @@ -29,6 +29,7 @@
@@ -104,7 +108,7 @@ index 4c4d51e..efe50f7 100644
  #include<list>
  // using std::list; // for GPolyList; GPolyPtrList;
  #include<vector>
-@@ -46,6 +47,11 @@ enum ClearMarker {clear};
+@@ -46,6 +47,12 @@ enum ClearMarker {clear};
  
  class GPoly;
  
@@ -113,9 +117,23 @@ index 4c4d51e..efe50f7 100644
 +extern std::function<void(ConstRefRingElem p)> reductionStartHandler;
 +extern std::function<void(ConstRefRingElem q)> reductionStepHandler;
 +extern std::function<void(ConstRefRingElem r)> reductionEndHandler;
++
  
  typedef std::list<GPoly> GPolyList;
  
+diff --git a/src/AlgebraicCore/CheckSourceFiles.sh b/src/AlgebraicCore/CheckSourceFiles.sh
+index b669e0f..cb0a66c 100755
+--- a/src/AlgebraicCore/CheckSourceFiles.sh
++++ b/src/AlgebraicCore/CheckSourceFiles.sh
+@@ -24,7 +24,7 @@ do
+ done
+ sort "$TMPFILE2" > "$TMPFILE1"
+ 
+-/bin/ls -d ./*.C | cut -b 3- > "$TMPFILE2"
++/bin/ls -d ./*.C | cut -b 3- | sort > "$TMPFILE2"
+ 
+ cmp "$TMPFILE1" "$TMPFILE2" > /dev/null
+ if [ $? = 0 ]
 diff --git a/src/AlgebraicCore/PolyRing-content.C b/src/AlgebraicCore/PolyRing-content.C
 index c5d0a0a..36d6d2b 100644
 --- a/src/AlgebraicCore/PolyRing-content.C
@@ -139,26 +157,26 @@ index c5d0a0a..36d6d2b 100644
    }
  
 diff --git a/src/AlgebraicCore/SparsePolyOps-reduce.C b/src/AlgebraicCore/SparsePolyOps-reduce.C
-index b5b8b43..11687f0 100644
+index 30e407a..b8789e2 100644
 --- a/src/AlgebraicCore/SparsePolyOps-reduce.C
 +++ b/src/AlgebraicCore/SparsePolyOps-reduce.C
-@@ -134,6 +134,7 @@ degree HereForProfilingOnlyWDeg(ConstRefPPMonoidElem cofactor1)
-       v.myGRingInfo().myCheckForTimeout("ReduceActiveLM");
+@@ -145,6 +145,7 @@ degree HereForProfilingOnlyWDeg(ConstRefPPMonoidElem cofactor1)
        s->myUpdate(F, *g);
+       //      std::cout << "ReduceActiveLM after s->myUpdate" << std::endl;
        F->myReduce(poly(*g), NumTerms(*g));
 +      if ( handlersEnabled ) reductionStepHandler(poly(*g));
      }//while
    }//ReduceActiveLM
  
-@@ -269,6 +270,7 @@ degree HereForProfilingOnlyWDeg(ConstRefPPMonoidElem cofactor1)
+@@ -283,6 +284,7 @@ degree HereForProfilingOnlyWDeg(ConstRefPPMonoidElem cofactor1)
    void GPoly::myReduce(const Reductors& theReductors)
    {
      if ( IsZero(*this) ) return;
 +    if ( handlersEnabled ) reductionStartHandler(myPoly());
      ReductionCog F = ChooseReductionCogGeobucket(myGRingInfo());
+     //    std::cout << "myreduce1: F is " << F << std::endl;
      F->myAssignReset(myPolyValue, myNumTerms); // myPolyValue gets 0
-     reduce(F, mySugar, theReductors); // mySugar updated
-@@ -278,6 +280,7 @@ degree HereForProfilingOnlyWDeg(ConstRefPPMonoidElem cofactor1)
+@@ -298,6 +300,7 @@ degree HereForProfilingOnlyWDeg(ConstRefPPMonoidElem cofactor1)
      if ( !IsZero(*this) && !IsOne(myLCValue) ) // makes myPolyValue monic
        if ( myGRingInfo().myCoeffRingType()==CoeffEncoding::Field )
          myGRingInfo().myNewSPR()->myDivByCoeff(raw(myPolyValue), raw(myLCValue));
@@ -167,7 +185,7 @@ index b5b8b43..11687f0 100644
      // if CoeffEncoding::FrFldOfGCDDomain myRelease makes poly content free
    }
 diff --git a/src/AlgebraicCore/TmpGPoly.C b/src/AlgebraicCore/TmpGPoly.C
-index ea250d4..3447d86 100644
+index 3163ca9..c10b8c2 100644
 --- a/src/AlgebraicCore/TmpGPoly.C
 +++ b/src/AlgebraicCore/TmpGPoly.C
 @@ -47,6 +47,11 @@ using std::vector;
@@ -182,7 +200,7 @@ index ea250d4..3447d86 100644
  
    //---------class GPoly-------------------------------
  
-@@ -301,7 +306,10 @@ void GPoly::myUpdateLenLPPLCDegComp()
+@@ -291,7 +296,10 @@ void GPoly::myUpdateLenLPPLCDegComp()
      if (the_gp.IsInputPoly())
        myPolyValue = poly(the_gp.myFirstGPoly());
      else
@@ -193,62 +211,3 @@ index ea250d4..3447d86 100644
      myUpdateLenLPPLCDegComp();
      myAge = the_age;
      // MAX: do these things only if necessary.
-diff --git a/configuration/gmp-check-cxxflags.sh b/configuration/gmp-check-cxxflags.sh
-index f34c10d..6c167a3 100755
---- a/configuration/gmp-check-cxxflags.sh
-+++ b/configuration/gmp-check-cxxflags.sh
-@@ -59,7 +59,7 @@ fi
- 
- 
- GMP_LDLIB=-lgmp
--if [ -f "$COCOA_EXTLIB_DIR"/lib/libgmp-symlink.a ]
-+if [ -f "$COCOA_EXTLIB_DIR"/lib/libgmp-symlink."$GMP_LIB_EXTN" ]
- then
-   GMP_LDLIB=-lgmp-symlink
- fi
-diff --git a/configure b/configure
-index 769750d..5ac5e90 100755
---- a/configure
-+++ b/configure
-@@ -336,6 +336,7 @@ fi
- # Next two lines required by the scripts which check GMP (see below).
- export CXX
- export CXXFLAGS
-+export GMP_LIB_EXTN
- 
- # Check compiler and flags are sane.
- # If all is well, result is either "gnu" or "not gnu" & return code is 0.
-@@ -467,6 +468,7 @@ else
-       # gmp-find.sh script worked, so message is full path of GMP library
-       /bin/ln -s "$GMP_MESG" $EXTLIBS/lib/libgmp-symlink.a
-       GMP_LIB="$GMP_MESG"
-+      GMP_LIB_EXTN="a"
-     fi
-   fi
- fi
-diff --git a/include/CoCoA/MakeUnifiedHeader.sh b/include/CoCoA/MakeUnifiedHeader.sh
-index 1111111..2222222 100755
---- a/include/CoCoA/MakeUnifiedHeader.sh
-+++ b/include/CoCoA/MakeUnifiedHeader.sh
-@@ -33,7 +33,7 @@ echobox()
- echobox()
- {
-   mesg=">>>>  $*  <<<<"
--  dashes=`echo "$mesg" | tr "\040-\377" "[-*]"`
-+  dashes=`echo "$mesg" | tr "\040-\377" "-"`
-   echo "$dashes"
-   echo "$mesg"
-   echo "$dashes"
-diff --git a/src/AlgebraicCore/CheckSourceFiles.sh b/src/AlgebraicCore/CheckSourceFiles.sh
-index 3333333..4444444 100755
---- a/src/AlgebraicCore/CheckSourceFiles.sh
-+++ b/src/AlgebraicCore/CheckSourceFiles.sh
-@@ -24,7 +24,7 @@ done
- done
- sort "$TMPFILE2" > "$TMPFILE1"
-
--/bin/ls -d ./*.C | cut -b 3- > "$TMPFILE2"
-+/bin/ls -d ./*.C | cut -b 3- | sort > "$TMPFILE2"
-
- cmp "$TMPFILE1" "$TMPFILE2" > /dev/null
- if [ $? = 0 ]

--- a/src/theory/ff/multi_roots.cpp
+++ b/src/theory/ff/multi_roots.cpp
@@ -114,6 +114,17 @@ bool isUnsat(const CoCoA::ideal& ideal)
          && CoCoA::deg(gens[0]) <= 0;
 }
 
+// True if a Groebner basis for `ideal` is available without (re)computation.
+//
+// Since CoCoALib 0.99850, computing the GBasis of the zero ideal no longer
+// marks it as stored (CoCoA::GBasis returns the trivially empty basis but
+// CoCoA::HasGBasis stays false); 0.99800 did mark it. The empty basis is always
+// available for the zero ideal, so treat that case as "has GBasis" too.
+bool hasGBasis(const CoCoA::ideal& ideal)
+{
+  return CoCoA::HasGBasis(ideal) || CoCoA::IsZero(ideal);
+}
+
 template <typename T>
 std::string ostring(const T& t)
 {
@@ -136,7 +147,7 @@ std::pair<size_t, CoCoA::RingElem> extractAssignment(
 std::unordered_set<std::string> assignedVars(const CoCoA::ideal& ideal)
 {
   std::unordered_set<std::string> ret{};
-  Assert(CoCoA::HasGBasis(ideal));
+  Assert(hasGBasis(ideal));
   for (const auto& g : CoCoA::GBasis(ideal))
   {
     if (CoCoA::deg(g) == 1)
@@ -163,7 +174,7 @@ std::unique_ptr<AssignmentEnumerator> applyRule(const CoCoA::ideal& ideal,
   CoCoA::PolyRing polyRing(ideal->myRing());
   Assert(!isUnsat(ideal));
   // first, we look for super-linear univariate polynomials.
-  Assert(CoCoA::HasGBasis(ideal));
+  Assert(hasGBasis(ideal));
   const auto& gens = CoCoA::GBasis(ideal);
   for (const auto& p : gens)
   {
@@ -259,7 +270,7 @@ std::vector<CoCoA::RingElem> findZero(const CoCoA::ideal& initialIdeal,
     const auto& ideal = ideals.back();
     // make sure we have a GBasis:
     GBasisTimeout(ideal, env.getResourceManager());
-    Assert(CoCoA::HasGBasis(ideal));
+    Assert(hasGBasis(ideal));
     // If the ideal is UNSAT, drop it.
     if (isUnsat(ideal))
     {
@@ -270,7 +281,7 @@ std::vector<CoCoA::RingElem> findZero(const CoCoA::ideal& initialIdeal,
     else if (allVarsAssigned(ideal))
     {
       std::unordered_map<size_t, CoCoA::RingElem> varNumToValue{};
-      Assert(CoCoA::HasGBasis(ideal));
+      Assert(hasGBasis(ideal));
       const auto& gens = CoCoA::GBasis(ideal);
       size_t numIndets = CoCoA::NumIndets(polyRing);
       Assert(gens.size() == numIndets);
@@ -313,7 +324,7 @@ std::vector<CoCoA::RingElem> findZero(const CoCoA::ideal& initialIdeal,
             << "level: " << branchers.size()
             << ", brancher: " << branchers.back()->name()
             << ", branch: " << choicePoly.value() << std::endl;
-        Assert(CoCoA::HasGBasis(ideal));
+        Assert(hasGBasis(ideal));
         std::vector<CoCoA::RingElem> newGens = CoCoA::GBasis(ideal);
         newGens.push_back(choicePoly.value());
         ideals.push_back(CoCoA::ideal(newGens));

--- a/src/theory/ff/uni_roots.cpp
+++ b/src/theory/ff/uni_roots.cpp
@@ -26,7 +26,6 @@
 #include <CoCoA/RingZZ.H>
 #include <CoCoA/SmallFpImpl.H>
 #include <CoCoA/SparsePolyOps-RingElem.H>
-#include <CoCoA/SparsePolyOps-vector.H>
 #include <CoCoA/factor.H>
 #include <CoCoA/factorization.H>
 #include <CoCoA/random.H>


### PR DESCRIPTION
This PR updates the CoCoALib dependency from 0.99800 to 0.99850.

### Changes

- **`cmake/FindCoCoA.cmake`**: bump the version and SHA256, fetch from the official CoCoALib tarball location, and pass `--only-cocoalib` to `configure`. The latter is required because 0.99850's `configure` now treats a missing BOOST installation (only needed for CoCoA-5) as a fatal error. cvc5 only builds the library (`make library`), so CoCoA-5 is not needed.
- **`cmake/deps-utils/CoCoALib-0.99850-trace.patch`**: regenerate the trace patch for 0.99850. The Gröbner-basis trace handler hooks that cvc5 relies on are preserved. Hunks that 0.99850 already incorporates upstream (per-user `TMP_DIR`, `libgmp-symlink` extension handling, `configure` env export) are dropped so the patch applies cleanly.
- **`src/theory/ff/uni_roots.cpp`**: drop the include of the now-removed header `CoCoA/SparsePolyOps-vector.H`. Its declarations moved into `CoCoA/SparsePolyOps-RingElem.H` (already included), and cvc5 did not use the symbols it provided.
- **`src/theory/ff/multi_roots.cpp`**: in 0.99850, computing the Gröbner basis of the *zero ideal* no longer marks it as stored (`CoCoA::GBasis` returns the trivially empty basis but `CoCoA::HasGBasis` stays `false`), whereas 0.99800 did. This tripped the `Assert(HasGBasis(ideal))` checks in `findZero` (e.g. `regress0/ff/issue11107.smt2`, `regress0/ff/issue12627.smt2`). A `hasGBasis()` helper that also accepts the zero ideal is added and used in those assertions.

### Testing

- The regenerated patch applies cleanly (no fuzz) to a fresh 0.99850 source tree.
- A full `--cocoa --gpl --auto-download` debug build (with assertions) compiles and links against CoCoALib 0.99850.
- All `regress0/ff/*` tests pass (including the two previously failing `issue11107`/`issue12627`), along with the CoCoA-backed coverings regressions.

### Note

The `URL` currently points to the official CoCoALib tarball (`cocoa.altervista.org`). It will be switched to the `cvc5/cvc5-deps` mirror once this PR is merged and the tarball is mirrored there.
