### PR TITLE
Link LibPoly statically on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,27 @@ jobs:
             macos-target: 11.0
             gpl-tag: -gpl
 
+          # Windows builds with CoCoALib are generated for testing purposes only
+          # but are not currently uploaded.
+          - name: win64:production-gpl
+            os: windows-latest
+            config: production --auto-download --gpl --cocoa
+            cache-key: production-win64-native-gpl
+            strip-bin: strip
+            windows-build: true
+            shell: 'msys2 {0}'
+            gpl-tag: -gpl
+
+          - name: win64:production-arm64-gpl
+            os: windows-11-arm
+            config: production --auto-download --gpl --cocoa
+            cache-key: production-win64-native-arm64-gpl
+            strip-bin: strip
+            java-version: 21
+            windows-build: true
+            shell: 'msys2 {0}'
+            gpl-tag: -gpl
+
         exclude:
           - gpl-build: false
             build:
@@ -255,7 +276,12 @@ jobs:
           - gpl-build: false
             build:
               name: macos:production-arm64-gpl
-
+          - gpl-build: false
+            build:
+              name: win64:production-gpl
+          - gpl-build: false
+            build:
+              name: win64:production-arm64-gpl
 
     name: ${{ matrix.build.name }}
     runs-on: ${{ matrix.build.os }}

--- a/cmake/FindPoly.cmake
+++ b/cmake/FindPoly.cmake
@@ -15,8 +15,20 @@
 
 include(deps-helper)
 
+# On Windows we always link LibPoly statically, even into a shared libcvc5.
+# A LibPoly DLL auto-exports the GMP symbols it statically embeds (MinGW
+# auto-export), and those re-exported symbols (e.g. __gmp_default_allocate)
+# then collide with cvc5's own static GMP when linking libcvc5.dll, which lld
+# rejects with "<sym> was replaced". A static (PIC) LibPoly has no export
+# table, so there is nothing to collide.
+if(BUILD_SHARED_LIBS AND NOT WIN32)
+  set(POLY_BUILD_SHARED ON)
+else()
+  set(POLY_BUILD_SHARED OFF)
+endif()
+
 find_path(Poly_INCLUDE_DIR NAMES poly/poly.h)
-if(BUILD_SHARED_LIBS)
+if(POLY_BUILD_SHARED)
   find_library(Poly_LIBRARIES NAMES poly)
   find_library(PolyXX_LIBRARIES NAMES polyxx)
 else()
@@ -86,7 +98,7 @@ if(NOT Poly_FOUND_SYSTEM)
 
   set(Poly_INCLUDE_DIR "${DEPS_BASE}/include/")
 
-  if(BUILD_SHARED_LIBS)
+  if(POLY_BUILD_SHARED)
     set(POLY_BUILD_STATIC OFF)
     set(POLY_TARGETS poly polyxx)
     set(POLY_INSTALL_CMD
@@ -210,7 +222,7 @@ endif()
 set(Poly_FOUND TRUE)
 
 
-if(BUILD_SHARED_LIBS)
+if(POLY_BUILD_SHARED)
   add_library(Poly SHARED IMPORTED GLOBAL)
   add_library(Polyxx SHARED IMPORTED GLOBAL)
   if(CMAKE_SYSTEM_NAME STREQUAL "Windows")


### PR DESCRIPTION
## Problem

Building cvc5 with CoCoALib on the MSYS2 CLANG64/CLANGARM64 toolchains fails when linking `libcvc5.dll` with:

```
ld.lld: error: __gmp_default_allocate was replaced
```

On Windows, LibPoly is built as a DLL that statically embeds GMP. MinGW auto-exports all symbols of a shared library by default, so `libpoly`/`libpolyxx` re-export the GMP symbols they embed, and their import libraries carry thunks for them (e.g. `__gmp_default_allocate`). When cvc5 also links the static GMP and a consumer (CoCoALib) references such a symbol, linking `libcvc5.dll` pulls in both the re-exported thunk (from the LibPoly import lib) and the static definition (from `libgmp.a`), which `lld` rejects with `"<sym> was replaced"`. GNU `ld` tolerates this via auto-import, which is why MINGW64 builds were unaffected — only the lld-based CLANG64/CLANGARM64 builds break.

Without CoCoALib nothing references the affected symbols across that boundary, so the conflict only surfaces once CoCoALib is enabled.

## Fix

Build LibPoly statically on Windows (even into a shared `libcvc5`), exactly as the static build already does. With no LibPoly DLL there is no export table to collide with, and GMP has a single definition in the final link. Other platforms are unaffected.

## Note

This changes the Windows **shared** package to embed LibPoly into `libcvc5.dll` instead of shipping `libpoly.dll`/`libpolyxx.dll`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)