### PR TITLE
Ensure Boolean skolems introduced by strings extf are marked as Boolean terms

### DIFF
--- a/src/theory/strings/extf_solver.cpp
+++ b/src/theory/strings/extf_solver.cpp
@@ -213,6 +213,18 @@ void ExtfSolver::doReduction(Node n, int pol)
     std::vector<Node> new_nodes;
     Node res = d_preproc.simplify(n, new_nodes);
     Assert(res != n);
+    // If we reduced a Boolean extended function (e.g. str.<=), then n is
+    // replaced by a fresh purification skolem standing for a Boolean term.
+    // Register it as a Boolean term skolem, so that it is consistently treated
+    // as a theory atom (and not as a plain Boolean variable). This matters in
+    // incremental mode, where the skolem may be reused as a Boolean term in a
+    // term position (e.g. an array element) in a subsequent check-sat: its CNF
+    // classification is fixed when its literal is first created here, so it
+    // must be registered before that point.
+    if (res.isVar() && res.getType().isBoolean())
+    {
+      d_env.registerBooleanTermSkolem(res);
+    }
     new_nodes.push_back(n.eqNode(res));
     Node nnlem =
         new_nodes.size() == 1 ? new_nodes[0] : nm->mkNode(Kind::AND, new_nodes);

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -179,6 +179,7 @@ set(regress_0_tests
   regress0/arrays/issue10494.smt2
   regress0/arrays/issue10494-2.smt2
   regress0/arrays/issue11889-eec-unsat.smt2
+  regress0/arrays/issue12756.smt2
   regress0/arrays/proj-issue322-has-term.smt2
   regress0/arrays/proj-issue391-minisat-elim.smt2
   regress0/arrays/proj-issue467-cm.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -179,7 +179,6 @@ set(regress_0_tests
   regress0/arrays/issue10494.smt2
   regress0/arrays/issue10494-2.smt2
   regress0/arrays/issue11889-eec-unsat.smt2
-  regress0/arrays/issue12756.smt2
   regress0/arrays/proj-issue322-has-term.smt2
   regress0/arrays/proj-issue391-minisat-elim.smt2
   regress0/arrays/proj-issue467-cm.smt2
@@ -2174,6 +2173,7 @@ set(regress_0_tests
   regress0/strings/issue12027-str-ae.smt2
   regress0/strings/issue12241-aci.smt2
   regress0/strings/issue12322-pf-eager-len-re.smt2
+  regress0/strings/issue12756-str-inc-model.smt2
   regress0/strings/issue1189.smt2
   regress0/strings/issue2958.smt2
   regress0/strings/issue3440.smt2

--- a/test/regress/cli/regress0/strings/issue12756-str-inc-model.smt2
+++ b/test/regress/cli/regress0/strings/issue12756-str-inc-model.smt2
@@ -1,3 +1,4 @@
+; COMMAND-LINE: -i
 ; EXPECT: sat
 ; EXPECT: sat
 (set-logic ALL)

--- a/test/regress/cli/regress0/strings/issue12756-str-inc-model.smt2
+++ b/test/regress/cli/regress0/strings/issue12756-str-inc-model.smt2
@@ -1,3 +1,5 @@
+; EXPECT: sat
+; EXPECT: sat
 (set-logic ALL)
 (declare-const x Int)
 (declare-const c String)

--- a/test/regress/cli/regress0/strings/issue12756-str-inc-model.smt2
+++ b/test/regress/cli/regress0/strings/issue12756-str-inc-model.smt2
@@ -1,0 +1,8 @@
+(set-logic ALL)
+(declare-const x Int)
+(declare-const c String)
+(declare-const c1 (Array String Bool))
+(assert (< (str.indexof "" "" x) (str.len (ite (str.<= "0" c) (str.from_int 0) ""))))
+(check-sat)
+(assert (distinct (store c1 "" false) (store c1 "" (str.<= "0" c))))
+(check-sat)


### PR DESCRIPTION
Fixes #12756

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>