### PR TITLE
Fix CPC+Eunoia distinct values for non-value datatype subterms

### DIFF
--- a/proofs/eo/cpc/programs/DistinctValues.eo
+++ b/proofs/eo/cpc/programs/DistinctValues.eo
@@ -110,15 +110,30 @@
   :signature (T T) Bool
   (
   (($dt_distinct_terms (f a) (g b))
-    ; Note that if the operators were shown to be distinct, then we return true.
-    ; If we returned false, then f and g are (partial) applications of the same
-    ; constructor, hence a and b have the same type and we recurse.
-    (eo::ite ($dt_distinct_terms f g) true ($are_distinct_terms (eo::typeof a) a b)))
+    ; If the operators were shown to be distinct, then we return true.
+    ; Otherwise, we may only recurse on the arguments a and b when f and g are
+    ; (partial) applications of the *same constructor*, since constructors are
+    ; injective. We must guard on this explicitly: f and g being non-distinct
+    ; does not imply they are constructors (e.g. they could be the same
+    ; selector or uninterpreted function, which are not injective). Without
+    ; this guard we could unsoundly conclude e.g. (sel x) and (sel y) distinct
+    ; whenever x and y are distinct. If f and g are not constructor
+    ; applications, we cannot conclude distinctness and return false.
+    (eo::ite ($dt_distinct_terms f g)
+      true
+      (eo::ite (eo::and ($is_cons_app f) ($is_cons_app g))
+        ($are_distinct_terms (eo::typeof a) a b)
+        false)))
   (($dt_distinct_terms ct (g a))  ($dt_distinct_terms ct g))
   (($dt_distinct_terms (f a) cs)  ($dt_distinct_terms f cs))
   (($dt_distinct_terms ct cs)
-    (eo::requires (eo::and ($dt_is_cons ct) ($dt_is_cons cs)) true
-      (eo::not (eo::eq ct cs))))
+    ; ct and cs may be arbitrary datatype terms reached when recursing on
+    ; constructor arguments (e.g. selectors or variables). They are distinct
+    ; only if both are (distinct) constructors; otherwise we cannot conclude
+    ; distinctness and return false.
+    (eo::ite (eo::and ($dt_is_cons ct) ($dt_is_cons cs))
+      (eo::not (eo::eq ct cs))
+      false))
   )
 )
 

--- a/proofs/eo/cpc/programs/DistinctValues.eo
+++ b/proofs/eo/cpc/programs/DistinctValues.eo
@@ -97,7 +97,7 @@
 
 ;;;;; Theory of datatypes
 
-; program: $dt_distinct_terms_arg
+; program: $dt_distinct_terms
 ; args:
 ; - t T: The first term, expected to be of datatype type.
 ; - s T: The second term, expected to be of datatype type.
@@ -105,35 +105,22 @@
 ;   True if we can show that t and s denote distinct terms. This is true
 ;   if t and s are distinct constructor applications, or are applications
 ;   of the same constructor and one of their arguments can be shown distinct.
+;   This method gets stuck if the given terms are not applications of datatype
+;   constructors.
 (program $dt_distinct_terms
   ((T Type) (U Type) (ct T) (cs T) (f (-> U T)) (a U) (g (-> U T)) (b U))
   :signature (T T) Bool
   (
   (($dt_distinct_terms (f a) (g b))
-    ; If the operators were shown to be distinct, then we return true.
-    ; Otherwise, we may only recurse on the arguments a and b when f and g are
-    ; (partial) applications of the *same constructor*, since constructors are
-    ; injective. We must guard on this explicitly: f and g being non-distinct
-    ; does not imply they are constructors (e.g. they could be the same
-    ; selector or uninterpreted function, which are not injective). Without
-    ; this guard we could unsoundly conclude e.g. (sel x) and (sel y) distinct
-    ; whenever x and y are distinct. If f and g are not constructor
-    ; applications, we cannot conclude distinctness and return false.
-    (eo::ite ($dt_distinct_terms f g)
-      true
-      (eo::ite (eo::and ($is_cons_app f) ($is_cons_app g))
-        ($are_distinct_terms (eo::typeof a) a b)
-        false)))
+    ; Note that if the operators were shown to be distinct, then we return true.
+    ; If we returned false, then f and g are (partial) applications of the same
+    ; constructor, hence a and b have the same type and we recurse.
+    (eo::ite ($dt_distinct_terms f g) true ($are_distinct_terms (eo::typeof a) a b)))
   (($dt_distinct_terms ct (g a))  ($dt_distinct_terms ct g))
   (($dt_distinct_terms (f a) cs)  ($dt_distinct_terms f cs))
   (($dt_distinct_terms ct cs)
-    ; ct and cs may be arbitrary datatype terms reached when recursing on
-    ; constructor arguments (e.g. selectors or variables). They are distinct
-    ; only if both are (distinct) constructors; otherwise we cannot conclude
-    ; distinctness and return false.
-    (eo::ite (eo::and ($dt_is_cons ct) ($dt_is_cons cs))
-      (eo::not (eo::eq ct cs))
-      false))
+    (eo::requires (eo::and ($dt_is_cons ct) ($dt_is_cons cs)) true
+      (eo::not (eo::eq ct cs))))
   )
 )
 
@@ -157,7 +144,10 @@
   (($are_distinct_terms_type t s Bool)        (eo::and (eo::is_bool t) (eo::is_bool s)))
   (($are_distinct_terms_type st ss (Set U))   (eo::or ($set_is_not_subset st ss U) ($set_is_not_subset ss st U)))
   (($are_distinct_terms_type sst sss (Seq U)) ($seq_distinct_terms sst sss U))
-  (($are_distinct_terms_type t s T)           ($dt_distinct_terms t s)) ; otherwise assume we are a user datatype
+  (($are_distinct_terms_type t s T)
+    ; Otherwise assume we are a user datatype. We check if the datatypes are
+    ; distinct, also handling the case where the side condition above is stuck.
+    (eo::define ((res ($dt_distinct_terms t s))) (eo::ite (eo::is_ok res) res false)))
   )
 )
 

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1529,6 +1529,8 @@ set(regress_0_tests
   regress0/proofs/dsl-cong-eval-cr.smt2
   regress0/proofs/dsl-no-eval.smt2
   regress0/proofs/dsl-rule-comp-types.smt2
+  regress0/proofs/dt-cons-eq-clash-qfdt.smt2
+  regress0/proofs/dt-cons-eq-clash-ufdt.smt2
   regress0/proofs/equal-eval-rw_340.smt2
   regress0/proofs/eval-rhs.smt2
   regress0/proofs/exists-shadow-simple.smt2

--- a/test/regress/cli/regress0/proofs/dt-cons-eq-clash-qfdt.smt2
+++ b/test/regress/cli/regress0/proofs/dt-cons-eq-clash-qfdt.smt2
@@ -1,0 +1,16 @@
+; EXPECT: unsat
+; Minimal QF_DT example (reduced from SMT-LIB barrett-jsat v1l20018) that
+; exercises dt-cons-eq-clash where the constructor clash (null vs cons in the
+; cdr) is only reached after recursing past a non-constructor sibling argument
+; (the selector application (car x2) in the car). The $dt_distinct_terms side
+; condition must return false for the non-constructor sibling rather than
+; aborting, while still finding the clash.
+(set-logic QF_DT)
+(declare-datatypes ((nat 0)(list 0)(tree 0)) (
+  ((succ (pred nat)) (zero))
+  ((cons (car tree) (cdr list)) (null))
+  ((node (children list)) (leaf (data nat)))))
+(declare-fun x2 () list)
+(declare-fun x3 () tree)
+(assert (= (cons (car x2) null) (cons x3 (cons x3 (children (car null))))))
+(check-sat)

--- a/test/regress/cli/regress0/proofs/dt-cons-eq-clash-ufdt.smt2
+++ b/test/regress/cli/regress0/proofs/dt-cons-eq-clash-ufdt.smt2
@@ -1,0 +1,13 @@
+; EXPECT: unsat
+; Minimal UFDT example (in the spirit of SMT-LIB cdt-cade2015) that exercises
+; dt-cons-eq-clash where the constructor clash (a vs b in the right child) is
+; only reached after recursing past a non-constructor sibling argument (the
+; uninterpreted-function application (f x) in the left child). The
+; $dt_distinct_terms side condition must return false for the non-constructor
+; sibling rather than aborting, while still finding the clash.
+(set-logic UFDT)
+(declare-datatype D ((c (left D) (right D)) (a) (b)))
+(declare-fun f (D) D)
+(declare-const x D)
+(assert (= (c (f x) a) (c a b)))
+(check-sat)


### PR DESCRIPTION
This fixes a corner case where the current CPC+Eunoia signature would incorrectly reject applications of the dt-cons-eq-clash rule. In particular, we would fail to check cases where the distinct values side condition was invoked on terms with datatype subterms that themselves were not applications of constructors.  This behavior is used solely for the rule dt-cons-eq-clash, where for instance we can show:
```
(cons 0 d) != (cons 1 e)
```
where `d` and `e` are datatype constants of type list.

The fix is to proceed even if the $dt_distinct_terms side condition gets stuck on a subterm pair (e.g. d and e in the disequality above), although note the clashing subterm must come *after* the non-value datatype for this bug to trigger.

This corrects 7 spurious failures on SMT-LIB. 2 representative regressions are added.

Logos/Lean proof is updated here: https://github.com/ajreynol/logos/pull/308

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>