### PR TITLE
Demote cegqiMidpoint to expert option, enable by default

### DIFF
--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -1692,11 +1692,10 @@ name   = "Quantifiers"
 
 [[option]]
   name       = "cegqiMidpoint"
-  category   = "regular"
+  category   = "expert"
   long       = "cegqi-midpoint"
   type       = "bool"
-  default    = "false"
-  no_support = ["proofs"]
+  default    = "true"
   help       = "choose substitutions based on midpoints of lower and upper bounds for counterexample-based quantifier instantiation"
 
 [[option]]

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -160,8 +160,6 @@ void SetDefaults::setDefaultsPre(Options& opts)
       SET_AND_NOTIFY(arith, nlCov, false, "safe options");
       // never use symmetry breaker, which does not have proofs
       SET_AND_NOTIFY(uf, ufSymmetryBreaker, false, "safe options");
-      // always use cegqi midpoint, which avoids virtual term substitution
-      SET_AND_NOTIFY(quantifiers, cegqiMidpoint, true, "safe options");
       // proofs not yet supported on main
       SET_AND_NOTIFY(quantifiers, cegqiBv, false, "safe options");
       // class of rewrites in quantifiers we don't have proof support for but is


### PR DESCRIPTION
Ensures the soundness issue on https://github.com/cvc5/cvc5/issues/12775 does not occur by default.

In detail, our default instantiation heuristic (in non-safe mode builds) uses virtual term substitution (VTS), which is enabled when `--cegqi-midpoint` is false.  We do not have proof support for this technique, hence it is disabled in safe mode.

Moreover, the technique seems to have bugs when nested quantified formulas are involved (which can be forced with `--miniscope-quant=agg`), leading to the issue.

This PR enables `--cegqi-midpoint` by default, which forces us to use Ferrante-Rackoff-based quantifier instantiation (i.e. midpoints of upper and lower bounds) instead of VTS. It furthermore makes this expert ensuring that VTS cannot be enabled in safe or stable mode.

As a downside, this will lead to slightly worse performance on *pure* arithmetic quantified logics e.g. `LIA`/`LRA`. As an upside, it avoids the soundness issue by default and makes our behavior is safe mode more consistent with default.

A followup pr will address the bug in VTS.