### PR TITLE
Fix regressions

### DIFF
--- a/test/regress/cli/regress0/strings/dd.instance12194.smt2
+++ b/test/regress/cli/regress0/strings/dd.instance12194.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE: --check-proofs-complete
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-const X String)

--- a/test/regress/cli/regress0/strings/dd.instance46612.smt2
+++ b/test/regress/cli/regress0/strings/dd.instance46612.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE: --check-proofs-complete
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-const X String)

--- a/test/regress/cli/regress0/strings/dd.instance51542.smt2
+++ b/test/regress/cli/regress0/strings/dd.instance51542.smt2
@@ -1,4 +1,3 @@
-; COMMAND-LINE: --check-proofs-complete
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-const X String)


### PR DESCRIPTION
We should not use `--check-proofs` or `--check-proofs-complete` as expected args, the latter breaks LFSC.

Fixes the nightlies.