### PR TITLE
Port PR #7517: Fix refinement for nested conversions.

### DIFF
--- a/src/theory/fp/theory_fp.cpp
+++ b/src/theory/fp/theory_fp.cpp
@@ -975,36 +975,41 @@ Node TheoryFp::purifyConversions(TNode n)
     toVisit.pop_back();
 
     Kind k = curr.getKind();
-    const auto& it = result.find(curr);
-    if (it != result.end())
+    auto [it, inserted] = result.emplace(curr, Node::null());
+    if (!inserted)
     {
       if (it->second.isNull())
       {
         NodeBuilder nb(nm, k);
         if (curr.getMetaKind() == kind::metakind::PARAMETERIZED)
         {
-          nb << result[curr.getOperator()];
+          auto itc = result.find(curr.getOperator());
+          Assert(itc != result.end());
+          Assert(!itc->second.isNull());
+          nb << itc->second;
         }
         for (TNode nc : curr)
         {
-          nb << result[nc];
+          auto itc = result.find(nc);
+          Assert(itc != result.end());
+          Assert(!itc->second.isNull());
+          nb << itc->second;
         }
-        result[curr] = nb;
+        it->second = nb;
       }
     }
     else if (curr.getNumChildren() == 0)
     {
-      result[curr] = curr;
+      it->second = curr;
     }
     else if (k == Kind::FLOATINGPOINT_TO_REAL_TOTAL
              || k == Kind::FLOATINGPOINT_TO_FP_FROM_REAL)
     {
       Node sk = sm->mkPurifySkolem(curr);
-      result[curr] = sk;
+      it->second = sk;
     }
     else
     {
-      result[curr] = Node::null();
       toVisit.push_back(curr);
       if (curr.getMetaKind() == kind::metakind::PARAMETERIZED)
       {
@@ -1013,7 +1018,7 @@ Node TheoryFp::purifyConversions(TNode n)
       toVisit.insert(toVisit.end(), curr.begin(), curr.end());
     }
   }
-  return result[n];
+  return result.at(n);
 }
 
 }  // namespace fp

--- a/src/theory/fp/theory_fp.cpp
+++ b/src/theory/fp/theory_fp.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "base/configuration.h"
+#include "expr/node_builder.h"
 #include "expr/skolem_manager.h"
 #include "options/fp_options.h"
 #include "smt/logic_exception.h"
@@ -522,23 +523,31 @@ void TheoryFp::registerTerm(TNode node)
   else if (k == Kind::FLOATINGPOINT_TO_REAL_TOTAL)
   {
     // Purify (fp.to_real x)
-    SkolemManager* sm = nm->getSkolemManager();
-    Node sk = sm->mkPurifySkolem(node);
+    Node sk = purifyConversions(node);
+    Assert(sk.getKind() == Kind::SKOLEM);
+    // Purify the children of this node and use it for the lemmas/refining the
+    // abstraction. This is required to properly process nested conversions.
+    // Otherwise, when getting the values for those terms from the model, we
+    // may get unexpected results if the nested conversions need to be refined
+    // still.
+    Node pn = nm->mkNode(Kind::FLOATINGPOINT_TO_REAL_TOTAL,
+                         purifyConversions(node[0]),
+                         purifyConversions(node[1]));
     handleLemma(node.eqNode(sk), InferenceId::FP_REGISTER_TERM);
-    d_abstractionMap.insert(sk, node);
+    d_abstractionMap.insert(sk, pn);
 
-    Node pd = nm->mkNode(
-        Kind::IMPLIES,
-        {nm->mkNode(Kind::OR,
-                    {nm->mkNode(Kind::FLOATINGPOINT_IS_NAN, node[0]),
-                     nm->mkNode(Kind::FLOATINGPOINT_IS_INF, node[0])}),
-         nm->mkNode(Kind::EQUAL, node, node[1])});
+    Node pd =
+        nm->mkNode(Kind::IMPLIES,
+                   {nm->mkNode(Kind::OR,
+                               {nm->mkNode(Kind::FLOATINGPOINT_IS_NAN, pn[0]),
+                                nm->mkNode(Kind::FLOATINGPOINT_IS_INF, pn[0])}),
+                    nm->mkNode(Kind::EQUAL, pn, pn[1])});
     handleLemma(pd, InferenceId::FP_REGISTER_TERM);
 
     Node z = nm->mkNode(
         Kind::IMPLIES,
-        {nm->mkNode(Kind::FLOATINGPOINT_IS_ZERO, node[0]),
-         nm->mkNode(Kind::EQUAL, node, nm->mkConstReal(Rational(0U)))});
+        {nm->mkNode(Kind::FLOATINGPOINT_IS_ZERO, pn[0]),
+         nm->mkNode(Kind::EQUAL, pn, nm->mkConstReal(Rational(0U)))});
     handleLemma(z, InferenceId::FP_REGISTER_TERM);
     return;
 
@@ -547,23 +556,31 @@ void TheoryFp::registerTerm(TNode node)
   else if (k == Kind::FLOATINGPOINT_TO_FP_FROM_REAL)
   {
     // Purify ((_ to_fp eb sb) rm x)
-    SkolemManager* sm = nm->getSkolemManager();
-    Node sk = sm->mkPurifySkolem(node);
+    Node sk = purifyConversions(node);
+    Assert(sk.getKind() == Kind::SKOLEM);
+    // Purify the children of this node and use it for the lemmas/refining the
+    // abstraction. This is required to properly process nested conversions.
+    // Otherwise, when getting the values for those terms from the model, we
+    // may get unexpected results if the nested conversions need to be refined
+    // still.
+    Node pn = nm->mkNode(Kind::FLOATINGPOINT_TO_FP_FROM_REAL,
+                         {node.getOperator(),
+                          purifyConversions(node[0]),
+                          purifyConversions(node[1])});
     handleLemma(node.eqNode(sk), InferenceId::FP_REGISTER_TERM);
-    d_abstractionMap.insert(sk, node);
+    d_abstractionMap.insert(sk, pn);
 
     Node nnan =
-        nm->mkNode(Kind::NOT, nm->mkNode(Kind::FLOATINGPOINT_IS_NAN, node));
+        nm->mkNode(Kind::NOT, nm->mkNode(Kind::FLOATINGPOINT_IS_NAN, pn));
     handleLemma(nnan, InferenceId::FP_REGISTER_TERM);
 
     Node z = nm->mkNode(
         Kind::IMPLIES,
-        {nm->mkNode(Kind::EQUAL, node[1], nm->mkConstReal(Rational(0U))),
-         nm->mkNode(
-             Kind::EQUAL,
-             node,
-             nm->mkConst(FloatingPoint::makeZero(
-                 node.getType().getConst<FloatingPointSize>(), false)))});
+        {nm->mkNode(Kind::EQUAL, pn[1], nm->mkConstReal(Rational(0U))),
+         nm->mkNode(Kind::EQUAL,
+                    pn,
+                    nm->mkConst(FloatingPoint::makeZero(
+                        pn.getType().getConst<FloatingPointSize>(), false)))});
     handleLemma(z, InferenceId::FP_REGISTER_TERM);
     return;
 
@@ -943,6 +960,60 @@ bool TheoryFp::collectModelValues(TheoryModel* m, const std::set<Node>& termSet)
   }
 
   return true;
+}
+
+Node TheoryFp::purifyConversions(TNode n)
+{
+  NodeManager* nm = nodeManager();
+  SkolemManager* sm = nm->getSkolemManager();
+
+  std::vector<TNode> toVisit = {n};
+  std::unordered_map<TNode, Node> result;
+  while (!toVisit.empty())
+  {
+    TNode curr = toVisit.back();
+    toVisit.pop_back();
+
+    Kind k = curr.getKind();
+    const auto& it = result.find(curr);
+    if (it != result.end())
+    {
+      if (it->second.isNull())
+      {
+        NodeBuilder nb(nm, k);
+        if (curr.getMetaKind() == kind::metakind::PARAMETERIZED)
+        {
+          nb << result[curr.getOperator()];
+        }
+        for (TNode nc : curr)
+        {
+          nb << result[nc];
+        }
+        result[curr] = nb;
+      }
+    }
+    else if (curr.getNumChildren() == 0)
+    {
+      result[curr] = curr;
+    }
+    else if (k == Kind::FLOATINGPOINT_TO_REAL_TOTAL
+             || k == Kind::FLOATINGPOINT_TO_FP_FROM_REAL)
+    {
+      Node sk = sm->mkPurifySkolem(curr);
+      result[curr] = sk;
+    }
+    else
+    {
+      result[curr] = Node::null();
+      toVisit.push_back(curr);
+      if (curr.getMetaKind() == kind::metakind::PARAMETERIZED)
+      {
+        toVisit.push_back(curr.getOperator());
+      }
+      toVisit.insert(toVisit.end(), curr.begin(), curr.end());
+    }
+  }
+  return result[n];
 }
 
 }  // namespace fp

--- a/src/theory/fp/theory_fp.h
+++ b/src/theory/fp/theory_fp.h
@@ -113,6 +113,11 @@ class TheoryFp : public Theory
 
   bool refineAbstraction(TheoryModel* m, TNode abstract, TNode concrete);
 
+  /**
+   * Purifies operators that convert between real and floating-point.
+   */
+  Node purifyConversions(TNode n);
+
   /** The terms registered via registerTerm(). */
   context::CDHashSet<Node> d_registeredTerms;
 

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2845,6 +2845,7 @@ set(regress_1_tests
   regress1/fp/issue8242-fp-eq-sub-div.smt2
   regress1/fp/issue8242-fp-max-div.smt2
   regress1/fp/issue8242-nested-div.smt2
+  regress1/fp/proj-issue327-nested-conversions.smt2
   regress1/fp/rti_3_5_bug_report.smt2
   regress1/fmf-fun-dbu.smt2
   regress1/fmf/ALG008-1.smt2

--- a/test/regress/cli/regress1/fp/proj-issue327-nested-conversions.smt2
+++ b/test/regress/cli/regress1/fp/proj-issue327-nested-conversions.smt2
@@ -1,5 +1,6 @@
 ; COMMAND-LINE: --fp-exp
 ; EXPECT: unsat
+; DISABLE-TESTER: cpc
 (set-logic ALL)
 (declare-const x Real)
 (declare-const x6 RoundingMode)

--- a/test/regress/cli/regress1/fp/proj-issue327-nested-conversions.smt2
+++ b/test/regress/cli/regress1/fp/proj-issue327-nested-conversions.smt2
@@ -1,0 +1,8 @@
+; COMMAND-LINE: --fp-exp
+; EXPECT: unsat
+(set-logic ALL)
+(declare-const x Real)
+(declare-const x6 RoundingMode)
+(assert (or (= x (/ 1 1000000000000000000000000000000000000000000000000000000)) (= x 1.0)))
+(set-info :status unsat)
+(check-sat-assuming ((and (> x 0.0) (> 0.0 (fp.to_real ((_ to_fp 8 24) x6 x))))))


### PR DESCRIPTION
Port of https://github.com/cvc5/cvc5/pull/7517 (4tXJ7f) onto main @906bd710d5.

Fixes https://github.com/cvc5/cvc5-projects/issues/327.

This is the base for several subsequent PRs to fix open issues with FP+Reals.

Co-Authored-By:  Andres Noetzli <andres.noetzli@gmail.com>