### PR TITLE
docs: Use permanent links to sources in release documentation

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -27,6 +27,15 @@ else()
   set(GOOGLE_ANALYTICS_ENABLE "False")
 endif()
 
+# Use permanent links to the tagged sources in the documentation of a release
+# (e.g. .../blob/cvc5-x.y.z/...), and links to the main branch otherwise, so
+# that links keep pointing at the files as they were at release time (#12194).
+if(CVC5_IS_RELEASE STREQUAL "true")
+  set(CVC5_GIT_REF "cvc5-${CVC5_VERSION_NUMBER}")
+else()
+  set(CVC5_GIT_REF "main")
+endif()
+
 configure_file(conf.py.in ${CMAKE_CURRENT_BINARY_DIR}/conf.py)
 configure_file(references.bib ${CMAKE_CURRENT_BINARY_DIR}/references.bib COPYONLY)
 

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -116,8 +116,8 @@ autosectionlabel_prefix_document = True
 # -- core extension:: sphinx.ext.extlinks ------------------------------------
 
 extlinks = {
-        'cvc5src': ('https://github.com/cvc5/cvc5/blob/main/src/%s', '%s'),
-        'cvc5repo': ('https://github.com/cvc5/cvc5/blob/main/%s', '%s'),
+        'cvc5src': ('https://github.com/cvc5/cvc5/blob/${CVC5_GIT_REF}/src/%s', '%s'),
+        'cvc5repo': ('https://github.com/cvc5/cvc5/blob/${CVC5_GIT_REF}/%s', '%s'),
 }
 
 
@@ -213,7 +213,7 @@ examples_types = {
 examples_file_patterns = {
         r'^<examples>(.*)': {
                 'local': '/../examples{}',
-                'url': 'https://github.com/cvc5/cvc5/tree/main/examples{}',
+                'url': 'https://github.com/cvc5/cvc5/tree/${CVC5_GIT_REF}/examples{}',
                 'urlname': 'examples{}',
         },
         r'<pythonicapi>(.*)': {


### PR DESCRIPTION
## Description

Currently the documentation for a cvc5 release links example and source files on the `main` branch. As noted in #12194, this is problematic because:

1. If a file is later removed, the link no longer points to a valid file.
2. If a file is later changed, the documentation links to a different revision than the one that existed at release time.

This PR makes the release documentation use permanent links to the tagged sources instead:

```
https://github.com/cvc5/cvc5/blob/cvc5-x.y.z/examples/...
```

Only the documentation built for `main` keeps linking to the `main` branch.

## Changes

- `docs/CMakeLists.txt`: add a `CVC5_GIT_REF` variable that resolves to `cvc5-${CVC5_VERSION_NUMBER}` for release builds (`CVC5_IS_RELEASE == true`) and to `main` otherwise, computed before `conf.py` is configured.
- `docs/conf.py.in`: use `${CVC5_GIT_REF}` in the `cvc5src` / `cvc5repo` extlinks and in the examples URL, replacing the hard-coded `main`.

The pythonic-API and ethos links point at other repositories with independent versioning and are intentionally left unchanged.

Fixes #12194

🤖 Generated with [Claude Code](https://claude.com/claude-code)