### PR TITLE
ci: Overwrite docs-new in place when copying processed docs

### DIFF
--- a/.github/workflows/docs_upload.yml
+++ b/.github/workflows/docs_upload.yml
@@ -104,7 +104,7 @@ jobs:
           pushd target-releases/
           python3 genversions.py
           popd
-          cp -rf "${TARGET_DIR}" docs-new
+          cp -rfT "${TARGET_DIR}" docs-new
 
       - name: Update docs
         run: |


### PR DESCRIPTION
## Description

In the `Update versions` step of the docs upload workflow, `genversions.py` injects the "Other versions" navigation block into the processed documentation under `target-releases/${TARGET_DIR}` (`cvc5-main` for main/PR builds). That processed tree is then copied back onto `docs-new` with:

```bash
cp -rf "${TARGET_DIR}" docs-new
```

Since `docs-new` already exists (it is the unpacked artifact), `cp -rf <dir> docs-new` copies the source **into** it, creating `docs-new/${TARGET_DIR}/`, rather than replacing the contents of `docs-new`. As a result the processed files end up nested one level below where they are expected, and the original top-level pages — which do not contain the version block — are the ones that get published.

## Fix

Add `-T` (`--no-target-directory`) so the processed tree overwrites `docs-new` in place:

```diff
-          cp -rf "${TARGET_DIR}" docs-new
+          cp -rfT "${TARGET_DIR}" docs-new
```

This does not retroactively update already-published pre-release docs, but every subsequent main/PR build will place the processed pages at the top level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)