### PR TITLE
Protect d_tcr_tcGraph from being ovewritten

### DIFF
--- a/src/theory/sets/theory_sets_rels.cpp
+++ b/src/theory/sets/theory_sets_rels.cpp
@@ -186,7 +186,15 @@ void TheorySetsRels::check()
       {
         while (term_it != k_t_it->second.end())
         {
-          buildTCGraphForRel(*term_it);
+          // Protect d_tcr_tcGraph from being overwritten,
+          // if it already exists
+          if (d_rel_nodes.find(*term_it) == d_rel_nodes.end()
+              && d_rRep_tcGraph.find(getRepresentative((*term_it)[0]))
+                     == d_rRep_tcGraph.end())
+          {
+            buildTCGraphForRel(*term_it);
+            d_rel_nodes.insert(*term_it);
+          }
           ++term_it;
         }
       }

--- a/src/theory/sets/theory_sets_rels.h
+++ b/src/theory/sets/theory_sets_rels.h
@@ -123,10 +123,47 @@ class TheorySetsRels : protected EnvObj
    * involving relational operators */
   std::map<Node, std::map<Kind, std::vector<Node> > > d_terms_cache;
 
-  /** Mapping between transitive closure relation TC(r) and its TC graph
-   * constructed based on the members of r*/
+  /**
+   * Transitive closure (TC) graphs.
+   *
+   * For a term (rel.tclosure r), we maintain a "TC graph": an adjacency-list
+   * representation of the known members of a binary relation, i.e. a map
+   * from element representative a to the set of element representatives b
+   * such that the pair (a, b) is currently asserted to be a member. These
+   * graphs are built lazily during a full-effort check (see
+   * buildTCGraphForRel) and cleared at the end of each such check; they are
+   * caches for a single call to check(Theory::Effort), not context-dependent
+   * data structures.
+   */
+  /**
+   * Mapping between the representative of a base relation r (the argument of a
+   * rel.tclosure term) and the TC graph induced by the asserted members of r
+   * only. Used by isTCReachable to recognize memberships of TC(r) that are
+   * already derivable from the members of r, in which case applyTCRule
+   * skips sending a redundant lemma. Also serves as a "graph already built"
+   * marker: check() and applyTCRule test this map before calling
+   * buildTCGraphForRel, which protects the entries in d_tcr_tcGraph from
+   * being overwritten (buildTCGraphForRel would discard the edges that
+   * applyTCRule has added there in the meantime).
+   */
   std::map<Node, std::map<Node, std::unordered_set<Node> > > d_rRep_tcGraph;
+  /**
+   * Mapping between a transitive closure term TC(r) = (rel.tclosure r) and its
+   * TC graph. Seeded by buildTCGraphForRel with the edges of d_rRep_tcGraph for
+   * r's representative, and extended by applyTCRule with pairs that are
+   * asserted to be members of TC(r) directly (and are not already reachable in
+   * the base graph). At the end of a full-effort check, doTCInference() closes
+   * each of these graphs transitively and infers the implied memberships.
+   */
   std::map<Node, std::map<Node, std::unordered_set<Node> > > d_tcr_tcGraph;
+  /**
+   * Maps a transitive closure term TC(r) to the explanations of the edges in
+   * its TC graph. Each edge (a, b) is keyed by the pair tuple
+   * RelsUtils::constructPair(TC(r), a, b) built from the endpoint
+   * representatives, and maps to the membership assertion that justifies the
+   * edge. doTCInference conjoins these explanations along a path to form the
+   * reason for each inferred membership.
+   */
   std::map<Node, std::map<Node, Node> > d_tcr_tcGraph_exps;
 
  private:
@@ -174,12 +211,68 @@ class TheorySetsRels : protected EnvObj
   void applyTableJoinRule(Node n, Node nRep, Node exp);
   void applyJoinImageRule(Node mem_rep, Node rel_rep, Node exp);
   void applyIdenRule(Node mem_rep, Node rel_rep, Node exp);
+  /**
+   * Process a membership in a transitive closure term.
+   *
+   * @param mem a tuple (a, b) asserted to be a member of rel_rep
+   * @param rel a term TC(r) = (rel.tclosure r) occurring in the equivalence
+   *        class of rel_rep
+   * @param rel_rep the representative of rel
+   * @param exp the explanation of the membership, of the form
+   *        (set.member mem s) where s is equal to rel
+   *
+   * If the membership is already derivable from the members of r (see
+   * isTCReachable), this method does nothing. Otherwise it records the edge
+   * (a, b) and its explanation in d_tcr_tcGraph / d_tcr_tcGraph_exps, and
+   * sends the lemma that unfolds the closure one step
+   * (InferenceId::SETS_RELS_TCLOSURE_UP):
+   *   (set.member (a, b) TC(r)) =>
+   *     (set.member (a, b) r)
+   *     or ((set.member (a, z1) r) and (set.member (z2, b) r)
+   *         and (z1 = z2 or (set.member (z1, z2) TC(r))))
+   * where z1, z2 are skolems for the intermediate nodes on the path
+   * from a to b.
+   */
   void applyTCRule(Node mem, Node rel, Node rel_rep, Node exp);
+  /**
+   * Construct the (partial) TC graph for tc_rel = (rel.tclosure r) from the
+   * currently asserted members of r, with all nodes and edges expressed in
+   * terms of representatives. If r has at least one member, the graph is stored
+   * in d_rRep_tcGraph (keyed by r's representative) and in d_tcr_tcGraph /
+   * d_tcr_tcGraph_exps (keyed by tc_rel), overwriting any existing entries;
+   * callers must check d_rRep_tcGraph and d_rel_nodes first so that edges
+   * previously added to d_tcr_tcGraph by applyTCRule are not lost.
+   */
   void buildTCGraphForRel(Node tc_rel);
+  /**
+   * Called at the end of a full-effort check. For each transitive closure
+   * term TC(r) with a graph in d_tcr_tcGraph, computes the transitive
+   * closure of that graph and infers all implied memberships
+   * (InferenceId::SETS_RELS_TCLOSURE_FWD) via the overload below.
+   */
   void doTCInference();
+  /**
+   * Infer all memberships implied by the TC graph rel_tc_graph of the
+   * transitive closure term tc_rel: for each edge, start a depth-first
+   * traversal (the recursive overload below) that derives a membership in
+   * tc_rel for every node reachable from the edge's source.
+   * rel_tc_graph_exps maps each edge of the graph to its explanation, as in
+   * d_tcr_tcGraph_exps.
+   */
   void doTCInference(std::map<Node, std::unordered_set<Node> > rel_tc_graph,
                      std::map<Node, Node> rel_tc_graph_exps,
                      Node tc_rel);
+  /**
+   * Recursive step of the traversal above, having reached cur_node_rep from
+   * start_node_rep. reasons holds the explanations of the edges along the
+   * current path; this method sends the inference that the pair (start of
+   * path, end of path) is a member of tc_rel, whose reason is the
+   * conjunction of reasons together with the equalities connecting adjacent
+   * path edges and connecting each explanation's relation term to tc_rel's
+   * base relation. It then recurses into the successors of cur_node_rep that
+   * are not in seen, the set of already-traversed nodes used to terminate on
+   * cycles.
+   */
   void doTCInference(Node tc_rel,
                      std::vector<Node> reasons,
                      std::map<Node, std::unordered_set<Node> >& tc_graph,
@@ -207,7 +300,20 @@ class TheorySetsRels : protected EnvObj
   void computeMembersForUnaryOpRel(Node);
   void computeMembersForJoinImageTerm(Node);
 
+  /**
+   * Is the membership of pair mem_rep in tc_rel = (rel.tclosure r) already
+   * derivable from the asserted members of r? Returns true if mem_rep is a
+   * known member of r's representative, or if the second element of mem_rep
+   * is reachable from its first element in the TC graph stored in
+   * d_rRep_tcGraph for r. Used by applyTCRule to avoid sending redundant
+   * lemmas.
+   */
   bool isTCReachable(Node mem_rep, Node tc_rel);
+  /**
+   * Recursive helper for the above: depth-first search in tc_graph, setting
+   * isReachable to true if dest can be reached from start. hasSeen is the
+   * set of already-visited nodes, used to terminate on cycles.
+   */
   void isTCReachable(Node start,
                      Node dest,
                      std::unordered_set<Node>& hasSeen,

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -3455,6 +3455,7 @@ set(regress_1_tests
   regress1/rels/rel_tp_join_2_1.cvc.smt2
   regress1/rels/set-strat.cvc.smt2
   regress1/rels/strat.cvc.smt2
+  regress1/rels/tc-overwrite-bug.smt2
   regress1/rr-verify/bool-crci.sy
   regress1/rr-verify/bv-term-32.sy
   regress1/rr-verify/bv-term.sy

--- a/test/regress/cli/regress1/rels/tc-overwrite-bug.smt2
+++ b/test/regress/cli/regress1/rels/tc-overwrite-bug.smt2
@@ -1,0 +1,24 @@
+; EXPECT: unsat
+(set-option :incremental false)
+(set-logic ALL)
+
+; Regression for a transitive-closure graph bug in TheorySetsRels::check().
+; An unguarded call to buildTCGraphForRel rebuilt the internal TC graph from the
+; base relation's members only, overwriting the closure memberships that
+; applyTCRule had already added for the same relation. As a result doTCInference
+; never chained the closure edge below and the solver diverged instead of
+; reporting unsat.
+
+(declare-fun x () (Relation Int Int))
+
+; base edge: (2,3) in x, hence (2,3) in (rel.tclosure x)
+(assert (set.member (tuple 2 3) x))
+
+; closure edge not derivable from x alone: (1,2) in (rel.tclosure x)
+(assert (set.member (tuple 1 2) (rel.tclosure x)))
+
+; transitivity of (1,2) and (2,3) forces (1,3) in (rel.tclosure x),
+; which contradicts the following assertion
+(assert (not (set.member (tuple 1 3) (rel.tclosure x))))
+
+(check-sat)


### PR DESCRIPTION
The graph structure d_tcr_tcGraph was previously able to be overwritten, so that memberships in transitively closed relations were not added to d_tcr_tcGraph to be processed by doTCInference (implementing the TClos Up rules). The new regression test previously did not terminate, now it does with this change.

**Longer description:**
The graphs d_rRep_tcGraph and d_tcr_tcGraph are built in buildTCGraphForRel. The former only adds base R memberships, the latter starts with base-R memberships and gets R+ memberships added. buildTCGraphForRel only adds base memberships to each graph. The tclosure memberships are added by applyTCRule.

buildTCGraphForRel is called in two places: first in applyTCRule (applies tclos down rule to memberships in transitively closed relations), where it checks if the graph for the input relation tc_rel already exists in d_rRep_tcGraph. If not, then buildTCGraphForRel is called, so the graph gets constructed. (The other constraints are that there are memberships in tc_rel, and tc_rel hasn’t already been explored in applyTCRule – dedup guard). 

The other call site is during the later term iteration phase of check(), under the RELATION_TCLOSURE branch. This iterates over every term, and for every equivalent representation that is a transitive closure, it calls buildTCGraphForRel. The bug here is that there was no existing check for either deduplication (i.e., presence of the term in d_rel_nodes) or existence of the term inside of d_rRep_tcGraph. This means that the memberships in the transitive closures of relations are deleted from d_tcr_tcGraph, since those are only added inside of applyTCRule. This is a problem when later calling doTCInference, which uses d_tcr_tcGraph to implement the TClos Up rules.

Consequence: in bug.smt2

> ; EXPECT: unsat
> (set-option :incremental false)
> (set-logic ALL)
> 
> (declare-fun x () (Relation Int Int))
> 
> (assert (set.member (tuple 2 3) x))
> (assert (set.member (tuple 1 2) (rel.tclosure x)))
> (assert (not (set.member (tuple 1 3) (rel.tclosure x))))
> 
> (check-sat)


2 → 3 is added to d_rRep_tcGraph and d_tcr_tcGraph when applyTCRule is called. 1→2 is also added to d_tcr_tcGraph only. Then when buildTCGraph is called later on when processing TCLOSURE terms in d_terms_cache, 1 → 2 is removed when d_tcr_tcGraph gets overwritten. Then doTCInference can’t conclude that 1→3 in tclosure x, so unsat is never derived.
