### PR TITLE
Update CPC+Eunoia quantifiers rules

### DIFF
--- a/proofs/eo/cpc/programs/Quantifiers.eo
+++ b/proofs/eo/cpc/programs/Quantifiers.eo
@@ -1,64 +1,79 @@
 (include "../theories/Builtin.eo")
 (include "../theories/Quantifiers.eo")
 
-; program: $contains_atomic_term
+; program: $is_closed_rec
 ; args:
-; - arg1 S: The term to process.
-; - arg2 U: The atomic (0-ary) term to find.
-; return: The result is true if arg2 is a subterm of arg1.
-(program $contains_atomic_term
-  ((T Type) (U Type) (S Type) (x U) (y S) (f (-> T S)) (a T))
-  :signature (S U) Bool
+; - s S: The term.
+; - xs @List: The current bound variables.
+; return: true iff s is closed, assuming xs are bound.
+; note: Assumes applications with lists as their first argument are binders.
+(program $is_closed_rec
+  ((T Type) (S Type) (x S) (f (-> T S)) (a T) (xs @List)
+   (q (-> @List T S)) (V Type) (v V) (vs @List :list) (s String)
+   (F Bool) (n Int) (r RegLan))
+  :signature (S @List) Bool
   (
-  (($contains_atomic_term (f a) x)  (eo::ite ($contains_atomic_term f x) true ($contains_atomic_term a x)))
-  (($contains_atomic_term x y)      (eo::eq x y))
+  (($is_closed_rec (q (@list v vs) a) xs)
+    (eo::and ($is_closed_rec q xs) ($is_closed_rec a (eo::list_concat @list (@list v vs) xs))))
+  (($is_closed_rec (f a) xs)
+    (eo::and ($is_closed_rec f xs) ($is_closed_rec a xs)))
+  (($is_closed_rec (eo::var s S) xs)
+    (eo::not (eo::is_neg (eo::list_find @list xs (eo::var s S)))))
+  ; symbols that are opaque but may contain free variables
+  ; we require the indices to be standalone closed
+  (($is_closed_rec (@quantifiers_skolemize F n) xs) ($is_closed_rec F xs))
+  (($is_closed_rec (@re_unfold_pos_component s r n) xs)
+    (eo::and ($is_closed_rec s xs) ($is_closed_rec r xs)))
+  ; otherwise true
+  (($is_closed_rec x xs) true)
   )
 )
 
-; program: $contains_atomic_term_list
+; program: $is_closed
 ; args:
-; - t T: The term to process.
-; - xs @List: The list of terms to find.
-; return: true if any atomic (0-ary) subterm of t is in xs.
-(program $contains_atomic_term_list ((T Type) (U Type) (S Type) (x U) (f (-> T S)) (a T) (xs @List))
-  :signature (T @List) Bool
-  (
-    (($contains_atomic_term_list (f a) xs)  (eo::ite ($contains_atomic_term_list f xs) true ($contains_atomic_term_list a xs)))
-    (($contains_atomic_term_list x xs)      (eo::not (eo::is_neg (eo::list_find @list xs x))))
-  )
-)
+; - t T: The term
+; return: true iff t is closed, i.e. has no free variables.
+(define $is_closed ((T Type :implicit) (t T))
+  ($is_closed_rec t @list.nil))
 
 ; program: $contains_atomic_term_list_free_rec
 ; args:
 ; - t T: The term to process.
-; - xs @List: The list of terms to find.
+; - xs @List: The list of variables to find.
 ; - bvs @List: The current bound variables.
 ; return: >
 ;   true if any atomic (0-ary) subterm of t is in xs and is not a bound variable
 ;   of t at that position or in the set of already bound variables bvs.
 ; note: Assumes applications with lists as their first argument are binders.
 (program $contains_atomic_term_list_free_rec
-  ((T Type) (U Type) (S Type) (x U) (q (-> @List T S)) (f (-> T S)) (a T) (xs @List) (bvs @List) (x U) (ys @List :list))
+  ((T Type) (U Type) (S Type) (x U) (q (-> @List T S)) (f (-> T S)) (a T)
+   (xs @List) (bvs @List) (x U) (ys @List :list) (s String)
+   (F Bool) (n Int) (r RegLan))
   :signature (T @List @List) Bool
   (
-    ; we assume that any function taking a list as a first argument is a binder
-    (($contains_atomic_term_list_free_rec (q (@list x ys) a) xs bvs)
-      ; concatenate these variables to the list of bound variables
-      ($contains_atomic_term_list_free_rec a xs (eo::list_concat @list (@list x ys) bvs)))
-    ; otherwise normal recursion
-    (($contains_atomic_term_list_free_rec (f a) xs bvs)
-      (eo::ite ($contains_atomic_term_list_free_rec f xs bvs) true ($contains_atomic_term_list_free_rec a xs bvs)))
-    (($contains_atomic_term_list_free_rec x xs bvs)
-      (eo::ite (eo::is_neg (eo::list_find @list xs x)) 
-        false
-        (eo::is_neg (eo::list_find @list bvs x))))
+  ; we assume that any function taking a list as a first argument is a binder
+  (($contains_atomic_term_list_free_rec (q (@list x ys) a) xs bvs)
+    ; concatenate these variables to the list of bound variables
+    ($contains_atomic_term_list_free_rec a xs (eo::list_concat @list (@list x ys) bvs)))
+  ; otherwise normal recursion
+  (($contains_atomic_term_list_free_rec (f a) xs bvs)
+    (eo::ite ($contains_atomic_term_list_free_rec f xs bvs) true ($contains_atomic_term_list_free_rec a xs bvs)))
+  ; if in xs, check whether or not it is bound in bvs
+  (($contains_atomic_term_list_free_rec (eo::var s T) xs bvs)
+    (eo::ite (eo::is_neg (eo::list_find @list xs (eo::var s T)))
+      false
+      (eo::is_neg (eo::list_find @list bvs (eo::var s T)))))
+  ; Otherwise false. We also double check that x is closed, in case x is an
+  ; application of an operator with opaque arguments.
+  (($contains_atomic_term_list_free_rec x xs bvs)
+    (eo::requires ($is_closed x) true false))
   )
 )
 
 ; define: $contains_atomic_term_list_free
 ; args:
 ; - t T: The term to process.
-; - xs @List: The list of terms to find.
+; - xs @List: The list of variables to find.
 ; return: >
 ;   true if any atomic (0-ary) subterm of t is in xs and is not a bound
 ;   variable of t at that position.
@@ -66,32 +81,64 @@
 (define $contains_atomic_term_list_free ((T Type :implicit) (x T) (xs @List))
   ($contains_atomic_term_list_free_rec x xs @list.nil))
 
-
-; program: $substitute
+; define: $contains_atomic_term_free
 ; args:
-; - arg1 S: The domain of the substitution.
-; - arg2 S: The range of the substitution.
-; - arg3 U: The term to process.
-; return: the result of replacing all occurrences of arg1 with arg2 in arg3.
+; - t T: The term to process.
+; - y S: The variable to find.
+; return: >
+;   true if any atomic (0-ary) subterm of t is in xs and is not a bound
+;   variable of t at that position.
+; note: Assumes applications with lists as their first argument are binders.
+(define $contains_atomic_term_free ((T Type :implicit) (S Type :implicit) (x T) (y S))
+  ($contains_atomic_term_list_free_rec x (@list y) @list.nil))
+
+; program: $substitute_simul_rec
+; args:
+; - isRename Bool: true iff this substitution should rename binders.
+; - s S: The term to substitute into.
+; - xs @List: The list of variables to substitute.
+; - ss @List: The terms to substitute. If isRename is true, this is expected to
+; be a list of variables.
+; return: the result of simultaneously substituting xs to ss in t.
 ; note: Assumes applications with lists as their first argument are binders.
 ; note: This method does not evaluate if variable capture is encountered.
-(program $substitute
-  ((T Type) (U Type) (S Type) (x S) (y S) (f (-> T U)) (a T) (z U)
-   (q (-> @List T S)) (V Type) (v V) (vs @List :list))
-  :signature (S S U) U
+(program $substitute_simul_rec
+  ((T Type) (S Type) (x S) (f (-> T S)) (a T) (xs @List :list) (ss @List :list)
+   (q (-> @List T S)) (V Type) (v V) (vs @List :list) (s String) (isr Bool)
+   (F Bool) (r RegLan) (n Int) (bvs @List :list))
+  :signature (Bool S @List @List @List) S
   (
-  ; we assume that any function taking a list as a first argument is a binder
+  ; We assume that any function taking a list as a first argument is a binder
   ; for binders, we ensure no variable capture, get stuck otherwise.
-  (($substitute x y (q (@list v vs) a))
-    (eo::requires ($contains_atomic_term_list_free y (@list v vs)) false
-      (q ($substitute x y (@list v vs)) ($substitute x y a))))
-  (($substitute x y (f a))              (_ ($substitute x y f) ($substitute x y a)))
-  (($substitute x y x)                  y)
-  (($substitute x y z)                  z)
+  ; If isr is true, we substitute the binder and its body.
+  ; If isr is false, we keep the binder and map all variables to themselves
+  ; inside the binder.
+  (($substitute_simul_rec isr (q (@list v vs) a) xs ss bvs)
+    (eo::requires ($contains_atomic_term_list_free ss (@list v vs)) false
+      (eo::ite isr
+        (q
+          ($substitute_simul_rec isr (@list v vs) xs ss bvs)
+          ($substitute_simul_rec isr a xs ss bvs))
+        (q
+          (@list v vs)
+          ($substitute_simul_rec isr a xs ss
+            (eo::list_concat @list (@list v vs) bvs))))))
+  (($substitute_simul_rec isr (f a) xs ss bvs)
+    (_ ($substitute_simul_rec isr f xs ss bvs) ($substitute_simul_rec isr a xs ss bvs)))
+  ; if a variable, check if it is in the substitution list
+  (($substitute_simul_rec isr (eo::var s S) xs ss bvs)
+    (eo::define ((ib (eo::list_find @list bvs (eo::var s S))))
+    (eo::define ((i (eo::list_find @list xs (eo::var s S))))
+      (eo::ite (eo::is_neg ib)
+        (eo::ite (eo::is_neg i) (eo::var s S) ($assoc_nil_nth @list ss i))
+        (eo::var s S)))))
+  ; Otherwise no change. We also double check that x is closed, in case x is an
+  ; application of an operator with opaque arguments.
+  (($substitute_simul_rec isr x xs ss bvs) (eo::requires ($is_closed x) true x))
   )
 )
 
-; program: $substitute_simul
+; define: $substitute_simul
 ; args:
 ; - s S: The term to substitute into.
 ; - xs @List: The list of variables to substitute.
@@ -99,22 +146,32 @@
 ; return: the result of simultaneously substituting xs to ss in t.
 ; note: Assumes applications with lists as their first argument are binders.
 ; note: This method does not evaluate if variable capture is encountered.
-(program $substitute_simul
-  ((T Type) (S Type) (x S) (f (-> T S)) (a T) (xs @List :list) (ss @List :list)
-   (q (-> @List T S)) (V Type) (v V) (vs @List :list))
-  :signature (S @List @List) S
-  (
-  ; we assume that any function taking a list as a first argument is a binder
-  ; for binders, we ensure no variable capture, get stuck otherwise.
-  (($substitute_simul (q (@list v vs) a) xs ss)
-    (eo::requires ($contains_atomic_term_list_free ss (@list v vs)) false
-      (q ($substitute_simul (@list v vs) xs ss) ($substitute_simul a xs ss))))
-  (($substitute_simul (f a) xs ss)                  (_ ($substitute_simul f xs ss) ($substitute_simul a xs ss)))
-  (($substitute_simul x xs ss)                      (eo::define ((i (eo::list_find @list xs x)))
-                                                      (eo::ite (eo::is_neg i) x ($assoc_nil_nth @list ss i))))
-  )
-)
+(define $substitute_simul ((S Type :implicit) (x S) (xs @List) (ys @List))
+  ($substitute_simul_rec false x xs ys @list.nil))
 
+; define: $substitute
+; args:
+; - x S: The domain of the substitution.
+; - y S: The range of the substitution.
+; - z U: The term to process.
+; return: the result of replacing all occurrences of x with y in z.
+; note: Assumes applications with lists as their first argument are binders.
+; note: This method does not evaluate if variable capture is encountered.
+(define $substitute ((U Type :implicit) (S Type :implicit) (x S) (y S) (z U))
+  ($substitute_simul_rec false z (@list x) (@list y) @list.nil))
+
+; define: $rename_simul
+; args:
+; - s S: The term to substitute into.
+; - xs @List: The list of variables to rename.
+; - ys @List: The list of variables xs are being renamed to.
+; return: the result of simultaneously renaming xs with ys in t.
+; note: Assumes applications with lists as their first argument are binders.
+; note: This method does not evaluate if variable capture is encountered.
+; note: In contrast to $substitute_simul, this replaces xs occurring in binders
+; with the corresponding variable in ys.
+(define $rename_simul ((S Type :implicit) (x S) (xs @List) (ys @List))
+  ($substitute_simul_rec true x xs ys @list.nil))
 ; program: $beta_reduce_type
 ; args:
 ; - T Type: A type.

--- a/proofs/eo/cpc/rules/Quantifiers.eo
+++ b/proofs/eo/cpc/rules/Quantifiers.eo
@@ -2,6 +2,22 @@
 (include "../programs/Datatypes.eo")
 (include "../theories/Quantifiers.eo")
 
+; program: $is_instantiation
+; args:
+; - xs @List: The bound variable list.
+; - ts @List: The term list.
+; return: >
+;   True iff the type of ts matches the type of xs.
+(program $is_instantiation
+  ((T Type) (xs @List :list) (ts @List :list) (t T) (s String))
+  :signature (@List @List) Bool
+  (
+  (($is_instantiation @list.nil @list.nil) true)
+  (($is_instantiation (@list (eo::var s T) xs) (@list t ts))
+    (eo::requires (eo::typeof t) T ($is_instantiation xs ts)))
+  )
+)
+
 ; rule: instantiate
 ; implements: ProofRule::INSTANTIATE.
 ; premises:
@@ -12,6 +28,7 @@
 (declare-rule instantiate ((F Bool) (xs @List) (ts @List))
   :premises ((forall xs F))
   :args (ts)
+  :requires ((($is_instantiation xs ts) true))
   :conclusion ($substitute_simul F xs ts))
 
 ; program: $mk_skolems
@@ -39,6 +56,7 @@
 ;   introduced via $mk_skolems.
 (declare-rule skolemize ((x @List) (G Bool))
   :premises ((not (forall x G)))
+  :requires ((($is_closed (forall x G)) true) ((eo::list_setof @list x) x))
   :conclusion ($substitute_simul (not G) x ($mk_skolems x (forall x G) 0))
 )
 
@@ -56,6 +74,38 @@
 
 ;;;;; ProofRule::ALPHA_EQUIV
 
+; define: $is_unique_var_list
+; args:
+; - xs @List: The first bound variable list.
+; return: true if xs is variable list that is pairwise unique.
+(define $is_unique_var_list ((xs @List))
+  (eo::and ($is_var_list xs) (eo::eq (eo::list_setof @list xs) xs)))
+
+; program: $is_renaming_rec
+; args:
+; - xs @List: The first bound variable list.
+; - ys @List: The second bound variable list.
+; return: >
+;   True iff the type of xs matches the type of ys.
+(program $is_renaming_rec
+  ((T Type) (xs @List :list) (ys @List :list) (s1 String) (s2 String))
+  :signature (@List @List) Bool
+  (
+  (($is_renaming_rec @list.nil @list.nil) true)
+  (($is_renaming_rec (@list (eo::var s1 T) xs) (@list (eo::var s2 T) ys))
+    ($is_renaming_rec xs ys))
+  )
+)
+; define: $is_renaming
+; args:
+; - xs @List: The first bound variable list.
+; - ys @List: The second bound variable list.
+; return: >
+;   True if ys is a valid renaming of xs, i.e. same type and both lists
+;   are pairwise unique.
+(define $is_renaming ((xs @List) (ys @List))
+  (eo::and ($is_unique_var_list xs) ($is_unique_var_list ys) ($is_renaming_rec xs ys)))
+
 ; rule: alpha_equiv
 ; implements: ProofRule::ALPHA_EQUIV.
 ; args:
@@ -72,11 +122,10 @@
 ;   t. The substitution is valid renaming due to the requirement check.
 (declare-rule alpha_equiv ((T Type) (t T) (vs @List) (ts @List))
   :args (t vs ts)
-  :requires ((($is_var_list vs) true)
-             (($is_var_list ts) true)
+  :requires ((($is_renaming vs ts) true)
              (($contains_atomic_term_list_free t vs) false)
-             (($contains_atomic_term_list t ts) false))
-  :conclusion (= t ($substitute_simul t vs ts))
+             (($contains_atomic_term_list_free t ts) false))
+  :conclusion (= t ($rename_simul t vs ts))
 )
 
 ;;;;; ProofRewriteRule::BETA_REDUCE
@@ -92,6 +141,7 @@
   :requires ((($beta_reduce a @list.nil) b))
   :conclusion (= a b)
 )
+
 
 ;;;;; ProofRule::QUANT_VAR_REORDERING
 
@@ -127,34 +177,18 @@
 
 ;;;;; ProofRewriteRule::QUANT_UNUSED_VARS
 
-; program: $mk_quant_unused_vars_rec
+; program: $get_unused_vars
 ; args:
-; - x @List: The list of variables of the quantified formula.
-; - F Bool: The body of the quantified formula.
-; return: the sublist of variables in x that should be quantified for F.
-(program $mk_quant_unused_vars_rec ((T Type) (xs @List :list) (x T) (F Bool))
-  :signature (@List Bool) eo::List
+; - F Bool: The quantified formula we are removing unused variables from.
+; - G Bool: The result of removing unused variables from F.
+; return: the variables that were removed from F to obtain G, discarding duplicates.
+(program $get_unused_vars ((Q (-> @List Bool Bool)) (x @List) (y @List) (F Bool))
+  :signature (Bool Bool) @List
   (
-  (($mk_quant_unused_vars_rec @list.nil F)    @list.nil)
-  (($mk_quant_unused_vars_rec (@list x xs) F) (eo::define ((r ($mk_quant_unused_vars_rec xs F)))
-                                              (eo::ite ($contains_atomic_term F x)
-                                                ; remove the duplicate of x in r if it exists
-                                                (_ @list x (eo::list_erase @list r x))
-                                                r)))
-  )
-)
-
-; program: $mk_quant
-; args:
-; - Q (-> @List Bool Bool): The quantifier, expected to be forall or exists.
-; - x @List: The list of variables of the quantified formula.
-; - F Bool: The body of the quantified formula.
-; return: The quantified formula (Q x F), or just F if x is the empty list.
-(program $mk_quant ((Q (-> @List Bool Bool)) (x @List) (F Bool))
-  :signature ((-> @List Bool Bool) @List Bool) Bool
-  (
-  (($mk_quant Q @list.nil F) F)
-  (($mk_quant Q x F) (Q x F))
+  (($get_unused_vars (Q x F) (Q y F)) (eo::define ((sx (eo::list_setof @list x)))
+                                      (eo::requires (eo::list_minclude @list sx y) true
+                                        (eo::list_diff @list sx y))))
+  (($get_unused_vars (Q x F) F)       (eo::list_setof @list x))
   )
 )
 
@@ -163,11 +197,12 @@
 ; args:
 ; - eq Bool: The equality whose left hand side is a quantified formula.
 ; requires: >
-;   The variables removed from the left hand side do not occur in its body.
+;   The variables removed from the left hand side do not occur free in the left hand side.
 ; conclusion: The given equality.
 (declare-rule quant-unused-vars ((Q (-> @List Bool Bool)) (x @List) (F Bool) (G Bool))
   :args ((= (Q x F) G))
-  :requires ((($mk_quant Q ($mk_quant_unused_vars_rec x F) F) G))
+  :requires (((eo::or (eo::eq Q forall) (eo::eq Q exists)) true)
+             (($contains_atomic_term_list_free G ($get_unused_vars (Q x F) G)) false))
   :conclusion (= (Q x F) G)
 )
 
@@ -244,12 +279,12 @@
 (program $is_quant_miniscope_or ((x @List) (xs @List :list) (ys @List :list) (f Bool) (fs Bool :list) (g Bool) (gs Bool :list))
   :signature (@List Bool Bool) Bool
   (
-  (($is_quant_miniscope_or x (or f fs) (or f gs))                     (eo::requires ($contains_atomic_term_list f x) false
+  (($is_quant_miniscope_or x (or f fs) (or f gs))                     (eo::requires ($contains_atomic_term_list_free f x) false
                                                                         ($is_quant_miniscope_or x fs gs)))
-  (($is_quant_miniscope_or x (or f fs) (or (forall @list.nil f) gs))  (eo::requires ($contains_atomic_term_list f x) false
+  (($is_quant_miniscope_or x (or f fs) (or (forall @list.nil f) gs))  (eo::requires ($contains_atomic_term_list_free f x) false
                                                                         ($is_quant_miniscope_or x fs gs)))
   (($is_quant_miniscope_or (@list x xs) (or f fs) (or (forall (@list x ys) f) gs))  
-                                                                      (eo::requires ($contains_atomic_term gs x) false
+                                                                      (eo::requires ($contains_atomic_term_free gs x) false
                                                                         ($is_quant_miniscope_or xs (or f fs) (or (forall ys f) gs))))
   (($is_quant_miniscope_or @list.nil false false)                     true)
   (($is_quant_miniscope_or x f g)                                     false)
@@ -282,7 +317,7 @@
 ; conclusion: The given equality.
 (declare-rule quant-miniscope-ite ((x @List) (A Bool) (F1 Bool) (F2 Bool))
   :args ((= (forall x (ite A F1 F2)) (ite A (forall x F1) (forall x F2))))
-  :requires ((($contains_atomic_term_list A x) false))
+  :requires ((($contains_atomic_term_list_free A x) false))
   :conclusion (= (forall x (ite A F1 F2)) (ite A (forall x F1) (forall x F2)))
 )
 
@@ -295,7 +330,7 @@
 ; return: >
 ;    The result of eliminating x from F. This method does not evaluate if t contains x.
 (define $mk_quant_var_elim_eq_subs ((T Type :implicit) (x T) (t T) (F Bool))
-  (eo::requires ($contains_atomic_term t x) false ($substitute x t F)))
+  (eo::requires ($contains_atomic_term_free t x) false ($substitute x t F)))
 
 ; program: $mk_quant_var_elim_eq
 ; args:
@@ -342,10 +377,13 @@
 (program $is_quant_dt_split_conj ((T Type) (U Type) (C Type) (W Type) (x T) (cx T) (c (-> U W)) (y U) (ys @List :list) (zs @List :list) (F Bool) (G Bool))
   :signature (T C @List Bool Bool) Bool
   (
-    (($is_quant_dt_split_conj x c (@list y ys) F (forall (@list y zs) G)) (eo::requires ($contains_atomic_term zs y) false  ; ensure no shadowing
-                                                                            ($is_quant_dt_split_conj x c ys F (forall zs G))))
-    (($is_quant_dt_split_conj x c @list.nil F (forall (@list y zs) G))    (eo::requires ($contains_atomic_term zs y) false  ; ensure no shadowing
-                                                                            ($is_quant_dt_split_conj x (c y) @list.nil F (forall zs G))))
+    (($is_quant_dt_split_conj x c (@list y ys) F (forall (@list y zs) G))
+      (eo::requires (eo::list_find @list zs y) -1  ; ensure no shadowing
+        ($is_quant_dt_split_conj x c ys F (forall zs G))))
+    (($is_quant_dt_split_conj x c @list.nil F (forall (@list y zs) G))
+      (eo::requires (eo::list_find @list zs y) -1  ; ensure no shadowing
+      (eo::requires ($contains_atomic_term_free F y) false
+        ($is_quant_dt_split_conj x (c y) @list.nil F (forall zs G)))))
     (($is_quant_dt_split_conj x c @list.nil F (forall @list.nil G))       ($is_quant_dt_split_conj x c @list.nil F G))
     (($is_quant_dt_split_conj x cx @list.nil F G)                         (eo::eq ($substitute x cx F) G))
   )

--- a/proofs/eo/cpc/rules/Quantifiers.eo
+++ b/proofs/eo/cpc/rules/Quantifiers.eo
@@ -364,6 +364,17 @@
 
 ;;;;; ProofRewriteRule::QUANT_DT_SPLIT
 
+; define: $is_quant_dt_split_conj_subs
+; args:
+; - x T: The variable we are eliminating.
+; - c C: The constructor term we are substituting x with.
+; - F Bool: The body of the left hand side of the equality.
+; - G Bool: The conjunct we are testing.
+; return: >
+;   True if G is the result of replacing x in F by c, and x and c have the same type.
+(define $is_quant_dt_split_conj_subs ((T Type :implicit) (x T) (c T) (F Bool) (G Bool))
+  (eo::requires (eo::typeof c) (eo::typeof x) (eo::eq ($substitute x c F) G)))
+
 ; program: $is_quant_dt_split_conj
 ; args:
 ; - x T: The variable we are eliminating.
@@ -384,8 +395,10 @@
       (eo::requires (eo::list_find @list zs y) -1  ; ensure no shadowing
       (eo::requires ($contains_atomic_term_free F y) false
         ($is_quant_dt_split_conj x (c y) @list.nil F (forall zs G)))))
-    (($is_quant_dt_split_conj x c @list.nil F (forall @list.nil G))       ($is_quant_dt_split_conj x c @list.nil F G))
-    (($is_quant_dt_split_conj x cx @list.nil F G)                         (eo::eq ($substitute x cx F) G))
+    (($is_quant_dt_split_conj x cx @list.nil F (forall @list.nil G))
+      ($is_quant_dt_split_conj_subs x cx F G))
+    (($is_quant_dt_split_conj x cx @list.nil F G)
+      ($is_quant_dt_split_conj_subs x cx F G))
   )
 )
 


### PR DESCRIPTION
This PR refactors quantifiers rules to versions that have been proven in Logos/Lean.  No changes are made to the meaning of these rules; only the Eunoia implementation is fixed to be amenable to verification.

The main change is to refactor all core methods to rely on an accurate definition of closedness (`$is_closed_rec`). This method must traverse certain opaque arguments, e.g. for quantifiers skolemize skolems, since these may theoretically hide free variables.  This does not happen in practice but was a theoretical blocker to proving the correctness of most rules for quantifiers.

Also makes significant changes to quant_var_reorder to e.g check multiple variables in a single traversal.

The updated versions of all quantified rules have been proven in Logos/Lean, e.g.:
https://github.com/ajreynol/logos/pull/378
https://github.com/ajreynol/logos/pull/374
https://github.com/ajreynol/logos/pull/373
https://github.com/ajreynol/logos/pull/353
https://github.com/ajreynol/logos/pull/316
https://github.com/ajreynol/logos/pull/381