### PR TITLE
cmake: Add GMP include directory to parser object targets

### DIFF
--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -70,10 +70,12 @@ add_dependencies(cvc5parser-objs gen-expr gen-options)
 add_dependencies(cvc5parserapi-objs cvc5parser-objs gen-expr)
 
 if(USE_POLY)
-  add_dependencies(cvc5parser-objs Polyxx)
-  target_include_directories(cvc5parser-objs SYSTEM PRIVATE ${Poly_INCLUDE_DIR})
-  add_dependencies(cvc5parserapi-objs Polyxx)
-  target_include_directories(cvc5parserapi-objs SYSTEM PRIVATE ${Poly_INCLUDE_DIR})
+  # The LibPoly headers include <gmp.h>, so GMP's include directory is needed
+  # here as well when GMP lives outside the default system include path.
+  add_dependencies(cvc5parser-objs Polyxx GMP)
+  target_include_directories(cvc5parser-objs SYSTEM PRIVATE ${Poly_INCLUDE_DIR} ${GMP_INCLUDE_DIR})
+  add_dependencies(cvc5parserapi-objs Polyxx GMP)
+  target_include_directories(cvc5parserapi-objs SYSTEM PRIVATE ${Poly_INCLUDE_DIR} ${GMP_INCLUDE_DIR})
 endif()
 
 add_library(cvc5parser


### PR DESCRIPTION
Build of 1.3.4 branch failed on MacOS, as `src/parser/CMakeLists.txt` gives the parser object targets LibPoly's include dir but not GMP's. poly/poly.h already does `#include <gmp.h>`. This is invisible on Linux (as GMP usually lives in a standard path like `/usr/include`) but in MacOS GMP is installed usually in `/opt/homebrew/include`.