### PR TITLE
Bound approx-branch-depth and replay-early-close-depth options

### DIFF
--- a/src/options/arith_options.toml
+++ b/src/options/arith_options.toml
@@ -230,6 +230,8 @@ name   = "Arithmetic Theory"
   long       = "approx-branch-depth=N"
   type       = "int64_t"
   default    = "200"
+  minimum    = "0"
+  maximum    = "2147483647"
   help       = "maximum branch depth the approximate solver is allowed to take"
 
 [[option]]
@@ -302,6 +304,7 @@ name   = "Arithmetic Theory"
   long       = "replay-early-close-depth=N"
   type       = "int64_t"
   default    = "1"
+  minimum    = "1"
   help       = "multiples of the depths to try to close the approx log eagerly"
 
 [[option]]

--- a/src/options/arith_options.toml
+++ b/src/options/arith_options.toml
@@ -305,6 +305,7 @@ name   = "Arithmetic Theory"
   type       = "int64_t"
   default    = "1"
   minimum    = "1"
+  maximum    = "2147483647"
   help       = "multiples of the depths to try to close the approx log eagerly"
 
 [[option]]

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2566,10 +2566,12 @@ set(regress_0_tests
   regress0/unconstrained/xor.smt2
   regress0/unsafe-type.smt2
   regress0/unsafe-type-2.smt2
+  regress0/use_approx/approx-branch-depth-range.smt2
   regress0/use_approx/bug812_approx.smt2
   regress0/use_approx/error0_approx.smt2
   regress0/use_approx/issue2429_approx.smt2
   regress0/use_approx/issue4714_approx.smt2
+  regress0/use_approx/replay-early-close-depth-range.smt2
   regress0/use_approx/siegel-nl-bases_approx.smt2
   regress0/use_approx/specsharp-WindowsCard.15.RTE.Terminate_System.Int32_approx.smt2
   regress0/wiki.01.cvc.smt2

--- a/test/regress/cli/regress0/use_approx/approx-branch-depth-range.smt2
+++ b/test/regress/cli/regress0/use_approx/approx-branch-depth-range.smt2
@@ -1,0 +1,14 @@
+; REQUIRES: glpk
+; COMMAND-LINE: --use-approx
+; EXPECT: (error "Error in option parsing: approx-branch-depth = 2809892243652038984 is not a legal setting, value should be at most 2147483647.")
+; EXPECT: sat
+;; An out-of-range approx-branch-depth must be rejected at option-parse time.
+;; Without the bound it is a valid int64 that truncates to a negative int in
+;; ApproxGLPK::setBranchingDepth (Assert(bd >= 0) in assertions builds).
+(set-logic QF_LIA)
+(set-option :approx-branch-depth 2809892243652038984)
+(declare-fun x () Int)
+(declare-fun x6 () Int)
+(declare-fun x4 () Int)
+(assert (and (= 0 (+ x6 1 (* 2 x4))) (= 0 (+ (* x 51725) (* x6 241)))))
+(check-sat)

--- a/test/regress/cli/regress0/use_approx/replay-early-close-depth-range.smt2
+++ b/test/regress/cli/regress0/use_approx/replay-early-close-depth-range.smt2
@@ -1,0 +1,29 @@
+; REQUIRES: glpk
+; COMMAND-LINE: --use-approx
+; EXPECT: (error "Error in option parsing: replay-early-close-depth = 0 is not a legal setting, value should be at least 1.")
+; EXPECT: unsat
+;; An out-of-range replay-early-close-depth must be rejected at option-parse
+;; time. Without the bound, a value < 1 reaches "depth % replayEarlyCloseDepths"
+;; in TheoryArithPrivate::replayLogRec: Assert(... >= 1) in assertions builds,
+;; and a real integer division-by-zero (SIGFPE) in production builds. The body
+;; recurses into replayLogRec, which is where the crash lives.
+(set-logic QF_LIA)
+(set-option :replay-early-close-depth 0)
+(declare-fun x0 () Int)
+(declare-fun x1 () Int)
+(declare-fun x2 () Int)
+(declare-fun x3 () Int)
+(declare-fun x4 () Int)
+(assert (<= -5 x0))
+(assert (<= x0 5))
+(assert (<= -5 x1))
+(assert (<= x1 5))
+(assert (<= -5 x2))
+(assert (<= x2 5))
+(assert (<= -5 x3))
+(assert (<= x3 5))
+(assert (<= -5 x4))
+(assert (<= x4 5))
+(assert (= (+ (* 70241 x0) (* 76389 x1) (* 66512 x2) (* 11267 x3) (* 9158 x4)) 82))
+(assert (= (+ (* 55644 x0) (* 74117 x1) (* (- 29262) x2) (* (- 76416) x3) (* (- 75644) x4)) -175))
+(check-sat)


### PR DESCRIPTION
# Summary

`approx-branch-depth` and `replay-early-close-depth` are `int64_t` options with no declared bounds. An out-of-range value is currently accepted at parse time and then trips an assertion inside the approximate arithmetic solver — and for `replay-early-close-depth` it is a genuine division-by-zero in release builds. This adds explicit `minimum`/`maximum` so such values are rejected up front with the standard option-parsing error, exactly as #6976 introduced the mechanism and #9588 used it for `strings-model-max-len`.

## `--approx-branch-depth <out-of-range>` (e.g. `2809892243652038984`).

The option is `int64_t`, but `ApproxGLPK::setBranchingDepth` takes an `int`, so the value truncates to a negative `int`:

### Today (assertions build):
```
Fatal failure within ... ApproxGLPK::setBranchingDepth(int)
  at src/theory/arith/linear/approx_simplex.cpp:348
 bd >= 0
```
(Production build: no error — the depth bound is silently mis-set.)

### After:
```
(error "Error in option parsing: approx-branch-depth = 2809892243652038984 is not a legal setting, value should be at most 2147483647.")
sat
```

## `--replay-early-close-depth 0` (on input that recurses into `replayLogRec`).

That code computes `depth % replayEarlyCloseDepths`.

### Today (assertions build):
```
Fatal failure within ... TheoryArithPrivate::replayLogRec(...)
  at src/theory/arith/linear/theory_arith_private.cpp:2771
 options().arith.replayEarlyCloseDepths >= 1
```
Today (**production** build): **SIGFPE / core dump** — integer division by zero.

### After:
```
(error "Error in option parsing: replay-early-close-depth = 0 is not a legal setting, value should be at least 1.")
unsat
```

### Fix

| option | bound | why |
| --- | --- | --- |
| `approx-branch-depth` | `minimum = "0"`, `maximum = "2147483647"` | non-negative, and within the `int` its setter takes (INT_MAX) |
| `replay-early-close-depth` | `minimum = "1"` | used as a modulus, so must be `>= 1` |

Defaults (`200` and `1`) are within the new bounds and unchanged.

### Tests

Two regression tests under `test/regress/cli/regress0/use_approx/` set the offending value and assert the parse-time error; both crash on the current code and pass with the fix. The `use_approx` group passes 8/8, no regressions.

### How this was found

Differential/soundness fuzzing with Murxla (`--use-approx` forced on arithmetic). Both are pre-existing and independent of any solver back-end; they surfaced as assertions on option values the fuzzer supplied.
