### PR TITLE
ci: Keep current main documentation during docs cleanup

### DIFF
--- a/.github/workflows/docs_cleanup.yml
+++ b/.github/workflows/docs_cleanup.yml
@@ -35,7 +35,15 @@ jobs:
             mod=`git log -1 HEAD --pretty="%ai" $file`
             touch -d "$mod" $file
           done
-          find ./ -maxdepth 1 -name "docs-*" -mtime +7 -exec git rm --quiet -r {} +
+          # Never prune the current main documentation: keep the docs-main
+          # symlink and the directory it points to regardless of age, since it
+          # is only refreshed when the main docs change and would otherwise be
+          # removed after 7 quiet days. Orphaned docs-main-* directories (no
+          # longer referenced by the symlink) still age out normally.
+          keep_main=
+          [ -L docs-main ] && keep_main=`readlink docs-main`
+          find ./ -maxdepth 1 -name "docs-*" ! -name docs-main ${keep_main:+! -name "$keep_main"} \
+            -mtime +7 -exec git rm --quiet -r {} +
           find ./ -maxdepth 1 -name "docs-*" -xtype l -exec git rm --quiet {} +
           git commit -m "Prune docs" --quiet || echo "Nothing to prune"
 


### PR DESCRIPTION
## Description

The documentation cleanup job (`.github/workflows/docs_cleanup.yml`) removes any `docs-*` entry in the `docs-ci` repository whose last commit is older than 7 days, and then removes any resulting dangling symlink:

```bash
find ./ -maxdepth 1 -name "docs-*" -mtime +7 -exec git rm --quiet -r {} +
find ./ -maxdepth 1 -name "docs-*" -xtype l -exec git rm --quiet {} +
```

The `docs-main` symlink and its target directory are only refreshed when the main documentation actually changes — the upload workflow's "Update docs" step ignores runs whose output is identical to the current `docs-main`. So when `main` goes a week without a doc-affecting commit, `docs-main-<hash>` is never re-committed, ages past the 7-day threshold, and gets pruned as if it were a stale PR snapshot. The `docs-main` symlink is then dangling and removed by the second `find`, which took https://cvc5.github.io/docs-ci/docs-main/ offline (404).

## Fix

Exclude the `docs-main` symlink and the directory it currently points to from the age-based prune:

```bash
keep_main=
[ -L docs-main ] && keep_main=`readlink docs-main`
find ./ -maxdepth 1 -name "docs-*" ! -name docs-main ${keep_main:+! -name "$keep_main"} \
  -mtime +7 -exec git rm --quiet -r {} +
```

Orphaned `docs-main-<hash>` directories that are no longer referenced by the symlink (e.g. after a newer main build repoints it) still age out normally, so this does not leak old builds.

## Notes

- This prevents recurrence but does not by itself restore the already-pruned `docs-main`; that needs a main documentation build to run again (e.g. re-running the latest `main` CI, which cascades into "Upload Docs", or any push to `main`).
- Verified the `find` exclusion logic locally: given aged `docs-main -> docs-main-AAA`, an orphaned `docs-main-BBB`, and a `docs-pr1 -> docs-pr1-CCC`, only `docs-main` and `docs-main-AAA` are preserved while the orphan, the PR target, and the resulting dangling PR symlink are pruned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)