### PR TITLE
Fixed CadicalSolver propagation only mode with assumptions.

### DIFF
--- a/src/prop/cadical/cadical.cpp
+++ b/src/prop/cadical/cadical.cpp
@@ -79,10 +79,13 @@ CadicalSolver::CadicalSolver(Env& env,
     : EnvObj(env),
       d_solver(new CaDiCaL::Solver()),
       d_context(context()),
+      d_propagateOnly(false),
       // Note: CaDiCaL variables start with index 1 rather than 0 since negated
       //       literals are represented as the negation of the index.
       d_nextVarIdx(1),
       d_inSatMode(false),
+      d_true(undefSatVariable),
+      d_false(undefSatVariable),
       d_statistics(registry, name)
 {
 }
@@ -161,7 +164,6 @@ SatValue CadicalSolver::_solve(const std::vector<SatLiteral>& assumptions)
       d_solver->assume(toCadicalLit(~lit));
     }
   }
-  SatValue res;
   for (const SatLiteral& lit : assumptions)
   {
     if (d_propagator)
@@ -175,7 +177,8 @@ SatValue CadicalSolver::_solve(const std::vector<SatLiteral>& assumptions)
   {
     d_propagator->in_search(true);
   }
-  res = toSatValue(d_solver->solve());
+  const SatValue res =
+      toSatValue(d_propagateOnly ? d_solver->propagate() : d_solver->solve());
   if (d_propagator)
   {
     Assert(res != SAT_VALUE_TRUE || d_propagator->done());
@@ -183,6 +186,7 @@ SatValue CadicalSolver::_solve(const std::vector<SatLiteral>& assumptions)
     d_propagator->in_search(false);
   }
   ++d_statistics.d_numSatCalls;
+  d_propagateOnly = false;
   d_inSatMode = (res == SAT_VALUE_TRUE);
   return res;
 }
@@ -250,7 +254,7 @@ SatValue CadicalSolver::solve(const std::vector<SatLiteral>& assumptions)
 
 bool CadicalSolver::setPropagateOnly()
 {
-  d_solver->limit("decisions", 0); /* Gets reset after next solve() call. */
+  d_propagateOnly = true;
   return true;
 }
 

--- a/src/prop/cadical/cadical.h
+++ b/src/prop/cadical/cadical.h
@@ -141,7 +141,9 @@ class CadicalSolver : public CDCLTSatSolver, protected EnvObj
    * query the solver if a given assumption is false.
    */
   std::vector<SatLiteral> d_assumptions;
-
+  /** When true, the next solve operation will only propagate. */
+  bool d_propagateOnly;
+  /** Next fresh SAT variable index. */
   unsigned d_nextVarIdx;
   /** The proof file */
   std::string d_pfFile;


### PR DESCRIPTION
By setting the decision limit to `0` in `CaDiCaL::setPropagateOnly` assumptions were ignored on the next solving call. Internally, CaDiCaL treats assumptions as decisions. By setting the decisions limit to 0, assumptions are never applied.
This PR changes the behavior to call `CaDiCaL::propagate()` instead of `CaDiCaL::solve` when requested; without limiting the number of decisions. With `CaDiCaL::propagate()` all assumptions are applied to the internal trail followed by a run of BCP without an actual decision. Thus unsatisfiability with assumptions is detected.