### PR TITLE
Liastar1: Fix typos and dead URLs in comments

### DIFF
--- a/src/prop/cnf_stream.h
+++ b/src/prop/cnf_stream.h
@@ -57,7 +57,7 @@ enum class FormulaLitPolicy : uint32_t
 
 /**
  * Implements the following recursive algorithm
- * http://people.inf.ethz.ch/daniekro/classes/251-0247-00/f2007/readings/Tseitin70.pdf
+ * https://link.springer.com/chapter/10.1007/978-3-642-81955-1_28
  * in a single pass.
  *
  * The general idea is to introduce a new literal that will be equivalent to

--- a/src/theory/arith/linear/normal_form.h
+++ b/src/theory/arith/linear/normal_form.h
@@ -112,7 +112,7 @@ namespace arith::linear {
 
 /**
  * Section 2: Helper Classes
- * The langauges accepted by each of these defintions
+ * The languages accepted by each of these definitions
  * roughly corresponds to one of the following helper classes:
  *  Variable
  *  Constant

--- a/src/theory/arith/linear/theory_arith_private.h
+++ b/src/theory/arith/linear/theory_arith_private.h
@@ -77,7 +77,7 @@ class InferBoundsResult;
 /**
  * Implementation of QF_LRA.
  * Based upon:
- * http://research.microsoft.com/en-us/um/people/leonardo/cav06.pdf
+ * https://leodemoura.github.io/files/cav06.pdf
  */
 class TheoryArithPrivate : protected EnvObj
 {

--- a/src/theory/arith/nl/nonlinear_extension.cpp
+++ b/src/theory/arith/nl/nonlinear_extension.cpp
@@ -74,7 +74,7 @@ NonlinearExtension::~NonlinearExtension() {}
 void NonlinearExtension::preRegisterTerm(TNode n)
 {
   // register terms with extended theory, to find extended terms that can be
-  // eliminated by context-depedendent simplification.
+  // eliminated by context-dependent simplification.
   if (d_extTheory.hasFunctionKind(n.getKind()))
   {
     d_hasNlTerms = true;

--- a/src/theory/arith/nl/nonlinear_extension.h
+++ b/src/theory/arith/nl/nonlinear_extension.h
@@ -279,4 +279,4 @@ class NonlinearExtension : EnvObj
 }  // namespace theory
 }  // namespace cvc5::internal
 
-#endif /* CVC5__THEORY__ARITH__NONLINEAR_EXTENSION_H */
+#endif /* CVC5__THEORY__ARITH__NL__NONLINEAR_EXTENSION_H */

--- a/src/theory/ext_theory.h
+++ b/src/theory/ext_theory.h
@@ -15,7 +15,7 @@
  *
  * At a high level, this technique implements a generic inference scheme based
  * on the combination of SAT-context-dependent equality reasoning and
- * SAT-context-indepedent rewriting.
+ * SAT-context-independent rewriting.
  *
  * As a simple example, say
  * (1) TheoryStrings tells us that the following facts hold in the SAT context:


### PR DESCRIPTION
Fixes misspellings (context-depedendent, langauges, defintions, SAT-context-indepedent), replaces two dead paper URLs with live ones, and corrects an include-guard comment.
This PR is the first among many for merging liastar into cvc5. These typos and comments were encountered during browsing the code. Only comments were changed and no code is touched in this PR. 