### PR TITLE
Generate premises for Alethe's `la_mult_abs_comparison` rule

### DIFF
--- a/src/proof/alethe/alethe_post_processor.cpp
+++ b/src/proof/alethe/alethe_post_processor.cpp
@@ -2870,7 +2870,7 @@ bool AletheProofPostprocessCallback::update(Node res,
       return addAletheStep(AletheRule::LA_MULT_ABS_COMPARISON,
                            res,
                            nm->mkNode(Kind::SEXPR, d_cl, res),
-                           {},
+                           children,
                            {},
                            *cdp);
     }


### PR DESCRIPTION
When implementing support for this rule in Carcara, I noticed that cvc5 doesn't actually include the premises when producing this rule. I assume this was a mistake.