### PR TITLE
Reset the solver in place instead of reconstructing it

### DIFF
--- a/include/cvc5/cvc5.h
+++ b/include/cvc5/cvc5.h
@@ -7049,6 +7049,16 @@ class CVC5_EXPORT Solver
   Solver(TermManager& tm, std::unique_ptr<internal::Options>&& original);
 
   /**
+   * Reset this solver to the state it had right after construction: the
+   * underlying SMT engine is rebuilt from the original option settings.
+   *
+   * Note that this preserves the identity of this object, so pointers and
+   * references to it (e.g. the one held by InputParser) stay valid, as does
+   * its term manager and hence all terms and sorts created so far.
+   */
+  void resetInternal();
+
+  /**
    * Synthesize n-ary function following specified syntactic constraints.
    *
    * SMT-LIB:

--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -6821,8 +6821,16 @@ Solver::Solver(TermManager& tm, std::unique_ptr<internal::Options>&& original)
     : d_tm(tm)
 {
   d_originalOptions = std::move(original);
+  resetInternal();
+}
+
+void Solver::resetInternal()
+{
+  // Release the previous engine, if any, before constructing the new one so
+  // that two engines are never alive at the same time.
+  d_slv.reset();
   d_slv.reset(
-      new internal::SolverEngine(tm.d_nm.get(), d_originalOptions.get()));
+      new internal::SolverEngine(d_tm.d_nm.get(), d_originalOptions.get()));
   d_slv->setSolver(this);
   d_rng.reset(new internal::Random(d_slv->getOptions().driver.seed));
 }

--- a/src/parser/commands.cpp
+++ b/src/parser/commands.cpp
@@ -165,17 +165,10 @@ void Cmd::printResult(cvc5::Solver* solver, std::ostream& out) const
 
 void Cmd::resetSolver(cvc5::Solver* solver)
 {
-  std::unique_ptr<internal::Options> opts =
-      std::make_unique<internal::Options>();
-  opts->copyValues(*solver->d_originalOptions);
-  // This reconstructs a new solver object at the same memory location as the
-  // current one. Note that this command does not own the solver object!
-  // It may be safer to instead make the ResetCommand a special case in the
-  // CommandExecutor such that this reconstruction can be done within the
-  // CommandExecutor, who actually owns the solver.
-  TermManager& tm = solver->getTermManager();
-  solver->~Solver();
-  new (solver) cvc5::Solver(tm, std::move(opts));
+  // Note that this command does not own the solver object, and other objects
+  // (e.g. the InputParser) hold a pointer to it, so the solver has to be reset
+  // in place rather than replaced.
+  solver->resetInternal();
 }
 
 internal::Node Cmd::termToNode(const cvc5::Term& term)


### PR DESCRIPTION
`Cmd::resetSolver` reconstructed the `Solver` by destructing it and placement-newing a new object at the same address:

```cpp
TermManager& tm = solver->getTermManager();
solver->~Solver();
new (solver) cvc5::Solver(tm, std::move(opts));
```

The address does have to stay stable — other objects hold a raw `Solver*`, most notably `InputParser`, which is constructed with `pExecutor->getSolver()` and keeps it for the whole run. But destroying the object is not necessary to achieve that. Of the `Solver`'s members (`d_tm`, `d_originalOptions`, `d_slv`, `d_rng`), a reset only needs to rebuild the last two: the term manager must be *preserved*, and the original options are unchanged by definition.

Reconstructing in place was also unsafe:

- Since #12054, `Solver` owns its `TermManager` as a by-value member, so `getTermManager()` returns a reference *into the object being destructed*. It dangles across `solver->~Solver()`, and the new `Solver` then copy-constructs its `d_tm` from that destructed storage — which aliases itself, as `tm` and `this->d_tm` are the same address — and afterwards reads `tm.d_nm.get()` back out of it.
- If the `SolverEngine` allocation threw, the storage was left holding a destructed object, so any later use of it, including `~Solver()`, would be undefined.

This adds `Solver::resetInternal()`, which rebuilds the engine while leaving the object and its term manager untouched, and has the constructor delegate to it so that "reset" stays defined as "re-run construction" and the two cannot drift apart. `Cmd::resetSolver` becomes a call to it.

`Env` copies the options it is handed (`d_options.copyValues(*opts)`), so `d_originalOptions.get()` can be passed straight through and the intermediate `Options` copy is no longer needed.

`d_slv.reset()` before the new allocation keeps peak memory the same as before; the trade-off is that a throwing allocation leaves `d_slv` null rather than holding the old engine — still a defined state.

I also dropped the comment suggesting the reconstruction move into `CommandExecutor`. `CommandExecutor` holds `std::unique_ptr<Solver>&` and could reseat it, but that is exactly what would leave `InputParser::d_solver` dangling.

### Testing

On a `Competition` build:

- `regress0` 2550/2550, `regress1` 1468/1468, `api/cpp/reset_assertions` and `api/c/capi_reset_assertions` all pass.
- `(reset)` semantics are unchanged: on a script that reads an option, overrides it, resets, and reads it again, this build and the previous one produce byte-identical output, with the option correctly restored to its command-line value.
- Under gdb, a reset no longer constructs or destructs any `TermManager` (previously the solver's own copy was destructed and rebuilt). A single `NodeManager` remains, and both engines are built against it, so terms and sorts created before the reset stay valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
