### PR TITLE
Fix uninitialized simplify-assertions depth counter

### DIFF
--- a/src/smt/process_assertions.cpp
+++ b/src/smt/process_assertions.cpp
@@ -53,7 +53,10 @@ class ScopeCounter
 };
 
 ProcessAssertions::ProcessAssertions(Env& env, SolverEngineStatistics& stats)
-    : EnvObj(env), d_slvStats(stats), d_preprocessingPassContext(nullptr)
+    : EnvObj(env),
+      d_slvStats(stats),
+      d_preprocessingPassContext(nullptr),
+      d_simplifyAssertionsDepth(0)
 {
   d_true = nodeManager()->mkConst(true);
 }


### PR DESCRIPTION
`ProcessAssertions::d_simplifyAssertionsDepth` is never initialized — it has no default member initializer, and it does not appear in the constructor's initialization list. `ScopeCounter` increments and decrements it around each `simplifyAssertions()` call, so the counter starts from whatever happens to occupy that memory.

Two preprocessing passes are gated on it:

- `miplib-trick` — `options().arith.arithMLTrick && ... && d_simplifyAssertionsDepth <= 1`
- `ite-simp` — `options().smt.doITESimp && (d_simplifyAssertionsDepth <= 1 || options().smt.doITESimpOnRepeat)`

In a fresh process the `SolverEngine` tends to land on freshly-mapped (zeroed) memory, the counter reads 0 and both passes run. When the engine is rebuilt on recycled memory the counter can start anywhere, and both passes are then **silently skipped** — no warning, no diagnostic, the passes simply never run.

`(reset)` reaches this easily, and the portfolio driver performs a reset in every worker before re-asserting the input (`PortfolioDriver` → `ExecutionContext::runResetCommand`), so portfolio configurations can lose `--miplib-trick` and `--ite-simp` nondeterministically.

### Impact

Found on a QF_LIA benchmark that `--ite-simp` solves in 0.1 s. Under `--use-portfolio` the first configuration enables `--ite-simp`, but the worker's reset left the counter at `394149505` (measured), the pass was skipped, and the run did not terminate. The ITE terms stay purified — 28 `@purify` skolems in the preprocessed output instead of 6.

Because the outcome depends on what the recycled allocation happens to contain, it looked like flakiness: unrelated edits to the part of the input *before* the `(reset)` flipped it either way.

| case | before | after |
|---|---|---|
| no reset | 6 purify skolems / 0.10 s | 6 / 0.10 s |
| `(reset)`, then re-assert | 28 / >2 min | 6 / 0.10 s |
| `(reset)`, different terms beforehand | 28 / >20 s | 6 / 0.10 s |

### Testing

`regress0` 2550/2550 and `regress1` 1468/1468 pass on a `Competition` build.

I did not add a regression test: whether the uninitialized read yields a value ≤ 1 depends on the allocator's state, so a test could not fail reliably.

`clang-tidy`'s `cppcoreguidelines-pro-type-member-init` does flag it deterministically, and points at exactly this field:

```
src/smt/process_assertions.cpp:56:1: warning: constructor does not initialize
these fields: d_simplifyAssertionsDepth [cppcoreguidelines-pro-type-member-init]
```

That check is not currently enabled in cvc5's `.clang-tidy`. Neither `-Wall -Wextra` (GCC or Clang) nor the checks cvc5 enables today report it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
