### PR TITLE
Fix INST_NO_PATTERN documentation: arity is 1

### DIFF
--- a/include/cvc5/cvc5_kind.h
+++ b/include/cvc5/cvc5_kind.h
@@ -5851,12 +5851,12 @@ enum ENUM(Kind)
   /**
    * Instantiation no-pattern.
    *
-   * Specifies a (list of) terms that should not be used as a pattern for
-   * quantifier instantiation.
+   * Specifies a term that should not be used as a pattern for quantifier
+   * instantiation.
    *
-   * - Arity: ``n > 0``
+   * - Arity: ``1``
    *
-   *   - ``1..n:`` Terms of any Sort
+   *   - ``1:`` Term of any Sort
    *
    * - Create Term of this Kind with:
    *


### PR DESCRIPTION
The kind is declared with `children = 1` in
src/theory/quantifiers/kinds.toml, so exactly one term is accepted, but the API documentation claimed an arity of `n > 0`. Update the documentation to match the implementation.

Fixes #12818

🤖 Generated with [Claude Code](https://claude.com/claude-code)