### PR TITLE
Fix build triplet detection on Windows on ARM

### DIFF
--- a/cmake/Helpers.cmake
+++ b/cmake/Helpers.cmake
@@ -45,7 +45,10 @@ elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
   if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64"
       OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "AMD64")
     set(BUILD_TRIPLET "x86_64-w64-mingw32")
-  elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64"
+      OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "ARM64")
+    # CMake derives the host processor on Windows from PROCESSOR_ARCHITECTURE,
+    # which reports "ARM64"; "aarch64" only shows up when uname is used.
     set(BUILD_TRIPLET "aarch64-w64-mingw32")
   endif()
 endif()


### PR DESCRIPTION
The nightly `win64:production-arm64-gpl` job started failing after the Normaliz dependency was added (#12812), while configuring Normaliz:

```
checking build system type... Invalid configuration `ARM64': machine `ARM64-unknown' not recognized
configure: error: /bin/sh ./cnf/config.sub ARM64 failed
```

On Windows, CMake derives `CMAKE_HOST_SYSTEM_PROCESSOR` from the `PROCESSOR_ARCHITECTURE` environment variable, which reports `ARM64`; `aarch64` only appears when the value comes from `uname`. The Windows branch of the `BUILD_TRIPLET` mapping in `cmake/Helpers.cmake` only matched `aarch64`, so on a Windows on ARM host no branch matched and `BUILD_TRIPLET` kept its fallback value, the raw `ARM64`, which was then passed verbatim as `--build` to the autotools dependencies.

This went unnoticed until now because GMP, the only other autotools dependency that receives `--build`, is found on the system on the Windows on ARM CI runner; Normaliz is the first one actually built there.

The fix matches `ARM64` as well, mirroring the existing `x86_64`/`AMD64` pair just above it.

Verified on a branch that forces the GPL matrix to run on push: `win64:production-arm64-gpl` and the rest of the matrix pass.
