### PR TITLE
Do not use mixed arithmetic for to_real in proofs, CPC

### DIFF
--- a/proofs/eo/cpc/theories/Arith.eo
+++ b/proofs/eo/cpc/theories/Arith.eo
@@ -71,9 +71,7 @@
       :chainable and)
 
 ; Conversion functions.
-; disclaimer: The type of this function in SMT-LIB only accepts an Int as argument.
-(declare-parameterized-const to_real ((T Type :implicit))
-  (-> T (eo::requires ($is_arith_type T) true Real)))
+(declare-const to_real (-> Int Real))
 (declare-const to_int (-> Real Int))
 (declare-const is_int (-> Real Bool))
 ; disclaimer: The type of this function in SMT-LIB only accepts an Int as argument.

--- a/src/expr/subtype_elim_node_converter.cpp
+++ b/src/expr/subtype_elim_node_converter.cpp
@@ -42,6 +42,14 @@ Node SubtypeElimNodeConverter::postConvert(Node n)
     // always ensure that the arguments of these operators are Real
     convertToRealChildren = true;
   }
+  else if (k == Kind::TO_REAL && isRealTypeStrict(n[0].getType()))
+  {
+    // TO_REAL is strictly Int -> Real. If its argument is already Real, the
+    // application is the identity and is eliminated here. Note this occurs
+    // e.g. if the user writes (to_real t) for a Real term t, which cvc5 permits
+    // when strict parsing is disabled.
+    return n[0];
+  }
   else if (k == Kind::DIVISION || k == Kind::DIVISION_TOTAL || k == Kind::GEQ
            || k == Kind::GT || k == Kind::LEQ || k == Kind::LT)
   {
@@ -56,8 +64,6 @@ Node SubtypeElimNodeConverter::postConvert(Node n)
         isRealTypeStrict(n[0].getType()) || isRealTypeStrict(n[1].getType());
   }
   // note that EQUAL is strictly typed so we don't need to handle it here
-  // also TO_REAL applied to reals is always rewritten, so it doesn't need to
-  // be handled.
   if (convertToRealChildren)
   {
     std::vector<Node> children;

--- a/src/expr/subtype_elim_node_converter.h
+++ b/src/expr/subtype_elim_node_converter.h
@@ -24,6 +24,8 @@ namespace cvc5::internal {
  * This converts a node into one that does not involve (arithmetic) subtyping.
  * In particular, all applications of arithmetic symbols that involve at least
  * one (strict) Real child are such that all children are cast to real.
+ * Moreover, applications of TO_REAL to Real terms are eliminated, since
+ * TO_REAL is strictly a function from Int to Real.
  *
  * Note this converter is necessary since our type rules for arithmetic
  * operators are more permissive internally than in SMT-LIB, since e.g. ADD

--- a/src/proof/subtype_elim_proof_converter.cpp
+++ b/src/proof/subtype_elim_proof_converter.cpp
@@ -559,7 +559,11 @@ bool SubtypeElimConverterCallback::prove(const Node& src,
   NodeManager* nm = nodeManager();
   for (size_t j = 0; j < 2; j++)
   {
-    conv[j] = nm->mkNode(Kind::TO_REAL, src[j]);
+    // note that TO_REAL is strictly Int -> Real, so we only cast the sides
+    // that are integer. Note that src may be a mixed arithmetic relation here,
+    // in which case one of its sides is already Real.
+    conv[j] = src[j].getType().isInteger() ? nm->mkNode(Kind::TO_REAL, src[j])
+                                           : src[j];
     convEq[j] = conv[j].eqNode(tgt[j]);
     if (conv[j] != tgt[j])
     {


### PR DESCRIPTION
This leads to fewer complications when verifying CPC in Logos/Lean, see: https://github.com/ajreynol/logos/pull/410. Notably we are able to drop manually crafted assumptions on 2 proof rules since `to_real` arguments can be inferred to be of integer type.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>