### PR TITLE
Fix interactive shell crash when HOME is unset

### DIFF
--- a/src/main/interactive_shell.cpp
+++ b/src/main/interactive_shell.cpp
@@ -116,28 +116,32 @@ InteractiveShell::InteractiveShell(main::CommandExecutor* cexec,
 
     if (d_lang == modes::InputLanguage::SMT_LIB_2_6)
     {
-      d_historyFilename = string(getenv("HOME")) + "/.cvc5_history_smtlib2";
+      const char* home = getenv("HOME");
+      if (home != nullptr)
+      {
+        d_historyFilename = string(home) + "/.cvc5_history_smtlib2";
+        int err = ::read_history(d_historyFilename.c_str());
+        if (d_solver->getOptionInfo("verbosity").intValue() >= 1)
+        {
+          if (err == 0)
+          {
+            d_solver->getDriverOptions().err()
+                << "Read " << ::history_length << " lines of history from "
+                << d_historyFilename << std::endl;
+          }
+          else
+          {
+            d_solver->getDriverOptions().err()
+                << "Could not read history from " << d_historyFilename << ": "
+                << strerror(err) << std::endl;
+          }
+        }
+      }
       commandsBegin = smt2_commands;
       commandsEnd =
           smt2_commands + sizeof(smt2_commands) / sizeof(*smt2_commands);
       d_usingEditline = true;
-      int err = ::read_history(d_historyFilename.c_str());
       ::stifle_history(s_historyLimit);
-      if (d_solver->getOptionInfo("verbosity").intValue() >= 1)
-      {
-        if (err == 0)
-        {
-          d_solver->getDriverOptions().err()
-              << "Read " << ::history_length << " lines of history from "
-              << d_historyFilename << std::endl;
-        }
-        else
-        {
-          d_solver->getDriverOptions().err()
-              << "Could not read history from " << d_historyFilename << ": "
-              << strerror(err) << std::endl;
-        }
-      }
     }
   }
 #endif /* HAVE_LIBEDITLINE */
@@ -146,6 +150,10 @@ InteractiveShell::InteractiveShell(main::CommandExecutor* cexec,
 InteractiveShell::~InteractiveShell()
 {
 #if HAVE_LIBEDITLINE
+  if (d_historyFilename.empty())
+  {
+    return;
+  }
   int err = ::write_history(d_historyFilename.c_str());
   if (d_solver->getOptionInfo("verbosity").intValue() >= 1)
   {

--- a/test/binary/CMakeLists.txt
+++ b/test/binary/CMakeLists.txt
@@ -49,4 +49,11 @@ if (USE_EDITLINE)
     WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
   )
   set_tests_properties(issue_10258 PROPERTIES LABELS "binary")
+  add_test(
+    NAME interactive_shell_no_home
+    COMMAND
+    "${Python_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/test/binary/interactive_shell_no_home.py"
+    WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
+  )
+  set_tests_properties(interactive_shell_no_home PROPERTIES LABELS "binary")
 endif()

--- a/test/binary/interactive_shell_no_home.py
+++ b/test/binary/interactive_shell_no_home.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+###############################################################################
+# This file is part of the cvc5 project.
+#
+# Copyright (c) 2009-2026 by the authors listed in the file AUTHORS
+# in the top-level source directory and their institutional affiliations.
+# All rights reserved.  See the file COPYING in the top-level source
+# directory for licensing information.
+# #############################################################################
+#
+# Interactive shell must start when HOME is unset.
+##
+
+import os
+import sys
+import pexpect
+
+def check_interactive_shell_no_home():
+    """
+    Start the interactive shell without HOME. The editline history path is
+    built from getenv("HOME"); an unset HOME must not crash.
+    """
+
+    env = os.environ.copy()
+    env.pop("HOME", None)
+
+    child = pexpect.spawnu("bin/cvc5", timeout=2, env=env)
+    child.expect("cvc5>")
+    child.sendline("(exit)")
+    child.expect(pexpect.EOF)
+
+    # Reap the child so that we can inspect how it terminated. Without HOME the
+    # destructor must skip write_history() rather than crash on shutdown, so a
+    # clean EOF alone is not enough to consider this a pass.
+    child.close()
+
+    if child.signalstatus is not None:
+        print(
+            "cvc5 was killed by signal {} with HOME unset".format(
+                child.signalstatus
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+    if child.exitstatus != 0:
+        print(
+            "cvc5 exited with status {} with HOME unset".format(
+                child.exitstatus
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+def main():
+    """
+    Runs our interactive shell test
+
+    Caveats:
+
+        * If we don't have the "pexpect" model, the test doesn't get run, but
+          passes
+
+        * We expect pexpect to raise and exit with a non-zero exit code if any
+          of the steps fail
+    """
+
+    # If any of the "steps" fail, the pexpect will raise a Python will exit
+    # with a non-zero error code
+    sys.exit(check_interactive_shell_no_home())
+
+if __name__ == "__main__":
+    main()
+
+# EOF


### PR DESCRIPTION
The editline-enabled interactive shell crashed with a NULL-pointer segfault when `HOME` was unset.

## Problem

With `--editline` and a TTY, SMT-LIB mode built the history file path as `std::string(getenv("HOME")) + "/.cvc5_history_smtlib2"`. `getenv` returns a null pointer when the variable is missing. Constructing a `std::string` from that pointer is undefined behavior.

Call chain: `cvc5` on a TTY (`src/main/driver_unified.cpp`) constructs `InteractiveShell` with `std::cin`. The constructor then takes the editline branch (`isatty(stdin)`) and hits `src/main/interactive_shell.cpp`.

Trigger: `env -u HOME cvc5` on a terminal, after a build with `--editline`. Production CI configures `--editline`.

Observed failure (unfixed binary):

```
cvc5 suffered a segfault.
Offending address is 0x0
Looks like a NULL pointer was dereferenced.
```

The same file already treats `TMPDIR` as optional in `src/util/utility.cpp` (`if (tmpDir != nullptr)`).

## Change

- Null-check `HOME` before building the history path.
- Skip `read_history` / `write_history` when there is no path.
- Still enable editline (tab completion) when `HOME` is missing.

## Validation

- Red: `test/binary/interactive_shell_no_home.py` against the unfixed binary exits 1 with the NULL-pointer message above.
- Green: the same test exits 0 after the fix.
- Existing PTY tests still pass: `interactive_shell.py`, `interactive_shell_parser_inc.py`.
- `clang-format --dry-run --Werror` on `src/main/interactive_shell.cpp`.

## Origin

The current `getenv("HOME")` line was introduced in [#10122](https://github.com/cvc5/cvc5/pull/10122) ([`3bd7eff5d8`](https://github.com/cvc5/cvc5/commit/3bd7eff5d8), 2023-11-28) when interactive history was restored for SMT-LIB. The getenv-into-string pattern is older than that (2011).
