### PR TITLE
Close JAR InputStream when extracting native libraries

### DIFF
--- a/src/api/java/io/github/cvc5/Utils.java
+++ b/src/api/java/io/github/cvc5/Utils.java
@@ -170,6 +170,23 @@ public final class Utils
   }
 
   /**
+   * Write all bytes from an input stream to a file and close the stream.
+   *
+   * <p>The input stream and the output file are closed on success and on failure.</p>
+   *
+   * @param inputStream The stream to read from
+   * @param dest The destination file
+   * @throws IOException If an I/O error occurs during reading or writing
+   */
+  public static void extractToFile(InputStream inputStream, File dest) throws IOException
+  {
+    try (InputStream in = inputStream; FileOutputStream outputStream = new FileOutputStream(dest))
+    {
+      transferTo(in, outputStream);
+    }
+  }
+
+  /**
    * Load a native library from a specified path within a JAR file and loads it into the JVM.
    *
    * @param tempDir The temporary directory where the extracted native library will be written.
@@ -194,10 +211,7 @@ public final class Utils
     tempLibrary.deleteOnExit(); // Mark the file for deletion on exit
 
     // Write the extracted library to the temp file
-    try (FileOutputStream outputStream = new FileOutputStream(tempLibrary))
-    {
-      transferTo(inputStream, outputStream);
-    }
+    extractToFile(inputStream, tempLibrary);
 
     // Load the library
     try

--- a/test/unit/api/java/CMakeLists.txt
+++ b/test/unit/api/java/CMakeLists.txt
@@ -36,6 +36,7 @@ set(java_test_src_files
   ${CMAKE_CURRENT_SOURCE_DIR}/TermTest.java
   ${CMAKE_CURRENT_SOURCE_DIR}/TermManagerTest.java
   ${CMAKE_CURRENT_SOURCE_DIR}/ProofTest.java
+  ${CMAKE_CURRENT_SOURCE_DIR}/UtilsTest.java
 )
 
 if(WIN32)
@@ -92,6 +93,7 @@ cvc5_add_java_api_test(SynthResultTest)
 cvc5_add_java_api_test(TermTest)
 cvc5_add_java_api_test(TermManagerTest)
 cvc5_add_java_api_test(ProofTest)
+cvc5_add_java_api_test(UtilsTest)
 
 # suppress deprecated warnings to not error in CI
 set_source_files_properties(UncoveredTest.cpp

--- a/test/unit/api/java/UtilsTest.java
+++ b/test/unit/api/java/UtilsTest.java
@@ -1,0 +1,74 @@
+/******************************************************************************
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2026 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Black box testing of Utils JAR extraction helpers.
+ */
+
+package tests;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.github.cvc5.Utils;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import org.junit.jupiter.api.Test;
+
+class UtilsTest
+{
+  private static final class TrackingInputStream extends FilterInputStream
+  {
+    boolean closed = false;
+
+    TrackingInputStream(InputStream in)
+    {
+      super(in);
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+      closed = true;
+      super.close();
+    }
+  }
+
+  @Test
+  void extractToFileClosesInputOnSuccess() throws Exception
+  {
+    byte[] payload = new byte[] {1, 2, 3, 4};
+    TrackingInputStream in = new TrackingInputStream(new ByteArrayInputStream(payload));
+    File dest = Files.createTempFile("cvc5-extract", ".bin").toFile();
+    dest.deleteOnExit();
+
+    Utils.extractToFile(in, dest);
+
+    assertTrue(in.closed);
+    assertArrayEquals(payload, Files.readAllBytes(dest.toPath()));
+  }
+
+  @Test
+  void extractToFileClosesInputWhenDestCannotBeOpened() throws Exception
+  {
+    TrackingInputStream in = new TrackingInputStream(new ByteArrayInputStream(new byte[] {1}));
+    File dest = Files.createTempDirectory("cvc5-extract").toFile();
+    try
+    {
+      assertThrows(IOException.class, () -> Utils.extractToFile(in, dest));
+      assertTrue(in.closed);
+    }
+    finally
+    {
+      dest.delete();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Close the JAR `InputStream` when extracting native libraries from a self-contained cvc5 Java API JAR.

## Problem

`Utils.loadLibraryFromJar` opens the library with `Utils.class.getResourceAsStream` and copies it to a temp file. The `FileOutputStream` is already in try-with-resources. The JAR `InputStream` is not closed on success or when opening the temp file fails.

That path runs on first use of the documented self-contained JAR (`docs/api/java/java.rst`). The leftover stream can keep a JAR file handle open until GC, which is especially visible on Windows.

`transferTo` is unchanged. It still does not close either stream, matching Java 9 `InputStream.transferTo`.

## Change

- Add `Utils.extractToFile`, which writes the stream to a file and closes both the input stream and the output file.
- `loadLibraryFromJar` uses `extractToFile` after the existing null check.
- Add `UtilsTest` with a `FilterInputStream` that records `close()` (plain `ByteArrayInputStream.close()` is a no-op).

## Validation

Standalone replica of the old vs new extract helper:

```
Red (old, input not closed):
  old success FAIL (stream still open)
  old dest-is-dir FAIL (stream still open)
  exit 1

Green (try-with-resources on input + output):
  new success PASS (stream closed)
  new dest-is-dir PASS (stream closed)
  exit 0
```

`UtilsTest` is registered in `test/unit/api/java/CMakeLists.txt` (`unit/api/java/UtilsTest`). I did not rebuild the full Java bindings locally; production CI compiles `--all-bindings` and runs the JUnit suite.

`clang-format --dry-run --Werror` (22.1.8) is clean on the Java files.

## Origin

The unclosed `getResourceAsStream` was introduced in [#11368](https://github.com/cvc5/cvc5/pull/11368) ([`d8b6d1c33f`](https://github.com/cvc5/cvc5/commit/d8b6d1c33f), 2024-12-02). The extract path was later adjusted in [#11560](https://github.com/cvc5/cvc5/pull/11560) without closing the stream.
