### PR TITLE
Fix CLN Integer fitsSignedInt lower bound and base-0 zero

### DIFF
--- a/src/util/integer_cln_imp.cpp
+++ b/src/util/integer_cln_imp.cpp
@@ -386,7 +386,8 @@ void Integer::parseInt(const std::string& s, unsigned base)
   if (base == 0)
   {
     // infer base in a manner consistent with GMP
-    if (s[0] == '0')
+    // A lone "0" is decimal zero. Rewriting it to "#o" is not a valid integer.
+    if (s[0] == '0' && s.size() > 1)
     {
       flags.lsyntax = cln::lsyntax_commonlisp;
       std::string st = s;
@@ -454,7 +455,7 @@ bool Integer::fitsSignedInt() const
   Assert(s_fastSignedIntMax <= s_slowSignedIntMax);
 
   return (d_value <= s_fastSignedIntMax || d_value <= s_slowSignedIntMax)
-         && (d_value >= s_fastSignedIntMin || d_value >= s_slowSignedIntMax);
+         && (d_value >= s_fastSignedIntMin || d_value >= s_slowSignedIntMin);
 }
 
 bool Integer::fitsUnsignedInt() const

--- a/test/unit/util/integer_black.cpp
+++ b/test/unit/util/integer_black.cpp
@@ -304,6 +304,20 @@ TEST_F(TestUtilBlackInteger, base_inference)
   ASSERT_EQ(Integer("0b1010", 0), 10);
   ASSERT_EQ(Integer("-1", 0), -1);
   ASSERT_EQ(Integer("42", 0), 42);
+  ASSERT_EQ(Integer("0", 0), 0);
+  ASSERT_EQ(Integer("-0", 0), 0);
+}
+
+TEST_F(TestUtilBlackInteger, fits_signed_int)
+{
+  Integer imin(std::numeric_limits<int>::min());
+  Integer imax(std::numeric_limits<int>::max());
+  Integer too_small(std::numeric_limits<int64_t>::min());
+  ASSERT_TRUE(imin.fitsSignedInt());
+  ASSERT_TRUE(imax.fitsSignedInt());
+  ASSERT_FALSE(too_small.fitsSignedInt());
+  ASSERT_EQ(imin.getSignedInt(), std::numeric_limits<int>::min());
+  ASSERT_EQ(imax.getSignedInt(), std::numeric_limits<int>::max());
 }
 
 TEST_F(TestUtilBlackInteger, parse_errors)


### PR DESCRIPTION
## Summary

Fix two CLN `Integer` bugs: `fitsSignedInt()` rejects `INT_MIN`, and `Integer("0", 0)` throws.

## Problem

`Integer::fitsSignedInt()` (CLN) uses a fast range around `+/- 2^29` and a slow range of the full signed-int bounds. The lower-bound clause compares against `s_slowSignedIntMax` instead of `s_slowSignedIntMin`:

```
(d_value >= s_fastSignedIntMin || d_value >= s_slowSignedIntMax)
```

Any value in `[INT_MIN, -2^29)` fails `fitsSignedInt()`. The public API is inconsistent:

- `Term::isInt32Value()` uses `checkIntegerBounds` (`Integer` vs `numeric_limits<int32_t>`) and correctly returns true for `-2147483648`.
- `Term::getInt32Value()` then calls `getSignedInt()`, which `Assert(fitsSignedInt())` in assertion builds (CI job `ubuntu:production-dbg-clang` is `--cln --assertions --unit-testing`).

Separately, base-0 inference treats a leading `0` as octal and rewrites `"0"` to `"#o"`. CLN rejects that string. GMP accepts `Integer("0", 0) == 0`. The existing `base_inference` test never used the string `"0"`.

Default GMP builds are not affected. Competition and GPL CI builds use CLN.

## Change

- Compare the lower bound against `s_slowSignedIntMin`.
- Only rewrite `0x` / `0b` / octal when the string is longer than one character, so `"0"` parses as decimal zero.

## Validation

GMP `mpz_class("+0", 0)` throws (`mpz_set_str`), so the shared test does not cover a leading plus.

Local `./configure.sh testing --cln --gpl --auto-download --no-poly`, then `integer_black`:

```
Red (before the production change):
  TestUtilBlackInteger.base_inference
    Integer() failed to parse value "#o" in base 0
  TestUtilBlackInteger.fits_signed_int
    imin.fitsSignedInt() Actual: false Expected: true
  [  FAILED  ] 2 tests

Green (after the production change):
  TestUtilBlackInteger.base_inference
  TestUtilBlackInteger.fits_signed_int
  [  PASSED  ] 2 tests
  [  PASSED  ] 28 tests  (full integer_black)
```

`clang-format --dry-run --Werror` (22.1.8) is clean on the two files.

## Origin

The `fitsSignedInt` typo has been present since the CLN impl was moved to `.cpp` in [#5304](https://github.com/cvc5/cvc5/pull/5304) ([`5a2f629f13`](https://github.com/cvc5/cvc5/commit/5a2f629f13), 2020-10-19). The `Max`/`Min` mix-up dates to Tim King 2015 ([`a39ad6584c`](https://github.com/cvc5/cvc5/commit/a39ad6584c)).

Base-0 inference was added in the same CLN move ([#5304](https://github.com/cvc5/cvc5/pull/5304)), on top of Tim King 2014 octal rewriting ([`98df8ccdd4`](https://github.com/cvc5/cvc5/commit/98df8ccdd4)).

Related CLN Integer unit-test coverage: [#12628](https://github.com/cvc5/cvc5/pull/12628).
