### PR TITLE
Stop leftover portfolio workers after a successful solve

### DIFF
--- a/src/main/portfolio_driver.cpp
+++ b/src/main/portfolio_driver.cpp
@@ -231,6 +231,28 @@ namespace {
 class Pipe
 {
  public:
+  Pipe() : d_pipe{-1, -1} {}
+  Pipe(const Pipe&) = delete;
+  Pipe& operator=(const Pipe&) = delete;
+  Pipe(Pipe&& o) noexcept : d_pipe{o.d_pipe[0], o.d_pipe[1]}
+  {
+    o.d_pipe[0] = -1;
+    o.d_pipe[1] = -1;
+  }
+  Pipe& operator=(Pipe&& o) noexcept
+  {
+    if (this != &o)
+    {
+      closeAll();
+      d_pipe[0] = o.d_pipe[0];
+      d_pipe[1] = o.d_pipe[1];
+      o.d_pipe[0] = -1;
+      o.d_pipe[1] = -1;
+    }
+    return *this;
+  }
+  ~Pipe() { closeAll(); }
+
   /** Open a new pipe */
   void open()
   {
@@ -253,12 +275,33 @@ class Pipe
     }
     close(d_pipe[0]);
     close(d_pipe[1]);
+    d_pipe[0] = -1;
+    d_pipe[1] = -1;
   }
   /**
    * Close the input of this pipe. This method should be called within the
    * parent process after forking.
    */
-  void closeIn() { close(d_pipe[1]); }
+  void closeIn()
+  {
+    if (d_pipe[1] != -1)
+    {
+      close(d_pipe[1]);
+      d_pipe[1] = -1;
+    }
+  }
+  /**
+   * Close the output of this pipe. This method should be called within the
+   * parent process after flushTo or when a job is abandoned.
+   */
+  void closeOut()
+  {
+    if (d_pipe[0] != -1)
+    {
+      close(d_pipe[0]);
+      d_pipe[0] = -1;
+    }
+  }
   /**
    * Copy the content of the pipe into the given output stream. This method
    * should be called within the parent process after the child process has
@@ -287,11 +330,31 @@ class Pipe
       }
       os.write(buf, cnt);
     }
+    closeOut();
   }
 
  private:
+  void closeAll()
+  {
+    closeIn();
+    closeOut();
+  }
   int d_pipe[2];
 };
+
+/** Kill pid if it is still live and reap it. */
+void reapPid(pid_t& pid)
+{
+  if (pid <= 0)
+  {
+    return;
+  }
+  kill(pid, SIGKILL);
+  while (waitpid(pid, nullptr, 0) == -1 && errno == EINTR)
+  {
+  }
+  pid = -1;
+}
 
 void printPortfolioConfig(Solver& solver, PortfolioConfig& config)
 {
@@ -358,6 +421,8 @@ class PortfolioProcessPool
   {
   }
 
+  ~PortfolioProcessPool() { stopRemaining(); }
+
   bool run(PortfolioStrategy& strategy)
   {
     for (const auto& s : strategy.d_strategies)
@@ -396,6 +461,27 @@ class PortfolioProcessPool
   }
 
  private:
+  /**
+   * Kill and reap remaining running jobs. Reap the timeout child before the
+   * worker so the timeout process cannot SIGKILL a reused worker pid.
+   */
+  void stopRemaining()
+  {
+    for (auto& job : d_jobs)
+    {
+      if (job.d_state != JobState::RUNNING)
+      {
+        continue;
+      }
+      reapPid(job.d_timeout);
+      reapPid(job.d_worker);
+      job.d_errPipe.closeOut();
+      job.d_outPipe.closeOut();
+      job.d_state = JobState::DONE;
+      --d_running;
+    }
+  }
+
   void startNextJob()
   {
     Assert(d_nextJob < d_jobs.size());
@@ -414,42 +500,51 @@ class PortfolioProcessPool
     }
     if (job.d_worker == 0)
     {
-      job.d_errPipe.dup(STDERR_FILENO);
-      job.d_outPipe.dup(STDOUT_FILENO);
-
-      std::vector<cvc5::Term> assertions = d_ctx.solver().getAssertions();
-      std::string logic = d_ctx.solver().getLogic();
-
-      std::string produceUnsatCoresValue =
-          d_ctx.solver().getOption("produce-unsat-cores");
-      std::string produceModelsValue =
-          d_ctx.solver().getOption("produce-models");
-      d_ctx.storeDeclarationsAndNamedTerms();
-
-      d_ctx.runResetCommand();
-
-      d_ctx.solver().setOption("produce-unsat-cores", produceUnsatCoresValue);
-      d_ctx.solver().setOption("produce-models", produceModelsValue);
-      job.d_config.applyOptions(d_ctx.solver());
-      d_ctx.solver().setLogic(logic);
-
-      for (Term& t : assertions)
-      {
-        d_ctx.solver().assertFormula(t);
-      }
-      // 0 = solved, 1 = not solved
+      // Catch everything. An uncaught exception would unwind through the
+      // parent's PortfolioProcessPool in this child and SIGKILL sibling
+      // workers (their pids are still in d_jobs). Record solve status
+      // before trailing commands so junk after (check-sat) keeps sat/unsat.
       SolveStatus rc = SolveStatus::STATUS_UNSOLVED;
-      if (d_ctx.runCheckSatCommand())
-      // if (d_ctx.solveCommands(d_commands))
+      try
       {
-        Result res = d_ctx.d_executor->getResult();
-        d_ctx.continueAfterSolving(d_parser);
-        if (res.isSat() || res.isUnsat())
+        job.d_errPipe.dup(STDERR_FILENO);
+        job.d_outPipe.dup(STDOUT_FILENO);
+
+        std::vector<cvc5::Term> assertions = d_ctx.solver().getAssertions();
+        std::string logic = d_ctx.solver().getLogic();
+
+        std::string produceUnsatCoresValue =
+            d_ctx.solver().getOption("produce-unsat-cores");
+        std::string produceModelsValue =
+            d_ctx.solver().getOption("produce-models");
+        d_ctx.storeDeclarationsAndNamedTerms();
+
+        d_ctx.runResetCommand();
+
+        d_ctx.solver().setOption("produce-unsat-cores", produceUnsatCoresValue);
+        d_ctx.solver().setOption("produce-models", produceModelsValue);
+        job.d_config.applyOptions(d_ctx.solver());
+        d_ctx.solver().setLogic(logic);
+
+        for (Term& t : assertions)
         {
-          rc = SolveStatus::STATUS_SOLVED;
+          d_ctx.solver().assertFormula(t);
         }
+        if (d_ctx.runCheckSatCommand())
+        {
+          Result res = d_ctx.d_executor->getResult();
+          if (res.isSat() || res.isUnsat())
+          {
+            rc = SolveStatus::STATUS_SOLVED;
+          }
+          d_ctx.continueAfterSolving(d_parser);
+        }
+        _exit(rc);
       }
-      _exit(rc);
+      catch (...)
+      {
+        _exit(rc);
+      }
     }
     job.d_errPipe.closeIn();
     job.d_outPipe.closeIn();
@@ -460,11 +555,18 @@ class PortfolioProcessPool
       job.d_timeout = fork();
       if (job.d_timeout == 0)
       {
-        auto duration = std::chrono::duration<double, std::milli>(
-            job.d_config.d_timeout * d_timeout);
-        std::this_thread::sleep_for(duration);
-        kill(job.d_worker, SIGKILL);
-        _exit(0);
+        try
+        {
+          auto duration = std::chrono::duration<double, std::milli>(
+              job.d_config.d_timeout * d_timeout);
+          std::this_thread::sleep_for(duration);
+          kill(job.d_worker, SIGKILL);
+          _exit(0);
+        }
+        catch (...)
+        {
+          _exit(0);
+        }
       }
     }
 
@@ -482,6 +584,19 @@ class PortfolioProcessPool
    */
   bool checkResults(pid_t child = -1, int status = 0)
   {
+    // wait() may reap a timeout child. Forget that pid so later reapPid
+    // does not waitpid a reused identifier.
+    if (child != -1)
+    {
+      for (auto& job : d_jobs)
+      {
+        if (job.d_state == JobState::RUNNING && job.d_timeout == child)
+        {
+          job.d_timeout = -1;
+          return false;
+        }
+      }
+    }
     // check d_jobs for items where worker has terminated and timeout != -1
     for (auto& job : d_jobs)
     {
@@ -496,7 +611,7 @@ class PortfolioProcessPool
       if (child == -1)
       {
         pid_t res = waitpid(job.d_worker, &wstatus, WNOHANG);
-        // has not terminated yet
+        // has not terminated yet; leave its timeout child running
         if (res == 0) continue;
         if (res == -1) continue;
       }
@@ -504,18 +619,18 @@ class PortfolioProcessPool
       {
         wstatus = status;
       }
+      // Worker is already reaped. Kill the timeout before anything else so
+      // it cannot SIGKILL a reused worker pid.
+      reapPid(job.d_timeout);
       // mark as analyzed
       Trace("portfolio") << "Finished " << job.d_config << std::endl;
-      // terminate the corresponding timeout process if it is still running
-      if (job.d_timeout > 0)
-      {
-        kill(job.d_timeout, SIGKILL);
-      }
       job.d_state = JobState::DONE;
       --d_running;
       // check if exited normally
       if (WIFSIGNALED(wstatus))
       {
+        job.d_errPipe.closeOut();
+        job.d_outPipe.closeOut();
         continue;
       }
       if (WIFEXITED(wstatus))
@@ -531,9 +646,12 @@ class PortfolioProcessPool
           }
           job.d_errPipe.flushTo(std::cerr);
           job.d_outPipe.flushTo(std::cout);
+          stopRemaining();
           return true;
         }
       }
+      job.d_errPipe.closeOut();
+      job.d_outPipe.closeOut();
     }
     return false;
   }

--- a/test/binary/CMakeLists.txt
+++ b/test/binary/CMakeLists.txt
@@ -14,13 +14,29 @@ include_directories(${PROJECT_SOURCE_DIR}/src)
 include_directories(${PROJECT_SOURCE_DIR}/src/include)
 include_directories(${PROJECT_BINARY_DIR}/src)
 
+# Portfolio uses POSIX fork/wait. After one worker solves, siblings and their
+# timeout children must be reaped before the parent exits. --use-portfolio is
+# an expert option, so skip safe/stable builds.
+if (UNIX AND NOT ENABLE_SAFE_MODE AND NOT ENABLE_STABLE_MODE)
+  add_test(
+    NAME portfolio_stop_siblings
+    COMMAND
+    "${Python_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/test/binary/portfolio_stop_siblings.py"
+    WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
+  )
+  set_tests_properties(portfolio_stop_siblings PROPERTIES LABELS "binary")
+endif()
+
+# Convenience target for every test labeled "binary" (portfolio and editline).
+# Keep this outside USE_EDITLINE so non-editline builds still have it.
+add_custom_target(binarytests
+  COMMAND ctest --output-on-failure -L "binary" -j${CTEST_NTHREADS} $$ARGS)
+
 # if we've built using libedit, (--editline) then we want the interactive shell tests
 if (USE_EDITLINE)
 
   check_python_module(pexpect)
 
-  add_custom_target(binarytests
-    COMMAND ctest --output-on-failure -L "binary" -j${CTEST_NTHREADS} $$ARGS)
   add_test(
     NAME interactive_shell
     COMMAND

--- a/test/binary/portfolio_stop_siblings.py
+++ b/test/binary/portfolio_stop_siblings.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+###############################################################################
+# This file is part of the cvc5 project.
+#
+# Copyright (c) 2009-2026 by the authors listed in the file AUTHORS
+# in the top-level source directory and their institutional affiliations.
+# All rights reserved.  See the file COPYING in the top-level source
+# directory for licensing information.
+# #############################################################################
+#
+# After a portfolio worker solves, remaining workers and timeout children
+# must be reaped before the parent exits.
+##
+
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+
+SMT = """(set-logic QF_LRA)
+(declare-fun x () Real)
+(assert (> x 0.0))
+(check-sat)
+"""
+
+
+def list_group(pgid):
+    try:
+        out = subprocess.check_output(["pgrep", "-g", str(pgid)], text=True)
+    except (subprocess.CalledProcessError, OSError):
+        return []
+    pids = []
+    for line in out.split():
+        try:
+            pids.append(int(line))
+        except ValueError:
+            pass
+    return pids
+
+
+def kill_group(pgid):
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except OSError:
+        pass
+
+
+def main():
+    # Capture output in a file so leftover children that inherit stdout
+    # cannot keep a pipe open and hide the parent's exit from communicate().
+    with tempfile.NamedTemporaryFile(mode="w+", prefix="cvc5-portfolio-") as out:
+        proc = subprocess.Popen(
+            [
+                "bin/cvc5",
+                "--use-portfolio",
+                "--portfolio-jobs=2",
+                "--tlimit=60000",
+                "-o",
+                "portfolio",
+            ],
+            stdin=subprocess.PIPE,
+            stdout=out,
+            stderr=subprocess.STDOUT,
+            text=True,
+            start_new_session=True,
+        )
+        pgid = os.getpgid(proc.pid)
+        leftover = []
+        try:
+            proc.stdin.write(SMT)
+            proc.stdin.close()
+            proc.wait(timeout=15)
+            out.flush()
+            out.seek(0)
+            stdout = out.read()
+            if "cannot be set in stable mode" in stdout or "cannot be set in safe mode" in stdout:
+                print("skip: --use-portfolio is unavailable in this build")
+                return 0
+            if proc.returncode != 0:
+                print(
+                    "cvc5 exited {}\noutput:\n{}".format(proc.returncode, stdout),
+                    file=sys.stderr,
+                )
+                return 1
+            if "sat" not in stdout.split():
+                print("expected sat, got:\n{}".format(stdout), file=sys.stderr)
+                return 1
+            leftover = [pid for pid in list_group(pgid) if pid != proc.pid]
+            if leftover:
+                print(
+                    "leftover portfolio processes after parent exit: {}".format(
+                        leftover
+                    ),
+                    file=sys.stderr,
+                )
+                return 1
+            return 0
+        except subprocess.TimeoutExpired:
+            print("cvc5 timed out waiting for portfolio solve", file=sys.stderr)
+            return 1
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+            still = [pid for pid in list_group(pgid) if pid != proc.pid]
+            if still:
+                kill_group(pgid)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Stop leftover `--use-portfolio` workers and timeout children after one job solves, and close the parent pipe read ends.

## Problem

`PortfolioProcessPool::checkResults` treats the first `STATUS_SOLVED` worker as the winner, kills only that job's timeout child, flushes its pipes, and returns. Other workers and their timeout processes keep running until they finish or their timeout fires. When `--tlimit` is 0 the envelope is 20 minutes (`1'200'000` ms).

Those leftover children inherit the parent's stdout. A caller that pipes `cvc5` therefore waits for the leftover timeout sleeper to exit, even though `sat`/`unsat` has already been printed. With `--portfolio-jobs=2 --tlimit=60000` on a trivial QF_LRA query, the second strategy's sleeper holds the pipe for about 35 seconds after `sat`.

`Pipe` also never closes the parent read end. Failed jobs never call `flushTo`, so each job leaks two file descriptors until process exit.

## Change

- On success, and in the pool destructor, `SIGKILL` and `waitpid` remaining workers and timeout children.
- Forget timeout pids that `wait()` already reaped, so a later `waitpid` cannot hit a reused identifier.
- Give `Pipe` an RAII destructor. Close the read end after `flushTo` and when a job is abandoned.

## Validation

Red (current `main`, leftover timeout child):

```
leftover portfolio processes after parent exit: [94795]
```

Green (this change):

```
python3 test/binary/portfolio_stop_siblings.py
# exit 0
```

`clang-format --dry-run --Werror` (22.1.8) is clean on `src/main/portfolio_driver.cpp`.

The test is UNIX-only (`fork`/`wait`). It does not use editline. It is registered in `test/binary/CMakeLists.txt` outside the `USE_EDITLINE` block.

## Origin

Portfolio process pool: [#8709](https://github.com/cvc5/cvc5/pull/8709) ([`4a34d8126e`](https://github.com/cvc5/cvc5/commit/4a34d8126e), Gereon Kremer, 2022-06-13).

Timeout-child kill for the finished job only: [#11670](https://github.com/cvc5/cvc5/pull/11670) ([`dfab059fab`](https://github.com/cvc5/cvc5/commit/dfab059fab), Daniel Larraz, 2025-04-24).

Related interrupt handling in the same driver: [#12422](https://github.com/cvc5/cvc5/pull/12422).
