### PR TITLE
Include <limits> in regexp_operation.cpp

### DIFF
--- a/src/theory/strings/regexp_operation.cpp
+++ b/src/theory/strings/regexp_operation.cpp
@@ -12,6 +12,7 @@
 
 #include "theory/strings/regexp_operation.h"
 
+#include <limits>
 #include <sstream>
 
 #include "expr/node_algorithm.h"


### PR DESCRIPTION
## Problem

`regexp_operation.cpp` uses `std::numeric_limits<unsigned>::max()` in two `Assert()` calls but never includes `<limits>`:

https://github.com/cvc5/cvc5/blob/main/src/theory/strings/regexp_operation.cpp#L926
https://github.com/cvc5/cvc5/blob/main/src/theory/strings/regexp_operation.cpp#L1015

It compiles in a GMP build because `gmpxx.h` pulls `<limits>` in transitively through `util/integer.h`. The CLN headers do not, so a CLN build with assertions fails to compile once the standard library stops providing `<limits>` transitively, as libstdc++ 15 does:

```
src/theory/strings/regexp_operation.cpp:926:25: error: 'numeric_limits' is not a member of 'std'
  926 |         Assert(b < std::numeric_limits<unsigned>::max());
      |                         ^~~~~~~~~~~~~~
src/theory/strings/regexp_operation.cpp:1015:34: error: 'numeric_limits' is not a member of 'std'
 1015 |         Assert(d_lastchar < std::numeric_limits<unsigned>::max());
      |                                  ^~~~~~~~~~~~~~
```

Both conditions have to hold to reproduce: CLN (so `<limits>` is not pulled in by GMP) and assertions (so the `Assert()` bodies are compiled). That combination is built by the GPL CI jobs.

## Change

Include `<limits>`.

## Validation

`./configure.sh testing --cln --gpl --auto-download`, g++ 15.2.0. Fails to build without the change, builds and tests clean with it:

```
integer_black             [  PASSED  ] 30 tests
api_term_manager_black    [  PASSED  ] 69 tests
api_term_black            [  PASSED  ] 40 tests
```

A default GMP build is unaffected either way, since it was already getting `<limits>` transitively.