### PR TITLE
test: Disable lfsc tester for regression added in #12788.

### DIFF
--- a/test/regress/cli/regress1/fp/proj-issue327-nested-conversions.smt2
+++ b/test/regress/cli/regress1/fp/proj-issue327-nested-conversions.smt2
@@ -1,6 +1,7 @@
 ; COMMAND-LINE: --fp-exp
 ; EXPECT: unsat
 ; DISABLE-TESTER: cpc
+; DISABLE-TESTER: lfsc
 (set-logic ALL)
 (declare-const x Real)
 (declare-const x6 RoundingMode)


### PR DESCRIPTION
Fixes nightlies failure.