### PR TITLE
Remaining changes to CPC+Eunoia for Lean/Logos

### DIFF
--- a/include/cvc5/cvc5_skolem_id.h
+++ b/include/cvc5/cvc5_skolem_id.h
@@ -369,7 +369,7 @@ enum ENUM(SkolemId)
    * - Sort: ``(-> Int Int)``
    *
    * The term `(@strings_itos_result n)` is equivalent to
-   * `(lambda ((x Int)) (mod n (** 10 x)))`.
+   * `(lambda ((x Int)) (ite (= x 0) 0 (str.to_int (str.substr (str.from_int n) 0 x))))`.
    */
   EVALUE(STRINGS_ITOS_RESULT),
   /**
@@ -382,7 +382,7 @@ enum ENUM(SkolemId)
    * - Sort: ``(-> Int Int)``
    *
    * The term `(@strings_stoi_result s)` is equivalent to
-   * `(lambda ((x Int)) (str.to_int (str.substr s 0 x)))`.
+   * `(lambda ((x Int)) (ite (= x 0) 0 (str.to_int (str.substr s 0 x))))`.
    */
   EVALUE(STRINGS_STOI_RESULT),
   /**

--- a/proofs/eo/cpc/Cpc.eo
+++ b/proofs/eo/cpc/Cpc.eo
@@ -324,7 +324,6 @@
                                            (eo::define ((ex ($run_evaluate xb)))
                                            (eo::define ((w ($bv_bitwidth (eo::typeof ex))))
                                              (eo::to_bin (eo::add w en) (eo::to_z ex))))))
-      (($run_evaluate (@bv n m))           (eo::to_bin ($run_evaluate m) ($run_evaluate n)))
       (($run_evaluate (@bvsize xb))        ($bv_bitwidth (eo::typeof xb)))
 
       ; arith bv conversions

--- a/proofs/eo/cpc/rules/Datatypes.eo
+++ b/proofs/eo/cpc/rules/Datatypes.eo
@@ -367,10 +367,12 @@
   ((D Type) (T Type) (U Type) (s (-> D T)) (t D) (a T) (c U) (n Int) (ss eo::List))
   :signature (D U eo::List) D
   (
-    (($mk_dt_updater_elim_rhs (update s t a) c ss)
-       ($dt_updater_elim_rhs (update s t a) ss ($dt_inst_cons_of (eo::typeof t) c))) ; ensure the constructor is annotated
-    (($mk_dt_updater_elim_rhs (tuple.update n t a) tuple ss)
-       ($tuple_updater_elim_rhs (tuple.update n t a) ss))
+  (($mk_dt_updater_elim_rhs (update s t a) c ss)
+    ; ensure the selector is in the list for this constructor
+    (eo::requires (eo::is_neg (eo::list_find @list ss s)) false
+      ($dt_updater_elim_rhs (update s t a) ss ($dt_inst_cons_of (eo::typeof t) c)))) ; ensure the constructor is annotated
+  (($mk_dt_updater_elim_rhs (tuple.update n t a) tuple ss)
+      ($tuple_updater_elim_rhs (tuple.update n t a) ss))
   )
 )
 

--- a/proofs/eo/cpc/rules/Strings.eo
+++ b/proofs/eo/cpc/rules/Strings.eo
@@ -219,7 +219,7 @@
 ; conclusion: The given witness skolem has length n.
 (declare-rule exists_string_length ((U Type) (n Int) (id Int))
   :args ((Seq U) n id)
-  :requires (((eo::gt n -1) true))
+  :requires ((($is_numeral n) true) (($is_numeral id) true))
   :conclusion (= (str.len (@witness_string_length (Seq U) n id)) n)
 )
 
@@ -466,6 +466,7 @@
 ; conclusion: The reduction predicate for s.
 (declare-rule string_reduction ((U Type) (s U))
   :args (s)
+  :requires ((($is_closed s) true))
   :conclusion (and ($str_reduction_pred s) (= s (@purify s)))
 )
 
@@ -559,7 +560,8 @@
 ; conclusion: The given equality.
 (declare-rule re-eq-elim ((r1 RegLan) (r2 RegLan) (Q Bool))
   :args ((= (= r1 r2) Q))
-  :requires ((Q (forall ((@var.re_eq String)) (= (str.in_re @var.re_eq r1) (str.in_re @var.re_eq r2)))))
+  :requires ((($is_closed (= r1 r2)) true)
+             (Q (forall ((@var.re_eq String)) (= (str.in_re @var.re_eq r1) (str.in_re @var.re_eq r2)))))
   :conclusion (= (= r1 r2) Q)
 )
 
@@ -941,7 +943,7 @@
 ; conclusion: The given equality.
 (declare-rule str-replace-re-all-eval ((s String) (r RegLan) (t String) (u String))
   :args ((= (str.replace_re_all s r t) u))
-  :requires ((($str_eval_replace_re_all s r t) u))
+  :requires (((eo::is_str s) true) (($str_eval_replace_re_all s r t) u))
   :conclusion (= (str.replace_re_all s r t) u)
 )
 

--- a/proofs/eo/cpc/theories/Arith.eo
+++ b/proofs/eo/cpc/theories/Arith.eo
@@ -6,6 +6,18 @@
 (declare-consts <numeral> Int)
 (declare-consts <rational> Real)
 
+; define: $is_numeral
+; args:
+; - n Int: The term
+; return: true iff n is a non-negative numeral literal.
+(define $is_numeral ((n Int)) (eo::gt n -1))
+
+; define: $is_pos_numeral
+; args:
+; - n Int: The term
+; return: true iff n is a positive numeral literal.
+(define $is_pos_numeral ((n Int)) (eo::gt n 0))
+
 ; program: $arith_mk_zero
 ; args:
 ; - T Type : The type of the zero, which should be Int or Real.

--- a/proofs/eo/cpc/theories/ArithBvConv.eo
+++ b/proofs/eo/cpc/theories/ArithBvConv.eo
@@ -1,7 +1,8 @@
 (include "../theories/BitVectors.eo")
 (include "../theories/Ints.eo")
 
-(declare-parameterized-const int_to_bv ((w Int :opaque)) (-> Int (BitVec w)))
+(declare-parameterized-const int_to_bv ((w Int :opaque))
+  (-> Int (eo::requires ($is_numeral w) true (BitVec w))))
 
 (declare-parameterized-const ubv_to_int ((m Int :implicit)) (-> (BitVec m) Int))
 
@@ -16,3 +17,8 @@
 ;   This function is not a function in SMT-LIB. It is a (deprecated) synonym of
 ;   the SMT-LIB standard operator ubv_to_int.
 (define bv2nat () ubv_to_int)
+
+; Symbolic BV constant.
+; note: We use this as an alias for int_to_bv, as the two have the same semantics.
+; note: The order of arguments swaps.
+(define @bv ((value Int) (w Int)) (int_to_bv w value))

--- a/proofs/eo/cpc/theories/Arrays.eo
+++ b/proofs/eo/cpc/theories/Arrays.eo
@@ -11,5 +11,5 @@
 ; The array diff skolem. (@array_deq_diff A B) denotes an index where A and B
 ; differ if A and B are not equal.
 (declare-parameterized-const @array_deq_diff
-  ((T Type :implicit) (U Type :implicit) (a (Array T U) :opaque) (b (Array T U) :opaque))
+  ((T Type :implicit) (U Type :implicit) (a (Array T U)) (b (Array T U)))
   T)

--- a/proofs/eo/cpc/theories/BitVectors.eo
+++ b/proofs/eo/cpc/theories/BitVectors.eo
@@ -2,6 +2,7 @@
 (include "../programs/Arith.eo")
 
 ; note: We do not currently check that the index of this sort is positive.
+;(declare-parameterized-const BitVec ((w Int)) (eo::requires (eo::and (eo::not (eo::is_neg w)) (eo::is_z w)) true Type))
 (declare-const BitVec (-> Int Type))
 (declare-consts <binary> (BitVec (eo::len eo::self)))
 
@@ -29,12 +30,14 @@
 
 (declare-parameterized-const extract ((n Int :implicit) (h Int :opaque) (l Int :opaque))
   (-> (BitVec n)
-      (BitVec (eo::requires (eo::gt (eo::add l 1) 0) true
+      (BitVec (eo::define ((r (eo::add h (eo::neg l) 1)))
+              (eo::requires ($is_numeral l) true
               (eo::requires (eo::gt n h) true
-                (eo::add h (eo::neg l) 1))))))
+              (eo::requires ($is_pos_numeral r) true
+                r)))))))
 
 (declare-parameterized-const repeat ((n Int :implicit) (i Int :opaque))
-  (-> (BitVec n) (BitVec (eo::mul i n))))
+  (-> (BitVec n) (eo::requires ($is_pos_numeral i) true (BitVec (eo::mul i n)))))
 
 (declare-parameterized-const bvnot ((m Int :implicit))
   (-> (BitVec m) (BitVec m)))
@@ -142,16 +145,16 @@
   (-> (BitVec m) (BitVec m) (BitVec m)))
 
 (declare-parameterized-const zero_extend ((m Int :implicit) (i Int :opaque))
-  (-> (BitVec m) (BitVec (eo::add m i))))
+  (-> (BitVec m) (eo::requires ($is_numeral i) true (BitVec (eo::add m i)))))
 
 (declare-parameterized-const sign_extend ((m Int :implicit) (i Int :opaque))
-  (-> (BitVec m) (BitVec (eo::add m i))))
+  (-> (BitVec m) (eo::requires ($is_numeral i) true (BitVec (eo::add m i)))))
 
 (declare-parameterized-const rotate_left ((m Int :implicit) (i Int :opaque))
-  (-> (BitVec m) (BitVec m)))
+  (-> (BitVec m) (eo::requires ($is_numeral i) true (BitVec m))))
  
 (declare-parameterized-const rotate_right ((m Int :implicit) (i Int :opaque))
-  (-> (BitVec m) (BitVec m)))
+  (-> (BitVec m) (eo::requires ($is_numeral i) true (BitVec m))))
 
 ; NOTE: does not require branches to be bitvector
 ; disclaimer: This function is not a function in SMT-LIB.
@@ -204,6 +207,3 @@
 (declare-parameterized-const @from_bools ((n Int :implicit))
   (-> Bool (BitVec n) (BitVec (eo::add 1 n)))
   :right-assoc-nil @bv_empty)
-
-; symbolic constant
-(declare-parameterized-const @bv ((value Int :opaque) (w Int :opaque)) (BitVec w))

--- a/proofs/eo/cpc/theories/Builtin.eo
+++ b/proofs/eo/cpc/theories/Builtin.eo
@@ -51,4 +51,4 @@
   :arg-list @tlist)
   
 ; The purification skolem.
-(declare-parameterized-const @purify ((A Type :implicit) (t A :opaque)) A)
+(declare-parameterized-const @purify ((A Type :implicit) (t A)) A)

--- a/proofs/eo/cpc/theories/Datatypes.eo
+++ b/proofs/eo/cpc/theories/Datatypes.eo
@@ -23,8 +23,17 @@
 ;   symbols over this sort are also not part of the SMT-LIB standard.
 (declare-const Tuple (-> Type Type Type) :right-assoc-nil UnitTuple)
 
+; define: $is_tuple_type
+; args:
+; - T Type: The type
+; return: true iff T is a Tuple type, i.e. it is a Tuple-list.
+(define $is_tuple_type ((T Type)) (eo::is_ok (eo::list_len Tuple T)))
+
 (declare-const tuple.unit UnitTuple)
-(declare-parameterized-const tuple ((T Type :implicit) (U Type :implicit)) (-> T U (_ Tuple T U)) :right-assoc-nil tuple.unit)
+(declare-parameterized-const tuple ((T Type :implicit) (U Type :implicit))
+  ; U must be a Tuple type
+  (-> T U (eo::requires ($is_tuple_type U) true (_ Tuple T U)))
+  :right-assoc-nil tuple.unit)
 (declare-parameterized-const tuple.select ((T Type :implicit) (i Int :opaque)) (-> T (eo::list_nth Tuple T i)))
 
 ; disclaimer: This function is not in the SMT-LIB standard.

--- a/proofs/eo/cpc/theories/Ints.eo
+++ b/proofs/eo/cpc/theories/Ints.eo
@@ -5,7 +5,6 @@
 ; Integer division, modulus, and exponentiation.
 (declare-const div (-> Int Int Int) :left-assoc)
 (declare-const mod (-> Int Int Int))
-(declare-const ** (-> Int Int Int))
 
 ; Divisible predicate.
 (declare-const divisible (-> Int Int Bool))
@@ -25,8 +24,6 @@
 (declare-const div_total (-> Int Int Int) :left-assoc)
 ; disclaimer: This function is not in SMT-LIB.
 (declare-const mod_total (-> Int Int Int))
-; disclaimer: This function is not in SMT-LIB.
-(declare-const **_total (-> Int Int Int))
 
 ; Skolem terms for integer division by zero and integer modulus by zero.
 ; note: equivalent to (lambda ((x Int)) (div x 0)).

--- a/proofs/eo/cpc/theories/Strings.eo
+++ b/proofs/eo/cpc/theories/Strings.eo
@@ -118,7 +118,8 @@
 
 (declare-const re.* (-> RegLan RegLan))
 (declare-const re.+ (-> RegLan RegLan))
-(declare-parameterized-const re.^ ((i Int :opaque)) (-> RegLan RegLan))
+(declare-parameterized-const re.^ ((i Int :opaque))
+  (-> RegLan (eo::requires ($is_numeral i) true RegLan)))
 (declare-const re.opt (-> RegLan RegLan))
 (declare-const re.comp (-> RegLan RegLan))
 (declare-const re.range (-> String String RegLan))
@@ -134,8 +135,12 @@
 ;   functions.
 (declare-const re.union (-> RegLan RegLan RegLan) :right-assoc-nil re.none)
 (declare-const re.diff (-> RegLan RegLan RegLan))
-(declare-parameterized-const re.loop ((l Int :opaque) (h Int :opaque)) (-> RegLan RegLan))
+(declare-parameterized-const re.loop ((l Int :opaque) (h Int :opaque))
+  (-> RegLan (eo::requires ($is_numeral l) true (eo::requires ($is_numeral h) true RegLan))))
 (declare-const str.in_re (-> String RegLan Bool))
+
+; Not supported by cvc5, used to define semantics of @re_unfold_pos_component
+(declare-const str.indexof_re_split (-> String RegLan RegLan Int))
 
 ; Sequence-specific operators.
 ; disclaimer: This function is not in SMT-LIB.
@@ -176,24 +181,23 @@
   ((s String :opaque) (r RegLan :opaque) (n Int :opaque)) 
   String)
 (declare-parameterized-const @strings_deq_diff
-  ((T Type :implicit) (s (Seq T) :opaque) (t (Seq T) :opaque))
+  ((T Type :implicit) (s (Seq T)) (t (Seq T)))
   Int)
-(declare-parameterized-const @strings_stoi_result ((s String :opaque))
+(declare-parameterized-const @strings_stoi_result ((s String))
   (-> Int Int))
-(declare-parameterized-const @strings_stoi_non_digit ((s String :opaque)) Int)
-(declare-parameterized-const @strings_itos_result ((n Int :opaque))
+(declare-parameterized-const @strings_stoi_non_digit ((s String)) Int)
+(declare-parameterized-const @strings_itos_result ((n Int))
   (-> Int Int))
 (declare-parameterized-const @strings_num_occur
   ((T Type :implicit) (s (Seq T)) (t (Seq T)))
   Int)
 (declare-parameterized-const @strings_num_occur_re 
-  ((e String :opaque) (b RegLan :opaque))
+  ((e String) (b RegLan))
   Int)
 (declare-parameterized-const @strings_occur_index
   ((T Type :implicit) (s (Seq T)) (t (Seq T)))
   (-> Int Int))
-(declare-parameterized-const @strings_occur_index_re
-  ((s String :opaque) (r RegLan :opaque))
+(declare-parameterized-const @strings_occur_index_re ((s String) (r RegLan))
   (-> Int Int))
 (declare-parameterized-const @strings_replace_all_result
   ((T Type :implicit) (s (Seq T)) (t (Seq T)) (r (Seq T)))

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -2271,6 +2271,8 @@ set(regress_0_tests
   regress0/strings/re-include-union.smt2
   regress0/strings/re-inclusion-am-pf.smt2
   regress0/strings/re-inter-all.smt2
+  regress0/strings/re-inter-inclusion-flat.smt2
+  regress0/strings/re-inter-inclusion-union.smt2
   regress0/strings/re_diff.smt2
   regress0/strings/re-in-rewrite.smt2
   regress0/strings/re-mem-eval-large.smt2
@@ -2306,6 +2308,7 @@ set(regress_0_tests
   regress0/strings/str_unsound_ext_rew_eq.smt2
   regress0/strings/str-dsl-missing-rew.smt2
   regress0/strings/str-in-re-mixed-include.smt2
+  regress0/strings/str-in-re-consume-inter-star.smt2
   regress0/strings/str-pred-small-rw_429.smt2
   regress0/strings/str-pred-small-rw_538.smt2
   regress0/strings/str-pred-small-rw_593.smt2

--- a/test/regress/cli/regress0/fp/proj-issue509-fp-set-comprehension.smt2
+++ b/test/regress/cli/regress0/fp/proj-issue509-fp-set-comprehension.smt2
@@ -1,4 +1,5 @@
 ; DISABLE-TESTER: lfsc
+; DISABLE-TESTER: cpc
 (set-logic ALL)
 (set-option :sets-exp true)
 (declare-datatype d ((c (s RoundingMode))))

--- a/test/regress/cli/regress0/fp/proj-issue509-fp-set-comprehension.smt2
+++ b/test/regress/cli/regress0/fp/proj-issue509-fp-set-comprehension.smt2
@@ -1,5 +1,4 @@
 ; DISABLE-TESTER: lfsc
-; DISABLE-TESTER: cpc
 (set-logic ALL)
 (set-option :sets-exp true)
 (declare-datatype d ((c (s RoundingMode))))

--- a/test/regress/cli/regress0/strings/re-inter-inclusion-flat.smt2
+++ b/test/regress/cli/regress0/strings/re-inter-inclusion-flat.smt2
@@ -1,0 +1,15 @@
+; EXPECT: unsat
+; Regression for CPC proof checking of the RE_INTER_INCLUSION rewrite when the
+; two regular expressions share a compound re.inter component. The flat-form
+; inclusion check ($str_re_includes_rec) must short-circuit on equal leading
+; components; otherwise it fails to prove R1 is a subset of R2 here.
+(set-logic QF_S)
+(declare-const x String)
+(define-fun INTER () RegLan
+  (re.inter (re.union (str.to_re "zn-alfa-1") (str.to_re "zn-brav-2"))
+            (re.++ (str.to_re "zn-") (re.* re.allchar))))
+(define-fun R1 () RegLan (re.++ (str.to_re "tag:svc:module:") INTER (str.to_re ":operator")))
+(define-fun R2 () RegLan (re.++ (str.to_re "tag:svc:module:") INTER (str.to_re ":operator") (re.* re.allchar)))
+(assert (str.in_re x R1))
+(assert (not (str.in_re x R2)))
+(check-sat)

--- a/test/regress/cli/regress0/strings/re-inter-inclusion-union.smt2
+++ b/test/regress/cli/regress0/strings/re-inter-inclusion-union.smt2
@@ -1,0 +1,21 @@
+; EXPECT: unsat
+; Regression for CPC proof checking of the RE_INTER_INCLUSION rewrite when a
+; compound component (here a re.union) appears as a plain concatenation component
+; on one side and as an re.inter operand on the other. The two occurrences have
+; the same meaning but slightly different flat forms (a singleton re.++ wrapper),
+; so the flat-form inclusion check ($str_re_includes_rec) must short-circuit on
+; equal components at its singleton-list cases; otherwise it fails to prove that
+; R1 is a subset of R2 here.
+(set-logic QF_S)
+(declare-const x String)
+(define-fun UNION () RegLan
+  (re.union (str.to_re "qq-delta-1") (str.to_re "zn-alfa-1") (str.to_re "zn-brav-2")))
+(define-fun R1 () RegLan
+  (re.++ (str.to_re "tag:svc:qx:")
+         (re.inter UNION (re.++ (str.to_re "qq") re.allchar (str.to_re "delta-1")))
+         (str.to_re ":tsk")))
+(define-fun R2 () RegLan
+  (re.++ (str.to_re "tag:svc:qx:") UNION (str.to_re ":tsk")))
+(assert (str.in_re x R1))
+(assert (not (str.in_re x R2)))
+(check-sat)

--- a/test/regress/cli/regress0/strings/str-in-re-consume-inter-star.smt2
+++ b/test/regress/cli/regress0/strings/str-in-re-consume-inter-star.smt2
@@ -1,0 +1,15 @@
+; EXPECT: unsat
+; Regression for CPC proof checking of the STR_IN_RE_CONSUME rewrite. The
+; intersection (re.* alnum) & (re.allchar ++ "qx") has its re.* child first, which
+; does not fully consume, so $str_re_consume_inter must still detect the conflict in
+; the second child ("...qx" cannot follow the "tag:svc:qx:" prefix). Also exercises
+; flattening of re.inter whose printed re.all terminator is an explicit operand.
+(set-logic QF_S)
+(declare-const resource String)
+(assert (str.in_re resource (re.++ (str.to_re "tag:svc:qx:") (re.* re.allchar))))
+(assert (str.in_re resource
+  (re.++ (str.to_re "tag:svc:")
+         (re.inter (re.* (re.union (re.range "a" "z") (re.range "0" "9") (str.to_re "-")))
+                   (re.++ re.allchar (str.to_re "qx")))
+         (str.to_re ":sector:tsk"))))
+(check-sat)


### PR DESCRIPTION
This makes the remaining changes to update CPC to the version that is verified in Logos/Lean.

This includes:
- Updates to type rules which ensures type preservation properties can be proven, and ensures that the Eunoia type checker disallows any term that we can't reason about in our SMT-LIB semantics. This includes e.g. restricting certain indexed operators to ensure their arguments are indeed numeral.
- Removing :opaque from many of the arguments to skolems, which makes them more consistent to reason about for e.g. closedness checking.
- Adding more conditions to proof rules.
- Change the documented syntax for a few string operators to the one used in the final proof, reverting the need for `**`.
- Miscellaneous fixes to proof rules not included in previous commits.
- Adds a few regressions which failed on intermediate fixes to strings.