### PR TITLE
Make proof production in arithmetic more robust to rewriting equalities

### DIFF
--- a/src/theory/arith/arith_poly_norm.cpp
+++ b/src/theory/arith/arith_poly_norm.cpp
@@ -499,6 +499,10 @@ bool PolyNorm::isArithPolyNormRel(TNode a, TNode b, Rational& ca, Rational& cb)
   Assert(a.getType().isBoolean());
   if (a == b)
   {
+    // must set the coefficients, since they may be used by the caller to
+    // construct the premise of ARITH_POLY_NORM_REL
+    ca = Rational(1);
+    cb = Rational(1);
     return true;
   }
   Kind k = a.getKind();

--- a/src/theory/arith/arith_proof_rcons.cpp
+++ b/src/theory/arith/arith_proof_rcons.cpp
@@ -16,6 +16,7 @@
 #include "proof/proof.h"
 #include "proof/proof_node.h"
 #include "theory/arith/arith_msum.h"
+#include "theory/arith/arith_proof_utilities.h"
 #include "theory/arith/arith_subs.h"
 #include "util/rational.h"
 
@@ -85,7 +86,16 @@ bool ArithProofRCons::solveEquality(CDProof& cdp,
     Node eq = m.first.eqNode(val);
     if (!CDProof::isSame(as, eq))
     {
-      cdp.addStep(eq, ProofRule::MACRO_SR_PRED_TRANSFORM, {as}, {eq});
+      // Note the solved equality may be equivalent to as up to polynomial
+      // normalization only, and not under rewriting alone.
+      if (addArithPolyNormRel(cdp, as, eq))
+      {
+        cdp.addStep(eq, ProofRule::EQ_RESOLVE, {as, as.eqNode(eq)}, {});
+      }
+      else
+      {
+        cdp.addStep(eq, ProofRule::MACRO_SR_PRED_TRANSFORM, {as}, {eq});
+      }
     }
     // to ensure a fixed point substitution, we apply the current
     // substitution to the range of previous substitutions

--- a/src/theory/arith/arith_proof_utilities.cpp
+++ b/src/theory/arith/arith_proof_utilities.cpp
@@ -12,7 +12,9 @@
 
 #include "theory/arith/arith_proof_utilities.h"
 
+#include "proof/proof_node_algorithm.h"
 #include "proof/proof_node_manager.h"
+#include "theory/arith/arith_poly_norm.h"
 #include "util/rational.h"
 
 namespace cvc5::internal {
@@ -119,17 +121,84 @@ Node expandMacroSumUb(NodeManager* nm,
   return sumBounds;
 }
 
+/**
+ * Is n a (possibly negated) arithmetic relation, i.e. one that can be related
+ * to another arithmetic relation via polynomial normalization?
+ */
+bool isArithRel(const Node& n)
+{
+  Node atom = n.getKind() == Kind::NOT ? n[0] : n;
+  Kind k = atom.getKind();
+  if (k != Kind::EQUAL && k != Kind::GEQ && k != Kind::LEQ && k != Kind::GT
+      && k != Kind::LT)
+  {
+    return false;
+  }
+  return atom[0].getType().isRealOrInt();
+}
+
 std::shared_ptr<ProofNode> ensurePredTransform(ProofNodeManager* pnm,
                                                std::shared_ptr<ProofNode>& pf,
                                                const Node& pred)
 {
-  if (pf->getResult() == pred)
+  Node res = pf->getResult();
+  if (res == pred)
   {
     return pf;
+  }
+  // Two arithmetic relations may be equivalent while having distinct rewritten
+  // forms, e.g. (= (+ x 1) 2) and (= x 1), or (= (to_real x) 0.0) and (= x 0),
+  // in which case they cannot be related by MACRO_SR_PRED_TRANSFORM. We relate
+  // such predicates by polynomial normalization instead, whenever possible.
+  if (Pf epf = mkArithPolyNormRel(pnm, res, pred); epf != nullptr)
+  {
+    return pnm->mkNode(ProofRule::EQ_RESOLVE, {pf, epf}, {}, pred);
   }
   // give the predicate as the expected result, which is important for
   // performance (does not require proof checking).
   return pnm->mkNode(ProofRule::MACRO_SR_PRED_TRANSFORM, {pf}, {pred}, pred);
+}
+
+std::shared_ptr<ProofNode> mkArithPolyNormRel(ProofNodeManager* pnm,
+                                              const Node& a,
+                                              const Node& b)
+{
+  bool negated = (a.getKind() == Kind::NOT);
+  if (!isArithRel(a) || !isArithRel(b) || negated != (b.getKind() == Kind::NOT))
+  {
+    return nullptr;
+  }
+  Node aatom = negated ? a[0] : a;
+  Node batom = negated ? b[0] : b;
+  Rational ca, cb;
+  if (!PolyNorm::isArithPolyNormRel(aatom, batom, ca, cb))
+  {
+    return nullptr;
+  }
+  Node premise = PolyNorm::getArithPolyNormRelPremise(aatom, batom, ca, cb);
+  Pf ppf = pnm->mkNode(ProofRule::ARITH_POLY_NORM, {}, {premise}, premise);
+  Node equiv = aatom.eqNode(batom);
+  Pf epf = pnm->mkNode(ProofRule::ARITH_POLY_NORM_REL, {ppf}, {equiv}, equiv);
+  if (negated)
+  {
+    // lift the equivalence of the atoms to the negated relations
+    Node nequiv = a.eqNode(b);
+    std::vector<Node> cargs;
+    ProofRule cr = expr::getCongRule(a, cargs);
+    epf = pnm->mkNode(cr, {epf}, cargs, nequiv);
+  }
+  return epf;
+}
+
+bool addArithPolyNormRel(CDProof& cdp, const Node& a, const Node& b)
+{
+  Pf pf = mkArithPolyNormRel(cdp.getManager(), a, b);
+  if (pf == nullptr)
+  {
+    return false;
+  }
+  cdp.addProof(pf);
+  return true;
 }
 
 }  // namespace arith

--- a/src/theory/arith/arith_proof_utilities.h
+++ b/src/theory/arith/arith_proof_utilities.h
@@ -83,6 +83,28 @@ std::shared_ptr<ProofNode> ensurePredTransform(ProofNodeManager* pnm,
                                                std::shared_ptr<ProofNode>& pf,
                                                const Node& pred);
 
+/**
+ * Return a proof of (= a b) by ProofRule::ARITH_POLY_NORM_REL, extended by a
+ * congruence step if a and b are negated. This is used for relating arithmetic
+ * relations that are equivalent but are not equivalent under rewriting alone,
+ * e.g. (= (+ x 1) 2) and (= x 1).
+ *
+ * @param pnm Reference to the proof manager.
+ * @param a The first relation, or its negation.
+ * @param b The second relation, or its negation.
+ * @return The proof of (= a b), or nullptr if a and b are not arithmetic
+ * relations that are equivalent up to polynomial normalization.
+ */
+std::shared_ptr<ProofNode> mkArithPolyNormRel(ProofNodeManager* pnm,
+                                              const Node& a,
+                                              const Node& b);
+
+/**
+ * Same as above, but adds the steps proving (= a b) to cdp. Returns false and
+ * adds no steps if a and b are not related by polynomial normalization.
+ */
+bool addArithPolyNormRel(CDProof& cdp, const Node& a, const Node& b);
+
 }  // namespace arith
 }  // namespace theory
 }  // namespace cvc5::internal

--- a/src/theory/arith/linear/congruence_manager.cpp
+++ b/src/theory/arith/linear/congruence_manager.cpp
@@ -547,6 +547,11 @@ bool ArithCongruenceManager::propagate(TNode x)
           Node peqi = peq[0][0].eqNode(ic);
           Node equiv = peq.eqNode(peqi);
           Rational cx, cy;
+          // Compute the coefficients relating the two sides. Note that
+          // ARITH_POLY_NORM_REL requires these to be non-zero.
+          bool isPolyNorm = PolyNorm::isArithPolyNormRel(peq, peqi, cx, cy);
+          Assert(isPolyNorm) << peq << " and " << peqi << " not poly norm";
+          AlwaysAssert(isPolyNorm);
           Node premise =
               PolyNorm::getArithPolyNormRelPremise(peq, peqi, cx, cy);
           cdp.addStep(premise, ProofRule::ARITH_POLY_NORM, {}, {premise});
@@ -704,11 +709,16 @@ TrustNode ArithCongruenceManager::explain(TNode external)
       assumptionPfs.push_back(
           d_pnm->mkNode(ProofRule::TRUE_INTRO, {d_pnm->mkAssume(a)}, {}));
     }
-    // uses substitution to true
+    // uses substitution to true, which proves the internal form of the fact
+    Node internalp = trn.getProven()[1];
     auto litPf = d_pnm->mkNode(ProofRule::MACRO_SR_PRED_TRANSFORM,
                                {assumptionPfs},
-                               {external},
-                               external);
+                               {internalp},
+                               internalp);
+    // The internal and external forms may be equivalent arithmetic relations
+    // that nevertheless have distinct rewritten forms. We thus relate the two
+    // by polynomial normalization if necessary.
+    litPf = ensurePredTransform(d_pnm, litPf, external);
     auto extPf = d_pnm->mkScope(litPf, assumptions);
     return d_pfGenExplain->mkTrustedPropagation(external, trn.getNode(), extPf);
   }

--- a/src/theory/arith/nl/ext/factoring_check.cpp
+++ b/src/theory/arith/nl/ext/factoring_check.cpp
@@ -15,7 +15,9 @@
 #include "expr/node.h"
 #include "expr/skolem_manager.h"
 #include "proof/proof.h"
+#include "proof/proof_node_algorithm.h"
 #include "theory/arith/arith_msum.h"
+#include "theory/arith/arith_proof_utilities.h"
 #include "theory/arith/inference_manager.h"
 #include "theory/arith/nl/ext/ext_state.h"
 #include "theory/arith/nl/nl_model.h"
@@ -170,10 +172,44 @@ void FactoringCheck::check(const std::vector<Node>& asserts,
             Node k_eq = kf.eqNode(sum);
             Node split = nm->mkNode(Kind::OR, lit, lit.notNode());
             proof->addStep(split, ProofRule::SPLIT, {}, {lit});
-            proof->addStep(flem,
-                           ProofRule::MACRO_SR_PRED_TRANSFORM,
-                           {split, k_eq},
-                           {flem});
+            // The atom of the given literal and the atom of the conclusion
+            // where the factor skolem is replaced by its definition may be
+            // equivalent up to polynomial normalization only, and not under
+            // rewriting alone. We prove the equivalence via
+            // ARITH_POLY_NORM_REL in that case.
+            Node polyns = polyn.substitute(TNode(kf), TNode(sum));
+            Node katoms = nm->mkNode(atom.getKind(), polyns, zero);
+            // Note that the literals are negated when polarity is false, in
+            // which case the equivalence is lifted to the negations.
+            Node cl = polarity ? katoms : katoms.notNode();
+            if (addArithPolyNormRel(*proof, lit, cl))
+            {
+              Node equiv = lit.eqNode(cl);
+              Node nlit = lit.notNode();
+              Node rrefl = nlit.eqNode(nlit);
+              proof->addStep(rrefl, ProofRule::REFL, {}, {nlit});
+              // flems is flem where the factor skolem is expanded and the
+              // literals are in the order of split
+              Node flems = nm->mkNode(Kind::OR, cl, nlit);
+              std::vector<Node> cargs2;
+              ProofRule cr2 = expr::getCongRule(split, cargs2);
+              Node dequiv = split.eqNode(flems);
+              proof->addStep(dequiv, cr2, {equiv, rrefl}, cargs2);
+              proof->addStep(flems, ProofRule::EQ_RESOLVE, {split, dequiv}, {});
+              // The final step accounts for the definition of the factor
+              // skolem, double negation and the order of the disjunction.
+              proof->addStep(flem,
+                             ProofRule::MACRO_SR_PRED_TRANSFORM,
+                             {flems, k_eq},
+                             {flem});
+            }
+            else
+            {
+              proof->addStep(flem,
+                             ProofRule::MACRO_SR_PRED_TRANSFORM,
+                             {split, k_eq},
+                             {flem});
+            }
           }
           d_data->d_im.addPendingLemma(
               flem, InferenceId::ARITH_NL_FACTOR, proof);

--- a/src/theory/arith/nl/ext/monomial_bounds_check.cpp
+++ b/src/theory/arith/nl/ext/monomial_bounds_check.cpp
@@ -16,6 +16,7 @@
 #include "options/arith_options.h"
 #include "proof/proof.h"
 #include "theory/arith/arith_msum.h"
+#include "theory/arith/arith_proof_utilities.h"
 #include "theory/arith/arith_utilities.h"
 #include "theory/arith/inference_manager.h"
 #include "theory/arith/nl/ext/ext_state.h"
@@ -366,40 +367,54 @@ void MonomialBoundsCheck::checkBounds(const std::vector<Node>& asserts,
                 // ARITH_TRICHOTOMY expects, and also their order is not clear.
                 // Hence, we apply MACRO_SR_PRED_TRANSFORM to them, and check
                 // which corresponds to which subterm of the premise.
-                proof->addStep(exp[1][0],
-                               ProofRule::AND_ELIM,
-                               {exp[1]},
-                               {nm->mkConstInt(Rational(0))});
-                proof->addStep(exp[1][1],
-                               ProofRule::AND_ELIM,
-                               {exp[1]},
-                               {nm->mkConstInt(Rational(1))});
-                Node lb = nm->mkNode(Kind::GEQ, simpleeq[0], simpleeq[1]);
-                Node rb = nm->mkNode(Kind::LEQ, simpleeq[0], simpleeq[1]);
-                if (CVC5_EQUAL(rewrite(lb), rewrite(exp[1][0])))
+                // Note that the explanation may also be an equality that is
+                // equivalent to simpleeq up to polynomial normalization only,
+                // in which case we relate the two directly.
+                if (exp[1].getKind() == Kind::EQUAL
+                    && addArithPolyNormRel(*proof, exp[1], simpleeq))
                 {
-                  proof->addStep(lb,
-                                 ProofRule::MACRO_SR_PRED_TRANSFORM,
-                                 {exp[1][0]},
-                                 {lb});
-                  proof->addStep(rb,
-                                 ProofRule::MACRO_SR_PRED_TRANSFORM,
-                                 {exp[1][1]},
-                                 {rb});
+                  proof->addStep(simpleeq,
+                                 ProofRule::EQ_RESOLVE,
+                                 {exp[1], exp[1].eqNode(simpleeq)},
+                                 {});
                 }
                 else
                 {
-                  proof->addStep(lb,
-                                 ProofRule::MACRO_SR_PRED_TRANSFORM,
-                                 {exp[1][1]},
-                                 {lb});
-                  proof->addStep(rb,
-                                 ProofRule::MACRO_SR_PRED_TRANSFORM,
-                                 {exp[1][0]},
-                                 {rb});
+                  proof->addStep(exp[1][0],
+                                 ProofRule::AND_ELIM,
+                                 {exp[1]},
+                                 {nm->mkConstInt(Rational(0))});
+                  proof->addStep(exp[1][1],
+                                 ProofRule::AND_ELIM,
+                                 {exp[1]},
+                                 {nm->mkConstInt(Rational(1))});
+                  Node lb = nm->mkNode(Kind::GEQ, simpleeq[0], simpleeq[1]);
+                  Node rb = nm->mkNode(Kind::LEQ, simpleeq[0], simpleeq[1]);
+                  if (CVC5_EQUAL(rewrite(lb), rewrite(exp[1][0])))
+                  {
+                    proof->addStep(lb,
+                                   ProofRule::MACRO_SR_PRED_TRANSFORM,
+                                   {exp[1][0]},
+                                   {lb});
+                    proof->addStep(rb,
+                                   ProofRule::MACRO_SR_PRED_TRANSFORM,
+                                   {exp[1][1]},
+                                   {rb});
+                  }
+                  else
+                  {
+                    proof->addStep(lb,
+                                   ProofRule::MACRO_SR_PRED_TRANSFORM,
+                                   {exp[1][1]},
+                                   {lb});
+                    proof->addStep(rb,
+                                   ProofRule::MACRO_SR_PRED_TRANSFORM,
+                                   {exp[1][0]},
+                                   {rb});
+                  }
+                  proof->addStep(
+                      simpleeq, ProofRule::ARITH_TRICHOTOMY, {lb, rb}, {});
                 }
-                proof->addStep(
-                    simpleeq, ProofRule::ARITH_TRICHOTOMY, {lb, rb}, {});
                 proof->addStep(
                     tmplem[0], ProofRule::AND_INTRO, {exp[0], simpleeq}, {});
                 proof->addStep(tmplem[1],


### PR DESCRIPTION
Work towards https://github.com/cvc5/cvc5/pull/12833.

This PR changes proof production in arithmetic to be more robust, e.g. not to assume that the fully normalized form of arithmetic equalities can be obtained from the rewriter. Instead, we rely as needed on ARITH_POLY_NORM_REL.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>