### PR TITLE
Set up preprocess and extended rewrites for arithmetic equality

### DIFF
--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -449,6 +449,16 @@ RewriteResponse ArithRewriter::postRewriteAtom(TNode atom)
   }
 }
 
+Node ArithRewriter::rewriteEqualityExt(Node node)
+{
+  Assert(node.getKind() == Kind::EQUAL);
+  if (!node[0].getType().isRealOrInt())
+  {
+    return node;
+  }
+  return rewriter::normalizeEquality(d_nm, node);
+}
+
 RewriteResponse ArithRewriter::preRewriteTerm(TNode t)
 {
   if (t.isConst())

--- a/src/theory/arith/arith_rewriter.h
+++ b/src/theory/arith/arith_rewriter.h
@@ -39,6 +39,17 @@ class ArithRewriter : public TheoryRewriter
    */
   Node expandDefinition(Node node) override;
   /**
+   * Return the normal form of the arithmetic equality node, see
+   * rewriter::normalizeEquality. The returned node is either an equality or a
+   * Boolean constant.
+   *
+   * Note this normalization is not applied by postRewrite, since it does not
+   * preserve the terms of the equality, which is incompatible with theory
+   * combination. It is instead applied to equalities in the input via
+   * ppStaticRewrite, and by the extended rewriter.
+   */
+  Node rewriteEqualityExt(Node node) override;
+  /**
    * Rewrite inequality to bv. If ineq contains a single bv2nat term, then
    * if possible, return an equivalent formula involving a bitvector inequality.
    * Otherwise, return ineq itself.

--- a/src/theory/arith/pp_rewrite_eq.cpp
+++ b/src/theory/arith/pp_rewrite_eq.cpp
@@ -13,7 +13,9 @@
 #include "theory/arith/pp_rewrite_eq.h"
 
 #include "options/arith_options.h"
+#include "proof/proof_node_manager.h"
 #include "smt/env.h"
+#include "theory/arith/arith_proof_utilities.h"
 #include "theory/builtin/proof_checker.h"
 #include "theory/rewriter.h"
 
@@ -29,11 +31,22 @@ PreprocessRewriteEq::PreprocessRewriteEq(Env& env)
 TrustNode PreprocessRewriteEq::ppRewriteEq(TNode atom)
 {
   Assert(atom.getKind() == Kind::EQUAL);
+  Assert(atom[0].getType().isRealOrInt());
   if (!options().arith.arithRewriteEq)
   {
-    return TrustNode::null();
+    // We are not splitting the equality into inequalities below, in which case
+    // we normalize it. Note this is applied here and not by Rewriter::rewrite,
+    // since normalizing an equality does not preserve its terms, which is
+    // incompatible with theory combination for equalities that are generated
+    // as literals in lemmas. It is instead an extended equality rewrite, see
+    // ArithRewriter::rewriteEqualityExt.
+    Node atomn = rewriteEqualityExt(atom);
+    if (atomn == atom)
+    {
+      return TrustNode::null();
+    }
+    return ppNormalizeEq(atom, atomn);
   }
-  Assert(atom[0].getType().isRealOrInt());
   Node leq = NodeBuilder(nodeManager(), Kind::LEQ) << atom[0] << atom[1];
   Node geq = NodeBuilder(nodeManager(), Kind::GEQ) << atom[0] << atom[1];
   Node rewritten = leq.andNode(geq);
@@ -52,6 +65,28 @@ TrustNode PreprocessRewriteEq::ppRewriteEq(TNode atom)
             TrustId::THEORY_INFERENCE_ARITH, {}, {}, eq));
   }
   return TrustNode::mkTrustRewrite(atom, rewritten, nullptr);
+}
+
+TrustNode PreprocessRewriteEq::ppNormalizeEq(TNode eq, TNode eqn)
+{
+  Assert(eq.getKind() == Kind::EQUAL);
+  if (d_env.isTheoryProofProducing())
+  {
+    ProofNodeManager* pnm = d_env.getProofNodeManager();
+    // The two are equivalent up to polynomial normalization, unless the
+    // normalized form is a Boolean constant.
+    if (std::shared_ptr<ProofNode> pf = mkArithPolyNormRel(pnm, eq, eqn);
+        pf != nullptr)
+    {
+      return d_ppPfGen.mkTrustedRewrite(eq, eqn, pf);
+    }
+    Node equiv = eq.eqNode(eqn);
+    return d_ppPfGen.mkTrustedRewrite(
+        eq,
+        eqn,
+        pnm->mkTrustedNode(TrustId::THEORY_INFERENCE_ARITH, {}, {}, equiv));
+  }
+  return TrustNode::mkTrustRewrite(eq, eqn, nullptr);
 }
 
 }  // namespace arith

--- a/src/theory/arith/pp_rewrite_eq.h
+++ b/src/theory/arith/pp_rewrite_eq.h
@@ -29,7 +29,8 @@ namespace arith {
  * This class is responsible for rewriting arithmetic equalities based on the
  * current options.
  *
- * In particular, we may rewrite (= x y) to (and (>= x y) (<= x y)).
+ * In particular, we may rewrite (= x y) to (and (>= x y) (<= x y)). Otherwise,
+ * we rewrite an equality to its normal form, e.g. (= (+ x 1) 2) to (= x 1).
  */
 class PreprocessRewriteEq : protected EnvObj
 {
@@ -39,10 +40,20 @@ class PreprocessRewriteEq : protected EnvObj
   /**
    * Preprocess equality, applies ppRewrite for equalities. This method is
    * distinct from ppRewrite since it is not allowed to construct lemmas.
+   *
+   * If the above option is not enabled, this returns the normal form of eq,
+   * see rewriter::normalizeEquality, if it differs from eq. Note this
+   * normalization is not applied by the rewriter, since it does not preserve
+   * the terms of the equality.
    */
   TrustNode ppRewriteEq(TNode eq);
 
  private:
+  /**
+   * Return a trust node proving that eq is equivalent to its normal form eqn,
+   * see rewriter::normalizeEquality.
+   */
+  TrustNode ppNormalizeEq(TNode eq, TNode eqn);
   /** Used to prove pp-rewrites */
   EagerProofGenerator d_ppPfGen;
 };

--- a/src/theory/arith/rewriter/rewrite_atom.cpp
+++ b/src/theory/arith/rewriter/rewrite_atom.cpp
@@ -371,6 +371,16 @@ Node buildRealInequality(NodeManager* nm, Sum&& sum, Kind k)
   return buildRelation(k, collectSum(nm, sum), rhs);
 }
 
+Node normalizeEquality(NodeManager* nm, TNode atom)
+{
+  Assert(atom.getKind() == Kind::EQUAL);
+  Assert(atom[0].getType().isRealOrInt());
+  // TODO: normalize the equality, which requires that the rewriter no longer
+  // normalizes equalities itself. Until then, the rewritten form of an
+  // equality is already its normal form, hence this is a no-op.
+  return atom;
+}
+
 std::pair<Node, Node> decomposeSum(NodeManager* nm,
                                    Sum&& sum,
                                    bool& negated,

--- a/src/theory/arith/rewriter/rewrite_atom.cpp
+++ b/src/theory/arith/rewriter/rewrite_atom.cpp
@@ -371,7 +371,7 @@ Node buildRealInequality(NodeManager* nm, Sum&& sum, Kind k)
   return buildRelation(k, collectSum(nm, sum), rhs);
 }
 
-Node normalizeEquality(NodeManager* nm, TNode atom)
+Node normalizeEquality(CVC5_UNUSED NodeManager* nm, TNode atom)
 {
   Assert(atom.getKind() == Kind::EQUAL);
   Assert(atom[0].getType().isRealOrInt());

--- a/src/theory/arith/rewriter/rewrite_atom.h
+++ b/src/theory/arith/rewriter/rewrite_atom.h
@@ -87,6 +87,24 @@ Node buildIntegerInequality(NodeManager* nm, Sum&& sum, Kind k);
 Node buildRealInequality(NodeManager* nm, Sum&& sum, Kind k);
 
 /**
+ * Return the normal form of the arithmetic equality atom, which is computed by
+ * moving all terms to the left hand side and normalizing the resulting sum.
+ * For example, this returns (= x 1) for the input (= (+ x 1) 2). The returned
+ * node is either an equality or a Boolean constant.
+ *
+ * Note this normalization is not applied by the rewriter, since it does not
+ * preserve the terms of the equality, which is incompatible with theory
+ * combination. It is instead applied to equalities in the input via
+ * ppStaticRewrite, and by the extended rewriter, see
+ * ArithRewriter::rewriteEqualityExt.
+ *
+ * @param nm Pointer to the node manager.
+ * @param atom The equality to normalize.
+ * @return The normal form of atom.
+ */
+Node normalizeEquality(NodeManager* nm, TNode atom);
+
+/**
  * Decompose sum into a (non-constant, constant) part.
  * @param nm Pointer to node manager.
  * @param sum The sum.

--- a/src/theory/quantifiers/extended_rewrite.cpp
+++ b/src/theory/quantifiers/extended_rewrite.cpp
@@ -288,6 +288,7 @@ Node ExtendedRewriter::extendedRewrite(Node n) const
     {
       case THEORY_STRINGS: new_ret = extendedRewriteStrings(ret); break;
       case THEORY_SETS: new_ret = extendedRewriteSets(ret); break;
+      case THEORY_ARITH: new_ret = extendedRewriteArith(ret); break;
       default: break;
     }
   }
@@ -2080,6 +2081,23 @@ Node ExtendedRewriter::extendedRewriteStrings(const Node& node) const
     return rr.d_node;
   }
 
+  return Node::null();
+}
+
+Node ExtendedRewriter::extendedRewriteArith(const Node& node) const
+{
+  if (node.getKind() == Kind::EQUAL)
+  {
+    // We invoke the extended equality rewriter, which normalizes the equality.
+    // Notice this is not applied by Rewriter::rewrite, since it does not
+    // preserve the terms of the equality, see rewriter::normalizeEquality.
+    Node ret = d_rew.rewriteEqualityExt(node);
+    if (ret != node)
+    {
+      debugExtendedRewrite(node, ret, "ARITH_EXT_EQ_REWRITE");
+      return ret;
+    }
+  }
   return Node::null();
 }
 

--- a/src/theory/quantifiers/extended_rewrite.h
+++ b/src/theory/quantifiers/extended_rewrite.h
@@ -242,6 +242,7 @@ class ExtendedRewriter
    */
   Node extendedRewriteStrings(const Node& ret) const;
   Node extendedRewriteSets(const Node& ret) const;
+  Node extendedRewriteArith(const Node& ret) const;
   //--------------------------------------end theory-specific top-level calls
 
   /**


### PR DESCRIPTION
Work towards https://github.com/cvc5/cvc5/pull/12833.

Arithmetic equalities won't be fully normalized. This introduces a stub (normalizeEquality) that will be equivalent to the current rewriter for arithmetic equality, and ensures that this is applied at preprocess time, and as an extended rewrite.