### PR TITLE
Miscellaneous changes in preparation for changing arithmetic equality rewriting.

### DIFF
--- a/src/theory/arith/bound_inference.cpp
+++ b/src/theory/arith/bound_inference.cpp
@@ -15,6 +15,7 @@
 #include "smt/env.h"
 #include "theory/arith/arith_utilities.h"
 #include "theory/arith/linear/normal_form.h"
+#include "theory/arith/rewriter/rewrite_atom.h"
 #include "theory/rewriter.h"
 
 using namespace cvc5::internal::kind;
@@ -56,6 +57,18 @@ const std::map<Node, Bounds>& BoundInference::get() const { return d_bounds; }
 bool BoundInference::add(const Node& n, bool onlyVariables)
 {
   Node tmp = rewrite(n);
+  if (tmp.getKind() == Kind::NOT && tmp[0].getKind() == Kind::EQUAL)
+  {
+    // Disequalities are not used for bound inference. Note we return here,
+    // since a disequality cannot necessarily be parsed as a comparison below.
+    return false;
+  }
+  if (tmp.getKind() == Kind::EQUAL)
+  {
+    // Normalize the equality, so that it can be parsed as a comparison below,
+    // see rewriter::normalizeEquality.
+    tmp = rewriter::normalizeEquality(nodeManager(), tmp);
+  }
   if (tmp.getKind() == Kind::CONST_BOOLEAN)
   {
     return false;
@@ -176,7 +189,12 @@ void BoundInference::update_lower_bound(const Node& origin,
 
     if (!b.lower_strict && !b.upper_strict && b.lower_value == b.upper_value)
     {
-      Node eq = mkEquality(lhs, value);
+      // If both bounds come from the same origin, then that origin already is
+      // (equivalent to) the equality we would construct here. We use it, which
+      // avoids constructing an equality of a different form, e.g. one whose
+      // sides are cast to real.
+      Node eq = b.lower_origin == b.upper_origin ? Node(b.lower_origin)
+                                                 : mkEquality(lhs, value);
       b.lower_bound = b.upper_bound = rewrite(eq);
     }
     else
@@ -211,7 +229,12 @@ void BoundInference::update_upper_bound(const Node& origin,
     b.upper_origin = origin;
     if (!b.lower_strict && !b.upper_strict && b.lower_value == b.upper_value)
     {
-      Node eq = mkEquality(lhs, value);
+      // If both bounds come from the same origin, then that origin already is
+      // (equivalent to) the equality we would construct here. We use it, which
+      // avoids constructing an equality of a different form, e.g. one whose
+      // sides are cast to real.
+      Node eq = b.lower_origin == b.upper_origin ? Node(b.lower_origin)
+                                                 : mkEquality(lhs, value);
       b.lower_bound = b.upper_bound = rewrite(eq);
     }
     else

--- a/src/theory/arith/bound_inference.cpp
+++ b/src/theory/arith/bound_inference.cpp
@@ -193,7 +193,7 @@ void BoundInference::update_lower_bound(const Node& origin,
       // (equivalent to) the equality we would construct here. We use it, which
       // avoids constructing an equality of a different form, e.g. one whose
       // sides are cast to real.
-      Node eq = b.lower_origin == b.upper_origin ? Node(b.lower_origin)
+      Node eq = b.lower_origin == b.upper_origin ? b.lower_origin
                                                  : mkEquality(lhs, value);
       b.lower_bound = b.upper_bound = rewrite(eq);
     }
@@ -233,7 +233,7 @@ void BoundInference::update_upper_bound(const Node& origin,
       // (equivalent to) the equality we would construct here. We use it, which
       // avoids constructing an equality of a different form, e.g. one whose
       // sides are cast to real.
-      Node eq = b.lower_origin == b.upper_origin ? Node(b.lower_origin)
+      Node eq = b.lower_origin == b.upper_origin ? b.lower_origin
                                                  : mkEquality(lhs, value);
       b.lower_bound = b.upper_bound = rewrite(eq);
     }

--- a/src/theory/arith/linear/normal_form.cpp
+++ b/src/theory/arith/linear/normal_form.cpp
@@ -695,7 +695,9 @@ SumPair SumPair::mkSumPair(const Polynomial& p)
 
 Comparison::Comparison(TNode n) : NodeWrapper(n)
 {
-  Assert(isNormalForm()) << "Bad comparison normal form: " << n;
+  // Note we do not assert that n is in normal form here, since this
+  // constructor is used by isNormalAtom to check whether it is. The assertion
+  // is made in parseNormalForm.
 }
 
 SumPair Comparison::toSumPair() const

--- a/src/theory/arith/linear/normal_form.h
+++ b/src/theory/arith/linear/normal_form.h
@@ -1483,9 +1483,13 @@ class Comparison : public NodeWrapper
 
   static Comparison parseNormalForm(TNode n);
 
+  /**
+   * Is n an atom in normal form? Note this method does not assume that n is
+   * in normal form, in contrast to parseNormalForm.
+   */
   inline static bool isNormalAtom(TNode n)
   {
-    Comparison parse = Comparison::parseNormalForm(n);
+    Comparison parse(n);
     return parse.isNormalForm();
   }
 

--- a/src/theory/arith/nl/icp/icp_solver.cpp
+++ b/src/theory/arith/nl/icp/icp_solver.cpp
@@ -21,6 +21,7 @@
 #include "theory/arith/inference_manager.h"
 #include "theory/arith/linear/normal_form.h"
 #include "theory/arith/nl/poly_conversion.h"
+#include "theory/arith/rewriter/rewrite_atom.h"
 #include "theory/rewriter.h"
 #include "util/poly_util.h"
 
@@ -87,6 +88,18 @@ std::vector<Node> ICPSolver::collectVariables(const Node& n) const
 std::vector<Candidate> ICPSolver::constructCandidates(const Node& n)
 {
   Node tmp = rewrite(n);
+  if (tmp.getKind() == Kind::NOT && tmp[0].getKind() == Kind::EQUAL)
+  {
+    // Disequalities are not used for propagation. Note we return here, since a
+    // disequality cannot necessarily be parsed as a comparison below.
+    return {};
+  }
+  if (tmp.getKind() == Kind::EQUAL)
+  {
+    // Normalize the equality, so that it can be parsed as a comparison below,
+    // see rewriter::normalizeEquality.
+    tmp = rewriter::normalizeEquality(nodeManager(), tmp);
+  }
   if (tmp.isConst())
   {
     return {};

--- a/src/theory/arith/rewriter/rewrite_atom.cpp
+++ b/src/theory/arith/rewriter/rewrite_atom.cpp
@@ -371,6 +371,16 @@ Node buildRealInequality(NodeManager* nm, Sum&& sum, Kind k)
   return buildRelation(k, collectSum(nm, sum), rhs);
 }
 
+Node normalizeEquality(NodeManager* nm, TNode atom)
+{
+  Assert(atom.getKind() == Kind::EQUAL);
+  Assert(atom[0].getType().isRealOrInt());
+  // TODO: normalize the equality, which requires that the rewriter no longer
+  // normalizes equalities itself. Until then, the rewritten form of an
+  // equality is already its normal form, hence this is a no-op.
+  return atom;
+}
+
 std::pair<Node, Node> decomposeSum(NodeManager* nm,
                                    Sum&& sum,
                                    bool& negated,

--- a/src/theory/arith/rewriter/rewrite_atom.cpp
+++ b/src/theory/arith/rewriter/rewrite_atom.cpp
@@ -371,7 +371,7 @@ Node buildRealInequality(NodeManager* nm, Sum&& sum, Kind k)
   return buildRelation(k, collectSum(nm, sum), rhs);
 }
 
-Node normalizeEquality(NodeManager* nm, TNode atom)
+Node normalizeEquality(CVC5_UNUSED NodeManager* nm, TNode atom)
 {
   Assert(atom.getKind() == Kind::EQUAL);
   Assert(atom[0].getType().isRealOrInt());

--- a/src/theory/arith/rewriter/rewrite_atom.h
+++ b/src/theory/arith/rewriter/rewrite_atom.h
@@ -87,6 +87,23 @@ Node buildIntegerInequality(NodeManager* nm, Sum&& sum, Kind k);
 Node buildRealInequality(NodeManager* nm, Sum&& sum, Kind k);
 
 /**
+ * Return the normal form of the arithmetic equality atom, which is computed by
+ * moving all terms to the left hand side and normalizing the resulting sum.
+ * For example, this returns (= x 1) for the input (= (+ x 1) 2). The returned
+ * node is either an equality or a Boolean constant.
+ *
+ * Note this normalization is not applied by the rewriter, since it does not
+ * preserve the terms of the equality, which is incompatible with theory
+ * combination. It is instead applied to equalities in the input via
+ * ppStaticRewrite, and by utilities that require equalities in normal form.
+ *
+ * @param nm Pointer to the node manager.
+ * @param atom The equality to normalize.
+ * @return The normal form of atom.
+ */
+Node normalizeEquality(NodeManager* nm, TNode atom);
+
+/**
  * Decompose sum into a (non-constant, constant) part.
  * @param nm Pointer to node manager.
  * @param sum The sum.

--- a/src/theory/strings/model_cons_default.cpp
+++ b/src/theory/strings/model_cons_default.cpp
@@ -53,14 +53,42 @@ void ModelConsDefault::separateByLength(TheoryModel* m,
   // look up the values of each length term
   for (Node& ll : lts)
   {
+    if (ll.isNull() || ll.isConst())
+    {
+      continue;
+    }
     // Previously we called Valuation::getCandidateModelValue for this purpose,
     // which relied on the arithmetic theory solver to confirm the value of ll.
     // However, it is better to simply ask the model object (which the
     // arithmetic solver has already populated for us). Moreover this
     // avoids assertion failures when using ee-mode=central.
-    if (!ll.isConst() && m->hasTerm(ll))
+    if (m->hasTerm(ll))
     {
       ll = m->getRepresentative(ll);
+      continue;
+    }
+    // Note that ll is the representative of the length in the equality engine
+    // of this theory, which the model may not know. This is possible when
+    // using ee-mode=central, where the representative may e.g. be a polynomial
+    // (+ (str.len x) (str.len y)) that the arithmetic solver treats as an
+    // auxiliary term and thus does not assign a value to. In this case, we
+    // look for a term in the equivalence class of ll whose value is known to
+    // the model, e.g. the length term (str.len z) itself.
+    eq::EqualityEngine* ee = d_state.getEqualityEngine();
+    eq::EqClassIterator eqc_i = eq::EqClassIterator(ll, ee);
+    while (!eqc_i.isFinished())
+    {
+      Node n = *eqc_i;
+      if (m->hasTerm(n))
+      {
+        Node nv = m->getRepresentative(n);
+        if (nv.isConst())
+        {
+          ll = nv;
+          break;
+        }
+      }
+      ++eqc_i;
     }
   }
 }


### PR DESCRIPTION
Work towards https://github.com/cvc5/cvc5/pull/12833.

This makes minor modifications to other modules that are indirectly impacted by the change to arithmetic equality rewriting, including strings model building, which is made to be more robust.