### PR TITLE
PyPI: Use GH action to install Windows dependencies

### DIFF
--- a/.github/workflows/package_pypi.yml
+++ b/.github/workflows/package_pypi.yml
@@ -79,27 +79,12 @@ jobs:
         python3 -m venv ~/.venv
         echo "$HOME/.venv/bin" >> $GITHUB_PATH
 
-    - uses: msys2/setup-msys2@v2
-      if: runner.os == 'Windows' && runner.arch == 'X64'
+    - name: Install cvc5 dependencies (Windows)
+      if: runner.os == 'Windows'
+      uses: ./.github/actions/install-dependencies
       with:
-        msystem: clang64
-        path-type: inherit
-        install: |
-          make
-          mingw-w64-clang-x86_64-cmake
-          mingw-w64-clang-x86_64-clang
-          mingw-w64-clang-x86_64-gmp
-
-    - uses: msys2/setup-msys2@v2
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      with:
-        msystem: clangarm64
-        path-type: inherit
-        install: |
-          make
-          mingw-w64-clang-aarch64-cmake
-          mingw-w64-clang-aarch64-clang
-          mingw-w64-clang-aarch64-gmp
+        windows-build: true
+        shell: ${{ matrix.shell }}
 
     # cibuildwheel requires pyproject.toml to be present from the beginning
     - name: Create pyproject.toml


### PR DESCRIPTION
This updates the PyPI packaging workflow to reuse the GitHub Action we use in CI to install cvc5 dependencies on Windows. The current workflow is broken because the CI dependency list was updated to include MPFR, but the corresponding change was not made in the PyPI packaging workflow. Note that this does not help on Linux, since wheels are built inside a Docker image.