### PR TITLE
test: Add a per-test ctest timeout for unit tests

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -43,6 +43,24 @@ if(ENABLE_SLOW_TESTS)
   list(APPEND CVC5_UNIT_TEST_FLAGS_BLACK -DCVC5_SLOW_TESTS)
 endif()
 
+# Per-test timeout (in seconds) for unit tests. Unit tests are otherwise
+# unbounded: a test that hangs or becomes pathologically slow stalls the whole
+# ctest run until the CI job's own inactivity timeout kills it, which reports
+# no indication of which test was responsible. Regression tests already get an
+# equivalent watchdog via TIMEOUT_AFTER_MATCH in test/regress/cli/CMakeLists.txt.
+set(CVC5_UNIT_TEST_TIMEOUT "" CACHE STRING
+    "Per-test timeout in seconds for unit tests (default: 900, or 7200 with -DENABLE_SLOW_TESTS=ON)")
+if(CVC5_UNIT_TEST_TIMEOUT STREQUAL "")
+  if(ENABLE_SLOW_TESTS)
+    # Exhaustive tests iterate over all Float16 values and are ~30x slower.
+    set(unit_test_timeout 7200)
+  else()
+    set(unit_test_timeout 900)
+  endif()
+else()
+  set(unit_test_timeout ${CVC5_UNIT_TEST_TIMEOUT})
+endif()
+
 # Generate and add unit test.
 macro(cvc5_add_unit_test is_white name output_dir)
   # Only enable white box unit tests if the compiler supports it and the build
@@ -86,7 +104,9 @@ macro(cvc5_add_unit_test is_white name output_dir)
       set(test_name unit/${output_dir}/${name})
     endif()
     add_test(${test_name} ${ENV_PATH_CMD} ${test_bin_dir}/${name})
-    set_tests_properties(${test_name} PROPERTIES LABELS "unit")
+    set_tests_properties(${test_name} PROPERTIES
+      LABELS "unit"
+      TIMEOUT ${unit_test_timeout})
     # set_tests_properties(${test_name} PROPERTIES FIXTURES_REQUIRED build_units_fixture)
   endif()
 endmacro()


### PR DESCRIPTION
Unit tests are registered with `add_test()` and no `TIMEOUT` property, and the project uses `enable_testing()` rather than `include(CTest)`, so no `DartConfiguration.tcl` is generated and no default timeout applies. A unit test that hangs or becomes pathologically slow therefore stalls the entire `ctest` run indefinitely.

### Why this is hard to diagnose today

`make check` runs `ctest --output-on-failure -j${CTEST_NTHREADS}`. In parallel mode ctest buffers each test's output and emits it only when the test *finishes*, and `--output-on-failure` then discards it for passing tests. So while a single long-running test is the last one standing, ctest prints nothing at all — even though the test binary itself is producing output.

The nightly build is eventually killed by buildbot's inactivity timeout, and the log ends with:

```
4425/4426 Test #4200: regress2/ufdt/tip2015-int_add_inv_left.smt2 ...***Skipped 793.12 sec

command timed out: 3600 seconds without output running [b'make', b'-j15', b'check'], attempting to kill
process killed by signal 9
```

There is no indication of which test was responsible. Recovering that requires diffing every `Start N:` line against every completed `Test #N:` line to find the one that never reported.

### Change

Sets a `TIMEOUT` property on unit tests so this is reported as an ordinary ctest failure that names the test:

```
The following tests FAILED:
	4478 - unit/util/floatingpoint_black (Timeout)           unit
```

The default is 900s, which is ample headroom: in a debug+ASan build the slowest unit test that completes is `unit/theory/rewriter_white` at ~115s, and everything else is under 62s. Slow (exhaustive) tests iterate over all Float16 values and are roughly 30x more expensive, so `-DENABLE_SLOW_TESTS=ON` raises the default to 7200s. Both can be overridden with `-DCVC5_UNIT_TEST_TIMEOUT=<seconds>`.

Regression tests already have an equivalent watchdog via `TIMEOUT_AFTER_MATCH` in `test/regress/cli/CMakeLists.txt`; this closes the same gap for unit tests.

### Note

This is a diagnostics change and does not fix the underlying slowness. On a debug+ASan build `unit/util/floatingpoint_black` currently takes ~19.5 min on an idle 20-core machine and longer on a loaded worker, so the nightly ASan job will now report it as a `Timeout` failure rather than hanging. That test became expensive when #12736 made MPFR the default FP literal backend, which enabled the `#ifdef CVC5_USE_MPFR` cross-check block in `test/unit/util/floatingpoint_black.cpp` (previously a single `GTEST_SKIP()`); `chainedRemAdd` (560s) and `fpRem` (258s) account for ~70% of its runtime. That is worth addressing separately — surfacing it as a named failure is the point of this PR.

### Testing

Verified in a `debug --asan` clang build:
- Default applies as `TIMEOUT "900"` in the generated `CTestTestfile.cmake`.
- With `-DCVC5_UNIT_TEST_TIMEOUT=20`, `unit/util/floatingpoint_black` is killed at 20.03s and reported as `(Timeout)`.
- Normal tests are unaffected (`unit/util/integer_black` passes in 0.05s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)