### PR TITLE
test: Reduce MPFR cross-check test budget when slow tests are disabled

### DIFF
--- a/test/unit/util/floatingpoint_black.cpp
+++ b/test/unit/util/floatingpoint_black.cpp
@@ -32,10 +32,21 @@ namespace test {
 class TestUtilBlackFloatingPoint : public TestInternal
 {
  protected:
+  // With CVC5_SLOW_TESTS, these complement the exhaustive Float16 testing
+  // below and we can afford a large number of them. Without it, they run on
+  // every CI and nightly build, where the cross-checks are otherwise by far
+  // the slowest unit test, so we use lower counts.
+#ifdef CVC5_SLOW_TESTS
   /** Default number of random tests when not exhaustively testing. */
   static constexpr uint32_t N_TESTS = 1000;
   /** Number of tests fp.rem (significantly slower than other operators). */
   static constexpr uint32_t N_TESTS_REM = 500;
+#else
+  /** Default number of random tests when not exhaustively testing. */
+  static constexpr uint32_t N_TESTS = 100;
+  /** Number of tests fp.rem (significantly slower than other operators). */
+  static constexpr uint32_t N_TESTS_REM = 50;
+#endif
   /** Min/max bit-vector width used in convertToBV cross-checks. */
   static constexpr uint32_t MIN_SIZE_TO_BV = 4;
   static constexpr uint32_t MAX_SIZE_TO_BV = 64;


### PR DESCRIPTION
#12736 made MPFR the default back end for floating-point literals. That enabled the `#ifdef CVC5_USE_MPFR` block in `test/unit/util/floatingpoint_black.cpp`, which had previously compiled down to a single `GTEST_SKIP()`, so ~20 MPFR-vs-SymFPU cross-check tests now run on every build. Each executes every operation twice, once per back end, over `N_TESTS` random values for each of fp16/32/64/128.

In a debug build with ASan the resulting test takes **~19.5 minutes** on an idle 20-core machine, making it by far the slowest unit test and stalling the nightly test run. Because unit tests currently have no ctest timeout, this surfaces only as buildbot killing the run after 3600s without output, with no indication of which test was responsible.

### Change

Keep the existing counts when `CVC5_SLOW_TESTS` is enabled — there these random tests complement the exhaustive Float16 coverage and a large number of them is affordable — and lower them substantially otherwise:

|                | `CVC5_SLOW_TESTS` on | off |
| -------------- | -------------------: | --: |
| `N_TESTS`      |  1000 *(unchanged)*  | 100 |
| `N_TESTS_REM`  |   500 *(unchanged)*  |  50 |

`fp.rem` is lowered further than the rest rather than scaling both uniformly. At `N_TESTS_REM = 500`, `fpRem` (258s) and `chainedRemAdd` (560s) alone account for 70% of the runtime — about 1.6s per iteration against ~0.35s for the other tests. The existing counts discount rem only 2x (1000 vs 500) though it is ~4.7x more expensive per iteration.

### Effect

Measured in a `debug --asan` clang build, all 29 tests still passing:

| test           |   before |   after |
| -------------- | -------: | ------: |
| chainedRemAdd  |  560.1 s |  50.9 s |
| fpRem          |  257.6 s |  26.1 s |
| fpFma          |   73.5 s |   6.6 s |
| fpSub          |   36.8 s |   3.4 s |
| fpAdd          |   36.7 s |   3.3 s |
| fpSqrt         |   32.5 s |   2.8 s |
| **total**      | **1167 s** | **114 s** |

Timing two tests that completed in the failing nightly gives a ~4.5x factor between that worker and the machine above (`rewriter_white` 115.30s vs 26.33s; `theory_quantifiers_bv_inverter_white` 61.97s vs 13.60s), so this should land at roughly 510s on the nightly worker, down from the >3600s at which it was killed.

### On fp128

Worth recording for whoever looks at this next: the iteration count is not really what drives the cost, fp128 is. At `N_TESTS_REM = 50` the two rem tests cost **7.0s** over fp16/32/64 but **76.4s** with fp128 included, so fp128 accounts for ~91% of the rem runtime.

This PR deliberately does not act on that. Reducing fp128 would buy back nearly all the runtime at any iteration count, but fp128 rem is plausibly where the two back ends are most likely to diverge, so it is the coverage least worth thinning. If this test gets tight again, that is the lever rather than the counts.

### Testing

- Default build: `[  PASSED  ] 29 tests.` in 114s, down from 1167s.
- `-DENABLE_SLOW_TESTS=ON` compiles clean and restores the original counts, verified via `convertToBV` returning to 269ms from 25ms — the expected 10x from `N_TESTS` going back to 1000. The full slow suite was not run; it is a multi-hour job by design under ASan.

Independent of #12855, which adds a per-test ctest timeout so that a recurrence of this is reported as a named `Timeout` failure rather than a silent hang. Either can land without the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)