### PR TITLE
Temporarily disable apt-get update in CI

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -26,7 +26,8 @@ runs:
       shell: ${{ inputs.shell }}
       run: |
         echo "::group::Install Linux software"
-        sudo apt-get update
+        # Temporarily disabled: apt-get update hangs in CI
+        # sudo apt-get update
         sudo apt-get install -y \
           build-essential \
           ccache \
@@ -72,7 +73,8 @@ runs:
       shell: ${{ inputs.shell }}
       run: |
         echo "::group::Install software for cross-compiling for Windows"
-        sudo apt-get update
+        # Temporarily disabled: apt-get update hangs in CI
+        # sudo apt-get update
         sudo apt-get install -y \
           mingw-w64
 
@@ -89,7 +91,8 @@ runs:
       shell: bash
       run: |
         echo "::group::Install software for WebAssembly compilation"
-        sudo apt-get update
+        # Temporarily disabled: apt-get update hangs in CI
+        # sudo apt-get update
         git clone https://github.com/emscripten-core/emsdk.git
         cd emsdk/
         ./emsdk install '3.1.70'

--- a/.github/workflows/docs_cleanup.yml
+++ b/.github/workflows/docs_cleanup.yml
@@ -10,7 +10,8 @@ jobs:
     steps:
       - name: Install Packages
         run: |
-          sudo apt-get update
+          # Temporarily disabled: apt-get update hangs in CI
+          # sudo apt-get update
           sudo apt-get install -y python3 python3-jinja2
 
       - name: Setup Deploy Key


### PR DESCRIPTION
The `apt-get update` calls in our workflows have been hanging, causing CI jobs to get stuck. This comments them out as a temporary workaround, relying on the package index pre-baked into the GitHub runner images.

Four call sites are disabled:

- `.github/workflows/docs_cleanup.yml` — before installing `python3`/`python3-jinja2`
- `.github/actions/install-dependencies/action.yml` — Linux build dependencies
- `.github/actions/install-dependencies/action.yml` — MinGW cross-compile for Windows
- `.github/actions/install-dependencies/action.yml` — WebAssembly/emsdk setup (this one was not followed by any `apt-get install`, so it was pure overhead)

Each is commented out rather than deleted, with a note marking it temporary, so it is easy to restore once the underlying issue is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)