### PR TITLE
license: Document the MPFR dependency in COPYING

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -56,6 +56,15 @@ licenses/lgpl-3.0.txt for a copy of that license.  Note that according to the
 terms of the LGPL, both cvc5's source, and the combined work (cvc5 linked with
 GMP) may (and do) remain under the more permissive modified BSD license.
 
+cvc5 can be optionally configured to link against The GNU Multiple Precision
+Floating-Point Reliable Library (MPFR), which it uses as the back end for
+floating-point constant folding.  This is enabled by default and can be turned
+off by configuring cvc5 with the "--no-mpfr" option, in which case cvc5 does
+not link against MPFR.  MPFR is licensed under GNU LGPL v3; see the file
+licenses/lgpl-3.0.txt for a copy of that license.  As with GMP, the terms of
+the LGPL allow both cvc5's source, and the combined work (cvc5 linked with
+MPFR), to remain under the more permissive modified BSD license.
+
 cvc5 also links against the CaDiCaL library
 (https://github.com/arminbiere/cadical), which is licensed under
 the MIT license.


### PR DESCRIPTION
Since #12736 made MPFR the default back end for floating-point constant folding, a default build of cvc5 links against MPFR — but `COPYING` does not mention MPFR anywhere. MPFR 4.x is licensed under GNU LGPL v3 or later, which is the same situation `COPYING` already describes for GMP:

> cvc5 by default links against The GNU Multiple Precision (GMP) Arithmetic Library, which is licensed under GNU LGPL v3. [...]

This adds an equivalent paragraph for MPFR, right after the GMP one.

### Notes on the wording

- GMP is an unconditional dependency (`find_package(GMP 6.3 REQUIRED)`), whereas MPFR is an option that merely defaults to on. The new paragraph therefore uses the "can be optionally configured to link against" phrasing that `COPYING` already uses for its other optional libraries, and names `--no-mpfr` explicitly so a reader can tell whether their own build links against MPFR.
- The GMP paragraph is left untouched.
- No new license file is needed: `licenses/lgpl-3.0.txt` is already present and covers MPFR, and the Python packaging (`src/api/python/CMakeLists.txt`) copies the whole `licenses/` directory into the wheel.
- MPFR is deliberately *not* added to the "OPTIONAL GPLv3 libraries" section. That section is about libraries whose linkage changes the license of the resulting combined work; LGPL linkage does not, which is why GMP is not listed there either.

Assisted-by: Claude Opus 5 (1M context), via Claude Code
