### PR TITLE
license: Fix the dangling GPL cross-references in INSTALL.rst

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -7,9 +7,9 @@ original or modified versions; distribution is under the terms of the modified
 BSD license (reproduced below).  Please note that cvc5 can be configured
 (however, by default it is not) to link against some GPLed libraries, and
 therefore the use of these builds may be restricted in non-GPL-compatible
-projects.  See below for a discussion of CLN and GLPK (the two GPLed optional
-library dependences for cvc5), and how to ensure you have a build that doesn't
-link against GPLed libraries.
+projects.  See below for a discussion of the GPLed optional library dependences
+for cvc5 (CLN, glpk-cut-log, CoCoALib, and Normaliz), and how to ensure you have
+a build that doesn't link against GPLed libraries.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -224,6 +224,25 @@ Optional Dependencies
 ---------------------
 
 
+Licensing of GPL dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+cvc5 itself is distributed under the modified BSD license, and by default it is
+built without any GPL-licensed dependency. Several of the optional dependencies
+below (CoCoA, CLN, glpk-cut-log and Normaliz) are covered by the `GNU General
+Public License, version 3 <https://www.gnu.org/licenses/gpl-3.0.en.html>`_. If
+you link cvc5 against any of them, the resulting combined work is covered by
+the GPLv3 as well.
+
+Each of these dependencies therefore requires the ``--gpl`` configuration flag
+in addition to its own flag. Configuring with ``--no-gpl`` (the default)
+guarantees that no GPL-licensed library is linked in, so that cvc5 can be used
+under the terms of the modified BSD license.
+
+See the section "OPTIONAL GPLv3 libraries" of the file ``COPYING`` in the cvc5
+source distribution for the full statement.
+
+
 CryptoMiniSat (Optional SAT solver)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -259,7 +278,8 @@ recommend downloading it using the ``--auto-download`` configuration flag,
 which applies our patch automatically. It is included in the build through the
 ``--cocoa --gpl`` configuration flag.
 
-CoCoA is covered by the GPLv3 license. See below for the ramifications of this.
+CoCoA is covered by the GPLv3 license; see `Licensing of GPL dependencies
+<#licensing-of-gpl-dependencies>`__ for the ramifications of this.
 
 CLN >= v1.3 (Class Library for Numbers)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -268,11 +288,8 @@ CLN >= v1.3 (Class Library for Numbers)
 package that may offer better performance and memory footprint than GMP.
 Configure cvc5 with ``configure.sh --cln --gpl`` to build with this dependency.
 
-Note that CLN is covered by the `GNU General Public License, version 3
-<https://www.gnu.org/licenses/gpl-3.0.en.html>`_. If you choose to use cvc5 with
-CLN support, you are licensing cvc5 under that same license. (Usually cvc5's
-license is more permissive than GPL, see the file `COPYING` in the cvc5 source
-distribution for details.)
+CLN is covered by the GPLv3 license; see `Licensing of GPL dependencies
+<#licensing-of-gpl-dependencies>`__ for the ramifications of this.
 
 
 glpk-cut-log (A fork of the GNU Linear Programming Kit)
@@ -289,10 +306,8 @@ the ``--auto-download`` configuration flag, which applies
 the patch automatically.
 Configure cvc5 with ``configure.sh --glpk --gpl`` to build with this dependency.
 
-Note that GLPK and glpk-cut-log are covered by the `GNU General Public License,
-version 3 <https://www.gnu.org/licenses/gpl-3.0.en.html>`_. If you choose to use
-cvc5 with GLPK support, you are licensing cvc5 under that same license. (Usually
-cvc5's license is more permissive; see above discussion.)
+GLPK and glpk-cut-log are covered by the GPLv3 license; see `Licensing of GPL
+dependencies <#licensing-of-gpl-dependencies>`__ for the ramifications of this.
 
 
 Editline library (Improved Interactive Experience)
@@ -314,7 +329,8 @@ liastar solver extension. We recommend downloading it using the ``--auto-downloa
 configuration flag. It is included in the build through the
 ``--normaliz --gpl`` configuration flag.
 
-Normaliz is covered by the GPLv3 license. See below for the ramifications of this.
+Normaliz is covered by the GPLv3 license; see `Licensing of GPL dependencies
+<#licensing-of-gpl-dependencies>`__ for the ramifications of this.
 
 
 Google Test Unit Testing Framework (Unit Tests)


### PR DESCRIPTION
`INSTALL.rst` tells the reader three times to look elsewhere for the ramifications of a GPLv3 dependency, but there is no licensing discussion anywhere in the file to look at. Two of the three pointers do not resolve:

- **CoCoA** (`INSTALL.rst:262`) — *"See below for the ramifications of this."* The nearest thing below is the CLN subsection, which is about a different dependency and never mentions CoCoA.
- **Normaliz** (`INSTALL.rst:317`) — *"See below for the ramifications of this."* Points at nothing at all: Normaliz is the last of the four GPL dependencies in the file, so everything below it is Google Test and build instructions. This looks like the CoCoA sentence copied without adjusting the direction.
- **glpk-cut-log** (`INSTALL.rst:295`) — *"see above discussion."* This one does resolve, but only to a near-verbatim restatement of the paragraph it is attached to.

The only prose on the subject lived inside the CLN and glpk-cut-log subsections, duplicated between them and drifted apart: one said cvc5's license is "more permissive than GPL", the other just "more permissive".

### What this changes

Adds a `Licensing of GPL dependencies` subsection at the top of the optional dependencies, stating the ramifications once: cvc5 is modified BSD, the four GPLv3 dependencies are named, linking any of them makes the combined work GPLv3, each requires `--gpl`, and `--no-gpl` (the default) keeps the build clean. It defers to the "OPTIONAL GPLv3 libraries" section of `COPYING` as the authority.

All four dependency subsections now carry the same anchored one-liner pointing at it. The direction words are gone, so reordering the subsections cannot break the references again, and the duplicated CLN/glpk boilerplate collapses into one place.

Also corrects `COPYING`, which described CLN and GLPK as "the two GPLed optional library dependences" while the section immediately below it lists four — CoCoA and Normaliz were added without updating that sentence.

### Notes

- The anchor slug `#licensing-of-gpl-dependencies` is generated identically by Sphinx and by GitHub's renderer, and `INSTALL.rst` is read through both (`docs/installation/installation.rst` includes it, `README.md` links to it on GitHub).
- The four references are anonymous (`` `__ ``) so the repeated link text does not collide. `docutils` reports 7 info-level messages against this file, down from 8 on `main` — no new ones, and the message that disappears is the duplicate GPLv3 link target that the old duplicated boilerplate was creating.
- The statement that each of these dependencies requires `--gpl` is enforced by the build: `CMakeLists.txt:663-669` raises `FATAL_ERROR` if `GPL_LIBS` is non-empty without `ENABLE_GPL`. `GPL_LIBS` is appended to in exactly four places (`cln`, `glpk`, `cocoa`, `normaliz`), so the list of four is complete.
- This is a documentation fix only: nothing changes about what the licensing terms actually are.

Assisted-by: Claude Opus 5 (1M context), via Claude Code
