### PR TITLE
license: Describe the GLPK dependency as the patched release cvc5 actually builds

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -112,10 +112,15 @@ Numbers, available here:
 
   http://www.ginac.de/CLN/
 
-cvc5 can be optionally configured to link against glpk-cut-log, a modified
-version of GLPK, the GNU Linear Programming Kit, available here:
+cvc5 can be optionally configured to link against a modified version of GLPK,
+the GNU Linear Programming Kit, available here:
 
-  https://github.com/timothy-king/glpk-cut-log
+  https://ftp.gnu.org/gnu/glpk/
+
+The modifications are the cut-log patch in cmake/deps-utils/glpk-cut-log.patch,
+which cvc5's build system applies to the GLPK release it downloads from there.
+That patch is taken from https://github.com/timothy-king/glpk-cut-log and is
+covered by the same license as GLPK itself.
 
 cvc5 can be optionally configured to link against CoCoALib, a C++ library for
 doing Computations in Commutative Algebra, available here:

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -275,18 +275,20 @@ license is more permissive than GPL, see the file `COPYING` in the cvc5 source
 distribution for details.)
 
 
-glpk-cut-log (A fork of the GNU Linear Programming Kit)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+GLPK with cut-log support (The GNU Linear Programming Kit)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-`glpk-cut-log <https://github.com/timothy-king/glpk-cut-log/>`_ is a fork of
-`GLPK <http://www.gnu.org/software/glpk/>`_ (the GNU Linear Programming Kit).
-This can be used to speed up certain classes of problems for the arithmetic
+`GLPK <https://www.gnu.org/software/glpk/>`_ (the GNU Linear Programming Kit)
+can be used to speed up certain classes of problems for the arithmetic
 implementation in cvc5. (This is not recommended for most users.)
 
-cvc5 is not compatible with the official version of the GLPK library.
-To use the patched version of it, we recommend downloading it using
-the ``--auto-download`` configuration flag, which applies
-the patch automatically.
+cvc5 cannot use a stock GLPK library: it requires the cut logging interface
+added by ``cmake/deps-utils/glpk-cut-log.patch``, and the build fails if the
+GLPK it finds does not provide it. We therefore recommend obtaining this
+dependency with the ``--auto-download`` configuration flag, which downloads the
+GLPK release from `ftp.gnu.org <https://ftp.gnu.org/gnu/glpk/>`_ and applies
+the patch automatically. The patch itself is taken from `glpk-cut-log
+<https://github.com/timothy-king/glpk-cut-log/>`_.
 Configure cvc5 with ``configure.sh --glpk --gpl`` to build with this dependency.
 
 Note that GLPK and glpk-cut-log are covered by the `GNU General Public License,


### PR DESCRIPTION
`COPYING` and `INSTALL.rst` both describe cvc5's GLPK dependency as glpk-cut-log, the fork at https://github.com/timothy-king/glpk-cut-log, and point the reader there to obtain it. The build has not fetched that repository since #10880 made GLPK an external project: `cmake/FindGLPK.cmake` downloads the stock GLPK release from `https://ftp.gnu.org/gnu/glpk/` and applies `cmake/deps-utils/glpk-cut-log.patch` to it. What gets built is patched upstream GLPK, and the fork survives only as the origin of that patch — which is exactly what the patch's own header says.

Two commits, one per file.

### `COPYING`

Points the entry at the release the build downloads and describes the modification as the in-tree patch that it is, keeping the fork URL as the patch's provenance. The GLPK version is deliberately not named so the paragraph does not go stale again when the pinned release changes (e.g. #10587, which moves 4.52 → 5.0).

### `INSTALL.rst`

The section was titled "glpk-cut-log (A fork of the GNU Linear Programming Kit)" and stated that "cvc5 is not compatible with the official version of the GLPK library", which reads as though upstream GLPK were unusable; what is actually missing is one interface the patch adds. It is retitled, the patch and the release it applies to are named, and the requirement is stated in terms of what the build enforces — `FindGLPK.cmake` probes a system GLPK for `glp_ios_get_cut` and fails if it is absent.

### Checks

- Nothing in the tree links to the old section anchor, so retitling breaks no cross-references.
- `INSTALL.rst` parses without docutils warnings both before and after; the heading underline matches the new title, and each of the three link names occurs exactly once, so there are no duplicate-target warnings.
- No conflict with #12861, which touches only the trailing licensing paragraph of the same subsection: the two branches merge cleanly in either order.

Assisted-by: Claude Opus 5 (1M context), via Claude Code
