### PR TITLE
Fully evaluate lambda model values that refer to symbols. Issue #12852

### DIFF
--- a/src/theory/theory_model_builder.cpp
+++ b/src/theory/theory_model_builder.cpp
@@ -13,6 +13,7 @@
 
 #include "expr/dtype.h"
 #include "expr/dtype_cons.h"
+#include "expr/node_algorithm.h"
 #include "expr/skolem_manager.h"
 #include "expr/sort_to_term.h"
 #include "expr/sort_type_size.h"
@@ -1127,6 +1128,11 @@ bool TheoryEngineModelBuilder::buildModel(TheoryModel* tm)
 
   Trace("model-builder") << "Copy representatives to model..." << std::endl;
   tm->d_reps.clear();
+  // Equivalence classes whose model value is a lambda whose body still
+  // contains symbols after the normalization below. These are assigned after
+  // this loop (see assignLambdaRepresentative), since their value may depend
+  // on the value of a function symbol, which is computed on demand.
+  std::map<Node, Node> lambdaReps;
   std::map<Node, Node>::iterator itMap;
   for (itMap = d_constantReps.begin(); itMap != d_constantReps.end(); ++itMap)
   {
@@ -1138,6 +1144,15 @@ bool TheoryEngineModelBuilder::buildModel(TheoryModel* tm)
     if (!normc.isConst())
     {
       normc = normalize(tm, normc, true);
+    }
+    if (normc.getKind() == Kind::LAMBDA && hasSymbol(normc))
+    {
+      // The body of the lambda refers to symbols whose model value we do not
+      // have yet, process it below.
+      Trace("model-builder") << "  Defer lambda value " << normc << " for "
+                             << itMap->first << std::endl;
+      lambdaReps[itMap->first] = normc;
+      continue;
     }
     // mark this as the final representative
     tm->assignRepresentative(itMap->first, normc, true);
@@ -1156,6 +1171,22 @@ bool TheoryEngineModelBuilder::buildModel(TheoryModel* tm)
     {
       tm->assignRepresentative(node, node, false);
     }
+  }
+
+  if (!lambdaReps.empty())
+  {
+    Trace("model-builder") << "Assign lambda representatives..." << std::endl;
+    // All other representatives are now available, hence we can evaluate the
+    // bodies of the lambdas we deferred above.
+    std::unordered_set<Node> processing;
+    for (const std::pair<const Node, Node>& lr : lambdaReps)
+    {
+      assignLambdaRepresentative(tm, lr.first, lambdaReps, processing);
+    }
+    // Values may have been cached above for terms whose value depends on an
+    // equivalence class that was not assigned yet at that point, hence we
+    // clear the cache.
+    tm->d_modelCache.clear();
   }
 
   // modelBuilder-specific initialization
@@ -1241,6 +1272,64 @@ void TheoryEngineModelBuilder::debugCheckModel(TheoryModel* tm)
 
   // builder-specific debugging
   debugModel(tm);
+}
+
+bool TheoryEngineModelBuilder::hasSymbol(TNode n)
+{
+  std::unordered_set<Node> syms;
+  expr::getSymbols(n, syms);
+  return !syms.empty();
+}
+
+void TheoryEngineModelBuilder::assignLambdaRepresentative(
+    TheoryModel* tm,
+    const Node& eqc,
+    const std::map<Node, Node>& lambdaReps,
+    std::unordered_set<Node>& processing)
+{
+  if (tm->d_reps.find(eqc) != tm->d_reps.end())
+  {
+    // already assigned
+    return;
+  }
+  std::map<Node, Node>::const_iterator itl = lambdaReps.find(eqc);
+  Assert(itl != lambdaReps.end());
+  Node lam = itl->second;
+  if (processing.insert(eqc).second)
+  {
+    // Ensure that the equivalence classes that the body of this lambda refers
+    // to are assigned first, so that the lambda is fully evaluated below.
+    // Note that if there is a cyclic dependency between lambdas, we do not
+    // recurse here, and the value of this equivalence class may be an
+    // arbitrary function value.
+    std::unordered_set<Node> syms;
+    expr::getSymbols(lam, syms);
+    for (const Node& s : syms)
+    {
+      if (!tm->d_equalityEngine->hasTerm(s))
+      {
+        continue;
+      }
+      Node sr = tm->d_equalityEngine->getRepresentative(s);
+      if (lambdaReps.find(sr) != lambdaReps.end())
+      {
+        assignLambdaRepresentative(tm, sr, lambdaReps, processing);
+      }
+    }
+    // The equivalence class may have been assigned while processing its
+    // dependencies above, in which case we are done.
+    if (tm->d_reps.find(eqc) != tm->d_reps.end())
+    {
+      return;
+    }
+  }
+  // Compute the value of the lambda, which evaluates the symbols in its body
+  // based on their model values. Note that the model values of function
+  // symbols are computed on demand here.
+  Node v = tm->getValue(lam);
+  Trace("model-builder") << "  Normalized lambda value " << lam << " to " << v
+                         << std::endl;
+  tm->assignRepresentative(eqc, v, true);
 }
 
 Node TheoryEngineModelBuilder::normalize(TheoryModel* m, TNode r, bool evalOnly)

--- a/src/theory/theory_model_builder.h
+++ b/src/theory/theory_model_builder.h
@@ -15,6 +15,7 @@
 #ifndef CVC5__THEORY__THEORY_MODEL_BUILDER_H
 #define CVC5__THEORY__THEORY_MODEL_BUILDER_H
 
+#include <map>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -147,6 +148,31 @@ class TheoryEngineModelBuilder : protected EnvObj
    * each child is constant.
    */
   Node normalize(TheoryModel* m, TNode r, bool evalOnly);
+  /**
+   * Does n contain a symbol, i.e. a variable that is not a bound variable?
+   */
+  static bool hasSymbol(TNode n);
+  /**
+   * Assign the representative of the equivalence class eqc, whose model value
+   * is the lambda lambdaReps[eqc]. The body of this lambda may contain free
+   * symbols, whose model values are used to fully evaluate it here.
+   *
+   * This is called after all other representatives have been assigned in
+   * buildModel, since the model values of function symbols, which the body of
+   * the lambda may depend on, are computed on demand.
+   *
+   * @param tm The model.
+   * @param eqc The equivalence class to assign, which must be a key of
+   * lambdaReps.
+   * @param lambdaReps Maps equivalence classes to the (non-evaluated) lambda
+   * values that were assigned to them.
+   * @param processing The equivalence classes we are currently processing,
+   * which is used to break cyclic dependencies between lambda values.
+   */
+  void assignLambdaRepresentative(TheoryModel* tm,
+                                  const Node& eqc,
+                                  const std::map<Node, Node>& lambdaReps,
+                                  std::unordered_set<Node>& processing);
   /** assign constant representative
    *
    * Called when equivalence class eqc is assigned a constant

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1040,6 +1040,7 @@ set(regress_0_tests
   regress0/ho/issue11923-2-finite-ho-deq.smt2
   regress0/ho/issue11923-finite-ho-deq.smt2
   regress0/ho/issue12256-fun-arg-ext.smt2
+  regress0/ho/issue12852-model-lam-fun-var.smt2
   regress0/ho/issue-ho-elim-fmf-bad-model.smt2
   regress0/ho/issue4434-const-preserve.smt2
   regress0/ho/issue4477.smt2

--- a/test/regress/cli/regress0/ho/issue12852-model-lam-fun-var.smt2
+++ b/test/regress/cli/regress0/ho/issue12852-model-lam-fun-var.smt2
@@ -1,0 +1,11 @@
+; COMMAND-LINE: --debug-check-models
+; EXPECT: sat
+(set-logic HO_ALL)
+(declare-fun f () (-> Int Int))
+(declare-fun g () (-> Int Int))
+(declare-fun a () (-> Int Int))
+(declare-fun b () (-> Int Int))
+(assert (= a (lambda ((x Int)) (f (g x)))))
+(assert (= b (lambda ((x Int)) (g (f x)))))
+(assert (distinct a b))
+(check-sat)


### PR DESCRIPTION
Fixes #12852.

When a lambda is the model value of an equivalence class, its body may refer to symbols whose model value is not available at the point where representatives are copied to the model in `TheoryEngineModelBuilder::buildModel`. In particular, in higher-order logic the values of function symbols are computed on demand (`TheoryModel::assignFunctionDefault`), and `normalize` does not consider the operator of a parameterized term. As a consequence, an equivalence class could be assigned e.g. `(lambda ((x Int)) (f (g x)))` as its final representative, which is not a model value.

This led to spurious `Failed representative check` warnings from `--debug-check-models`, and made it impossible to evaluate (dis)equalities between such classes. For the benchmark below, `(distinct a b)` evaluated to `(not (= (lambda ((x Int)) (f (g x))) (lambda ((x Int)) (g (f x)))))`, giving `THEORY_UF has an asserted fact that the model may not satisfy`:

```smt2
(set-logic HO_ALL)
(declare-fun f () (-> Int Int))
(declare-fun g () (-> Int Int))
(declare-fun a () (-> Int Int))
(declare-fun b () (-> Int Int))
(assert (= a (lambda ((x Int)) (f (g x)))))
(assert (= b (lambda ((x Int)) (g (f x)))))
(assert (distinct a b))
(check-sat)
```

Note that `get-model` was already printing the correct (fully evaluated) values, since it goes through `TheoryModel::getValue`; only the representatives stored in the model were stale.

This PR defers such lambdas until all other representatives have been assigned, and then evaluates them, which is the point at which the values of the function symbols they depend on can be safely computed. Deferred lambdas are assigned in dependency order, so that a lambda whose body refers to another deferred equivalence class is assigned after it; cyclic dependencies are broken so that we do not recurse indefinitely. Lambdas that `normalize` already fully resolved are unaffected.

A regression is added.
