### PR TITLE
bv abstract: Add regression test for issue #9874.

### DIFF
--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -305,6 +305,7 @@ set(regress_0_tests
   regress0/bv/abstract/bv_urem_pow2.smt2
   regress0/bv/abstract/cross-term-div-mul-rem.smt2
   regress0/bv/abstract/eagerrefine1.smt2
+  regress0/bv/abstract/issue9874.smt2
   regress0/bv/abstract/murxla-346218efd24c9aba.min.smt2
   regress0/bv/abstract/murxla-67f411058e7b0ea7.min.smt2
   regress0/bv/abstract/murxla-a2f5f3aa83d5a854.min.smt2

--- a/test/regress/cli/regress0/bv/abstract/issue9874.smt2
+++ b/test/regress/cli/regress0/bv/abstract/issue9874.smt2
@@ -1,7 +1,5 @@
 ; COMMAND-LINE: --bv-abstraction
 ; EXPECT: unsat
-; DISABLE-TESTER: cpc
-; DISABLE-TESTER: lfsc
 ; DISABLE-TESTER: proof
 (set-logic QF_BV)
 (declare-const a (_ BitVec 64))

--- a/test/regress/cli/regress0/bv/abstract/issue9874.smt2
+++ b/test/regress/cli/regress0/bv/abstract/issue9874.smt2
@@ -1,0 +1,9 @@
+; COMMAND-LINE: --bv-abstraction
+; EXPECT: unsat
+; DISABLE-TESTER: cpc
+; DISABLE-TESTER: lfsc
+; DISABLE-TESTER: proof
+(set-logic QF_BV)
+(declare-const a (_ BitVec 64))
+(assert (= a (bvurem (bvnot a) a)))
+(check-sat)


### PR DESCRIPTION
The smt2 input given in this issue is an example for when bit-blasting fails to scale for large bit-widths on bvurem. This is now solved with the abstraction-refinement technique for bit-vector arithmetic added in #12789.

Fixes #9874.