### PR TITLE
Java API: Avoid truncating hash values in hashCode

### DIFF
--- a/src/api/java/io/github/cvc5/Datatype.java
+++ b/src/api/java/io/github/cvc5/Datatype.java
@@ -290,8 +290,8 @@ public class Datatype extends AbstractPointer implements Iterable<DatatypeConstr
   @Override
   public int hashCode()
   {
-    return hashCode(pointer);
+    return Long.hashCode(hashCode(pointer));
   }
 
-  private native int hashCode(long pointer);
+  private native long hashCode(long pointer);
 }

--- a/src/api/java/io/github/cvc5/DatatypeConstructor.java
+++ b/src/api/java/io/github/cvc5/DatatypeConstructor.java
@@ -254,8 +254,8 @@ public class DatatypeConstructor extends AbstractPointer implements Iterable<Dat
   @Override
   public int hashCode()
   {
-    return hashCode(pointer);
+    return Long.hashCode(hashCode(pointer));
   }
 
-  private native int hashCode(long pointer);
+  private native long hashCode(long pointer);
 }

--- a/src/api/java/io/github/cvc5/DatatypeConstructorDecl.java
+++ b/src/api/java/io/github/cvc5/DatatypeConstructorDecl.java
@@ -118,8 +118,8 @@ public class DatatypeConstructorDecl extends AbstractPointer
   @Override
   public int hashCode()
   {
-    return hashCode(pointer);
+    return Long.hashCode(hashCode(pointer));
   }
 
-  private native int hashCode(long pointer);
+  private native long hashCode(long pointer);
 }

--- a/src/api/java/io/github/cvc5/DatatypeDecl.java
+++ b/src/api/java/io/github/cvc5/DatatypeDecl.java
@@ -141,8 +141,8 @@ public class DatatypeDecl extends AbstractPointer
   @Override
   public int hashCode()
   {
-    return hashCode(pointer);
+    return Long.hashCode(hashCode(pointer));
   }
 
-  private native int hashCode(long pointer);
+  private native long hashCode(long pointer);
 }

--- a/src/api/java/io/github/cvc5/DatatypeSelector.java
+++ b/src/api/java/io/github/cvc5/DatatypeSelector.java
@@ -137,8 +137,8 @@ public class DatatypeSelector extends AbstractPointer
   @Override
   public int hashCode()
   {
-    return hashCode(pointer);
+    return Long.hashCode(hashCode(pointer));
   }
 
-  private native int hashCode(long pointer);
+  private native long hashCode(long pointer);
 }

--- a/src/api/java/io/github/cvc5/Grammar.java
+++ b/src/api/java/io/github/cvc5/Grammar.java
@@ -143,8 +143,8 @@ public class Grammar extends AbstractPointer
   @Override
   public int hashCode()
   {
-    return hashCode(pointer);
+    return Long.hashCode(hashCode(pointer));
   }
 
-  private native int hashCode(long pointer);
+  private native long hashCode(long pointer);
 }

--- a/src/api/java/io/github/cvc5/Op.java
+++ b/src/api/java/io/github/cvc5/Op.java
@@ -143,8 +143,8 @@ public class Op extends AbstractPointer
   @Override
   public int hashCode()
   {
-    return hashCode(pointer);
+    return Long.hashCode(hashCode(pointer));
   }
 
-  private native int hashCode(long pointer);
+  private native long hashCode(long pointer);
 }

--- a/src/api/java/io/github/cvc5/Proof.java
+++ b/src/api/java/io/github/cvc5/Proof.java
@@ -150,8 +150,8 @@ public class Proof extends AbstractPointer
   @Override
   public int hashCode()
   {
-    return hashCode(pointer);
+    return Long.hashCode(hashCode(pointer));
   }
 
-  private native int hashCode(long pointer);
+  private native long hashCode(long pointer);
 }

--- a/src/api/java/io/github/cvc5/Result.java
+++ b/src/api/java/io/github/cvc5/Result.java
@@ -151,8 +151,8 @@ public class Result extends AbstractPointer
   @Override
   public int hashCode()
   {
-    return hashCode(pointer);
+    return Long.hashCode(hashCode(pointer));
   }
 
-  private native int hashCode(long pointer);
+  private native long hashCode(long pointer);
 }

--- a/src/api/java/io/github/cvc5/Sort.java
+++ b/src/api/java/io/github/cvc5/Sort.java
@@ -919,8 +919,8 @@ public class Sort extends AbstractPointer implements Comparable<Sort>
   @Override
   public int hashCode()
   {
-    return hashCode(pointer);
+    return Long.hashCode(hashCode(pointer));
   }
 
-  private native int hashCode(long pointer);
+  private native long hashCode(long pointer);
 }

--- a/src/api/java/io/github/cvc5/SynthResult.java
+++ b/src/api/java/io/github/cvc5/SynthResult.java
@@ -130,8 +130,8 @@ public class SynthResult extends AbstractPointer
   @Override
   public int hashCode()
   {
-    return hashCode(pointer);
+    return Long.hashCode(hashCode(pointer));
   }
 
-  private native int hashCode(long pointer);
+  private native long hashCode(long pointer);
 }

--- a/src/api/java/io/github/cvc5/Term.java
+++ b/src/api/java/io/github/cvc5/Term.java
@@ -961,8 +961,8 @@ public class Term extends AbstractPointer implements Comparable<Term>, Iterable<
   @Override
   public int hashCode()
   {
-    return hashCode(pointer);
+    return Long.hashCode(hashCode(pointer));
   }
 
-  private native int hashCode(long pointer);
+  private native long hashCode(long pointer);
 }

--- a/src/api/java/jni/datatype.cpp
+++ b/src/api/java/jni/datatype.cpp
@@ -259,8 +259,8 @@ JNIEXPORT jstring JNICALL Java_io_github_cvc5_Datatype_toString(JNIEnv* env,
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_io_github_cvc5_Datatype_hashCode(JNIEnv* env,
-                                                             jobject,
-                                                             jlong pointer)
+                                                              jobject,
+                                                              jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   Datatype* result = reinterpret_cast<Datatype*>(pointer);

--- a/src/api/java/jni/datatype.cpp
+++ b/src/api/java/jni/datatype.cpp
@@ -256,14 +256,14 @@ JNIEXPORT jstring JNICALL Java_io_github_cvc5_Datatype_toString(JNIEnv* env,
 /*
  * Class:     io_github_cvc5_Datatype
  * Method:    hashCode
- * Signature: (J)I
+ * Signature: (J)J
  */
-JNIEXPORT jint JNICALL Java_io_github_cvc5_Datatype_hashCode(JNIEnv* env,
+JNIEXPORT jlong JNICALL Java_io_github_cvc5_Datatype_hashCode(JNIEnv* env,
                                                              jobject,
                                                              jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   Datatype* result = reinterpret_cast<Datatype*>(pointer);
-  return static_cast<jint>(std::hash<cvc5::Datatype>()(*result));
+  return static_cast<jlong>(std::hash<cvc5::Datatype>()(*result));
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, 0);
 }

--- a/src/api/java/jni/datatype_constructor.cpp
+++ b/src/api/java/jni/datatype_constructor.cpp
@@ -186,13 +186,13 @@ JNIEXPORT jstring JNICALL Java_io_github_cvc5_DatatypeConstructor_toString(
 /*
  * Class:     io_github_cvc5_DatatypeConstructor
  * Method:    hashCode
- * Signature: (J)I
+ * Signature: (J)J
  */
-JNIEXPORT jint JNICALL Java_io_github_cvc5_DatatypeConstructor_hashCode(
+JNIEXPORT jlong JNICALL Java_io_github_cvc5_DatatypeConstructor_hashCode(
     JNIEnv* env, jobject, jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   DatatypeConstructor* result = reinterpret_cast<DatatypeConstructor*>(pointer);
-  return static_cast<jint>(std::hash<cvc5::DatatypeConstructor>()(*result));
+  return static_cast<jlong>(std::hash<cvc5::DatatypeConstructor>()(*result));
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, 0);
 }

--- a/src/api/java/jni/datatype_constructor_decl.cpp
+++ b/src/api/java/jni/datatype_constructor_decl.cpp
@@ -142,14 +142,14 @@ JNIEXPORT jstring JNICALL Java_io_github_cvc5_DatatypeConstructorDecl_toString(
 /*
  * Class:     io_github_cvc5_DatatypeConstructorDecl
  * Method:    hashCode
- * Signature: (J)I
+ * Signature: (J)J
  */
-JNIEXPORT jint JNICALL Java_io_github_cvc5_DatatypeConstructorDecl_hashCode(
+JNIEXPORT jlong JNICALL Java_io_github_cvc5_DatatypeConstructorDecl_hashCode(
     JNIEnv* env, jobject, jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   DatatypeConstructorDecl* result =
       reinterpret_cast<DatatypeConstructorDecl*>(pointer);
-  return static_cast<jint>(std::hash<cvc5::DatatypeConstructorDecl>()(*result));
+  return static_cast<jlong>(std::hash<cvc5::DatatypeConstructorDecl>()(*result));
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, 0);
 }

--- a/src/api/java/jni/datatype_constructor_decl.cpp
+++ b/src/api/java/jni/datatype_constructor_decl.cpp
@@ -150,6 +150,7 @@ JNIEXPORT jlong JNICALL Java_io_github_cvc5_DatatypeConstructorDecl_hashCode(
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   DatatypeConstructorDecl* result =
       reinterpret_cast<DatatypeConstructorDecl*>(pointer);
-  return static_cast<jlong>(std::hash<cvc5::DatatypeConstructorDecl>()(*result));
+  return static_cast<jlong>(
+      std::hash<cvc5::DatatypeConstructorDecl>()(*result));
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, 0);
 }

--- a/src/api/java/jni/datatype_decl.cpp
+++ b/src/api/java/jni/datatype_decl.cpp
@@ -149,8 +149,8 @@ Java_io_github_cvc5_DatatypeDecl_getName(JNIEnv* env, jobject, jlong pointer)
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_io_github_cvc5_DatatypeDecl_hashCode(JNIEnv* env,
-                                                                 jobject,
-                                                                 jlong pointer)
+                                                                  jobject,
+                                                                  jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   DatatypeDecl* result = reinterpret_cast<DatatypeDecl*>(pointer);

--- a/src/api/java/jni/datatype_decl.cpp
+++ b/src/api/java/jni/datatype_decl.cpp
@@ -146,14 +146,14 @@ Java_io_github_cvc5_DatatypeDecl_getName(JNIEnv* env, jobject, jlong pointer)
 /*
  * Class:     io_github_cvc5_DatatypeDecl
  * Method:    hashCode
- * Signature: (J)I
+ * Signature: (J)J
  */
-JNIEXPORT jint JNICALL Java_io_github_cvc5_DatatypeDecl_hashCode(JNIEnv* env,
+JNIEXPORT jlong JNICALL Java_io_github_cvc5_DatatypeDecl_hashCode(JNIEnv* env,
                                                                  jobject,
                                                                  jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   DatatypeDecl* result = reinterpret_cast<DatatypeDecl*>(pointer);
-  return static_cast<jint>(std::hash<cvc5::DatatypeDecl>()(*result));
+  return static_cast<jlong>(std::hash<cvc5::DatatypeDecl>()(*result));
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, 0);
 }

--- a/src/api/java/jni/datatype_selector.cpp
+++ b/src/api/java/jni/datatype_selector.cpp
@@ -134,13 +134,13 @@ JNIEXPORT jstring JNICALL Java_io_github_cvc5_DatatypeSelector_toString(
 /*
  * Class:     io_github_cvc5_DatatypeSelector
  * Method:    hashCode
- * Signature: (J)I
+ * Signature: (J)J
  */
-JNIEXPORT jint JNICALL Java_io_github_cvc5_DatatypeSelector_hashCode(
+JNIEXPORT jlong JNICALL Java_io_github_cvc5_DatatypeSelector_hashCode(
     JNIEnv* env, jobject, jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   DatatypeSelector* result = reinterpret_cast<DatatypeSelector*>(pointer);
-  return static_cast<jint>(std::hash<cvc5::DatatypeSelector>()(*result));
+  return static_cast<jlong>(std::hash<cvc5::DatatypeSelector>()(*result));
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, 0);
 }

--- a/src/api/java/jni/grammar.cpp
+++ b/src/api/java/jni/grammar.cpp
@@ -166,14 +166,14 @@ JNIEXPORT jstring JNICALL Java_io_github_cvc5_Grammar_toString(JNIEnv* env,
 /*
  * Class:     io_github_cvc5_Grammar
  * Method:    hashCode
- * Signature: (J)I
+ * Signature: (J)J
  */
-JNIEXPORT jint JNICALL Java_io_github_cvc5_Grammar_hashCode(JNIEnv* env,
+JNIEXPORT jlong JNICALL Java_io_github_cvc5_Grammar_hashCode(JNIEnv* env,
                                                             jobject,
                                                             jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   Grammar* grammar = reinterpret_cast<Grammar*>(pointer);
-  return static_cast<jint>(std::hash<cvc5::Grammar>()(*grammar));
+  return static_cast<jlong>(std::hash<cvc5::Grammar>()(*grammar));
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, 0);
 }

--- a/src/api/java/jni/grammar.cpp
+++ b/src/api/java/jni/grammar.cpp
@@ -169,8 +169,8 @@ JNIEXPORT jstring JNICALL Java_io_github_cvc5_Grammar_toString(JNIEnv* env,
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_io_github_cvc5_Grammar_hashCode(JNIEnv* env,
-                                                            jobject,
-                                                            jlong pointer)
+                                                             jobject,
+                                                             jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   Grammar* grammar = reinterpret_cast<Grammar*>(pointer);

--- a/src/api/java/jni/op.cpp
+++ b/src/api/java/jni/op.cpp
@@ -158,8 +158,8 @@ JNIEXPORT jstring JNICALL Java_io_github_cvc5_Op_toString(JNIEnv* env,
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_io_github_cvc5_Op_hashCode(JNIEnv* env,
-                                                       jobject,
-                                                       jlong pointer)
+                                                        jobject,
+                                                        jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   Op* result = reinterpret_cast<Op*>(pointer);

--- a/src/api/java/jni/op.cpp
+++ b/src/api/java/jni/op.cpp
@@ -155,14 +155,14 @@ JNIEXPORT jstring JNICALL Java_io_github_cvc5_Op_toString(JNIEnv* env,
 /*
  * Class:     io_github_cvc5_Op
  * Method:    hashCode
- * Signature: (J)I
+ * Signature: (J)J
  */
-JNIEXPORT jint JNICALL Java_io_github_cvc5_Op_hashCode(JNIEnv* env,
+JNIEXPORT jlong JNICALL Java_io_github_cvc5_Op_hashCode(JNIEnv* env,
                                                        jobject,
                                                        jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   Op* result = reinterpret_cast<Op*>(pointer);
-  return static_cast<jint>(std::hash<cvc5::Op>()(*result));
+  return static_cast<jlong>(std::hash<cvc5::Op>()(*result));
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, 0);
 }

--- a/src/api/java/jni/proof.cpp
+++ b/src/api/java/jni/proof.cpp
@@ -147,8 +147,8 @@ JNIEXPORT jboolean JNICALL Java_io_github_cvc5_Proof_equals(JNIEnv* env,
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_io_github_cvc5_Proof_hashCode(JNIEnv* env,
-                                                          jobject,
-                                                          jlong pointer)
+                                                           jobject,
+                                                           jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   Proof* current = reinterpret_cast<Proof*>(pointer);

--- a/src/api/java/jni/proof.cpp
+++ b/src/api/java/jni/proof.cpp
@@ -144,14 +144,14 @@ JNIEXPORT jboolean JNICALL Java_io_github_cvc5_Proof_equals(JNIEnv* env,
 /*
  * Class:     io_github_cvc5_Proof
  * Method:    hashCode
- * Signature: (J)I
+ * Signature: (J)J
  */
-JNIEXPORT jint JNICALL Java_io_github_cvc5_Proof_hashCode(JNIEnv* env,
+JNIEXPORT jlong JNICALL Java_io_github_cvc5_Proof_hashCode(JNIEnv* env,
                                                           jobject,
                                                           jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   Proof* current = reinterpret_cast<Proof*>(pointer);
-  return static_cast<jint>(std::hash<cvc5::Proof>()(*current));
+  return static_cast<jlong>(std::hash<cvc5::Proof>()(*current));
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, 0);
 }

--- a/src/api/java/jni/result.cpp
+++ b/src/api/java/jni/result.cpp
@@ -155,8 +155,8 @@ JNIEXPORT jstring JNICALL Java_io_github_cvc5_Result_toString(JNIEnv* env,
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_io_github_cvc5_Result_hashCode(JNIEnv* env,
-                                                           jobject,
-                                                           jlong pointer)
+                                                            jobject,
+                                                            jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   Result* result = reinterpret_cast<Result*>(pointer);

--- a/src/api/java/jni/result.cpp
+++ b/src/api/java/jni/result.cpp
@@ -152,14 +152,14 @@ JNIEXPORT jstring JNICALL Java_io_github_cvc5_Result_toString(JNIEnv* env,
 /*
  * Class:     io_github_cvc5_Result
  * Method:    hashCode
- * Signature: (J)I
+ * Signature: (J)J
  */
-JNIEXPORT jint JNICALL Java_io_github_cvc5_Result_hashCode(JNIEnv* env,
+JNIEXPORT jlong JNICALL Java_io_github_cvc5_Result_hashCode(JNIEnv* env,
                                                            jobject,
                                                            jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   Result* result = reinterpret_cast<Result*>(pointer);
-  return static_cast<jint>(std::hash<cvc5::Result>()(*result));
+  return static_cast<jlong>(std::hash<cvc5::Result>()(*result));
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, 0);
 }

--- a/src/api/java/jni/sort.cpp
+++ b/src/api/java/jni/sort.cpp
@@ -1115,14 +1115,14 @@ JNIEXPORT jlong JNICALL Java_io_github_cvc5_Sort_getNullableElementSort(
 /*
  * Class:     io_github_cvc5_Sort
  * Method:    hashCode
- * Signature: (J)I
+ * Signature: (J)J
  */
-JNIEXPORT jint JNICALL Java_io_github_cvc5_Sort_hashCode(JNIEnv* env,
+JNIEXPORT jlong JNICALL Java_io_github_cvc5_Sort_hashCode(JNIEnv* env,
                                                          jobject,
                                                          jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   Sort* result = reinterpret_cast<Sort*>(pointer);
-  return static_cast<jint>(std::hash<cvc5::Sort>()(*result));
+  return static_cast<jlong>(std::hash<cvc5::Sort>()(*result));
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, 0);
 }

--- a/src/api/java/jni/sort.cpp
+++ b/src/api/java/jni/sort.cpp
@@ -1118,8 +1118,8 @@ JNIEXPORT jlong JNICALL Java_io_github_cvc5_Sort_getNullableElementSort(
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_io_github_cvc5_Sort_hashCode(JNIEnv* env,
-                                                         jobject,
-                                                         jlong pointer)
+                                                          jobject,
+                                                          jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   Sort* result = reinterpret_cast<Sort*>(pointer);

--- a/src/api/java/jni/synth_result.cpp
+++ b/src/api/java/jni/synth_result.cpp
@@ -132,14 +132,14 @@ Java_io_github_cvc5_SynthResult_toString(JNIEnv* env, jobject, jlong pointer)
 /*
  * Class:     io_github_cvc5_SynthResult
  * Method:    hashCode
- * Signature: (J)I
+ * Signature: (J)J
  */
-JNIEXPORT jint JNICALL Java_io_github_cvc5_SynthResult_hashCode(JNIEnv* env,
+JNIEXPORT jlong JNICALL Java_io_github_cvc5_SynthResult_hashCode(JNIEnv* env,
                                                                 jobject,
                                                                 jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   SynthResult* result = reinterpret_cast<SynthResult*>(pointer);
-  return static_cast<jint>(std::hash<cvc5::SynthResult>()(*result));
+  return static_cast<jlong>(std::hash<cvc5::SynthResult>()(*result));
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, 0);
 }

--- a/src/api/java/jni/synth_result.cpp
+++ b/src/api/java/jni/synth_result.cpp
@@ -135,8 +135,8 @@ Java_io_github_cvc5_SynthResult_toString(JNIEnv* env, jobject, jlong pointer)
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_io_github_cvc5_SynthResult_hashCode(JNIEnv* env,
-                                                                jobject,
-                                                                jlong pointer)
+                                                                 jobject,
+                                                                 jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   SynthResult* result = reinterpret_cast<SynthResult*>(pointer);

--- a/src/api/java/jni/term.cpp
+++ b/src/api/java/jni/term.cpp
@@ -1139,14 +1139,14 @@ JNIEXPORT jlong JNICALL Java_io_github_cvc5_Term_iterator(JNIEnv* env,
 /*
  * Class:     io_github_cvc5_Term
  * Method:    hashCode
- * Signature: (J)I
+ * Signature: (J)J
  */
-JNIEXPORT jint JNICALL Java_io_github_cvc5_Term_hashCode(JNIEnv* env,
+JNIEXPORT jlong JNICALL Java_io_github_cvc5_Term_hashCode(JNIEnv* env,
                                                          jobject,
                                                          jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   Term* result = reinterpret_cast<Term*>(pointer);
-  return static_cast<jint>(std::hash<cvc5::Term>()(*result));
+  return static_cast<jlong>(std::hash<cvc5::Term>()(*result));
   CVC5_JAVA_API_TRY_CATCH_END_RETURN(env, 0);
 }

--- a/src/api/java/jni/term.cpp
+++ b/src/api/java/jni/term.cpp
@@ -1142,8 +1142,8 @@ JNIEXPORT jlong JNICALL Java_io_github_cvc5_Term_iterator(JNIEnv* env,
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_io_github_cvc5_Term_hashCode(JNIEnv* env,
-                                                         jobject,
-                                                         jlong pointer)
+                                                          jobject,
+                                                          jlong pointer)
 {
   CVC5_JAVA_API_TRY_CATCH_BEGIN;
   Term* result = reinterpret_cast<Term*>(pointer);


### PR DESCRIPTION
The JNI hashCode implementations computed std::hash<...> on the underlying C++ object and then narrowed the resulting size_t to a jint, discarding the upper half of the hash on 64-bit platforms.

This truncation caused PR #12848 to fail on the GrammarTest API unit test due to a hash collision.