### PR TITLE
Fix assertion failure in exponential monotonicity check

### DIFF
--- a/src/theory/arith/nl/transcendental/exponential_solver.cpp
+++ b/src/theory/arith/nl/transcendental/exponential_solver.cpp
@@ -164,11 +164,14 @@ void ExponentialSolver::checkMonotonic()
   for (const Node& tf : it->second)
   {
     Node mva = d_data->d_model.computeAbstractModelValue(tf);
-    if (mva == tf)
+    if (!mva.isConst())
     {
-      // if it was not assigned a model value by the linear solver, it is
-      // not a relevant term. This can happen for terms like (exp (exp 1.0)),
+      // If it was not assigned a model value by the linear solver, it is not
+      // a relevant term. This can happen for terms like (exp (exp 1.0)),
       // where (exp 1.0) is not relevant until we purify (exp (exp 1.0)).
+      // Note that the abstract model value of such a term is not necessarily
+      // the term itself: it is computed from the model values of its
+      // arguments, e.g. (exp c) for a constant c, which does not evaluate.
       continue;
     }
     Node a = tf[0];

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1178,6 +1178,7 @@ set(regress_0_tests
   regress0/nl/dd.polypaver-bench-exp-3d-chunk-0067.smt2
   regress0/nl/dd.sin-cos-346-b-chunk-0210.smt2
   regress0/nl/dd.sin-cos-346-b-chunk-0210_unsat.smt2
+  regress0/nl/exp-monotonic-nonconst-mv.smt2
   regress0/nl/iand0.smt2
   regress0/nl/iand-no-init.smt2
   regress0/nl/issue10145-ir-pow.smt2

--- a/test/regress/cli/regress0/nl/exp-monotonic-nonconst-mv.smt2
+++ b/test/regress/cli/regress0/nl/exp-monotonic-nonconst-mv.smt2
@@ -1,0 +1,25 @@
+; COMMAND-LINE: --rlimit=10000
+; EXPECT: unknown
+;
+; Reduced from regress2/nl/dumortier-050317.smt2. When checking monotonicity of
+; exponential terms, an (exp t) term whose value was not assigned by the linear
+; solver was previously identified by comparing its abstract model value to the
+; term itself. That value is instead computed from the model values of the
+; arguments, e.g. (exp c) for a constant c, which is not itself constant. Such
+; terms were thus not filtered out, leading to an assertion failure.
+;
+; Note this benchmark does not terminate on its own, hence the resource limit.
+(set-logic QF_NRAT)
+(declare-fun t0 () Real)
+(declare-fun t1 () Real)
+(declare-fun t2 () Real)
+(declare-fun y0 () Real)
+(declare-fun y1 () Real)
+(declare-fun y2 () Real)
+(declare-fun b0 () Bool)
+(declare-fun b1 () Bool)
+(assert (= t0 0.0))
+(assert (or (not b0) (and (= y1 (* y0 (exp (- t1 t0)))) (or (= y1 y0) (not (= t0 t1))))))
+(assert (or (not b1) (and (= y2 (* y1 (exp (- t2 t1)))) (or (= y2 y1) (not (= t1 t2))))))
+(assert b1)
+(check-sat)


### PR DESCRIPTION
When checking monotonicity of exponential terms, `ExponentialSolver::checkMonotonic` skips terms that were not assigned a model value by the linear solver. Such terms were detected by testing whether the abstract model value of the term is the term itself:

```cpp
Node mva = d_data->d_model.computeAbstractModelValue(tf);
if (mva == tf)
{
  continue;
}
```

This is not accurate. When the linear solver did not assign a value, `NlModel::computeModelValue` falls through to the generic case and rebuilds the node from the model values of its arguments. For an exponential term this gives `(exp c)` for a constant `c`, which does not evaluate. The result is therefore neither constant nor equal to the original term, so such terms were not skipped, and the assertion below failed:

```
non-constant model value (exp 1.0) for (exp t2)
```

Note `(exp 0)` rewrites to `1`, which is why this only shows up for particular models.

We now skip terms whose abstract model value is not constant. That is the property actually required by the code below, and it subsumes the previous check since an application of `exp` is never constant. Terms filtered here are ones the linear solver did not assign a value to, so the only effect is that no monotonicity lemma is produced for them.

The added regression is reduced from `regress2/nl/dumortier-050317.smt2`, which is currently in `regression_disabled_tests` and hits this assertion. That benchmark does not terminate, so the new test uses a resource limit and expects `unknown`, following `regress0/solver/issue8854-get-model-after-unknown.smt2`.

Verified on 491 arith/nl regressions and on all 81 benchmarks in the suite that use transcendental functions: the only change in behavior is that `dumortier-050317.smt2` now reaches its timeout instead of aborting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)