### PR TITLE
Java API: Fix equals/hashCode contract violations

### DIFF
--- a/src/api/java/io/github/cvc5/Pair.java
+++ b/src/api/java/io/github/cvc5/Pair.java
@@ -12,6 +12,8 @@
 
 package io.github.cvc5;
 
+import java.util.Objects;
+
 /**
  * A simple generic container class to hold a pair of objects.
  *
@@ -46,7 +48,9 @@ public class Pair<K, V>
    * Compare this Pair to the specified object for equality.
    *
    * It returns {@code true} if the given object is also a Pair and
-   * both the first and second elements are equal (using their equals method).
+   * both the first and second elements are equal. Elements are compared with
+   * {@link java.util.Objects#equals(Object, Object)}, so {@code null} elements
+   * are permitted and compare equal to each other.
    *
    * @param pair the object to compare with this pair
    * @return {@code true} if the specified object is equal to this pair,
@@ -60,6 +64,22 @@ public class Pair<K, V>
     if (pair == null || getClass() != pair.getClass())
       return false;
 
-    return first.equals(((Pair<?, ?>) pair).first) && second.equals(((Pair<?, ?>) pair).second);
+    return Objects.equals(first, ((Pair<?, ?>) pair).first)
+        && Objects.equals(second, ((Pair<?, ?>) pair).second);
+  }
+
+  /**
+   * Return a hash code value for this pair.
+   *
+   * The hash code is derived from the hash codes of the first and second
+   * elements, so that pairs that are equal according to
+   * {@link #equals(Object)} have the same hash code.
+   *
+   * @return a hash code value for this pair
+   */
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(first, second);
   }
 }

--- a/src/api/java/io/github/cvc5/Solver.java
+++ b/src/api/java/io/github/cvc5/Solver.java
@@ -98,6 +98,21 @@ public class Solver extends AbstractPointer
   }
 
   /**
+   * Return a hash code value for this solver.
+   *
+   * The hash code is derived from the underlying native pointer, which is what
+   * {@link #equals(Object)} compares, so that instances that are equal have the
+   * same hash code.
+   *
+   * @return a hash code value for this solver
+   */
+  @Override
+  public int hashCode()
+  {
+    return Long.hashCode(pointer);
+  }
+
+  /**
    * Get the associated term manager instance
    * @return The term manager.
    */

--- a/src/api/java/io/github/cvc5/SymbolManager.java
+++ b/src/api/java/io/github/cvc5/SymbolManager.java
@@ -91,6 +91,21 @@ public class SymbolManager extends AbstractPointer
   }
 
   /**
+   * Return a hash code value for this symbol manager.
+   *
+   * The hash code is derived from the underlying native pointer, which is what
+   * {@link #equals(Object)} compares, so that instances that are equal have the
+   * same hash code.
+   *
+   * @return a hash code value for this symbol manager
+   */
+  @Override
+  public int hashCode()
+  {
+    return Long.hashCode(pointer);
+  }
+
+  /**
    * Determine if the logic of this symbol manager has been set.
    *
    * @return True if the logic of this symbol manager has been set.

--- a/src/api/java/io/github/cvc5/TermManager.java
+++ b/src/api/java/io/github/cvc5/TermManager.java
@@ -73,6 +73,21 @@ public class TermManager extends AbstractPointer
   }
 
   /**
+   * Return a hash code value for this term manager.
+   *
+   * The hash code is derived from the underlying native pointer, which is what
+   * {@link #equals(Object)} compares, so that instances that are equal have the
+   * same hash code.
+   *
+   * @return a hash code value for this term manager
+   */
+  @Override
+  public int hashCode()
+  {
+    return Long.hashCode(pointer);
+  }
+
+  /**
    * Get a snapshot of the current state of the statistic values of this
    * term manager.
    *

--- a/src/api/java/io/github/cvc5/Triplet.java
+++ b/src/api/java/io/github/cvc5/Triplet.java
@@ -12,6 +12,8 @@
 
 package io.github.cvc5;
 
+import java.util.Objects;
+
 /**
  * A generic container class to hold a triplet of objects.
  *
@@ -48,6 +50,9 @@ public class Triplet<A, B, C>
    * Indicate whether some other object is "equal to" this one.
    * Two {@code Triplet} instances are equal if their corresponding
    * {@code first}, {@code second}, and {@code third} elements are equal.
+   * Elements are compared with
+   * {@link java.util.Objects#equals(Object, Object)}, so {@code null} elements
+   * are permitted and compare equal to each other.
    *
    * @param object the object to compare with
    * @return {@code true} if this object is equal to the specified object;
@@ -61,8 +66,23 @@ public class Triplet<A, B, C>
     if (object == null || getClass() != object.getClass())
       return false;
 
-    return this.first.equals(((Triplet<?, ?, ?>) object).first)
-        && this.second.equals(((Triplet<?, ?, ?>) object).second)
-        && this.third.equals(((Triplet<?, ?, ?>) object).third);
+    return Objects.equals(this.first, ((Triplet<?, ?, ?>) object).first)
+        && Objects.equals(this.second, ((Triplet<?, ?, ?>) object).second)
+        && Objects.equals(this.third, ((Triplet<?, ?, ?>) object).third);
+  }
+
+  /**
+   * Return a hash code value for this triplet.
+   *
+   * The hash code is derived from the hash codes of the {@code first},
+   * {@code second} and {@code third} elements, so that triplets that are equal
+   * according to {@link #equals(Object)} have the same hash code.
+   *
+   * @return a hash code value for this triplet
+   */
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(first, second, third);
   }
 }

--- a/test/unit/api/java/CMakeLists.txt
+++ b/test/unit/api/java/CMakeLists.txt
@@ -27,6 +27,7 @@ set(java_test_src_files
   ${CMAKE_CURRENT_SOURCE_DIR}/LifetimeTest.java
   ${CMAKE_CURRENT_SOURCE_DIR}/OpTest.java
   ${CMAKE_CURRENT_SOURCE_DIR}/ParserLifetimeTest.java
+  ${CMAKE_CURRENT_SOURCE_DIR}/PairTest.java
   ${CMAKE_CURRENT_SOURCE_DIR}/ParserTest.java
   ${CMAKE_CURRENT_SOURCE_DIR}/ResultTest.java
   ${CMAKE_CURRENT_SOURCE_DIR}/SolverTest.java
@@ -35,6 +36,7 @@ set(java_test_src_files
   ${CMAKE_CURRENT_SOURCE_DIR}/SynthResultTest.java
   ${CMAKE_CURRENT_SOURCE_DIR}/TermTest.java
   ${CMAKE_CURRENT_SOURCE_DIR}/TermManagerTest.java
+  ${CMAKE_CURRENT_SOURCE_DIR}/TripletTest.java
   ${CMAKE_CURRENT_SOURCE_DIR}/ProofTest.java
   ${CMAKE_CURRENT_SOURCE_DIR}/UtilsTest.java
 )
@@ -85,6 +87,7 @@ cvc5_add_java_api_test(InputParserTest)
 cvc5_add_java_api_test(LifetimeTest)
 cvc5_add_java_api_test(ParserLifetimeTest)
 cvc5_add_java_api_test(OpTest)
+cvc5_add_java_api_test(PairTest)
 cvc5_add_java_api_test(ResultTest)
 cvc5_add_java_api_test(SolverTest)
 cvc5_add_java_api_test(SortTest)
@@ -92,6 +95,7 @@ cvc5_add_java_api_test(SymbolManagerTest)
 cvc5_add_java_api_test(SynthResultTest)
 cvc5_add_java_api_test(TermTest)
 cvc5_add_java_api_test(TermManagerTest)
+cvc5_add_java_api_test(TripletTest)
 cvc5_add_java_api_test(ProofTest)
 cvc5_add_java_api_test(UtilsTest)
 

--- a/test/unit/api/java/PairTest.java
+++ b/test/unit/api/java/PairTest.java
@@ -1,0 +1,75 @@
+/******************************************************************************
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2026 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Black box testing of the Pair class of the Java API.
+ */
+
+package tests;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.github.cvc5.Pair;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class PairTest
+{
+  @Test
+  void equalHash()
+  {
+    Pair<String, Integer> p1 = new Pair<>("x", 1);
+    Pair<String, Integer> p2 = new Pair<>("x", 1);
+    Pair<String, Integer> p3 = new Pair<>("y", 1);
+    Pair<String, Integer> p4 = new Pair<>("x", 2);
+
+    assertEquals(p1, p1);
+    assertEquals(p1, p2);
+    assertNotEquals(p1, p3);
+    assertNotEquals(p1, p4);
+
+    assertEquals(p1.hashCode(), p1.hashCode());
+    assertEquals(p1.hashCode(), p2.hashCode());
+  }
+
+  @Test
+  void nullElements()
+  {
+    Pair<String, Integer> p1 = new Pair<>(null, 1);
+    Pair<String, Integer> p2 = new Pair<>(null, 1);
+    Pair<String, Integer> p3 = new Pair<>("x", null);
+
+    assertEquals(p1, p2);
+    assertEquals(p1.hashCode(), p2.hashCode());
+    assertNotEquals(p1, p3);
+    assertNotEquals(p1, new Pair<>("x", 1));
+    assertNotEquals(new Pair<>("x", 1), p1);
+
+    Set<Pair<String, Integer>> set = new HashSet<>();
+    set.add(new Pair<>(null, 1));
+    assertTrue(set.contains(new Pair<>(null, 1)));
+  }
+
+  @Test
+  void hashBasedCollections()
+  {
+    Set<Pair<String, Integer>> set = new HashSet<>();
+    set.add(new Pair<>("x", 1));
+    set.add(new Pair<>("x", 1));
+    assertEquals(1, set.size());
+    assertTrue(set.contains(new Pair<>("x", 1)));
+    assertFalse(set.contains(new Pair<>("x", 2)));
+
+    Map<Pair<String, Integer>, String> map = new HashMap<>();
+    map.put(new Pair<>("x", 1), "value");
+    assertEquals("value", map.get(new Pair<>("x", 1)));
+  }
+}

--- a/test/unit/api/java/SolverTest.java
+++ b/test/unit/api/java/SolverTest.java
@@ -49,6 +49,15 @@ class SolverTest
   }
 
   @Test
+  void equalHash()
+  {
+    Solver solver = new Solver(d_tm);
+    assertEquals(d_solver, d_solver);
+    assertNotEquals(d_solver, solver);
+    assertEquals(d_solver.hashCode(), d_solver.hashCode());
+  }
+
+  @Test
   void recoverableException() throws CVC5ApiException
   {
     d_solver.setOption("produce-models", "true");

--- a/test/unit/api/java/SymbolManagerTest.java
+++ b/test/unit/api/java/SymbolManagerTest.java
@@ -37,6 +37,15 @@ class SymbolManagerTest extends ParserTest
   }
 
   @Test
+  void equalHash()
+  {
+    SymbolManager symman = new SymbolManager(d_tm);
+    assertEquals(d_symman, d_symman);
+    assertNotEquals(d_symman, symman);
+    assertEquals(d_symman.hashCode(), d_symman.hashCode());
+  }
+
+  @Test
   void isLogicSet()
   {
     assertEquals(d_symman.isLogicSet(), false);

--- a/test/unit/api/java/TermManagerTest.java
+++ b/test/unit/api/java/TermManagerTest.java
@@ -43,6 +43,15 @@ class TermManagerTest
   }
 
   @Test
+  void equalHash()
+  {
+    TermManager tm = new TermManager();
+    assertEquals(d_tm, d_tm);
+    assertNotEquals(d_tm, tm);
+    assertEquals(d_tm.hashCode(), d_tm.hashCode());
+  }
+
+  @Test
   void getBooleanSort() throws CVC5ApiException
   {
     assertDoesNotThrow(() -> d_tm.getBooleanSort());

--- a/test/unit/api/java/TripletTest.java
+++ b/test/unit/api/java/TripletTest.java
@@ -1,0 +1,77 @@
+/******************************************************************************
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2026 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * Black box testing of the Triplet class of the Java API.
+ */
+
+package tests;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.github.cvc5.Triplet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class TripletTest
+{
+  @Test
+  void equalHash()
+  {
+    Triplet<String, Integer, Boolean> t1 = new Triplet<>("x", 1, true);
+    Triplet<String, Integer, Boolean> t2 = new Triplet<>("x", 1, true);
+    Triplet<String, Integer, Boolean> t3 = new Triplet<>("y", 1, true);
+    Triplet<String, Integer, Boolean> t4 = new Triplet<>("x", 2, true);
+    Triplet<String, Integer, Boolean> t5 = new Triplet<>("x", 1, false);
+
+    assertEquals(t1, t1);
+    assertEquals(t1, t2);
+    assertNotEquals(t1, t3);
+    assertNotEquals(t1, t4);
+    assertNotEquals(t1, t5);
+
+    assertEquals(t1.hashCode(), t1.hashCode());
+    assertEquals(t1.hashCode(), t2.hashCode());
+  }
+
+  @Test
+  void nullElements()
+  {
+    Triplet<String, Integer, Boolean> t1 = new Triplet<>(null, 1, true);
+    Triplet<String, Integer, Boolean> t2 = new Triplet<>(null, 1, true);
+    Triplet<String, Integer, Boolean> t3 = new Triplet<>("x", 1, null);
+
+    assertEquals(t1, t2);
+    assertEquals(t1.hashCode(), t2.hashCode());
+    assertNotEquals(t1, t3);
+    assertNotEquals(t1, new Triplet<>("x", 1, true));
+    assertNotEquals(new Triplet<>("x", 1, true), t1);
+
+    Set<Triplet<String, Integer, Boolean>> set = new HashSet<>();
+    set.add(new Triplet<>(null, 1, true));
+    assertTrue(set.contains(new Triplet<>(null, 1, true)));
+  }
+
+  @Test
+  void hashBasedCollections()
+  {
+    Set<Triplet<String, Integer, Boolean>> set = new HashSet<>();
+    set.add(new Triplet<>("x", 1, true));
+    set.add(new Triplet<>("x", 1, true));
+    assertEquals(1, set.size());
+    assertTrue(set.contains(new Triplet<>("x", 1, true)));
+    assertFalse(set.contains(new Triplet<>("x", 1, false)));
+
+    Map<Triplet<String, Integer, Boolean>, String> map = new HashMap<>();
+    map.put(new Triplet<>("x", 1, true), "value");
+    assertEquals("value", map.get(new Triplet<>("x", 1, true)));
+  }
+}


### PR DESCRIPTION
Follow-up to #12874, which fixed hash truncation in the twelve Java API classes that have a native `hashCode`. This PR covers the remaining `equals`/`hashCode` problems in the Java API: five classes override `equals` without overriding `hashCode`, so equal instances inherit distinct identity hash codes.

| Class | `equals` compares | Added `hashCode` |
|---|---|---|
| `Pair` | `first`, `second` by value | `Objects.hash(first, second)` |
| `Triplet` | `first`, `second`, `third` by value | `Objects.hash(first, second, third)` |
| `Solver` | native `pointer` | `Long.hashCode(pointer)` |
| `SymbolManager` | native `pointer` | `Long.hashCode(pointer)` |
| `TermManager` | native `pointer` | `Long.hashCode(pointer)` |

For `Pair` and `Triplet` this is a user-visible bug. `Pair` is part of the public API surface — it is returned by `Solver.getTimeoutCore()` and `Solver.getTimeoutCoreAssuming()`, consumed by `mkRecordSort()`, and yielded when iterating `Statistics` — so equal pairs are not deduplicated by a `HashSet` and cannot be looked up in a `HashMap`:

```java
Map<Pair<String, Integer>, String> m = new HashMap<>();
m.put(new Pair<>("x", 1), "value");
m.get(new Pair<>("x", 1));  // null before this PR
```

For the three `AbstractPointer` subclasses the fix is defensive rather than observable today: `Solver.getTermManager()` allocates a fresh native `TermManager`, so two wrappers sharing one pointer are not currently reachable through the public API. Defining `hashCode` alongside `equals` is still the correct pairing and costs nothing.

This PR additionally makes `Pair.equals()` and `Triplet.equals()` null-safe. They dereferenced their elements directly and threw `NullPointerException` whenever an element was `null`; they now compare with `Objects.equals()`, which matches the null handling of the new `hashCode()` implementations. Javadoc on both methods was updated to state that `null` elements are permitted and compare equal to each other.

## Behavior changes

Both are consequences of fixing the bug rather than compatibility breaks, but worth calling out for reviewers:

- `hashCode()` values for these five classes change from identity hashes to value-derived ones.
- `Pair`/`Triplet` equality involving a `null` element goes from `NullPointerException` to a normal `true`/`false`.

## Testing

New `PairTest` and `TripletTest` cover equality/hash consistency, `HashSet`/`HashMap` behavior, and the null-element cases. Short `equalHash` tests were added to `SolverTest`, `SymbolManagerTest` and `TermManagerTest`.

Per the discussion on #12874 about hash-collision fragility, none of these tests assert that *unequal* objects have *different* hash codes.