### PR TITLE
Update cpc tester to ensure we have a proof of false

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,10 @@ cvc5 1.3.5 prerelease
   `--bv-solver=bitblast-internal` (enabling option `--bv-abstraction` has no
   effect).
 
+- CPC proofs now always end with a `step` command. Previously, when `false` was
+  directly an input assertion, the proof would instead end with an `assume`
+  command.
+
 cvc5 1.3.4
 ==========
 

--- a/contrib/get-ethos-checker
+++ b/contrib/get-ethos-checker
@@ -27,7 +27,7 @@ EO_DIR="$BASE_DIR/ethos-checker"
 mkdir -p $EO_DIR
 
 # download and unpack ethos
-ETHOS_VERSION="1238fd167cc29377e554e28a7b776bb396eee8ee"
+ETHOS_VERSION="0b1a6dd98cd152b23f747de52165e4034f62135b"
 download "https://github.com/cvc5/ethos/archive/$ETHOS_VERSION.tar.gz" $BASE_DIR/tmp/ethos.tgz
 tar --strip 1 -xzf $BASE_DIR/tmp/ethos.tgz -C $EO_DIR
 

--- a/src/proof/eo/eo_printer.cpp
+++ b/src/proof/eo/eo_printer.cpp
@@ -970,8 +970,8 @@ void EoPrinter::printAssumeBodyStep(EoPrintChannelOut& aout,
   // The body of the proof is an assumption. This is the case e.g. if false is
   // one of the input assertions, in which case the proof of false is the
   // assumption of false itself. Since we require that proofs end with a step
-  // (concluding false), we print a dummy derivation of the assumed formula F
-  // from the assumption of F:
+  // and not an assume command, we print a dummy derivation of the assumed
+  // formula F from the assumption of F:
   //
   //                            ------------- refl
   //   @p_a: F                  @p_r: (= F F)
@@ -991,6 +991,10 @@ void EoPrinter::printAssumeBodyStep(EoPrintChannelOut& aout,
   aout.printStep("refl", f.eqNode(f), rid, {}, {f});
   d_pfIdCounter++;
   aout.printStep("eq_resolve", f, d_pfIdCounter, {aid, rid}, {});
+  // Note that F is not necessarily false here, since this method applies to
+  // any proof whose body is an assumption, e.g. the preprocessed input proof
+  // printed when proof logging. The dummy step is unnecessary in that case,
+  // but harmless.
 }
 
 void EoPrinter::printNext(EoPrintChannelOut& aout,

--- a/src/proof/eo/eo_printer.cpp
+++ b/src/proof/eo/eo_printer.cpp
@@ -954,6 +954,43 @@ void EoPrinter::print(EoPrintChannelOut& aout,
     // [5] print proof body
     printProofInternal(ao, pnBody, i == 1);
   }
+  // [6] If the body of the proof is an assumption, then no step was printed
+  // for it above and the proof would end with an assume command. We print a
+  // dummy step here so that the proof always ends with a step.
+  if (pnBody->getRule() == ProofRule::ASSUME)
+  {
+    printAssumeBodyStep(aout, pnBody);
+  }
+}
+
+void EoPrinter::printAssumeBodyStep(EoPrintChannelOut& aout,
+                                    const ProofNode* pn)
+{
+  Assert(pn->getRule() == ProofRule::ASSUME);
+  // The body of the proof is an assumption. This is the case e.g. if false is
+  // one of the input assertions, in which case the proof of false is the
+  // assumption of false itself. Since we require that proofs end with a step
+  // (concluding false), we print a dummy derivation of the assumed formula F
+  // from the assumption of F:
+  //
+  //                            ------------- refl
+  //   @p_a: F                  @p_r: (= F F)
+  //  ------------------------------------------ eq_resolve
+  //   @p_c: F
+  Node f = d_tproc.convert(pn->getResult());
+  bool wasAlloc = false;
+  size_t aid = allocateAssumeId(pn->getResult(), wasAlloc);
+  if (wasAlloc)
+  {
+    // Print the assumption if it was not printed above, which should only
+    // happen if we are not printing the proof within a scope.
+    aout.printAssume(f, aid, false);
+  }
+  d_pfIdCounter++;
+  size_t rid = d_pfIdCounter;
+  aout.printStep("refl", f.eqNode(f), rid, {}, {f});
+  d_pfIdCounter++;
+  aout.printStep("eq_resolve", f, d_pfIdCounter, {aid, rid}, {});
 }
 
 void EoPrinter::printNext(EoPrintChannelOut& aout,

--- a/src/proof/eo/eo_printer.h
+++ b/src/proof/eo/eo_printer.h
@@ -141,6 +141,16 @@ class EoPrinter : protected EnvObj
                           const ProofNode* pn,
                           bool addToCache);
   /**
+   * Helper for print. Prints a (dummy) step concluding the formula assumed by
+   * pn, which is expected to be an application of ProofRule::ASSUME that is
+   * the body of the proof we are printing. This ensures that proofs always end
+   * with a step and not an assume command.
+   *
+   * @param aout The output channel to print to.
+   * @param pn The (assumption) proof node that is the body of the proof.
+   */
+  void printAssumeBodyStep(EoPrintChannelOut& aout, const ProofNode* pn);
+  /**
    * Called at preorder traversal of proof node pn. Prints (if necessary) to
    * out.
    */

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1519,6 +1519,7 @@ set(regress_0_tests
   regress0/proofs/alethe-res-need-or-step.smt2
   regress0/proofs/arith-poly-norm-rel-mixed.smt2
   regress0/proofs/arith-pp-assert-solved-eq.smt2
+  regress0/proofs/assume-false-final-step-check.smt2
   regress0/proofs/assume-false-final-step.smt2
   regress0/proofs/big-rec-len.smt2
   regress0/proofs/big-ss-len-include.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1519,6 +1519,7 @@ set(regress_0_tests
   regress0/proofs/alethe-res-need-or-step.smt2
   regress0/proofs/arith-poly-norm-rel-mixed.smt2
   regress0/proofs/arith-pp-assert-solved-eq.smt2
+  regress0/proofs/assume-false-final-step.smt2
   regress0/proofs/big-rec-len.smt2
   regress0/proofs/big-ss-len-include.smt2
   regress0/proofs/cyclic-ucp.smt2

--- a/test/regress/cli/regress0/proofs/assume-false-final-step-check.smt2
+++ b/test/regress/cli/regress0/proofs/assume-false-final-step-check.smt2
@@ -1,0 +1,8 @@
+; EXPECT: unsat
+;; Companion to assume-false-final-step.smt2, which checks that the dummy step
+;; is printed. This test has plain unsat expected output so that the cpc tester
+;; applies to it, which checks the proof with ethos and hence covers that the
+;; proof is accepted under --require-proof-of-false.
+(set-logic ALL)
+(assert false)
+(check-sat)

--- a/test/regress/cli/regress0/proofs/assume-false-final-step.smt2
+++ b/test/regress/cli/regress0/proofs/assume-false-final-step.smt2
@@ -2,6 +2,9 @@
 ; SCRUBBER: grep -o -E 'unsat|:rule eq_resolve' | sed 's/:rule //'
 ; EXPECT: unsat
 ; EXPECT: eq_resolve
+;; Note the cpc tester does not apply to this test, since its expected output
+;; is not plain unsat. See assume-false-final-step-check.smt2 for the test that
+;; checks the resulting proof with ethos.
 (set-logic ALL)
 (set-option :produce-proofs true)
 (assert false)

--- a/test/regress/cli/regress0/proofs/assume-false-final-step.smt2
+++ b/test/regress/cli/regress0/proofs/assume-false-final-step.smt2
@@ -1,0 +1,8 @@
+; COMMAND-LINE: --dump-proofs --proof-format=cpc
+; SCRUBBER: grep -o -E 'unsat|:rule eq_resolve' | sed 's/:rule //'
+; EXPECT: unsat
+; EXPECT: eq_resolve
+(set-logic ALL)
+(set-option :produce-proofs true)
+(assert false)
+(check-sat)

--- a/test/regress/cli/run_regression.py
+++ b/test/regress/cli/run_regression.py
@@ -397,6 +397,7 @@ class CpcTester(Tester):
                 return exit_code
             output, error, exit_status = run_process(
                 [benchmark_info.ethos_binary] +
+                ["--require-proof-of-false"] +
                 [tmpf.name],
                 benchmark_info.benchmark_dir,
                 timeout=benchmark_info.timeout,

--- a/test/regress/cli/run_regression.py
+++ b/test/regress/cli/run_regression.py
@@ -389,12 +389,9 @@ class CpcTester(Tester):
                 return EXIT_FAILURE
             tmpf.write(output)
             tmpf.flush()
-            output, error = output.decode(), error.decode()
-            if ("step" not in output) and ("assume" not in output):
-                print_error("Empty proof")
-                return EXIT_FAILURE
-            if exit_code != EXIT_OK:
-                return exit_code
+            # note we do not check that the proof is non-empty here, since
+            # ethos is run with --require-proof-of-false below, which fails on
+            # an empty proof as it has no step concluding false.
             output, error, exit_status = run_process(
                 [benchmark_info.ethos_binary] +
                 ["--require-proof-of-false"] +
@@ -406,6 +403,11 @@ class CpcTester(Tester):
             exit_code = self.check_exit_status(EXIT_OK, exit_status, output,
                                                error, cvc5_args)
             if exit_code != EXIT_OK:
+                if exit_code == EXIT_FAILURE:
+                    # print the output of ethos, which says why it failed, e.g.
+                    # a step did not check or the proof did not conclude false.
+                    print()
+                    print_outputs(output, error)
                 return exit_code
             if ("correct" not in output) and ("incomplete" not in output):
                 print_error("Invalid proof")


### PR DESCRIPTION
Updates the ethos version, uses the new command line option.

This requires a minor fix to cpc output to print a dummy proof of false if an assume was literally false. Previously we would provide no step.

Note that the API proof and the cpc output differs in this regard (we do not rewrite the proof object in our API to contain this dummy proof).