### PR TITLE
Minor fixes to CPC

### DIFF
--- a/proofs/eo/cpc/programs/PolyNorm.eo
+++ b/proofs/eo/cpc/programs/PolyNorm.eo
@@ -14,7 +14,7 @@
 (declare-const @@Polynomial Type)
 (define @Polynomial () @@Polynomial)
 (declare-const @@poly.zero @Polynomial)
-(define @poly.zero () @@Polynomial)
+(define @poly.zero () @@poly.zero)
 (declare-const @@poly (-> @Monomial @Polynomial @Polynomial) :right-assoc-nil @poly.zero)
 (define @poly () @@poly)
 

--- a/proofs/eo/cpc/theories/Strings.eo
+++ b/proofs/eo/cpc/theories/Strings.eo
@@ -139,9 +139,6 @@
   (-> RegLan (eo::requires ($is_numeral l) true (eo::requires ($is_numeral h) true RegLan))))
 (declare-const str.in_re (-> String RegLan Bool))
 
-; Not supported by cvc5, used to define semantics of @re_unfold_pos_component
-(declare-const str.indexof_re_split (-> String RegLan RegLan Int))
-
 ; Sequence-specific operators.
 ; disclaimer: This function is not in SMT-LIB.
 (declare-parameterized-const seq.unit ((T Type :implicit)) (-> T (Seq T)))


### PR DESCRIPTION
This fixes a definition in arith poly norm where zero was accidentally defined to be the same as the type of polynomials. This does not impact the semantics since neither symbol have SMT-LIB semantics (prefix `@@`), although this definition is clearly unintuitive.

It also removes a symbol from CPC which was solely used to define the semantics of re unfold pos. The compilation toolchain now can define this at a different level without changing the frontend CPC.

Logos verification pending: https://github.com/ajreynol/logos/pull/435