### PR TITLE
Pass cvc5 compile flags for assertion and build mode to CaDiCaL.

### DIFF
--- a/cmake/FindCaDiCaL.cmake
+++ b/cmake/FindCaDiCaL.cmake
@@ -90,7 +90,15 @@ if(NOT CaDiCaL_FOUND_SYSTEM)
   # avoid configure script and instantiate the makefile manually the configure
   # scripts unnecessarily fails for cross compilation thus we do the bare
   # minimum from the configure script here
-  set(CaDiCaL_CXXFLAGS "-fPIC -O3 -DNDEBUG -DQUIET -std=c++11")
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CaDiCaL_CXXFLAGS "-fPIC -Og -g -DQUIET -std=c++11")
+  else()
+    set(CaDiCaL_CXXFLAGS "-fPIC -O3 -DQUIET -std=c++11")
+  endif()
+  # Also enable assertions in CaDiCaL when cvc5 assertions are enabled
+  if(NOT ENABLE_ASSERTIONS)
+    string(APPEND CaDiCaL_CXXFLAGS " -DNDEBUG")
+  endif()
   if(CMAKE_CROSSCOMPILING_MACOS)
     set(CaDiCaL_CXXFLAGS "${CaDiCaL_CXXFLAGS} -arch ${CMAKE_OSX_ARCHITECTURES}")
   endif()


### PR DESCRIPTION
Up to now CaDiCaL was always built without assertions and full optimizations enabled, even on cvc5 debug/assertion builds. As CaDiCaL is essential for the soundness of cvc5, a failed CaDiCaL assertion (e.g. due to some incorrectly used interface) might have severe consequences for cvc5.
This PR enables assertions and debug symbols for the CaDiCaL dependency build when assertions and debug symbols are enabled in cvc5, respectively. 