### PR TITLE
Fix regression with unknown

### DIFF
--- a/test/regress/cli/regress0/use_approx/specsharp-WindowsCard.15.RTE.Terminate_System.Int32_approx.smt2
+++ b/test/regress/cli/regress0/use_approx/specsharp-WindowsCard.15.RTE.Terminate_System.Int32_approx.smt2
@@ -1,6 +1,9 @@
 ; REQUIRES: glpk
 ; DISABLE-TESTER: unsat-core
-; COMMAND-LINE: --use-approx
+;; --enum-inst is required since #12833, after which the rewriter no longer
+;; fully normalizes arithmetic equalities and E-matching alone does not find
+;; the instantiation needed to close this benchmark.
+; COMMAND-LINE: --use-approx --enum-inst
 ; EXPECT: unsat
 ;; Unary AND is not supported in Alethe
 ; DISABLE-TESTER: alethe


### PR DESCRIPTION
This regression uses GLPK and its failure (to unknown) isnt caught on CI. @daniel-larraz not sure if this is expected