### PR TITLE
Modify internal RARE semantics to not export APPLY_INDEXED_SYMBOLIC

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -361,6 +361,12 @@ enum ENUM(ProofRule)
    * formulas or change the representation of :math:`t` in a way that is a
    * no-op in external proof formats.
    *
+   * Note that this conversion never introduces applications of indexed
+   * operators whose indices are given as explicit arguments (internally
+   * represented as `APPLY_INDEXED_SYMBOLIC`). Such terms are used internally by
+   * RARE rewrite reconstruction only; they are folded away by
+   * :cpp:enumerator:`DSL_REWRITE` and hence do not appear in proofs.
+   *
    * Note this rule can be treated as a
    * :cpp:enumerator:`REFL <cvc5::ProofRule::REFL>` when appropriate in
    * external proof formats.
@@ -378,8 +384,9 @@ enum ENUM(ProofRule)
    * where `id` is a :cpp:enum:`ProofRewriteRule` whose definition in the
    * RARE DSL is
    * :math:`\forall x_1 \dots x_n. (G_1 \wedge \cdots \wedge G_n) \Rightarrow G`
-   * where for :math:`i=1, \dots n`, we have that :math:`F_i = \sigma(G_i)`
-   * and :math:`F = \sigma(G)` where :math:`\sigma` is the substitution
+   * where for :math:`i=1, \dots n`, we have that
+   * :math:`F_i = \downarrow\sigma(G_i)` and :math:`F = \downarrow\sigma(G)`
+   * where :math:`\sigma` is the substitution
    * :math:`\{x_1\mapsto t_1,\dots,x_n\mapsto t_n\}`.
    *
    * Notice that the application of the substitution takes into account the
@@ -389,6 +396,15 @@ enum ENUM(ProofRule)
    * :math:`\texttt{expr::narySubstitute}` (for details, see
    * :cvc5src:`expr/nary_term_util.h`) which replaces each :math:`x_i` with the
    * list :math:`t_i` in its place.
+   *
+   * Here, :math:`\downarrow t` denotes the *folding* of :math:`t`, which
+   * replaces each application of an indexed operator whose indices are given as
+   * explicit arguments by the corresponding ordinary application of that
+   * indexed operator, e.g. the term denoting `(extract 3 0 x)` is folded to
+   * `((_ extract 3 0) x)`. This is applied to all subterms of :math:`t` whose
+   * indices evaluate to numeral constants; subterms whose indices do not are
+   * left unchanged. Note that folding is the identity for RARE rules that do
+   * not mention indexed operators, which is the common case.
    * \endverbatim
    */
   EVALUE(DSL_REWRITE),

--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -361,12 +361,6 @@ enum ENUM(ProofRule)
    * formulas or change the representation of :math:`t` in a way that is a
    * no-op in external proof formats.
    *
-   * Note that this conversion never introduces applications of indexed
-   * operators whose indices are given as explicit arguments (internally
-   * represented as `APPLY_INDEXED_SYMBOLIC`). Such terms are used internally by
-   * RARE rewrite reconstruction only; they are folded away by
-   * :cpp:enumerator:`DSL_REWRITE` and hence do not appear in proofs.
-   *
    * Note this rule can be treated as a
    * :cpp:enumerator:`REFL <cvc5::ProofRule::REFL>` when appropriate in
    * external proof formats.
@@ -384,9 +378,8 @@ enum ENUM(ProofRule)
    * where `id` is a :cpp:enum:`ProofRewriteRule` whose definition in the
    * RARE DSL is
    * :math:`\forall x_1 \dots x_n. (G_1 \wedge \cdots \wedge G_n) \Rightarrow G`
-   * where for :math:`i=1, \dots n`, we have that
-   * :math:`F_i = \downarrow\sigma(G_i)` and :math:`F = \downarrow\sigma(G)`
-   * where :math:`\sigma` is the substitution
+   * where for :math:`i=1, \dots n`, we have that :math:`F_i = \sigma(G_i)`
+   * and :math:`F = \sigma(G)` where :math:`\sigma` is the substitution
    * :math:`\{x_1\mapsto t_1,\dots,x_n\mapsto t_n\}`.
    *
    * Notice that the application of the substitution takes into account the
@@ -396,15 +389,6 @@ enum ENUM(ProofRule)
    * :math:`\texttt{expr::narySubstitute}` (for details, see
    * :cvc5src:`expr/nary_term_util.h`) which replaces each :math:`x_i` with the
    * list :math:`t_i` in its place.
-   *
-   * Here, :math:`\downarrow t` denotes the *folding* of :math:`t`, which
-   * replaces each application of an indexed operator whose indices are given as
-   * explicit arguments by the corresponding ordinary application of that
-   * indexed operator, e.g. the term denoting `(extract 3 0 x)` is folded to
-   * `((_ extract 3 0) x)`. This is applied to all subterms of :math:`t` whose
-   * indices evaluate to numeral constants; subterms whose indices do not are
-   * left unchanged. Note that folding is the identity for RARE rules that do
-   * not mention indexed operators, which is the common case.
    * \endverbatim
    */
   EVALUE(DSL_REWRITE),

--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -169,7 +169,7 @@ bool RewriteDbProofCons::proveEqStratified(CDProof* cdp,
   // this flag may additionally be set during the search below, if a RARE rule
   // that mentions an indexed operator is applied.
   d_currFold =
-      (eq != eqi) && expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, eqi);
+      (eq != eqi) && IndexedOpFoldNodeConverter::hasIndexedSymbolic(eqi);
   bool success = false;
   // first, try the basic utility, which is run on the folded form of eqi
   Node eqif = fold(eqi);
@@ -1468,7 +1468,7 @@ bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
           // are always numeral constants in the terms we lift, and side
           // conditions of RARE rules compute indices that evaluate.
           if (d_currFold
-              && expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, conc))
+              && IndexedOpFoldNodeConverter::hasIndexedSymbolic(conc))
           {
             Trace("rpc-debug")
                 << "Failed to fold conclusion " << conc << std::endl;

--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -168,8 +168,8 @@ bool RewriteDbProofCons::proveEqStratified(CDProof* cdp,
   // traverse eqi when it is the (unconverted) input equality. Note also that
   // this flag may additionally be set during the search below, if a RARE rule
   // that mentions an indexed operator is applied.
-  d_currFold = (eq != eqi)
-               && expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, eqi);
+  d_currFold =
+      (eq != eqi) && expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, eqi);
   bool success = false;
   // first, try the basic utility, which is run on the folded form of eqi
   Node eqif = fold(eqi);
@@ -1669,8 +1669,8 @@ Node RewriteDbProofCons::fold(const Node& n)
 }
 
 void RewriteDbProofCons::getCongPremises(const Node& n,
-                                        const Node& fn,
-                                        std::vector<Node>& ps)
+                                         const Node& fn,
+                                         std::vector<Node>& ps)
 {
   if (n.getKind() != Kind::APPLY_INDEXED_SYMBOLIC
       || fn.getKind() == Kind::APPLY_INDEXED_SYMBOLIC)

--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -36,7 +36,9 @@ RewriteDbProofCons::RewriteDbProofCons(Env& env, RewriteDb* db)
     : EnvObj(env),
       d_notify(*this),
       d_trrc(env),
-      d_rdnc(nodeManager()),
+      d_rdnc(nodeManager(), true),
+      d_iofnc(nodeManager()),
+      d_currFold(false),
       d_db(db),
       d_eval(nullptr),
       d_currRecLimit(0),
@@ -128,13 +130,19 @@ bool RewriteDbProofCons::prove(CDProof* cdp,
       Trace("rpc") << "...success (post-prove basic)" << std::endl;
       success = true;
     }
-    else if (eqi != eq && d_trrc.postProve(cdp, eqi[0], eqi[1], tmode))
+    else if (eqi != eq)
     {
-      Trace("rpc") << "...success (post-prove basic)" << std::endl;
-      d_trrc.ensureProofForEncodeTransform(cdp, eq, eqi);
-      success = true;
+      // note we run this on the folded form of eqi, which is the form of terms
+      // used in proofs
+      Node eqif = fold(eqi);
+      if (eqif != eq && d_trrc.postProve(cdp, eqif[0], eqif[1], tmode))
+      {
+        Trace("rpc") << "...success (post-prove basic)" << std::endl;
+        d_trrc.ensureProofForEncodeTransform(cdp, eq, eqif);
+        success = true;
+      }
     }
-    else
+    if (!success)
     {
       Trace("rpc") << "...fail" << std::endl;
     }
@@ -153,9 +161,16 @@ bool RewriteDbProofCons::proveEqStratified(CDProof* cdp,
                                            int64_t stepLimit,
                                            TheoryRewriteMode tmode)
 {
+  // Determine whether the search below may involve indexed operators that were
+  // lifted to APPLY_INDEXED_SYMBOLIC. If so, the proof we construct is for the
+  // folded form of eqi, which is the form of terms used in proofs. Note this
+  // may additionally be set during the search below, if a RARE rule that
+  // mentions an indexed operator is applied.
+  d_currFold = expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, eqi);
   bool success = false;
-  // first, try the basic utility
-  if (d_trrc.prove(cdp, eqi[0], eqi[1], tmode))
+  // first, try the basic utility, which is run on the folded form of eqi
+  Node eqif = fold(eqi);
+  if (d_trrc.prove(cdp, eqif[0], eqif[1], tmode))
   {
     Trace("rpc") << "...success (basic)" << std::endl;
     success = true;
@@ -185,10 +200,12 @@ bool RewriteDbProofCons::proveEqStratified(CDProof* cdp,
   }
   if (success)
   {
+    // recompute, since the search above may have introduced indexed operators
+    eqif = fold(eqi);
     // if eqi was converted, update the proof to account for this
-    if (eq != eqi)
+    if (eq != eqif)
     {
-      d_trrc.ensureProofForEncodeTransform(cdp, eq, eqi);
+      d_trrc.ensureProofForEncodeTransform(cdp, eq, eqif);
     }
     return true;
   }
@@ -358,8 +375,12 @@ bool RewriteDbProofCons::proveEq(CDProof* cdp,
   {
     ++d_statTotalInputSuccess;
     Trace("rpc-debug") << "- ensure proof" << std::endl;
-    ensureProofInternal(cdp, eqi);
-    AlwaysAssert(cdp->hasStep(eqi)) << eqi;
+    if (!ensureProofInternal(cdp, eqi))
+    {
+      Trace("rpc-debug") << "- failed to ensure proof" << std::endl;
+      return false;
+    }
+    AlwaysAssert(cdp->hasStep(fold(eqi))) << eqi;
     Trace("rpc-debug") << "- finish ensure proof" << std::endl;
     return true;
   }
@@ -768,6 +789,10 @@ bool RewriteDbProofCons::proveWithRule(RewriteProofStatus id,
   {
     Assert(id == RewriteProofStatus::DSL);
     const RewriteProofRule& rpr = d_db->getRule(r);
+    // If this rule mentions an indexed operator, its instances must be folded
+    // when we construct the proof below, even if the current target does not
+    // itself contain one, since the rule may introduce one.
+    d_currFold = d_currFold || rpr.hasIndexedOperator();
     // does it conclusion match what we are trying to show?
     Node conc = rpr.getConclusion();
     Assert(conc.getKind() == Kind::EQUAL && target.getKind() == Kind::EQUAL);
@@ -1126,6 +1151,13 @@ bool RewriteDbProofCons::proveInternalBase(const Node& eqi,
 
 bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
 {
+  // Note that the equalities we traverse below (and which are the keys of
+  // d_pcache) are in the representation used by the internal search, where
+  // indexed operators may have been lifted to APPLY_INDEXED_SYMBOLIC. The
+  // proof we construct is for their folded form, hence every conclusion and
+  // premise passed to cdp below is wrapped in a call to fold. Note that fold
+  // is the identity (and does no traversal at all) unless the current call
+  // involves indexed operators, which is the common case.
   // note we could use single internal cdp to improve subproof sharing
   NodeManager* nm = nodeManager();
   std::unordered_map<TNode, bool> visited;
@@ -1152,7 +1184,7 @@ bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
       Trace("rpc-debug") << "Ensure proof for " << cur << std::endl;
       visit.push_back(cur);
       // may already have a proof rule from a previous call
-      if (cdp->hasStep(cur))
+      if (cdp->hasStep(fold(cur)))
       {
         it->second = true;
         Trace("rpc-debug") << "...already proven" << std::endl;
@@ -1166,31 +1198,33 @@ bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
           it->second = true;
           // trivial proof
           Assert(cur[0] == cur[1]);
-          cdp->addStep(cur, ProofRule::REFL, {}, {cur[0]});
+          Node fcur = fold(cur);
+          cdp->addStep(fcur, ProofRule::REFL, {}, {fcur[0]});
         }
         else if (pcur.d_id == RewriteProofStatus::EVAL)
         {
           it->second = true;
           // NOTE: this could just evaluate the equality itself
           Assert(cur.getKind() == Kind::EQUAL);
+          Node fcur = fold(cur);
           std::vector<Node> transc;
           for (size_t i = 0; i < 2; ++i)
           {
-            Node curv = doEvaluate(cur[i]);
-            if (curv == cur[i])
+            Node curv = doEvaluate(fcur[i]);
+            if (curv == fcur[i])
             {
               continue;
             }
-            Node eq = cur[i].eqNode(curv);
+            Node eq = fcur[i].eqNode(curv);
             // flip orientation for second child
-            transc.push_back(i == 1 ? curv.eqNode(cur[i]) : eq);
+            transc.push_back(i == 1 ? curv.eqNode(fcur[i]) : eq);
             // trivial evaluation, add evaluation method id
-            cdp->addStep(eq, ProofRule::EVALUATE, {}, {cur[i]});
+            cdp->addStep(eq, ProofRule::EVALUATE, {}, {fcur[i]});
           }
           if (transc.size() == 2)
           {
             // do transitivity if both sides evaluate
-            cdp->addStep(cur, ProofRule::TRANS, transc, {});
+            cdp->addStep(fcur, ProofRule::TRANS, transc, {});
           }
         }
         else
@@ -1225,18 +1259,22 @@ bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
                 Assert(d < pcur.d_subs.size());
                 rsubs.push_back(pcur.d_subs[d]);
               }
-              // get the conditions, store into premises of cur.
+              // Get the conditions, store into premises of cur. Note these
+              // are kept in their unfolded form, since they are the keys of
+              // d_pcache; they are folded when passed to cdp below.
               if (!rpr.getObligations(vs, rsubs, ps))
               {
                 DebugUnhandled() << "failed a side condition?";
                 return false;
               }
-              pfac.insert(pfac.end(), rsubs.begin(), rsubs.end());
+              // the arguments of the proof step are the folded substitution
+              std::vector<Node> frsubs = fold(rsubs);
+              pfac.insert(pfac.end(), frsubs.begin(), frsubs.end());
             }
             else
             {
               Assert(pcur.d_id == RewriteProofStatus::THEORY_REWRITE);
-              pfac.push_back(cur);
+              pfac.push_back(fold(cur));
             }
           }
           // recurse on premises
@@ -1263,15 +1301,18 @@ bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
       }
       if (status == RewriteProofStatus::TRANS)
       {
-        conc = ps[0][0].eqNode(ps.back()[1]);
-        cdp->addStep(conc, ProofRule::TRANS, ps, {});
+        conc = fold(ps[0][0].eqNode(ps.back()[1]));
+        cdp->addStep(conc, ProofRule::TRANS, fold(ps), {});
       }
       else if (status == RewriteProofStatus::CONG)
       {
+        Node fcur = fold(cur);
+        std::vector<Node> fps = fold(ps);
+        getCongPremises(cur[0], fcur[0], fps);
         // get the appropriate CONG rule
         std::vector<Node> cargs;
-        ProofRule cr = expr::getCongRule(cur[0], cargs);
-        cdp->addStep(cur, cr, ps, cargs);
+        ProofRule cr = expr::getCongRule(fcur[0], cargs);
+        cdp->addStep(fcur, cr, fps, cargs);
       }
       else if (status == RewriteProofStatus::CONG_EVAL)
       {
@@ -1282,7 +1323,8 @@ bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
         //   t1 == c1 ... tn == cn
         // The final proof is a congruence step + evaluation:
         //   (f t1 ... tn) == (f c1 ... cn) == c.
-        Node lhs = cur[0];
+        Node fcur = fold(cur);
+        Node lhs = fcur[0];
         std::vector<Node> lhsTgtc;
         if (cur[0].getMetaKind() == metakind::PARAMETERIZED)
         {
@@ -1293,41 +1335,45 @@ bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
           Assert(eq.getKind() == Kind::EQUAL);
           lhsTgtc.push_back(eq[1]);
         }
-        Node lhsTgt = nm->mkNode(cur[0].getKind(), lhsTgtc);
-        Node rhs = doEvaluate(cur[1]);
+        Node lhsTgt = fold(nm->mkNode(cur[0].getKind(), lhsTgtc));
+        Node rhs = doEvaluate(fcur[1]);
         Assert(!rhs.isNull());
         Node eq1 = lhs.eqNode(lhsTgt);
         Node eq2 = lhsTgt.eqNode(rhs);
         std::vector<Node> transChildren = {eq1, eq2};
+        std::vector<Node> fps = fold(ps);
+        getCongPremises(cur[0], lhs, fps);
         // get the appropriate CONG rule
         std::vector<Node> cargs;
         ProofRule cr = expr::getCongRule(eq1[0], cargs);
-        cdp->addStep(eq1, cr, ps, cargs);
+        cdp->addStep(eq1, cr, fps, cargs);
         cdp->addStep(eq2, ProofRule::EVALUATE, {}, {lhsTgt});
-        if (rhs != cur[1])
+        if (rhs != fcur[1])
         {
-          cdp->addStep(cur[1].eqNode(rhs), ProofRule::EVALUATE, {}, {cur[1]});
-          transChildren.push_back(rhs.eqNode(cur[1]));
+          cdp->addStep(fcur[1].eqNode(rhs), ProofRule::EVALUATE, {}, {fcur[1]});
+          transChildren.push_back(rhs.eqNode(fcur[1]));
         }
-        cdp->addStep(cur, ProofRule::TRANS, transChildren, {});
+        cdp->addStep(fcur, ProofRule::TRANS, transChildren, {});
       }
       else if (status == RewriteProofStatus::TRUE_ELIM)
       {
-        conc = ps[0][0];
-        cdp->addStep(conc, ProofRule::TRUE_ELIM, ps, {});
+        conc = fold(ps[0][0]);
+        cdp->addStep(conc, ProofRule::TRUE_ELIM, fold(ps), {});
       }
       else if (status == RewriteProofStatus::TRUE_INTRO)
       {
-        conc = ps[0].eqNode(d_true);
-        cdp->addStep(conc, ProofRule::TRUE_INTRO, ps, {});
+        conc = fold(ps[0]).eqNode(d_true);
+        cdp->addStep(conc, ProofRule::TRUE_INTRO, fold(ps), {});
       }
       else if (status == RewriteProofStatus::ABSORB)
       {
-        cdp->addStep(cur, ProofRule::ABSORB, {}, {cur});
+        Node fcur = fold(cur);
+        cdp->addStep(fcur, ProofRule::ABSORB, {}, {fcur});
       }
       else if (status == RewriteProofStatus::ACI_NORM)
       {
-        cdp->addStep(cur, ProofRule::ACI_NORM, {}, {cur});
+        Node fcur = fold(cur);
+        cdp->addStep(fcur, ProofRule::ACI_NORM, {}, {fcur});
       }
       else if (status == RewriteProofStatus::ARITH_POLY_NORM)
       {
@@ -1336,16 +1382,18 @@ bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
         bool isBitVec = (tn.isBitVector());
         ProofRule pr =
             isBitVec ? ProofRule::BV_POLY_NORM : ProofRule::ARITH_POLY_NORM;
+        Node fcur = fold(cur);
         if (pcur.d_vars.empty())
         {
-          cdp->addStep(cur, pr, {}, {cur});
+          cdp->addStep(fcur, pr, {}, {fcur});
         }
         else
         {
           ProofRule prr = isBitVec ? ProofRule::BV_POLY_NORM_EQ
                                    : ProofRule::ARITH_POLY_NORM_REL;
-          cdp->addStep(pcur.d_vars[0], pr, {}, {pcur.d_vars[0]});
-          cdp->addStep(cur, prr, {pcur.d_vars[0]}, {cur});
+          Node fp = fold(pcur.d_vars[0]);
+          cdp->addStep(fp, pr, {}, {fp});
+          cdp->addStep(fcur, prr, {fp}, {fcur});
         }
       }
       else if (status == RewriteProofStatus::DSL_FIXED_POINT)
@@ -1374,14 +1422,22 @@ bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
           Trace("rpc-debug") << "  - step: " << s << std::endl;
           // Fixed-point steps are an explicit rewrite chain. Register them as
           // pre-rewrites so they are applied in the recorded order before
-          // child rewriting changes the current redex.
-          tcpg.addRewriteStep(
-              s[0], s[1], cdp, true, TrustId::NONE, false, emptyPath ? 0 : tc);
+          // child rewriting changes the current redex. Note that no RARE rule
+          // that is applied to fixed point mentions an indexed operator, hence
+          // folding the steps does not change the path computed above.
+          Node fs = fold(s);
+          tcpg.addRewriteStep(fs[0],
+                              fs[1],
+                              cdp,
+                              true,
+                              TrustId::NONE,
+                              false,
+                              emptyPath ? 0 : tc);
           // the next rewrite should be applied at the depth that adds the
           // length of the path.
           tc += path.size();
         }
-        std::shared_ptr<ProofNode> pfn = tcpg.getProofFor(cur);
+        std::shared_ptr<ProofNode> pfn = tcpg.getProofFor(fold(cur));
         Assert(pfn != nullptr);
         cdp->addProof(pfn);
       }
@@ -1394,23 +1450,51 @@ bool RewriteDbProofCons::ensureProofInternal(CDProof* cdp, const Node& eqi)
         ProofRule pfr;
         if (status == RewriteProofStatus::DSL)
         {
+          // note the arguments are already the folded substitution
           std::vector<Node> subs(args.begin() + 1, args.end());
           const RewriteProofRule& rpr = d_db->getRule(pcur.d_dslId);
-          conc = rpr.getConclusionFor(subs);
+          conc = fold(rpr.getConclusionFor(subs));
           Trace("rpc-debug") << "Finalize proof for " << cur << std::endl;
-          Trace("rpc-debug") << "Proved: " << cur << std::endl;
+          Trace("rpc-debug") << "Proved: " << fold(cur) << std::endl;
           Trace("rpc-debug") << "From: " << conc << std::endl;
+          // If the conclusion still mentions an indexed operator, its
+          // indices did not evaluate to numeral constants and hence could not
+          // be folded. We do not construct a proof in this case, rather than
+          // emit a step whose conclusion has no counterpart in external proof
+          // formats. Note this is not expected to be possible, since indices
+          // are always numeral constants in the terms we lift, and side
+          // conditions of RARE rules compute indices that evaluate.
+          if (d_currFold
+              && expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, conc))
+          {
+            Trace("rpc-debug")
+                << "Failed to fold conclusion " << conc << std::endl;
+            return false;
+          }
           pfr = ProofRule::DSL_REWRITE;
-          cdp->addStep(conc, pfr, ps, args);
+          cdp->addStep(conc, pfr, fold(ps), args);
         }
         else
         {
           Assert(status == RewriteProofStatus::THEORY_REWRITE);
+          Node fcur = fold(cur);
+          if (fcur != cur
+              && d_env.getRewriter()->rewriteViaRule(pcur.d_dslId, fcur[0])
+                     != fcur[1])
+          {
+            // The theory rewrite no longer applies to the folded form of the
+            // conclusion. This should never happen in practice; we fail here
+            // instead of constructing a proof that mentions
+            // APPLY_INDEXED_SYMBOLIC.
+            Trace("rpc-debug") << "Failed to fold theory rewrite "
+                               << pcur.d_dslId << " for " << cur << std::endl;
+            return false;
+          }
           // Use the utility, possibly to do macro expansion.
           // We use a fresh CDProof to avoid duplicate substeps.
           CDProof cdpt(d_env);
-          d_trrc.ensureProofForTheoryRewrite(&cdpt, pcur.d_dslId, cur);
-          cdp->addProof(cdpt.getProofFor(cur));
+          d_trrc.ensureProofForTheoryRewrite(&cdpt, pcur.d_dslId, fcur);
+          cdp->addProof(cdpt.getProofFor(fcur));
         }
       }
     }
@@ -1567,6 +1651,49 @@ Node RewriteDbProofCons::rewriteConcrete(const Node& n)
     return n;
   }
   return rewrite(n);
+}
+
+Node RewriteDbProofCons::fold(const Node& n)
+{
+  if (!d_currFold)
+  {
+    // Common case: the current call does not involve indexed operators, so
+    // folding is guaranteed to be the identity. We avoid the traversal (and
+    // populating the cache of d_iofnc) entirely here.
+    return n;
+  }
+  return d_iofnc.convert(n);
+}
+
+void RewriteDbProofCons::getCongPremises(const Node& n,
+                                        const Node& fn,
+                                        std::vector<Node>& ps)
+{
+  if (n.getKind() != Kind::APPLY_INDEXED_SYMBOLIC
+      || fn.getKind() == Kind::APPLY_INDEXED_SYMBOLIC)
+  {
+    // not an application of an indexed operator, or it was not folded
+    return;
+  }
+  Assert(ps.size() == n.getNumChildren());
+  Assert(ps.size() > fn.getNumChildren());
+  // the leading premises are the (trivial) equalities between indices
+  ps.erase(ps.begin(), ps.begin() + (ps.size() - fn.getNumChildren()));
+}
+
+std::vector<Node> RewriteDbProofCons::fold(const std::vector<Node>& ns)
+{
+  if (!d_currFold)
+  {
+    return ns;
+  }
+  std::vector<Node> ret;
+  ret.reserve(ns.size());
+  for (const Node& n : ns)
+  {
+    ret.emplace_back(d_iofnc.convert(n));
+  }
+  return ret;
 }
 
 Node RewriteDbProofCons::doFlatten(const Node& n)

--- a/src/rewriter/rewrite_db_proof_cons.cpp
+++ b/src/rewriter/rewrite_db_proof_cons.cpp
@@ -163,10 +163,13 @@ bool RewriteDbProofCons::proveEqStratified(CDProof* cdp,
 {
   // Determine whether the search below may involve indexed operators that were
   // lifted to APPLY_INDEXED_SYMBOLIC. If so, the proof we construct is for the
-  // folded form of eqi, which is the form of terms used in proofs. Note this
-  // may additionally be set during the search below, if a RARE rule that
-  // mentions an indexed operator is applied.
-  d_currFold = expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, eqi);
+  // folded form of eqi, which is the form of terms used in proofs. Note that
+  // lifting is the only way such terms are introduced, hence we do not have to
+  // traverse eqi when it is the (unconverted) input equality. Note also that
+  // this flag may additionally be set during the search below, if a RARE rule
+  // that mentions an indexed operator is applied.
+  d_currFold = (eq != eqi)
+               && expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, eqi);
   bool success = false;
   // first, try the basic utility, which is run on the folded form of eqi
   Node eqif = fold(eqi);

--- a/src/rewriter/rewrite_db_proof_cons.h
+++ b/src/rewriter/rewrite_db_proof_cons.h
@@ -308,6 +308,35 @@ class RewriteDbProofCons : protected EnvObj
    * have concrete bitwidths).
    */
   Node rewriteConcrete(const Node& n);
+  /**
+   * Fold the applications of APPLY_INDEXED_SYMBOLIC in n to their concrete
+   * representation, e.g. the term denoting (extract 3 0 x) is folded to
+   * ((_ extract 3 0) x).
+   *
+   * The internal search of this class operates on terms where indexed
+   * operators are lifted to APPLY_INDEXED_SYMBOLIC, since this is required for
+   * matching against the left hand side of RARE rules. Such terms have no
+   * counterpart in external proof formats, so all conclusions are folded when
+   * the proof is constructed in ensureProofInternal.
+   *
+   * This method is a no-op (and does no traversal at all) when d_currFold is
+   * false, which is the case whenever the current call to prove does not
+   * involve indexed operators. This is the common case.
+   */
+  Node fold(const Node& n);
+  /** Fold each node in ns, see above. */
+  std::vector<Node> fold(const std::vector<Node>& ns);
+  /**
+   * Adjust the premises ps of a congruence step over n, where fn is the folded
+   * form of n. If n is an application of APPLY_INDEXED_SYMBOLIC that was folded
+   * to an ordinary application of an indexed operator, its indices are part of
+   * the operator of fn and hence are no longer arguments the congruence step is
+   * over. In this case, the premises for the indices are dropped from ps.
+   * Otherwise, this method does nothing.
+   */
+  static void getCongPremises(const Node& n,
+                              const Node& fn,
+                              std::vector<Node>& ps);
   /** Notify class for matches */
   RdpcMatchTrieNotify d_notify;
   /**
@@ -318,6 +347,13 @@ class RewriteDbProofCons : protected EnvObj
   BasicRewriteRCons d_trrc;
   /** Node converter utility */
   RewriteDbNodeConverter d_rdnc;
+  /** Node converter for folding APPLY_INDEXED_SYMBOLIC, see fold below */
+  IndexedOpFoldNodeConverter d_iofnc;
+  /**
+   * Whether the current call to prove may involve APPLY_INDEXED_SYMBOLIC, and
+   * hence whether folding is required when constructing its proof.
+   */
+  bool d_currFold;
   /** Pointer to rewrite database */
   RewriteDb* d_db;
   /** the evaluator utility */

--- a/src/rewriter/rewrite_db_term_process.cpp
+++ b/src/rewriter/rewrite_db_term_process.cpp
@@ -16,6 +16,7 @@
 #include "expr/attribute.h"
 #include "expr/dtype.h"
 #include "expr/dtype_cons.h"
+#include "expr/node_algorithm.h"
 #include "proof/conv_proof_generator.h"
 #include "theory/builtin/generic_op.h"
 #include "theory/bv/theory_bv_utils.h"
@@ -33,9 +34,10 @@ namespace cvc5::internal {
 namespace rewriter {
 
 RewriteDbNodeConverter::RewriteDbNodeConverter(NodeManager* nm,
+                                               bool liftIndexed,
                                                TConvProofGenerator* tpg,
                                                CDProof* p)
-    : NodeConverter(nm), d_tpg(tpg), d_proof(p)
+    : NodeConverter(nm), d_liftIndexed(liftIndexed), d_tpg(tpg), d_proof(p)
 {
 }
 
@@ -135,8 +137,8 @@ Node RewriteDbNodeConverter::postConvert(Node n)
       }
     }
   }
-  // convert indexed operators to symbolic
-  if (GenericOp::isNumeralIndexedOperatorKind(k))
+  // convert indexed operators to symbolic, if applicable
+  if (d_liftIndexed && GenericOp::isNumeralIndexedOperatorKind(k))
   {
     std::vector<Node> indices =
         GenericOp::getIndicesForOperator(k, n.getOperator());
@@ -198,6 +200,33 @@ void RewriteDbNodeConverter::recordProofStep(const Node& n,
   }
 }
 
+IndexedOpFoldNodeConverter::IndexedOpFoldNodeConverter(NodeManager* nm)
+    : NodeConverter(nm)
+{
+}
+
+Node IndexedOpFoldNodeConverter::postConvert(Node n)
+{
+  if (n.getKind() == Kind::APPLY_INDEXED_SYMBOLIC)
+  {
+    // note this returns n itself if the indices are not numeral constants
+    return GenericOp::getConcreteApp(n);
+  }
+  return n;
+}
+
+Node IndexedOpFoldNodeConverter::fold(NodeManager* nm, const Node& n)
+{
+  // check first, to avoid allocating the caches of the converter in the
+  // (common) case where there is nothing to fold
+  if (!expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, n))
+  {
+    return n;
+  }
+  IndexedOpFoldNodeConverter c(nm);
+  return c.convert(n);
+}
+
 ProofRewriteDbNodeConverter::ProofRewriteDbNodeConverter(Env& env)
     : EnvObj(env),
       d_wktc(Kind::INST_PATTERN_LIST),
@@ -215,7 +244,7 @@ ProofRewriteDbNodeConverter::ProofRewriteDbNodeConverter(Env& env)
 
 std::shared_ptr<ProofNode> ProofRewriteDbNodeConverter::convert(const Node& n)
 {
-  RewriteDbNodeConverter rdnc(nodeManager(), &d_tpg, &d_proof);
+  RewriteDbNodeConverter rdnc(nodeManager(), false, &d_tpg, &d_proof);
   Node nr = rdnc.convert(n);
   Node equiv = n.eqNode(nr);
   return d_tpg.getProofFor(equiv);

--- a/src/rewriter/rewrite_db_term_process.cpp
+++ b/src/rewriter/rewrite_db_term_process.cpp
@@ -16,7 +16,6 @@
 #include "expr/attribute.h"
 #include "expr/dtype.h"
 #include "expr/dtype_cons.h"
-#include "expr/node_algorithm.h"
 #include "proof/conv_proof_generator.h"
 #include "theory/builtin/generic_op.h"
 #include "theory/bv/theory_bv_utils.h"
@@ -200,6 +199,17 @@ void RewriteDbNodeConverter::recordProofStep(const Node& n,
   }
 }
 
+struct HasIndexedSymbolicTag
+{
+};
+struct HasIndexedSymbolicComputedTag
+{
+};
+/** Attribute true for terms containing APPLY_INDEXED_SYMBOLIC */
+using HasIndexedSymbolicAttr = expr::Attribute<HasIndexedSymbolicTag, bool>;
+using HasIndexedSymbolicComputedAttr =
+    expr::Attribute<HasIndexedSymbolicComputedTag, bool>;
+
 IndexedOpFoldNodeConverter::IndexedOpFoldNodeConverter(NodeManager* nm)
     : NodeConverter(nm)
 {
@@ -219,12 +229,72 @@ Node IndexedOpFoldNodeConverter::fold(NodeManager* nm, const Node& n)
 {
   // check first, to avoid allocating the caches of the converter in the
   // (common) case where there is nothing to fold
-  if (!expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, n))
+  if (!hasIndexedSymbolic(n))
   {
     return n;
   }
   IndexedOpFoldNodeConverter c(nm);
   return c.convert(n);
+}
+
+bool IndexedOpFoldNodeConverter::hasIndexedSymbolic(TNode n)
+{
+  HasIndexedSymbolicAttr hisa;
+  HasIndexedSymbolicComputedAttr hisca;
+  std::vector<TNode> visit;
+  visit.push_back(n);
+  do
+  {
+    TNode cur = visit.back();
+    if (cur.getAttribute(hisca))
+    {
+      visit.pop_back();
+      continue;
+    }
+    if (cur.getKind() == Kind::APPLY_INDEXED_SYMBOLIC)
+    {
+      visit.pop_back();
+      cur.setAttribute(hisa, true);
+      cur.setAttribute(hisca, true);
+      continue;
+    }
+    // otherwise, compute based on the operator and children, which we visit
+    // if they have not been computed yet
+    bool computed = true;
+    bool hasIs = false;
+    if (cur.hasOperator())
+    {
+      TNode op = cur.getOperator();
+      if (op.getAttribute(hisca))
+      {
+        hasIs = op.getAttribute(hisa);
+      }
+      else
+      {
+        computed = false;
+        visit.push_back(op);
+      }
+    }
+    for (TNode cn : cur)
+    {
+      if (cn.getAttribute(hisca))
+      {
+        hasIs = hasIs || cn.getAttribute(hisa);
+      }
+      else
+      {
+        computed = false;
+        visit.push_back(cn);
+      }
+    }
+    if (computed)
+    {
+      visit.pop_back();
+      cur.setAttribute(hisa, hasIs);
+      cur.setAttribute(hisca, true);
+    }
+  } while (!visit.empty());
+  return n.getAttribute(hisa);
 }
 
 ProofRewriteDbNodeConverter::ProofRewriteDbNodeConverter(Env& env)

--- a/src/rewriter/rewrite_db_term_process.h
+++ b/src/rewriter/rewrite_db_term_process.h
@@ -120,6 +120,13 @@ class IndexedOpFoldNodeConverter : public NodeConverter
    * not benefit from caching across calls.
    */
   static Node fold(NodeManager* nm, const Node& n);
+  /**
+   * Does n contain a subterm of kind APPLY_INDEXED_SYMBOLIC, i.e. is there
+   * anything to fold in n? The result of this method is cached as an attribute
+   * on n, since it is queried often on the same terms during DSL proof
+   * reconstruction.
+   */
+  static bool hasIndexedSymbolic(TNode n);
 };
 
 /** A proof producing version of the above class */

--- a/src/rewriter/rewrite_db_term_process.h
+++ b/src/rewriter/rewrite_db_term_process.h
@@ -44,6 +44,15 @@ namespace rewriter {
  * to the representation of terms required by the DSL proof reconstruction
  * algorithm.
  *
+ * Note that (3) is applied only when liftIndexed is true, which is the case
+ * for the internal search of the DSL proof reconstruction algorithm, where it
+ * is required for matching against the left hand side of RARE rules. It is
+ * *not* applied when this class is used to define the semantics of
+ * ProofRule::ENCODE_EQ_INTRO, since APPLY_INDEXED_SYMBOLIC has no counterpart
+ * in external proof formats. Instead, applications of APPLY_INDEXED_SYMBOLIC
+ * are folded back to their concrete representation (see
+ * IndexedOpFoldNodeConverter) when the proof is constructed.
+ *
  * Notice that this converter is independent of the end target proof checker,
  * and thus we do not do any target-specific processing (e.g. converting to
  * curried form).
@@ -52,10 +61,17 @@ class RewriteDbNodeConverter : public NodeConverter
 {
  public:
   /**
+   * @param nm The node manager.
+   * @param liftIndexed Whether indexed operators are lifted to
+   * APPLY_INDEXED_SYMBOLIC, see (3) above.
+   * @param tpg The proof generator, if proof producing.
+   * @param p The proof, if proof producing.
+   *
    * The latter two arguments are used internally if we are proof producing
    * via ProofRewriteDbNodeConverter.
    */
   RewriteDbNodeConverter(NodeManager* nm,
+                         bool liftIndexed = false,
                          TConvProofGenerator* tpg = nullptr,
                          CDProof* p = nullptr);
   /**
@@ -65,6 +81,8 @@ class RewriteDbNodeConverter : public NodeConverter
   Node postConvert(Node n) override;
 
  protected:
+  /** Whether we lift indexed operators to APPLY_INDEXED_SYMBOLIC */
+  bool d_liftIndexed;
   /** A pointer to a TConvProofGenerator, if proof producing */
   TConvProofGenerator* d_tpg;
   /** A CDProof, if proof producing */
@@ -73,6 +91,35 @@ class RewriteDbNodeConverter : public NodeConverter
   void recordProofStep(const Node& n, const Node& ret, ProofRule r);
   /** Should we traverse n? */
   bool shouldTraverse(Node n) override;
+};
+
+/**
+ * Folds applications of indexed operators whose indices are given as explicit
+ * arguments (APPLY_INDEXED_SYMBOLIC) to their concrete representation, e.g.
+ *   (APPLY_INDEXED_SYMBOLIC (extract) 3 0 x)
+ * is converted to
+ *   ((_ extract 3 0) x).
+ * This is the inverse of the lifting performed by RewriteDbNodeConverter, see
+ * (3) in its documentation above. Subterms whose indices do not evaluate to
+ * numeral constants are left unchanged.
+ *
+ * This class is used to map the terms occurring in the internal search of the
+ * DSL proof reconstruction algorithm back to their concrete representation,
+ * which is the representation used in proofs. It is also used to define the
+ * semantics of ProofRule::DSL_REWRITE.
+ */
+class IndexedOpFoldNodeConverter : public NodeConverter
+{
+ public:
+  IndexedOpFoldNodeConverter(NodeManager* nm);
+  /** Fold n, see class documentation above. */
+  Node postConvert(Node n) override;
+  /**
+   * Convenience method, folds n using a fresh converter. Should be used only
+   * when a persistent instance of this class is not available, since it does
+   * not benefit from caching across calls.
+   */
+  static Node fold(NodeManager* nm, const Node& n);
 };
 
 /** A proof producing version of the above class */

--- a/src/rewriter/rewrite_proof_rule.cpp
+++ b/src/rewriter/rewrite_proof_rule.cpp
@@ -24,7 +24,10 @@ using namespace cvc5::internal::kind;
 namespace cvc5::internal {
 namespace rewriter {
 
-RewriteProofRule::RewriteProofRule() : d_id(ProofRewriteRule::NONE) {}
+RewriteProofRule::RewriteProofRule()
+    : d_id(ProofRewriteRule::NONE), d_hasIndexedOp(false)
+{
+}
 
 void RewriteProofRule::init(ProofRewriteRule id,
                             const std::vector<Node>& userFvs,
@@ -106,6 +109,19 @@ void RewriteProofRule::init(ProofRewriteRule id,
                     << v;
       }
     }
+  }
+
+  // Determine whether this rule mentions an indexed operator whose indices are
+  // given as explicit arguments. If so, its instances must be folded when
+  // constructing proofs, see RewriteDbProofCons::fold.
+  d_hasIndexedOp =
+      expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, d_conc)
+      || (!d_context.isNull()
+          && expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, d_context));
+  for (const Node& c : d_cond)
+  {
+    d_hasIndexedOp = d_hasIndexedOp
+                     || expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, c);
   }
 
   d_numFv = fvs.size();
@@ -190,6 +206,8 @@ Kind RewriteProofRule::getListContext(Node v) const
   }
   return Kind::UNDEFINED_KIND;
 }
+bool RewriteProofRule::hasIndexedOperator() const { return d_hasIndexedOp; }
+
 bool RewriteProofRule::hasConditions() const { return !d_cond.empty(); }
 
 const std::vector<Node>& RewriteProofRule::getConditions() const

--- a/src/rewriter/rewrite_proof_rule.cpp
+++ b/src/rewriter/rewrite_proof_rule.cpp
@@ -18,6 +18,7 @@
 #include "expr/nary_term_util.h"
 #include "expr/node_algorithm.h"
 #include "proof/proof_checker.h"
+#include "rewriter/rewrite_db_term_process.h"
 
 using namespace cvc5::internal::kind;
 
@@ -115,13 +116,13 @@ void RewriteProofRule::init(ProofRewriteRule id,
   // given as explicit arguments. If so, its instances must be folded when
   // constructing proofs, see RewriteDbProofCons::fold.
   d_hasIndexedOp =
-      expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, d_conc)
+      IndexedOpFoldNodeConverter::hasIndexedSymbolic(d_conc)
       || (!d_context.isNull()
-          && expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, d_context));
+          && IndexedOpFoldNodeConverter::hasIndexedSymbolic(d_context));
   for (const Node& c : d_cond)
   {
     d_hasIndexedOp =
-        d_hasIndexedOp || expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, c);
+        d_hasIndexedOp || IndexedOpFoldNodeConverter::hasIndexedSymbolic(c);
   }
 
   d_numFv = fvs.size();

--- a/src/rewriter/rewrite_proof_rule.cpp
+++ b/src/rewriter/rewrite_proof_rule.cpp
@@ -120,8 +120,8 @@ void RewriteProofRule::init(ProofRewriteRule id,
           && expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, d_context));
   for (const Node& c : d_cond)
   {
-    d_hasIndexedOp = d_hasIndexedOp
-                     || expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, c);
+    d_hasIndexedOp =
+        d_hasIndexedOp || expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, c);
   }
 
   d_numFv = fvs.size();

--- a/src/rewriter/rewrite_proof_rule.h
+++ b/src/rewriter/rewrite_proof_rule.h
@@ -86,6 +86,13 @@ class RewriteProofRule
    * d_context is (lambda x (f a (g x b))), then d_pathToCtx = [1,0].
    */
   const std::vector<size_t> getPathToContextVar() const { return d_pathToCtx; }
+  /**
+   * Does the statement of this rule mention an indexed operator whose indices
+   * are given as explicit arguments (APPLY_INDEXED_SYMBOLIC)? If so, instances
+   * of this rule must be folded when constructing proofs, since such terms
+   * have no counterpart in external proof formats.
+   */
+  bool hasIndexedOperator() const;
   /** Does this rule have conditions? */
   bool hasConditions() const;
   /** Get (declared) conditions */
@@ -205,6 +212,8 @@ class RewriteProofRule
   std::vector<Node> d_fvs;
   /** number of free variables */
   size_t d_numFv;
+  /** Whether this rule mentions an indexed operator, see above */
+  bool d_hasIndexedOp;
   /**
    * The free variables that do not occur in the conditions. These cannot be
    * "holes" in a proof.

--- a/src/smt/proof_final_callback.cpp
+++ b/src/smt/proof_final_callback.cpp
@@ -13,7 +13,6 @@
 #include "smt/proof_final_callback.h"
 
 #include "expr/node_algorithm.h"
-
 #include "expr/skolem_manager.h"
 #include "options/base_options.h"
 #include "options/proof_options.h"

--- a/src/smt/proof_final_callback.cpp
+++ b/src/smt/proof_final_callback.cpp
@@ -12,6 +12,8 @@
 
 #include "smt/proof_final_callback.h"
 
+#include "expr/node_algorithm.h"
+
 #include "expr/skolem_manager.h"
 #include "options/base_options.h"
 #include "options/proof_options.h"
@@ -81,6 +83,11 @@ void ProofFinalCallback::finalize(std::shared_ptr<ProofNode> pn)
   ProofRule r = pn->getRule();
   ProofNodeManager* pnm = d_env.getProofNodeManager();
   Assert(pnm != nullptr);
+  // TEMPORARY DEBUG CHECK
+  if (expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, pn->getResult()))
+  {
+    std::cout << "AIS-IN-PROOF " << r << " : " << pn->getResult() << std::endl;
+  }
   // if not doing eager pedantic checking, fail if below threshold
   if (options().proof.proofCheck != options::ProofCheckMode::EAGER)
   {

--- a/src/smt/proof_final_callback.cpp
+++ b/src/smt/proof_final_callback.cpp
@@ -82,8 +82,9 @@ void ProofFinalCallback::finalize(std::shared_ptr<ProofNode> pn)
   ProofRule r = pn->getRule();
   ProofNodeManager* pnm = d_env.getProofNodeManager();
   Assert(pnm != nullptr);
-  // APPLY_INDEXED_SYMBOLIC should only be used internally during RARE reconstruction
-  Assert (!expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, pn->getResult()));
+  // APPLY_INDEXED_SYMBOLIC should only be used internally during RARE
+  // reconstruction
+  Assert(!expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, pn->getResult()));
   // if not doing eager pedantic checking, fail if below threshold
   if (options().proof.proofCheck != options::ProofCheckMode::EAGER)
   {

--- a/src/smt/proof_final_callback.cpp
+++ b/src/smt/proof_final_callback.cpp
@@ -12,13 +12,13 @@
 
 #include "smt/proof_final_callback.h"
 
-#include "expr/node_algorithm.h"
 #include "expr/skolem_manager.h"
 #include "options/base_options.h"
 #include "options/proof_options.h"
 #include "proof/eo/eo_printer.h"
 #include "proof/proof_checker.h"
 #include "proof/proof_node_manager.h"
+#include "rewriter/rewrite_db_term_process.h"
 #include "rewriter/rewrite_proof_rule.h"
 #include "smt/env.h"
 #include "smt/set_defaults.h"
@@ -84,7 +84,8 @@ void ProofFinalCallback::finalize(std::shared_ptr<ProofNode> pn)
   Assert(pnm != nullptr);
   // APPLY_INDEXED_SYMBOLIC should only be used internally during RARE
   // reconstruction
-  Assert(!expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, pn->getResult()));
+  Assert(!rewriter::IndexedOpFoldNodeConverter::hasIndexedSymbolic(
+      pn->getResult()));
   // if not doing eager pedantic checking, fail if below threshold
   if (options().proof.proofCheck != options::ProofCheckMode::EAGER)
   {

--- a/src/smt/proof_final_callback.cpp
+++ b/src/smt/proof_final_callback.cpp
@@ -82,11 +82,8 @@ void ProofFinalCallback::finalize(std::shared_ptr<ProofNode> pn)
   ProofRule r = pn->getRule();
   ProofNodeManager* pnm = d_env.getProofNodeManager();
   Assert(pnm != nullptr);
-  // TEMPORARY DEBUG CHECK
-  if (expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, pn->getResult()))
-  {
-    std::cout << "AIS-IN-PROOF " << r << " : " << pn->getResult() << std::endl;
-  }
+  // APPLY_INDEXED_SYMBOLIC should only be used internally during RARE reconstruction
+  Assert (!expr::hasSubtermKind(Kind::APPLY_INDEXED_SYMBOLIC, pn->getResult()));
   // if not doing eager pedantic checking, fail if below threshold
   if (options().proof.proofCheck != options::ProofCheckMode::EAGER)
   {

--- a/src/theory/builtin/proof_checker.cpp
+++ b/src/theory/builtin/proof_checker.cpp
@@ -490,7 +490,6 @@ Node BuiltinProofRuleChecker::checkInternal(ProofRule id,
     // Note that we fold applications of indexed operators whose indices are
     // given as explicit arguments, which is a no-op for the (common) case of
     // rules that do not mention indexed operators.
-    NodeManager* nm = nodeManager();
     for (size_t i = 0, nchildren = children.size(); i < nchildren; i++)
     {
       Node scond = expr::narySubstitute(conds[i], varList, subs);

--- a/src/theory/builtin/proof_checker.cpp
+++ b/src/theory/builtin/proof_checker.cpp
@@ -487,15 +487,21 @@ Node BuiltinProofRuleChecker::checkInternal(ProofRule id,
     {
       return Node::null();
     }
+    // Note that we fold applications of indexed operators whose indices are
+    // given as explicit arguments, which is a no-op for the (common) case of
+    // rules that do not mention indexed operators.
+    NodeManager* nm = nodeManager();
     for (size_t i = 0, nchildren = children.size(); i < nchildren; i++)
     {
       Node scond = expr::narySubstitute(conds[i], varList, subs);
+      scond = rewriter::IndexedOpFoldNodeConverter::fold(nm, scond);
       if (scond != children[i])
       {
         return Node::null();
       }
     }
-    return rpr.getConclusionFor(subs);
+    Node conc = rpr.getConclusionFor(subs);
+    return rewriter::IndexedOpFoldNodeConverter::fold(nm, conc);
   }
   else if (id == ProofRule::THEORY_REWRITE)
   {


### PR DESCRIPTION
Current terms with the internal-only kind APPLY_INDEXED_SYMBOLIC are exported into proof terms in our API, based on the semantics of ENCODE_PRED_TRANSFORM/DSL_REWRITE.

Instead of exporting this operator in our API, this modifies RARE to eliminate these terms immediately during proof reconstruction.

In detail, the existing lifting to APPLY_INDEXED_SYMBOLIC is kept, so that the RARE algorithm can continue to run as is. Recall here that APPLY_INDEXED_SYMBOLIC is introduced to have a uniform view of terms where index positions can be matched upon.

However, we now provide a second variant of the semantics which instantiates APPLY_INDEXED_SYMBOLIC terms to their concrete versions, which is guaranteed to be complete: we never allow terms with truly symbolic indices in proofs (i.e. `(_ extract s t)` for symbolic `s,t`) already.

This has two advantages:
- Internal-only terms do not escape to the proof API,
- Proofs are now smaller as they require fewer ENCODE_PRED_TRANSFORM steps.

This has no impact on SMT-LIB logics without bitvectors/FP.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>