### PR TITLE
Fixed install dir for dependent projects.

### DIFF
--- a/cmake/FindCryptoMiniSat.cmake
+++ b/cmake/FindCryptoMiniSat.cmake
@@ -49,6 +49,7 @@ if(NOT CryptoMiniSat_FOUND_SYSTEM)
     CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
                # make sure not to register with cmake
                -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON
+               -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
                -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
                -DENABLE_ASSERTIONS=OFF

--- a/cmake/FindGTest.cmake
+++ b/cmake/FindGTest.cmake
@@ -61,6 +61,7 @@ if(NOT GTest_FOUND_SYSTEM)
         DOWNLOAD_NAME gtest.tar.gz
         CMAKE_ARGS
           -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+          -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
           -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
         BUILD_COMMAND ${CMAKE_COMMAND} --build .
             --config ${CMAKE_BUILD_TYPE} --target gtest


### PR DESCRIPTION
The dependent projects cryptominisat and gtests will do their own installation directory resolution based on the global cmake install dir variable. On some special install prefix, like `--prefix=/`, this will lead to unexpected rewriting of the install directory based on the distribution and the Linux file system structure rules. This will make the cvc5 build fail, as `CryptoMiniSat_LIBRARIES` and `GTest_LIBRARIES` expect the directory without rewriting. By explicitly setting `-DCMAKE_INSTALL_LIBDIR` for the dependent project's cmake fixes any unintended rewriting.