### PR TITLE
Optimizations for get-value

### DIFF
--- a/src/smt/expand_definitions.cpp
+++ b/src/smt/expand_definitions.cpp
@@ -32,6 +32,11 @@ ExpandDefs::ExpandDefs(Env& env) : EnvObj(env) {}
 
 ExpandDefs::~ExpandDefs() {}
 
+Node ExpandDefs::expandDefinitions(TNode n)
+{
+  return expandDefinitions(n, d_cache);
+}
+
 Node ExpandDefs::expandDefinitions(TNode n,
                                    std::unordered_map<Node, Node>& cache)
 {

--- a/src/smt/expand_definitions.h
+++ b/src/smt/expand_definitions.h
@@ -42,13 +42,31 @@ class ExpandDefs : protected EnvObj
   ExpandDefs(Env& env);
   ~ExpandDefs();
   /**
-   * Expand definitions in term n. Return the expanded form of n.
+   * Expand definitions in term n, using the cache owned by this class.
+   *
+   * Note that the expanded form of a term is a function of the term itself and
+   * the theory rewriters of this environment only. In particular, it does not
+   * depend on the current assertions, the top-level substitutions, or the
+   * user context. It is thus safe to maintain this cache for the lifetime of
+   * this object, e.g. across (incremental) calls to check-sat and across
+   * user-context push/pop.
+   *
+   * @param n The node to expand
+   * @return The expanded term.
+   */
+  Node expandDefinitions(TNode n);
+  /**
+   * Same as above, where the caller provides the cache of previous results.
    *
    * @param n The node to expand
    * @param cache Cache of previous results
    * @return The expanded term.
    */
   Node expandDefinitions(TNode n, std::unordered_map<Node, Node>& cache);
+
+ private:
+  /** The cache used by the method above that takes no cache argument */
+  std::unordered_map<Node, Node> d_cache;
 };
 
 }  // namespace smt

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -107,6 +107,7 @@ SolverEngine::SolverEngine(NodeManager* nm, const Options* optr)
       d_smtSolver(nullptr),
       d_smtDriver(nullptr),
       d_checkModels(nullptr),
+      d_expDef(nullptr),
       d_pfManager(nullptr),
       d_ucManager(nullptr),
       d_sygusSolver(nullptr),
@@ -125,6 +126,8 @@ SolverEngine::SolverEngine(NodeManager* nm, const Options* optr)
   d_stats.reset(new SolverEngineStatistics(d_env->getStatisticsRegistry()));
   // make the SMT solver
   d_smtSolver.reset(new SmtSolver(*d_env, *d_stats));
+  // make the expand definitions utility, used for getting model values
+  d_expDef.reset(new ExpandDefs(*d_env.get()));
   // make the context manager
   d_ctxManager.reset(new ContextManager(*d_env.get(), *d_state));
   // make the SyGuS solver
@@ -1239,12 +1242,19 @@ Node SolverEngine::getValue(const Node& t, bool fromUser)
   // a division-by-zero term, we require getting the appropriate skolem
   // function corresponding to division-by-zero which may have been used during
   // the previous satisfiability check.
-  std::unordered_map<Node, Node> cache;
-  ExpandDefs expDef(*d_env.get());
+  //
+  // Note that each of the three steps below (substitution, expand definitions,
+  // rewriting) is cached by the utility that implements it, where each such
+  // cache is invalidated when the state it depends on changes. In particular,
+  // d_expDef maintains its cache for the lifetime of this solver engine, since
+  // expanded forms do not depend on the current assertions. This makes
+  // repeated calls to get-value on the same term (e.g. when enumerating
+  // models) constant time in the size of that term.
+  //
   // Must apply substitutions first to ensure we expand definitions in the
   // solved form of t as well.
   Node n = d_smtSolver->getPreprocessor()->applySubstitutions(t);
-  n = expDef.expandDefinitions(n, cache);
+  n = d_expDef->expandDefinitions(n);
 
   Trace("smt") << "--- getting value of " << n << endl;
   // There are two ways model values for terms are computed (for historical
@@ -1262,7 +1272,36 @@ Node SolverEngine::getValue(const Node& t, bool fromUser)
   Trace("smt") << "--- getting value of " << n << endl;
   TheoryModel* m = getAvailableModel("get-value");
   Assert(m != nullptr);
-  Node resultNode = m->getValue(n);
+  Node resultNode;
+  // Fast path: if n is a Boolean term that the prop engine already has a SAT
+  // literal for, and that literal has a value on the current SAT trail, then
+  // that value is its value in the model. This is since the model is
+  // constructed to satisfy the literals that were asserted to the theories,
+  // which are those of the trail, and since the values of Boolean variables in
+  // the model are read directly from the SAT solver, see
+  // ModelManager::collectModelBooleanVariables. Taking this path avoids
+  // evaluating n in the model, which is linear in the size of n and which must
+  // be redone after each satisfiability check.
+  //
+  // Note that we do not call PropEngine::ensureLiteral here: get-value must not
+  // add literals or clauses to the SAT solver. We also require that we are in
+  // SAT mode, since in SAT_UNKNOWN mode the available model may have been
+  // generated for a last call check, after which the SAT solver may have
+  // backtracked, in which case the trail does not correspond to the model.
+  bool bvalue;
+  prop::PropEngine* pe = d_smtSolver->getPropEngine();
+  if (expectedType.isBoolean() && d_state->getMode() == SmtMode::SAT
+      && pe->isSatLiteral(n) && pe->hasValue(n, bvalue))
+  {
+    resultNode = d_env->getNodeManager()->mkConst(bvalue);
+    Assert(resultNode == m->getValue(n))
+        << "Value of " << n << " on the SAT trail is " << resultNode
+        << ", but its value in the model is " << m->getValue(n);
+  }
+  else
+  {
+    resultNode = m->getValue(n);
+  }
   Trace("smt") << "--- got value " << n << " = " << resultNode << endl;
   Trace("smt") << "--- type " << resultNode.getType() << endl;
   Trace("smt") << "--- expected type " << expectedType << endl;

--- a/src/smt/solver_engine.cpp
+++ b/src/smt/solver_engine.cpp
@@ -663,7 +663,7 @@ void SolverEngine::defineFunctionRec(Node func,
   defineFunctionsRec(funcs, formals_multi, formulas, global);
 }
 
-TheoryModel* SolverEngine::getAvailableModel(const char* c) const
+void SolverEngine::checkModelAvailable(const char* c) const
 {
   if (!d_env->getOptions().theory.assignFunctionValues)
   {
@@ -687,6 +687,11 @@ TheoryModel* SolverEngine::getAvailableModel(const char* c) const
     ss << "Cannot " << c << " when produce-models options is off.";
     throw ModalException(ss.str().c_str());
   }
+}
+
+TheoryModel* SolverEngine::getAvailableModel(const char* c) const
+{
+  checkModelAvailable(c);
   TheoryEngine* te = d_smtSolver->getTheoryEngine();
   Assert(te != nullptr);
   // If the solver is in UNKNOWN mode, we use the latest available model (e.g.,
@@ -1269,39 +1274,53 @@ Node SolverEngine::getValue(const Node& t, bool fromUser)
     n = d_env->getRewriter()->rewrite(n);
   }
 
-  Trace("smt") << "--- getting value of " << n << endl;
-  TheoryModel* m = getAvailableModel("get-value");
-  Assert(m != nullptr);
-  Node resultNode;
   // Fast path: if n is a Boolean term that the prop engine already has a SAT
   // literal for, and that literal has a value on the current SAT trail, then
   // that value is its value in the model. This is since the model is
   // constructed to satisfy the literals that were asserted to the theories,
   // which are those of the trail, and since the values of Boolean variables in
   // the model are read directly from the SAT solver, see
-  // ModelManager::collectModelBooleanVariables. Taking this path avoids
-  // evaluating n in the model, which is linear in the size of n and which must
-  // be redone after each satisfiability check.
+  // ModelManager::collectModelBooleanVariables.
   //
-  // Note that we do not call PropEngine::ensureLiteral here: get-value must not
-  // add literals or clauses to the SAT solver. We also require that we are in
-  // SAT mode, since in SAT_UNKNOWN mode the available model may have been
-  // generated for a last call check, after which the SAT solver may have
+  // Taking this path means we do not build the theory model at all, which is
+  // the main motivation for it: a caller that repeatedly checks satisfiability
+  // and reads the values of literals of the input (e.g. to compute an
+  // implicant or to add a blocking clause) never pays for model construction.
+  //
+  // We are conservative in the conditions under which we do this:
+  // (1) We require SAT mode. In SAT_UNKNOWN mode the available model may have
+  // been generated for a last call check, after which the SAT solver may have
   // backtracked, in which case the trail does not correspond to the model.
+  // (2) We require that model cores are not being computed, since these are
+  // computed as a side effect of getting the model in getAvailableModel.
+  // (3) We do not call PropEngine::ensureLiteral, that is, we only take this
+  // path for terms that already have a SAT literal. Getting a value should not
+  // add literals or clauses to the SAT solver.
+  // Note that we still check that a model is available, so that the exceptions
+  // thrown by this method do not depend on which path is taken.
   bool bvalue;
   prop::PropEngine* pe = d_smtSolver->getPropEngine();
   if (expectedType.isBoolean() && d_state->getMode() == SmtMode::SAT
+      && d_env->getOptions().smt.modelCoresMode == options::ModelCoresMode::NONE
       && pe->isSatLiteral(n) && pe->hasValue(n, bvalue))
   {
-    resultNode = d_env->getNodeManager()->mkConst(bvalue);
-    Assert(resultNode == m->getValue(n))
-        << "Value of " << n << " on the SAT trail is " << resultNode
-        << ", but its value in the model is " << m->getValue(n);
+    checkModelAvailable("get-value");
+    Node bret = d_env->getNodeManager()->mkConst(bvalue);
+    Trace("smt") << "--- got value " << n << " = " << bret
+                 << " (from SAT trail)" << endl;
+    // Check that this agrees with the value the model would give. Note this
+    // builds the model, hence we only do this when assertions are enabled.
+    Assert(bret == getAvailableModel("get-value")->getValue(n))
+        << "Value of " << n << " on the SAT trail is " << bret
+        << ", but its value in the model is "
+        << getAvailableModel("get-value")->getValue(n);
+    return bret;
   }
-  else
-  {
-    resultNode = m->getValue(n);
-  }
+
+  Trace("smt") << "--- getting value of " << n << endl;
+  TheoryModel* m = getAvailableModel("get-value");
+  Assert(m != nullptr);
+  Node resultNode = m->getValue(n);
   Trace("smt") << "--- got value " << n << " = " << resultNode << endl;
   Trace("smt") << "--- type " << resultNode.getType() << endl;
   Trace("smt") << "--- expected type " << expectedType << endl;

--- a/src/smt/solver_engine.h
+++ b/src/smt/solver_engine.h
@@ -971,6 +971,17 @@ class CVC5_EXPORT SolverEngine
    */
   theory::TheoryModel* getAvailableModel(const char* c) const;
   /**
+   * Check that a model is available, i.e. that cvc5 is producing models and is
+   * in "SAT mode", otherwise throw a (recoverable) exception. This is the
+   * portion of getAvailableModel that does not require the theory model to
+   * have been built. It is used by get-value in cases where the value of a
+   * term can be determined without building a model, see getValue.
+   *
+   * @param c used for giving an error message to indicate the context
+   * this method was called.
+   */
+  void checkModelAvailable(const char* c) const;
+  /**
    * Get the available proof, which is that of the prop engine if SAT
    * proof producing, or else a dummy proof SAT_REFUTATION whose assumptions
    * are the preprocessed input formulas.

--- a/src/smt/solver_engine.h
+++ b/src/smt/solver_engine.h
@@ -60,6 +60,7 @@ class ContextManager;
 class SolverEngineState;
 class ResourceOutListener;
 class CheckModels;
+class ExpandDefs;
 /** Subsolvers */
 class SmtSolver;
 class SmtDriver;
@@ -1092,6 +1093,14 @@ class CVC5_EXPORT SolverEngine
    * The utility used for checking models
    */
   std::unique_ptr<smt::CheckModels> d_checkModels;
+
+  /**
+   * The utility used for expanding definitions, which is used when getting
+   * model values. Note this object maintains a cache of expanded forms that
+   * is valid for the lifetime of this solver engine, see
+   * ExpandDefs::expandDefinitions.
+   */
+  std::unique_ptr<smt::ExpandDefs> d_expDef;
 
   /**
    * The proof manager, which manages all things related to checking,


### PR DESCRIPTION
This adds two optimizations for get-value:
(1) we maintain a global cache for the expand definitions utility that is run on all terms passed to getValue.
(2) we consult the SAT solver directly if the term we are asking for is a SAT literal.

The former is a clear win and makes a noticeable difference on benchmarks where get-value dominates run time. The second is a bit more limited, but should also be a clear win for performance.