### PR TITLE
Fix ouroborous C API test for strict C11 compilation

### DIFF
--- a/test/api/c/ouroborous.c
+++ b/test/api/c/ouroborous.c
@@ -29,6 +29,21 @@
 #include <stdlib.h>
 #include <string.h>
 
+/**
+ * Return a heap-allocated copy of the given string.
+ * @note We do not use strdup() here since it is not part of the C11
+ *       standard (it is POSIX / C23), and this file is compiled with
+ *       -std=c11.
+ */
+static char* copy_string(const char* str)
+{
+  size_t len = strlen(str) + 1;
+  char* res = malloc(len);
+  assert(res);
+  memcpy(res, str, len);
+  return res;
+}
+
 char* parse(const char* instr, const char* inlang, const char* outlang)
 {
   assert(strcmp(inlang, "smt2") == 0);
@@ -73,7 +88,7 @@ char* parse(const char* instr, const char* inlang, const char* outlang)
   const char* error_msg;
   Cvc5Term e = cvc5_parser_next_term(parser, &error_msg);
   assert(!error_msg);
-  char* s = strdup(cvc5_term_to_string(e));
+  char* s = copy_string(cvc5_term_to_string(e));
   assert(!cvc5_parser_next_term(parser, &error_msg));
   assert(!error_msg);
   cvc5_parser_delete(parser);


### PR DESCRIPTION
The `ouroborous` C API test uses `strdup()`, which is not part of C11 (it is POSIX / C23) and thus not declared when compiling with `-std=c11` (the project sets `CMAKE_C_STANDARD 11` with `CMAKE_C_EXTENSIONS OFF`). Older compilers only warn about the implicit declaration, but GCC 14+ treats it as an error, which breaks the build of this test:

```
test/api/c/ouroborous.c:76:13: error: implicit declaration of function 'strdup'; did you mean 'strcmp'? [-Wimplicit-function-declaration]
test/api/c/ouroborous.c:76:13: error: initialization of 'char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
```

This replaces `strdup()` with a small local helper based on `malloc`/`memcpy`. Verified by compiling with `gcc -std=c11 -Werror=implicit-function-declaration` and running the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)