### PR TITLE
Fix memory management issues in the C API

### DIFF
--- a/examples/api/c/parser.c
+++ b/examples/api/c/parser.c
@@ -57,6 +57,7 @@ int main()
   Cvc5Result r = cvc5_check_sat(slv);
   printf("expected: unsat\n");
   printf("result: %s\n", cvc5_result_to_string(r));
+  cvc5_parser_delete(parser);
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
 }

--- a/examples/api/c/parser_sym_manager.c
+++ b/examples/api/c/parser_sym_manager.c
@@ -70,6 +70,9 @@ int main()
   } while (t);
   printf("Finished parsing terms\n");
 
+  cvc5_parser_delete(parser2);
+  cvc5_parser_delete(parser1);
+  cvc5_symbol_manager_delete(sm);
   cvc5_delete(slv);
   cvc5_term_manager_delete(tm);
 }

--- a/src/api/c/cvc5_c_structs.cpp
+++ b/src/api/c/cvc5_c_structs.cpp
@@ -333,6 +333,7 @@ void Cvc5TermManager::release()
 {
   d_alloc_sorts.clear();
   d_alloc_terms.clear();
+  d_alloc_ops.clear();
   d_alloc_dts.clear();
   d_alloc_dt_conss.clear();
   d_alloc_dt_sels.clear();
@@ -441,12 +442,10 @@ cvc5_proof_t* Cvc5::copy(cvc5_proof_t* proof)
 
 Cvc5Grammar Cvc5::export_grammar(const cvc5::Grammar& grammar)
 {
-  auto [it, inserted] = d_alloc_grammars.try_emplace(grammar, this, grammar);
-  if (!inserted)
-  {
-    copy(&it->second);
-  }
-  return &it->second;
+  auto g = std::make_unique<cvc5_grammar_t>(this, grammar);
+  cvc5_grammar_t* res = g.get();
+  d_alloc_grammars.emplace(res, std::move(g));
+  return res;
 }
 
 void Cvc5::release(cvc5_grammar_t* grammar)
@@ -454,8 +453,8 @@ void Cvc5::release(cvc5_grammar_t* grammar)
   grammar->d_refs -= 1;
   if (grammar->d_refs == 0)
   {
-    Assert(d_alloc_grammars.find(grammar->d_grammar) != d_alloc_grammars.end());
-    d_alloc_grammars.erase(grammar->d_grammar);
+    Assert(d_alloc_grammars.find(grammar) != d_alloc_grammars.end());
+    d_alloc_grammars.erase(grammar);
   }
 }
 

--- a/src/api/c/cvc5_c_structs.h
+++ b/src/api/c/cvc5_c_structs.h
@@ -18,7 +18,9 @@ extern "C" {
 }
 #include <cvc5/cvc5.h>
 
+#include <deque>
 #include <fstream>
+#include <memory>
 
 /* -------------------------------------------------------------------------- */
 /* Wrapper structs (associated with Cvc5TermManager)                          */
@@ -179,6 +181,54 @@ struct cvc5_dt_cons_decl_t
   uint32_t d_refs = 1;
   /** The associated term manager. */
   Cvc5TermManager* d_tm = nullptr;
+};
+
+/*
+ * Note: the statistic(s) wrappers must be complete types before the
+ * definition of Cvc5TermManager below, which stores them in a std::deque
+ * (which, unlike std::vector, does not support incomplete element types
+ * with all standard library implementations, e.g., libc++).
+ */
+/** Wrapper for cvc5 C++ statistic. */
+struct cvc5_stat_t
+{
+  /**
+   * Constructor.
+   * @param tm     The associated term manager instance.
+   * @param stat   The wrapped C++ statistic.
+   */
+  cvc5_stat_t(Cvc5TermManager* tm, const cvc5::Stat& stat)
+      : d_stat(stat), d_tm(tm)
+  {
+  }
+  /** The wrapped C++ statistic. */
+  cvc5::Stat d_stat;
+  /** External refs count. */
+  uint32_t d_refs = 1;
+  /** The associated term manager instance. */
+  Cvc5TermManager* d_tm = nullptr;
+};
+
+/** Wrapper for cvc5 C++ statistics. */
+struct cvc5_stats_t
+{
+  /**
+   * Constructor.
+   * @param tm     The associated term manager instance.
+   * @param stat   The wrapped C++ statistics.
+   */
+  cvc5_stats_t(Cvc5TermManager* tm, const cvc5::Statistics& stat)
+      : d_stat(stat), d_tm(tm)
+  {
+  }
+  /** The wrapped C++ statistics. */
+  cvc5::Statistics d_stat;
+  /** External refs count. */
+  uint32_t d_refs = 1;
+  /** The associated term manager instance. */
+  Cvc5TermManager* d_tm = nullptr;
+  /** The associated iterator. */
+  std::unique_ptr<cvc5::Statistics::iterator> d_iter = nullptr;
 };
 
 /**
@@ -369,10 +419,17 @@ struct CVC5_EXPORT Cvc5TermManager
   /** Cache of allocated datatype constructor declarations. */
   std::unordered_map<cvc5::DatatypeConstructorDecl, cvc5_dt_cons_decl_t>
       d_alloc_dt_cons_decls;
-  /** Cache of allocated statistic objects. */
-  std::vector<cvc5_stat_t> d_alloc_stats;
-  /** Cache of allocated statistics objects. */
-  std::vector<cvc5_stats_t> d_alloc_statistics;
+  /**
+   * Cache of allocated statistic objects.
+   * @note We use a deque here to ensure that pointers to its elements remain
+   *       valid on insertion.
+   */
+  std::deque<cvc5_stat_t> d_alloc_stats;
+  /**
+   * Cache of allocated statistics objects.
+   * @note See `d_alloc_stats`.
+   */
+  std::deque<cvc5_stats_t> d_alloc_statistics;
 };
 
 /* -------------------------------------------------------------------------- */
@@ -555,8 +612,16 @@ struct Cvc5
       d_alloc_synth_results;
   /** Cache of allocated proofs. */
   std::unordered_map<cvc5::Proof, cvc5_proof_t> d_alloc_proofs;
-  /** Cache of allocated grammars. */
-  std::unordered_map<cvc5::Grammar, cvc5_grammar_t> d_alloc_grammars;
+  /**
+   * Cache of allocated grammars.
+   * @note Grammars are mutable (rules can be added after creation) and their
+   *       hash depends on their content. We thus can not use the grammar as
+   *       key (as for the other objects above) but key the cache on the
+   *       allocated wrapper object. Grammars are never exported more than
+   *       once, so we do not lose anything here.
+   */
+  std::unordered_map<cvc5_grammar_t*, std::unique_ptr<cvc5_grammar_t>>
+      d_alloc_grammars;
   /** Out file stream for output tag (configured via `cvc5_get_output()`. */
   std::ofstream d_output_tag_file_stream;
   /**
@@ -590,66 +655,6 @@ struct Cvc5
     Cvc5Plugin* d_plugin;
   };
   std::unique_ptr<PluginCpp> d_plugin = nullptr;
-};
-
-/** Wrapper for cvc5 C++ statistic. */
-struct cvc5_stat_t
-{
-  /**
-   * Constructor.
-   * @param tm     The associated term manager instance.
-   * @param result The wrapped C++ statistic.
-   */
-  cvc5_stat_t(Cvc5TermManager* tm, const cvc5::Stat& stat)
-      : d_stat(stat), d_tm(tm)
-  {
-  }
-  /**
-   * Constructor.
-   * @param cvc5   The associated solver instance.
-   * @param result The wrapped C++ statistic.
-   */
-  cvc5_stat_t(Cvc5* cvc5, const cvc5::Stat& stat)
-      : d_stat(stat), d_tm(cvc5->d_tm)
-  {
-  }
-  /** The wrapped C++ statistic. */
-  cvc5::Stat d_stat;
-  /** External refs count. */
-  uint32_t d_refs = 1;
-  /** The associated term manager instance. */
-  Cvc5TermManager* d_tm = nullptr;
-};
-
-/** Wrapper for cvc5 C++ statistics. */
-struct cvc5_stats_t
-{
-  /**
-   * Constructor.
-   * @param tm     The associated term manager instance.
-   * @param result The wrapped C++ statistics.
-   */
-  cvc5_stats_t(Cvc5TermManager* tm, const cvc5::Statistics& stat)
-      : d_stat(stat), d_tm(tm)
-  {
-  }
-  /**
-   * Constructor.
-   * @param cvc5   The associated solver instance.
-   * @param result The wrapped C++ statistics.
-   */
-  cvc5_stats_t(Cvc5* cvc5, const cvc5::Statistics& stat)
-      : d_stat(stat), d_tm(cvc5->d_tm)
-  {
-  }
-  /** The wrapped C++ statistics. */
-  cvc5::Statistics d_stat;
-  /** External refs count. */
-  uint32_t d_refs = 1;
-  /** The associated term manager instance. */
-  Cvc5TermManager* d_tm = nullptr;
-  /** The associated iterator. */
-  std::unique_ptr<cvc5::Statistics::iterator> d_iter = nullptr;
 };
 
 /* -------------------------------------------------------------------------- */

--- a/src/api/c/cvc5_parser.cpp
+++ b/src/api/c/cvc5_parser.cpp
@@ -17,6 +17,7 @@ extern "C" {
 #include <cvc5/cvc5.h>
 #include <cvc5/cvc5_parser.h>
 
+#include <deque>
 #include <fstream>
 
 #include "api/c/cvc5_c_structs.h"
@@ -114,8 +115,12 @@ struct Cvc5InputParser
    * given via constructor but created by the parser.
    */
   std::unique_ptr<Cvc5SymbolManager> d_sm_wrapped;
-  /** The allocated command objects. */
-  std::vector<cvc5_cmd_t> d_alloc_cmds;
+  /**
+   * The allocated command objects.
+   * @note We use a deque here to ensure that pointers to its elements remain
+   *       valid on insertion.
+   */
+  std::deque<cvc5_cmd_t> d_alloc_cmds;
 };
 
 /* -------------------------------------------------------------------------- */

--- a/test/unit/api/c/capi_grammar_black.cpp
+++ b/test/unit/api/c/capi_grammar_black.cpp
@@ -330,4 +330,20 @@ TEST_F(TestCApiBlackGrammar, copy_release)
   // we cannot reliably check that querying on the (now freed) grammar fails
   // unless ASAN is enabled
 }
+TEST_F(TestCApiBlackGrammar, release_after_add_rule)
+{
+  // Grammars are mutable, releasing a grammar after it was modified must
+  // still find (and free) it.
+  cvc5_set_option(d_solver, "sygus", "true");
+  Cvc5Term start = cvc5_mk_var(d_tm, d_bool, "start");
+  std::vector<Cvc5Term> bvars;
+  std::vector<Cvc5Term> symbols = {start};
+  Cvc5Grammar g = cvc5_mk_grammar(
+      d_solver, bvars.size(), bvars.data(), symbols.size(), symbols.data());
+  cvc5_grammar_add_rule(g, start, cvc5_mk_false(d_tm));
+  cvc5_grammar_add_any_constant(g, start);
+  cvc5_grammar_release(g);
+  ASSERT_FALSE(cvc5_has_error());
+}
+
 }  // namespace cvc5::internal::test

--- a/test/unit/api/c/capi_statistics_black.cpp
+++ b/test/unit/api/c/capi_statistics_black.cpp
@@ -202,4 +202,26 @@ TEST_F(TestCApiBlackStatistics, stats_to_string)
   (void)cvc5_stats_to_string(stats);
 }
 
+TEST_F(TestCApiBlackStatistics, stat_handles_remain_valid)
+{
+  // Handles to statistic objects must remain valid while further statistic
+  // objects are created.
+  Cvc5Statistics stats = cvc5_get_statistics(d_solver);
+  std::vector<Cvc5Stat> handles;
+  std::vector<std::string> strs;
+  cvc5_stats_iter_init(stats, true, true);
+  while (cvc5_stats_iter_has_next(stats))
+  {
+    Cvc5Stat stat = cvc5_stats_iter_next(stats, nullptr);
+    handles.push_back(stat);
+    strs.push_back(cvc5_stat_to_string(stat));
+  }
+  ASSERT_GT(handles.size(), 1);
+  for (size_t i = 0; i < handles.size(); ++i)
+  {
+    ASSERT_EQ(cvc5_stat_to_string(handles[i]), strs[i]);
+  }
+  ASSERT_FALSE(cvc5_has_error());
+}
+
 }  // namespace cvc5::internal::test


### PR DESCRIPTION
A few independent, pre-existing memory management issues in the C API, uncovered while working on #12895 (split out of #12897, which depends on this PR):

- **Releasing a modified grammar failed.** Grammars are mutable (`cvc5_grammar_add_rule()` etc.) and `std::hash<cvc5::Grammar>` hashes their content, but the C API cached grammar wrappers in a map keyed by the grammar. `cvc5_grammar_release()` after modifying the grammar thus failed to find it (assertion failure with assertions enabled, otherwise the wrapper was silently never freed). The cache is now keyed on the wrapper object (grammars are only ever exported once, so no deduplication is lost).
- **Dangling `Cvc5Stat` / `Cvc5Statistics` / `Cvc5Command` handles.** These wrappers were stored in a `std::vector` and pointers to its elements handed out, which are invalidated whenever the vector grows (e.g., while iterating over statistics). They now use a `std::deque`, which keeps references valid on insertion. Since libc++'s `std::deque` does not support incomplete element types, the statistic(s) wrappers are now defined before `Cvc5TermManager` (their unused `Cvc5*` constructors are removed).
- `cvc5_term_manager_release()` did not release operators.
- The `parser` and `parser_sym_manager` examples did not delete their parser / symbol manager.

Regression tests are added for the first two issues; both fail on `main` (assertion abort resp. ASAN heap-use-after-free) and pass with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)