### PR TITLE
ci: Build the debug jobs with GLPK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
           - name: ubuntu:production-dbg-clang
             os: ubuntu-22.04
             use-clang: true
-            config: production --auto-download --assertions --tracing --cln --gpl --unit-testing -DNO_GLOBAL_POLY_CTX=1
+            config: production --auto-download --assertions --tracing --cln --gpl --glpk --unit-testing -DNO_GLOBAL_POLY_CTX=1
             cache-key: dbgclang
             exclude_regress: 3-4
             run_regression_args: --tester cpc --tester alethe --tester base --tester model --tester synth --tester abduct --tester unsat-core --tester dump

--- a/cmake/FindGLPK.cmake
+++ b/cmake/FindGLPK.cmake
@@ -107,7 +107,7 @@ if(NOT GLPK_FOUND_SYSTEM)
   ExternalProject_Add(
     GLPK-EP
     ${COMMON_EP_CONFIG}
-    URL "https://ftp.gnu.org/gnu/glpk/glpk-${GLPK_VERSION}.tar.gz"
+    URL https://github.com/cvc5/cvc5-deps/blob/main/glpk-${GLPK_VERSION}.tar.gz?raw=true
     URL_HASH SHA256=9a5dab356268b4f177c33e00ddf8164496dc2434e83bd1114147024df983a3bb
     PATCH_COMMAND ${Patch_EXECUTABLE} -p1 -d <SOURCE_DIR>
         -i ${CMAKE_CURRENT_LIST_DIR}/deps-utils/glpk-cut-log.patch


### PR DESCRIPTION
No CI job that runs on a pull request builds with `--glpk`, so the eight regressions gated on `REQUIRES: glpk` are never exercised. The GPL jobs that do pass it are selected by the `gpl-build` matrix key, which is set only for tag pushes and scheduled runs.

#12889 is what that gap costs. After #12833 the `--use-approx` benchmark `specsharp-WindowsCard.15.RTE.Terminate_System.Int32_approx.smt2` began answering `unknown` instead of `unsat`, and no pull request run could have noticed. It stayed broken until someone happened to build with GLPK by hand.

This adds `--glpk` to `ubuntu:production-dbg-clang`.

### Turning `--glpk` on exposes a second problem, fixed here too

`cmake/FindGLPK.cmake` fetched the tarball from `ftp.gnu.org`, which GitHub-hosted runners cannot reach at all — the host's IPv6 address is unroutable from them and its IPv4 address does not answer:

```
Immediate connect fail for 2001:470:142:3::b: Network is unreachable
connect to 209.51.188.20 port 443 failed: Connection timed out
error: downloading 'https://ftp.gnu.org/gnu/glpk/glpk-4.52.tar.gz' failed
```

This is pre-existing and independent of this PR: the scheduled `macos:production-arm64-gpl` job failed exactly this way in [run 33152342977](https://github.com/cvc5/cvc5/actions/runs/33152342977), spending 75s per connection attempt before taking the build down. So the GPL jobs that nominally cover GLPK today are not actually building it either.

The second commit fetches GLPK from `cvc5/cvc5-deps` instead, matching what `FindGMP.cmake`, `FindMPFR.cmake` and `FindCoCoA.cmake` already do.

### Checks

- The cvc5-deps copy is byte-identical to the GNU tarball — same 2810031 bytes, `sha256` matching the pinned `9a5dab35…` — so `URL_HASH` is unchanged and still verified.
- Configured and built `GLPK-EP` through `FindGLPK.cmake` with **CMake 3.16.9**, which is what CI uses: `.github/actions/setup-cmake` installs the minimum supported version rather than the newest. The tarball downloads in one attempt, the hash verifies, and the patch, configure and install steps complete.
- All eight `REQUIRES: glpk` regressions live in `regress0`, so the job's `exclude_regress: 3-4` drops none of them.
- `ci.yml` parses and the job's `config` resolves with both `--gpl` and `--glpk` present.
