### PR TITLE
alethe: Translate MACRO_ARITH_SCALE_SUM_UB directly to la_generic

### DIFF
--- a/src/proof/alethe/alethe_post_processor.cpp
+++ b/src/proof/alethe/alethe_post_processor.cpp
@@ -2348,6 +2348,57 @@ bool AletheProofPostprocessCallback::update(Node res,
                            d_resPivots ? resArgs : std::vector<Node>(),
                            *cdp);
     }
+    // ======== Adding Scaled Inequalities
+    //
+    // -------------------------------------- LA_GENERIC
+    // (cl (not P1) ... (not Pn) (>< t1 t2))              P1 ... Pn
+    // ------------------------------------------------------------- RESOLUTION
+    //  (cl (>< t1 t2))*
+    //
+    // The coefficients given to LA_GENERIC are derived from the scaling
+    // factors k1 ... kn of this rule: inequality premises are given |ki|,
+    // since la_generic accounts for the direction of the inequality itself,
+    // while equality premises are given (- ki). The conclusion is given
+    // coefficient 1.
+    //
+    // * the corresponding proof node is (>< t1 t2)
+    case ProofRule::MACRO_ARITH_SCALE_SUM_UB:
+    {
+      // the conclusion of this rule is always an inequality (the fusion of the
+      // premise relations, which are over-approximated by inequalities)
+      Assert(res.getKind() != Kind::EQUAL);
+      std::vector<Node> resArgs;
+      std::vector<Node> resChildren;
+      std::vector<Node> lits{d_cl};
+      for (size_t i = 0, size = children.size(); i < size; i++)
+      {
+        const Node& child = children[i];
+        lits.push_back(child.notNode());
+        Rational coeff = args[i].getConst<Rational>();
+        // equality premises are scaled by the negated coefficient, so that
+        // their contribution cancels against the conclusion's, whereas
+        // inequality premises take the absolute value of the coefficient (the
+        // sign of the coefficient in this rule only marks whether the premise
+        // is a lower or an upper bound, which la_generic derives from the
+        // relation itself)
+        coeff = child.getKind() == Kind::EQUAL ? -coeff : coeff.abs();
+        new_args.push_back(nm->mkConstRealOrInt(args[i].getType(), coeff));
+        resArgs.push_back(child);
+        resArgs.push_back(d_false);
+      }
+      lits.push_back(res);
+      new_args.push_back(nm->mkConstReal(Rational(1)));
+      Node laGen = nm->mkNode(Kind::SEXPR, lits);
+      addAletheStep(AletheRule::LA_GENERIC, laGen, laGen, {}, new_args, *cdp);
+      resChildren.push_back(laGen);
+      resChildren.insert(resChildren.end(), children.begin(), children.end());
+      return addAletheStep(AletheRule::RESOLUTION,
+                           res,
+                           nm->mkNode(Kind::SEXPR, d_cl, res),
+                           resChildren,
+                           d_resPivots ? resArgs : std::vector<Node>(),
+                           *cdp);
+    }
     // Direct translation
     case ProofRule::ARITH_MULT_POS:
     case ProofRule::ARITH_MULT_NEG:

--- a/src/proof/alethe/alethe_post_processor.cpp
+++ b/src/proof/alethe/alethe_post_processor.cpp
@@ -2353,22 +2353,19 @@ bool AletheProofPostprocessCallback::update(Node res,
     // -------------------------------------- LA_GENERIC
     // (cl (not P1) ... (not Pn) (>< t1 t2))              P1 ... Pn
     // ------------------------------------------------------------- RESOLUTION
-    //  (cl (>< t1 t2))*
+    //  (cl (>< t1 t2))
     //
     // The coefficients given to LA_GENERIC are derived from the scaling
     // factors k1 ... kn of this rule: inequality premises are given |ki|,
     // since la_generic accounts for the direction of the inequality itself,
     // while equality premises are given (- ki). The conclusion is given
     // coefficient 1.
-    //
-    // * the corresponding proof node is (>< t1 t2)
     case ProofRule::MACRO_ARITH_SCALE_SUM_UB:
     {
       // the conclusion of this rule is always an inequality (the fusion of the
       // premise relations, which are over-approximated by inequalities)
       Assert(res.getKind() != Kind::EQUAL);
       std::vector<Node> resArgs;
-      std::vector<Node> resChildren;
       std::vector<Node> lits{d_cl};
       for (size_t i = 0, size = children.size(); i < size; i++)
       {
@@ -2390,7 +2387,7 @@ bool AletheProofPostprocessCallback::update(Node res,
       new_args.push_back(nm->mkConstReal(Rational(1)));
       Node laGen = nm->mkNode(Kind::SEXPR, lits);
       addAletheStep(AletheRule::LA_GENERIC, laGen, laGen, {}, new_args, *cdp);
-      resChildren.push_back(laGen);
+      std::vector<Node> resChildren{laGen};
       resChildren.insert(resChildren.end(), children.begin(), children.end());
       return addAletheStep(AletheRule::RESOLUTION,
                            res,

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -138,11 +138,7 @@ PfManager::PfManager(Env& env)
     {
       d_pfpp->setEliminateRule(ProofRule::CHAIN_M_RESOLUTION);
     }
-    // The Alethe translation handles this macro directly via la_generic,
-    // which supports arbitrary rational coefficients, so we do not expand it
-    // (the expansion introduces multiplication steps, i.e. ARITH_MULT_POS and
-    // ARITH_MULT_NEG, which lead to Alethe rules for non-linear arithmetic
-    // being used for linear reasoning).
+    // The Alethe translation handles this macro directly via la_generic
     if (options().proof.proofFormatMode != options::ProofFormatMode::ALETHE)
     {
       d_pfpp->setEliminateRule(ProofRule::MACRO_ARITH_SCALE_SUM_UB);

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -138,7 +138,15 @@ PfManager::PfManager(Env& env)
     {
       d_pfpp->setEliminateRule(ProofRule::CHAIN_M_RESOLUTION);
     }
-    d_pfpp->setEliminateRule(ProofRule::MACRO_ARITH_SCALE_SUM_UB);
+    // The Alethe translation handles this macro directly via la_generic,
+    // which supports arbitrary rational coefficients, so we do not expand it
+    // (the expansion introduces multiplication steps, i.e. ARITH_MULT_POS and
+    // ARITH_MULT_NEG, which lead to Alethe rules for non-linear arithmetic
+    // being used for linear reasoning).
+    if (options().proof.proofFormatMode != options::ProofFormatMode::ALETHE)
+    {
+      d_pfpp->setEliminateRule(ProofRule::MACRO_ARITH_SCALE_SUM_UB);
+    }
     if (options().proof.proofGranularityMode
         != options::ProofGranularityMode::REWRITE)
     {


### PR DESCRIPTION
The Alethe post-processor now translates `MACRO_ARITH_SCALE_SUM_UB` into a
single `la_generic` step, which is expressive enough to represent it, plus one
resolution against the premises. Coefficients map as in the existing
`ARITH_SUM_UB` translation: absolute value for inequality premises, negated for
equalities, 1 for the conclusion.

This avoids introducing non-linear arithmetic rules, `la_mult_pos`/`la_mult_neg`
which are used by the macro expansion, for purely linear reasoning. Moreover an
evaluation on combinations of UFLIRA logics in SMT-LIB logics (~19k unsat
benchmarks in 120s solving, checking with Carcara) leads to 16.5% fewer proof
steps and 5% smaller proofs files overall (QF_LIA: 39% smaller); checking time
down 1.6% (QF_LIA: 11%); 8 more benchmarks solved-and-validated, no losses.

Claude was used to identify this improvement, implement it, and in the
evaluation analysis. I designed the evaluation and reviewed the changes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
