### PR TITLE
Rename CI job names and ccache keys after the build type rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         gpl-build:
           - ${{ startsWith(github.ref, 'refs/tags/') || (github.event_name == 'schedule') }}
         build:
-          - name: ubuntu:production
+          - name: ubuntu:unrestricted
             os: ubuntu-22.04
             config: unrestricted --auto-download --all-bindings --editline -DBUILD_GMP=1
             cache-key: production
@@ -60,7 +60,7 @@ jobs:
             exclude_regress: 3-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
-          - name: ubuntu:safe-mode
+          - name: ubuntu:safe
             os: ubuntu-22.04
             config: safe --auto-download --all-bindings --editline -DBUILD_GMP=1
             cache-key: production-safe
@@ -71,7 +71,7 @@ jobs:
             exclude_regress: 3-4
             run_regression_args: --tester base --tester proof --tester cpc --tester model --tester synth --tester abduct --tester dump
 
-          - name: ubuntu:stable-mode
+          - name: ubuntu:stable
             os: ubuntu-22.04
             config: stable --auto-download --all-bindings --editline -DBUILD_GMP=1
             cache-key: production-stable
@@ -82,7 +82,7 @@ jobs:
             exclude_regress: 3-4
             run_regression_args: --tester base --tester proof --tester cpc --tester model --tester dump
 
-          - name: ubuntu:production-libc++
+          - name: ubuntu:unrestricted-libc++
             os: ubuntu-24.04
             use-clang: true
             use-libcxx: true
@@ -94,7 +94,7 @@ jobs:
             exclude_regress: 3-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
-          - name: ubuntu:production-arm64
+          - name: ubuntu:unrestricted-arm64
             os: ubuntu-22.04-arm
             config: unrestricted --auto-download --all-bindings --editline -DBUILD_GMP=1
             cache-key: production-arm64
@@ -106,7 +106,7 @@ jobs:
             exclude_regress: 3-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
-          - name: ubuntu:production-arm64-libc++
+          - name: ubuntu:unrestricted-arm64-libc++
             os: ubuntu-24.04-arm
             use-clang: true
             use-libcxx: true
@@ -118,7 +118,7 @@ jobs:
             exclude_regress: 3-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
-          - name: macos:production
+          - name: macos:unrestricted
             os: macos-15-intel
             config: unrestricted --auto-download --all-bindings --editline -DBUILD_GMP=1
             cache-key: production
@@ -131,7 +131,7 @@ jobs:
             exclude_regress: 3-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
-          - name: macos:production-arm64
+          - name: macos:unrestricted-arm64
             os: macos-15
             config: unrestricted --auto-download --all-bindings --editline -DBUILD_GMP=1
             cache-key: production-arm64
@@ -145,7 +145,7 @@ jobs:
             exclude_regress: 3-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
-          - name: win64:production
+          - name: win64:unrestricted
             os: windows-latest
             config: unrestricted --auto-download --all-bindings
             cache-key: production-win64-native
@@ -159,7 +159,7 @@ jobs:
             exclude_regress: 1-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
-          - name: win64:production-arm64
+          - name: win64:unrestricted-arm64
             os: windows-11-arm
             config: unrestricted --auto-download --all-bindings
             cache-key: production-win64-native-arm64
@@ -174,7 +174,7 @@ jobs:
             exclude_regress: 1-4
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester dump
 
-          - name: wasm:production
+          - name: wasm:unrestricted
             os: ubuntu-22.04
             config: unrestricted --static --static-binary --auto-download --wasm-web=no-modular-static-page
             cache-key: productionwasm
@@ -184,7 +184,7 @@ jobs:
             build-static: true
 
             # Job used to build the documentation
-          - name: ubuntu:production-dbg
+          - name: ubuntu:unrestricted-dbg
             os: ubuntu-24.04 # Use Doxygen version from this Ubuntu release
             config: >-
               unrestricted --auto-download --assertions --tracing --unit-testing --editline
@@ -198,7 +198,7 @@ jobs:
             run_regression_args: --tester base --tester model --tester synth --tester abduct --tester proof --tester dump
 
           # Use NO_GLOBAL_POLY_CTX=1 to ensure cvc5 does not use LibPoly's global context (testing purposes)
-          - name: ubuntu:production-dbg-clang
+          - name: ubuntu:unrestricted-dbg-clang
             os: ubuntu-22.04
             use-clang: true
             config: unrestricted --auto-download --assertions --tracing --cln --gpl --glpk --unit-testing -DNO_GLOBAL_POLY_CTX=1
@@ -207,7 +207,7 @@ jobs:
             run_regression_args: --tester cpc --tester alethe --tester base --tester model --tester synth --tester abduct --tester unsat-core --tester dump
 
           # GPL versions
-          - name: ubuntu:production-gpl
+          - name: ubuntu:unrestricted-gpl
             os: ubuntu-22.04
             config: unrestricted --auto-download --editline --gpl --cln --glpk --cocoa --normaliz -DBUILD_GMP=1 -DBUILD_CLN=1
             cache-key: production-gpl
@@ -215,7 +215,7 @@ jobs:
             package-name: cvc5-Linux-x86_64
             gpl-tag: -gpl
 
-          - name: ubuntu:production-arm64-gpl
+          - name: ubuntu:unrestricted-arm64-gpl
             os: ubuntu-22.04-arm
             config: unrestricted --auto-download --editline --gpl --cln --glpk --cocoa --normaliz -DBUILD_GMP=1 -DBUILD_CLN=1
             cache-key: production-arm64-gpl
@@ -223,7 +223,7 @@ jobs:
             package-name: cvc5-Linux-arm64
             gpl-tag: -gpl
 
-          - name: macos:production-gpl
+          - name: macos:unrestricted-gpl
             os: macos-15-intel
             config: unrestricted --auto-download --editline --gpl --cln --glpk --cocoa --normaliz -DBUILD_GMP=1 -DBUILD_CLN=1
             cache-key: production-gpl
@@ -232,7 +232,7 @@ jobs:
             macos-target: 10.13
             gpl-tag: -gpl
 
-          - name: macos:production-arm64-gpl
+          - name: macos:unrestricted-arm64-gpl
             os: macos-15
             config: unrestricted --auto-download --editline --gpl --cln --glpk --cocoa --normaliz -DBUILD_GMP=1 -DBUILD_CLN=1
             cache-key: production-arm64-gpl
@@ -244,7 +244,7 @@ jobs:
 
           # Windows builds with CoCoALib are generated for testing purposes only
           # but are not currently uploaded.
-          - name: win64:production-gpl
+          - name: win64:unrestricted-gpl
             os: windows-latest
             config: unrestricted --auto-download --gpl --cocoa --normaliz
             cache-key: production-win64-native-gpl
@@ -253,7 +253,7 @@ jobs:
             shell: 'msys2 {0}'
             gpl-tag: -gpl
 
-          - name: win64:production-arm64-gpl
+          - name: win64:unrestricted-arm64-gpl
             os: windows-11-arm
             config: unrestricted --auto-download --gpl --cocoa --normaliz
             cache-key: production-win64-native-arm64-gpl
@@ -266,22 +266,22 @@ jobs:
         exclude:
           - gpl-build: false
             build:
-              name: ubuntu:production-gpl
+              name: ubuntu:unrestricted-gpl
           - gpl-build: false
             build:
-              name: ubuntu:production-arm64-gpl
+              name: ubuntu:unrestricted-arm64-gpl
           - gpl-build: false
             build:
-              name: macos:production-gpl
+              name: macos:unrestricted-gpl
           - gpl-build: false
             build:
-              name: macos:production-arm64-gpl
+              name: macos:unrestricted-arm64-gpl
           - gpl-build: false
             build:
-              name: win64:production-gpl
+              name: win64:unrestricted-gpl
           - gpl-build: false
             build:
-              name: win64:production-arm64-gpl
+              name: win64:unrestricted-arm64-gpl
 
     name: ${{ matrix.build.name }}
     runs-on: ${{ matrix.build.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           - name: ubuntu:unrestricted
             os: ubuntu-22.04
             config: unrestricted --auto-download --all-bindings --editline -DBUILD_GMP=1
-            cache-key: production
+            cache-key: unrestricted
             strip-bin: strip
             python-bindings: true
             java-bindings: true
@@ -63,7 +63,7 @@ jobs:
           - name: ubuntu:safe
             os: ubuntu-22.04
             config: safe --auto-download --all-bindings --editline -DBUILD_GMP=1
-            cache-key: production-safe
+            cache-key: safe
             strip-bin: strip
             python-bindings: true
             java-bindings: true
@@ -74,7 +74,7 @@ jobs:
           - name: ubuntu:stable
             os: ubuntu-22.04
             config: stable --auto-download --all-bindings --editline -DBUILD_GMP=1
-            cache-key: production-stable
+            cache-key: stable
             strip-bin: strip
             python-bindings: true
             java-bindings: true
@@ -87,7 +87,7 @@ jobs:
             use-clang: true
             use-libcxx: true
             config: unrestricted --auto-download -DBUILD_GMP=1
-            cache-key: production-libcxx
+            cache-key: unrestricted-libcxx
             strip-bin: strip
             check-examples: true
             package-name: cvc5-Linux-x86_64-libcxx
@@ -97,7 +97,7 @@ jobs:
           - name: ubuntu:unrestricted-arm64
             os: ubuntu-22.04-arm
             config: unrestricted --auto-download --all-bindings --editline -DBUILD_GMP=1
-            cache-key: production-arm64
+            cache-key: unrestricted-arm64
             strip-bin: strip
             python-bindings: true
             java-bindings: true
@@ -111,7 +111,7 @@ jobs:
             use-clang: true
             use-libcxx: true
             config: unrestricted --auto-download -DBUILD_GMP=1
-            cache-key: production-arm64-libcxx
+            cache-key: unrestricted-arm64-libcxx
             strip-bin: strip
             check-examples: true
             package-name: cvc5-Linux-arm64-libcxx
@@ -121,7 +121,7 @@ jobs:
           - name: macos:unrestricted
             os: macos-15-intel
             config: unrestricted --auto-download --all-bindings --editline -DBUILD_GMP=1
-            cache-key: production
+            cache-key: unrestricted
             strip-bin: strip
             python-bindings: true
             java-bindings: true
@@ -134,7 +134,7 @@ jobs:
           - name: macos:unrestricted-arm64
             os: macos-15
             config: unrestricted --auto-download --all-bindings --editline -DBUILD_GMP=1
-            cache-key: production-arm64
+            cache-key: unrestricted-arm64
             strip-bin: strip
             python-bindings: true
             java-bindings: true
@@ -148,7 +148,7 @@ jobs:
           - name: win64:unrestricted
             os: windows-latest
             config: unrestricted --auto-download --all-bindings
-            cache-key: production-win64-native
+            cache-key: unrestricted-win64-native
             strip-bin: strip
             python-bindings: true
             java-bindings: true
@@ -162,7 +162,7 @@ jobs:
           - name: win64:unrestricted-arm64
             os: windows-11-arm
             config: unrestricted --auto-download --all-bindings
-            cache-key: production-win64-native-arm64
+            cache-key: unrestricted-win64-native-arm64
             strip-bin: strip
             python-bindings: true
             java-bindings: true
@@ -177,7 +177,7 @@ jobs:
           - name: wasm:unrestricted
             os: ubuntu-22.04
             config: unrestricted --static --static-binary --auto-download --wasm-web=no-modular-static-page
-            cache-key: productionwasm
+            cache-key: unrestricted-wasm
             wasm-build: true
             wasm-pkg-name: cvc5-Wasm
             build-shared: false
@@ -210,7 +210,7 @@ jobs:
           - name: ubuntu:unrestricted-gpl
             os: ubuntu-22.04
             config: unrestricted --auto-download --editline --gpl --cln --glpk --cocoa --normaliz -DBUILD_GMP=1 -DBUILD_CLN=1
-            cache-key: production-gpl
+            cache-key: unrestricted-gpl
             strip-bin: strip
             package-name: cvc5-Linux-x86_64
             gpl-tag: -gpl
@@ -218,7 +218,7 @@ jobs:
           - name: ubuntu:unrestricted-arm64-gpl
             os: ubuntu-22.04-arm
             config: unrestricted --auto-download --editline --gpl --cln --glpk --cocoa --normaliz -DBUILD_GMP=1 -DBUILD_CLN=1
-            cache-key: production-arm64-gpl
+            cache-key: unrestricted-arm64-gpl
             strip-bin: strip
             package-name: cvc5-Linux-arm64
             gpl-tag: -gpl
@@ -226,7 +226,7 @@ jobs:
           - name: macos:unrestricted-gpl
             os: macos-15-intel
             config: unrestricted --auto-download --editline --gpl --cln --glpk --cocoa --normaliz -DBUILD_GMP=1 -DBUILD_CLN=1
-            cache-key: production-gpl
+            cache-key: unrestricted-gpl
             strip-bin: strip
             package-name: cvc5-macOS-x86_64
             macos-target: 10.13
@@ -235,7 +235,7 @@ jobs:
           - name: macos:unrestricted-arm64-gpl
             os: macos-15
             config: unrestricted --auto-download --editline --gpl --cln --glpk --cocoa --normaliz -DBUILD_GMP=1 -DBUILD_CLN=1
-            cache-key: production-arm64-gpl
+            cache-key: unrestricted-arm64-gpl
             strip-bin: strip
             package-name: cvc5-macOS-arm64
             java-version: 11
@@ -247,7 +247,7 @@ jobs:
           - name: win64:unrestricted-gpl
             os: windows-latest
             config: unrestricted --auto-download --gpl --cocoa --normaliz
-            cache-key: production-win64-native-gpl
+            cache-key: unrestricted-win64-native-gpl
             strip-bin: strip
             windows-build: true
             shell: 'msys2 {0}'
@@ -256,7 +256,7 @@ jobs:
           - name: win64:unrestricted-arm64-gpl
             os: windows-11-arm
             config: unrestricted --auto-download --gpl --cocoa --normaliz
-            cache-key: production-win64-native-arm64-gpl
+            cache-key: unrestricted-win64-native-arm64-gpl
             strip-bin: strip
             java-version: 21
             windows-build: true

--- a/.github/workflows/cmake-version.yml
+++ b/.github/workflows/cmake-version.yml
@@ -4,7 +4,7 @@ name: cmake-version
 jobs:
   build:
     continue-on-error: true
-    name: ubuntu:production-dbg
+    name: ubuntu:unrestricted-dbg
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/cross_compilation.yml
+++ b/.github/workflows/cross_compilation.yml
@@ -13,19 +13,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: ubuntu:production-arm64-cross
+          - name: ubuntu:unrestricted-arm64-cross
             os: ubuntu-latest
             config: unrestricted --auto-download --arm64
             strip-bin: aarch64-linux-gnu-strip
 
-          - name: macos:production-arm64-cross
+          - name: macos:unrestricted-arm64-cross
             os: macos-15-intel
             config: unrestricted --auto-download --all-bindings --editline --arm64
             strip-bin: strip
             python-bindings: true
             macos-target: 11.0
 
-          - name: win64:production-cross
+          - name: win64:unrestricted-cross
             os: ubuntu-latest
             config: unrestricted --auto-download --win64
             strip-bin: x86_64-w64-mingw32-strip


### PR DESCRIPTION
Follow-up to #12899, which renamed the `configure.sh` build types but deliberately left the CI naming alone.

The job names and ccache keys in the workflows still referred to the retired build types, so they are renamed to match:

| before | after |
| --- | --- |
| `<platform>:production*` | `<platform>:unrestricted*` |
| `ubuntu:safe-mode` | `ubuntu:safe` |
| `ubuntu:stable-mode` | `ubuntu:stable` |
| `cache-key: production*` | `cache-key: unrestricted*` |
| `cache-key: production-safe` / `production-stable` | `cache-key: safe` / `stable` |

This covers `ci.yml` (19 matrix entries), `cross_compilation.yml` and the `cmake-version.yml` job name. The `dbg` and `dbgclang` cache keys are unchanged. The `productionwasm` key also picks up the hyphen it was missing, as `unrestricted-wasm`.

Note that the job names are not purely cosmetic in `ci.yml`: the `exclude:` rules that keep the `*-gpl` builds off regular runs match on `build.name`, so those six entries are renamed in lockstep. I verified after the rename that all 19 matrix entries parse and all six `exclude` rules still resolve to an existing entry.

Renaming the ccache keys causes a **one-time cache miss** for the affected jobs, after which they repopulate under the new names. Note that the `contrib` and `deps` caches are keyed on `hashFiles('.github/**')` anyway, so those are invalidated by any change to this directory regardless. The keys that were shared between the Linux and macOS jobs are still shared, and `cache-key` remains combined with `runner.os`, so no two jobs collide.

⚠️ **This PR requires an admin to update the required status checks on `main` before it is merged.** The following ten checks are configured under the old job names and will stop reporting, blocking every PR until they are renamed:

| required status check | rename to |
| --- | --- |
| `macos:production` | `macos:unrestricted` |
| `macos:production-arm64` | `macos:unrestricted-arm64` |
| `ubuntu:production` | `ubuntu:unrestricted` |
| `ubuntu:production-arm64` | `ubuntu:unrestricted-arm64` |
| `ubuntu:production-dbg` | `ubuntu:unrestricted-dbg` |
| `ubuntu:production-dbg-clang` | `ubuntu:unrestricted-dbg-clang` |
| `ubuntu:safe-mode` | `ubuntu:safe` |
| `ubuntu:stable-mode` | `ubuntu:stable` |
| `win64:production` | `win64:unrestricted` |
| `win64:production-arm64` | `win64:unrestricted-arm64` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
