### PR TITLE
fp: Fix zero case of MPFR fp.max literal back end.

### DIFF
--- a/src/util/floatingpoint_literal_mpfr.cpp
+++ b/src/util/floatingpoint_literal_mpfr.cpp
@@ -674,16 +674,18 @@ std::unique_ptr<FloatingPointLiteral> FloatingPointLiteralMPFR::maxTotal(
     return clone();
   }
 
-  // Handle the +-zero case
+  // Handle the +-zero case.
   if (isZero() && a.isZero())
   {
     if (isNegative() != a.isNegative())
     {
       if (zeroCaseLeft)
       {
-        return clone();
+        // The right operand is selected for max, as defined by SymFPU's max,
+        // which is what FLOATINGPOINT_MAX_TOTAL is word-blasted to.
+        return a.clone();
       }
-      return a.clone();
+      return clone();
     }
     return clone();
   }
@@ -715,13 +717,15 @@ std::unique_ptr<FloatingPointLiteral> FloatingPointLiteralMPFR::minTotal(
     return clone();
   }
 
-  // Handle the +-zero case
+  // Handle the +-zero case.
   if (isZero() && a.isZero())
   {
     if (isNegative() != a.isNegative())
     {
       if (zeroCaseLeft)
       {
+        // The left operand is selected for min, as defined by SymFPU's min,
+        // which is what FLOATINGPOINT_MIN_TOTAL is word-blasted to.
         return clone();
       }
       return a.clone();

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1013,6 +1013,7 @@ set(regress_0_tests
   regress0/fp/issue12354-from-real-refine.smt2
   regress0/fp/issue12370-from-real-refine.smt2
   regress0/fp/issue12780-from-real-refine.smt2
+  regress0/fp/issue12867-min-max-zero.smt2
   regress0/fp/issuepr650.smt2
   regress0/fp/proj-issue329-prereg-context.smt2
   regress0/fp/proj-issue477-fp-set-comprehension.smt2

--- a/test/regress/cli/regress0/fp/issue12867-min-max-zero.smt2
+++ b/test/regress/cli/regress0/fp/issue12867-min-max-zero.smt2
@@ -1,0 +1,12 @@
+; REQUIRES: unrestricted-mode
+; COMMAND-LINE: --check-models
+; EXPECT: sat
+;; The zero case of fp.min/fp.max is unspecified. Check that the value the
+;; model assigns to it agrees with the way FLOATINGPOINT_{MIN,MAX}_TOTAL is
+;; bit-blasted, for both operand orders and both literal back ends.
+(set-logic QF_FP)
+(assert (fp.isNegative (fp.max (_ +zero 8 24) (_ -zero 8 24))))
+(assert (fp.isPositive (fp.max (_ -zero 8 24) (_ +zero 8 24))))
+(assert (fp.isPositive (fp.min (_ +zero 8 24) (_ -zero 8 24))))
+(assert (fp.isNegative (fp.min (_ -zero 8 24) (_ +zero 8 24))))
+(check-sat)


### PR DESCRIPTION
FloatingPointLiteralMPFR::maxTotal returned the left operand when the zero-case selector was set, but SymFPU's max -- which is what the word blaster word-blasts FLOATINGPOINT_MAX_TOTAL to -- returns the right one.

Fixes #12867.