### PR TITLE
fp: Rename zeroCaseLeft case selector of fp.min/fp.max literals.

### DIFF
--- a/src/util/floatingpoint.cpp
+++ b/src/util/floatingpoint.cpp
@@ -289,9 +289,9 @@ FloatingPoint FloatingPoint::rem(const FloatingPoint& arg) const
 }
 
 FloatingPoint FloatingPoint::maxTotal(const FloatingPoint& arg,
-                                      bool zeroCaseLeft) const
+                                      bool zeroCaseRight) const
 {
-  return FloatingPoint(d_fpl->maxTotal(*arg.d_fpl, zeroCaseLeft));
+  return FloatingPoint(d_fpl->maxTotal(*arg.d_fpl, zeroCaseRight));
 }
 
 FloatingPoint FloatingPoint::minTotal(const FloatingPoint& arg,

--- a/src/util/floatingpoint.h
+++ b/src/util/floatingpoint.h
@@ -233,14 +233,18 @@ class FloatingPoint
 
   /**
    * Floating-point max (total version).
-   * zeroCase: true to return the left (rather than the right operand) in case
-   *           of max(-0,+0) or max(+0,-0).
+   * @param arg           The floating-point to compare for max.
+   * @param zeroCaseRight True to return the right (rather than the left
+   *                      operand) in case of max(-0,+0) or max(+0,-0).
+   *                      Note that the polarity is the opposite of minTotal's,
+   *                      see FloatingPointLiteral::maxTotal.
    */
-  FloatingPoint maxTotal(const FloatingPoint& arg, bool zeroCaseLeft) const;
+  FloatingPoint maxTotal(const FloatingPoint& arg, bool zeroCaseRight) const;
   /**
    * Floating-point min (total version).
-   * zeroCase: true to return the left (rather than the right operand) in case
-   *           of min(-0,+0) or min(+0,-0).
+   * @param arg          The floating-point to compare for min.
+   * @param zeroCaseLeft True to return the left (rather than the right operand)
+   *                     in case of min(-0,+0) or min(+0,-0).
    */
   FloatingPoint minTotal(const FloatingPoint& arg, bool zeroCaseLeft) const;
 

--- a/src/util/floatingpoint_literal.h
+++ b/src/util/floatingpoint_literal.h
@@ -197,18 +197,28 @@ class FloatingPointLiteral
 
   /**
    * Floating-point max (total version).
-   * @param arg      The floating-point to compare this with.
-   * @param zeroCase True to return the left (rather than the right operand) in
-   *                 case of max(-0,+0) or max(+0,-0).
+   *
+   * @note The result of max(-0,+0) and max(+0,-0) is unspecified in SMT-LIB
+   *       and resolved by `zeroCaseRight`, which *must* be interpreted exactly
+   *       as SymFPU's `max` interprets it, since that is what the word blaster
+   *       word-blasts FLOATINGPOINT_MAX_TOTAL to (see fp_word_blaster.cpp).
+   *       Note that the polarity is the opposite of `minTotal`.
+   *
+   * @param arg           The floating-point to compare this with.
+   * @param zeroCaseRight True to return the **right** (rather than the left)
+   *                      operand in case of max(-0,+0) or max(+0,-0).
    * @return The floating-point max of this and `arg`.
    */
   virtual std::unique_ptr<FloatingPointLiteral> maxTotal(
-      const FloatingPointLiteral& arg, bool zeroCaseLeft) const = 0;
+      const FloatingPointLiteral& arg, bool zeroCaseRight) const = 0;
   /**
    * Floating-point min (total version).
-   * @param arg      The floating-point to compare this with.
-   * @param zeroCase True to return the left (rather than the right operand) in
-   *                 case of min(-0,+0) or min(+0,-0).
+   *
+   * @note See `maxTotal` on how `zeroCaseLeft` must be interpreted.
+   *
+   * @param arg          The floating-point to compare this with.
+   * @param zeroCaseLeft True to return the left (rather than the right) operand
+   *                     in case of min(-0,+0) or min(+0,-0).
    * @return The floating-point min of this and `arg`.
    */
   virtual std::unique_ptr<FloatingPointLiteral> minTotal(

--- a/src/util/floatingpoint_literal_mpfr.cpp
+++ b/src/util/floatingpoint_literal_mpfr.cpp
@@ -654,7 +654,7 @@ std::unique_ptr<FloatingPointLiteral> FloatingPointLiteralMPFR::rem(
 /* -------------------------------------------------------------------------- */
 
 std::unique_ptr<FloatingPointLiteral> FloatingPointLiteralMPFR::maxTotal(
-    const FloatingPointLiteral& arg, bool zeroCaseLeft) const
+    const FloatingPointLiteral& arg, bool zeroCaseRight) const
 {
   const auto& a = asMPFR(arg);
   Assert(d_fp_size == a.d_fp_size);
@@ -679,7 +679,7 @@ std::unique_ptr<FloatingPointLiteral> FloatingPointLiteralMPFR::maxTotal(
   {
     if (isNegative() != a.isNegative())
     {
-      if (zeroCaseLeft)
+      if (zeroCaseRight)
       {
         return clone();
       }

--- a/src/util/floatingpoint_literal_mpfr.h
+++ b/src/util/floatingpoint_literal_mpfr.h
@@ -108,7 +108,7 @@ class FloatingPointLiteralMPFR : public FloatingPointLiteral
       const FloatingPointLiteral& arg) const override;
 
   std::unique_ptr<FloatingPointLiteral> maxTotal(
-      const FloatingPointLiteral& arg, bool zeroCaseLeft) const override;
+      const FloatingPointLiteral& arg, bool zeroCaseRight) const override;
   std::unique_ptr<FloatingPointLiteral> minTotal(
       const FloatingPointLiteral& arg, bool zeroCaseLeft) const override;
 

--- a/src/util/floatingpoint_literal_symfpu.cpp
+++ b/src/util/floatingpoint_literal_symfpu.cpp
@@ -433,14 +433,14 @@ std::unique_ptr<FloatingPointLiteral> FloatingPointLiteralSymFPU::rem(
 /* -------------------------------------------------------------------------- */
 
 std::unique_ptr<FloatingPointLiteral> FloatingPointLiteralSymFPU::maxTotal(
-    const FloatingPointLiteral& arg, bool zeroCaseLeft) const
+    const FloatingPointLiteral& arg, bool zeroCaseRight) const
 {
   const auto& a = asSymFPU(arg);
   Assert(d_fp_size == a.d_fp_size);
   return std::unique_ptr<FloatingPointLiteral>(new FloatingPointLiteralSymFPU(
       d_fp_size,
       symfpu::max<symfpuLiteral::traits>(
-          d_fp_size, *d_symuf, *a.d_symuf, zeroCaseLeft)));
+          d_fp_size, *d_symuf, *a.d_symuf, zeroCaseRight)));
 }
 
 std::unique_ptr<FloatingPointLiteral> FloatingPointLiteralSymFPU::minTotal(

--- a/src/util/floatingpoint_literal_symfpu.h
+++ b/src/util/floatingpoint_literal_symfpu.h
@@ -118,7 +118,7 @@ class FloatingPointLiteralSymFPU : public FloatingPointLiteral
       const FloatingPointLiteral& arg) const override;
 
   std::unique_ptr<FloatingPointLiteral> maxTotal(
-      const FloatingPointLiteral& arg, bool zeroCaseLeft) const override;
+      const FloatingPointLiteral& arg, bool zeroCaseRight) const override;
   std::unique_ptr<FloatingPointLiteral> minTotal(
       const FloatingPointLiteral& arg, bool zeroCaseLeft) const override;
 


### PR DESCRIPTION
Rename the flag to indicate which case to select in the zero case of `fp.min`/`fp.max` and improve documentation.