### PR TITLE
bv: Replace int-blaster trusted step with BV_INTBLAST proof rules

### DIFF
--- a/include/cvc5/cvc5_proof_rule.h
+++ b/include/cvc5/cvc5_proof_rule.h
@@ -1423,6 +1423,49 @@ enum ENUM(ProofRule)
   EVALUE(BV_POLY_NORM_EQ),
   /**
    * \verbatim embed:rst:leading-asterisk
+   * **Bit-vectors -- Int-blasting translation step**
+   *
+   * .. math::
+   *
+   *   \inferrule{-\mid F}{F}
+   *
+   * where :math:`F` is an equality between a bit-vector (or Boolean) term and
+   * its integer translation, computed by the int-blasting preprocessing pass.
+   * This rule is a placeholder that does not yet check the correctness of
+   * :math:`F`.
+   * \endverbatim
+   */
+  EVALUE(BV_INTBLAST_STEP),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Bit-vectors -- Int-blasting range constraint**
+   *
+   * .. math::
+   *
+   *   \inferrule{-\mid F}{F}
+   *
+   * where :math:`F` is a range constraint on an integer variable introduced
+   * by the int-blasting preprocessing pass. This rule is a placeholder that
+   * does not yet check the correctness of :math:`F`.
+   * \endverbatim
+   */
+  EVALUE(BV_INTBLAST_RANGE),
+  /**
+   * \verbatim embed:rst:leading-asterisk
+   * **Bit-vectors -- Int-blasting bitwise constraint**
+   *
+   * .. math::
+   *
+   *   \inferrule{-\mid F}{F}
+   *
+   * where :math:`F` is a bitwise constraint introduced by the int-blasting
+   * preprocessing pass when translating bit-wise operators. This rule is a
+   * placeholder that does not yet check the correctness of :math:`F`.
+   * \endverbatim
+   */
+  EVALUE(BV_INTBLAST_BITWISE),
+  /**
+   * \verbatim embed:rst:leading-asterisk
    * **Datatypes -- Split**
    *
    * .. math::

--- a/proofs/eo/cpc/rules/BitVectors.eo
+++ b/proofs/eo/cpc/rules/BitVectors.eo
@@ -273,3 +273,52 @@
   :requires (((eo::to_z one) 1) ((eo::zmod (eo::to_z cx) 2) 1) ((eo::zmod (eo::to_z cy) 2) 1))
   :conclusion (= (= xb1 xb2) (= yb1 yb2))
 )
+
+;;;;; ProofRule::BV_INTBLAST_STEP
+
+; rule: bv_intblast_step
+; implements: ProofRule::BV_INTBLAST_STEP.
+; args:
+; - F Bool: The proven formula.
+; conclusion: The given formula F.
+; note: >
+;   This rule is a placeholder for facts derived by the int-blasting
+;   preprocessing pass, which is not yet formalized in the Eunoia signature.
+;   It accepts any formula F without checking it.
+(declare-rule bv_intblast_step ((F Bool))
+  :args (F)
+  :conclusion F
+)
+
+;;;;; ProofRule::BV_INTBLAST_RANGE
+
+; rule: bv_intblast_range
+; implements: ProofRule::BV_INTBLAST_RANGE.
+; args:
+; - F Bool: The proven formula.
+; conclusion: The given formula F.
+; note: >
+;   This rule is a placeholder for range constraints on integer variables
+;   introduced by the int-blasting preprocessing pass, which is not yet
+;   formalized in the Eunoia signature. It accepts any formula F without
+;   checking it.
+(declare-rule bv_intblast_range ((F Bool))
+  :args (F)
+  :conclusion F
+)
+
+;;;;; ProofRule::BV_INTBLAST_BITWISE
+
+; rule: bv_intblast_bitwise
+; implements: ProofRule::BV_INTBLAST_BITWISE.
+; args:
+; - F Bool: The proven formula.
+; conclusion: The given formula F.
+; note: >
+;   This rule is a placeholder for bitwise constraints introduced by the
+;   int-blasting preprocessing pass, which is not yet formalized in the
+;   Eunoia signature. It accepts any formula F without checking it.
+(declare-rule bv_intblast_bitwise ((F Bool))
+  :args (F)
+  :conclusion F
+)

--- a/src/api/cpp/cvc5_proof_rule_template.cpp
+++ b/src/api/cpp/cvc5_proof_rule_template.cpp
@@ -120,6 +120,9 @@ const char* toString(ProofRule rule)
     case ProofRule::BV_EAGER_ATOM: return "BV_EAGER_ATOM";
     case ProofRule::BV_POLY_NORM: return "BV_POLY_NORM";
     case ProofRule::BV_POLY_NORM_EQ: return "BV_POLY_NORM_EQ";
+    case ProofRule::BV_INTBLAST_STEP: return "BV_INTBLAST_STEP";
+    case ProofRule::BV_INTBLAST_RANGE: return "BV_INTBLAST_RANGE";
+    case ProofRule::BV_INTBLAST_BITWISE: return "BV_INTBLAST_BITWISE";
     //================================================= Datatype rules
     case ProofRule::DT_SPLIT: return "DT_SPLIT";
     //================================================= Quantifiers rules

--- a/src/proof/eo/eo_printer.cpp
+++ b/src/proof/eo/eo_printer.cpp
@@ -184,6 +184,9 @@ bool EoPrinter::isHandled(const Options& opts, const ProofNode* pfn)
     case ProofRule::ARITH_POLY_NORM_REL:
     case ProofRule::BV_POLY_NORM:
     case ProofRule::BV_POLY_NORM_EQ:
+    case ProofRule::BV_INTBLAST_STEP:
+    case ProofRule::BV_INTBLAST_RANGE:
+    case ProofRule::BV_INTBLAST_BITWISE:
     case ProofRule::EXISTS_STRING_LENGTH:
     case ProofRule::DSL_REWRITE: return true;
     case ProofRule::BV_BITBLAST_STEP:

--- a/src/proof/trust_id.cpp
+++ b/src/proof/trust_id.cpp
@@ -119,7 +119,6 @@ const char* toString(TrustId id)
       return "MACRO_THEORY_REWRITE_RCONS";
     case TrustId::MACRO_THEORY_REWRITE_RCONS_SIMPLE:
       return "MACRO_THEORY_REWRITE_RCONS_SIMPLE";
-    case TrustId::INT_BLASTER: return "INT_BLASTER";
     // unknown sources
     case TrustId::UNKNOWN_PREPROCESS: return "UNKNOWN_PREPROCESS";
     case TrustId::UNKNOWN_PREPROCESS_LEMMA: return "UNKNOWN_PREPROCESS_LEMMA";

--- a/src/proof/trust_id.h
+++ b/src/proof/trust_id.h
@@ -229,8 +229,6 @@ enum class TrustId : uint32_t
    * require the use of theory rewrites to prove.
    */
   MACRO_THEORY_REWRITE_RCONS_SIMPLE,
-  /** An unproven step from the int-blaster */
-  INT_BLASTER,
   /** Untracked sources of trust, which are discouraged */
   /** A rewrite of the input formula by a preprocessing pass without a proof */
   UNKNOWN_PREPROCESS,

--- a/src/theory/bv/int_blaster.cpp
+++ b/src/theory/bv/int_blaster.cpp
@@ -53,6 +53,7 @@ IntBlaster::IntBlaster(Env& env,
       d_intblastCache(userContext()),
       d_rangeNodes(userContext()),
       d_bitwiseAssertions(userContext()),
+      d_factProofRule(userContext()),
       d_iandUtils(nodeManager()),
       d_mode(mode),
       d_context(userContext())
@@ -68,9 +69,10 @@ IntBlaster::~IntBlaster() {}
 
 std::shared_ptr<ProofNode> IntBlaster::getProofFor(Node fact)
 {
-  // proofs not yet supported
   CDProof cdp(d_env);
-  cdp.addTrustedStep(fact, TrustId::INT_BLASTER, {}, {});
+  CDNodeRuleMap::const_iterator it = d_factProofRule.find(fact);
+  Assert(it != d_factProofRule.end());
+  cdp.addStep(fact, (*it).second, {}, {fact});
   return cdp.getProofFor(fact);
 }
 
@@ -88,6 +90,7 @@ void IntBlaster::addRangeConstraint(Node node,
     Trace("int-blaster-debug")
         << "node added to cache and constraints added to lemmas " << std::endl;
     d_rangeNodes.insert(node);
+    d_factProofRule.insert(rangeConstraint, ProofRule::BV_INTBLAST_RANGE);
     TrustNode trn = TrustNode::mkTrustLemma(rangeConstraint, this);
     lemmas.push_back(trn);
   }
@@ -119,6 +122,7 @@ void IntBlaster::addQuantifiedRangeConstraint(Node f,
                                   "range constraint added to cache and lemmas "
                                << std::endl;
     d_rangeNodes.insert(f);
+    d_factProofRule.insert(rangeConstraint, ProofRule::BV_INTBLAST_RANGE);
     TrustNode trn = TrustNode::mkTrustLemma(rangeConstraint, this);
     lemmas.push_back(trn);
   }
@@ -133,6 +137,7 @@ void IntBlaster::addBitwiseConstraint(Node bitwiseConstraint,
         << "bitwise constraint added to cache and lemmas: " << bitwiseConstraint
         << std::endl;
     d_bitwiseAssertions.insert(bitwiseConstraint);
+    d_factProofRule.insert(bitwiseConstraint, ProofRule::BV_INTBLAST_BITWISE);
     TrustNode trn = TrustNode::mkTrustLemma(bitwiseConstraint, this);
     lemmas.push_back(trn);
   }
@@ -286,6 +291,7 @@ TrustNode IntBlaster::trustedIntBlast(Node n,
   {
     return TrustNode::null();
   }
+  d_factProofRule.insert(n.eqNode(res), ProofRule::BV_INTBLAST_STEP);
   return TrustNode::mkTrustRewrite(n, res, this);
 }
 

--- a/src/theory/bv/int_blaster.h
+++ b/src/theory/bv/int_blaster.h
@@ -18,6 +18,7 @@
 #include "context/cdhashmap.h"
 #include "context/cdhashset.h"
 #include "context/cdo.h"
+#include "cvc5/cvc5_proof_rule.h"
 #include "options/smt_options.h"
 #include "proof/proof_generator.h"
 #include "proof/trust_node.h"
@@ -93,6 +94,7 @@ namespace cvc5::internal {
 class IntBlaster : protected EnvObj, public ProofGenerator
 {
   using CDNodeMap = context::CDHashMap<Node, Node>;
+  using CDNodeRuleMap = context::CDHashMap<Node, ProofRule>;
 
  public:
   /**
@@ -137,8 +139,11 @@ class IntBlaster : protected EnvObj, public ProofGenerator
   /**
    * Get proof for fact, where fact may correspond to:
    * (1) An equality of the form (= n n') where n was rewritten to n' in the
-   * method trustedIntBlast.
-   * (2) A lemma added to lemmas in the method trustedIntBlast.
+   * method trustedIntBlast, proven by ProofRule::BV_INTBLAST_STEP.
+   * (2) A range constraint added in addRangeConstraint or
+   * addQuantifiedRangeConstraint, proven by ProofRule::BV_INTBLAST_RANGE.
+   * (3) A bitwise constraint added in addBitwiseConstraint, proven by
+   * ProofRule::BV_INTBLAST_BITWISE.
    */
   std::shared_ptr<ProofNode> getProofFor(Node fact) override;
   /** identify */
@@ -376,6 +381,13 @@ class IntBlaster : protected EnvObj, public ProofGenerator
    *   used in for options::SolveBVAsIntMode::BITWISE
    */
   context::CDHashSet<Node> d_bitwiseAssertions;
+
+  /**
+   * Maps facts proved by this generator (either translation equalities or
+   * lemmas) to the proof rule that proves them, so that getProofFor can
+   * dispatch to the appropriate rule.
+   */
+  CDNodeRuleMap d_factProofRule;
 
   /** Useful constants */
   Node d_zero;

--- a/src/theory/bv/proof_checker.cpp
+++ b/src/theory/bv/proof_checker.cpp
@@ -30,6 +30,9 @@ void BVProofRuleChecker::registerTo(ProofChecker* pc)
   pc->registerChecker(ProofRule::BV_POLY_NORM, this);
   pc->registerChecker(ProofRule::BV_POLY_NORM_EQ, this);
   pc->registerChecker(ProofRule::BV_EAGER_ATOM, this);
+  pc->registerChecker(ProofRule::BV_INTBLAST_STEP, this);
+  pc->registerChecker(ProofRule::BV_INTBLAST_RANGE, this);
+  pc->registerChecker(ProofRule::BV_INTBLAST_BITWISE, this);
 }
 
 Node BVProofRuleChecker::checkInternal(ProofRule id,
@@ -128,6 +131,14 @@ Node BVProofRuleChecker::checkInternal(ProofRule id,
       return Node::null();
     }
     return ret;
+  }
+  else if (id == ProofRule::BV_INTBLAST_STEP || id == ProofRule::BV_INTBLAST_RANGE
+           || id == ProofRule::BV_INTBLAST_BITWISE)
+  {
+    Assert(children.empty());
+    Assert(args.size() == 1);
+    // placeholder rules for int-blasting proofs, accept any fact
+    return args[0];
   }
   // no rule
   return Node::null();


### PR DESCRIPTION
Add BV_INTBLAST_STEP, BV_INTBLAST_RANGE and BV_INTBLAST_BITWISE so that int-blasting facts are proven by named rules instead of TrustId::INT_BLASTER, which is now removed. The rules are placeholders that accept any fact; the Eunoia side conditions are not implemented yet.