### PR TITLE
bv-to-int: Cast untranslated bit-vector leaves to integers

### DIFF
--- a/src/theory/bv/int_blaster.cpp
+++ b/src/theory/bv/int_blaster.cpp
@@ -875,6 +875,15 @@ Node IntBlaster::translateNoChildren(Node original,
       Rational r = Rational(c, Integer(1));
       translation = d_nm->mkConstInt(r);
     }
+    else if (original.getType().isBitVector())
+    {
+      // Other leaves of bit-vector type, e.g. nullary operators of that type
+      // such as sep.nil, are not translated. We cast them to an integer so
+      // that the translation has the same type as the translation of any
+      // other bit-vector term, as reconstructNode does for terms with
+      // children.
+      translation = castToType(original, d_nm->integerType());
+    }
     else
     {
       // Other constants or operators stay the same.

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1947,6 +1947,7 @@ set(regress_0_tests
   regress0/sep/dispose-1.smt2
   regress0/sep/dup-nemp.smt2
   regress0/sep/issue10213-empty-model.smt2
+  regress0/sep/issue12915-bv-to-int-sep-nil.smt2
   regress0/sep/issue3720-check-model.smt2
   regress0/sep/issue5343-err.smt2
   regress0/sep/issue8659-wand-diff-heaps.smt2

--- a/test/regress/cli/regress0/sep/issue12915-bv-to-int-sep-nil.smt2
+++ b/test/regress/cli/regress0/sep/issue12915-bv-to-int-sep-nil.smt2
@@ -1,0 +1,8 @@
+; REQUIRES: unrestricted-mode
+; EXPECT: sat
+; DISABLE-TESTER: model
+(set-logic QF_ALL)
+(set-option :solve-bv-as-int bitwise)
+(declare-heap ((_ BitVec 4) (_ BitVec 4)))
+(assert (= (as sep.nil (_ BitVec 4)) (_ bv0 4)))
+(check-sat)


### PR DESCRIPTION
`--solve-bv-as-int` crashes on a separation logic problem over a bit-vector heap as soon as `sep.nil` of that sort is mentioned. `IntBlaster::translateNoChildren` turns bit-vector variables into integer variables and bit-vector constants into their integer value, but leaves every other bit-vector leaf untranslated, so `sep.nil` stays a bit-vector while the other side of its equality has become an integer.

The fix casts such a leaf to an integer with `castToType`, the way `reconstructNode` already does for terms with children, so the translation of a bit-vector term is an integer in every case. A regression test is added; the separation logic suite and the 84 existing `--solve-bv-as-int`/`bv2nat` regressions pass.

Fixes #12915.
