### PR TITLE
sep: Never construct an empty set of heap locations

### DIFF
--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -1199,9 +1199,11 @@ void TheorySep::initializeBounds()
   {
     n_emp = d_card_max;
   }
-  else if (d_type_references.empty())
+  if (n_emp == 0 && d_type_references.empty())
   {
-    // must include at least one constant TODO: remove?
+    // We must include at least one constant, so that the set of locations is
+    // not empty. Otherwise, computeLabelModel has no location to fall back on
+    // for a location in the model that has no corresponding term.
     n_emp = 1;
   }
   Trace("sep-bound") << "Cardinality element size : " << d_card_max

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1947,6 +1947,7 @@ set(regress_0_tests
   regress0/sep/dispose-1.smt2
   regress0/sep/dup-nemp.smt2
   regress0/sep/issue10213-empty-model.smt2
+  regress0/sep/issue12916-wand-not-emp-no-pto.smt2
   regress0/sep/issue3720-check-model.smt2
   regress0/sep/issue5343-err.smt2
   regress0/sep/issue8659-wand-diff-heaps.smt2

--- a/test/regress/cli/regress0/sep/issue12916-wand-not-emp-no-pto.smt2
+++ b/test/regress/cli/regress0/sep/issue12916-wand-not-emp-no-pto.smt2
@@ -1,0 +1,8 @@
+; REQUIRES: unrestricted-mode
+; EXPECT: sat
+; DISABLE-TESTER: model
+(set-logic QF_ALL)
+(declare-heap (Bool Bool))
+(declare-const b Bool)
+(assert (wand (not sep.emp) b))
+(check-sat)


### PR DESCRIPTION
A magic wand with antecedent `(not sep.emp)`, in a problem with no `pto`, crashes in `TheorySep::computeLabelModel`, which falls back to `d_type_references[0]` for a heap location with no corresponding term — but the set of locations is empty, because `initializeBounds` only forces a location constant when the cardinality bound is *invalid*, and here it is valid and zero.

`initializeBounds` now constructs at least one constant whenever no location is known. Enlarging the location set is sound: it is an upper bound on the heap. The regression test uses a `Bool` heap, since over an infinite location sort the fixed result is `unknown` (positive-wand incompleteness, as in #12920) rather than a decided answer. The separation logic suite passes.

Fixes #12916.
