### PR TITLE
sep: Allow a label to have more than one list of children

### DIFF
--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -429,17 +429,21 @@ void TheorySep::reduceFact(TNode atom, bool polarity, TNode fact)
       // A is the disjoint union of B and C.
       if (!sharesRootLabel(slbl, d_base_label))
       {
-        std::map<Node, std::vector<Node> >::iterator itc =
+        std::map<Node, std::vector<std::vector<Node> > >::iterator itc =
             d_childrenMap.find(slbl);
         if (itc != d_childrenMap.end())
         {
-          std::vector<Node> disjs;
-          for (const Node& c : itc->second)
+          // apply downwards closure for each list of children of slbl
+          for (const std::vector<Node>& cs : itc->second)
           {
-            disjs.push_back(nm->mkNode(Kind::SEP_LABEL, satom, c));
+            std::vector<Node> disjs;
+            for (const Node& c : cs)
+            {
+              disjs.push_back(nm->mkNode(Kind::SEP_LABEL, satom, c));
+            }
+            Node conc2 = nm->mkNode(Kind::OR, disjs);
+            conc = conc.isNull() ? conc2 : nm->mkNode(Kind::AND, conc, conc2);
           }
-          Node conc2 = nm->mkNode(Kind::OR, disjs);
-          conc = conc.isNull() ? conc2 : nm->mkNode(Kind::AND, conc, conc2);
         }
       }
       // note semantics of sep.nil is enforced globally
@@ -1378,8 +1382,11 @@ void TheorySep::makeDisjointHeap(Node parent, const std::vector<Node>& children)
   Assert(children.size() >= 2);
   if (!sharesRootLabel(parent, d_base_label))
   {
-    Assert(d_childrenMap.find(parent) == d_childrenMap.end());
-    d_childrenMap[parent] = children;
+    std::vector<std::vector<Node> >& cm = d_childrenMap[parent];
+    if (std::find(cm.begin(), cm.end(), children) == cm.end())
+    {
+      cm.push_back(children);
+    }
   }
   // remember parent relationships
   for (const Node& c : children)

--- a/src/theory/sep/theory_sep.h
+++ b/src/theory/sep/theory_sep.h
@@ -249,10 +249,14 @@ class TheorySep : public Theory
    */
   std::map<Node, std::vector<Node> > d_parentMap;
   /**
-   * Maps label sets to their direct children. This map is only stored for
-   * labels with children that do not share a root label with the base label.
+   * Maps label sets to the lists of their direct children. This map is only
+   * stored for labels with children that do not share a root label with the
+   * base label. A label may have more than one list of children: the label of
+   * the conclusion of a sep.wand is the disjoint union of the label of the
+   * wand and the label of its premise, and if that conclusion is itself a
+   * sep.star, it is also the disjoint union of the labels of its arguments.
    */
-  std::map<Node, std::vector<Node> > d_childrenMap;
+  std::map<Node, std::vector<std::vector<Node> > > d_childrenMap;
 
   /**
    * This sends the lemmas:

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1947,6 +1947,7 @@ set(regress_0_tests
   regress0/sep/dispose-1.smt2
   regress0/sep/dup-nemp.smt2
   regress0/sep/issue10213-empty-model.smt2
+  regress0/sep/issue12917-wand-star-consequent.smt2
   regress0/sep/issue3720-check-model.smt2
   regress0/sep/issue5343-err.smt2
   regress0/sep/issue8659-wand-diff-heaps.smt2

--- a/test/regress/cli/regress0/sep/issue12917-wand-star-consequent.smt2
+++ b/test/regress/cli/regress0/sep/issue12917-wand-star-consequent.smt2
@@ -1,0 +1,7 @@
+; REQUIRES: unrestricted-mode
+; EXPECT: sat
+; DISABLE-TESTER: model
+(set-logic QF_ALL)
+(declare-heap (Int Int))
+(assert (sep true (wand sep.emp (sep sep.emp sep.emp))))
+(check-sat)


### PR DESCRIPTION
A magic wand whose consequent is itself a `sep`, under an outer `sep`, trips the `d_childrenMap` overwrite assertion in `makeDisjointHeap`: the consequent label is recorded once as the disjoint union of the wand and its antecedent, and again as the disjoint union of the `sep`'s arguments. Both decompositions are valid.

`d_childrenMap` now maps a label to the list of its decompositions, and the `pto` downward closure — its only reader — is applied for each. A regression test is added; the separation logic suite passes.

Fixes #12917.
