### PR TITLE
sep: Accept a non-constant pto data value under function-value-mode=hole

### DIFF
--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -22,6 +22,7 @@
 #include "options/quantifiers_options.h"
 #include "options/sep_options.h"
 #include "options/smt_options.h"
+#include "options/theory_options.h"
 #include "proof/trust_id.h"
 #include "smt/logic_exception.h"
 #include "theory/builtin/proof_checker.h"
@@ -246,7 +247,13 @@ void TheorySep::postProcessModel(TheoryModel* m)
       {
         Trace("sep-model") << d_pto_model[l];
         Node vpto = m->getValue(d_pto_model[l]);
-        Assert(vpto.isConst());
+        // The value is not necessarily a constant: with
+        // --default-function-value-mode=hole, the value of an application of
+        // an uninterpreted function may be a distinguished (non-constant)
+        // skolem.
+        Assert(vpto.isConst()
+               || options().theory.defaultFunctionValueMode
+                      == options::DefaultFunctionValueMode::HOLE);
         pto_children.push_back(vpto);
       }
       Trace("sep-model") << std::endl;

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1947,6 +1947,7 @@ set(regress_0_tests
   regress0/sep/dispose-1.smt2
   regress0/sep/dup-nemp.smt2
   regress0/sep/issue10213-empty-model.smt2
+  regress0/sep/issue12918-hole-pto-data.smt2
   regress0/sep/issue3720-check-model.smt2
   regress0/sep/issue5343-err.smt2
   regress0/sep/issue8659-wand-diff-heaps.smt2

--- a/test/regress/cli/regress0/sep/issue12918-hole-pto-data.smt2
+++ b/test/regress/cli/regress0/sep/issue12918-hole-pto-data.smt2
@@ -1,0 +1,11 @@
+; REQUIRES: unrestricted-mode
+; COMMAND-LINE: --produce-models
+; EXPECT: sat
+; DISABLE-TESTER: model
+(set-logic QF_ALL)
+(set-option :default-function-value-mode hole)
+(declare-heap ((_ BitVec 36) (_ BitVec 36)))
+(declare-fun f ((_ BitVec 36)) (_ BitVec 36))
+(declare-const a (_ BitVec 36))
+(assert (sep (pto a (f a)) (bvslt a #xbeae7625a)))
+(check-sat)


### PR DESCRIPTION
With `--default-function-value-mode=hole`, a `pto` whose data is an application of an uninterpreted function takes a non-constant (distinguished-skolem) value, tripping the `vpto.isConst()` assertion in `TheorySep::postProcessModel`.

Nothing downstream of the heap model requires the data to be a constant, so the assertion now admits a non-constant value in `hole` mode. The reported heap then shows the hole in the `pto`, matching the value the model gives the function. A regression test is added; the separation logic suite passes.

Fixes #12918.
