### PR TITLE
sep: Give the guarded reduction its own sublabels, scoped to its fact

### DIFF
--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -505,8 +505,40 @@ void TheorySep::reduceFact(TNode atom, bool polarity, TNode fact)
     AlwaysAssert(!lit.isNull());
     d_neg_guards.push_back(lit);
     d_guard_to_assertion[lit] = satom;
-    // Node lem = nm->mkNode( EQUAL, lit, conc );
-    Node lem = nm->mkNode(Kind::OR, lit.negate(), conc);
+    // The guarded reduction is a search: for a negated star, for a partition
+    // witnessing the star; for a positive wand, for an extension refuting
+    // it. The guard is decided true by STRAT_SEP_NEG_GUARD to run the search
+    // and is learned false only when the search is exhausted, in which case
+    // the constraint holds and postCheck may skip it. That reading is only
+    // correct if the search ranges over sublabels that are free when it
+    // starts. The sublabels of the positive reduction (d_label_map) may
+    // already be fixed, e.g. by that reduction having been used
+    // contrapositively, so the search uses its own (d_guard_label_map).
+    Node gconc = conc;
+    if (satom.getKind() == Kind::SEP_STAR || satom.getKind() == Kind::SEP_WAND)
+    {
+      std::vector<Node> gchildren;
+      std::vector<Node> glabels;
+      getLabelChildren(satom, slbl, gchildren, glabels, true);
+      Assert(gchildren.size() > 1);
+      if (satom.getKind() == Kind::SEP_STAR)
+      {
+        makeDisjointHeap(slbl, glabels);
+      }
+      else
+      {
+        Assert(!d_nil_ref.isNull());
+        Node nrlem =
+            nm->mkNode(Kind::SET_MEMBER, d_nil_ref, glabels[0]).negate();
+        d_im.lemma(nrlem, InferenceId::SEP_NIL_NOT_IN_HEAP);
+        makeDisjointHeap(glabels[1], {slbl, glabels[0]});
+      }
+      gconc = nm->mkNode(Kind::AND, gchildren);
+    }
+    // The reduction is also conditioned on the fact: the guard and its
+    // strategy persist across backtracking, the fact does not, and a guard
+    // whose fact is not asserted must be inert.
+    Node lem = nm->mkNode(Kind::OR, {fact.negate(), lit.negate(), gconc});
     Trace("sep-lemma") << "Sep::Lemma : (neg) reduction : " << lem << std::endl;
     d_im.lemma(lem, InferenceId::SEP_NEG_REDUCTION);
   }
@@ -685,7 +717,7 @@ void TheorySep::postCheck(Effort level)
         {
           Assert(atom.getKind() == Kind::SEP_LABEL);
           TNode slbl = atom[1];
-          std::map<Node, std::map<int, Node> >& lms = d_label_map[satom];
+          std::map<Node, std::map<int, Node> >& lms = d_guard_label_map[satom];
           if (lms.find(slbl) != lms.end())
           {
             Trace("sep-process-debug") << "Active lbl : " << slbl << std::endl;
@@ -723,7 +755,7 @@ void TheorySep::postCheck(Effort level)
     Trace("sep-process") << "--> Active negated atom : " << satom
                          << ", lbl = " << slbl << std::endl;
     // add refinement lemma
-    if (!ContainsKey(d_label_map[satom], slbl))
+    if (!ContainsKey(d_guard_label_map[satom], slbl))
     {
       Trace("sep-process-debug") << "  no children." << std::endl;
       Assert(satom.getKind() == Kind::SEP_PTO
@@ -741,7 +773,7 @@ void TheorySep::postCheck(Effort level)
     // get model values
     std::map<int, Node> mvals;
     for (const std::pair<const int, Node>& sub_element :
-         d_label_map[satom][slbl])
+         d_guard_label_map[satom][slbl])
     {
       int sub_index = sub_element.first;
       Node sub_lbl = sub_element.second;
@@ -759,8 +791,15 @@ void TheorySep::postCheck(Effort level)
     // new refinement
     // instantiate the label
     std::map<Node, Node> visited;
-    Node inst = instantiateLabel(
-        satom, slbl, slbl, o_b_lbl_mval, visited, d_pto_model, tn, active_lbl);
+    Node inst = instantiateLabel(satom,
+                                 slbl,
+                                 slbl,
+                                 o_b_lbl_mval,
+                                 visited,
+                                 d_pto_model,
+                                 tn,
+                                 active_lbl,
+                                 true);
     Trace("sep-inst-debug") << "    applied inst : " << inst << std::endl;
     if (inst.isNull())
     {
@@ -1356,17 +1395,19 @@ Node TheorySep::mkUnion(TypeNode tn, std::vector<Node>& locs)
   }
 }
 
-Node TheorySep::getLabel(Node atom, int child, Node lbl)
+Node TheorySep::getLabel(Node atom, int child, Node lbl, bool guard)
 {
-  std::map<int, Node>::iterator it = d_label_map[atom][lbl].find(child);
-  if (it == d_label_map[atom][lbl].end())
+  std::map<Node, std::map<Node, std::map<int, Node> > >& lmap =
+      guard ? d_guard_label_map : d_label_map;
+  std::map<int, Node>::iterator it = lmap[atom][lbl].find(child);
+  if (it == lmap[atom][lbl].end())
   {
     Assert(!d_type_ref.isNull());
     std::stringstream ss;
-    ss << "__Lc" << child;
+    ss << (guard ? "__Lg" : "__Lc") << child;
     TypeNode ltn = nodeManager()->mkSetType(d_type_ref);
     Node n_lbl = NodeManager::mkDummySkolem(ss.str(), ltn);
-    d_label_map[atom][lbl][child] = n_lbl;
+    lmap[atom][lbl][child] = n_lbl;
     return n_lbl;
   }
   else
@@ -1527,9 +1568,12 @@ Node TheorySep::instantiateLabel(Node n,
                                  std::map<Node, Node>& pto_model,
                                  TypeNode rtn,
                                  std::map<Node, bool>& active_lbl,
+                                 bool guard,
                                  unsigned ind)
 {
   NodeManager* nm = nodeManager();
+  std::map<Node, std::map<Node, std::map<int, Node> > >& lmap =
+      guard ? d_guard_label_map : d_label_map;
   Trace("sep-inst-debug") << "Instantiate label " << n << " " << lbl << " "
                           << lbl_v << std::endl;
   if (options().sep.sepMinimalRefine && lbl != o_lbl
@@ -1561,10 +1605,10 @@ Node TheorySep::instantiateLabel(Node n,
       {
         std::vector<Node> children;
         children.resize(n.getNumChildren());
-        Assert(d_label_map[n].find(lbl) != d_label_map[n].end());
+        Assert(lmap[n].find(lbl) != lmap[n].end());
         std::map<int, Node> mvals;
-        for (std::map<int, Node>::iterator itl = d_label_map[n][lbl].begin();
-             itl != d_label_map[n][lbl].end();
+        for (std::map<int, Node>::iterator itl = lmap[n][lbl].begin();
+             itl != lmap[n][lbl].end();
              ++itl)
         {
           Node sub_lbl = itl->second;
@@ -1575,8 +1619,8 @@ Node TheorySep::instantiateLabel(Node n,
           Node lbl_mval;
           if (n.getKind() == Kind::SEP_WAND && sub_index == 1)
           {
-            Assert(d_label_map[n][lbl].find(0) != d_label_map[n][lbl].end());
-            Node sub_lbl_0 = d_label_map[n][lbl][0];
+            Assert(lmap[n][lbl].find(0) != lmap[n][lbl].end());
+            Node sub_lbl_0 = lmap[n][lbl][0];
             computeLabelModel(sub_lbl_0);
             Assert(d_label_model.find(sub_lbl_0) != d_label_model.end());
             lbl_mval = nodeManager()->mkNode(
@@ -1601,6 +1645,7 @@ Node TheorySep::instantiateLabel(Node n,
                                                  pto_model,
                                                  rtn,
                                                  active_lbl,
+                                                 guard,
                                                  ind + 1);
           if (children[sub_index].isNull())
           {
@@ -1616,8 +1661,8 @@ Node TheorySep::instantiateLabel(Node n,
           bchildren.insert(bchildren.end(), children.begin(), children.end());
           Node vsu;
           std::vector<Node> vs;
-          for (std::map<int, Node>::iterator itl = d_label_map[n][lbl].begin();
-               itl != d_label_map[n][lbl].end();
+          for (std::map<int, Node>::iterator itl = lmap[n][lbl].begin();
+               itl != lmap[n][lbl].end();
                ++itl)
           {
             Node sub_lbl = itl->second;
@@ -1648,7 +1693,7 @@ Node TheorySep::instantiateLabel(Node n,
         {
           std::vector<Node> wchildren;
           // disjoint constraints
-          Node sub_lbl_0 = d_label_map[n][lbl][0];
+          Node sub_lbl_0 = lmap[n][lbl][0];
           Node lbl_mval_0 =
               d_label_model[sub_lbl_0].getValue(nodeManager(), rtn);
           wchildren.push_back(nodeManager()
@@ -1741,6 +1786,7 @@ Node TheorySep::instantiateLabel(Node n,
                                       pto_model,
                                       rtn,
                                       active_lbl,
+                                      guard,
                                       ind);
           if (aln.isNull())
           {
@@ -1783,9 +1829,13 @@ void TheorySep::setInactiveAssertionRec(
   TNode slbl = atom[1];
   if (satom.getKind() == Kind::SEP_WAND || satom.getKind() == Kind::SEP_STAR)
   {
+    // the children of a guarded (negated star / positive wand) assertion
+    // live at the labels of its guarded reduction
+    bool use_polarity =
+        satom.getKind() == Kind::SEP_WAND ? !polarity : polarity;
     for (size_t j = 0, nchild = satom.getNumChildren(); j < nchild; j++)
     {
-      Node lblc = getLabel(satom, j, slbl);
+      Node lblc = getLabel(satom, j, slbl, !use_polarity);
       for (unsigned k = 0; k < lbl_to_assertions[lblc].size(); k++)
       {
         setInactiveAssertionRec(
@@ -1798,11 +1848,12 @@ void TheorySep::setInactiveAssertionRec(
 void TheorySep::getLabelChildren(Node satom,
                                  Node lbl,
                                  std::vector<Node>& children,
-                                 std::vector<Node>& labels)
+                                 std::vector<Node>& labels,
+                                 bool guard)
 {
   for (size_t i = 0, nchild = satom.getNumChildren(); i < nchild; i++)
   {
-    Node lblc = getLabel(satom, i, lbl);
+    Node lblc = getLabel(satom, i, lbl, guard);
     Assert(!lblc.isNull());
     std::map<Node, Node> visited;
     Node lc = applyLabel(satom[i], lblc, visited);

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -429,17 +429,21 @@ void TheorySep::reduceFact(TNode atom, bool polarity, TNode fact)
       // A is the disjoint union of B and C.
       if (!sharesRootLabel(slbl, d_base_label))
       {
-        std::map<Node, std::vector<Node> >::iterator itc =
+        std::map<Node, std::vector<std::vector<Node> > >::iterator itc =
             d_childrenMap.find(slbl);
         if (itc != d_childrenMap.end())
         {
-          std::vector<Node> disjs;
-          for (const Node& c : itc->second)
+          // apply downwards closure for each list of children of slbl
+          for (const std::vector<Node>& cs : itc->second)
           {
-            disjs.push_back(nm->mkNode(Kind::SEP_LABEL, satom, c));
+            std::vector<Node> disjs;
+            for (const Node& c : cs)
+            {
+              disjs.push_back(nm->mkNode(Kind::SEP_LABEL, satom, c));
+            }
+            Node conc2 = nm->mkNode(Kind::OR, disjs);
+            conc = conc.isNull() ? conc2 : nm->mkNode(Kind::AND, conc, conc2);
           }
-          Node conc2 = nm->mkNode(Kind::OR, disjs);
-          conc = conc.isNull() ? conc2 : nm->mkNode(Kind::AND, conc, conc2);
         }
       }
       // note semantics of sep.nil is enforced globally
@@ -1378,8 +1382,11 @@ void TheorySep::makeDisjointHeap(Node parent, const std::vector<Node>& children)
   Assert(children.size() >= 2);
   if (!sharesRootLabel(parent, d_base_label))
   {
-    Assert(d_childrenMap.find(parent) == d_childrenMap.end());
-    d_childrenMap[parent] = children;
+    std::vector<std::vector<Node> >& cm = d_childrenMap[parent];
+    if (std::find(cm.begin(), cm.end(), children) == cm.end())
+    {
+      cm.push_back(children);
+    }
   }
   // remember parent relationships
   for (const Node& c : children)

--- a/src/theory/sep/theory_sep.h
+++ b/src/theory/sep/theory_sep.h
@@ -242,6 +242,16 @@ class TheorySep : public Theory
   Node d_emp_arg;
   // map from ( atom, label, child index ) -> label
   std::map<Node, std::map<Node, std::map<int, Node> > > d_label_map;
+  /**
+   * Like d_label_map, but for the sublabels of the guarded reduction of a
+   * negated star/pto/emp or a positive wand (see reduceFact). The guarded
+   * reduction is a search for a witness partition (resp. counterexample
+   * extension) over fresh sublabels, and its outcome is only meaningful if
+   * those sublabels are free when the search runs. They are therefore not
+   * shared with the positive reduction of the same atom at the same label,
+   * whose sublabels may already be fixed for other reasons (issue #12913).
+   */
+  std::map<Node, std::map<Node, std::map<int, Node> > > d_guard_label_map;
 
   /**
    * Maps label sets to their direct parents. A set may have multiple parents
@@ -318,7 +328,12 @@ class TheorySep : public Theory
   // get location/data type
   // get the base label for the spatial assertion
   Node getBaseLabel();
-  Node getLabel(Node atom, int child, Node lbl);
+  /**
+   * Get the label for the child-th child of atom at label lbl, creating it if
+   * it does not exist. If guard is true, this is the label used by the
+   * guarded reduction (d_guard_label_map), otherwise d_label_map.
+   */
+  Node getLabel(Node atom, int child, Node lbl, bool guard = false);
   /**
    * Apply label lbl to all top-level spatial assertions, recursively, in n.
    */
@@ -326,7 +341,8 @@ class TheorySep : public Theory
   void getLabelChildren(Node atom,
                         Node lbl,
                         std::vector<Node>& children,
-                        std::vector<Node>& labels);
+                        std::vector<Node>& labels,
+                        bool guard = false);
 
   class HeapInfo
   {
@@ -364,6 +380,7 @@ class TheorySep : public Theory
                         std::map<Node, Node>& pto_model,
                         TypeNode rtn,
                         std::map<Node, bool>& active_lbl,
+                        bool guard,
                         unsigned ind = 0);
   void setInactiveAssertionRec(
       Node fact,

--- a/src/theory/sep/theory_sep.h
+++ b/src/theory/sep/theory_sep.h
@@ -249,10 +249,14 @@ class TheorySep : public Theory
    */
   std::map<Node, std::vector<Node> > d_parentMap;
   /**
-   * Maps label sets to their direct children. This map is only stored for
-   * labels with children that do not share a root label with the base label.
+   * Maps label sets to the lists of their direct children. This map is only
+   * stored for labels with children that do not share a root label with the
+   * base label. A label may have more than one list of children: the label of
+   * the conclusion of a sep.wand is the disjoint union of the label of the
+   * wand and the label of its premise, and if that conclusion is itself a
+   * sep.star, it is also the disjoint union of the labels of its arguments.
    */
-  std::map<Node, std::vector<Node> > d_childrenMap;
+  std::map<Node, std::vector<std::vector<Node> > > d_childrenMap;
 
   /**
    * This sends the lemmas:

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1947,6 +1947,7 @@ set(regress_0_tests
   regress0/sep/dispose-1.smt2
   regress0/sep/dup-nemp.smt2
   regress0/sep/issue10213-empty-model.smt2
+  regress0/sep/issue12917-wand-star-consequent.smt2
   regress0/sep/issue3720-check-model.smt2
   regress0/sep/issue5343-err.smt2
   regress0/sep/issue8659-wand-diff-heaps.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1947,6 +1947,7 @@ set(regress_0_tests
   regress0/sep/dispose-1.smt2
   regress0/sep/dup-nemp.smt2
   regress0/sep/issue10213-empty-model.smt2
+  regress0/sep/issue12913-neg-guard-soundness.smt2
   regress0/sep/issue12917-wand-star-consequent.smt2
   regress0/sep/issue3720-check-model.smt2
   regress0/sep/issue5343-err.smt2

--- a/test/regress/cli/regress0/sep/issue12913-neg-guard-soundness.smt2
+++ b/test/regress/cli/regress0/sep/issue12913-neg-guard-soundness.smt2
@@ -1,0 +1,11 @@
+; REQUIRES: unrestricted-mode
+; COMMAND-LINE: --decision=justification
+; COMMAND-LINE: --decision=internal
+; COMMAND-LINE: --sat-solver=minisat --decision=justification
+; COMMAND-LINE: --sat-solver=minisat --decision=internal
+; EXPECT: unsat
+(set-logic QF_ALL)
+(declare-heap (Int Int))
+(assert (sep (pto 1 2) (pto 3 2)))
+(assert (= (sep (not (pto 1 2)) true true) (pto 3 2)))
+(check-sat)

--- a/test/regress/cli/regress0/sep/issue12917-wand-star-consequent.smt2
+++ b/test/regress/cli/regress0/sep/issue12917-wand-star-consequent.smt2
@@ -1,0 +1,7 @@
+; REQUIRES: unrestricted-mode
+; EXPECT: sat
+; DISABLE-TESTER: model
+(set-logic QF_ALL)
+(declare-heap (Int Int))
+(assert (sep true (wand sep.emp (sep sep.emp sep.emp))))
+(check-sat)


### PR DESCRIPTION
A negated star/pto/emp (or a positive wand) is reduced lazily through a guard `G`: deciding `G` true runs a witness search over a partition, and a learned `¬G` lets `postCheck` skip the constraint as exhausted. That reading requires the search's sublabels to be free, but `getLabel` shared them with the positive reduction of the same atom, which may already have fixed them — and been used contrapositively to derive the negated fact in the first place — so `¬G` could be propagated from a single non-witness partition. Separately, the guard outlives its fact across backtracking, so a stale guard kept forcing the positive reduction of a constraint that was no longer asserted.

The guarded reduction now has its own sublabels (`d_guard_label_map`), the refinement instantiates over them, and the reduction is `fact ∧ G ⇒ conc`. The reproducer answers `unsat` under both SAT solvers and both decision heuristics, and the regression test runs all four. The separation logic suite and the `regress0` tier pass. As a side effect the #12872 reproducer now returns a model that satisfies its assertion (details in the commit message).

Stacked on #12923: a label may now carry two partitions, and the first commit here is that change.

Fixes #12913.
