### PR TITLE
bv abstract: Support n-ary multiplication.

### DIFF
--- a/src/theory/bv/abstract/abstraction_module.cpp
+++ b/src/theory/bv/abstract/abstraction_module.cpp
@@ -38,6 +38,10 @@ AbstractionModule::AbstractionModule(Env& env, TheoryBV* bv)
 AbstractionModule::Statistics::Statistics(StatisticsRegistry& reg)
     : d_numAbstractions(
           reg.registerInt("theory::bv::abstraction::numAbstractions")),
+      d_numBinarizations(
+          reg.registerInt("theory::bv::abstraction::numBinarizations")),
+      d_binarizedArity(reg.registerHistogram<uint64_t>(
+          "theory::bv::abstraction::binarizedArity")),
       d_numChecks(reg.registerInt("theory::bv::abstraction::numChecks")),
       d_numLemmasTier12(
           reg.registerInt("theory::bv::abstraction::numLemmasTier12")),
@@ -48,25 +52,26 @@ AbstractionModule::Statistics::Statistics(StatisticsRegistry& reg)
 {
 }
 
-bool AbstractionModule::abstractable(TNode n) const
+bool AbstractionModule::abstractable(TNode node) const
 {
-  Kind k = n.getKind();
+  Kind k = node.getKind();
   if (k != Kind::BITVECTOR_MULT && k != Kind::BITVECTOR_UDIV
       && k != Kind::BITVECTOR_UREM)
   {
     return false;
   }
-  // The lemma schemes are binary; cvc5 allows n-ary BITVECTOR_MULT.
-  if (n.getNumChildren() != 2)
-  {
-    return false;
-  }
-  return utils::getSize(n) >= d_absSize;
+  // Note: BITVECTOR_UDIV and BITVECTOR_UREM are binary, whereas cvc5 allows
+  //       n-ary BITVECTOR_MULT. The lemma schemes are binary, thus an n-ary
+  //       multiplication is binarized by abstract(), see binarize().
+  return utils::getSize(node) >= d_absSize;
 }
 
 Node AbstractionModule::abstractNode(TNode node)
 {
   Assert(abstractable(node));
+  Assert(node.getNumChildren() == 2)
+      << "the lemma schemes are binary, n-ary multiplications must be "
+         "binarized before they are abstracted";
   auto it = d_cache.find(node);
   // If the cached node is different from `node`, it must be an abstraction
   // constant. Hence, we don't have to check for d_abs2node.find(it->second).
@@ -80,10 +85,28 @@ Node AbstractionModule::abstractNode(TNode node)
   // or model construction.
   Node t = NodeManager::mkDummySkolem("bvabs", node.getType());
   d_abs2node.emplace(t, node);
-  // Note: We do not insert into d_cache here: the caller writes the mapping
-  // through a live iterator, which an insertion could invalidate (rehash).
+  // Note: This may invalidate iterators into d_cache (rehash), thus callers
+  //       must not hold a live iterator across a call to this function.
+  d_cache[node] = t;
   ++d_stats.d_numAbstractions;
   return t;
+}
+
+Node AbstractionModule::binarize(TNode node)
+{
+  Assert(abstractable(node));
+  Assert(node.getKind() == Kind::BITVECTOR_MULT);
+  Assert(node.getNumChildren() > 2);
+  NodeManager* nm = nodeManager();
+  size_t arity = node.getNumChildren();
+  ++d_stats.d_numBinarizations;
+  d_stats.d_binarizedArity << arity;
+  Node res = node[0];
+  for (size_t i = 1; i < arity; ++i)
+  {
+    res = abstractNode(nm->mkNode(Kind::BITVECTOR_MULT, res, node[i]));
+  }
+  return res;
 }
 
 Node AbstractionModule::abstract(TNode fact)
@@ -133,9 +156,13 @@ Node AbstractionModule::abstract(TNode fact)
       Node ret = rebuild ? nm->mkNode(cur.getKind(), children) : Node(cur);
       if (abstractable(ret))
       {
-        ret = abstractNode(ret);
+        ret = ret.getNumChildren() > 2 ? binarize(ret) : abstractNode(ret);
       }
-      it->second = rewrite(ret);
+      // Note: We do not write through `it` here: abstractNode() inserts into
+      //       d_cache, which may have invalidated it (rehash). Since `cur` is
+      //       already a key of d_cache, operator[] does not insert and thus
+      //       cannot rehash.
+      d_cache[cur] = rewrite(ret);
     }
     visit.pop_back();
   } while (!visit.empty());
@@ -152,6 +179,7 @@ void AbstractionModule::check(std::vector<Node>& lemmas)
   for (const auto& [t, n] : d_abs2node)
   {
     Assert(abstractable(n));
+    Assert(n.getNumChildren() == 2);
     Kind kind = n.getKind();
     TNode x = n[0];
     TNode s = n[1];
@@ -242,6 +270,7 @@ bool AbstractionModule::isModelConsistent()
   for (const auto& [t, n] : d_abs2node)
   {
     Assert(abstractable(n));
+    Assert(n.getNumChildren() == 2);
     Node xval = d_bv->getValue(n[0]);
     Node sval = d_bv->getValue(n[1]);
     Node tval = d_bv->getValue(t);

--- a/src/theory/bv/abstract/abstraction_module.h
+++ b/src/theory/bv/abstract/abstraction_module.h
@@ -17,6 +17,15 @@
  * abstractions for arithmetic terms `op(x, s)` with op in {bvmul, bvudiv,
  * bvurem} whose bit-width is at least a configurable threshold.
  *
+ * The lemma schemes are binary (they relate `x`, `s` and `t`), whereas cvc5's
+ * BITVECTOR_MULT is n-ary and the rewriter flattens nested multiplications
+ * into a single n-ary node. An n-ary multiplication is therefore left-
+ * associated into a chain of binary multiplications, each of which is
+ * abstracted by its own constant, e.g., `bvmul(a, b, c)` becomes `t2` with
+ * `t1 = bvmul(a, b)` and `t2 = bvmul(t1, c)`. Every level of the chain must be
+ * abstracted: the abstraction constant is what keeps the rewriter from
+ * flattening the chain back into an n-ary node.
+ *
  * This over-approximates the bit-vector facts that come in. If an abstraction
  * is consistent wrt. the semantics of the abstracted arithmetic operation, it
  * is refined via a tiered refined strategy. The first tier is implemented by
@@ -59,8 +68,9 @@ class AbstractionModule : protected EnvObj
   /**
    * Replace every abstractable arithmetic subterm of `fact` (down to theory
    * leaves, we do not descend into theory leafs) by a fresh constant, recording
-   * the abstraction map. Abstractable terms are binary bvmul/bvudiv/bvurem
-   * nodes whose bit-width is at least the abstraction threshold (d_absSize).
+   * the abstraction map. Abstractable terms are bvmul/bvudiv/bvurem nodes whose
+   * bit-width is at least the abstraction threshold (d_absSize); an n-ary
+   * bvmul is left-associated into binary multiplications first, see binarize().
    *
    * @param fact The fact to abstract.
    * @return The abstracted fact (`fact` if nothing was abstracted).
@@ -83,15 +93,25 @@ class AbstractionModule : protected EnvObj
    */
   void check(std::vector<Node>& lemmas);
 
-  /** @return True if `n` is a term that should be abstracted. */
-  bool abstractable(TNode n) const;
+  /**
+   * Determine if a given node is a term that should be abstracted.
+   * @param node The node to check.
+   * @return True if `node` is a term that should be abstracted.
+   * @note This includes n-ary multiplications, which are not abstracted by a
+   *       single constant but binarized into a chain of abstracted binary
+   *       multiplications (the n-ary node maps to the constant of the
+   *       outermost chain element).
+   */
+  bool abstractable(TNode node) const;
 
   /** @return True if given node has been abstracted by a constant. */
   bool isAbstracted(TNode node) const;
 
   /**
-   * @return The abstraction introduced for given node. Asserts that the
-   *         node has been abstracted.
+   * Get the abstraction introduced for given node.
+   * Asserts that the node has been abstracted.
+   * @param node The node to get the abstraction for.
+   * @return The abstraction.
    */
   TNode getAbstraction(TNode node) const;
 
@@ -106,10 +126,30 @@ class AbstractionModule : protected EnvObj
 
  private:
   /**
-   * @return The abstraction constant for an abstractable `node`. Creates a
-   *         fresh abstraction constant for each abstracted node.
+   * Create abstraction constant for an abstractable *binary* `node`.
+   *
+   * Creates a fresh abstraction constant for each abstracted node and records
+   * it in d_abs2node and d_cache.
+   *
+   * @param node The node to abstract.
+   * @return The abstraction constant.
    */
   Node abstractNode(TNode node);
+
+  /**
+   * Left-associate an n-ary multiplication into binary multiplications and
+   * abstract each of them, e.g., `bvmul(a, b, c)` yields `t2` with
+   * `t1 = bvmul(a, b)` and `t2 = bvmul(t1, c)`.
+   *
+   * All chain elements have the same bit-width as `node` and thus are
+   * abstractable iff `node` is. They are cached in d_cache, hence chains that
+   * share a prefix (e.g., `bvmul(a, b, c)` and `bvmul(a, b, d)`) share the
+   * abstraction constants of that prefix.
+   *
+   * @param node An abstractable BITVECTOR_MULT node with more than 2 children.
+   * @return The abstraction constant of the outermost chain element.
+   */
+  Node binarize(TNode node);
 
   /** The associated bit-vector theory engine. */
   TheoryBV* d_bv;
@@ -125,12 +165,18 @@ class AbstractionModule : protected EnvObj
   /** The refinement lemma schemes, used by the refinement loop. */
   LemmaRegistry d_lemmas;
 
-  /** Map from abstraction constant `t` to the node it abstracts. */
+  /**
+   * Map from abstraction constant `t` to the node it abstracts. The abstracted
+   * node is always binary (n-ary multiplications are binarized first), which
+   * the binary lemma schemes of d_lemmas rely on.
+   */
   std::unordered_map<Node, Node> d_abs2node;
 
   /**
    * Memoization cache for abstract(), maps abstracted node to their
-   * abstraction constant `t`, and all other nodes to themselves.
+   * abstraction constant `t`, and all other nodes to themselves. Also holds
+   * the binary chain elements introduced for n-ary multiplications, which do
+   * not occur in any fact themselves.
    */
   std::unordered_map<Node, Node> d_cache;
 
@@ -146,8 +192,16 @@ class AbstractionModule : protected EnvObj
   struct Statistics
   {
     Statistics(StatisticsRegistry& reg);
-    /** Number of arithmetic terms abstracted. */
+    /**
+     * Number of arithmetic terms abstracted. Note that a binarized n-ary
+     * multiplication of arity n accounts for n-1 of these, one per element of
+     * its chain of binary multiplications.
+     */
     IntStat d_numAbstractions;
+    /** Number of n-ary multiplications binarized. */
+    IntStat d_numBinarizations;
+    /** Arities of the n-ary multiplications that were binarized. */
+    HistogramStat<uint64_t> d_binarizedArity;
     /** Number of refinement consistency checks (refinement rounds). */
     IntStat d_numChecks;
     /** Number of tier-1/2 (Table-2 scheme) refinement lemmas added. */

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -314,8 +314,13 @@ set(regress_0_tests
   regress0/bv/abstract/murxla-a2f5f3aa83d5a854.min.smt2
   regress0/bv/abstract/murxla-cc7db96bcf2e620d.min.smt2
   regress0/bv/abstract/murxla-d9523963f3a24521.min.smt2
+  regress0/bv/abstract/nary-mul-const-factor.smt2
+  regress0/bv/abstract/nary-mul-shared-prefix.smt2
+  regress0/bv/abstract/nary-mul-tier4.smt2
   regress0/bv/abstract/red-bench-8002.smt2
   regress0/bv/abstract/sat-mul-refine.smt2
+  regress0/bv/abstract/sat-nary-mul-refine.smt2
+  regress0/bv/abstract/unsat-nary-mul-odd.smt2
   regress0/bv/abstract/unsatcore1.smt2
   regress0/bv/ackermann1.smt2
   regress0/bv/ackermann2.smt2

--- a/test/regress/cli/regress0/bv/abstract/nary-mul-const-factor.smt2
+++ b/test/regress/cli/regress0/bv/abstract/nary-mul-const-factor.smt2
@@ -1,0 +1,16 @@
+; REQUIRES: unrestricted-mode
+; COMMAND-LINE: --bv-abstraction --bv-abstraction-size=3
+; EXPECT: sat
+; An n-ary multiplication with a (non-power-of-two) constant factor. The
+; rewriter folds all constant factors into a single one and sorts it last, so
+; left-associating the chain leaves the constant multiplication as the
+; outermost element, which is what the coefficient-extraction invariant of the
+; BV normalization rewrites expects ("only one constant, at the end").
+(set-logic QF_BV)
+(set-info :status sat)
+(declare-fun a () (_ BitVec 16))
+(declare-fun b () (_ BitVec 16))
+(assert (= (bvmul a b (_ bv3 16)) (_ bv30 16)))
+(assert (bvugt a (_ bv1 16)))
+(assert (bvugt b (_ bv1 16)))
+(check-sat)

--- a/test/regress/cli/regress0/bv/abstract/nary-mul-shared-prefix.smt2
+++ b/test/regress/cli/regress0/bv/abstract/nary-mul-shared-prefix.smt2
@@ -1,0 +1,17 @@
+; REQUIRES: unrestricted-mode
+; COMMAND-LINE: --bv-abstraction --bv-abstraction-size=3
+; EXPECT: sat
+; Two n-ary multiplications sharing a prefix. Since the chain elements are
+; cached, the abstraction constant introduced for (bvmul a b) is shared by both
+; chains, i.e. three abstraction constants are introduced rather than four.
+; Refining the shared element constrains both products at once.
+(set-logic QF_BV)
+(set-info :status sat)
+(declare-fun a () (_ BitVec 16))
+(declare-fun b () (_ BitVec 16))
+(declare-fun c () (_ BitVec 16))
+(declare-fun d () (_ BitVec 16))
+(assert (bvult (bvmul a b c) (bvmul a b d)))
+(assert (bvugt a (_ bv1 16)))
+(assert (bvugt b (_ bv1 16)))
+(check-sat)

--- a/test/regress/cli/regress0/bv/abstract/nary-mul-tier4.smt2
+++ b/test/regress/cli/regress0/bv/abstract/nary-mul-tier4.smt2
@@ -1,0 +1,21 @@
+; REQUIRES: unrestricted-mode
+; COMMAND-LINE: --bv-abstraction --bv-abstraction-size=3 --bv-abstraction-value-limiter=100
+; EXPECT: sat
+; Forces the tier-4 bit-blasting fallback on a binarized chain: the tier-3
+; value-instantiation budget is bit-width/100 = 0, so any chain element that
+; no Table-2 lemma rules out falls back to asserting the real multiplication
+; right away. Note that tier 4 on a chain element asserts t2 = bvmul(t1, c)
+; against the still-abstract t1, i.e. it bit-blasts a single multiplier: the
+; whole product only becomes exact once every element has fallen back.
+(set-logic QF_BV)
+(set-info :status sat)
+(declare-fun a () (_ BitVec 16))
+(declare-fun b () (_ BitVec 16))
+(declare-fun c () (_ BitVec 16))
+(declare-fun d () (_ BitVec 16))
+(assert (= (bvmul a b c d) (_ bv210 16)))
+(assert (bvugt a (_ bv1 16)))
+(assert (bvugt b (_ bv1 16)))
+(assert (bvugt c (_ bv1 16)))
+(assert (bvugt d (_ bv1 16)))
+(check-sat)

--- a/test/regress/cli/regress0/bv/abstract/sat-nary-mul-refine.smt2
+++ b/test/regress/cli/regress0/bv/abstract/sat-nary-mul-refine.smt2
@@ -1,0 +1,18 @@
+; REQUIRES: unrestricted-mode
+; COMMAND-LINE: --bv-abstraction --bv-abstraction-size=3
+; EXPECT: sat
+; A satisfiable n-ary multiplication (a * b * c = 30 with a, b, c > 1).
+; BITVECTOR_MULT is n-ary in cvc5, whereas the Table-2 lemma schemes are
+; binary, so the term is left-associated into a chain of binary
+; multiplications, each abstracted by its own constant. Both chain elements
+; have to be refined before the model is consistent with the multiplication.
+(set-logic QF_BV)
+(set-info :status sat)
+(declare-fun a () (_ BitVec 16))
+(declare-fun b () (_ BitVec 16))
+(declare-fun c () (_ BitVec 16))
+(assert (= (bvmul a b c) (_ bv30 16)))
+(assert (bvugt a (_ bv1 16)))
+(assert (bvugt b (_ bv1 16)))
+(assert (bvugt c (_ bv1 16)))
+(check-sat)

--- a/test/regress/cli/regress0/bv/abstract/unsat-nary-mul-odd.smt2
+++ b/test/regress/cli/regress0/bv/abstract/unsat-nary-mul-odd.smt2
@@ -1,0 +1,20 @@
+; REQUIRES: unrestricted-mode
+; COMMAND-LINE: --bv-abstraction --bv-abstraction-size=3
+; EXPECT: unsat
+; DISABLE-TESTER: proof
+; If a, b and c are odd then a * b * c is odd. The multiplication is written
+; in explicitly nested binary form: the rewriter flattens nested bvmul into a
+; single n-ary node, so this is the very same term as (bvmul a b c) by the
+; time the abstraction sees it -- an n-ary multiplication cannot be avoided by
+; writing it as a chain. Refuting this only needs the MUL4_ODD scheme
+; instantiated for each element of the binarized chain, no tier-3/4 fallback.
+(set-logic QF_BV)
+(set-info :status unsat)
+(declare-fun a () (_ BitVec 32))
+(declare-fun b () (_ BitVec 32))
+(declare-fun c () (_ BitVec 32))
+(assert (= ((_ extract 0 0) a) #b1))
+(assert (= ((_ extract 0 0) b) #b1))
+(assert (= ((_ extract 0 0) c) #b1))
+(assert (= ((_ extract 0 0) (bvmul (bvmul a b) c)) #b0))
+(check-sat)


### PR DESCRIPTION
For multiplication, abstractable terms were restricted to the binary case. BITVECTOR_MULT is n-ary, and binarized n-ary multiplications are flattened by the rewriter via RewriteRule<FlattenAssocCommut> into a single n-ary node.

This commit refactors the handling of n-ary multiplication in the abstraction module to support abstraction via binarization. An n-ary multiplication is left-associated into a chain of binary multiplications, each abstracted by its own constant, e.g., `bvmul(a, b, c)` becomes `t2` with `t1 = bvmul(a, b)` and `t2 = bvmul(t1, c)`. Every chain element is abstracted and the abstraction constant is what keeps the rewriter from flattening the chain back into an n-ary node. Chain elements are cached, hence multiplications sharing a prefix share the abstraction constants of that prefix.

Note that in tier-4, for a chain we now assert `t_i = bvmul(t_i-1, x_i)` against the still abstract `t_i-1`, i.e., as expected, we bit-blast a single multiplier. The product only becomes exact once the fallback fired for every element of its chain.

Initial prototyping supported by Claude.