### PR TITLE
fp: Extend TO_FP_FROM_REAL refinement to the outermost rounding cells.

### DIFF
--- a/src/theory/fp/theory_fp.cpp
+++ b/src/theory/fp/theory_fp.cpp
@@ -385,76 +385,87 @@ bool TheoryFp::refineAbstraction(TheoryModel* m, TNode abstract, TNode concrete)
       RoundingMode rm = rmValue.getConst<RoundingMode>();
       bool sent = false;
 
+      // Build the lemma stating that a literal about the abstraction holds iff
+      // x lies in the set of reals bounded below by b, resp. iff it lies in
+      // the complement of that set if negated is true.
+      //
+      // @param lit The literal about the abstraction.
+      // @param b The lower boundary of the set of reals.
+      // @param negated True if lit corresponds to the complement of the set.
+      // @return The lemma.
+      auto boundLemma = [&](const Node& lit,
+                            const utils::RoundingCellLowerBound& b,
+                            bool negated) {
+        if (b.d_kind != utils::RoundingCellLowerBound::Kind::BOUNDED)
+        {
+          // The set is all of the reals or empty, thus lit holds for every x
+          // or for none.
+          bool holds =
+              (b.d_kind == utils::RoundingCellLowerBound::Kind::ALL) != negated;
+          return holds ? lit : nm->mkNode(Kind::NOT, lit);
+        }
+        Kind kind = negated ? (b.d_strict ? Kind::LEQ : Kind::LT)
+                            : (b.d_strict ? Kind::GT : Kind::GEQ);
+        return nm->mkNode(
+            Kind::EQUAL,
+            {lit, nm->mkNode(kind, concrete[1], nm->mkConstReal(b.d_bound))});
+      };
+
       // For a float constant c and a fixed rounding mode, to_fp(rm, x) >=_fp c
-      // holds iff x is (strictly) above the exact real lower boundary of c's
-      // rounding cell, and dually to_fp(rm, x) <=_fp c holds iff x is
-      // (strictly) below the lower boundary of the cell of nextUp(c). These
-      // cell-boundary equivalences are sound and exclude the whole spurious
-      // rounding cell in one step, which is required for the refinement loop
-      // to converge (the model value of x could otherwise slide from cell to
-      // cell indefinitely).
+      // holds iff x is (strictly) above the exact real lower boundary of the
+      // reals that convert to at least c, i.e., the lower boundary of the
+      // rounding cell of c (see utils::roundingCellLowerBound). Dually,
+      // to_fp(rm, x) <=_fp c holds iff x is (strictly) below the boundary
+      // determined by nextUp(c), since F <=_fp c iff not (F >=_fp nextUp(c))
+      // for non-NaN F. These cell-boundary equivalences are sound and exclude
+      // the whole spurious rounding cell in one step, which is required for
+      // the refinement loop to converge (the model value of x could otherwise
+      // slide from cell to cell indefinitely).
       //
-      // Where the boundary is not available, i.e., if c is an infinity or if
-      // the cell of c is unbounded (c is the largest resp. smallest finite
-      // value of its format), fall back to the monotonicity implication
-      // anchored at a real v that converts to c:
-      //   x >= v  -->  to_fp(rm, x) >=_fp c
-      // and dually for <=. Note that only this direction is valid: rounding
-      // is monotone but not injective, thus to_fp(rm, x) >=_fp to_fp(rm, v)
-      // does not imply x >= v (x slightly below v may round to the same
-      // float). Asserting the equivalence excludes satisfiable regions around
-      // v and makes the solver refutation unsound (see issues #12370,
-      // #12780). Since v is in the cell of c, this implication is the weaker,
-      // model-anchored variant of the cell-boundary equivalence above.
+      // Note that anchoring at the model value instead, i.e., asserting
+      //   x >= v  <->  to_fp(rm, x) >=_fp to_fp(rm, v)
+      // for the model value v of x, is refutation unsound: rounding is
+      // monotone but not injective, thus the right-to-left direction does not
+      // hold (x slightly below v may round to the same float). Such a lemma
+      // excludes satisfiable regions around v (see issues #12370, #12780).
+      // Only its left-to-right direction is valid, and that is implied by the
+      // equivalences above for every real in the cell of c, so no additional
+      // lemmas anchored at the model values are required.
       //
-      // Note that the equivalences also imply the monotonicity implications
-      // for every real in the cell of c, thus no additional lemmas anchored
-      // at the model values are required.
+      // At the extremes of the format the set of reals that convert to at
+      // least c is all of the reals resp. empty, e.g., under a rounding mode
+      // that saturates at maxNormal no real converts to +oo. There the
+      // equivalence degenerates to the FP-side literal resp. its negation,
+      // which are the (sound) overflow and saturation lemmas, e.g.
+      //   rm = RNE  ->  (to_fp(rm, x) >=_fp +oo  <->  x >= 2^128 - 2^103)
+      // for Float32, and
+      //   rm = RTZ  ->  not (to_fp(rm, x) >=_fp +oo).
+      // Without these, the refinement loop cannot converge on any model whose
+      // abstraction value is an infinity: it would walk the cells of the
+      // finite floats one by one (see issue #12371).
       //
       // @param c The float to anchor the lemmas at, must not be NaN.
-      // @param v A real that converts to c, null if there is none.
-      auto sendCellLemmas = [&](const FloatingPoint& c, TNode v) {
+      auto sendCellLemmas = [&](const FloatingPoint& c) {
         Assert(!c.isNaN());
         Node cn = nm->mkConst(c);
-        Node geq = nm->mkNode(Kind::FLOATINGPOINT_GEQ, abstract, cn);
-        Node leq = nm->mkNode(Kind::FLOATINGPOINT_LEQ, abstract, cn);
         Node lower, upper;
-        // The cell of c has a finite lower boundary unless c is an infinity or
-        // the smallest finite value of its format.
-        if (!c.isInfinite() && !FloatingPoint::nextDown(c).isInfinite())
+        // Note that a lemma is only informative while c is not at the extreme
+        // of the FP order it is compared against: to_fp(rm, x) >=_fp -oo and
+        // to_fp(rm, x) <=_fp +oo hold for every non-NaN result. The latter is
+        // also where the identity used for the upper bound breaks down, since
+        // nextUp(+oo) is +oo.
+        if (!(c.isInfinite() && c.isNegative()))
         {
-          auto [lb, lstrict] = utils::roundingCellLowerBound(c, rm);
-          lower = nm->mkNode(Kind::EQUAL,
-                             {geq,
-                              nm->mkNode(lstrict ? Kind::GT : Kind::GEQ,
-                                         concrete[1],
-                                         nm->mkConstReal(lb))});
+          lower = boundLemma(nm->mkNode(Kind::FLOATINGPOINT_GEQ, abstract, cn),
+                             utils::roundingCellLowerBound(c, rm),
+                             false);
         }
-        else if (!v.isNull())
+        if (!(c.isInfinite() && c.isPositive()))
         {
-          lower = nm->mkNode(Kind::IMPLIES,
-                             {nm->mkNode(Kind::GEQ, concrete[1], v), geq});
-        }
-        // The cell of c has a finite upper boundary, the lower boundary of the
-        // cell of nextUp(c), unless c is an infinity or the largest finite
-        // value of its format. Note that F <=_fp c iff not (F >=_fp nextUp(c))
-        // for non-NaN F.
-        FloatingPoint s = FloatingPoint::nextUp(c);
-        if (!c.isInfinite() && !s.isInfinite())
-        {
-          // nextDown(s) is c (up to the sign of zero) and thus finite, hence
-          // s being finite is all the preconditions require here
-          auto [ub, sstrict] = utils::roundingCellLowerBound(s, rm);
-          upper = nm->mkNode(Kind::EQUAL,
-                             {leq,
-                              nm->mkNode(sstrict ? Kind::LEQ : Kind::LT,
-                                         concrete[1],
-                                         nm->mkConstReal(ub))});
-        }
-        else if (!v.isNull())
-        {
-          upper = nm->mkNode(Kind::IMPLIES,
-                             {nm->mkNode(Kind::LEQ, concrete[1], v), leq});
+          upper = boundLemma(
+              nm->mkNode(Kind::FLOATINGPOINT_LEQ, abstract, cn),
+              utils::roundingCellLowerBound(FloatingPoint::nextUp(c), rm),
+              true);
         }
         for (const Node& l : {lower, upper})
         {
@@ -470,31 +481,19 @@ bool TheoryFp::refineAbstraction(TheoryModel* m, TNode abstract, TNode concrete)
 
       // Anchor the lemmas at the correct rounding of the model value of x,
       // which the model value of the abstraction disagrees with, ...
-      sendCellLemmas(concreteValue.getConst<FloatingPoint>(), realValue);
-      // ... and at the model value of the abstraction, which converts to
-      // itself unless it is an infinity.
-      const FloatingPoint& av = abstractValue.getConst<FloatingPoint>();
-      Node realValueOfAbstract;
-      if (!av.isInfinite())
-      {
-        realValueOfAbstract =
-            rewrite(nm->mkNode(Kind::FLOATINGPOINT_TO_REAL_TOTAL,
-                               abstractValue,
-                               nm->mkConstReal(Rational(0U))));
-      }
-      sendCellLemmas(av, realValueOfAbstract);
+      sendCellLemmas(concreteValue.getConst<FloatingPoint>());
+      // ... and at the model value of the abstraction.
+      sendCellLemmas(abstractValue.getConst<FloatingPoint>());
 
       if (!sent)
       {
         // All refinement lemmas for these model values were already sent in a
         // previous round. Either the model is inconsistent with the current
         // assertions (cf. the NaN case above), or the lemmas are too weak to
-        // exclude it: unlike in the FLOATINGPOINT_TO_REAL_TOTAL case above,
-        // they are implications rather than equivalences, and they are
-        // formulated in terms of fp.leq/fp.geq and of the rationals the
-        // results denote, all of which identify -zero and +zero (which is why
-        // registerTerm() constrains the sign of the abstraction separately).
-        // Give up on this model rather than accept it.
+        // exclude it: they are formulated in terms of fp.leq/fp.geq and of the
+        // rationals the results denote, all of which identify -zero and +zero
+        // (which is why registerTerm() constrains the sign of the abstraction
+        // separately). Give up on this model rather than accept it.
         Assert(getValuation().isModelUnsound())
             << "model of " << abstract
             << " is not excluded by its refinement lemmas";

--- a/src/theory/fp/theory_fp.h
+++ b/src/theory/fp/theory_fp.h
@@ -139,9 +139,10 @@ class TheoryFp : public Theory
    *   (normal/subnormal float for fp.to_real, non-NaN values for to_fp),
    *   refinement lemmas anchored at the current model values are sent: for
    *   fp.to_real, order equivalences around the argument and result values;
-   *   for to_fp, monotonicity implications plus exact rounding-cell boundary
-   *   equivalences (see utils::roundingCellLowerBound) that exclude the
-   *   entire spurious rounding cell under the model's rounding mode.
+   *   for to_fp, exact rounding-cell boundary equivalences (see
+   *   utils::roundingCellLowerBound) that exclude the entire spurious
+   *   rounding cell under the model's rounding mode, degenerating to the
+   *   overflow resp. saturation lemmas at the extremes of the format.
    * - If no progress is possible -- the model values are non-constant (model
    *   construction in another theory failed), they contradict the
    *   registration lemmas (NaN/infinity/zero cases), or every refinement

--- a/src/theory/fp/theory_fp_utils.cpp
+++ b/src/theory/fp/theory_fp_utils.cpp
@@ -61,37 +61,112 @@ void checkForExperimentalFloatingPointType(const Node& n)
   }
 }
 
-std::pair<Rational, bool> roundingCellLowerBound(const FloatingPoint& c,
-                                                 RoundingMode rm)
+namespace {
+
+/**
+ * The magnitude the infinities overflow from, i.e., 2^(emax+1) for the given
+ * format. It is not representable in the format, but it is the neighbor of
+ * +-maxNormal that determines the boundaries of the outermost rounding cells:
+ * a result rounded in an unbounded exponent range overflows iff its magnitude
+ * is at least this value (see IEEE 754-2019, Section 7.4).
+ * @param size The format.
+ * @return The magnitude the infinities overflow from.
+ */
+Rational overflowMagnitude(const FloatingPointSize& size)
 {
-  Assert(!c.isNaN() && !c.isInfinite());
+  FloatingPoint max = FloatingPoint::makeMaxNormal(size, false);
+  Rational rmax = max.convertToRationalTotal(Rational(0));
+  // The spacing of the largest binade. Note that nextDown(maxNormal) is in
+  // that binade for any format, since the significand of maxNormal is all
+  // ones and thus does not underflow into the binade below.
+  Rational step =
+      rmax - FloatingPoint::nextDown(max).convertToRationalTotal(Rational(0));
+  return rmax + step;
+}
+
+}  // namespace
+
+RoundingCellLowerBound roundingCellLowerBound(const FloatingPoint& c,
+                                              RoundingMode rm)
+{
+  Assert(!c.isNaN());
+
+  bool saturatesUp = rm == RoundingMode::ROUND_TOWARD_POSITIVE
+                     || rm == RoundingMode::ROUND_TOWARD_ZERO;
+  bool saturatesDown = rm == RoundingMode::ROUND_TOWARD_NEGATIVE
+                       || rm == RoundingMode::ROUND_TOWARD_ZERO;
+
+  // No real converts to less than -oo, thus all of them convert to at least
+  // -oo. Note that this holds for every rounding mode, in particular for the
+  // ones that never yield an infinity.
+  if (c.isInfinite() && c.isNegative())
+  {
+    return {RoundingCellLowerBound::Kind::ALL};
+  }
+  // The rounding modes that round towards zero resp. towards -oo saturate at
+  // maxNormal instead of overflowing to +oo, thus no real converts to +oo.
+  if (c.isInfinite() && saturatesDown)
+  {
+    return {RoundingCellLowerBound::Kind::NONE};
+  }
   FloatingPoint p = FloatingPoint::nextDown(c);
-  Assert(!p.isInfinite());
-  Rational rc = c.convertToRationalTotal(Rational(0));
-  Rational rp = p.convertToRationalTotal(Rational(0));
+  // Dually, the rounding modes that round towards zero resp. towards +oo
+  // saturate at -maxNormal, thus all reals convert to at least -maxNormal.
+  if (p.isInfinite() && saturatesUp)
+  {
+    Assert(!c.isInfinite());
+    return {RoundingCellLowerBound::Kind::ALL};
+  }
+
+  // The values of c and of the float below it. At the extremes of the format
+  // one of the two is not representable; there the magnitude the infinities
+  // overflow from stands in for the missing value, which is exactly what
+  // rounding in an unbounded exponent range compares against.
+  Rational rc, rp;
+  if (c.isInfinite())
+  {
+    rc = overflowMagnitude(c.getSize());
+    rp = p.convertToRationalTotal(Rational(0));
+  }
+  else
+  {
+    rc = c.convertToRationalTotal(Rational(0));
+    rp = p.isInfinite() ? -overflowMagnitude(c.getSize())
+                        : p.convertToRationalTotal(Rational(0));
+  }
   switch (rm)
   {
     case RoundingMode::ROUND_TOWARD_POSITIVE:
       // x in (real(p), real(c)] rounds up to c
-      return {rp, true};
+      return {RoundingCellLowerBound::Kind::BOUNDED, rp, true};
     case RoundingMode::ROUND_TOWARD_NEGATIVE:
       // x in [real(c), real(nextUp(c))) rounds down to c
-      return {rc, false};
+      return {RoundingCellLowerBound::Kind::BOUNDED, rc, false};
     case RoundingMode::ROUND_TOWARD_ZERO:
       // positive: rounds down, as for ROUND_TOWARD_NEGATIVE
       // negative and zero: rounds up, as for ROUND_TOWARD_POSITIVE
-      return rc > 0 ? std::make_pair(rc, false) : std::make_pair(rp, true);
+      return rc > 0
+                 ? RoundingCellLowerBound{RoundingCellLowerBound::Kind::BOUNDED,
+                                          rc,
+                                          false}
+                 : RoundingCellLowerBound{
+                       RoundingCellLowerBound::Kind::BOUNDED, rp, true};
     case RoundingMode::ROUND_NEAREST_TIES_TO_EVEN:
       // the tie (midpoint) rounds to the neighbor with even significand; the
       // significand lsbs of adjacent packed values alternate, thus the
-      // boundary is strict iff the significand of c is odd
-      return {(rp + rc) / 2, c.pack().getValue().testBit(0)};
+      // boundary is strict iff the significand of c is odd. Note that this
+      // also determines the tie at the overflow boundary correctly: the
+      // significand of the infinities is zero, i.e., even, and IEEE 754-2019,
+      // Section 7.4, indeed has the tie overflow.
+      return {RoundingCellLowerBound::Kind::BOUNDED,
+              (rp + rc) / 2,
+              c.pack().getValue().testBit(0)};
     case RoundingMode::ROUND_NEAREST_TIES_TO_AWAY:
     {
       // the tie rounds away from zero: to c if the midpoint is positive,
       // to p if it is negative
       Rational t0 = (rp + rc) / 2;
-      return {t0, t0 < 0};
+      return {RoundingCellLowerBound::Kind::BOUNDED, t0, t0 < 0};
     }
     default: Unreachable() << "Unknown rounding mode";
   }

--- a/src/theory/fp/theory_fp_utils.h
+++ b/src/theory/fp/theory_fp_utils.h
@@ -15,8 +15,6 @@
 #ifndef CVC5__THEORY__FP__UTILS_H
 #define CVC5__THEORY__FP__UTILS_H
 
-#include <utility>
-
 #include "expr/type_node.h"
 #include "util/floatingpoint.h"
 #include "util/integer.h"
@@ -43,21 +41,56 @@ Integer getCardinality(const TypeNode& type);
 void checkForExperimentalFloatingPointType(const Node& n);
 
 /**
- * Compute the exact lower boundary of the rounding cell of a finite
- * floating-point value c under rounding mode rm: the rational threshold t0
- * such that for all reals x,
- *   to_fp(rm, x) >=_fp c  iff  (strict ? x > t0 : x >= t0).
- *
- * Requires that c is neither NaN nor infinite, and that the cell of c has a
- * finite lower boundary, i.e., that nextDown(c) is not -infinity.
- *
- * @param c The floating-point value whose rounding cell is considered.
- * @param rm The rounding mode.
- * @return The threshold t0 and a flag that is true if the lower bound is
- *         strict.
+ * The lower boundary of the set of reals that convert to at least a given
+ * floating-point value, see roundingCellLowerBound().
  */
-std::pair<Rational, bool> roundingCellLowerBound(const FloatingPoint& c,
-                                                 RoundingMode rm);
+struct RoundingCellLowerBound
+{
+  /** The kind of the boundary. */
+  enum class Kind
+  {
+    /** The set is bounded below by d_bound. */
+    BOUNDED,
+    /** The set is all of the reals. */
+    ALL,
+    /** The set is empty. */
+    NONE,
+  };
+  /** The kind of this boundary. */
+  Kind d_kind = Kind::BOUNDED;
+  /** The boundary, only meaningful if d_kind is BOUNDED. */
+  Rational d_bound = Rational();
+  /** True if d_bound is excluded, only meaningful if d_kind is BOUNDED. */
+  bool d_strict = false;
+};
+
+/**
+ * Compute the exact lower boundary of the set of reals that convert to at
+ * least a given floating-point value c under rounding mode rm,
+ *   S(c, rm) = { x in R | to_fp(rm, x) >=_fp c },
+ * which is upwards closed since rounding is monotone. If S(c, rm) is bounded
+ * below, the result is the rational threshold t0 and a strictness flag such
+ * that for all reals x,
+ *   to_fp(rm, x) >=_fp c  iff  (strict ? x > t0 : x >= t0),
+ * i.e., t0 is the lower boundary of the rounding cell of c. Otherwise the
+ * result indicates that S(c, rm) is all of the reals or that it is empty.
+ *
+ * The degenerate cases occur at the extremes of the format: S(c, rm) is all of
+ * the reals if c is -infinity, and if c is the smallest finite value of its
+ * format under the rounding modes that saturate towards it rather than
+ * overflowing to -infinity. It is empty if c is +infinity under the rounding
+ * modes that saturate towards the largest finite value.
+ *
+ * Note that >=_fp identifies -zero and +zero, and thus so does S(c, rm).
+ *
+ * Requires that c is not NaN.
+ *
+ * @param c The floating-point value considered.
+ * @param rm The rounding mode.
+ * @return The lower boundary of S(c, rm).
+ */
+RoundingCellLowerBound roundingCellLowerBound(const FloatingPoint& c,
+                                              RoundingMode rm);
 
 }  // namespace utils
 }  // namespace fp

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -975,6 +975,9 @@ set(regress_0_tests
   regress0/fp/bvcomp-rewrite.smt2
   regress0/fp/down-cast-RNA.smt2
   regress0/fp/ext-rew-test.smt2
+  regress0/fp/from-real-overflow-boundary.smt2
+  regress0/fp/from-real-overflow-negative.smt2
+  regress0/fp/from-real-overflow-saturate.smt2
   regress0/fp/from-real-shared-purified-arg.smt2
   regress0/fp/from-real-zero-sign.smt2
   regress0/fp/from_ubv.smt2
@@ -1012,6 +1015,7 @@ set(regress_0_tests
   regress0/fp/issue12340-from-real-refine.smt2
   regress0/fp/issue12354-from-real-refine.smt2
   regress0/fp/issue12370-from-real-refine.smt2
+  regress0/fp/issue12371-from-real-overflow.smt2
   regress0/fp/issue12780-from-real-refine.smt2
   regress0/fp/issue12867-min-max-zero.smt2
   regress0/fp/issuepr650.smt2

--- a/test/regress/cli/regress0/fp/from-real-overflow-boundary.smt2
+++ b/test/regress/cli/regress0/fp/from-real-overflow-boundary.smt2
@@ -1,0 +1,16 @@
+; REQUIRES: unrestricted-mode
+; EXPECT: unsat
+; The exact overflow threshold of Float32 under RNE is the midpoint between
+; the largest finite value and 2^128, i.e. 2^128 - 2^103 = 340282356779733661
+; 637539395458142568448. The tie rounds to +oo, so the reals converting to
+; +oo are exactly those at or above the threshold. Both disjuncts contradict
+; that: x is strictly below the threshold and y is at it.
+(set-logic ALL)
+(declare-const x Real)
+(declare-const y Real)
+(assert (or (and (> x 340282356779733661637539395458142568447.0)
+                 (< x 340282356779733661637539395458142568448.0)
+                 (fp.isInfinite ((_ to_fp 8 24) RNE x)))
+            (and (>= y 340282356779733661637539395458142568448.0)
+                 (not (fp.isInfinite ((_ to_fp 8 24) RNE y))))))
+(check-sat)

--- a/test/regress/cli/regress0/fp/from-real-overflow-negative.smt2
+++ b/test/regress/cli/regress0/fp/from-real-overflow-negative.smt2
@@ -1,0 +1,10 @@
+; REQUIRES: unrestricted-mode
+; COMMAND-LINE: --check-models
+; EXPECT: sat
+; Satisfiable negative overflow: the model has to pick an x at or below the
+; negative overflow threshold of Float32 under RNE.
+(set-logic ALL)
+(declare-const x Real)
+(assert (fp.isInfinite ((_ to_fp 8 24) RNE x)))
+(assert (fp.isNegative ((_ to_fp 8 24) RNE x)))
+(check-sat)

--- a/test/regress/cli/regress0/fp/from-real-overflow-saturate.smt2
+++ b/test/regress/cli/regress0/fp/from-real-overflow-saturate.smt2
@@ -1,0 +1,15 @@
+; REQUIRES: unrestricted-mode
+; EXPECT: unsat
+; The rounding modes that round towards zero never overflow to an infinity,
+; and the directed modes only overflow to the infinity they round towards, so
+; no real converts to the infinities below.
+(set-logic ALL)
+(declare-const x Real)
+(declare-const y Real)
+(declare-const z Real)
+(assert (or (fp.isInfinite ((_ to_fp 8 24) RTZ x))
+            (and (fp.isInfinite ((_ to_fp 8 24) RTN y))
+                 (fp.isPositive ((_ to_fp 8 24) RTN y)))
+            (and (fp.isInfinite ((_ to_fp 8 24) RTP z))
+                 (fp.isNegative ((_ to_fp 8 24) RTP z)))))
+(check-sat)

--- a/test/regress/cli/regress0/fp/issue12371-from-real-overflow.smt2
+++ b/test/regress/cli/regress0/fp/issue12371-from-real-overflow.smt2
@@ -1,0 +1,14 @@
+; REQUIRES: unrestricted-mode
+; COMMAND-LINE:
+; COMMAND-LINE: --check-unsat-cores
+; EXPECT: unsat
+; The quantified formula is false: any x large enough overflows to +oo, and
+; then the body requires 0.0 >= x. Refuting it requires the refinement of the
+; conversion abstraction to determine that the model's +oo value for the
+; conversion means that x is at least the overflow threshold. Without that
+; lemma the refinement walks the rounding cells of the finite floats one by
+; one and never converges.
+(set-logic ALL)
+(assert (forall ((x Real))
+  (>= 0.0 (ite (fp.isInfinite ((_ to_fp 8 24) RNE x)) x 0.0))))
+(check-sat)

--- a/test/unit/theory/theory_fp_utils_black.cpp
+++ b/test/unit/theory/theory_fp_utils_black.cpp
@@ -49,33 +49,84 @@ class TestTheoryBlackFpUtils : public TestInternal
   }
 
   /**
+   * Whether a >=_fp b for non-NaN a and b, i.e., the order that places the
+   * infinities outside the finite values and identifies -0 and +0.
+   */
+  static bool geqFp(const FloatingPoint& a, const FloatingPoint& b)
+  {
+    Assert(!a.isNaN() && !b.isNaN());
+    if (a.isInfinite() && a.isPositive())
+    {
+      return true;
+    }
+    if (b.isInfinite() && b.isNegative())
+    {
+      return true;
+    }
+    // a is -oo and b is not, or b is +oo and a is finite
+    if (a.isInfinite() || b.isInfinite())
+    {
+      return false;
+    }
+    return a.convertToRationalTotal(Rational(0))
+           >= b.convertToRationalTotal(Rational(0));
+  }
+
+  /**
    * Check the contract of roundingCellLowerBound for float c, rounding mode
    * rm and a real sample point x:
-   *   to_fp(rm, x) >=_fp c  iff  (strict ? x > t0 : x >= t0),
-   * where >=_fp compares the denoted extended real values (-0 and +0 both
-   * denote 0), computed via the exact conversion of x.
+   *   to_fp(rm, x) >=_fp c  iff  x is above the boundary b,
+   * where >=_fp is geqFp() above, computed via the exact conversion of x.
    */
   void checkContractAt(const FloatingPoint& c,
                        RoundingMode rm,
-                       const Rational& t0,
-                       bool strict,
+                       const utils::RoundingCellLowerBound& b,
                        const Rational& x)
   {
     FloatingPoint fx(c.getSize(), rm, x);
     ASSERT_FALSE(fx.isNaN());
-    bool geq;
-    if (fx.isInfinite())
+    bool above;
+    switch (b.d_kind)
     {
-      geq = fx.isPositive();
+      case utils::RoundingCellLowerBound::Kind::ALL: above = true; break;
+      case utils::RoundingCellLowerBound::Kind::NONE: above = false; break;
+      default: above = b.d_strict ? x > b.d_bound : x >= b.d_bound; break;
     }
-    else
-    {
-      geq = fx.convertToRationalTotal(Rational(0))
-            >= c.convertToRationalTotal(Rational(0));
-    }
-    ASSERT_EQ(geq, strict ? x > t0 : x >= t0)
-        << "c = " << c << ", rm = " << rm << ", t0 = " << t0
-        << ", strict = " << strict << ", x = " << x;
+    ASSERT_EQ(geqFp(fx, c), above)
+        << "c = " << c << ", rm = " << rm
+        << ", kind = " << static_cast<uint32_t>(b.d_kind)
+        << ", t0 = " << b.d_bound << ", strict = " << b.d_strict
+        << ", x = " << x;
+  }
+
+  /**
+   * The boundary of a rounding cell that is expected to be bounded below.
+   * @param c The float whose rounding cell is considered.
+   * @param rm The rounding mode.
+   * @return The boundary and its strictness.
+   */
+  std::pair<Rational, bool> bound(const FloatingPoint& c, RoundingMode rm)
+  {
+    utils::RoundingCellLowerBound b = utils::roundingCellLowerBound(c, rm);
+    EXPECT_EQ(b.d_kind, utils::RoundingCellLowerBound::Kind::BOUNDED)
+        << "c = " << c << ", rm = " << rm;
+    return {b.d_bound, b.d_strict};
+  }
+
+  /**
+   * The floats at the extremes of a format, where the rounding cells are
+   * unbounded or empty depending on the rounding mode.
+   */
+  std::vector<FloatingPoint> extremes(const FloatingPointSize& size)
+  {
+    FloatingPoint maxNormalPos = FloatingPoint::makeMaxNormal(size, false);
+    FloatingPoint maxNormalNeg = FloatingPoint::makeMaxNormal(size, true);
+    return {FloatingPoint::makeInf(size, false),
+            FloatingPoint::makeInf(size, true),
+            maxNormalPos,
+            maxNormalNeg,
+            FloatingPoint::nextDown(maxNormalPos),
+            FloatingPoint::nextUp(maxNormalNeg)};
   }
 
   std::vector<FloatingPointSize> d_all_formats;
@@ -91,19 +142,11 @@ TEST_F(TestTheoryBlackFpUtils, roundingCellLowerBoundPreconditions)
   // tests fork the process and are expensive)
   FloatingPointSize size(5, 11);
   RoundingMode rm = RoundingMode::ROUND_NEAREST_TIES_TO_EVEN;
-  // no rounding cell for NaN and the infinities
+  // NaN is not in the range of the conversion and is unordered, so it has no
+  // rounding cell. The infinities and the extremal finite values do have one,
+  // see roundingCellLowerBoundExtremes below.
   ASSERT_DEATH(utils::roundingCellLowerBound(FloatingPoint::makeNaN(size), rm),
-               "!c.isNaN\\(\\) && !c.isInfinite\\(\\)");
-  ASSERT_DEATH(
-      utils::roundingCellLowerBound(FloatingPoint::makeInf(size, false), rm),
-      "!c.isNaN\\(\\) && !c.isInfinite\\(\\)");
-  ASSERT_DEATH(
-      utils::roundingCellLowerBound(FloatingPoint::makeInf(size, true), rm),
-      "!c.isNaN\\(\\) && !c.isInfinite\\(\\)");
-  // nextDown(-maxNormal) is -oo, so its cell has no finite lower boundary
-  ASSERT_DEATH(utils::roundingCellLowerBound(
-                   FloatingPoint::makeMaxNormal(size, true), rm),
-               "!p.isInfinite\\(\\)");
+               "!c.isNaN\\(\\)");
 }
 #endif
 
@@ -117,31 +160,26 @@ TEST_F(TestTheoryBlackFpUtils, roundingCellLowerBoundKnownValues)
   Rational t0;
   bool strict;
 
-  std::tie(t0, strict) =
-      utils::roundingCellLowerBound(one, RoundingMode::ROUND_TOWARD_POSITIVE);
+  std::tie(t0, strict) = bound(one, RoundingMode::ROUND_TOWARD_POSITIVE);
   ASSERT_EQ(t0, Rational(2047, 2048));
   ASSERT_TRUE(strict);
 
-  std::tie(t0, strict) =
-      utils::roundingCellLowerBound(one, RoundingMode::ROUND_TOWARD_NEGATIVE);
+  std::tie(t0, strict) = bound(one, RoundingMode::ROUND_TOWARD_NEGATIVE);
   ASSERT_EQ(t0, Rational(1));
   ASSERT_FALSE(strict);
 
   // positive values round towards zero as for ROUND_TOWARD_NEGATIVE
-  std::tie(t0, strict) =
-      utils::roundingCellLowerBound(one, RoundingMode::ROUND_TOWARD_ZERO);
+  std::tie(t0, strict) = bound(one, RoundingMode::ROUND_TOWARD_ZERO);
   ASSERT_EQ(t0, Rational(1));
   ASSERT_FALSE(strict);
 
   // the tie rounds to 1.0 (even), so the boundary is inclusive
-  std::tie(t0, strict) = utils::roundingCellLowerBound(
-      one, RoundingMode::ROUND_NEAREST_TIES_TO_EVEN);
+  std::tie(t0, strict) = bound(one, RoundingMode::ROUND_NEAREST_TIES_TO_EVEN);
   ASSERT_EQ(t0, Rational(4095, 4096));
   ASSERT_FALSE(strict);
 
   // the positive tie rounds away from zero, i.e., up to 1.0
-  std::tie(t0, strict) = utils::roundingCellLowerBound(
-      one, RoundingMode::ROUND_NEAREST_TIES_TO_AWAY);
+  std::tie(t0, strict) = bound(one, RoundingMode::ROUND_NEAREST_TIES_TO_AWAY);
   ASSERT_EQ(t0, Rational(4095, 4096));
   ASSERT_FALSE(strict);
 
@@ -150,72 +188,159 @@ TEST_F(TestTheoryBlackFpUtils, roundingCellLowerBoundKnownValues)
   FloatingPoint mone(
       f16, RoundingMode::ROUND_NEAREST_TIES_TO_EVEN, Rational(-1));
 
-  std::tie(t0, strict) =
-      utils::roundingCellLowerBound(mone, RoundingMode::ROUND_TOWARD_POSITIVE);
+  std::tie(t0, strict) = bound(mone, RoundingMode::ROUND_TOWARD_POSITIVE);
   ASSERT_EQ(t0, Rational(-1025, 1024));
   ASSERT_TRUE(strict);
 
-  std::tie(t0, strict) =
-      utils::roundingCellLowerBound(mone, RoundingMode::ROUND_TOWARD_NEGATIVE);
+  std::tie(t0, strict) = bound(mone, RoundingMode::ROUND_TOWARD_NEGATIVE);
   ASSERT_EQ(t0, Rational(-1));
   ASSERT_FALSE(strict);
 
   // negative values round towards zero as for ROUND_TOWARD_POSITIVE
-  std::tie(t0, strict) =
-      utils::roundingCellLowerBound(mone, RoundingMode::ROUND_TOWARD_ZERO);
+  std::tie(t0, strict) = bound(mone, RoundingMode::ROUND_TOWARD_ZERO);
   ASSERT_EQ(t0, Rational(-1025, 1024));
   ASSERT_TRUE(strict);
 
   // the tie rounds to -1.0 (even), so the boundary is inclusive
-  std::tie(t0, strict) = utils::roundingCellLowerBound(
-      mone, RoundingMode::ROUND_NEAREST_TIES_TO_EVEN);
+  std::tie(t0, strict) = bound(mone, RoundingMode::ROUND_NEAREST_TIES_TO_EVEN);
   ASSERT_EQ(t0, Rational(-2049, 2048));
   ASSERT_FALSE(strict);
 
   // the negative tie rounds away from zero, i.e., down to -1025/1024, so
   // the boundary of -1.0's cell is exclusive
-  std::tie(t0, strict) = utils::roundingCellLowerBound(
-      mone, RoundingMode::ROUND_NEAREST_TIES_TO_AWAY);
+  std::tie(t0, strict) = bound(mone, RoundingMode::ROUND_NEAREST_TIES_TO_AWAY);
   ASSERT_EQ(t0, Rational(-2049, 2048));
+  ASSERT_TRUE(strict);
+}
+
+TEST_F(TestTheoryBlackFpUtils, roundingCellLowerBoundExtremes)
+{
+  using Kind = utils::RoundingCellLowerBound::Kind;
+  // Hand-computed boundaries at the extremes of Float16 (5, 11): the largest
+  // finite value is 2^16 - 2^5 = 65504, the magnitude the infinities overflow
+  // from is 2^16 = 65536, and the midpoint between the two is 65520.
+  FloatingPointSize f16(5, 11);
+  FloatingPoint inf = FloatingPoint::makeInf(f16, false);
+  FloatingPoint ninf = FloatingPoint::makeInf(f16, true);
+  FloatingPoint maxNormal = FloatingPoint::makeMaxNormal(f16, false);
+  FloatingPoint nmaxNormal = FloatingPoint::makeMaxNormal(f16, true);
+  Rational t0;
+  bool strict;
+
+  // Every real converts to at least -oo, under every rounding mode.
+  for (RoundingMode rm : d_all_rms)
+  {
+    ASSERT_EQ(utils::roundingCellLowerBound(ninf, rm).d_kind, Kind::ALL);
+  }
+
+  // The nearest modes overflow to +oo at the midpoint, which is a tie that
+  // rounds to +oo (the significand of the infinities is even), thus the
+  // boundary is inclusive.
+  for (RoundingMode rm : {RoundingMode::ROUND_NEAREST_TIES_TO_EVEN,
+                          RoundingMode::ROUND_NEAREST_TIES_TO_AWAY})
+  {
+    std::tie(t0, strict) = bound(inf, rm);
+    ASSERT_EQ(t0, Rational(65520));
+    ASSERT_FALSE(strict);
+  }
+  // Rounding up overflows above the largest finite value.
+  std::tie(t0, strict) = bound(inf, RoundingMode::ROUND_TOWARD_POSITIVE);
+  ASSERT_EQ(t0, Rational(65504));
+  ASSERT_TRUE(strict);
+  // The modes that round down resp. towards zero saturate at the largest
+  // finite value, thus no real converts to +oo.
+  for (RoundingMode rm :
+       {RoundingMode::ROUND_TOWARD_NEGATIVE, RoundingMode::ROUND_TOWARD_ZERO})
+  {
+    ASSERT_EQ(utils::roundingCellLowerBound(inf, rm).d_kind, Kind::NONE);
+  }
+
+  // Dually for the smallest finite value: the modes that round up resp.
+  // towards zero saturate at it, thus every real converts to at least -65504.
+  for (RoundingMode rm :
+       {RoundingMode::ROUND_TOWARD_POSITIVE, RoundingMode::ROUND_TOWARD_ZERO})
+  {
+    ASSERT_EQ(utils::roundingCellLowerBound(nmaxNormal, rm).d_kind, Kind::ALL);
+  }
+  // The tie at -65520 rounds away to -oo, so the boundary of the cell of
+  // -65504 is exclusive.
+  for (RoundingMode rm : {RoundingMode::ROUND_NEAREST_TIES_TO_EVEN,
+                          RoundingMode::ROUND_NEAREST_TIES_TO_AWAY})
+  {
+    std::tie(t0, strict) = bound(nmaxNormal, rm);
+    ASSERT_EQ(t0, Rational(-65520));
+    ASSERT_TRUE(strict);
+  }
+  // Rounding down overflows below the smallest finite value.
+  std::tie(t0, strict) = bound(nmaxNormal, RoundingMode::ROUND_TOWARD_NEGATIVE);
+  ASSERT_EQ(t0, Rational(-65504));
+  ASSERT_FALSE(strict);
+
+  // The cell of the largest finite value itself is the generic case: the
+  // value below it is 65504 - 32 = 65472 and the tie at 65488 rounds to it
+  // (the significand of 65504 is odd), so the boundary is exclusive.
+  std::tie(t0, strict) =
+      bound(maxNormal, RoundingMode::ROUND_NEAREST_TIES_TO_EVEN);
+  ASSERT_EQ(t0, Rational(65488));
   ASSERT_TRUE(strict);
 }
 
 TEST_F(TestTheoryBlackFpUtils, roundingCellLowerBoundContract)
 {
+  using Kind = utils::RoundingCellLowerBound::Kind;
   // Validate the documented equivalence
-  //   to_fp(rm, x) >=_fp c  iff  (strict ? x > t0 : x >= t0)
+  //   to_fp(rm, x) >=_fp c  iff  x is above the boundary
   // against the exact from-rational conversion, at sample points around the
-  // boundary, at the cell's own values, and far away on both sides. The
-  // equivalence is global, so any sample point must agree.
+  // boundary, at the values of c and its neighbors, and far outside the range
+  // of the format on both sides. The equivalence is global, so any sample
+  // point must agree. The floats at the extremes of the format, where the
+  // boundary is degenerate, are always tested; the remaining ones are
+  // sampled.
   for (const auto& size : d_all_formats)
   {
     uint32_t bvSize = size.exponentWidth() + size.significandWidth();
+    Rational rmax = FloatingPoint::makeMaxNormal(size, false)
+                        .convertToRationalTotal(Rational(0));
+    Rational rminSub = FloatingPoint::makeMinSubnormal(size, false)
+                           .convertToRationalTotal(Rational(0));
+    std::vector<FloatingPoint> cs = extremes(size);
     for (uint32_t i = 0; i < N_TESTS; ++i)
     {
-      FloatingPoint c(size, BitVector::mkRandom(bvSize));
-      // the preconditions of roundingCellLowerBound
-      if (c.isNaN() || c.isInfinite()
-          || FloatingPoint::nextDown(c).isInfinite())
+      cs.emplace_back(size, BitVector::mkRandom(bvSize));
+    }
+    for (const FloatingPoint& c : cs)
+    {
+      // NaN has no rounding cell, the only precondition
+      if (c.isNaN())
       {
         continue;
       }
       for (RoundingMode rm : d_all_rms)
       {
-        auto [t0, strict] = utils::roundingCellLowerBound(c, rm);
-        Rational rc = c.convertToRationalTotal(Rational(0));
-        Rational rp =
-            FloatingPoint::nextDown(c).convertToRationalTotal(Rational(0));
-        Rational quarter = (rc - rp) / 4;
-        for (const Rational& x : {t0,
-                                  t0 - quarter,
-                                  t0 + quarter,
-                                  rp,
-                                  rc,
-                                  (rp + rc) / 2,
-                                  t0 - Rational(1000000),
-                                  t0 + Rational(1000000)})
+        utils::RoundingCellLowerBound b = utils::roundingCellLowerBound(c, rm);
+        std::vector<Rational> xs = {
+            Rational(0), rmax * 2, -rmax * 2, rminSub / 2, -rminSub / 2};
+        if (!c.isInfinite())
         {
-          checkContractAt(c, rm, t0, strict, x);
+          xs.push_back(c.convertToRationalTotal(Rational(0)));
+        }
+        if (b.d_kind == Kind::BOUNDED)
+        {
+          // an offset that is smaller than the width of any rounding cell at
+          // the magnitude of the boundary, so that the neighboring points lie
+          // in the adjacent cells
+          Rational t = b.d_bound < 0 ? -b.d_bound : b.d_bound;
+          Rational delta =
+              t.isZero()
+                  ? rminSub / 4
+                  : t / Rational(Integer(2).pow(size.significandWidth() + 3));
+          xs.push_back(b.d_bound);
+          xs.push_back(b.d_bound - delta);
+          xs.push_back(b.d_bound + delta);
+        }
+        for (const Rational& x : xs)
+        {
+          checkContractAt(c, rm, b, x);
         }
       }
     }


### PR DESCRIPTION
Fixes #12371.

The refinement of the real-to-FP conversion abstraction excludes a spurious model by asserting cell-boundary equivalences: for the model's rounding mode, to_fp(rm, x) >=_fp c holds iff x is (strictly) above the exact real lower boundary of the rounding cell of c. This was restricted to floats whose cell has a finite boundary in the format, i.e., it excluded the infinities and the extremal finite values, where the code fell back to a monotonicity implication anchored at a real that converts to c -- of which there is none for an infinity, so nothing at all was asserted there.

As a consequence, the refinement could not converge on any model whose value for the abstraction is an infinity, which is required whenever the input asserts something like `fp.isInfinite` of a conversion: only the cell of the current (finite) value of x was excluded, so the loop walked the cells of the finite floats one by one.

The boundaries of the outermost cells are available, we now compute them:

- `utils::roundingCellLowerBound()` now takes any non-NaN float and returns the lower boundary of `S(c, rm) = { x | to_fp(rm, x) >=_fp c }`, which is either a rational with a strictness flag, or all of the reals, or empty. The missing neighbor of +-maxNormal is the (unrepresentable) magnitude the infinities overflow from, 2^(emax+1), which is exactly the value rounding in an unbounded exponent range compares against (IEEE 754-2019, Section 7.4). The nearest modes therefore overflow at the midpoint between maxNormal and that magnitude, and the tie overflows, which the existing significand parity rule determines correctly since the significand of the infinities is even. The directed modes only overflow to the infinity they round towards and saturate otherwise, which gives the degenerate cases.

- `TheoryFp::refineAbstraction()` turns the degenerate boundaries into the FP-side literal resp. its negation, i.e., into the overflow and saturation lemmas, e.g.

    `rm = RNE`  ->  `(to_fp(rm, x) >= +oo`  <->  `x >= 2^128 - 2^103)`
    `rm = RTZ`  ->  `not (to_fp(rm, x) >= +oo)`

  for Float32. Every anchor now has a boundary, which makes the model-anchored fallback dead code, so it is removed.

Analysis and fixes supported/based on suggestions by Claude. The framing of the missing lemmas as "the smallest thing that converts to the value" is due to a review comment by Martin Brain on #12795.